### PR TITLE
feat(models): vendor GraniteMoE SWA checkpoint support

### DIFF
--- a/tests/test_granitemoe_swa_vendored.py
+++ b/tests/test_granitemoe_swa_vendored.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused synthetic coverage for the vendored GraniteMoE SWA model."""
+
+import importlib
+import sys
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+
+@pytest.fixture(autouse=True)
+def _clear_vendored_registration():
+    sys.modules.pop("mlx_lm.models.granitemoe_swa", None)
+    yield
+    sys.modules.pop("mlx_lm.models.granitemoe_swa", None)
+
+
+def _tiny_args(**overrides):
+    from vllm_mlx.models.granitemoe_swa import ModelArgs
+
+    values = {
+        "model_type": "granitemoe_swa",
+        "vocab_size": 128,
+        "hidden_size": 64,
+        "intermediate_size": 32,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_local_experts": 4,
+        "num_experts_per_tok": 2,
+        "shared_intermediate_size": 64,
+        "max_position_embeddings": 128,
+        "rms_norm_eps": 1e-5,
+        "embedding_multiplier": 1.0,
+        "attention_multiplier": 0.125,
+        "residual_multiplier": 1.0,
+        "logits_scaling": 1.0,
+        "sliding_window": 4,
+        "layer_types": [
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        "rope_parameters": {"rope_theta": 10000.0},
+    }
+    values.update(overrides)
+    return ModelArgs(**values)
+
+
+def test_registers_with_mlx_lm_loader_lookup():
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    module = importlib.import_module("mlx_lm.models.granitemoe_swa")
+    assert module.__name__ == "vllm_mlx.models.granitemoe_swa"
+    assert module.ModelArgs is not None
+
+
+def test_mixed_cache_contract_and_tiny_forward():
+    from vllm_mlx.models.granitemoe_swa import Model
+
+    model = Model(_tiny_args())
+    cache = model.make_cache()
+    assert isinstance(cache[0], KVCache)
+    assert isinstance(cache[1], RotatingKVCache)
+    assert cache[1].max_size == 4
+    assert isinstance(cache[3], KVCache)
+
+    capped = model.make_cache(max_kv_size=8)
+    assert isinstance(capped[0], RotatingKVCache)
+    assert capped[0].max_size == 8
+    assert capped[1].max_size == 4
+
+    logits = model(mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32), cache=cache)
+    mx.eval(logits, [entry.state for entry in cache])
+    assert logits.shape == (1, 5, 128)
+    assert model.supports_speculative_rollback is True
+
+
+def test_sanitize_splits_gate_up_by_halves_and_drops_tied_lm_head():
+    from vllm_mlx.models.granitemoe_swa import Model
+
+    model = Model(_tiny_args(num_hidden_layers=1, layer_types=["full_attention"]))
+    fused = mx.arange(2 * 8 * 4).reshape(2, 8, 4)
+    sanitized = model.sanitize(
+        {
+            "model.layers.0.block_sparse_moe.experts.gate_up_proj": fused,
+            "model.layers.0.block_sparse_moe.experts.down_proj": mx.ones((2, 4, 8)),
+            "lm_head.weight": mx.ones((128, 64)),
+        }
+    )
+    gate = sanitized["model.layers.0.block_sparse_moe.experts.gate_proj.weight"]
+    up = sanitized["model.layers.0.block_sparse_moe.experts.up_proj.weight"]
+    assert gate.shape == up.shape == (2, 4, 4)
+    assert mx.array_equal(gate, fused[:, :4, :])
+    assert mx.array_equal(up, fused[:, 4:, :])
+    assert "model.layers.0.block_sparse_moe.experts.down_proj.weight" in sanitized
+    assert "lm_head.weight" not in sanitized

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -205,6 +205,16 @@ def test_deepseek_v4_substring_triggers_downgrade():
     assert decision.downgraded is True
 
 
+def test_granite_swash_name_triggers_sliding_window_downgrade():
+    decision = resolve_kv_cache_dtype(
+        "int4",
+        model_name="ibm-granite/granite-swash-3b-a600m",
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "sliding-window" in decision.reason.lower()
+
+
 def test_kimi_k2_substring_triggers_downgrade():
     decision = resolve_kv_cache_dtype(
         "int4",

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -187,6 +187,16 @@ def test_deepseek_v4_substring_triggers_downgrade():
     assert decision.downgraded is True
 
 
+def test_granite_swash_name_triggers_sliding_window_downgrade():
+    decision = resolve_kv_cache_dtype(
+        "int4",
+        model_name="ibm-granite/granite-swash-3b-a600m",
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "sliding-window" in decision.reason.lower()
+
+
 def test_kimi_k2_substring_triggers_downgrade():
     decision = resolve_kv_cache_dtype(
         "int4",

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2587,9 +2587,7 @@ class TestCheckpointMetadataFallback:
         assert config.tool_call_parser is None
         assert config.is_moe is True
 
-    def test_granitemoe_swa_set_captured_marker_is_not_wire_evidence(
-        self, monkeypatch
-    ):
+    def test_granitemoe_swa_set_captured_marker_is_not_wire_evidence(self, monkeypatch):
         """A marker swallowed by a ``{% set %}`` capture is not rendered."""
         monkeypatch.setattr(
             auto_config_mod,

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2524,6 +2524,108 @@ class TestCheckpointMetadataFallback:
         assert "experimental" in format_profile_summary("local-flash-next", flash)
         assert "⚠ experimental" in format_profile_table("local-flash-next", flash)
 
+    def test_granitemoe_swa_metadata_uses_granite_and_mixed_cache_gates(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                "{% if tools %}<|tool_call|>"
+                '[{"name": "example", "arguments": {}}]{% endif %}',
+            ),
+        )
+
+        config = detect_model_config("publisher/repacked-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser == "granite"
+        assert config.reasoning_parser is None
+        assert config.is_hybrid is False
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
+    def test_granitemoe_swa_without_template_keeps_architecture_but_no_tools(
+        self, monkeypatch
+    ):
+        """A repackage's template is the wire contract: no template, no parser."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                None,
+            ),
+        )
+
+        config = detect_model_config("publisher/templateless-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser is None
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
+    def test_granitemoe_swa_uncalled_macro_marker_is_not_wire_evidence(
+        self, monkeypatch
+    ):
+        """A ``<|tool_call|>`` literal inside an uncalled macro never renders,
+        so it must not advertise the granite parser."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                "{% macro dormant() %}{% if tools %}<|tool_call|>"
+                "{% endif %}{% endmacro %}{% if tools %}plain{% endif %}",
+            ),
+        )
+
+        config = detect_model_config("publisher/dormant-macro-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser is None
+        assert config.is_moe is True
+
+    def test_granitemoe_swa_set_captured_marker_is_not_wire_evidence(
+        self, monkeypatch
+    ):
+        """A marker swallowed by a ``{% set %}`` capture is not rendered."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                "{% set hidden %}{% if tools %}<|tool_call|>{% endif %}"
+                "{% endset %}{% if tools %}plain{% endif %}",
+            ),
+        )
+
+        config = detect_model_config("publisher/set-capture-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser is None
+        assert config.is_moe is True
+
+    def test_granitemoe_swa_plain_template_does_not_advertise_granite_tools(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                "{{ messages[0].content }}",
+            ),
+        )
+
+        config = detect_model_config("publisher/plain-template-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser is None
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
     def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
         # The template PARSES successfully (``{% endif %}`` is present), but the
         # XML tool contract is genuinely INCOMPLETE: it opens

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2349,6 +2349,27 @@ class TestCheckpointMetadataFallback:
         assert config.is_moe is True
         assert config.supports_spec_decode is False
 
+    def test_granitemoe_swa_metadata_uses_granite_and_mixed_cache_gates(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "granitemoe_swa", "sliding_window": 128},
+                '<|tool_call|>[{"name": "example", "arguments": {}}]',
+            ),
+        )
+
+        config = detect_model_config("publisher/repacked-granite-swash")
+
+        assert config is not None
+        assert config.tool_call_parser == "granite"
+        assert config.reasoning_parser is None
+        assert config.is_hybrid is False
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
     def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
         # The template PARSES successfully (``{% endif %}`` is present), but the
         # XML tool contract is genuinely INCOMPLETE: it opens

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -423,6 +423,7 @@ class TestSkipList:
             ("mlx-community/gemma3-9b", SKIP_REASON_SLIDING),
             ("openai/gpt-oss-120b", SKIP_REASON_SLIDING),
             ("gpt_oss_20b", SKIP_REASON_SLIDING),
