### PR TITLE
fix(mac): restore markdown code block and table visibility

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -379,6 +379,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/math-rendering
 
+      - name: 'Golden flow: markdown-appearance'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow markdown-appearance
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/markdown-appearance
+
       - name: 'Golden flow: slow-stream-stop'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow slow-stream-stop
@@ -477,7 +483,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 24
+          expected = 25
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -379,12 +379,6 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/math-rendering
 
-      - name: 'Golden flow: markdown-appearance'
-        continue-on-error: true
-        run: ./scripts/gui-golden-flows.sh --flow markdown-appearance
-        env:
-          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/markdown-appearance
-
       - name: 'Golden flow: slow-stream-stop'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow slow-stream-stop
@@ -483,7 +477,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 25
+          expected = 24
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Options/MarkdownOptions.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Options/MarkdownOptions.swift
@@ -80,13 +80,30 @@ struct MarkdownOptions: @unchecked Sendable {
 
     // MARK: - Code blocks
 
-    /// 实测: sampled #F8F8F8. The nearest token is `bg/tertiary` (#F3F3F3);
-    /// the 5-unit gap suggests a distinct swatch, so the measured literal wins
-    /// until we can prove otherwise.
-    public var codeBlockBackground: NSColor = NSColor(
-        srgbRed: 0.973, green: 0.973, blue: 0.973, alpha: 1
+    /// 实测 (light) was #F8F8F8, and that measurement is now deliberately not
+    /// used: sampled against ChatGPT's white page it separates, but this app's
+    /// canvas is `RapidTheme.canvas` #FAFAF9, two levels away — the card
+    /// vanished into the transcript. #F1F0EC is the same distance below our
+    /// canvas that the measured swatch sat below ChatGPT's.
+    ///
+    /// The dark value is NOT measured — ChatGPT's reference conversation was
+    /// captured in light mode. It is `RapidTheme.card`'s #1A1D21, i.e. one
+    /// step *above* the #141619 canvas rather than the recessed
+    /// `surfaceCode`: a code card sits directly on the transcript, so a
+    /// recessed fill would be indistinguishable from the background.
+    ///
+    /// This used to be a single light literal, which meant the card stayed
+    /// near-white in dark mode while the syntax palette resolved to its dark
+    /// variants — pale purple keywords on white. Both halves have to switch
+    /// together, so this has to be dynamic.
+    public var codeBlockBackground: NSColor = markdownDynamicColor(
+        light: (0xF1, 0xF0, 0xEC), dark: (0x1A, 0x1D, 0x21)
     )
-    public var codeBlockBorder: NSColor?
+    /// Same hairline the table uses, for the same reason: fill alone is not
+    /// enough separation from the canvas at these low contrasts.
+    public var codeBlockBorder: NSColor? = markdownDynamicColor(
+        light: (0xE0, 0xE0, 0xDC), dark: (0x2E, 0x32, 0x38)
+    )
     /// 实测: circle-fit 14.24 (n=40, mid-arc samples).
     public var codeCornerRadius: CGFloat = 14
     /// 待校准.
@@ -105,10 +122,12 @@ struct MarkdownOptions: @unchecked Sendable {
 
     // MARK: - Tables
     //
-    // Note the absence of a grid-line colour. ChatGPT's field list has
-    // `tableCellInsets`, `tableBorderCornerRadius`, `tableHeaderBackgroundColor`
-    // and `tableTextStyle` — and nothing for cell borders. That absence is
-    // evidence: the table has no grid, only a header fill and row rhythm.
+    // ChatGPT's field list has `tableCellInsets`, `tableBorderCornerRadius`,
+    // `tableHeaderBackgroundColor` and `tableTextStyle` — and nothing for cell
+    // borders, which we first read as evidence that the table is separated by
+    // rhythm alone. In practice a borderless table in this transcript reads as
+    // three columns of loose text, so `tableBorderColor` is ours rather than
+    // transcribed. `nil` restores the original borderless rendering.
 
     /// 推导 from the measured 42pt row height.
     public var tableCellInsets: NSDirectionalEdgeInsets = .init(
@@ -116,7 +135,23 @@ struct MarkdownOptions: @unchecked Sendable {
     )
     /// 待校准.
     public var tableBorderCornerRadius: CGFloat = 8
-    public var tableHeaderBackgroundColor: NSColor?
+    /// Grid line around the table and between its cells. Quiet enough to
+    /// stay out of the prose's way — one step softer than
+    /// `RapidTheme.hairlineStrong` in both modes.
+    public var tableBorderColor: NSColor? = markdownDynamicColor(
+        light: (0xE0, 0xE0, 0xDC), dark: (0x2E, 0x32, 0x38)
+    )
+    public var tableBorderWidth: CGFloat = 1
+    /// A quiet fill so the header row reads as a header.
+    ///
+    /// Left nil originally, on the reading that ChatGPT's table separates rows
+    /// by rhythm alone. It does — but rhythm plus a header fill, and with the
+    /// fill absent the whole table collapsed into three columns of loose text
+    /// with nothing marking the head. `Color.clear` under a nil is still the
+    /// escape hatch for a caller that wants the fill gone.
+    public var tableHeaderBackgroundColor: NSColor? = markdownDynamicColor(
+        light: (0xF1, 0xF1, 0xEF), dark: (0x22, 0x25, 0x2A)
+    )
     /// 实测: AX row frame h=42, confirmed by baseline Δ=42.
     public var tableRowHeight: CGFloat = 42
     public var tablePointSize: CGFloat = 14
@@ -178,6 +213,36 @@ struct MarkdownOptions: @unchecked Sendable {
     public var hugsTextHorizontally: Bool = false
 
     public init() {}
+}
+
+/// An appearance-aware `NSColor` for markdown chrome.
+///
+/// Every colour in this file has to be resolved at *draw* time, not at struct
+/// construction: `MarkdownOptions` is built once per view update and outlives
+/// an appearance change, so a colour baked from a light/dark test at init
+/// freezes to whatever the theme was on that pass — the same failure the
+/// syntax palette documents in ``SyntaxHighlighter``. A dynamic provider is
+/// re-evaluated by AppKit on each resolve instead.
+///
+/// Spelled out here rather than reusing `RapidTheme`'s tokens because those
+/// are SwiftUI `Color`s and this layer needs `NSColor`; the round trip back
+/// through `NSColor(_:)` loses the dynamic provider.
+func markdownDynamicColor(
+    light: (Int, Int, Int), dark: (Int, Int, Int)
+) -> NSColor {
+    NSColor(name: nil, dynamicProvider: { appearance in
+        let match = appearance.bestMatch(from: [
+            .aqua, .darkAqua, .accessibilityHighContrastDarkAqua
+        ])
+        let isDark = (match == .darkAqua || match == .accessibilityHighContrastDarkAqua)
+        let c = isDark ? dark : light
+        return NSColor(
+            deviceRed: CGFloat(c.0) / 255.0,
+            green: CGFloat(c.1) / 255.0,
+            blue: CGFloat(c.2) / 255.0,
+            alpha: 1
+        )
+    })
 }
 
 // MARK: - Presets

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownBlockStack.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownBlockStack.swift
@@ -201,10 +201,16 @@ private struct MarkdownCodeBlockRepresentable: NSViewRepresentable {
 
 /// Table rendering.
 ///
-/// Note what is absent: grid lines. ChatGPT's option table has
-/// `tableCellInsets`, `tableBorderCornerRadius`, `tableHeaderBackgroundColor`
-/// and `tableTextStyle` — and no field for cell borders. That absence is the
-/// evidence: rows are separated by rhythm and a header fill, not by rules.
+/// A `Grid` rather than a `VStack` of `HStack`s. The stacked version sized
+/// every row independently, so its columns only lined up while each cell was
+/// under the 80pt minimum — any longer value staggered the whole table. That
+/// was survivable while the table was borderless; with grid lines it is not,
+/// because a misaligned divider is visible in a way misaligned text is not.
+///
+/// Grid lines themselves are ours, not transcribed: ChatGPT's option table has
+/// no cell-border field, but a borderless table in this transcript reads as
+/// loose columns of text. `tableBorderColor` set to nil restores that
+/// rendering.
 struct MarkdownTableView: View {
     let block: MarkdownItem.TableBlock
     let options: MarkdownOptions
@@ -213,37 +219,87 @@ struct MarkdownTableView: View {
         // Horizontal scrolling because `nonTableMaxWidth` in the original says
         // tables may exceed the prose column rather than compress into it.
         ScrollView(.horizontal, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
-                row(block.header, isHeader: true)
-                ForEach(Array(block.rows.enumerated()), id: \.offset) { _, cells in
-                    row(cells, isHeader: false)
+            Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow { cells(block.header, rowIndex: 0, isHeader: true) }
+                ForEach(Array(block.rows.enumerated()), id: \.offset) { index, row in
+                    GridRow { cells(row, rowIndex: index + 1, isHeader: false) }
                 }
             }
-            .clipShape(RoundedRectangle(
-                cornerRadius: options.tableBorderCornerRadius, style: .continuous
-            ))
+            .clipShape(borderShape)
+            // `strokeBorder` rather than `stroke`: the line is drawn inside
+            // the shape, so the clip above does not shave half of it off.
+            .overlay {
+                if let border = options.tableBorderColor {
+                    borderShape.strokeBorder(
+                        Color(nsColor: border), lineWidth: options.tableBorderWidth
+                    )
+                }
+            }
         }
     }
 
-    private func row(_ cells: [[InlineRun]], isHeader: Bool) -> some View {
-        HStack(spacing: 0) {
-            ForEach(Array(cells.enumerated()), id: \.offset) { index, runs in
-                Text(styled(runs, isHeader: isHeader))
-                    .frame(
-                        minWidth: 80,
-                        alignment: alignment(for: index)
-                    )
-                    .padding(.horizontal, options.tableCellInsets.leading)
-                    .padding(.vertical, options.tableCellInsets.top)
+    private var borderShape: RoundedRectangle {
+        RoundedRectangle(
+            cornerRadius: options.tableBorderCornerRadius, style: .continuous
+        )
+    }
+
+    /// One row's cells. Each draws only its leading and top dividers, so a
+    /// shared edge is painted once rather than twice — two hairlines on the
+    /// same seam render as a double-weight line at non-integral scale factors.
+    @ViewBuilder
+    private func cells(
+        _ cells: [[InlineRun]], rowIndex: Int, isHeader: Bool
+    ) -> some View {
+        ForEach(Array(cells.enumerated()), id: \.offset) { column, runs in
+            let cell = Text(styled(runs, isHeader: isHeader))
+                .frame(minWidth: 80, alignment: alignment(for: column))
+                .padding(.horizontal, options.tableCellInsets.leading)
+                .padding(.vertical, options.tableCellInsets.top)
+                // `maxHeight` so a short cell still fills a row made tall by a
+                // wrapped neighbour — otherwise its dividers stop short.
+                .frame(minHeight: options.tableRowHeight, maxHeight: .infinity)
+                .background(isHeader
+                    ? Color(nsColor: options.tableHeaderBackgroundColor ?? .clear)
+                    : Color.clear)
+                .overlay(alignment: .leading) {
+                    divider(column > 0, vertical: true)
+                }
+                .overlay(alignment: .top) {
+                    divider(rowIndex > 0, vertical: false)
+                }
+            // Column alignment is a property of the column, so it is declared
+            // once — on the header — rather than restated by every row.
+            if isHeader {
+                cell.gridColumnAlignment(horizontalAlignment(for: column))
+            } else {
+                cell
             }
         }
-        .frame(minHeight: options.tableRowHeight, alignment: .leading)
-        .background(isHeader
-            ? Color(nsColor: options.tableHeaderBackgroundColor ?? .clear)
-            : Color.clear)
+    }
+
+    @ViewBuilder
+    private func divider(_ visible: Bool, vertical: Bool) -> some View {
+        if visible, let border = options.tableBorderColor {
+            Rectangle()
+                .fill(Color(nsColor: border))
+                .frame(
+                    width: vertical ? options.tableBorderWidth : nil,
+                    height: vertical ? nil : options.tableBorderWidth
+                )
+        }
     }
 
     private func alignment(for column: Int) -> SwiftUI.Alignment {
+        guard column < block.alignments.count else { return .leading }
+        switch block.alignments[column] {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
+    }
+
+    private func horizontalAlignment(for column: Int) -> HorizontalAlignment {
         guard column < block.alignments.count else { return .leading }
         switch block.alignments[column] {
         case .leading: return .leading

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownCodeBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownCodeBlockView.swift
@@ -80,13 +80,39 @@ final class MarkdownCodeBlockView: NSView {
         headerLabel.stringValue = language?.capitalized ?? ""
         headerLabel.isHidden = (language?.isEmpty ?? true)
         layer?.cornerRadius = options.codeCornerRadius
-        layer?.backgroundColor = options.codeBlockBackground.cgColor
-        if let border = options.codeBlockBorder {
-            layer?.borderWidth = 1
-            layer?.borderColor = border.cgColor
-        }
+        applyAppearanceDependentColors()
         needsDisplay = true
         invalidateIntrinsicContentSize()
+    }
+
+    /// Paint the card fill and border for the CURRENT appearance.
+    ///
+    /// A `CALayer` takes a `CGColor`, which is a resolved value — asking a
+    /// dynamic `NSColor` for `.cgColor` snapshots it against whatever
+    /// appearance happens to be current and never updates again. So the
+    /// resolve is wrapped in `performAsCurrentDrawingAppearance` (which makes
+    /// this view's effective appearance the one the provider sees) and re-run
+    /// from ``viewDidChangeEffectiveAppearance`` on every light/dark flip.
+    /// Without the second half, switching to dark left a near-white card
+    /// behind dark-palette syntax colours until the block was rebuilt.
+    private func applyAppearanceDependentColors() {
+        let fill = options.codeBlockBackground
+        let border = options.codeBlockBorder
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = fill.cgColor
+            layer?.borderWidth = border == nil ? 0 : 1
+            layer?.borderColor = border?.cgColor
+        }
+    }
+
+    public override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyAppearanceDependentColors()
+        // The syntax palette is resolved into the attributed string at build
+        // time, so unlike the fill it cannot re-resolve itself — the text has
+        // to be rebuilt against the new appearance.
+        renderer.setCode(code, language: language)
+        needsDisplay = true
     }
 
     private var headerHeight: CGFloat {

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownChromeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownChromeTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Testing
+
+@testable import Rapid
+
+@Suite("Markdown chrome appearance")
+struct MarkdownChromeTests {
+    @Test("Code and table chrome resolve to distinct light and dark palettes")
+    func dynamicChromeColors() throws {
+        let options = MarkdownOptions()
+
+        #expect(try rgb(options.codeBlockBackground, in: .aqua) == [0xF1, 0xF0, 0xEC])
+        #expect(try rgb(options.codeBlockBackground, in: .darkAqua) == [0x1A, 0x1D, 0x21])
+        #expect(try rgb(#require(options.codeBlockBorder), in: .aqua) == [0xE0, 0xE0, 0xDC])
+        #expect(try rgb(#require(options.codeBlockBorder), in: .darkAqua) == [0x2E, 0x32, 0x38])
+        #expect(try rgb(#require(options.tableHeaderBackgroundColor), in: .aqua)
+            == [0xF1, 0xF1, 0xEF])
+        #expect(try rgb(#require(options.tableHeaderBackgroundColor), in: .darkAqua)
+            == [0x22, 0x25, 0x2A])
+        #expect(try rgb(#require(options.tableBorderColor), in: .aqua) == [0xE0, 0xE0, 0xDC])
+        #expect(try rgb(#require(options.tableBorderColor), in: .darkAqua) == [0x2E, 0x32, 0x38])
+    }
+
+    @MainActor
+    @Test("A live code block repaints its layer when appearance changes")
+    func codeBlockRepaintsWithoutReconstruction() throws {
+        let options = MarkdownOptions()
+        let view = MarkdownCodeBlockView(options: options)
+        view.appearance = NSAppearance(named: .aqua)
+        view.configure(code: "let answer = 42", language: "swift", options: options)
+        #expect(try rgb(#require(view.layer?.backgroundColor), in: .aqua)
+            == [0xF1, 0xF0, 0xEC])
+        #expect(try rgb(#require(view.layer?.borderColor), in: .aqua)
+            == [0xE0, 0xE0, 0xDC])
+
+        view.appearance = NSAppearance(named: .darkAqua)
+        view.viewDidChangeEffectiveAppearance()
+        #expect(try rgb(#require(view.layer?.backgroundColor), in: .darkAqua)
+            == [0x1A, 0x1D, 0x21])
+        #expect(try rgb(#require(view.layer?.borderColor), in: .darkAqua)
+            == [0x2E, 0x32, 0x38])
+    }
+
+    private func rgb(_ color: NSColor, in appearanceName: NSAppearance.Name) throws -> [Int] {
+        let appearance = try #require(NSAppearance(named: appearanceName))
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.deviceRGB)
+        }
+        let device = try #require(resolved)
+        return [device.redComponent, device.greenComponent, device.blueComponent].map {
+            Int(($0 * 255).rounded())
+        }
+    }
+
+    private func rgb(_ color: CGColor, in appearanceName: NSAppearance.Name) throws -> [Int] {
+        try rgb(#require(NSColor(cgColor: color)), in: appearanceName)
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -36,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, markdown-appearance, math-rendering, launch-integrations,
+Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -2079,6 +2079,40 @@ flow_math_rendering() {
         "$OUT/math-settled.json" >/dev/null; then
         die "SwiftMath took the literal-source fallback in the assembled app"
     fi
+
+    # #2056: keep code and table chrome visible through a live appearance
+    # transition. Three short turns fit the hosted runner's 1024x681 window;
+    # unlike chat-depth's five-turn fixture, none of these AX nodes virtualize.
+    send_prompt "shape:code show me fibonacci in python" "markdown-code"
+    wait_send_idle "$OUT/code-settled.json"
+    send_prompt "shape:table compare those two models for me" "markdown-table"
+    wait_send_idle "$OUT/table-settled.json"
+    transcript_only "$OUT/table-settled.json" "$OUT/light-transcript.json"
+    assert_markdown_code_and_table "$OUT/light-transcript.json" "$OUT/light"
+
+    open_settings
+    see_settings "$OUT/settings.json"
+    press "$OUT/settings.json" Settings.Category.appearance "$OUT/appearance-open.json" \
+        || die "Appearance category is not pressable during markdown theme coverage"
+    see_settings "$OUT/appearance.json"
+    press "$OUT/appearance.json" Settings.Appearance.Theme.dark "$OUT/dark-press.json" \
+        || die "Dark appearance is not pressable during markdown theme coverage"
+    see_settings "$OUT/dark.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.dark")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/dark.json" >/dev/null || die "Dark appearance did not become selected"
+    transcript_only "$OUT/dark.json" "$OUT/dark-transcript.json"
+    assert_markdown_code_and_table "$OUT/dark-transcript.json" "$OUT/dark"
+
+    press "$OUT/dark.json" Settings.Appearance.Theme.light "$OUT/light-press.json" \
+        || die "Light appearance is not pressable after the dark markdown check"
+    see_settings "$OUT/light.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.light")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/light.json" >/dev/null || die "Light appearance did not become selected"
+    log "  live Light → Dark → Light kept math, code blocks, and tables rendered"
     cleanup_persona
 }
 
@@ -2917,58 +2951,15 @@ flow_chat_depth() {
     cleanup_persona
 }
 
-flow_markdown_appearance() {
-    # #2056: a two-turn counterpart to chat-depth that fits the hosted
-    # runner's 1024x681 window. Five turns are intentionally excluded from CI
-    # because transcript virtualization removes the oldest AX nodes there;
-    # two keep both the fenced block and table realised while still exercising
-    # the real runtime appearance transition.
-    start_persona markdown-appearance
-    dismiss_first_run
-    start_model
-    send_prompt "shape:code show me fibonacci in python" "markdown-code"
-    wait_send_idle "$OUT/code-settled.json"
-    send_prompt "shape:table compare those two models for me" "markdown-table"
-    wait_send_idle "$OUT/table-settled.json"
-
-    transcript_only "$OUT/table-settled.json" "$OUT/light-transcript.json"
-    assert_markdown_code_and_table "$OUT/light-transcript.json" "$OUT/light"
-
-    open_settings
-    see_settings "$OUT/settings.json"
-    press "$OUT/settings.json" Settings.Category.appearance "$OUT/appearance-open.json" \
-        || die "Appearance category is not pressable during markdown theme coverage"
-    see_settings "$OUT/appearance.json"
-    press "$OUT/appearance.json" Settings.Appearance.Theme.dark "$OUT/dark-press.json" \
-        || die "Dark appearance is not pressable during markdown theme coverage"
-    see_settings "$OUT/dark.json"
-    jq -e '.data.ui_elements[]?
-           | select(.identifier == "Settings.Appearance.Theme.dark")
-           | select(.selected == true or .value == 1 or .value == "1")' \
-        "$OUT/dark.json" >/dev/null || die "Dark appearance did not become selected"
-    transcript_only "$OUT/dark.json" "$OUT/dark-transcript.json"
-    assert_markdown_code_and_table "$OUT/dark-transcript.json" "$OUT/dark"
-
-    press "$OUT/dark.json" Settings.Appearance.Theme.light "$OUT/light-press.json" \
-        || die "Light appearance is not pressable after the dark markdown check"
-    see_settings "$OUT/light.json"
-    jq -e '.data.ui_elements[]?
-           | select(.identifier == "Settings.Appearance.Theme.light")
-           | select(.selected == true or .value == 1 or .value == "1")' \
-        "$OUT/light.json" >/dev/null || die "Light appearance did not become selected"
-    log "  live Light → Dark → Light kept code blocks and tables rendered"
-    cleanup_persona
-}
-
 assert_markdown_code_and_table() {
     local transcript="$1" scratch="$2"
     local code_message="$scratch-code.json" table_message="$scratch-table.json"
-    assistant_message_only "$transcript" 1 "$code_message"
+    assistant_message_only "$transcript" 2 "$code_message"
     assert_code_block_is_its_own_view "$code_message" \
         "Here is the function you asked for" "def fib(n)"
     assert_tree_text "$code_message" "    return a"
 
-    assistant_message_only "$transcript" 2 "$table_message"
+    assistant_message_only "$transcript" 3 "$table_message"
     assert_rendered_as_separate_nodes "$table_message" "table cells" \
         "qwen3.5-9b" "5.2 GB" "74 tok/s" "llama-3.1-8b" "4.5 GB" "68 tok/s"
     jq -e '[.data.ui_elements[]?] as $e
@@ -4346,7 +4337,6 @@ case "$FLOW" in
     restored-tools) flow_restored_tools ;;
     tool-loop-budget) flow_tool_loop_budget ;;
     chat-depth) flow_chat_depth ;;
-    markdown-appearance) flow_markdown_appearance ;;
     math-rendering) flow_math_rendering ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
