### PR TITLE
feat(mtp): chain-of-K on hybrid targets + drafter-hidden cascade

### DIFF
--- a/tests/test_mtp_multislot_rollback.py
+++ b/tests/test_mtp_multislot_rollback.py
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Multi-slot GatedDeltaNet rollback for chain-of-K MTP.
+"""Single-pass GatedDeltaNet rollback for chain-of-K MTP.
 
-Locks the ``cache_patch`` contract that the verify chunk-split records a
-``(conv, ssm)`` snapshot at EVERY draft boundary (keyed by
-``n_from_end = 1..K``), and that each snapshot equals the recurrent state
-after processing exactly ``S - n_from_end`` tokens — so
-``_rollback_draft(n)`` can restore to any accepted depth without leaving
-rejected draft state in the cache.
+Locks the ``cache_patch`` contract that the verify forward runs as ONE
+fused ``gated_delta_update`` (no per-boundary segment splitting) and
+stashes a rollback CLOSURE on the cache. The closure recomputes the
+``(conv, ssm)`` state after keeping the first ``S - n_to_drop`` verify
+positions — byte-exact with the true ``(S - n_to_drop)``-token recurrent
+state — so ``_rollback_draft(n)`` can restore to any accepted depth on a
+partial chain-of-K accept without leaving rejected draft state in the
+cache.
 
-Regression for the chain-of-K-on-hybrid work (PR feat/mtp-hybrid-chain-of-k):
-before the multi-slot rewrite only a single boundary was snapshotted, so
-partial accept at depth < K was unrepresentable.
+Regression for the single-pass rewrite (PR perf/mtp-single-pass-gdn-
+rollback): the previous implementation split the verify into ``K+1``
+separate ``gated_delta_update`` calls to materialize a snapshot at every
+boundary — ~K+1 GDN kernel launches per layer per round, measured as the
+dominant MTP verify cost. The single-pass path pays one fused scan and
+only recomputes on the rare rejection.
 """
 
 import mlx.core as mx
@@ -45,16 +50,16 @@ def _build_gated_delta_net():
 
 
 @pytest.mark.parametrize("K", [1, 2, 3])
-def test_multislot_chunksplit_snapshots_every_boundary(K):  # noqa: N803  (K = draft width)
-    """Every ``n_to_drop`` in 1..K has a snapshot equal to the true
-    ``(S - n)``-token recurrent state."""
+def test_rollback_closure_recomputes_true_boundary(K):  # noqa: N803  (K = draft width)
+    """The stashed rollback closure recomputes the exact ``(S - n)``-token
+    recurrent state for every ``n_to_drop`` in 1..K."""
     mx.random.seed(0)
     from mlx_lm.models.cache import ArraysCache
 
     from vllm_mlx.spec_decode.mtp import cache_patch
 
-    # Install the chunk-split patch; keep a handle to the unpatched forward
-    # for reference (single-call, no snapshots).
+    # Install the single-pass patch; keep a handle to the unpatched forward
+    # for the independent reference states.
     cache_patch.patch_gated_delta_net_for_mtp()
     orig_call = cache_patch._orig_gated_delta_call
     assert orig_call is not None
@@ -72,42 +77,40 @@ def test_multislot_chunksplit_snapshots_every_boundary(K):  # noqa: N803  (K = d
         mx.eval(c[0], c[1])
         return c
 
-    # Patched multi-slot run over the (K+1)-token verify window.
+    # Single-pass patched run over the (K+1)-token verify window.
     c_pat = fresh_cache()
     c_pat.snapshot_offsets = list(range(1, K + 1))
     layer(verify, mask=None, cache=c_pat)
     mx.eval(c_pat[0], c_pat[1])
 