+            ("ibm-granite/granite-swash-3b-a600m", SKIP_REASON_SLIDING),
             ("deepseek-ai/deepseek-v3", SKIP_REASON_MLA),
             ("deepseek_v4_lite", SKIP_REASON_MLA),
             ("kimi-k2.5-flash", SKIP_REASON_MLA),

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -418,6 +418,7 @@ class TestSkipList:
             ("mlx-community/gemma3-9b", SKIP_REASON_SLIDING),
             ("openai/gpt-oss-120b", SKIP_REASON_SLIDING),
             ("gpt_oss_20b", SKIP_REASON_SLIDING),
+            ("ibm-granite/granite-swash-3b-a600m", SKIP_REASON_SLIDING),
             ("deepseek-ai/deepseek-v3", SKIP_REASON_MLA),
             ("deepseek_v4_lite", SKIP_REASON_MLA),
             ("kimi-k2.5-flash", SKIP_REASON_MLA),

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -69,6 +69,8 @@ _SLIDING_WINDOW_PATTERNS: tuple[str, ...] = (
     "gemma3",
     "gpt-oss",
     "gpt_oss",
+    "granite-swash",
+    "granite_swash",
 )
 
 # Multi-head Latent Attention families. The K projection is already

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1154,6 +1154,22 @@ def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
     )
 
 