@@ -4373,7 +4363,6 @@ case "$FLOW" in
         flow_restored_tools
         flow_tool_loop_budget
         flow_chat_depth
-        flow_markdown_appearance
         flow_math_rendering
         flow_slow_stream_stop
         flow_model_crash_recovery

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -36,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
+Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, markdown-appearance, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -2883,38 +2883,6 @@ flow_chat_depth() {
     log "  no raw fences, pipe rows or list markers, code block nested and intact,"
     log "  and the CJK answer kept its emoji and its right-to-left run"
 
-    # #2056: changing appearance used to leave the code card resolved against
-    # the old theme. Exercise the live transition on a transcript that already
-    # contains both a fenced block and a table, then hold every rendered shape
-    # to the same contract in Dark before returning to the light baseline.
-    open_settings
-    see_settings "$OUT/depth-settings.json"
-    press "$OUT/depth-settings.json" Settings.Category.appearance \
-        "$OUT/depth-appearance-open.json" \
-        || die "Appearance category is not pressable during markdown theme coverage"
-    see_settings "$OUT/depth-appearance.json"
-    press "$OUT/depth-appearance.json" Settings.Appearance.Theme.dark \
-        "$OUT/depth-dark-press.json" \
-        || die "Dark appearance is not pressable during markdown theme coverage"
-    see_settings "$OUT/depth-dark.json"
-    jq -e '.data.ui_elements[]?
-           | select(.identifier == "Settings.Appearance.Theme.dark")
-           | select(.selected == true or .value == 1 or .value == "1")' \
-        "$OUT/depth-dark.json" >/dev/null \
-        || die "Dark appearance did not become selected"
-    transcript_only "$OUT/depth-dark.json" "$OUT/depth-dark-transcript.json"
-    assert_rendered_shapes "$OUT/depth-dark-transcript.json" "$OUT/depth-dark"
-
-    press "$OUT/depth-dark.json" Settings.Appearance.Theme.light \
-        "$OUT/depth-light-press.json" \
-        || die "Light appearance is not pressable after the dark markdown check"
-    see_settings "$OUT/depth-light.json"
-    jq -e '.data.ui_elements[]?
-           | select(.identifier == "Settings.Appearance.Theme.light")
-           | select(.selected == true or .value == 1 or .value == "1")' \
-        "$OUT/depth-light.json" >/dev/null \
-        || die "Light appearance did not become selected"
-    log "  live Light → Dark → Light kept code blocks and tables rendered"
     baseline chat-depth.five-turns "$OUT/turn5-settled.json"
 
     # Restore has to bring back the WHOLE conversation. `chat-restore` only
@@ -2947,6 +2915,68 @@ flow_chat_depth() {
     log "  and every shape still rendered the way it was before the relaunch"
     baseline chat-depth.restored "$OUT/depth-restored-transcript.json"
     cleanup_persona
+}
+
+flow_markdown_appearance() {
+    # #2056: a two-turn counterpart to chat-depth that fits the hosted
+    # runner's 1024x681 window. Five turns are intentionally excluded from CI
+    # because transcript virtualization removes the oldest AX nodes there;
+    # two keep both the fenced block and table realised while still exercising
+    # the real runtime appearance transition.
+    start_persona markdown-appearance
+    dismiss_first_run
+    start_model
+    send_prompt "shape:code show me fibonacci in python" "markdown-code"
+    wait_send_idle "$OUT/code-settled.json"
+    send_prompt "shape:table compare those two models for me" "markdown-table"
+    wait_send_idle "$OUT/table-settled.json"
+
+    transcript_only "$OUT/table-settled.json" "$OUT/light-transcript.json"
+    assert_markdown_code_and_table "$OUT/light-transcript.json" "$OUT/light"
+
+    open_settings
+    see_settings "$OUT/settings.json"
+    press "$OUT/settings.json" Settings.Category.appearance "$OUT/appearance-open.json" \
+        || die "Appearance category is not pressable during markdown theme coverage"
+    see_settings "$OUT/appearance.json"
+    press "$OUT/appearance.json" Settings.Appearance.Theme.dark "$OUT/dark-press.json" \
+        || die "Dark appearance is not pressable during markdown theme coverage"
+    see_settings "$OUT/dark.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.dark")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/dark.json" >/dev/null || die "Dark appearance did not become selected"
+    transcript_only "$OUT/dark.json" "$OUT/dark-transcript.json"
+    assert_markdown_code_and_table "$OUT/dark-transcript.json" "$OUT/dark"
+
+    press "$OUT/dark.json" Settings.Appearance.Theme.light "$OUT/light-press.json" \
+        || die "Light appearance is not pressable after the dark markdown check"
+    see_settings "$OUT/light.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.light")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/light.json" >/dev/null || die "Light appearance did not become selected"
+    log "  live Light → Dark → Light kept code blocks and tables rendered"
+    cleanup_persona
+}
+
+assert_markdown_code_and_table() {
+    local transcript="$1" scratch="$2"
+    local code_message="$scratch-code.json" table_message="$scratch-table.json"
+    assistant_message_only "$transcript" 1 "$code_message"
+    assert_code_block_is_its_own_view "$code_message" \
+        "Here is the function you asked for" "def fib(n)"
+    assert_tree_text "$code_message" "    return a"
+
+    assistant_message_only "$transcript" 2 "$table_message"
+    assert_rendered_as_separate_nodes "$table_message" "table cells" \
+        "qwen3.5-9b" "5.2 GB" "74 tok/s" "llama-3.1-8b" "4.5 GB" "68 tok/s"
+    jq -e '[.data.ui_elements[]?] as $e
+            | any($e[]; .role == "AXOutline" and .description == "Markdown table")
+              and ([ $e[] | select(.role == "AXRow") ] | length >= 2)
+              and ([ $e[] | select(.role == "AXCell") ] | length >= 6)' \
+        "$table_message" >/dev/null \
+        || die "markdown table lost its navigable row/cell structure"
 }
 
 flow_catalog_integrity() {
@@ -4316,6 +4346,7 @@ case "$FLOW" in
     restored-tools) flow_restored_tools ;;
     tool-loop-budget) flow_tool_loop_budget ;;
     chat-depth) flow_chat_depth ;;