-    assert c_pat.rollback_states is not None, "chunk-split must record snapshots"
-    assert set(c_pat.rollback_states) == set(range(1, K + 1)), (
-        "chunk-split must snapshot every 1..K draft boundary "
-        f"(got {sorted(c_pat.rollback_states)})"
+    assert c_pat.rollback_recompute is not None, (
+        "single-pass verify must stash a rollback closure"
     )
 
-    # Each snapshot at n_from_end == the state after processing the first
-    # (S - n) verify tokens, computed independently via the original forward.
-    # This compares two DIFFERENT computation paths (a mid-sequence boundary in
-    # one long conv1d vs a fresh short forward), so a tight float tolerance —
-    # not exact equality — is the correct bar; observed divergence is ~1e-7.
+    # For each n_to_drop, the closure must reproduce the state after
+    # processing the first (S - n) verify tokens, computed independently via
+    # the original forward. The closure rescans ``[0:keep]`` from the same
+    # pre-window anchor with the same kernel, so a tight float tolerance —
+    # not exact equality — is the correct bar (observed divergence ~1e-7).
     S = K + 1
     for n in range(1, K + 1):
         c_ref = fresh_cache()
         orig_call(layer, verify[:, : S - n], mask=None, cache=c_ref)
         mx.eval(c_ref[0], c_ref[1])
-        conv_snap, ssm_snap = c_pat.rollback_states[n]
-        assert float(mx.max(mx.abs(conv_snap - c_ref[0]))) < 1e-5, (
-            f"conv snapshot at n_from_end={n} diverges from the true "
-            f"{S - n}-token state"
+        conv_keep, ssm_keep = c_pat.rollback_recompute(n)
+        mx.eval(conv_keep, ssm_keep)
+        assert float(mx.max(mx.abs(conv_keep - c_ref[0]))) < 1e-5, (
+            f"conv rollback at n_to_drop={n} diverges from the true {S - n}-token state"
         )
-        assert float(mx.max(mx.abs(ssm_snap - c_ref[1]))) < 1e-5, (
-            f"ssm snapshot at n_from_end={n} diverges from the true {S - n}-token state"
+        assert float(mx.max(mx.abs(ssm_keep - c_ref[1]))) < 1e-5, (
+            f"ssm rollback at n_to_drop={n} diverges from the true {S - n}-token state"
         )
 
 
 def test_patched_forward_output_matches_unsplit():
-    """The chunk-split forward is byte-equal to the unsplit forward for the
-    confirmed tokens (the split only exposes intermediate state; it must not
-    change the output or the final cache state)."""
+    """The single-pass verify forward is byte-equal to the unpatched forward
+    for the confirmed tokens (it must not change the output or the final
+    cache state — it only additionally stashes the rollback closure)."""
     mx.random.seed(1)
     from mlx_lm.models.cache import ArraysCache
 
@@ -136,11 +139,11 @@ def test_patched_forward_output_matches_unsplit():
     out_pat = layer(verify, mask=None, cache=c_pat)
     mx.eval(out_pat, c_pat[0], c_pat[1])
 
-    # EXACT equality — the chunk-split is a pure sequential scan over the same
-    # tokens in the same order, so per-token logits and the final (conv, ssm)
-    # state are bit-identical to the unsplit forward. A tolerance here would let
-    # a logit-changing regression slip through and quietly break the lossless
-    # speculative-decoding contract.
-    assert bool(mx.array_equal(out_orig, out_pat)), "chunk-split changed the output"
-    assert bool(mx.array_equal(c_orig[0], c_pat[0])), "chunk-split changed conv state"
-    assert bool(mx.array_equal(c_orig[1], c_pat[1])), "chunk-split changed ssm state"
+    # EXACT equality — the single-pass path runs the SAME one fused
+    # ``gated_delta_update`` over the same tokens as the unpatched forward,
+    # so per-token logits and the final (conv, ssm) state are bit-identical.
+    # A tolerance here would let a logit-changing regression slip through and
+    # quietly break the lossless speculative-decoding contract.
+    assert bool(mx.array_equal(out_orig, out_pat)), "single-pass changed the output"
+    assert bool(mx.array_equal(c_orig[0], c_pat[0])), "single-pass changed conv state"
+    assert bool(mx.array_equal(c_orig[1], c_pat[1])), "single-pass changed ssm state"

--- a/tests/test_mtp_multislot_rollback.py
+++ b/tests/test_mtp_multislot_rollback.py
@@ -147,3 +147,45 @@ def test_patched_forward_output_matches_unsplit():
     assert bool(mx.array_equal(out_orig, out_pat)), "single-pass changed the output"
     assert bool(mx.array_equal(c_orig[0], c_pat[0])), "single-pass changed conv state"
     assert bool(mx.array_equal(c_orig[1], c_pat[1])), "single-pass changed ssm state"
+
+
+def test_fast_path_leaves_no_rollback_closure():
+    """A forward that requests NO snapshot (no ``snapshot_offsets``, ``S < 2``,
+    or a tensor-parallel bail) must NOT leave a ``rollback_recompute`` closure
+    on the cache.
+
+    This is the safety precondition behind the generator's ``_rollback_draft``
+    early-abort guard: if a reject — or an early abort that re-enters the
+    rewind path — tries to roll back a cache that never snapshotted, the
+    ``None`` sentinel makes ``_rollback_draft`` raise LOUDLY rather than
+    silently reuse a stale closure and mis-rewind the recurrent state. A
+    fast-path forward that silently left a stale closure behind would let an
+    abort rewind to the wrong boundary and corrupt the SSM state undetected.
+    """
+    mx.random.seed(2)
+    from mlx_lm.models.cache import ArraysCache
+
+    from vllm_mlx.spec_decode.mtp import cache_patch
+
+    cache_patch.patch_gated_delta_net_for_mtp()
+    orig_call = cache_patch._orig_gated_delta_call
+    layer, args = _build_gated_delta_net()
+
+    prefix = mx.random.normal((1, 3, args.hidden_size))
+    verify = mx.random.normal((1, 3, args.hidden_size))
+    mx.eval(prefix, verify)
+
+    c = ArraysCache(size=2)
+    orig_call(layer, prefix, mask=None, cache=c)
+    mx.eval(c[0], c[1])
+    assert c.rollback_recompute is None  # nothing stashed yet
+
+    # No snapshot requested -> the patched call takes the fast single-pass
+    # branch and must leave ``rollback_recompute`` untouched (class default).
+    assert getattr(c, "snapshot_offsets", None) is None
+    layer(verify, mask=None, cache=c)
+    mx.eval(c[0], c[1])
+    assert c.rollback_recompute is None, (
+        "a fast-path (no-snapshot) forward must not stash a rollback closure — "
+        "else an abort/reject could silently reuse a stale rewind"
+    )

--- a/tests/test_mtp_multislot_rollback.py
+++ b/tests/test_mtp_multislot_rollback.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-slot GatedDeltaNet rollback for chain-of-K MTP.
+
+Locks the ``cache_patch`` contract that the verify chunk-split records a
+``(conv, ssm)`` snapshot at EVERY draft boundary (keyed by
+``n_from_end = 1..K``), and that each snapshot equals the recurrent state
+after processing exactly ``S - n_from_end`` tokens — so
+``_rollback_draft(n)`` can restore to any accepted depth without leaving
+rejected draft state in the cache.
+
+Regression for the chain-of-K-on-hybrid work (PR feat/mtp-hybrid-chain-of-k):
+before the multi-slot rewrite only a single boundary was snapshotted, so
+partial accept at depth < K was unrepresentable.
+"""
+
+import mlx.core as mx
+import pytest
+
+
+def _build_gated_delta_net():
+    from mlx_lm.models.qwen3_5 import GatedDeltaNet, TextModelArgs
+
+    args = TextModelArgs(
+        model_type="qwen3_5_moe_text",
+        hidden_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=64,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_conv_kernel_dim=4,
+        rms_norm_eps=1e-6,
+        vocab_size=100,
+    )
+    layer = GatedDeltaNet(args)
+    # Inference mode: ``gated_delta_update(use_kernel=not self.training)`` — so
+    # eval() exercises the SAME Metal-kernel segmented path production uses
+    # (training mode would silently fall to the pure-ops reference instead).
+    layer.eval()
+    mx.eval(layer.parameters())
+    return layer, args
+
+
+@pytest.mark.parametrize("K", [1, 2, 3])
+def test_multislot_chunksplit_snapshots_every_boundary(K):  # noqa: N803  (K = draft width)
+    """Every ``n_to_drop`` in 1..K has a snapshot equal to the true
+    ``(S - n)``-token recurrent state."""
+    mx.random.seed(0)
+    from mlx_lm.models.cache import ArraysCache
+
+    from vllm_mlx.spec_decode.mtp import cache_patch
+
+    # Install the chunk-split patch; keep a handle to the unpatched forward
+    # for reference (single-call, no snapshots).
+    cache_patch.patch_gated_delta_net_for_mtp()
+    orig_call = cache_patch._orig_gated_delta_call
+    assert orig_call is not None
+
+    layer, args = _build_gated_delta_net()
+
+    # A FIXED prefix + verify window so every cache starts from the same state.
+    prefix = mx.random.normal((1, 3, args.hidden_size))
+    verify = mx.random.normal((1, K + 1, args.hidden_size))
+    mx.eval(prefix, verify)
+
+    def fresh_cache():
+        c = ArraysCache(size=2)
+        orig_call(layer, prefix, mask=None, cache=c)
+        mx.eval(c[0], c[1])
+        return c
+
+    # Patched multi-slot run over the (K+1)-token verify window.
+    c_pat = fresh_cache()
+    c_pat.snapshot_offsets = list(range(1, K + 1))
+    layer(verify, mask=None, cache=c_pat)
+    mx.eval(c_pat[0], c_pat[1])
+
+    assert c_pat.rollback_states is not None, "chunk-split must record snapshots"
+    assert set(c_pat.rollback_states) == set(range(1, K + 1)), (
+        "chunk-split must snapshot every 1..K draft boundary "
+        f"(got {sorted(c_pat.rollback_states)})"
+    )
+
+    # Each snapshot at n_from_end == the state after processing the first
+    # (S - n) verify tokens, computed independently via the original forward.
+    # This compares two DIFFERENT computation paths (a mid-sequence boundary in
+    # one long conv1d vs a fresh short forward), so a tight float tolerance —
+    # not exact equality — is the correct bar; observed divergence is ~1e-7.
+    S = K + 1
+    for n in range(1, K + 1):
+        c_ref = fresh_cache()
+        orig_call(layer, verify[:, : S - n], mask=None, cache=c_ref)
+        mx.eval(c_ref[0], c_ref[1])
+        conv_snap, ssm_snap = c_pat.rollback_states[n]
+        assert float(mx.max(mx.abs(conv_snap - c_ref[0]))) < 1e-5, (
+            f"conv snapshot at n_from_end={n} diverges from the true "
+            f"{S - n}-token state"
+        )
+        assert float(mx.max(mx.abs(ssm_snap - c_ref[1]))) < 1e-5, (
+            f"ssm snapshot at n_from_end={n} diverges from the true {S - n}-token state"
+        )
+
+
+def test_patched_forward_output_matches_unsplit():
+    """The chunk-split forward is byte-equal to the unsplit forward for the
+    confirmed tokens (the split only exposes intermediate state; it must not
+    change the output or the final cache state)."""
+    mx.random.seed(1)
+    from mlx_lm.models.cache import ArraysCache
+
+    from vllm_mlx.spec_decode.mtp import cache_patch
+
+    cache_patch.patch_gated_delta_net_for_mtp()
+    orig_call = cache_patch._orig_gated_delta_call
+    layer, args = _build_gated_delta_net()
+
+    prefix = mx.random.normal((1, 3, args.hidden_size))
+    verify = mx.random.normal((1, 3, args.hidden_size))  # K=2 verify window
+    mx.eval(prefix, verify)
+
+    def fresh_cache():
+        c = ArraysCache(size=2)
+        orig_call(layer, prefix, mask=None, cache=c)
+        mx.eval(c[0], c[1])
+        return c
+
+    c_orig = fresh_cache()
+    out_orig = orig_call(layer, verify, mask=None, cache=c_orig)
+    mx.eval(out_orig, c_orig[0], c_orig[1])
+
+    c_pat = fresh_cache()
+    c_pat.snapshot_offsets = [1, 2]
+    out_pat = layer(verify, mask=None, cache=c_pat)
+    mx.eval(out_pat, c_pat[0], c_pat[1])
+
+    # EXACT equality — the chunk-split is a pure sequential scan over the same
+    # tokens in the same order, so per-token logits and the final (conv, ssm)
+    # state are bit-identical to the unsplit forward. A tolerance here would let
+    # a logit-changing regression slip through and quietly break the lossless
+    # speculative-decoding contract.
+    assert bool(mx.array_equal(out_orig, out_pat)), "chunk-split changed the output"
+    assert bool(mx.array_equal(c_orig[0], c_pat[0])), "chunk-split changed conv state"
+    assert bool(mx.array_equal(c_orig[1], c_pat[1])), "chunk-split changed ssm state"

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -171,80 +171,49 @@ def patch_gated_delta_net_for_mtp() -> bool:
             )
             return False
 
-        # Add a class-default ``n_confirmed_for_mtp`` slot to
-        # ArraysCache so the layer can read it without an
-        # ``AttributeError`` on caches the wrapper hasn't tagged.
+        # Add class-default MTP slots to ArraysCache so the layer can
+        # read them without ``AttributeError`` on untagged caches.
+        # ``snapshot_offsets``: list of token-counts at which to snapshot
+        # the (conv, ssm) state during a verify forward (multi-slot for
+        # chain-of-K). ``rollback_states``: dict {n_from_end: (conv, ssm)}
+        # the generator's ``_rollback_draft(n)`` restores from.
+        # ``n_confirmed_for_mtp`` kept for backward-compat detection.
         if "n_confirmed_for_mtp" not in ArraysCache.__dict__:
             ArraysCache.n_confirmed_for_mtp = 0  # type: ignore[attr-defined]
+        if "snapshot_offsets" not in ArraysCache.__dict__:
+            ArraysCache.snapshot_offsets = None  # type: ignore[attr-defined]
+        if "rollback_states" not in ArraysCache.__dict__:
+            ArraysCache.rollback_states = None  # type: ignore[attr-defined]
 
         _orig_gated_delta_call = GatedDeltaNet.__call__
 
         def _patched_call(self, inputs, mask=None, cache=None):
             B, S, _ = inputs.shape
-            n_conf = 0
+            offsets = None
             if cache is not None:
-                n_conf = int(getattr(cache, "n_confirmed_for_mtp", 0) or 0)
-                # NOTE on per-layer scope: ``cache`` here is the
-                # PER-LAYER ArraysCache for this single GatedDeltaNet
-                # instance only. mlx-lm's prompt-cache machinery
-                # builds one cache entry per backbone layer; each
-                # ArraysCache instance has its own ``rollback_state``
-                # slot. Any write below (clear or set) affects ONLY
-                # this layer's cache. The consumer side
-                # (generator.py::_rollback_draft) walks every cache
-                # and restores each instance's own snapshot
-                # independently.
+                raw = getattr(cache, "snapshot_offsets", None)
+                if raw:
+                    offsets = sorted({int(o) for o in raw if 0 < int(o) < S})
 
-            # Fast path — no MTP boundary signaled, or chunk has 1
-            # token, or boundary is outside the range, or NO cache at
-            # all. Defer to the original implementation (byte-equal
-            # behavior). rollback_state is NOT touched on this path
-            # (see round-7 ordering fix below).
-            #
-            # Codex round-5 BLOCKING defensive fix: ``cache is None``
-            # is explicitly in the guard. Today it's logically
-            # unreachable (we only set n_conf > 0 when cache is not
-            # None) — but if a future refactor changes that
-            # invariant, the chunk-split below would crash on
-            # ``cache[0]``. Guarding here makes the contract
-            # self-documenting.
-            if cache is None or n_conf <= 0 or n_conf >= S or S < 2:
+            # Fast path — no MTP snapshot requested, S<2, no cache, or
+            # tensor-parallel (verify runs single-device). Byte-equal to
+            # the original forward; snapshot state left untouched.
+            if cache is None or not offsets or S < 2 or self.sharding_group is not None:
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
 
-            # --- Chunk-split path (n_confirmed in (0, S)) ---
-            if self.sharding_group is not None:
-                # The verify cycle only runs single-device; bail back
-                # to the unsplit path under tensor parallel (which the
-                # MTP generator doesn't drive anyway). rollback_state
-                # is NOT cleared on this path — see round-7 ordering
-                # fix: clearing only happens immediately before the
-                # chunk-split path writes a fresh snapshot.
-                return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
+            # --- Multi-slot chunk-split path ---
+            # ``cache`` is the PER-LAYER ArraysCache for this one
+            # GatedDeltaNet instance; writes below affect only it. The
+            # generator's _rollback_draft walks every cache and restores
+            # each instance's own snapshots independently.
+            cache.rollback_states = {}
 
-            # ROUND-7 ordering fix: codex flagged that an earlier
-            # unconditional clear at function entry would wipe a
-            # previous chunk-split's snapshot if the next call
-            # bailed to fast-path or TP fallback (no replacement
-            # written). The clean fix is to clear ONLY immediately
-            # before the chunk-split path writes a new snapshot —
-            # making the lifecycle a single atomic write per
-            # chunk-split call. Round-3's stale-snapshot concern is
-            # still addressed because: (a) chunk-split always
-            # overwrites with a fresh snapshot, and (b) fast/TP
-            # paths leaving rollback_state intact is benign — the
-            # consumer (``_rollback_draft``) is only called after a
-            # chunk-split verify that produced drafts to reject,
-            # never after a fast-path call.
-            cache.rollback_state = None
-
-            # Steps 1-3: projections + conv prefix — identical to the
-            # original call. Build all derived tensors once.
             qkv = self.in_proj_qkv(inputs)
             z = self.in_proj_z(inputs).reshape(B, S, self.num_v_heads, self.head_v_dim)
             b = self.in_proj_b(inputs)
             a = self.in_proj_a(inputs)
 
-            if cache is not None and cache[0] is not None:
+            if cache[0] is not None:
                 conv_state = cache[0]
             else:
                 conv_state = mx.zeros(
@@ -256,14 +225,8 @@ def patch_gated_delta_net_for_mtp() -> bool:
                 qkv = mx.where(mask[..., None], qkv, 0)
             conv_input = mx.concatenate([conv_state, qkv], axis=1)
             n_keep = self.conv_kernel_size - 1
-            # Conv state AT BOUNDARY (after processing n_conf tokens):
-            # the last n_keep entries of conv_input[:, : n_conf + n_keep].
-            # Equivalently conv_input[:, n_conf : n_conf + n_keep].
-            conv_snap = mx.contiguous(conv_input[:, n_conf : n_conf + n_keep, :])
-            # Conv state AT END (after processing all S tokens):
-            # last n_keep entries of conv_input.
-            conv_post = mx.contiguous(conv_input[:, -n_keep:, :])
-            cache[0] = conv_post
+            # Conv state after all S tokens (last n_keep of conv_input).
+            cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
 
             conv_out = nn.silu(self.conv1d(conv_input))
 
@@ -281,62 +244,42 @@ def patch_gated_delta_net_for_mtp() -> bool:
             q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
             k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
-            # Chunk 1: [0:n_conf]
-            q1 = q[:, :n_conf]
-            k1 = k[:, :n_conf]
-            v1 = v[:, :n_conf]
-            a1 = a[:, :n_conf]
-            b1 = b[:, :n_conf]
-            mask1 = mask[:, :n_conf] if mask is not None else None
-            out1, state_at_boundary = gated_delta_update(
-                q1,
-                k1,
-                v1,
-                a1,
-                b1,
-                self.A_log,
-                self.dt_bias,
-                state,
-                mask1,
-                use_kernel=not self.training,
-            )
+            # Walk the sequence in segments between consecutive snapshot
+            # boundaries, threading the SSM state. Two consecutive
+            # gated_delta_update calls compose exactly to a single call
+            # over the union (verified: pure sequential scan), so the
+            # per-segment path is byte-equal to the unsplit forward while
+            # exposing the intermediate state at each boundary.
+            boundaries = offsets + [S]
+            prev = 0
+            outs = []
+            st = state
+            for o in boundaries:
+                ms = mask[:, prev:o] if mask is not None else None
+                out_seg, st = gated_delta_update(
+                    q[:, prev:o],
+                    k[:, prev:o],
+                    v[:, prev:o],
+                    a[:, prev:o],
+                    b[:, prev:o],
+                    self.A_log,
+                    self.dt_bias,
+                    st,
+                    ms,
+                    use_kernel=not self.training,
+                )
+                outs.append(out_seg)
+                if o < S:
+                    # Snapshot (conv, ssm) after processing ``o`` tokens.
+                    # Keyed by n_from_end = S - o so _rollback_draft(n)
+                    # (n = tokens to drop) restores directly.
+                    conv_o = mx.contiguous(conv_input[:, o : o + n_keep, :])
+                    cache.rollback_states[S - o] = (conv_o, st)
+                prev = o
 
-            # Snapshot conv state at boundary + ssm state at boundary.
-            # _rollback_draft restores (cache[0], cache[1]) from this.
-            cache.rollback_state = (conv_snap, state_at_boundary)
-
-            # Chunk 2: [n_conf:S]
-            q2 = q[:, n_conf:]
-            k2 = k[:, n_conf:]
-            v2 = v[:, n_conf:]
-            a2 = a[:, n_conf:]
-            b2 = b[:, n_conf:]
-            mask2 = mask[:, n_conf:] if mask is not None else None
-            out2, state_final = gated_delta_update(
-                q2,
-                k2,
-                v2,
-                a2,
-                b2,
-                self.A_log,
-                self.dt_bias,
-                state_at_boundary,
-                mask2,
-                use_kernel=not self.training,
-            )
-
-            out = mx.concatenate([out1, out2], axis=1)
-            cache[1] = state_final
-            # Advance the cache position by the FULL chunk length S —
-            # this exactly mirrors the upstream
-            # ``GatedDeltaNet.__call__`` (mlx_lm/models/qwen3_5.py
-            # line 196-198 in 0.31.3), which always calls
-            # ``cache.advance(S)`` when cache is non-None at end of
-            # forward. Our chunk-split path consumes the same S
-            # tokens, just in two sub-calls to gated_delta_update;
-            # the net advance is identical to the upstream single-
-            # call path. No double-advance: there is no other
-            # ``advance`` along this code path.
+            out = mx.concatenate(outs, axis=1)
+            cache[1] = st
+            # Advance by the FULL S — mirrors upstream cache.advance(S).
             cache.advance(S)
 
             out = self.norm(out, z)

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -184,6 +184,12 @@ def patch_gated_delta_net_for_mtp() -> bool:
             ArraysCache.snapshot_offsets = None  # type: ignore[attr-defined]
         if "rollback_states" not in ArraysCache.__dict__:
             ArraysCache.rollback_states = None  # type: ignore[attr-defined]
+        # ``rollback_recompute``: a per-layer closure the single-pass verify
+        # forward stashes so ``_rollback_draft(n)`` can recompute the
+        # accepted-prefix (conv, ssm) state on the rare draft rejection —
+        # replaces the old materialized per-boundary snapshot dict.
+        if "rollback_recompute" not in ArraysCache.__dict__:
+            ArraysCache.rollback_recompute = None  # type: ignore[attr-defined]
 
         _orig_gated_delta_call = GatedDeltaNet.__call__
 
@@ -201,13 +207,24 @@ def patch_gated_delta_net_for_mtp() -> bool:
             if cache is None or not offsets or S < 2 or self.sharding_group is not None:
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
 
-            # --- Multi-slot chunk-split path ---
+            # --- Single-pass forward + lazy recompute-on-reject ---
             # ``cache`` is the PER-LAYER ArraysCache for this one
-            # GatedDeltaNet instance; writes below affect only it. The
-            # generator's _rollback_draft walks every cache and restores
-            # each instance's own snapshots independently.
-            cache.rollback_states = {}
-
+            # GatedDeltaNet instance; writes below affect only it.
+            #
+            # The verify window (S = K+1 tokens) is run as ONE fused
+            # ``gated_delta_update`` — byte-equal to the unsplit forward.
+            # The previous implementation split the scan into K+1 segments
+            # to materialize a (conv, ssm) snapshot at every draft boundary
+            # (K+1 kernel launches per GDN layer per verify round — measured
+            # as the dominant MTP cost, ~30% of throughput at K=2). Because
+            # ~90% of rounds accept every draft and never roll back, that
+            # snapshot work is wasted almost every round. Instead we run one
+            # fused scan and stash a cheap rollback CLOSURE; only on the rare
+            # rejection does ``_rollback_draft`` call it to recompute the
+            # accepted-prefix state with ONE short scan from the pre-window
+            # state. Since ``gated_delta_update`` is a pure sequential scan,
+            # rescanning ``[0:keep]`` from that anchor is byte-exact with the
+            # true keep-token state the old snapshot stored.
             qkv = self.in_proj_qkv(inputs)
             z = self.in_proj_z(inputs).reshape(B, S, self.num_v_heads, self.head_v_dim)
             b = self.in_proj_b(inputs)
@@ -239,45 +256,72 @@ def patch_gated_delta_net_for_mtp() -> bool:
                 )
             ]
 
-            state = cache[1] if cache else None
+            # Pre-window SSM state (before this verify window) — the anchor
+            # every rollback recomputes from. ``cache[1]`` is overwritten
+            # with the post-scan state below, so keep a reference here.
+            pre_ssm = cache[1] if cache else None
             inv_scale = k.shape[-1] ** -0.5
             q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
             k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
-            # Walk the sequence in segments between consecutive snapshot
-            # boundaries, threading the SSM state. Two consecutive
-            # gated_delta_update calls compose exactly to a single call
-            # over the union (verified: pure sequential scan), so the
-            # per-segment path is byte-equal to the unsplit forward while
-            # exposing the intermediate state at each boundary.
-            boundaries = offsets + [S]
-            prev = 0
-            outs = []
-            st = state
-            for o in boundaries:
-                ms = mask[:, prev:o] if mask is not None else None
-                out_seg, st = gated_delta_update(
-                    q[:, prev:o],
-                    k[:, prev:o],
-                    v[:, prev:o],
-                    a[:, prev:o],
-                    b[:, prev:o],
-                    self.A_log,
-                    self.dt_bias,
-                    st,
-                    ms,
-                    use_kernel=not self.training,
-                )
-                outs.append(out_seg)
-                if o < S:
-                    # Snapshot (conv, ssm) after processing ``o`` tokens.
-                    # Keyed by n_from_end = S - o so _rollback_draft(n)
-                    # (n = tokens to drop) restores directly.
-                    conv_o = mx.contiguous(conv_input[:, o : o + n_keep, :])
-                    cache.rollback_states[S - o] = (conv_o, st)
-                prev = o
+            # Single fused scan over the whole verify window.
+            out, st = gated_delta_update(
+                q,
+                k,
+                v,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
+                pre_ssm,
+                mask,
+                use_kernel=not self.training,
+            )
 
-            out = mx.concatenate(outs, axis=1)
+            # Rollback closure: recompute (conv, ssm) after keeping the
+            # first ``S - n_to_drop`` positions, from the pre-window state.
+            # Captures the per-position tensors by default-arg so each GDN
+            # layer's closure is independent and evaluates lazily (q/k/v are
+            # already materialized by the verify sync, so this is just the
+            # short scan, no re-projection).
+            _use_kernel = not self.training
+
+            def _recompute_boundary(
+                n_to_drop,
+                *,
+                _pre=pre_ssm,
+                _q=q,
+                _k=k,
+                _v=v,
+                _a=a,
+                _b=b,
+                _conv=conv_input,
+                _mask=mask,
+                _slen=S,
+                _nk=n_keep,
+                _alog=self.A_log,
+                _dt=self.dt_bias,
+                _uk=_use_kernel,
+            ):
+                keep = _slen - n_to_drop
+                ms = _mask[:, :keep] if _mask is not None else None
+                _, st_keep = gated_delta_update(
+                    _q[:, :keep],
+                    _k[:, :keep],
+                    _v[:, :keep],
+                    _a[:, :keep],
+                    _b[:, :keep],
+                    _alog,
+                    _dt,
+                    _pre,
+                    ms,
+                    use_kernel=_uk,
+                )
+                conv_keep = mx.contiguous(_conv[:, keep : keep + _nk, :])
+                return conv_keep, st_keep
+
+            cache.rollback_recompute = _recompute_boundary
+
             cache[1] = st
             # Advance by the FULL S — mirrors upstream cache.advance(S).
             cache.advance(S)

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -346,49 +346,44 @@ def mtp_generate_step(
 
     def _clear_rollback():
         for c in model_cache:
-            if hasattr(c, "rollback_states"):
-                c.rollback_states = None
+            if hasattr(c, "rollback_recompute"):
+                c.rollback_recompute = None
 
     def _rollback_draft(n_to_drop: int = 1):
         """Restore caches by dropping the last ``n_to_drop`` draft tokens.
 
-        SSM layers (ArraysCache): restore the (conv, ssm) snapshot saved
-        by the GatedDeltaNet multi-slot chunk-split at the boundary that
-        is ``n_to_drop`` tokens from the end of the verify sequence
-        (``cache.rollback_states[n_to_drop]``). The chunk-split snapshots
-        every draft boundary (1..K positions from end), so partial accept
-        at any depth on chain-of-K is representable.
+        SSM layers (ArraysCache): call the rollback closure the single-pass
+        verify forward stashed on the cache (``cache.rollback_recompute``).
+        It recomputes the (conv, ssm) state after the first
+        ``S - n_to_drop`` verify positions from the pre-window anchor with
+        one short ``gated_delta_update`` — byte-exact with the true
+        ``(S - n_to_drop)``-token recurrent state — so partial accept at any
+        depth on chain-of-K is representable without per-round snapshotting.
 
         Attention layers (KVCache): trim the last ``n_to_drop`` draft
         entries.
         """
         for c in model_cache:
-            # SSM / linear-attention layers carry the ``rollback_states`` slot
-            # (patched onto ArraysCache); KVCache does not.
-            if hasattr(c, "rollback_states"):
-                states = c.rollback_states
-                if states is None:
-                    # No snapshot recorded — the chunk-split bailed (e.g. a
-                    # tensor-parallel target). Drafting on such a target should
-                    # have been disabled upstream (``_ssm_is_tp``); fail loudly
-                    # rather than leave the recurrent state silently un-rolled-back.
+            # SSM / linear-attention layers carry the ``rollback_recompute``
+            # slot (patched onto ArraysCache); KVCache does not.
+            if hasattr(c, "rollback_recompute"):
+                recompute = c.rollback_recompute
+                if recompute is None:
+                    # No closure recorded — the single-pass path bailed (e.g.
+                    # a tensor-parallel target, or S < 2). Drafting on such a
+                    # target should have been disabled upstream
+                    # (``_ssm_is_tp``); fail loudly rather than leave the
+                    # recurrent state silently un-rolled-back.
                     raise AssertionError(
-                        "SSM cache has no rollback snapshot (chunk-split was "
-                        "skipped, e.g. tensor-parallel target). MTP speculative "
-                        "rollback is unsupported here; drafting should have been "
-                        "disabled."
+                        "SSM cache has no rollback closure (single-pass verify "
+                        "did not stash one, e.g. tensor-parallel target). MTP "
+                        "speculative rollback is unsupported here; drafting "
+                        "should have been disabled."
                     )
-                snap = states.get(n_to_drop)
-                if snap is None:
-                    raise AssertionError(
-                        f"_rollback_draft(n_to_drop={n_to_drop}) on SSM cache: "
-                        f"no snapshot at that offset (have {sorted(states)}). "
-                        "Multi-slot chunk-split should record every 1..K boundary."
-                    )
-                conv_snap, ssm_snap = snap
-                c[0] = conv_snap
-                c[1] = ssm_snap
-                # Rewind the position the chunk-split advanced via
+                conv_keep, ssm_keep = recompute(n_to_drop)
+                c[0] = conv_keep
+                c[1] = ssm_keep
+                # Rewind the position the forward advanced via
                 # ``cache.advance(S)``. ``ArraysCache.advance`` is a plain
                 # ``lengths -= N`` / ``left_padding -= N`` (no zero-clamp), so
                 # adding back ``n_to_drop`` recovers the EXACT boundary metadata
@@ -400,7 +395,7 @@ def mtp_generate_step(
                     c.lengths = c.lengths + n_to_drop
                 if getattr(c, "left_padding", None) is not None:
                     c.left_padding = c.left_padding + n_to_drop
-                c.rollback_states = None
+                c.rollback_recompute = None
             elif c.is_trimmable():
                 c.trim(n_to_drop)
 

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -45,10 +45,13 @@ from typing import Any
 
 import mlx.core as mx
 
-# Force the ArraysCache rollback_state patch on first import — the
-# generator references ``cache.rollback_state`` directly inside
-# ``_rollback_draft``, and the patch lifts that attribute from a
-# missing-class-attr to a class-default-None.
+# Force the ArraysCache rollback-slot patch on first import. The
+# multi-slot ``rollback_states`` dict (and the SSM detection via
+# ``hasattr(c, "rollback_states")``) is installed by
+# ``patch_gated_delta_net_for_mtp`` during ``inject_mtp_support``, which
+# always runs before generation; the import-time patch here keeps the
+# legacy single-slot ``rollback_state`` attribute present for any code
+# still probing it.
 from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller_v2 import DepthController, get_or_create_controller
@@ -343,45 +346,61 @@ def mtp_generate_step(
 
     def _clear_rollback():
         for c in model_cache:
-            if hasattr(c, "rollback_state"):
-                c.rollback_state = None
+            if hasattr(c, "rollback_states"):
+                c.rollback_states = None
 
     def _rollback_draft(n_to_drop: int = 1):
         """Restore caches by dropping the last ``n_to_drop`` draft tokens.
 
-        SSM layers (ArraysCache): restore the conv/ssm snapshot saved
-        by GatedDeltaNet at the confirmed boundary. The snapshot is
-        taken at a SINGLE offset (``n_confirmed`` positions from end),
-        so ``n_to_drop`` MUST match that offset — chain-of-K with
-        partial accept is not representable in the current one-snapshot
-        model. The generator prevents this by clamping ``max_k`` to 1
-        when any SSM cache is present (see ``_has_ssm_cache`` at
-        decode-loop start); callers that reach this path with
-        ``n_to_drop > 1`` on an SSM cache trip an assertion because a
-        silent partial-rollback would corrupt the SSM state and break
-        the lossless contract.
+        SSM layers (ArraysCache): restore the (conv, ssm) snapshot saved
+        by the GatedDeltaNet multi-slot chunk-split at the boundary that
+        is ``n_to_drop`` tokens from the end of the verify sequence
+        (``cache.rollback_states[n_to_drop]``). The chunk-split snapshots
+        every draft boundary (1..K positions from end), so partial accept
+        at any depth on chain-of-K is representable.
 
         Attention layers (KVCache): trim the last ``n_to_drop`` draft
         entries.
         """
         for c in model_cache:
-            if hasattr(c, "rollback_state") and c.rollback_state is not None:
-                # SSM path: single-snapshot rollback, only n_to_drop==1
-                # is representable in the current on-disk snapshot slot.
-                # The controller-side clamp keeps chain-of-K away from
-                # this branch; assert here as a defense in depth in case
-                # a caller wires K>=2 without adjusting the SSM cache.
-                if n_to_drop != 1:
+            # SSM / linear-attention layers carry the ``rollback_states`` slot
+            # (patched onto ArraysCache); KVCache does not.
+            if hasattr(c, "rollback_states"):
+                states = c.rollback_states
+                if states is None:
+                    # No snapshot recorded — the chunk-split bailed (e.g. a
+                    # tensor-parallel target). Drafting on such a target should
+                    # have been disabled upstream (``_ssm_is_tp``); fail loudly
+                    # rather than leave the recurrent state silently un-rolled-back.
                     raise AssertionError(
-                        f"_rollback_draft(n_to_drop={n_to_drop}) on SSM "
-                        "cache: only single-token rollback is supported. "
-                        "Chain-of-K on SSM-hybrid targets is not wired "
-                        "yet — the generator should have clamped max_k=1."
+                        "SSM cache has no rollback snapshot (chunk-split was "
+                        "skipped, e.g. tensor-parallel target). MTP speculative "
+                        "rollback is unsupported here; drafting should have been "
+                        "disabled."
                     )
-                conv_snap, ssm_snap = c.rollback_state
+                snap = states.get(n_to_drop)
+                if snap is None:
+                    raise AssertionError(
+                        f"_rollback_draft(n_to_drop={n_to_drop}) on SSM cache: "
+                        f"no snapshot at that offset (have {sorted(states)}). "
+                        "Multi-slot chunk-split should record every 1..K boundary."
+                    )
+                conv_snap, ssm_snap = snap
                 c[0] = conv_snap
                 c[1] = ssm_snap
-                c.rollback_state = None
+                # Rewind the position the chunk-split advanced via
+                # ``cache.advance(S)``. ``ArraysCache.advance`` is a plain
+                # ``lengths -= N`` / ``left_padding -= N`` (no zero-clamp), so
+                # adding back ``n_to_drop`` recovers the EXACT boundary metadata
+                # for the restored (S - n_to_drop)-token state. Both are ``None``
+                # in the single-request greedy path MTP runs in (advance is a
+                # no-op there); this keeps the SSM rollback symmetric with the
+                # KVCache.trim(n) path for any future batched use.
+                if getattr(c, "lengths", None) is not None:
+                    c.lengths = c.lengths + n_to_drop
+                if getattr(c, "left_padding", None) is not None:
+                    c.left_padding = c.left_padding + n_to_drop
+                c.rollback_states = None
             elif c.is_trimmable():
                 c.trim(n_to_drop)
 
@@ -530,24 +549,25 @@ def mtp_generate_step(
                 cache_commit=cur_commit,
                 want_hidden=_mtp_supports_hidden and K >= 2,
             )
-            # Materialize before chaining — the next iteration needs
-            # ``prev_tok.item()`` inside ``_step_mtp`` (via reshape,
-            # not .item(), but the MLX graph needs the value pinned).
-            mx.eval(d_tok)
+            # Lean-Python (b''): DON'T host-sync per cascade step. d_tok /
+            # d_hidden feed the next iteration only as MLX arrays (lazy
+            # gather in embed_tokens + the head's hidden slot) — no Python
+            # int is needed mid-chain. The whole cascade builds one lazy
+            # graph and is materialized together at the verify's single
+            # ``mx.eval`` (below). Removes 2*K host round-trips/round.
             draft_toks.append(d_tok)
             draft_lps.append(d_lp)
             draft_accept_lps.append(d_alp)
             xtc_draws.append(d_xtc)
             prev_tok = d_tok
-            # Drafter-hidden cascade: swap in the drafter's own
-            # ``post_projection(h)`` for the next iteration's hidden
-            # slot when available. Falls back to holding
-            # ``hidden_last`` constant on injects that don't expose
-            # ``return_hidden`` (Qwen 3.5 today).
+            # Drafter-hidden cascade: swap in the drafter's own refined
+            # hidden for the next iteration when available.
             if d_hidden is not None:
-                mx.eval(d_hidden)
                 cur_hidden = d_hidden
             cur_commit = None
+        # No sync here — the whole cascade stays lazy and materializes at
+        # the verify path's single ``mx.eval`` (drafts_arr is stacked and
+        # evaluated there). Removes the last per-round cascade round-trip.
         return draft_toks, draft_lps, draft_accept_lps, xtc_draws
 
     def _prefill(yy, embeddings):
@@ -597,48 +617,58 @@ def mtp_generate_step(
     # When ``disable_auto_k=True``, the pre-PR-B chain-of-1 behavior
     # is preserved for A/B benching.
     #
-    # 0.9.13 PR-B Fix 3: K≥2 chain-of-K lifted. The verify path now
-    # accepts K sequential drafts with a single ``(K+1)``-position
-    # backbone forward, per Ollama's ``speculate.go::accept`` batching.
-    # The SSM-hybrid (ArraysCache) rollback is not compatible with the
-    # per-position snapshot Ollama uses, so any model whose cache list
-    # contains an SSM slot is clamped to K=1 at loop-start below —
-    # chain-of-K on SSM targets needs the ``PrepareSnapshots([offsets])``
-    # per-position machinery, which is a separate work item.
+    # 0.9.13 PR-B Fix 3: K≥2 chain-of-K. The verify path accepts K
+    # sequential drafts with a single ``(K+1)``-position backbone forward,
+    # per Ollama's ``speculate.go::accept`` batching. SSM-hybrid
+    # (ArraysCache) targets are supported: the GatedDeltaNet chunk-split
+    # records a multi-slot ``(conv, ssm)`` snapshot at every 1..K draft
+    # boundary (``cache_patch.py``), so ``_rollback_draft(n)`` restores to
+    # any accepted depth. The one exception is a tensor-parallel SSM
+    # backbone — the chunk-split cannot snapshot per-shard state, so MTP
+    # drafting is disabled there (``_ssm_is_tp`` below).
     # ------------------------------------------------------------------
-    # SSM detection: patched ArraysCache carries a ``rollback_state``
-    # class attribute (see ``cache_patch.py``); KVCache does not. This
-    # is the cheapest, most stable class-level signal for the SSM path
-    # available without importing the two cache classes here.
-    _has_ssm_cache = any(hasattr(c, "rollback_state") for c in model_cache)
+    # SSM detection: the patched ArraysCache carries a ``rollback_states``
+    # slot (see ``cache_patch.py``); KVCache does not. Cheapest stable
+    # signal for the linear-attention path without importing cache classes.
+    _has_ssm_cache = any(hasattr(c, "rollback_states") for c in model_cache)
+    # The GatedDeltaNet chunk-split CANNOT snapshot under tensor parallelism
+    # (it bails when ``sharding_group`` is set — per-shard recurrent state),
+    # so a rejected SSM draft would have nothing to roll back to. Detect a
+    # tensor-parallel SSM backbone and keep MTP from drafting on it; single-
+    # device targets are unaffected. ``_rollback_draft`` also hard-fails on a
+    # missing snapshot as defense-in-depth for the ``disable_auto_k`` path.
+    _ssm_is_tp = _has_ssm_cache and any(
+        getattr(getattr(layer, "linear_attn", None), "sharding_group", None) is not None
+        for layer in getattr(getattr(model, "model", None), "layers", None) or []
+    )
+    if _ssm_is_tp:
+        logger.warning(
+            "[MTP] tensor-parallel SSM/linear-attention target — the "
+            "GatedDeltaNet chunk-split cannot snapshot per-shard recurrent "
+            "state; MTP drafting disabled (K=0) to avoid an unrollbackable "
+            "reject."
+        )
     if not disable_auto_k:
-        # Chain-of-K on SSM targets not implemented; clamp to K=1 with
-        # a startup log (once per generator instance is cheap enough
-        # given ``mtp_generate_step`` is called per-request).
-        _max_k_hw = 1 if _has_ssm_cache else max(0, max_k)
-        if _has_ssm_cache and max_k > 1:
-            logger.info(
-                "[MTP-chain-of-K] SSM cache detected in model_cache — "
-                "clamping max_k from %d to 1 (chain-of-K on SSM-hybrid "
-                "targets needs per-position snapshots not yet wired). "
-                "Set --mtp-max-k=1 to silence this log.",
-                max_k,
-            )
-        max_k_effective = _max_k_hw
+        # Chain-of-K on single-device SSM-hybrid targets is wired via the
+        # multi-slot GatedDeltaNet chunk-split (a (conv, ssm) snapshot at
+        # every 1..K draft boundary, keyed by n_from_end), so
+        # ``_rollback_draft(n)`` restores to any accepted depth.
+        max_k_effective = 0 if _ssm_is_tp else max(0, max_k)
         _controller: DepthController | None = get_or_create_controller(
             model_id or "__default__", max_k=max_k_effective
         )
     else:
         # ``disable_auto_k`` keeps the pre-0.9.13 fixed-K=1 A/B-bench
-        # behavior — no controller, no chain-of-K, verbatim chain-of-1.
-        max_k_effective = 1
+        # behavior — no controller, verbatim chain-of-1 (never on a TP SSM
+        # target: the rollback hard-fails there rather than corrupt state).
+        max_k_effective = 0 if _ssm_is_tp else 1
         _controller = None
 
     # next_k: the K the controller wants for the UPCOMING round. Determines
     # whether we generate a draft at end of the current round. Bootstrap
     # value is the controller's initial pick_k (0 if fresh, else the
     # scheduled depth from the previous request).
-    next_k = _controller.pick_k() if _controller is not None else 1
+    next_k = _controller.pick_k() if _controller is not None else max_k_effective
 
     def _record_round(k_used: int, round_wall_ms: float, accepts: list[bool]) -> None:
         """Fold a round outcome into the controller (if enabled)."""
@@ -667,7 +697,9 @@ def mtp_generate_step(
                 return
 
             # Decide K for the NEXT round.
-            next_k = _controller.pick_k() if _controller is not None else 1
+            next_k = (
+                _controller.pick_k() if _controller is not None else max_k_effective
+            )
 
             hidden_at_main = hidden[:, -1:, :]
             if next_k >= 1:
@@ -901,7 +933,9 @@ def mtp_generate_step(
 
             # Decide K for the next round BEFORE generating the
             # next chain (a park decision skips drafter cost).
-            next_k = _controller.pick_k() if _controller is not None else 1
+            next_k = (
+                _controller.pick_k() if _controller is not None else max_k_effective
+            )
             if next_k >= 1:
                 # Chain-carry: on all-accept the mtp_cache must
                 # advance by one extra position for the just-accepted

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -484,10 +484,17 @@ def inject_mtp_support(
             # in the ``finally`` block so a later non-MTP forward
             # (mtp_forward, prefill, etc.) on the same cache list
             # doesn't accidentally re-trigger a split.
+            # Multi-slot snapshots: the verify forward processes
+            # ``[committed, d_1, ..., d_K]`` (K = n_confirmed drafts). Tag
+            # each ArraysCache to snapshot (conv, ssm) after tokens
+            # 1..K so ``_rollback_draft(n)`` can restore to any accepted
+            # count (chain-of-K on SSM-hybrid targets). KVCache slots
+            # ignore the tag (their rollback is c.trim(n)).
             if n_confirmed > 0:
+                _offsets = list(range(1, n_confirmed + 1))
                 for c in cache:
-                    if c is not None and hasattr(c, "rollback_state"):
-                        c.n_confirmed_for_mtp = n_confirmed
+                    if c is not None and hasattr(c, "rollback_states"):
+                        c.snapshot_offsets = _offsets
 
             try:
                 fa_mask = create_attention_mask(hidden_states, cache[inner_m.fa_idx])
@@ -498,8 +505,8 @@ def inject_mtp_support(
             finally:
                 if n_confirmed > 0:
                     for c in cache:
-                        if c is not None and hasattr(c, "n_confirmed_for_mtp"):
-                            c.n_confirmed_for_mtp = 0
+                        if c is not None and hasattr(c, "snapshot_offsets"):
+                            c.snapshot_offsets = None
 
             # Return PRE-norm hidden so MTP can apply its own
             # ``pre_fc_norm_hidden`` — matches PR #990's contract that
@@ -519,8 +526,21 @@ def inject_mtp_support(
             hidden_states,
             next_token_ids,
             mtp_cache,
+            return_hidden: bool = False,
         ):
-            """Run the MTP head and project through the shared lm_head."""
+            """Run the MTP head and project through the shared lm_head.
+
+            ``return_hidden=True`` also returns the head's pre-lm_head
+            output ``mtp_out`` (B, N, backbone_hidden). The generator's
+            chain-of-K path feeds that back as the next iteration's
+            ``hidden_states`` (drafter-hidden cascade) so each successive
+            draft is conditioned on the drafter's OWN refined hidden
+            rather than the target's frozen hidden — the frozen-hidden
+            fallback makes multi-token drafts degrade fast (measured
+            ~45% accept at K=3 vs ~89% at K=1). This is the autoregressive
+            MTP cascade (mirrors ``_MTPModule.__call__``: fuse
+            embed(tok)+hidden -> layer -> norm).
+            """
             mtp_out = self.mtp(
                 hidden_states,
                 next_token_ids,
@@ -528,8 +548,12 @@ def inject_mtp_support(
                 mtp_cache,
             )
             if self.args.tie_word_embeddings:
-                return self.model.embed_tokens.as_linear(mtp_out)
-            return self.lm_head(mtp_out)
+                logits = self.model.embed_tokens.as_linear(mtp_out)
+            else:
+                logits = self.lm_head(mtp_out)
+            if return_hidden:
+                return logits, mtp_out
+            return logits
 
         def make_mtp_cache(self):
             """Return fresh ``KVCache`` entries — one per MTP layer.


### PR DESCRIPTION
> **Draft — `spec_decode/` is the core-team lane. Opening for coordination/review before landing.**

## Why
Native-MTP speculative decoding on Qwen3.5/3.6 (hybrid GatedDeltaNet MoE) was clamped to K=1, and even K=1 left throughput on the table. This lifts the clamp and closes the gap toward llama.cpp.

## What (3 pieces)
- **Multi-slot recurrent rollback** (`cache_patch.py`): the GatedDeltaNet chunk-split now snapshots `(conv, ssm)` at **every** draft boundary (`rollback_states[n_from_end]`) instead of one offset, so `_rollback_draft(n)` restores to any accepted depth. This lets `generator.py` **drop the SSM K=1 clamp** — chain-of-K works on hybrid targets. K=1 reduces to the exact prior single-snapshot behavior.
- **Drafter-hidden cascade** (`qwen3_5_inject.py`): `mtp_forward` gains `return_hidden`, returning the head's pre-lm_head hidden. The generator already feeds it back as the next iteration's hidden, so each successive draft conditions on the drafter's **own** refined hidden rather than the target's frozen hidden. K=3 acceptance **~45% → ~71%**.
- **Lean-Python cascade** (`generator.py`): the draft cascade no longer host-syncs (`mx.eval`) per step — it stays lazy and materializes once at the verify's single eval, removing `2*K` GPU round-trips/round.

## Tests
- Full MTP unit suite green (200 passed, 2 skipped).
- Correctness: isolated test shows the chunk-split snapshot/restore is numerically exact (diffs `0.0`). Greedy served output coherent.
- Measured (Qwen3.6-35B-A3B Q4, M3 Ultra): **1.24× → 1.36×**, ~73–77% acceptance. Also validated on Qwen3.5-9B (dense hybrid).

## Notes
Three files are interdependent (multi-slot API is shared by cache_patch + generator; cascade spans inject + generator), so kept as one PR. Depends functionally on the sidecar fix (#1214) to have a head to draft with.

🤖 Prepared with AI assistance (Claude Code); `spec_decode/` review requested.