+def _template_emits_granite_tool_calls(template: str | None) -> bool:
+    """Recognise Granite's ``<|tool_call|>`` JSON tool contract.
+
+    The template — not the architecture — is the authoritative wire contract
+    for a repackage, so the marker must actually be rendered by the checked-in
+    template before the granite parser is advertised. Path-aware on purpose:
+    a marker that exists only inside an uncalled macro or a ``{% set %}``
+    capture is never rendered and must not count as wire evidence.
+    """
+    result = _template_output_paths(template)
+    if result is None:
+        return False
+    paths, variables = result
+    return "tools" in variables and any("<|tool_call|>" in path for path in paths)
+
+
 def _template_injects_qwen_thinking(template: str | None) -> bool:
     """Recognise Qwen's ``enable_thinking`` / ``<think>`` template contract."""
     contract = _template_output_contract(template)
@@ -1233,6 +1249,25 @@ def _detect_metadata_config(
             supports_spec_decode=False,
         )
         reasons.append("linear/recurrent attention architecture")
+    elif "granitemoe_swa" in model_types:
+        # Granite Swash is pure attention but sparse MoE with mixed
+        # full/sliding KV caches. Keep spec decode disabled until the
+        # mixed-cache server path has a real-weight run. The architecture
+        # facts are config-derived, but the tool parser is only advertised
+        # when the checkpoint's own template emits the Granite
+        # ``<|tool_call|>`` JSON protocol — a repackage's template is the
+        # authoritative wire contract.
+        settings.update(
+            is_moe=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("GraniteMoE SWA architecture")
+        if _template_emits_granite_tool_calls(metadata.chat_template):
+            settings.update(
+                tool_call_parser="granite",
+                reasoning_parser=None,
+            )
+            reasons.append("Granite tool template")
 
     if _template_uses_parameterized_xml_tools(metadata.chat_template):
         settings["tool_call_parser"] = "hermes"

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1123,6 +1123,18 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
             supports_spec_decode=False,
         )
         reasons.append("dense Qwen3.5 architecture")
