### PR TITLE
feat(models): vendor Sarvam MLA checkpoint support

### DIFF
--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -195,6 +195,18 @@ def test_bailing_hybrid_model_type_triggers_downgrade():
     assert "mla" in decision.reason.lower()
 
 
+def test_sarvam_mla_config_triggers_downgrade_without_q_lora_rank():
+    """Sarvam uses direct q_proj, so its MLA signal is the model type."""
+    decision = resolve_kv_cache_dtype(
+        "int4",
+        model_name="sarvam-105b-mock",
+        hf_config={"model_type": "sarvam_mla", "kv_lora_rank": 512},
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "mla" in decision.reason.lower()
+
+
 def test_deepseek_v4_substring_triggers_downgrade():
     decision = resolve_kv_cache_dtype(
         "int4",

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -177,6 +177,18 @@ def test_deepseek_v3_config_triggers_downgrade():
     assert "mla" in decision.reason.lower()
 
 
+def test_sarvam_mla_config_triggers_downgrade_without_q_lora_rank():
+    """Sarvam uses direct q_proj, so its MLA signal is the model type."""
+    decision = resolve_kv_cache_dtype(
+        "int4",
+        model_name="sarvam-105b-mock",
+        hf_config={"model_type": "sarvam_mla", "kv_lora_rank": 512},
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "mla" in decision.reason.lower()
+
+
 def test_deepseek_v4_substring_triggers_downgrade():
     decision = resolve_kv_cache_dtype(
         "int4",

--- a/tests/test_sarvam_mla.py
+++ b/tests/test_sarvam_mla.py
@@ -79,7 +79,7 @@ def test_loader_routes_sarvam_config_to_vendored_path(tmp_path, monkeypatch):
     expected = (object(), object())
     seen = []
 
-    def _fake_vendor_loader(model_name):
+    def _fake_vendor_loader(model_name, *, enable_dspark=False):
         seen.append(model_name)
         return expected
 

--- a/tests/test_sarvam_mla.py
+++ b/tests/test_sarvam_mla.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused synthetic coverage for the vendored Sarvam MLA adapter."""
+
+import importlib
+import sys
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import make_prompt_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_vendored_registration():
+    from vllm_mlx.utils.tokenizer import _VENDORED_MODEL_TYPES
+
+    sys.modules.pop("mlx_lm.models.sarvam_mla", None)
+    _VENDORED_MODEL_TYPES.discard("sarvam_mla")
+    yield
+    sys.modules.pop("mlx_lm.models.sarvam_mla", None)
+    _VENDORED_MODEL_TYPES.discard("sarvam_mla")
+
+
+def _tiny_args(**overrides):
+    from vllm_mlx.models.sarvam_mla import ModelArgs
+
+    values = {
+        "vocab_size": 128,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "moe_intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        # Sarvam's omitted group default is routed_experts / 8 with top-2
+        # groups, so 16 is the smallest synthetic shape with valid 2/2
+        # group routing.
+        "num_experts": 16,
+        "num_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "first_k_dense_replace": 1,
+        "kv_lora_rank": 4,
+        "qk_rope_head_dim": 8,
+        "qk_nope_head_dim": 8,
+        "v_head_dim": 8,
+    }
+    values.update(overrides)
+    return ModelArgs(**values)
+
+
+def test_sarvam_config_remap_defaults_and_explicit_group_controls():
+    args = _tiny_args()
+    assert args.model_type == "sarvam_mla"
+    assert args.q_lora_rank is None
+    assert (args.n_routed_experts, args.n_shared_experts) == (16, 1)
+    assert (args.n_group, args.topk_group) == (2, 2)
+
+    explicit = _tiny_args(n_group=1, topk_group=1)
+    assert (explicit.n_group, explicit.topk_group) == (1, 1)
+
+
+def test_registers_with_mlx_lm_loader_lookup():
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    module = importlib.import_module("mlx_lm.models.sarvam_mla")
+    assert module.__name__ == "vllm_mlx.models.sarvam_mla"
+    assert module.ModelArgs is not None
+
+
+def test_loader_routes_sarvam_config_to_vendored_path(tmp_path, monkeypatch):
+    import json
+
+    from vllm_mlx.utils import tokenizer
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "sarvam_mla"}),
+        encoding="utf-8",
+    )
+    expected = (object(), object())
+    seen = []
+
+    def _fake_vendor_loader(model_name):
+        seen.append(model_name)
+        return expected
+
+    monkeypatch.setattr(tokenizer, "_load_with_tokenizer_fallback", _fake_vendor_loader)
+
+    assert tokenizer._load_model_with_fallback_impl(str(tmp_path)) is expected
+    assert seen == [str(tmp_path)]
+
+
+def test_sanitize_and_prompt_cache_follow_deepseek_v3_contract():
+    from vllm_mlx.models.sarvam_mla import Model
+
+    model = Model(_tiny_args())
+    sanitized = model.sanitize(
+        {
+            "model.layers.0.rotary_emb.inv_freq": mx.ones((4,)),
+            "model.layers.0.input_layernorm.weight": mx.ones((64,)),
+        }
+    )
+    assert "model.layers.0.rotary_emb.inv_freq" not in sanitized
+    assert "model.layers.0.input_layernorm.weight" in sanitized
+
+    cache = make_prompt_cache(model)
+    assert len(cache) == model.args.num_hidden_layers
+    logits = model(mx.array([[1, 2]], dtype=mx.int32), cache=cache)
+    mx.eval(logits, [entry.state for entry in cache])
+    assert logits.shape == (1, 2, model.args.vocab_size)

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -420,6 +420,7 @@ class TestSkipList:
             ("gpt_oss_20b", SKIP_REASON_SLIDING),
             ("deepseek-ai/deepseek-v3", SKIP_REASON_MLA),
             ("deepseek_v4_lite", SKIP_REASON_MLA),
+            ("sarvam-105b-instruct", SKIP_REASON_MLA),
             ("kimi-k2.5-flash", SKIP_REASON_MLA),
             ("Kimi-K2.6-Preview", SKIP_REASON_MLA),
         ],
@@ -461,6 +462,13 @@ class TestSkipList:
     def test_skip_by_model_type_deepseek_v3(self):
         skip, reason = is_incompatible_with_turboquant(
             model_name="generic", hf_config={"model_type": "deepseek_v3"}
+        )
+        assert skip is True
+        assert reason == SKIP_REASON_MLA
+
+    def test_skip_by_model_type_sarvam_mla(self):
+        skip, reason = is_incompatible_with_turboquant(
+            model_name="generic", hf_config={"model_type": "sarvam_mla"}
         )
         assert skip is True
         assert reason == SKIP_REASON_MLA

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -81,6 +81,9 @@ _MLA_PATTERNS: tuple[str, ...] = (
     "deepseek_v4",
     "kimi-k2",
     "kimi_k2",
+    "sarvam-105b",
+    "sarvam_105b",
+    "sarvam_mla",
 )
 
 # HF ``model_type`` values that imply MLA. Conservative — we'd rather
@@ -96,6 +99,7 @@ _MLA_MODEL_TYPES: frozenset[str] = frozenset(
         # family signal — the "ling" name alone is too generic for
         # _MLA_PATTERNS.
         "bailing_hybrid",
+        "sarvam_mla",
     }
 )
 

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -81,6 +81,9 @@ _MLA_PATTERNS: tuple[str, ...] = (
     "deepseek_v4",
     "kimi-k2",
     "kimi_k2",
+    "sarvam-105b",
+    "sarvam_105b",
+    "sarvam_mla",
 )
 
 # HF ``model_type`` values that imply MLA. Conservative — we'd rather
@@ -90,6 +93,7 @@ _MLA_MODEL_TYPES: frozenset[str] = frozenset(
     {
         "deepseek_v3",
         "deepseek_v4",
+        "sarvam_mla",
     }
 )
 

--- a/vllm_mlx/models/sarvam_mla.py
+++ b/vllm_mlx/models/sarvam_mla.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Apple Inc.
+"""Sarvam-105B MLA-MoE compatibility model.
+
+Sarvam-105B uses the ``sarvam_mla`` configuration schema but its attention,
+MoE routing, latent-cache layout, and checkpoint sanitization follow
+DeepSeek-V3.  This intentionally thin adapter remaps only its differing
+configuration names, leaving the mature DeepSeek-V3 implementation to own the
+forward, cache, and weight-sanitization paths.
+"""
+
+from dataclasses import dataclass
+
+from mlx_lm.models.deepseek_v3 import Model as DeepseekV3ForCausalLM
+from mlx_lm.models.deepseek_v3 import ModelArgs as _V3Args
+
+
+@dataclass
+class ModelArgs(_V3Args):
+    """Map Sarvam's config keys onto MLX's DeepSeek-V3 model arguments."""
+
+    model_type: str = "sarvam_mla"
+    num_experts: int | None = None
+    num_shared_experts: int | None = None
+    # Sarvam has direct q_proj rather than DeepSeek-V3's q_a/q_b LoRA path.
+    q_lora_rank: int | None = None
+    # None distinguishes an absent key from an explicit ``1`` (no group limit).
+    n_group: int | None = None
+    topk_group: int | None = None
+    # Retain Sarvam-only config fields so BaseModelArgs.from_dict accepts them.
+    q_head_dim: int = 192
+    head_dim: int = 576
+    use_qk_norm: bool = False
+    moe_router_enable_expert_bias: bool = True
+    default_theta: float = 10000.0
+
+    def __post_init__(self):
+        if self.num_experts is not None:
+            self.n_routed_experts = self.num_experts
+        if self.num_shared_experts is not None:
+            self.n_shared_experts = self.num_shared_experts
+
+        # Sarvam's published config omits these group-routing controls. Its
+        # reference gate defaults to routed_experts / 8 groups and top-2 groups.
+        # Do not replace an explicit ``1``: it means no group restriction.
+        n_routed = self.n_routed_experts or self.num_experts or 128
+        if self.n_group is None:
+            self.n_group = n_routed // 8
+        if self.topk_group is None:
+            self.topk_group = 2
+
+
+class Model(DeepseekV3ForCausalLM):
+    """Sarvam configuration wrapper over MLX's DeepSeek-V3 model."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__(config)
+        self.model_type = config.model_type

--- a/vllm_mlx/models/sarvam_mla.py
+++ b/vllm_mlx/models/sarvam_mla.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Apple Inc.
+"""Sarvam-105B MLA-MoE compatibility model.
+
+Sarvam-105B uses the ``sarvam_mla`` configuration schema but its attention,
+MoE routing, latent-cache layout, and checkpoint sanitization follow
+DeepSeek-V3.  This intentionally thin adapter remaps only its differing
+configuration names, leaving the mature DeepSeek-V3 implementation to own the
+forward, cache, and weight-sanitization paths.
+"""
+
+from dataclasses import dataclass
+
+# MUST run before any mlx_lm import: mlx_lm's package initializer captures a
+# thread-local MLX stream, which is unusable on M5 single-stream GPUs (#404).
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.deepseek_v3 import Model as DeepseekV3ForCausalLM
+from mlx_lm.models.deepseek_v3 import ModelArgs as _V3Args
+
+
+@dataclass
+class ModelArgs(_V3Args):
+    """Map Sarvam's config keys onto MLX's DeepSeek-V3 model arguments."""
+
+    model_type: str = "sarvam_mla"
+    num_experts: int | None = None
+    num_shared_experts: int | None = None
+    # Sarvam has direct q_proj rather than DeepSeek-V3's q_a/q_b LoRA path.
+    q_lora_rank: int | None = None
+    # None distinguishes an absent key from an explicit ``1`` (no group limit).
+    n_group: int | None = None
+    topk_group: int | None = None
+    # Retain Sarvam-only config fields so BaseModelArgs.from_dict accepts them.
+    q_head_dim: int = 192
+    head_dim: int = 576
+    use_qk_norm: bool = False
+    moe_router_enable_expert_bias: bool = True
+    default_theta: float = 10000.0
+
+    def __post_init__(self):
+        if self.num_experts is not None:
+            self.n_routed_experts = self.num_experts
+        if self.num_shared_experts is not None:
+            self.n_shared_experts = self.num_shared_experts
+
+        # Sarvam's published config omits these group-routing controls. Its
+        # reference gate defaults to routed_experts / 8 groups and top-2 groups.
+        # Do not replace an explicit ``1``: it means no group restriction.
+        n_routed = self.n_routed_experts or self.num_experts or 128
+        if self.n_group is None:
+            self.n_group = n_routed // 8
+        if self.topk_group is None:
+            self.topk_group = 2
+
+
+class Model(DeepseekV3ForCausalLM):
+    """Sarvam configuration wrapper over MLX's DeepSeek-V3 model."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__(config)
+        self.model_type = config.model_type

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -218,6 +218,8 @@ MODELS_INCOMPATIBLE_WITH_TURBOQUANT: dict[str, str] = {
     r"deepseek[-_]?v4": SKIP_REASON_MLA,
     r"kimi[-_]?k2\.?5": SKIP_REASON_MLA,
     r"kimi[-_]?k2\.?6": SKIP_REASON_MLA,
+    r"sarvam[-_]?105b": SKIP_REASON_MLA,
+    r"sarvam[-_]?mla": SKIP_REASON_MLA,
 }
 
 _COMPILED_SKIP_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
@@ -263,7 +265,7 @@ def is_incompatible_with_turboquant(
             mt = model_type.lower()
             if mt in {"gemma3", "gemma3_text", "gpt_oss"}:
                 return True, SKIP_REASON_SLIDING
-            if mt in {"deepseek_v3", "deepseek_v4"}:
+            if mt in {"deepseek_v3", "deepseek_v4", "sarvam_mla"}:
                 return True, SKIP_REASON_MLA
         # MLA rank-pair check (DeepSeek-class): rank pair only counts
         # when paired with a known MLA family name, mirroring
@@ -271,7 +273,15 @@ def is_incompatible_with_turboquant(
         needle = f"{model_name or ''} {hf_path or ''}".lower()
         if any(
             pat in needle
-            for pat in ("deepseek-v3", "deepseek_v3", "deepseek-v4", "deepseek_v4")
+            for pat in (
+                "deepseek-v3",
+                "deepseek_v3",
+                "deepseek-v4",
+                "deepseek_v4",
+                "sarvam-105b",
+                "sarvam_105b",
+                "sarvam_mla",
+            )
         ):
             q_rank = hf_config.get("q_lora_rank")
             kv_rank = hf_config.get("kv_lora_rank")

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -666,6 +666,30 @@ def _register_vendored_archs() -> None:
         else:
             _VENDORED_MODEL_TYPES.add("cohere2_moe")
 
+    if "mlx_lm.models.sarvam_mla" not in sys.modules:
+        # Keep the adapter only until mlx-lm provides a native module; then
+        # defer to upstream while retaining the tokenizer-fallback route for
+        # Transformers versions that do not recognize ``sarvam_mla``.
+        import importlib.util as _importlib_util
+
+        _native_spec = None
+        try:
+            _native_spec = _importlib_util.find_spec("mlx_lm.models.sarvam_mla")
+        except (ImportError, ValueError):
+            _native_spec = None
+
+        if _native_spec is None:
+            try:
+                from ..models import sarvam_mla as _sarvam_mla
+
+                sys.modules.setdefault("mlx_lm.models.sarvam_mla", _sarvam_mla)
+            except Exception as e:
+                logger.warning("sarvam_mla vendored module failed to register: %s", e)
+            else:
+                _VENDORED_MODEL_TYPES.add("sarvam_mla")
+        else:
+            _VENDORED_MODEL_TYPES.add("sarvam_mla")
+
     if "mlx_lm.models.hy_v3" not in sys.modules:
         # If mlx-lm ever ships native ``hy_v3`` support (upstream PR #1211
         # merges into 0.32+), defer to their copy so we don't shadow real

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -628,6 +628,30 @@ def _register_vendored_archs() -> None:
         except Exception as e:
             logger.debug(f"deepseek_v4 vendored module unavailable: {e}")
 
+    if "mlx_lm.models.sarvam_mla" not in sys.modules:
+        # Keep the adapter only until mlx-lm provides a native module; then
+        # defer to upstream while retaining the tokenizer-fallback route for
+        # Transformers versions that do not recognize ``sarvam_mla``.
+        import importlib.util as _importlib_util
+
+        _native_spec = None
+        try:
+            _native_spec = _importlib_util.find_spec("mlx_lm.models.sarvam_mla")
+        except (ImportError, ValueError):
+            _native_spec = None
+
+        if _native_spec is None:
+            try:
+                from ..models import sarvam_mla as _sarvam_mla
+
+                sys.modules.setdefault("mlx_lm.models.sarvam_mla", _sarvam_mla)
+            except Exception as e:
+                logger.warning("sarvam_mla vendored module failed to register: %s", e)
+            else:
+                _VENDORED_MODEL_TYPES.add("sarvam_mla")
+        else:
+            _VENDORED_MODEL_TYPES.add("sarvam_mla")
+
     if "mlx_lm.models.hy_v3" not in sys.modules:
         # If mlx-lm ever ships native ``hy_v3`` support (upstream PR #1211
         # merges into 0.32+), defer to their copy so we don't shadow real


### PR DESCRIPTION
# feat(models): vendor Sarvam MLA checkpoint support

Source: [ml-explore/mlx-lm#1530](https://github.com/ml-explore/mlx-lm/pull/1530)

Review state: **follow-up validated — public q6 artifact available**

## Summary

Add a native-first compatibility vendor for the `sarvam_mla` architecture,
adapted to Rapid-MLX's model loader and cache-safety conventions.

## Why

Sarvam-105B is a 105B-total / 10.3B-active MLA MoE model. The adapter is a thin
config remap over MLX-LM's DeepSeek-V3 implementation, but Rapid-MLX needs an
Apple-Silicon-practical checkpoint before support is useful to users. A public
q6 MLX artifact is now available:
[`pierrelamy/sarvam-105b-mlx-q6`](https://huggingface.co/pierrelamy/sarvam-105b-mlx-q6).

The lab q4 quant was tested and is not suitable: it loads but collapses to
whitespace with probability 1.0. q6 is the smallest validated practical artifact
for this architecture in the lab.

## Implementation

- Vendor the Sarvam MLA model only while the installed `mlx-lm` lacks native
  support, and automatically defer once upstream support is present.
- Register `sarvam_mla` through Rapid's direct loader fallback.
- Route Sarvam MLA through Rapid's MLA-aware KV-cache dtype and TurboQuant
  safety gates.
- Add synthetic model, cache, sanitization, and production loader-dispatch
  coverage.

## Test plan

- [x] `pytest -q tests/test_sarvam_mla.py tests/test_kv_cache_dtype.py
  tests/test_turboquant_k8v4.py` — 94 passed.
- [x] Ruff check on all changed Python files.
- [x] Ruff format check on all changed Python files.
- [x] `git diff --check`.
- [x] Coordinator repair of the synthetic MoE configuration.
- [x] Production loader-dispatch regression for local `sarvam_mla` configs.
- [x] Real-weight load, generation, MLA cache behavior, and TurboQuant/int4
  safety validation.

## Real-weight validation

Validation was run on Apple Silicon against the q6 artifact
`pierrelamy/sarvam-105b-mlx-q6`, using the local artifact copy at
`/Users/pierrelamy/Desktop/mlx-uag/sarvam-105b-mlx-q6`.

- Direct Rapid loader path routed `model_type=sarvam_mla` through the vendored
  architecture path and loaded real q6 weights.
- q6 config verified as 6-bit affine, group size 64, 32-layer MLA with
  `kv_lora_rank=512`.
- MLA prompt cache populated 32/32 layers with compressed latent cache state.
- Direct generation was coherent:
  - `"The capital of France is"` produced `" a city of lights..."`
  - top-token probe ranked `" a"` and `" Paris"` first/tied for the same prompt.
  - `def add(a, b):\n    return` predicted `" a"` at 0.986564.
- Safety gates passed:
  - requested int4 KV resolves to bf16 for MLA;
  - TurboQuant reports `skip=True, reason="mla"`.
- Rapid OpenAI-compatible server booted the artifact locally, completed warmup,
  reported 131072 context through `/v1/models`, and `/v1/completions` returned
  `"Paris, a city of light, love"` for `"The capital of France is"` with
  `max_tokens=8, temperature=0`.
- Server metrics reported effective KV dtype bf16 and TurboQuant disabled.

## Attribution

The vendor module preserves Apple copyright and Apache-2.0 attribution and is
adapted from mlx-lm #1530 for Rapid-MLX's native-first vendoring path.

---
Draft opened from `pierre427` fork after duplicate-checking fresh `raullenchai/Rapid-MLX@b3ccb921cd2d435b7238d89b079134258f7d3485`.