+    markdown-appearance) flow_markdown_appearance ;;
     math-rendering) flow_math_rendering ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
@@ -4342,6 +4373,7 @@ case "$FLOW" in
         flow_restored_tools
         flow_tool_loop_budget
         flow_chat_depth
+        flow_markdown_appearance
         flow_math_rendering
         flow_slow_stream_stop
         flow_model_crash_recovery

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2882,6 +2882,39 @@ flow_chat_depth() {
     log "  markdown rendered: table cells and list items are their own elements,"
     log "  no raw fences, pipe rows or list markers, code block nested and intact,"
     log "  and the CJK answer kept its emoji and its right-to-left run"
+
+    # #2056: changing appearance used to leave the code card resolved against
+    # the old theme. Exercise the live transition on a transcript that already
+    # contains both a fenced block and a table, then hold every rendered shape
+    # to the same contract in Dark before returning to the light baseline.
+    open_settings
+    see_settings "$OUT/depth-settings.json"
+    press "$OUT/depth-settings.json" Settings.Category.appearance \
+        "$OUT/depth-appearance-open.json" \
+        || die "Appearance category is not pressable during markdown theme coverage"
+    see_settings "$OUT/depth-appearance.json"
+    press "$OUT/depth-appearance.json" Settings.Appearance.Theme.dark \
+        "$OUT/depth-dark-press.json" \
+        || die "Dark appearance is not pressable during markdown theme coverage"
+    see_settings "$OUT/depth-dark.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.dark")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/depth-dark.json" >/dev/null \
+        || die "Dark appearance did not become selected"
+    transcript_only "$OUT/depth-dark.json" "$OUT/depth-dark-transcript.json"
+    assert_rendered_shapes "$OUT/depth-dark-transcript.json" "$OUT/depth-dark"
+
+    press "$OUT/depth-dark.json" Settings.Appearance.Theme.light \
+        "$OUT/depth-light-press.json" \
+        || die "Light appearance is not pressable after the dark markdown check"
+    see_settings "$OUT/depth-light.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.light")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/depth-light.json" >/dev/null \
+        || die "Light appearance did not become selected"
+    log "  live Light → Dark → Light kept code blocks and tables rendered"
     baseline chat-depth.five-turns "$OUT/turn5-settled.json"
 
     # Restore has to bring back the WHOLE conversation. `chat-restore` only


### PR DESCRIPTION
## What does this PR do?

  - Adds appearance-aware colors for Markdown code block backgrounds and borders.
  - Re-resolves code block colors and syntax highlighting when macOS switches between light and dark mode.
  - Adds table header fills, borders, and grid lines in both appearance modes.
  - Replaces independently sized table rows with SwiftUI `Grid` so columns remain aligned when cells wrap.

  ## Why is this needed?

  Markdown code blocks could blend into the chat canvas in light mode and remain near-white after switching to dark mode, making dark-theme syntax highlighting difficult to read.

  Markdown tables also lacked enough visual structure and sized each row independently, causing them to look like loose text and producing misaligned columns when cells contained longer content. This restores clear, readable Markdown rendering across both appearance modes.