+    elif "granitemoe_swa" in model_types:
+        # Granite Swash is pure attention but sparse MoE with mixed
+        # full/sliding KV caches. Its checkpoint template emits the existing
+        # Granite ``<|tool_call|>`` JSON protocol. Keep spec decode disabled
+        # until the mixed-cache server path has a real-weight run.
+        settings.update(
+            tool_call_parser="granite",
+            reasoning_parser=None,
+            is_moe=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("GraniteMoE SWA architecture and Granite tool template")
 
     if _template_uses_parameterized_xml_tools(metadata.chat_template):
         settings["tool_call_parser"] = "hermes"

--- a/vllm_mlx/models/granitemoe_swa.py
+++ b/vllm_mlx/models/granitemoe_swa.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vendored IBM GraniteMoE sliding-window attention architecture.
+
+Adapted from ml-explore/mlx-lm#1608 for ``granitemoe_swa`` checkpoints such
+as ``ibm-granite/granite-swash-3b-a600m``. It uses the pinned mlx-lm cache and
+attention primitives, with full-attention layers retaining ``KVCache`` and
+sliding layers using ``RotatingKVCache``.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.activations import swiglu  # noqa: E402
+from mlx_lm.models.base import (  # noqa: E402
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import KVCache, RotatingKVCache  # noqa: E402
+from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_local_experts: int
+    num_experts_per_tok: int
+    shared_intermediate_size: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    embedding_multiplier: float
+    attention_multiplier: float
+    residual_multiplier: float
+    logits_scaling: float
+    sliding_window: int
+    layer_types: list[str]
+    attention_bias: bool = False
+    tie_word_embeddings: bool = True
+    rope_theta: float = 10000.0
+    rope_parameters: dict[str, Any] | None = None
+
+    def __post_init__(self):
+        if self.rope_parameters:
+            self.rope_theta = float(
+                self.rope_parameters.get("rope_theta", self.rope_theta)
+            )
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = dim // self.n_heads
+        self.scale = args.attention_multiplier
+        self.q_proj = nn.Linear(dim, self.n_heads * head_dim, bias=args.attention_bias)
+        self.k_proj = nn.Linear(
+            dim, self.n_kv_heads * head_dim, bias=args.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            dim, self.n_kv_heads * head_dim, bias=args.attention_bias
+        )
+        self.o_proj = nn.Linear(self.n_heads * head_dim, dim, bias=args.attention_bias)
+        self.sinks = mx.zeros((self.n_heads,))
+        self.rope = initialize_rope(
+            head_dim,
+            args.rope_theta,
+            False,
+            None,
+            args.max_position_embeddings,
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        batch, length, _ = x.shape
+        q = (
+            self.q_proj(x)
+            .reshape(batch, length, self.n_heads, -1)
+            .transpose(0, 2, 1, 3)
+        )
+        k = (
+            self.k_proj(x)
+            .reshape(batch, length, self.n_kv_heads, -1)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            self.v_proj(x)
+            .reshape(batch, length, self.n_kv_heads, -1)
+            .transpose(0, 2, 1, 3)
+        )
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=mask, sinks=self.sinks
+        )
+        return self.o_proj(out.transpose(0, 2, 1, 3).reshape(batch, length, -1))
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.router = nn.Linear(args.hidden_size, args.num_local_experts, bias=False)
+        self.experts = SwitchGLU(
+            args.hidden_size, args.intermediate_size, args.num_local_experts
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        logits = self.router(x).astype(mx.float32)
+        indices = mx.argpartition(logits, kth=-self.top_k, axis=-1)[..., -self.top_k :]
+        gates = mx.softmax(
+            mx.take_along_axis(logits, indices, axis=-1), precise=True, axis=-1
+        )
+        values = self.experts(x, indices)
+        return (values * gates[..., None]).sum(axis=-2).astype(values.dtype)
+
+
+class SharedMLP(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.input_linear = nn.Linear(
+            args.hidden_size, args.shared_intermediate_size * 2, bias=False
+        )
+        self.output_linear = nn.Linear(
+            args.shared_intermediate_size, args.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate, up = mx.split(self.input_linear(x), 2, axis=-1)
+        return self.output_linear(swiglu(gate, up))
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_type: str):
+        super().__init__()
+        self.layer_type = layer_type
+        self.residual_multiplier = args.residual_multiplier
+        self.self_attn = Attention(args)
+        self.block_sparse_moe = MoE(args)
+        self.shared_mlp = SharedMLP(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        hidden = x + self.self_attn(self.input_layernorm(x), mask, cache) * (
+            self.residual_multiplier
+        )
+        normed = self.post_attention_layernorm(hidden)
+        mlp_out = self.block_sparse_moe(normed) + self.shared_mlp(normed)
+        return hidden + mlp_out * self.residual_multiplier
+
+
+class GraniteMoeSwaModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(args, layer_type) for layer_type in args.layer_types
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.embedding_multiplier = args.embedding_multiplier
+        self.layer_types = args.layer_types
+        self.window_size = args.sliding_window
+        self.full_index = args.layer_types.index("full_attention")
+        self.sliding_index = (
+            args.layer_types.index("sliding_attention")
+            if "sliding_attention" in args.layer_types
+            else self.full_index
+        )
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        hidden = self.embed_tokens(inputs) * self.embedding_multiplier
+        if cache is None:
+            cache = [None] * len(self.layers)
+        full_mask = create_attention_mask(hidden, cache[self.full_index])
+        sliding_mask = create_attention_mask(
+            hidden,
+            cache[self.sliding_index],
+            window_size=self.window_size,
+        )
+        for layer, layer_cache in zip(self.layers, cache):
+            mask = full_mask if layer.layer_type == "full_attention" else sliding_mask
+            hidden = layer(hidden, mask, layer_cache)
+        return self.norm(hidden)
+
+
+class Model(nn.Module):
+    """GraniteMoE model with full and sliding attention cache lanes."""
+
+    supports_speculative_rollback = True
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = GraniteMoeSwaModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.logits_scaling = args.logits_scaling
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        output = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            output = self.model.embed_tokens.as_linear(output)
+        else:
+            output = self.lm_head(output)
+        return output / self.logits_scaling
+
+    def sanitize(self, weights):
+        if any("experts.gate_proj" in key for key in weights):
+            return weights
+        sanitized = {}
+        for key, value in weights.items():
+            if key.endswith("block_sparse_moe.experts.gate_up_proj"):
+                intermediate = value.shape[1]
+                sanitized[key.replace("gate_up_proj", "gate_proj") + ".weight"] = value[
+                    :, : intermediate // 2, :
+                ]
+                sanitized[key.replace("gate_up_proj", "up_proj") + ".weight"] = value[
+                    :, intermediate // 2 :, :
+                ]
+            elif key.endswith("block_sparse_moe.experts.down_proj"):
+                sanitized[key + ".weight"] = value
+            elif key == "lm_head.weight" and self.args.tie_word_embeddings:
+                continue
+            else:
+                sanitized[key] = value
+        return sanitized
+
+    def make_cache(self, max_kv_size=None):
+        return [
+            (RotatingKVCache(max_size=max_kv_size) if max_kv_size else KVCache())
+            if layer_type == "full_attention"
+            else RotatingKVCache(max_size=self.args.sliding_window)
+            for layer_type in self.model.layer_types
+        ]
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("block_sparse_moe.router"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -211,6 +211,7 @@ MODELS_INCOMPATIBLE_WITH_TURBOQUANT: dict[str, str] = {
     # TurboQuant V-side codebook assumes contiguous tokens.
     r"gemma[-_]?3": SKIP_REASON_SLIDING,
     r"gpt[-_]?oss": SKIP_REASON_SLIDING,
+    r"granite[-_]?swash": SKIP_REASON_SLIDING,
     # Multi-head Latent Attention — K projection is already compressed
     # via q_lora_rank / kv_lora_rank, stacking quant on top compounds
     # error on reasoning workloads.

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -221,6 +221,7 @@ MODELS_INCOMPATIBLE_WITH_TURBOQUANT: dict[str, str] = {
     # TurboQuant V-side codebook assumes contiguous tokens.
     r"gemma[-_]?3": SKIP_REASON_SLIDING,
     r"gpt[-_]?oss": SKIP_REASON_SLIDING,
+    r"granite[-_]?swash": SKIP_REASON_SLIDING,
     # Multi-head Latent Attention — K projection is already compressed
     # via q_lora_rank / kv_lora_rank, stacking quant on top compounds
     # error on reasoning workloads.

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -666,6 +666,28 @@ def _register_vendored_archs() -> None:
         else:
             _VENDORED_MODEL_TYPES.add("cohere2_moe")
 
+    if "mlx_lm.models.granitemoe_swa" not in sys.modules:
+        import importlib.util as _importlib_util
+
+        try:
+            _native_spec = _importlib_util.find_spec("mlx_lm.models.granitemoe_swa")
+        except (ImportError, ValueError):
+            _native_spec = None
+
+        if _native_spec is None:
+            try:
+                from ..models import granitemoe_swa as _granitemoe_swa
+
+                sys.modules.setdefault("mlx_lm.models.granitemoe_swa", _granitemoe_swa)
+            except Exception as e:
+                logger.warning(
+                    "granitemoe_swa vendored module failed to register: %s", e
+                )
+            else:
+                _VENDORED_MODEL_TYPES.add("granitemoe_swa")
+        else:
+            _VENDORED_MODEL_TYPES.add("granitemoe_swa")
+
     if "mlx_lm.models.hy_v3" not in sys.modules:
         # If mlx-lm ever ships native ``hy_v3`` support (upstream PR #1211
         # merges into 0.32+), defer to their copy so we don't shadow real

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -628,6 +628,28 @@ def _register_vendored_archs() -> None:
         except Exception as e:
             logger.debug(f"deepseek_v4 vendored module unavailable: {e}")
 
+    if "mlx_lm.models.granitemoe_swa" not in sys.modules:
+        import importlib.util as _importlib_util
+
+        try:
+            _native_spec = _importlib_util.find_spec("mlx_lm.models.granitemoe_swa")
+        except (ImportError, ValueError):
+            _native_spec = None
+
+        if _native_spec is None:
+            try:
+                from ..models import granitemoe_swa as _granitemoe_swa
+
+                sys.modules.setdefault("mlx_lm.models.granitemoe_swa", _granitemoe_swa)
+            except Exception as e:
+                logger.warning(
+                    "granitemoe_swa vendored module failed to register: %s", e
+                )
+            else:
+                _VENDORED_MODEL_TYPES.add("granitemoe_swa")
+        else:
+            _VENDORED_MODEL_TYPES.add("granitemoe_swa")
+
     if "mlx_lm.models.hy_v3" not in sys.modules:
         # If mlx-lm ever ships native ``hy_v3`` support (upstream PR #1211
         # merges into 0.32+), defer to their copy so we don't shadow real


### PR DESCRIPTION
# feat(models): vendor GraniteMoE SWA checkpoint support

Source: [ml-explore/mlx-lm#1608](https://github.com/ml-explore/mlx-lm/pull/1608)

Review state: **validated — real server/prefix/continuous-batching/spec smoke passed**

## Why

Granite Swash is a small, permissively usable MoE with mixed full/sliding-window attention, which makes it a good Rapid regression and dogfood target: it is cheap enough for routine Apple Silicon validation but still exercises the cache shapes, MoE routing, parser metadata, and speculative-safety boundaries that dense toy models miss. Shipping the vendor path gives Rapid users a fast local Granite family option without relaxing conservative mixed-cache gates by default.

## Summary

Add a native-first `granitemoe_swa` compatibility path for Granite Swash,
including mixed full/sliding attention caches and Rapid-MLX metadata routing.

## AI assistance disclosure

OpenAI Codex Terra implemented the initial adaptation. The coordinator
independently inspected the diff, reran focused tests, Ruff, format, and
whitespace checks, and performed a serialized local real-weight loader/cache
smoke after confirming no model-serving contention.

## Implementation

- Vendor `granitemoe_swa` only while installed `mlx-lm` lacks native support.
- Support mixed `KVCache` / `RotatingKVCache` layers, attention sinks, the
  shared expert, nested RoPE configuration, and fused expert-weight
  sanitization.
- Route local Granite Swash checkpoints to Rapid's existing Granite tool
  parser and mark the architecture as MoE.
- Disable server speculative decoding, int4 KV cache, and TurboQuant until
  their mixed-cache behavior is qualified with real weights.

## Test plan

- [x] `pytest -q tests/test_granitemoe_swa_vendored.py
  tests/test_kv_cache_dtype.py tests/test_model_auto_config.py
  tests/test_turboquant_k8v4.py` — 409 passed.
- [x] Ruff check on all changed Python files.
- [x] Ruff format check on all changed Python files.
- [x] `git diff --check`.
- [x] Local checkpoint configuration confirms 8 full and 20 sliding layers, a
  128-token window, attention sinks, and fused expert weights.
- [x] Real local checkpoint load from
  `/Users/pierrelamy/mlx-models/granite-swash-3b-a600m-mlx-4bit`.
- [x] Real cache construction produced 28 layers: 8 `KVCache` and
  20 `RotatingKVCache` layers.
- [x] Short `mlx_lm.generate` smoke completed without loader/cache error.
- [x] Real Rapid server validation on Apple Silicon: `/v1/models` advertised
  text/tools with the Granite parser, a 410-token prompt crossed the
  128-token sliding-window boundary twice with stable repeat output, four
  concurrent chat requests completed through the batched server, and a
  forced-spec smoke completed without runtime/rollback errors. Exact-repeat
  and one-suffix completion probes reused 9 cached prompt tokens.

## Remaining validation

This pass validates the practical Rapid server route, prefix reuse, continuous
batching, and a forced-spec smoke. Broader quality benchmarking and deeper
long-context mixed-cache parity can follow separately; the PR still keeps
speculative decoding, int4 KV cache, and TurboQuant conservative by default.

## Attribution

The vendor module preserves Apache-2.0 attribution and is adapted from mlx-lm
#1608 for Rapid-MLX's native-first vendoring seam.

---
Draft opened from `pierre427` fork after duplicate-checking fresh `raullenchai/Rapid-MLX@b3ccb921cd2d435b7238d89b079134258f7d3485`.
