### PR TITLE
feat(chat): name conversations, and offer what to ask next

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/BackgroundCompletionClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/BackgroundCompletionClient.swift
@@ -110,7 +110,18 @@ struct BackgroundCompletionClient {
         defer { timeout.cancel() }
 
         do {
-            try await work.value
+            // `work` is unstructured, so it does not inherit cancellation from
+            // whoever is awaiting it, and `work.value` is not itself a
+            // cancellation-aware suspension point. Without this handler,
+            // cancelling the caller left the request running for the whole
+            // deadline — measured at 6.3s against a server that never
+            // answered, holding an engine admission slot in front of the turn
+            // the reader had just asked for.
+            try await withTaskCancellationHandler {
+                try await work.value
+            } onCancel: {
+                work.cancel()
+            }
         } catch {
             return nil
         }

--- a/apps/rapid-mac/Sources/Rapid/Chat/BackgroundCompletionClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/BackgroundCompletionClient.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// One completion, taken for the app's own purposes rather than the reader's.
+///
+/// Both background features — naming a conversation and proposing follow-up
+/// questions — need the same thing: ask the model something short, get a
+/// string back, and if anything at all goes wrong, get nothing back and say
+/// nothing about it. That contract is the whole type.
+///
+/// ## Why it streams
+///
+/// The wire body's `stream` is hardcoded `true` (``ChatStreamClient``), and a
+/// one-shot `stream: false` path would be the first desktop code to use the
+/// server's non-streaming branch — untested here, and worse, invisible to the
+/// one harness that can drive this end to end: `scripts/fake-rapid-mlx.sh`
+/// answers every chat request with `Content-Type: text/event-stream` and never
+/// reads the `stream` field at all, so a JSON-expecting client would decode-fail
+/// in the golden flows and silently fall back forever. Accumulating deltas also
+/// inherits what ``ChatStreamClient/send(_:bearerToken:onEvent:)`` already
+/// owns: bearer injection, the pre-stream retry, HTTP-status bodies drained
+/// into a readable error, the SSE line cap, `[DONE]`, and both cancellation
+/// shapes. For a ≤96-token reply the framing overhead is noise.
+///
+/// ## Why it can never be loud
+///
+/// There is no error surface, no retry, and no log the reader sees — the same
+/// contract ``ServerProfileFetcher`` states for its own background fetch:
+/// there is no UI affordance for "the title call failed" because there is
+/// nothing the reader could do about it. Every failure is `nil`, and every
+/// caller treats `nil` as "leave things as they are".
+@MainActor
+struct BackgroundCompletionClient {
+
+    /// Where to send, resolved at call time.
+    ///
+    /// Never cached: ``ServerManager/activeBearer`` rotates on every `start()`
+    /// and is cleared on stop and on crash, so a handle held across a restart
+    /// is a guaranteed 401. The alias comes from the `.ready(alias:)` state
+    /// for the same reason it must not be chosen freely — naming a model that
+    /// is not resident would issue a real `/v1/models/load`, and with the
+    /// assistant replacement group that evicts the model the reader is using.
+    struct Target {
+        let port: Int
+        let bearer: String?
+        let alias: String
+    }
+
+    /// Test seam. Production leaves this nil and takes
+    /// ``ChatStreamClient``'s shared ephemeral session.
+    var session: URLSession?
+
+    /// The reply text, or nil.
+    ///
+    /// `deadline` is a ceiling on the whole call, separate from the client's
+    /// inactivity timeout: a background request that is merely slow is one we
+    /// would rather abandon than let sit in the engine's batch.
+    func complete(
+        _ messages: [ChatMessage],
+        target: Target,
+        maxTokens: Int,
+        temperature: Double,
+        topP: Double = 0.9,
+        deadline: Duration
+    ) async -> String? {
+        var client = ChatStreamClient(
+            baseURL: ChatStreamClient.loopbackURL(port: target.port),
+            session: session
+        )
+        client.requestTimeout = 20
+
+        let request = ChatStreamClient.Request(
+            alias: target.alias,
+            messages: messages,
+            temperature: temperature,
+            topP: topP,
+            maxTokens: maxTokens,
+            // No tools: a background call that advertises them can finish
+            // with `tool_calls` and no content at all.
+            tools: nil,
+            // Mandatory. On a hybrid model with thinking on, the reasoning
+            // trace alone exhausts a 24-token budget and the reply comes back
+            // `finish_reason: "length"` with empty content — the failure
+            // ``SamplingConfig`` documents. Both features would be
+            // permanently dead on Qwen 3.x and its relatives.
+            enableThinking: false,
+            forcedTool: nil
+        )
+        // Note what is NOT here: any stop sequence. ``Request`` cannot express
+        // one, which is the point — the engine's batch-compatibility key is
+        // `(frozenset(stop_token_ids), bool(ignore_eos))`, and a request whose
+        // key differs from the live batch is requeued until every running
+        // request drains. Being unable to set it is a stronger guarantee than
+        // remembering not to.
+
+        let sink = TextSink()
+        // Two tasks racing rather than a task group: the send closure
+        // captures a main-actor client, which a group's `sending` parameter
+        // will not accept. Cancelling the work closes the socket, which the
+        // engine's disconnect guard turns into an abort that frees its
+        // admission slot — so an abandoned call stops costing anything.
+        let work = Task { @MainActor in
+            try await client.send(request, bearerToken: target.bearer) { event in
+                if case .content(let delta) = event { sink.text += delta }
+            }
+        }
+        let timeout = Task {
+            try await Task.sleep(for: deadline)
+            work.cancel()
+        }
+        defer { timeout.cancel() }
+
+        do {
+            try await work.value
+        } catch {
+            return nil
+        }
+
+        let text = sink.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
+    /// The accumulator has to be a reference: ``ChatStreamClient/send``'s
+    /// handler is an escaping `@MainActor` closure, which cannot capture a
+    /// mutable local.
+    @MainActor private final class TextSink {
+        var text = ""
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -449,6 +449,14 @@ final class ChatViewModel {
         inflight = nil
         backgroundAssist?.cancel()
         backgroundAssist = nil
+        // The rail belongs to the assist, so it is torn down with it. Keeping
+        // this here rather than at the call sites is the same argument the
+        // helper was created for, and the same bug: of the six sites, three
+        // remembered to put the rail away and three did not. A cancelled
+        // assist exits without publishing, so nothing downstream clears the
+        // anchor — and `ChatView` mounts the rail on the anchor alone, at a
+        // fixed height whatever it shows.
+        clearFollowUps()
     }
 
     /// A settled assistant answer worth building on.
@@ -826,7 +834,6 @@ final class ChatViewModel {
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
         cancelInflightWork()
-        clearFollowUps()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -854,7 +861,6 @@ final class ChatViewModel {
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
             cancelInflightWork()
-            clearFollowUps()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -984,7 +990,6 @@ final class ChatViewModel {
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
         cancelInflightWork()
-        clearFollowUps()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it
@@ -1064,7 +1069,6 @@ final class ChatViewModel {
         // has moved on, and on the serialised vision lane it would be sitting
         // in front of the turn they just asked for.
         cancelInflightWork()
-        followUp = .idle
 
         let user = ChatMessage(
             role: .user,

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -443,6 +443,14 @@ final class ChatViewModel {
         inflight = nil
         backgroundAssist?.cancel()
         backgroundAssist = nil
+        // The rail belongs to the assist, so it is torn down with it. Keeping
+        // this here rather than at the call sites is the same argument the
+        // helper was created for, and the same bug: of the six sites, three
+        // remembered to put the rail away and three did not. A cancelled
+        // assist exits without publishing, so nothing downstream clears the
+        // anchor — and `ChatView` mounts the rail on the anchor alone, at a
+        // fixed height whatever it shows.
+        clearFollowUps()
     }
 
     /// A settled assistant answer worth building on.
@@ -820,7 +828,6 @@ final class ChatViewModel {
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
         cancelInflightWork()
-        clearFollowUps()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -848,7 +855,6 @@ final class ChatViewModel {
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
             cancelInflightWork()
-            clearFollowUps()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -941,7 +947,6 @@ final class ChatViewModel {
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
         cancelInflightWork()
-        clearFollowUps()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it
@@ -1016,7 +1021,6 @@ final class ChatViewModel {
         // has moved on, and on the serialised vision lane it would be sitting
         // in front of the turn they just asked for.
         cancelInflightWork()
-        followUp = .idle
 
         // Small local models are unreliable at the first step of tool use:
         // deciding that an explicitly live/dated question needs the web. Do

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -455,6 +455,10 @@ final class ChatViewModel {
     struct SettledTurn: Equatable {
         let assistantID: UUID
         let lastUserText: String
+        /// The answer being followed up on. Used as the language reference,
+        /// because it is longer and more representative of the conversation
+        /// than a user message that might be one English word.
+        let assistantText: String
     }
 
     /// The transcript ends in an answer a reader could act on, or nil.
@@ -475,7 +479,9 @@ final class ChatViewModel {
               (last.toolCalls?.isEmpty ?? true),
               let user = messages.last(where: { $0.role == .user })
         else { return nil }
-        return SettledTurn(assistantID: last.id, lastUserText: user.content)
+        return SettledTurn(
+            assistantID: last.id, lastUserText: user.content, assistantText: last.content
+        )
     }
 
     /// Is this the first exchange — the only one that gets a title?
@@ -497,16 +503,21 @@ final class ChatViewModel {
     /// otherwise disable both features permanently, and the damage on that
     /// path is already bounded by `max_tokens`, the deadline, and the fact
     /// that the reader's next send cancels us.
+    ///
+    /// There is deliberately no "is the model busy" clause. One was here and
+    /// was wrong twice over. On the batched text lane a busy model is the
+    /// normal case and costs nothing — continuous batching is why this
+    /// feature is affordable at all. And the only writer of `residency` polls
+    /// every five seconds (``ContentView``), so at a turn boundary the
+    /// freshest snapshot was taken *during* the answer: any reply that
+    /// streamed for five seconds or more was guaranteed to look busy, which
+    /// silently disabled both features on exactly the long answers follow-ups
+    /// exist for. On the serialised lane, `modality` already refuses.
     nonisolated static func laneAllowsBackgroundWork(
         _ residency: ModelResidencySnapshot, alias: String
     ) -> Bool {
-        if let modality = residency.modality(for: alias), modality != "text" {
-            return false
-        }
-        if let active = residency.activeRequests(for: alias), active > 0 {
-            return false
-        }
-        return true
+        guard let modality = residency.modality(for: alias) else { return true }
+        return modality == "text"
     }
 
     /// Ask the model to name this conversation and to propose what to ask
@@ -525,9 +536,13 @@ final class ChatViewModel {
         let conversationID = activeConversationID
         let epoch = conversationEpoch
         let transcript = messages
-        let needsTitle = Self.isFirstExchange(messages)
-            && conversations.first { $0.id == conversationID }
-                .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
+        // Not "is this the first exchange": that forfeits the one chance
+        // permanently if the call is cancelled, which `send` does on the very
+        // next message. `hasGeneratedTitle` already means "a title has
+        // landed", so gating on it keeps the once-per-conversation promise
+        // while letting a cancelled or failed attempt be retried next turn.
+        let needsTitle = conversations.first { $0.id == conversationID }
+            .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
 
         followUp = .pending
         followUpAnchorID = turn.assistantID
@@ -545,24 +560,38 @@ final class ChatViewModel {
             // conversation, so its double occupancy of the engine is a
             // once-ever event, while the chips are what the reader is waiting
             // to see on every turn.
-            async let titleReply: String? = needsTitle
-                ? client.complete(
-                    ConversationTitleSuggestion.messages(forFirstExchange: transcript) ?? [],
-                    target: target, maxTokens: 24, temperature: 0.2, deadline: .seconds(15)
-                )
+            let titlePrompt = needsTitle
+                ? ConversationTitleSuggestion.messages(forFirstExchange: transcript)
                 : nil
-            async let followUpReply: String? = client.complete(
-                FollowUpSuggestion.messages(forTurn: transcript) ?? [],
-                target: target, maxTokens: 96, temperature: 0.6, topP: 0.95,
-                deadline: .seconds(8)
-            )
+            async let titleReply: String? = {
+                guard let titlePrompt else { return nil }
+                return await client.complete(
+                    titlePrompt, target: target, maxTokens: 24,
+                    temperature: 0.2, deadline: .seconds(15)
+                )
+            }()
+            let followUpPrompt = FollowUpSuggestion.messages(forTurn: transcript)
+            async let followUpReply: String? = {
+                guard let followUpPrompt else { return nil }
+                return await client.complete(
+                    followUpPrompt, target: target, maxTokens: 96,
+                    temperature: 0.6, topP: 0.95, deadline: .seconds(8)
+                )
+            }()
 
             let (title, suggestions) = await (titleReply, followUpReply)
-            guard !Task.isCancelled, epoch == self.conversationEpoch else { return }
+            guard !Task.isCancelled, epoch == self.conversationEpoch else {
+                // Cancelled after the rail reserved its space. Without this it
+                // stays `.pending` — a blank band with no way out but a new
+                // turn.
+                self.clearFollowUps()
+                return
+            }
 
             if let title { self.applyGeneratedTitle(title, to: conversationID) }
             self.publishFollowUps(
-                suggestions, anchoredTo: turn.assistantID, excluding: turn.lastUserText
+                suggestions, anchoredTo: turn.assistantID,
+                excluding: turn.lastUserText, reference: turn.assistantText
             )
         }
     }
@@ -573,18 +602,43 @@ final class ChatViewModel {
     /// from a test without a server — the same reason
     /// ``finishStartupCancellation`` is its own method.
     func publishFollowUps(
-        _ raw: String?, anchoredTo anchorID: UUID, excluding lastUserText: String
+        _ raw: String?,
+        anchoredTo anchorID: UUID,
+        excluding lastUserText: String,
+        reference: String? = nil
     ) {
         // One condition covers a switched conversation, a deleted one, a new
         // turn, and an edit or retry that rewrote the tail.
         guard messages.last?.id == anchorID else {
-            followUp = .idle
-            followUpAnchorID = nil
+            clearFollowUps()
             return
         }
-        guard let raw else { followUp = .idle; return }
-        let questions = FollowUpSuggestion.parse(raw, excluding: lastUserText)
-        followUp = questions.isEmpty ? .idle : .ready(questions)
+        guard let raw else { clearFollowUps(); return }
+        let questions = FollowUpSuggestion.parse(
+            raw, excluding: lastUserText, reference: reference
+        )
+        guard !questions.isEmpty else { clearFollowUps(); return }
+        // Sets the anchor as well as the state. `scheduleBackgroundAssist`
+        // already set it before spawning, but publishing one without the other
+        // is a combination the screen can never show — ``ChatView`` mounts the
+        // rail on the anchor — so the two are written together here rather
+        // than depending on a caller having done half the job.
+        followUpAnchorID = anchorID
+        followUp = .ready(questions)
+    }
+
+    /// Put the rail away.
+    ///
+    /// Clearing the anchor as well as the state is the load-bearing half:
+    /// ``ChatView`` mounts the rail on the anchor alone, and the rail holds a
+    /// fixed 40pt whatever it is showing. Leaving the anchor set after a
+    /// failure — a deadline, unparseable output, a script mismatch, all of
+    /// which are common — left an empty band under the answer until the next
+    /// turn. Shrinking the document is safe; it is growth the scroll probe
+    /// cannot absorb.
+    func clearFollowUps() {
+        followUp = .idle
+        followUpAnchorID = nil
     }
 
     /// Land a machine-generated title. Silent on every rejection.
@@ -772,6 +826,7 @@ final class ChatViewModel {
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
         cancelInflightWork()
+        clearFollowUps()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -799,6 +854,7 @@ final class ChatViewModel {
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
             cancelInflightWork()
+            clearFollowUps()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -928,6 +984,7 @@ final class ChatViewModel {
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
         cancelInflightWork()
+        clearFollowUps()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -204,7 +204,10 @@ final class ChatViewModel {
             // A turn just ended (stream finished, failed, or was stopped) —
             // snapshot the final exchange into history + disk. Covers every
             // completion path without hooking each one.
-            if oldValue && !isStreaming { persistActive() }
+            if oldValue && !isStreaming {
+                persistActive()
+                scheduleBackgroundAssist()
+            }
         }
     }
     /// Most recent transport / parse error. Cleared on the next ``send``.
@@ -228,6 +231,27 @@ final class ChatViewModel {
     private(set) var lastFailureAlias: String?
 
     private var inflight: Task<Void, Never>?
+
+    /// The title / follow-up completions. One handle for both arms, so one
+    /// `cancel()` stops everything this model started on its own account.
+    private var backgroundAssist: Task<Void, Never>?
+
+    /// Chips under the last answer. Never persisted — a restored transcript
+    /// shows no suggestions, which is right: they were about a moment.
+    private(set) var followUp: FollowUpState = .idle
+
+    /// The message the current chips belong to. Publishing is gated on this
+    /// still being the last row, which covers a new turn, an edit, a retry,
+    /// and a conversation switch in one condition.
+    private(set) var followUpAnchorID: UUID?
+
+    enum FollowUpState: Equatable {
+        /// Nothing asked for, or nothing came back.
+        case idle
+        /// Asked; the rail is holding its space so the arrival costs no layout.
+        case pending
+        case ready([String])
+    }
 
     /// Tests that exercise turn replay can disable disk I/O so seeded
     /// transcripts never read or overwrite the user's conversation history.
@@ -382,7 +406,10 @@ final class ChatViewModel {
                 // A renamed row keeps its name. Re-deriving unconditionally
                 // meant the next streamed token silently reverted the user's
                 // rename back to the first prompt's opening words.
-                if !conversation.hasCustomTitle {
+                // Two owners can take the title away from the derivation:
+                // the user (a rename) and the background titler. Neither may
+                // be reverted by the next streamed token.
+                if !conversation.hasCustomTitle && !conversation.hasGeneratedTitle {
                     conversation.title = title
                 }
                 conversation.customInstructions = Self.normalizedInstruction(
@@ -405,6 +432,178 @@ final class ChatViewModel {
                 at: 0
             )
         }
+        saveConversations()
+    }
+
+    // MARK: - Background assist (titles, follow-ups)
+
+    /// Every task this model started on its own account, plus the reader's
+    /// stream.
+    ///
+    /// Folded into one helper because all five call sites were already
+    /// performing the identical two-line dance for ``inflight``, and a second
+    /// task would have made that six places to remember. The class of bug
+    /// this removes is "somebody added a third task and missed site four".
+    private func cancelInflightWork() {
+        inflight?.cancel()
+        inflight = nil
+        backgroundAssist?.cancel()
+        backgroundAssist = nil
+    }
+
+    /// A settled assistant answer worth building on.
+    struct SettledTurn: Equatable {
+        let assistantID: UUID
+        let lastUserText: String
+    }
+
+    /// The transcript ends in an answer a reader could act on, or nil.
+    ///
+    /// Mirrors ``MessageRow``'s `showsAssistantActions`: an answer worth a
+    /// Copy button is an answer worth following up on, and keeping the two
+    /// judgements the same means chips never appear under a row that offers
+    /// no other affordance. Adds one clause of its own — a turn the reader
+    /// stopped is one they did not want more of.
+    nonisolated static func settledTurn(_ messages: [ChatMessage]) -> SettledTurn? {
+        guard let last = messages.last,
+              last.role == .assistant,
+              last.status == .complete,
+              // ``finaliseCancellation`` marks a stopped turn this way.
+              last.errorMessage != "Stopped.",
+              !last.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              // A tool-dispatch shell is scaffolding, not an answer.
+              (last.toolCalls?.isEmpty ?? true),
+              let user = messages.last(where: { $0.role == .user })
+        else { return nil }
+        return SettledTurn(assistantID: last.id, lastUserText: user.content)
+    }
+
+    /// Is this the first exchange — the only one that gets a title?
+    nonisolated static func isFirstExchange(_ messages: [ChatMessage]) -> Bool {
+        messages.filter { $0.role == .user }.count == 1
+    }
+
+    /// Whether the engine's lane will batch our request alongside the
+    /// reader's, or serialise it in front of their next turn.
+    ///
+    /// The `--mllm` vision lane runs one request at a time, so a background
+    /// call there is not free — it is a queue. Residency carries the engine's
+    /// own modality per alias, which is the authoritative signal;
+    /// ``ModelBrandStyle/modelType(forAlias:)`` is a name-based guess that
+    /// classifies whole families as vision and would kill this feature on the
+    /// most common models.
+    ///
+    /// An unknown alias allows. A sidecar too old to report residency would
+    /// otherwise disable both features permanently, and the damage on that
+    /// path is already bounded by `max_tokens`, the deadline, and the fact
+    /// that the reader's next send cancels us.
+    nonisolated static func laneAllowsBackgroundWork(
+        _ residency: ModelResidencySnapshot, alias: String
+    ) -> Bool {
+        if let modality = residency.modality(for: alias), modality != "text" {
+            return false
+        }
+        if let active = residency.activeRequests(for: alias), active > 0 {
+            return false
+        }
+        return true
+    }
+
+    /// Ask the model to name this conversation and to propose what to ask
+    /// next. Runs at the turn boundary; every reason not to is checked here,
+    /// on the main actor, before anything is spawned.
+    private func scheduleBackgroundAssist() {
+        // Last turn's chips are stale the moment this turn ends, whatever
+        // happens next.
+        followUp = .idle
+        followUpAnchorID = nil
+
+        guard let server, case .ready(let alias) = server.state else { return }
+        guard Self.laneAllowsBackgroundWork(server.residency, alias: alias) else { return }
+        guard let turn = Self.settledTurn(messages) else { return }
+
+        let conversationID = activeConversationID
+        let epoch = conversationEpoch
+        let transcript = messages
+        let needsTitle = Self.isFirstExchange(messages)
+            && conversations.first { $0.id == conversationID }
+                .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
+
+        followUp = .pending
+        followUpAnchorID = turn.assistantID
+
+        backgroundAssist = Task { [weak self] in
+            guard let self else { return }
+            let target = BackgroundCompletionClient.Target(
+                port: server.activePort,
+                bearer: server.activeBearer,
+                alias: alias
+            )
+            let client = BackgroundCompletionClient()
+
+            // Concurrent rather than sequential: the title happens once per
+            // conversation, so its double occupancy of the engine is a
+            // once-ever event, while the chips are what the reader is waiting
+            // to see on every turn.
+            async let titleReply: String? = needsTitle
+                ? client.complete(
+                    ConversationTitleSuggestion.messages(forFirstExchange: transcript) ?? [],
+                    target: target, maxTokens: 24, temperature: 0.2, deadline: .seconds(15)
+                )
+                : nil
+            async let followUpReply: String? = client.complete(
+                FollowUpSuggestion.messages(forTurn: transcript) ?? [],
+                target: target, maxTokens: 96, temperature: 0.6, topP: 0.95,
+                deadline: .seconds(8)
+            )
+
+            let (title, suggestions) = await (titleReply, followUpReply)
+            guard !Task.isCancelled, epoch == self.conversationEpoch else { return }
+
+            if let title { self.applyGeneratedTitle(title, to: conversationID) }
+            self.publishFollowUps(
+                suggestions, anchoredTo: turn.assistantID, excluding: turn.lastUserText
+            )
+        }
+    }
+
+    /// Show the chips, if they are still about the answer on screen.
+    ///
+    /// Split out rather than left inline so the staleness rule is reachable
+    /// from a test without a server — the same reason
+    /// ``finishStartupCancellation`` is its own method.
+    func publishFollowUps(
+        _ raw: String?, anchoredTo anchorID: UUID, excluding lastUserText: String
+    ) {
+        // One condition covers a switched conversation, a deleted one, a new
+        // turn, and an edit or retry that rewrote the tail.
+        guard messages.last?.id == anchorID else {
+            followUp = .idle
+            followUpAnchorID = nil
+            return
+        }
+        guard let raw else { followUp = .idle; return }
+        let questions = FollowUpSuggestion.parse(raw, excluding: lastUserText)
+        followUp = questions.isEmpty ? .idle : .ready(questions)
+    }
+
+    /// Land a machine-generated title. Silent on every rejection.
+    ///
+    /// Addresses the conversation by id rather than by "whichever is active",
+    /// so a late reply cannot rename the wrong row — the epoch check above
+    /// already dropped it, and this makes the write safe even if that check
+    /// were ever relaxed.
+    ///
+    /// Deliberately does not touch `updatedAt`: naming a row is not working
+    /// on it, so the sidebar must not reshuffle. Same choice
+    /// ``renameConversation`` makes, and for the same reason.
+    func applyGeneratedTitle(_ raw: String, to id: UUID) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        guard !conversations[index].hasCustomTitle else { return }
+        guard !conversations[index].hasGeneratedTitle else { return }
+        guard let title = ConversationTitleSuggestion.parse(raw) else { return }
+        conversations[index].title = title
+        conversations[index].hasGeneratedTitle = true
         saveConversations()
     }
 
@@ -572,8 +771,7 @@ final class ChatViewModel {
     /// currently open first. Cancels any in-flight stream.
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
-        inflight?.cancel()
-        inflight = nil
+        cancelInflightWork()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -600,8 +798,7 @@ final class ChatViewModel {
         // persistActive() via didSet while the deleted messages + id are
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
-            inflight?.cancel()
-            inflight = nil
+            cancelInflightWork()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -730,8 +927,7 @@ final class ChatViewModel {
     /// Start a fresh conversation — drops the transcript and any stale
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
-        inflight?.cancel()
-        inflight = nil
+        cancelInflightWork()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it
@@ -805,6 +1001,13 @@ final class ChatViewModel {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty || !imageAttachments.isEmpty || !fileAttachments.isEmpty else { return }
         guard !isStreaming else { return }
+
+        // The reader has taken the wheel. Anything we were asking the model
+        // on our own account stops now — it would land on a transcript that
+        // has moved on, and on the serialised vision lane it would be sitting
+        // in front of the turn they just asked for.
+        cancelInflightWork()
+        followUp = .idle
 
         let user = ChatMessage(
             role: .user,
@@ -1062,7 +1265,7 @@ final class ChatViewModel {
     /// has produced so far. The placeholder transitions to ``.complete``
     /// with whatever bytes already arrived.
     func stop() {
-        inflight?.cancel()
+        cancelInflightWork()
     }
 
     /// Stop AND snapshot, synchronously, for the app-termination path.
@@ -1076,7 +1279,7 @@ final class ChatViewModel {
     /// actor. The task's own cleanup remains harmless: it re-persists the same
     /// state if it ever gets to run.
     func stopAndPersist() {
-        inflight?.cancel()
+        cancelInflightWork()
         guard isStreaming else { return }
         // Finalise through the SHARED cancellation contract before snapshotting.
         // Persisting a message still marked ``.streaming`` writes a turn that

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -204,7 +204,10 @@ final class ChatViewModel {
             // A turn just ended (stream finished, failed, or was stopped) —
             // snapshot the final exchange into history + disk. Covers every
             // completion path without hooking each one.
-            if oldValue && !isStreaming { persistActive() }
+            if oldValue && !isStreaming {
+                persistActive()
+                scheduleBackgroundAssist()
+            }
         }
     }
     /// Most recent transport / parse error. Cleared on the next ``send``.
@@ -228,6 +231,27 @@ final class ChatViewModel {
     private(set) var lastFailureAlias: String?
 
     private var inflight: Task<Void, Never>?
+
+    /// The title / follow-up completions. One handle for both arms, so one
+    /// `cancel()` stops everything this model started on its own account.
+    private var backgroundAssist: Task<Void, Never>?
+
+    /// Chips under the last answer. Never persisted — a restored transcript
+    /// shows no suggestions, which is right: they were about a moment.
+    private(set) var followUp: FollowUpState = .idle
+
+    /// The message the current chips belong to. Publishing is gated on this
+    /// still being the last row, which covers a new turn, an edit, a retry,
+    /// and a conversation switch in one condition.
+    private(set) var followUpAnchorID: UUID?
+
+    enum FollowUpState: Equatable {
+        /// Nothing asked for, or nothing came back.
+        case idle
+        /// Asked; the rail is holding its space so the arrival costs no layout.
+        case pending
+        case ready([String])
+    }
 
     /// Tests that exercise turn replay can disable disk I/O so seeded
     /// transcripts never read or overwrite the user's conversation history.
@@ -376,7 +400,10 @@ final class ChatViewModel {
                 // A renamed row keeps its name. Re-deriving unconditionally
                 // meant the next streamed token silently reverted the user's
                 // rename back to the first prompt's opening words.
-                if !conversation.hasCustomTitle {
+                // Two owners can take the title away from the derivation:
+                // the user (a rename) and the background titler. Neither may
+                // be reverted by the next streamed token.
+                if !conversation.hasCustomTitle && !conversation.hasGeneratedTitle {
                     conversation.title = title
                 }
                 conversation.customInstructions = Self.normalizedInstruction(
@@ -399,6 +426,178 @@ final class ChatViewModel {
                 at: 0
             )
         }
+        saveConversations()
+    }
+
+    // MARK: - Background assist (titles, follow-ups)
+
+    /// Every task this model started on its own account, plus the reader's
+    /// stream.
+    ///
+    /// Folded into one helper because all five call sites were already
+    /// performing the identical two-line dance for ``inflight``, and a second
+    /// task would have made that six places to remember. The class of bug
+    /// this removes is "somebody added a third task and missed site four".
+    private func cancelInflightWork() {
+        inflight?.cancel()
+        inflight = nil
+        backgroundAssist?.cancel()
+        backgroundAssist = nil
+    }
+
+    /// A settled assistant answer worth building on.
+    struct SettledTurn: Equatable {
+        let assistantID: UUID
+        let lastUserText: String
+    }
+
+    /// The transcript ends in an answer a reader could act on, or nil.
+    ///
+    /// Mirrors ``MessageRow``'s `showsAssistantActions`: an answer worth a
+    /// Copy button is an answer worth following up on, and keeping the two
+    /// judgements the same means chips never appear under a row that offers
+    /// no other affordance. Adds one clause of its own — a turn the reader
+    /// stopped is one they did not want more of.
+    nonisolated static func settledTurn(_ messages: [ChatMessage]) -> SettledTurn? {
+        guard let last = messages.last,
+              last.role == .assistant,
+              last.status == .complete,
+              // ``finaliseCancellation`` marks a stopped turn this way.
+              last.errorMessage != "Stopped.",
+              !last.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              // A tool-dispatch shell is scaffolding, not an answer.
+              (last.toolCalls?.isEmpty ?? true),
+              let user = messages.last(where: { $0.role == .user })
+        else { return nil }
+        return SettledTurn(assistantID: last.id, lastUserText: user.content)
+    }
+
+    /// Is this the first exchange — the only one that gets a title?
+    nonisolated static func isFirstExchange(_ messages: [ChatMessage]) -> Bool {
+        messages.filter { $0.role == .user }.count == 1
+    }
+
+    /// Whether the engine's lane will batch our request alongside the
+    /// reader's, or serialise it in front of their next turn.
+    ///
+    /// The `--mllm` vision lane runs one request at a time, so a background
+    /// call there is not free — it is a queue. Residency carries the engine's
+    /// own modality per alias, which is the authoritative signal;
+    /// ``ModelBrandStyle/modelType(forAlias:)`` is a name-based guess that
+    /// classifies whole families as vision and would kill this feature on the
+    /// most common models.
+    ///
+    /// An unknown alias allows. A sidecar too old to report residency would
+    /// otherwise disable both features permanently, and the damage on that
+    /// path is already bounded by `max_tokens`, the deadline, and the fact
+    /// that the reader's next send cancels us.
+    nonisolated static func laneAllowsBackgroundWork(
+        _ residency: ModelResidencySnapshot, alias: String
+    ) -> Bool {
+        if let modality = residency.modality(for: alias), modality != "text" {
+            return false
+        }
+        if let active = residency.activeRequests(for: alias), active > 0 {
+            return false
+        }
+        return true
+    }
+
+    /// Ask the model to name this conversation and to propose what to ask
+    /// next. Runs at the turn boundary; every reason not to is checked here,
+    /// on the main actor, before anything is spawned.
+    private func scheduleBackgroundAssist() {
+        // Last turn's chips are stale the moment this turn ends, whatever
+        // happens next.
+        followUp = .idle
+        followUpAnchorID = nil
+
+        guard let server, case .ready(let alias) = server.state else { return }
+        guard Self.laneAllowsBackgroundWork(server.residency, alias: alias) else { return }
+        guard let turn = Self.settledTurn(messages) else { return }
+
+        let conversationID = activeConversationID
+        let epoch = conversationEpoch
+        let transcript = messages
+        let needsTitle = Self.isFirstExchange(messages)
+            && conversations.first { $0.id == conversationID }
+                .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
+
+        followUp = .pending
+        followUpAnchorID = turn.assistantID
+
+        backgroundAssist = Task { [weak self] in
+            guard let self else { return }
+            let target = BackgroundCompletionClient.Target(
+                port: server.activePort,
+                bearer: server.activeBearer,
+                alias: alias
+            )
+            let client = BackgroundCompletionClient()
+
+            // Concurrent rather than sequential: the title happens once per
+            // conversation, so its double occupancy of the engine is a
+            // once-ever event, while the chips are what the reader is waiting
+            // to see on every turn.
+            async let titleReply: String? = needsTitle
+                ? client.complete(
+                    ConversationTitleSuggestion.messages(forFirstExchange: transcript) ?? [],
+                    target: target, maxTokens: 24, temperature: 0.2, deadline: .seconds(15)
+                )
+                : nil
+            async let followUpReply: String? = client.complete(
+                FollowUpSuggestion.messages(forTurn: transcript) ?? [],
+                target: target, maxTokens: 96, temperature: 0.6, topP: 0.95,
+                deadline: .seconds(8)
+            )
+
+            let (title, suggestions) = await (titleReply, followUpReply)
+            guard !Task.isCancelled, epoch == self.conversationEpoch else { return }
+
+            if let title { self.applyGeneratedTitle(title, to: conversationID) }
+            self.publishFollowUps(
+                suggestions, anchoredTo: turn.assistantID, excluding: turn.lastUserText
+            )
+        }
+    }
+
+    /// Show the chips, if they are still about the answer on screen.
+    ///
+    /// Split out rather than left inline so the staleness rule is reachable
+    /// from a test without a server — the same reason
+    /// ``finishStartupCancellation`` is its own method.
+    func publishFollowUps(
+        _ raw: String?, anchoredTo anchorID: UUID, excluding lastUserText: String
+    ) {
+        // One condition covers a switched conversation, a deleted one, a new
+        // turn, and an edit or retry that rewrote the tail.
+        guard messages.last?.id == anchorID else {
+            followUp = .idle
+            followUpAnchorID = nil
+            return
+        }
+        guard let raw else { followUp = .idle; return }
+        let questions = FollowUpSuggestion.parse(raw, excluding: lastUserText)
+        followUp = questions.isEmpty ? .idle : .ready(questions)
+    }
+
+    /// Land a machine-generated title. Silent on every rejection.
+    ///
+    /// Addresses the conversation by id rather than by "whichever is active",
+    /// so a late reply cannot rename the wrong row — the epoch check above
+    /// already dropped it, and this makes the write safe even if that check
+    /// were ever relaxed.
+    ///
+    /// Deliberately does not touch `updatedAt`: naming a row is not working
+    /// on it, so the sidebar must not reshuffle. Same choice
+    /// ``renameConversation`` makes, and for the same reason.
+    func applyGeneratedTitle(_ raw: String, to id: UUID) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        guard !conversations[index].hasCustomTitle else { return }
+        guard !conversations[index].hasGeneratedTitle else { return }
+        guard let title = ConversationTitleSuggestion.parse(raw) else { return }
+        conversations[index].title = title
+        conversations[index].hasGeneratedTitle = true
         saveConversations()
     }
 
@@ -566,8 +765,7 @@ final class ChatViewModel {
     /// currently open first. Cancels any in-flight stream.
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
-        inflight?.cancel()
-        inflight = nil
+        cancelInflightWork()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -594,8 +792,7 @@ final class ChatViewModel {
         // persistActive() via didSet while the deleted messages + id are
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
-            inflight?.cancel()
-            inflight = nil
+            cancelInflightWork()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -687,8 +884,7 @@ final class ChatViewModel {
     /// Start a fresh conversation — drops the transcript and any stale
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
-        inflight?.cancel()
-        inflight = nil
+        cancelInflightWork()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it
@@ -757,6 +953,13 @@ final class ChatViewModel {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty || !imageAttachments.isEmpty || !fileAttachments.isEmpty else { return }
         guard !isStreaming else { return }
+
+        // The reader has taken the wheel. Anything we were asking the model
+        // on our own account stops now — it would land on a transcript that
+        // has moved on, and on the serialised vision lane it would be sitting
+        // in front of the turn they just asked for.
+        cancelInflightWork()
+        followUp = .idle
 
         // Small local models are unreliable at the first step of tool use:
         // deciding that an explicitly live/dated question needs the web. Do
@@ -1078,7 +1281,7 @@ final class ChatViewModel {
     /// has produced so far. The placeholder transitions to ``.complete``
     /// with whatever bytes already arrived.
     func stop() {
-        inflight?.cancel()
+        cancelInflightWork()
     }
 
     /// Stop AND snapshot, synchronously, for the app-termination path.
@@ -1092,7 +1295,7 @@ final class ChatViewModel {
     /// actor. The task's own cleanup remains harmless: it re-persists the same
     /// state if it ever gets to run.
     func stopAndPersist() {
-        inflight?.cancel()
+        cancelInflightWork()
         guard isStreaming else { return }
         // Finalise through the SHARED cancellation contract before snapshotting.
         // Persisting a message still marked ``.streaming`` writes a turn that

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -449,6 +449,10 @@ final class ChatViewModel {
     struct SettledTurn: Equatable {
         let assistantID: UUID
         let lastUserText: String
+        /// The answer being followed up on. Used as the language reference,
+        /// because it is longer and more representative of the conversation
+        /// than a user message that might be one English word.
+        let assistantText: String
     }
 
     /// The transcript ends in an answer a reader could act on, or nil.
@@ -469,7 +473,9 @@ final class ChatViewModel {
               (last.toolCalls?.isEmpty ?? true),
               let user = messages.last(where: { $0.role == .user })
         else { return nil }
-        return SettledTurn(assistantID: last.id, lastUserText: user.content)
+        return SettledTurn(
+            assistantID: last.id, lastUserText: user.content, assistantText: last.content
+        )
     }
 
     /// Is this the first exchange — the only one that gets a title?
@@ -491,16 +497,21 @@ final class ChatViewModel {
     /// otherwise disable both features permanently, and the damage on that
     /// path is already bounded by `max_tokens`, the deadline, and the fact
     /// that the reader's next send cancels us.
+    ///
+    /// There is deliberately no "is the model busy" clause. One was here and
+    /// was wrong twice over. On the batched text lane a busy model is the
+    /// normal case and costs nothing — continuous batching is why this
+    /// feature is affordable at all. And the only writer of `residency` polls
+    /// every five seconds (``ContentView``), so at a turn boundary the
+    /// freshest snapshot was taken *during* the answer: any reply that
+    /// streamed for five seconds or more was guaranteed to look busy, which
+    /// silently disabled both features on exactly the long answers follow-ups
+    /// exist for. On the serialised lane, `modality` already refuses.
     nonisolated static func laneAllowsBackgroundWork(
         _ residency: ModelResidencySnapshot, alias: String
     ) -> Bool {
-        if let modality = residency.modality(for: alias), modality != "text" {
-            return false
-        }
-        if let active = residency.activeRequests(for: alias), active > 0 {
-            return false
-        }
-        return true
+        guard let modality = residency.modality(for: alias) else { return true }
+        return modality == "text"
     }
 
     /// Ask the model to name this conversation and to propose what to ask
@@ -519,9 +530,13 @@ final class ChatViewModel {
         let conversationID = activeConversationID
         let epoch = conversationEpoch
         let transcript = messages
-        let needsTitle = Self.isFirstExchange(messages)
-            && conversations.first { $0.id == conversationID }
-                .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
+        // Not "is this the first exchange": that forfeits the one chance
+        // permanently if the call is cancelled, which `send` does on the very
+        // next message. `hasGeneratedTitle` already means "a title has
+        // landed", so gating on it keeps the once-per-conversation promise
+        // while letting a cancelled or failed attempt be retried next turn.
+        let needsTitle = conversations.first { $0.id == conversationID }
+            .map { !$0.hasCustomTitle && !$0.hasGeneratedTitle } == true
 
         followUp = .pending
         followUpAnchorID = turn.assistantID
@@ -539,24 +554,38 @@ final class ChatViewModel {
             // conversation, so its double occupancy of the engine is a
             // once-ever event, while the chips are what the reader is waiting
             // to see on every turn.
-            async let titleReply: String? = needsTitle
-                ? client.complete(
-                    ConversationTitleSuggestion.messages(forFirstExchange: transcript) ?? [],
-                    target: target, maxTokens: 24, temperature: 0.2, deadline: .seconds(15)
-                )
+            let titlePrompt = needsTitle
+                ? ConversationTitleSuggestion.messages(forFirstExchange: transcript)
                 : nil
-            async let followUpReply: String? = client.complete(
-                FollowUpSuggestion.messages(forTurn: transcript) ?? [],
-                target: target, maxTokens: 96, temperature: 0.6, topP: 0.95,
-                deadline: .seconds(8)
-            )
+            async let titleReply: String? = {
+                guard let titlePrompt else { return nil }
+                return await client.complete(
+                    titlePrompt, target: target, maxTokens: 24,
+                    temperature: 0.2, deadline: .seconds(15)
+                )
+            }()
+            let followUpPrompt = FollowUpSuggestion.messages(forTurn: transcript)
+            async let followUpReply: String? = {
+                guard let followUpPrompt else { return nil }
+                return await client.complete(
+                    followUpPrompt, target: target, maxTokens: 96,
+                    temperature: 0.6, topP: 0.95, deadline: .seconds(8)
+                )
+            }()
 
             let (title, suggestions) = await (titleReply, followUpReply)
-            guard !Task.isCancelled, epoch == self.conversationEpoch else { return }
+            guard !Task.isCancelled, epoch == self.conversationEpoch else {
+                // Cancelled after the rail reserved its space. Without this it
+                // stays `.pending` — a blank band with no way out but a new
+                // turn.
+                self.clearFollowUps()
+                return
+            }
 
             if let title { self.applyGeneratedTitle(title, to: conversationID) }
             self.publishFollowUps(
-                suggestions, anchoredTo: turn.assistantID, excluding: turn.lastUserText
+                suggestions, anchoredTo: turn.assistantID,
+                excluding: turn.lastUserText, reference: turn.assistantText
             )
         }
     }
@@ -567,18 +596,43 @@ final class ChatViewModel {
     /// from a test without a server — the same reason
     /// ``finishStartupCancellation`` is its own method.
     func publishFollowUps(
-        _ raw: String?, anchoredTo anchorID: UUID, excluding lastUserText: String
+        _ raw: String?,
+        anchoredTo anchorID: UUID,
+        excluding lastUserText: String,
+        reference: String? = nil
     ) {
         // One condition covers a switched conversation, a deleted one, a new
         // turn, and an edit or retry that rewrote the tail.
         guard messages.last?.id == anchorID else {
-            followUp = .idle
-            followUpAnchorID = nil
+            clearFollowUps()
             return
         }
-        guard let raw else { followUp = .idle; return }
-        let questions = FollowUpSuggestion.parse(raw, excluding: lastUserText)
-        followUp = questions.isEmpty ? .idle : .ready(questions)
+        guard let raw else { clearFollowUps(); return }
+        let questions = FollowUpSuggestion.parse(
+            raw, excluding: lastUserText, reference: reference
+        )
+        guard !questions.isEmpty else { clearFollowUps(); return }
+        // Sets the anchor as well as the state. `scheduleBackgroundAssist`
+        // already set it before spawning, but publishing one without the other
+        // is a combination the screen can never show — ``ChatView`` mounts the
+        // rail on the anchor — so the two are written together here rather
+        // than depending on a caller having done half the job.
+        followUpAnchorID = anchorID
+        followUp = .ready(questions)
+    }
+
+    /// Put the rail away.
+    ///
+    /// Clearing the anchor as well as the state is the load-bearing half:
+    /// ``ChatView`` mounts the rail on the anchor alone, and the rail holds a
+    /// fixed 40pt whatever it is showing. Leaving the anchor set after a
+    /// failure — a deadline, unparseable output, a script mismatch, all of
+    /// which are common — left an empty band under the answer until the next
+    /// turn. Shrinking the document is safe; it is growth the scroll probe
+    /// cannot absorb.
+    func clearFollowUps() {
+        followUp = .idle
+        followUpAnchorID = nil
     }
 
     /// Land a machine-generated title. Silent on every rejection.
@@ -766,6 +820,7 @@ final class ChatViewModel {
     func selectConversation(_ id: UUID) {
         guard id != activeConversationID else { return }
         cancelInflightWork()
+        clearFollowUps()
         conversationEpoch &+= 1
         // Archive + unstick BEFORE swapping buffers, so the old transcript
         // is what gets persisted and a mid-stream switch doesn't leave the
@@ -793,6 +848,7 @@ final class ChatViewModel {
         // still active, re-inserting the conversation we just removed.
         if id == activeConversationID {
             cancelInflightWork()
+            clearFollowUps()
             conversationEpoch &+= 1
             messages.removeAll()
             branchedAway.removeAll()
@@ -885,6 +941,7 @@ final class ChatViewModel {
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
         cancelInflightWork()
+        clearFollowUps()
         conversationEpoch &+= 1
         // Fix: without this a New Chat during a stream leaves the empty
         // chat stuck showing Stop (isStreaming never reset). Setting it

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -147,6 +147,7 @@ struct ChatConversation: Identifiable, Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, title, messages, branches, activeLeafID, branchChoices
         case createdAt, updatedAt, isPinned, isArchived, hasCustomTitle
+        case hasGeneratedTitle
         case customInstructions, folderID
     }
 
@@ -189,6 +190,7 @@ struct ChatConversation: Identifiable, Codable, Equatable {
         try c.encode(isPinned, forKey: .isPinned)
         try c.encode(isArchived, forKey: .isArchived)
         try c.encode(hasCustomTitle, forKey: .hasCustomTitle)
+        try c.encode(hasGeneratedTitle, forKey: .hasGeneratedTitle)
         try c.encodeIfPresent(customInstructions, forKey: .customInstructions)
         try c.encodeIfPresent(folderID, forKey: .folderID)
     }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -60,6 +60,27 @@ struct ChatConversation: Identifiable, Codable, Equatable {
     /// this flag is what makes the derivation skip an owned title.
     var hasCustomTitle: Bool = false
 
+    /// Set once a background completion has written a machine title.
+    ///
+    /// Deliberately NOT ``hasCustomTitle``. That flag means the *user* owns
+    /// the name — only ``ChatViewModel/renameConversation(_:to:)`` sets it,
+    /// and nothing may overwrite a title it guards. Reusing it here would
+    /// make a generated name indistinguishable from a rename, and the
+    /// generator could no longer tell "leave this alone, the user named it"
+    /// from "leave this alone, I named it".
+    ///
+    /// What this buys is narrower: it stops ``ChatViewModel/persistActive``
+    /// re-deriving the title from the first user turn on the next save. A
+    /// rename still wins outright — it sets ``hasCustomTitle``, and the
+    /// generator refuses to write when that is true.
+    ///
+    /// One known benign interaction: a generated title landing while the
+    /// sidebar's inline rename editor is open is invisible, because the row
+    /// is showing the editor's `@State` draft. Committing that draft claims
+    /// the title as the user's, which is the right outcome; cancelling shows
+    /// the generated one. The window is one turn wide, once per conversation.
+    var hasGeneratedTitle: Bool = false
+
     /// Instructions scoped to this conversation. Optional on disk so history
     /// written before custom instructions shipped remains valid.
     var customInstructions: String? = nil
@@ -84,6 +105,7 @@ struct ChatConversation: Identifiable, Codable, Equatable {
         isPinned: Bool = false,
         isArchived: Bool = false,
         hasCustomTitle: Bool = false,
+        hasGeneratedTitle: Bool = false,
         customInstructions: String? = nil,
         folderID: UUID? = nil
     ) {
@@ -110,6 +132,7 @@ struct ChatConversation: Identifiable, Codable, Equatable {
         self.isPinned = isPinned
         self.isArchived = isArchived
         self.hasCustomTitle = hasCustomTitle
+        self.hasGeneratedTitle = hasGeneratedTitle
         self.customInstructions = customInstructions
         self.folderID = folderID
     }
@@ -211,6 +234,7 @@ struct ChatConversation: Identifiable, Codable, Equatable {
         isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         isArchived = try c.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
         hasCustomTitle = try c.decodeIfPresent(Bool.self, forKey: .hasCustomTitle) ?? false
+        hasGeneratedTitle = try c.decodeIfPresent(Bool.self, forKey: .hasGeneratedTitle) ?? false
         customInstructions = try c.decodeIfPresent(String.self, forKey: .customInstructions)
         folderID = try c.decodeIfPresent(UUID.self, forKey: .folderID)
     }
@@ -367,13 +391,19 @@ enum ConversationStore {
             .filter { !$0.isEmpty }
             .joined(separator: " ")
         if collapsed.isEmpty, let filename = first.fileAttachments.first?.filename {
-            return filename.count > 42
-                ? String(filename.prefix(42)) + "…"
-                : filename
+            return capped(filename)
         }
         if collapsed.isEmpty { return "New chat" }
-        return collapsed.count > 42
-            ? String(collapsed.prefix(42)) + "…"
-            : collapsed
+        return capped(collapsed)
+    }
+
+    /// The sidebar row's one-line budget.
+    ///
+    /// Extracted so a generated title obeys the identical rule rather than a
+    /// second copy of the number: the row is `.lineLimit(1)` either way, and
+    /// two caps that drift produce titles that truncate differently depending
+    /// on where they came from.
+    static func capped(_ title: String) -> String {
+        title.count > 42 ? String(title.prefix(42)) + "…" : title
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationTitleSuggestion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationTitleSuggestion.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Builds and reads the one background completion that names a conversation.
+///
+/// Pure and `nonisolated` on both sides: the prompt is a function of the
+/// transcript and the title is a function of the reply, so the interesting
+/// half of this feature is testable without a server, a view model, or an
+/// actor hop. ``ChatViewModel`` owns the request; this owns the words.
+///
+/// The parser is deliberately lopsided — generous about what it accepts and
+/// strict about what it returns. A small local model asked for a title will
+/// wrap it in quotes, prefix it with `Title:`, fence it, number it, or write
+/// a paragraph explaining its choice. The first four are recoverable and are
+/// stripped. The last is not, and is rejected: truncating prose to the
+/// sidebar's 42 characters reads worse than the opening words of the user's
+/// own question, which is what the row already shows.
+///
+/// Every rejection returns nil, which ``ChatViewModel/applyGeneratedTitle(_:to:)``
+/// turns into "leave the derived title alone". There is no retry, no error
+/// state, and nothing the reader can see — the same contract
+/// ``ServerProfileFetcher`` states for its own background fetch.
+enum ConversationTitleSuggestion {
+
+    /// How much of each side to send. A title needs the topic, not the
+    /// transcript, and a short prefill is most of what keeps this call cheap.
+    static let excerptLimit = 400
+
+    /// Longer than this and the reply is prose, not a title.
+    static let rejectLongerThan = 80
+
+    // MARK: - Prompt
+
+    static let systemPrompt = """
+        You name chat conversations. Reply with ONLY the title: 3 to 6 words, \
+        no quotes, no trailing punctuation, no markdown, no explanation. \
+        Write the title in the same language the conversation is in.
+        """
+
+    /// The first user turn and the answer it drew, or nil when the transcript
+    /// does not yet hold both.
+    nonisolated static func messages(
+        forFirstExchange transcript: [ChatMessage]
+    ) -> [ChatMessage]? {
+        guard let user = transcript.first(where: { $0.role == .user }),
+              let assistant = transcript.first(where: {
+                  $0.role == .assistant
+                      && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+              })
+        else { return nil }
+
+        let prompt = """
+            User: \(excerpt(user.content))
+            Assistant: \(excerpt(assistant.content))
+
+            Title:
+            """
+        return [
+            ChatMessage(role: .system, content: systemPrompt),
+            ChatMessage(role: .user, content: prompt),
+        ]
+    }
+
+    private nonisolated static func excerpt(_ text: String) -> String {
+        let collapsed = ModelReplyText.collapsingWhitespace(text)
+        return collapsed.count > excerptLimit
+            ? String(collapsed.prefix(excerptLimit))
+            : collapsed
+    }
+
+    // MARK: - Parsing
+
+    /// The title to show, or nil to keep the derived one.
+    nonisolated static func parse(_ raw: String) -> String? {
+        guard let line = ModelReplyText.firstMeaningfulLine(raw) else { return nil }
+        // Measured before stripping: a paragraph that happens to open with a
+        // quote is still a paragraph, and stripping first would let it
+        // through at 78 characters.
+        guard line.count <= rejectLongerThan else { return nil }
+
+        var title = ModelReplyText.strippingLabel(line, labels: ["title", "标题", "titre", "título"])
+        title = ModelReplyText.strippingListMarker(title)
+        title = ModelReplyText.strippingWrappers(title)
+        title = ModelReplyText.strippingTrailingStop(title)
+        title = ModelReplyText.collapsingWhitespace(title)
+
+        guard title.count >= 2 else { return nil }
+        guard !ModelReplyText.looksLikeRefusal(title) else { return nil }
+        guard title != "New chat" else { return nil }
+        // A markdown table row is a row, whatever else it is.
+        guard !title.hasPrefix("|") else { return nil }
+        // A trailing colon means the model wrote the lead-in to a list and
+        // stopped — "Three things, in order:" names nothing.
+        guard let last = title.last, last != ":", last != "：" else { return nil }
+        // More than one sentence is prose. A title is a phrase; the moment a
+        // full stop has text after it we are reading the answer, not a name
+        // for it.
+        guard !isMultiSentence(title) else { return nil }
+
+        return ConversationStore.capped(title)
+    }
+
+    /// True when the line reads as more than one sentence.
+    ///
+    /// Crude on purpose: a stop with text after it. That also catches
+    /// "Dr. Who and the daleks" and "e.g. modular arithmetic", and those are
+    /// accepted losses — the two costs are not symmetric. A false reject
+    /// keeps the derived title, which is the opening words of the user's own
+    /// question and is what the row shows today. A false accept puts a
+    /// paragraph in the sidebar. Distinguishing an abbreviation from a
+    /// sentence boundary needs a list of abbreviations per language, which is
+    /// a great deal of machinery to rescue a title nobody has lost yet.
+    private nonisolated static func isMultiSentence(_ title: String) -> Bool {
+        if title.contains(". ") { return true }
+        // Full-width stops are unambiguous — no abbreviations use them — so
+        // only a trailing one is fine.
+        return title.dropLast().contains { $0 == "。" || $0 == "！" }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationTitleSuggestion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationTitleSuggestion.swift
@@ -31,13 +31,29 @@ enum ConversationTitleSuggestion {
     // MARK: - Prompt
 
     static let systemPrompt = """
-        You name chat conversations. Reply with ONLY the title: 3 to 6 words, \
-        no quotes, no trailing punctuation, no markdown, no explanation. \
-        Write the title in the same language the conversation is in.
+        You are a conversation titler. Given a chat, you output a short noun \
+        phrase naming what it is about, and nothing else. Use the language of \
+        the chat.
         """
 
     /// The first user turn and the answer it drew, or nil when the transcript
     /// does not yet hold both.
+    ///
+    /// ## Why the instruction reads the way it does
+    ///
+    /// Measured against the bundled 1.2B model, which is the one most readers
+    /// will see first. An earlier wording — "Reply with ONLY the title: 3 to 6
+    /// words, no quotes…" — returned, verbatim and repeatably, `3 to 6 words`
+    /// and `Chat conversations`. A model this size will lift a noun phrase out
+    /// of the instruction and hand it back, so the instruction must not
+    /// contain one that could pass for an answer. Hence a verb ("naming what
+    /// it is about") where the old one had a noun ("the title"), and the
+    /// constraints moved off the sentence that says what to output.
+    ///
+    /// Same exchanges after the rewrite, three samples each: a correct
+    /// Chinese noun phrase for the Chinese one, `Function reverse` for the
+    /// code one, `Deploy command` for the deployment one — against `3`, `3`,
+    /// `3` before it.
     nonisolated static func messages(
         forFirstExchange transcript: [ChatMessage]
     ) -> [ChatMessage]? {
@@ -49,10 +65,11 @@ enum ConversationTitleSuggestion {
         else { return nil }
 
         let prompt = """
+            Chat:
             User: \(excerpt(user.content))
             Assistant: \(excerpt(assistant.content))
 
-            Title:
+            Name it in 2 to 5 words:
             """
         return [
             ChatMessage(role: .system, content: systemPrompt),
@@ -77,7 +94,7 @@ enum ConversationTitleSuggestion {
         // through at 78 characters.
         guard line.count <= rejectLongerThan else { return nil }
 
-        var title = ModelReplyText.strippingLabel(line, labels: ["title", "标题", "titre", "título"])
+        var title = ModelReplyText.strippingLabel(line, labels: ["title"])
         title = ModelReplyText.strippingListMarker(title)
         title = ModelReplyText.strippingWrappers(title)
         title = ModelReplyText.strippingTrailingStop(title)
@@ -85,7 +102,7 @@ enum ConversationTitleSuggestion {
 
         guard title.count >= 2 else { return nil }
         guard !ModelReplyText.looksLikeRefusal(title) else { return nil }
-        guard title != "New chat" else { return nil }
+        guard !isGenericNonTitle(title) else { return nil }
         // A markdown table row is a row, whatever else it is.
         guard !title.hasPrefix("|") else { return nil }
         // A trailing colon means the model wrote the lead-in to a list and
@@ -97,6 +114,52 @@ enum ConversationTitleSuggestion {
         guard !isMultiSentence(title) else { return nil }
 
         return ConversationStore.capped(title)
+    }
+
+    /// Words that name the *thing being titled* rather than what it is about.
+    ///
+    /// A model with nothing to work from — a bare greeting in any language —
+    /// reaches for these, and they are the one output worse than no title at
+    /// all: "Chat" in a list of chats says less than the reader's own "hi"
+    /// does. Measured on the bundled 1.2B model, a bare greeting returns
+    /// `Chat` on every sample, in English, whatever language it was greeted
+    /// in — which is why the list needs no translations.
+    ///
+    /// Note what is *not* here: "Greeting". Naming a greeting as a greeting is
+    /// a real answer about a real (if slight) exchange, and a larger model
+    /// gives exactly that. This list is only for words that describe the
+    /// container.
+    private static let genericNonTitles: Set<String> = [
+        "chat", "chats", "chat topic", "chat conversations", "conversation",
+        "conversations", "topic", "topics", "exchange", "discussion", "dialogue",
+        "summary", "title", "untitled", "new chat", "help", "assistance",
+        "user assistant", "message", "messages", "response", "answer",
+    ]
+
+    private nonisolated static func isGenericNonTitle(_ title: String) -> Bool {
+        let key = title
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespaces))
+        if genericNonTitles.contains(key) { return true }
+        return isLengthSpecification(key)
+    }
+
+    /// "3 to 6 words" — the reported defect, verbatim.
+    ///
+    /// A denylist of echoed phrases is whack-a-mole: the instruction that
+    /// produced that one has been rewritten, and the next wording would leak
+    /// a different literal. This is the general form instead — no
+    /// conversation is ever named after how long its name should be — so it
+    /// keeps working whatever the instruction says next.
+    private nonisolated static func isLengthSpecification(_ key: String) -> Bool {
+        let parts = key.split(whereSeparator: { $0 == " " })
+        guard parts.count >= 3, parts.count <= 4 else { return false }
+        guard Int(parts[0]) != nil else { return false }
+        guard ["to", "-", "–"].contains(String(parts[1])) else { return false }
+        guard Int(parts[2]) != nil else { return false }
+        guard parts.count == 3 || ["word", "words"].contains(String(parts[3]))
+        else { return false }
+        return true
     }
 
     /// True when the line reads as more than one sentence.

--- a/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Builds and reads the one background completion that proposes what to ask
+/// next.
+///
+/// Same split as ``ConversationTitleSuggestion``: the prompt is a function of
+/// the turn, the chips are a function of the reply, and neither needs a
+/// server to test.
+///
+/// ## Why every line must end in a question mark
+///
+/// It is one predicate, and it does the work of a dozen. A model asked for
+/// three questions will often add "Here are three follow-up questions:", or
+/// number them, or answer in a markdown table, or drift into a paragraph.
+/// Requiring a terminal `?` kills the preamble, the table separator row, the
+/// stray prose and any code, while compliant output passes by construction
+/// because questions are what was asked for. Softer rules — "drop the first
+/// line if it ends in a colon", "strip numbering" — each handle one failure
+/// and miss the next.
+///
+/// ## Why fewer than three is nothing
+///
+/// One or two lonely chips read as a bug rather than as a feature being
+/// modest. The whole thing is garnish; rendering nothing is always an
+/// acceptable outcome, and it is the outcome for every reply this parser
+/// does not fully understand.
+enum FollowUpSuggestion {
+
+    /// Chips shown. Also the exact number required — see the type comment.
+    static let count = 3
+
+    /// Per-side excerpt budgets. The answer gets more room than the question
+    /// because that is where the threads to pull on are.
+    static let userExcerptLimit = 600
+    static let assistantExcerptLimit = 1200
+
+    /// Longer than this and it is not a chip a reader can scan.
+    static let rejectLongerThan = 80
+
+    // MARK: - Prompt
+
+    static let systemPrompt = """
+        You suggest what the user might ask next. Reply with exactly 3 lines. \
+        Each line is one short question the user could ask next — 3 to 10 \
+        words, written in the user's voice, ending in a question mark, in the \
+        same language as the conversation. No numbering, no bullets, no \
+        quotes, no other text.
+        """
+
+    /// The last exchange, or nil when there isn't one to follow up on.
+    /// Caller is expected to have already decided the turn is worth it —
+    /// see ``ChatViewModel/settledTurn(_:)``.
+    nonisolated static func messages(
+        forTurn transcript: [ChatMessage]
+    ) -> [ChatMessage]? {
+        guard let assistant = transcript.last,
+              assistant.role == .assistant,
+              !assistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let user = transcript.last(where: { $0.role == .user })
+        else { return nil }
+
+        let prompt = """
+            User: \(excerpt(user.content, limit: userExcerptLimit))
+            Assistant: \(excerpt(assistant.content, limit: assistantExcerptLimit))
+
+            Three follow-up questions:
+            """
+        return [
+            ChatMessage(role: .system, content: systemPrompt),
+            ChatMessage(role: .user, content: prompt),
+        ]
+    }
+
+    private nonisolated static func excerpt(_ text: String, limit: Int) -> String {
+        let collapsed = ModelReplyText.collapsingWhitespace(text)
+        return collapsed.count > limit ? String(collapsed.prefix(limit)) : collapsed
+    }
+
+    // MARK: - Parsing
+
+    /// Exactly ``count`` questions, or an empty array.
+    ///
+    /// `excluding` is the user's last message: a model that suggests the
+    /// question just asked is offering to go in a circle.
+    nonisolated static func parse(_ raw: String, excluding lastUserMessage: String = "") -> [String] {
+        let excluded = ModelReplyText.collapsingWhitespace(lastUserMessage).lowercased()
+        var seen = Set<String>()
+        var questions: [String] = []
+
+        for line in ModelReplyText.meaningfulLines(raw) {
+            var question = ModelReplyText.strippingListMarker(line)
+            question = ModelReplyText.strippingWrappers(question)
+            question = ModelReplyText.collapsingWhitespace(question)
+
+            // A row of table pipes or rule dashes carries no letters.
+            guard question.contains(where: \.isLetter) else { continue }
+            guard question.count <= rejectLongerThan else { continue }
+            guard let last = question.last, last == "?" || last == "？" else { continue }
+
+            let key = question.lowercased()
+            guard key != excluded, seen.insert(key).inserted else { continue }
+
+            questions.append(question)
+            if questions.count == count { return questions }
+        }
+        return []
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
@@ -42,9 +42,8 @@ enum FollowUpSuggestion {
     static let systemPrompt = """
         You suggest what the user might ask next. Reply with exactly 3 lines. \
         Each line is one short question the user could ask next — 3 to 10 \
-        words, written in the user's voice, ending in a question mark, in the \
-        same language as the conversation. No numbering, no bullets, no \
-        quotes, no other text.
+        words, ending in a question mark. No numbering, no bullets, no quotes, \
+        no other text. CRITICAL: write in the same language the user wrote in.
         """
 
     /// The last exchange, or nil when there isn't one to follow up on.
@@ -101,8 +100,41 @@ enum FollowUpSuggestion {
             guard key != excluded, seen.insert(key).inserted else { continue }
 
             questions.append(question)
-            if questions.count == count { return questions }
+            if questions.count == count {
+                return sharesScript(questions.joined(), lastUserMessage) ? questions : []
+            }
         }
         return []
+    }
+
+    /// Do the suggestions and the conversation use the same writing system?
+    ///
+    /// Prompting alone does not settle this. Measured over 20 turns on the
+    /// bundled 1.2B model, the instruction to match the user's language was
+    /// obeyed 10 times; adding a `CRITICAL:` clause took it to 12. Both
+    /// numbers mean a reader writing Chinese regularly gets three English
+    /// chips, which is worse than no chips — it reads as the app not having
+    /// noticed what they said.
+    ///
+    /// So the last word is a deterministic check rather than a better
+    /// sentence. A mismatch throws the whole set away, which is the failure
+    /// this feature already uses everywhere else.
+    ///
+    /// Scoped to CJK-versus-not because that is the mismatch that was
+    /// measured. A Cyrillic or Arabic conversation may well have the same
+    /// problem, but guessing at a failure mode nobody has watched would be
+    /// writing a rule for a bug that has not been seen.
+    nonisolated static func sharesScript(_ suggestions: String, _ conversation: String) -> Bool {
+        // An empty reference tells us nothing, so it cannot veto.
+        guard conversation.contains(where: \.isLetter) else { return true }
+        return usesCJK(suggestions) == usesCJK(conversation)
+    }
+
+    private nonisolated static func usesCJK(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            (0x4E00...0x9FFF).contains(scalar.value)      // unified ideographs
+                || (0x3040...0x30FF).contains(scalar.value)  // kana
+                || (0xAC00...0xD7AF).contains(scalar.value)  // hangul
+        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/FollowUpSuggestion.swift
@@ -81,7 +81,18 @@ enum FollowUpSuggestion {
     ///
     /// `excluding` is the user's last message: a model that suggests the
     /// question just asked is offering to go in a circle.
-    nonisolated static func parse(_ raw: String, excluding lastUserMessage: String = "") -> [String] {
+    /// `excluding` is the user's last message — a model that suggests the
+    /// question just asked is offering to go in a circle. `reference` is what
+    /// the language check compares against; it defaults to `excluding` but
+    /// should be the answer being followed up on, which is longer and more
+    /// representative. A last user message of `SwiftUI?` in a Chinese chat is
+    /// not evidence that the chat is English.
+    nonisolated static func parse(
+        _ raw: String,
+        excluding lastUserMessage: String = "",
+        reference: String? = nil
+    ) -> [String] {
+        let reference = reference ?? lastUserMessage
         let excluded = ModelReplyText.collapsingWhitespace(lastUserMessage).lowercased()
         var seen = Set<String>()
         var questions: [String] = []
@@ -101,7 +112,7 @@ enum FollowUpSuggestion {
 
             questions.append(question)
             if questions.count == count {
-                return sharesScript(questions.joined(), lastUserMessage) ? questions : []
+                return sharesScript(questions, reference) ? questions : []
             }
         }
         return []
@@ -124,10 +135,16 @@ enum FollowUpSuggestion {
     /// measured. A Cyrillic or Arabic conversation may well have the same
     /// problem, but guessing at a failure mode nobody has watched would be
     /// writing a rule for a bug that has not been seen.
-    nonisolated static func sharesScript(_ suggestions: String, _ conversation: String) -> Bool {
+    nonisolated static func sharesScript(_ questions: [String], _ conversation: String) -> Bool {
         // An empty reference tells us nothing, so it cannot veto.
         guard conversation.contains(where: \.isLetter) else { return true }
-        return usesCJK(suggestions) == usesCJK(conversation)
+        let wanted = usesCJK(conversation)
+        // A majority, not "any scalar anywhere". The first version joined the
+        // questions and asked whether the result contained a CJK character, so
+        // one Chinese word inside one otherwise-English suggestion threw all
+        // three away.
+        let matching = questions.filter { usesCJK($0) == wanted }.count
+        return matching * 2 > questions.count
     }
 
     private nonisolated static func usesCJK(_ text: String) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ModelReplyText.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ModelReplyText.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Shared cleanup for text a model wrote when it was asked for a *value*
+/// rather than for prose.
+///
+/// Both background completions — the conversation title and the follow-up
+/// questions — ask for something with a shape, and both get back the shape
+/// wrapped in whatever the model felt like adding: a `Title:` label, a
+/// markdown fence, a numbered list, smart quotes, a leftover `<think>` block.
+/// The wrapping is the same in each case, so it is stripped in one place;
+/// what differs is what each caller accepts afterwards, and that stays with
+/// the caller.
+///
+/// Everything here is `nonisolated` and total — no throws, no optionals
+/// beyond "there was nothing here", no I/O. That is the point: the part of
+/// this feature that decides what a reader sees can be tested exhaustively
+/// without a model.
+enum ModelReplyText {
+
+    /// Text with any reasoning block removed.
+    ///
+    /// Both callers send `enableThinking: false`, and the kwarg is only
+    /// emitted when thinking is off (``ChatStreamClient``), so this should
+    /// never fire. It stays because several chat templates emit the block
+    /// from the template itself regardless of the kwarg, and a `<think>`
+    /// preamble would otherwise become the title.
+    nonisolated static func strippingReasoning(_ text: String) -> String {
+        guard let close = text.range(of: "</think>", options: .backwards) else {
+            return text
+        }
+        return String(text[close.upperBound...])
+    }
+
+    /// Text with whole-line markdown fences removed. Only lines that are
+    /// *nothing but* a fence go — a line of prose containing backticks is
+    /// left for the caller to judge.
+    nonisolated static func strippingFenceLines(_ text: String) -> String {
+        text.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") else { return true }
+                // ``` or ```swift — but not ``` some prose ```
+                return trimmed.dropFirst(3).contains(where: \.isWhitespace)
+            }
+            .joined(separator: "\n")
+    }
+
+    /// The first line with something on it, after reasoning and fences are
+    /// gone. Nil when the reply was empty or was nothing but scaffolding.
+    nonisolated static func firstMeaningfulLine(_ text: String) -> String? {
+        strippingFenceLines(strippingReasoning(text))
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .lazy
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty }
+    }
+
+    /// Every line with something on it, in order.
+    nonisolated static func meaningfulLines(_ text: String) -> [String] {
+        strippingFenceLines(strippingReasoning(text))
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Drops a leading `Label:` / `标题：` and the separator after it.
+    /// Matching is case-insensitive and the separator may be a colon, a
+    /// full-width colon, a dash or an em dash.
+    nonisolated static func strippingLabel(_ line: String, labels: [String]) -> String {
+        let lowered = line.lowercased()
+        for label in labels where lowered.hasPrefix(label.lowercased()) {
+            let rest = line.dropFirst(label.count)
+                .drop { $0 == " " }
+            guard let separator = rest.first,
+                  ":：-—".contains(separator) else { continue }
+            return String(rest.dropFirst()).trimmingCharacters(in: .whitespaces)
+        }
+        return line
+    }
+
+    /// Drops `1.` / `2)` / `-` / `*` / `•` and the space after it.
+    nonisolated static func strippingListMarker(_ line: String) -> String {
+        var rest = Substring(line)
+        if let first = rest.first, "-*•".contains(first) {
+            rest = rest.dropFirst()
+        } else {
+            let digits = rest.prefix(while: \.isNumber)
+            guard !digits.isEmpty, digits.count <= 2,
+                  let punctuation = rest.dropFirst(digits.count).first,
+                  ".)".contains(punctuation)
+            else { return line }
+            rest = rest.dropFirst(digits.count + 1)
+        }
+        // A marker is only a marker when something follows it with a space
+        // between — `-42` is a number, not a bulleted 42.
+        guard let next = rest.first, next == " " else { return line }
+        return String(rest).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Symmetric wrappers a model adds when it thinks it is quoting: matched
+    /// quotes of several nationalities, and markdown emphasis.
+    private static let wrappers: [(String, String)] = [
+        ("\"", "\""), ("'", "'"), ("“", "”"), ("‘", "’"),
+        ("«", "»"), ("「", "」"), ("『", "』"), ("《", "》"),
+        ("**", "**"), ("*", "*"), ("`", "`"), ("[", "]"), ("(", ")"),
+    ]
+
+    /// Peels matched wrappers, outermost first, until none match. Bounded by
+    /// the wrapper count so a pathological reply cannot spin.
+    nonisolated static func strippingWrappers(_ line: String) -> String {
+        var result = line.trimmingCharacters(in: .whitespaces)
+        for _ in 0..<wrappers.count {
+            guard let match = wrappers.first(where: { open, close in
+                result.hasPrefix(open) && result.hasSuffix(close)
+                    && result.count > open.count + close.count
+            }) else { break }
+            result = String(
+                result.dropFirst(match.0.count).dropLast(match.1.count)
+            ).trimmingCharacters(in: .whitespaces)
+        }
+        return result
+    }
+
+    /// Drops a trailing full stop. A question mark stays — a question makes
+    /// a perfectly good title, and it is load-bearing for follow-ups.
+    nonisolated static func strippingTrailingStop(_ line: String) -> String {
+        guard let last = line.last, last == "." || last == "。" else { return line }
+        return String(line.dropLast()).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Runs of whitespace — including newlines — become single spaces.
+    /// Same fold ``ConversationStore/title(from:)`` applies, so a generated
+    /// title and a derived one are normalised identically.
+    nonisolated static func collapsingWhitespace(_ text: String) -> String {
+        text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    /// Openings a model uses when it is talking to you instead of answering.
+    private static let refusalPrefixes = [
+        "i ", "i'm", "i'd", "sure", "here", "here's", "certainly", "of course",
+        "as an", "okay", "ok,", "understood", "好的", "当然", "抱歉", "作为",
+    ]
+
+    nonisolated static func looksLikeRefusal(_ line: String) -> Bool {
+        let lowered = line.lowercased()
+        return refusalPrefixes.contains { lowered.hasPrefix($0) }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/ModelReplyText.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ModelReplyText.swift
@@ -63,9 +63,9 @@ enum ModelReplyText {
             .filter { !$0.isEmpty }
     }
 
-    /// Drops a leading `Label:` / `标题：` and the separator after it.
-    /// Matching is case-insensitive and the separator may be a colon, a
-    /// full-width colon, a dash or an em dash.
+    /// Drops a leading `Label:` and the separator after it. Matching is
+    /// case-insensitive and the separator may be a colon, a full-width colon
+    /// (which a CJK keyboard produces), a dash or an em dash.
     nonisolated static func strippingLabel(_ line: String, labels: [String]) -> String {
         let lowered = line.lowercased()
         for label in labels where lowered.hasPrefix(label.lowercased()) {
@@ -140,7 +140,7 @@ enum ModelReplyText {
     /// Openings a model uses when it is talking to you instead of answering.
     private static let refusalPrefixes = [
         "i ", "i'm", "i'd", "sure", "here", "here's", "certainly", "of course",
-        "as an", "okay", "ok,", "understood", "好的", "当然", "抱歉", "作为",
+        "as an", "okay", "ok,", "understood",
     ]
 
     nonisolated static func looksLikeRefusal(_ line: String) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -241,6 +241,26 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
         }
         return model.displayName(preferredAlias: fallback)
     }
+
+    /// The engine's own modality for whatever is serving `alias`, or nil when
+    /// this snapshot has never heard of it — an old sidecar that reports no
+    /// residency, or the window before the first poll lands.
+    ///
+    /// This is the authoritative lane signal. ``ModelBrandStyle/modelType(forAlias:)``
+    /// is a second, name-based guess that already decides whether image parts
+    /// go on the wire, but it classifies whole families (`qwen3.5-`, `gemma3-`)
+    /// as vision — accurate enough for "might accept an image", far too broad
+    /// for "is this the serialised one-at-a-time lane".
+    func modality(for alias: String) -> String? {
+        models.first { $0.matches(alias) && $0.state != "evicting" }?.modality
+    }
+
+    /// Requests the engine currently has in flight on `alias`. On the
+    /// serialised `--mllm` lane a non-zero value means anything we send now
+    /// queues behind real work.
+    func activeRequests(for alias: String) -> Int? {
+        models.first { $0.matches(alias) && $0.state != "evicting" }?.activeRequests
+    }
 }
 
 /// User-visible risk carried by an alias-replacing model activation.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -134,6 +134,26 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
         }
         return model.displayName(preferredAlias: fallback)
     }
+
+    /// The engine's own modality for whatever is serving `alias`, or nil when
+    /// this snapshot has never heard of it — an old sidecar that reports no
+    /// residency, or the window before the first poll lands.
+    ///
+    /// This is the authoritative lane signal. ``ModelBrandStyle/modelType(forAlias:)``
+    /// is a second, name-based guess that already decides whether image parts
+    /// go on the wire, but it classifies whole families (`qwen3.5-`, `gemma3-`)
+    /// as vision — accurate enough for "might accept an image", far too broad
+    /// for "is this the serialised one-at-a-time lane".
+    func modality(for alias: String) -> String? {
+        models.first { $0.matches(alias) && $0.state != "evicting" }?.modality
+    }
+
+    /// Requests the engine currently has in flight on `alias`. On the
+    /// serialised `--mllm` lane a non-zero value means anything we send now
+    /// queues behind real work.
+    func activeRequests(for alias: String) -> Int? {
+        models.first { $0.matches(alias) && $0.state != "evicting" }?.activeRequests
+    }
 }
 
 enum ResidentModelLoadResult: Sendable, Equatable {

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -470,6 +470,21 @@ struct ChatView: View {
                     .id(message.id)
                 }
             }
+            // A sibling of the ForEach, not a row inside it: that is what
+            // makes "under the last answer" true without MessageRow needing
+            // any notion of which row is last. The anchor check is what makes
+            // it the last *assistant* answer — a new user turn appends a row,
+            // the anchor stops matching, and the rail goes.
+            if let anchor = viewModel.followUpAnchorID, anchor == messages.last?.id {
+                FollowUpSuggestionRail(
+                    state: viewModel.followUp,
+                    isEnabled: readiness.sendAllowed,
+                    disabledTooltip: readiness.sendTooltip,
+                    onSelect: sendSuggestion
+                )
+                .frame(maxWidth: contentMaxWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
             Color.clear
                 .frame(height: 1)
         }
@@ -879,6 +894,25 @@ struct ChatView: View {
             imageAttachments: submission.images,
             fileAttachments: submission.files
         )
+    }
+
+    /// Send a suggestion chip's question.
+    ///
+    /// A sibling of ``send()`` rather than a generalisation of it. The chip
+    /// sends its own text and leaves the composer alone — quietly consuming a
+    /// staged image or a half-typed draft would make one tap do two things,
+    /// and the reader did not ask for the second.
+    ///
+    /// Routed through ``acknowledgeIfNotReady()`` because that is the rule for
+    /// this surface: ``ChatViewModel/send(_:alias:supportsImageInput:imageAttachments:fileAttachments:)``
+    /// carries no readiness gate of its own, so anything that re-enters it
+    /// from the view has to answer to the gate here — the same reason
+    /// ``MessageRow``'s Edit and Retry callbacks do.
+    private func sendSuggestion(_ text: String) {
+        guard !viewModel.isStreaming, !attachmentDraft.isImportingFiles else { return }
+        guard acknowledgeIfNotReady() else { return }
+        composeFocusToken &+= 1
+        viewModel.send(text, alias: alias, supportsImageInput: supportsImageInput)
     }
 
     private var attachmentStrip: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -469,6 +469,21 @@ struct ChatView: View {
                     .id(message.id)
                 }
             }
+            // A sibling of the ForEach, not a row inside it: that is what
+            // makes "under the last answer" true without MessageRow needing
+            // any notion of which row is last. The anchor check is what makes
+            // it the last *assistant* answer — a new user turn appends a row,
+            // the anchor stops matching, and the rail goes.
+            if let anchor = viewModel.followUpAnchorID, anchor == messages.last?.id {
+                FollowUpSuggestionRail(
+                    state: viewModel.followUp,
+                    isEnabled: readiness.sendAllowed,
+                    disabledTooltip: readiness.sendTooltip,
+                    onSelect: sendSuggestion
+                )
+                .frame(maxWidth: contentMaxWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
             Color.clear
                 .frame(height: 1)
         }
@@ -832,6 +847,25 @@ struct ChatView: View {
             imageAttachments: images,
             fileAttachments: files
         )
+    }
+
+    /// Send a suggestion chip's question.
+    ///
+    /// A sibling of ``send()`` rather than a generalisation of it. The chip
+    /// sends its own text and leaves the composer alone — quietly consuming a
+    /// staged image or a half-typed draft would make one tap do two things,
+    /// and the reader did not ask for the second.
+    ///
+    /// Routed through ``acknowledgeIfNotReady()`` because that is the rule for
+    /// this surface: ``ChatViewModel/send(_:alias:imageAttachments:fileAttachments:)``
+    /// carries no readiness gate of its own, so anything that re-enters it
+    /// from the view has to answer to the gate here — the same reason
+    /// ``MessageRow``'s Edit and Retry callbacks do.
+    private func sendSuggestion(_ text: String) {
+        guard !viewModel.isStreaming, !isImportingFiles else { return }
+        guard acknowledgeIfNotReady() else { return }
+        composeFocusToken &+= 1
+        viewModel.send(text, alias: alias)
     }
 
     private var supportsImageInput: Bool {

--- a/apps/rapid-mac/Sources/Rapid/UI/FollowUpSuggestionRail.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FollowUpSuggestionRail.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// The three questions offered under the last answer.
+///
+/// ## Why it holds its height while it is empty
+///
+/// This is the whole reason the type has a `reservedHeight` at all.
+///
+/// ``TranscriptScrollPositionProbe`` follows the bottom of the transcript by
+/// watching the document frame: any growth while the reader is pinned pulls
+/// the view down. During a stream that is right, and there is a release valve
+/// for the case where the answer outgrows the viewport — but the valve is
+/// gated on `isStreaming`, which is already false by the time a settled-turn
+/// footer could appear. Chips arriving a second after the answer settles
+/// would therefore yank a pinned reader with nothing to stop them, and the
+/// same growth flips `isPinnedToBottom` false for a frame, which pops the
+/// jump-to-bottom button and pops it back.
+///
+/// So the rail mounts at its final height the instant the turn settles — in
+/// the same layout pass that adds the stats caption and the action row — and
+/// the chips fade in *inside* that reservation. There is one document growth
+/// per turn, at the moment the reader already expects one. Filling the rail
+/// changes no height, posts no frame notification, and therefore cannot move
+/// anybody. The hazard is removed by construction rather than guarded
+/// against, which is why the probe needs no changes at all.
+///
+/// The height is a constant because the rail can never wrap: one line, one
+/// horizontal scroller, `.lineLimit(1)` on every chip. That is also why the
+/// row scrolls sideways rather than flowing — a flowing layout would make the
+/// height depend on the text, and the text comes from a model.
+struct FollowUpSuggestionRail: View {
+
+    let state: ChatViewModel.FollowUpState
+    let isEnabled: Bool
+    let disabledTooltip: String
+    let onSelect: (String) -> Void
+
+    /// One control plus the gap above it. Fixed — see the type comment.
+    static let reservedHeight: CGFloat =
+        RapidTheme.ControlHeight.small + RapidTheme.Space.md
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            // Holds the space open in every state, including `.idle`, so the
+            // rail's arrival and departure are the only layout events.
+            Color.clear
+            if case .ready(let questions) = state {
+                chips(questions)
+            }
+        }
+        .frame(height: Self.reservedHeight, alignment: .bottom)
+        .rapidAnimation(RapidMotion.quick, value: state)
+    }
+
+    private func chips(_ questions: [String]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: RapidTheme.Space.sm) {
+                ForEach(Array(questions.enumerated()), id: \.offset) { index, question in
+                    Button {
+                        onSelect(question)
+                    } label: {
+                        Text(question)
+                            .font(.caption)
+                            .lineLimit(1)
+                            .padding(.horizontal, RapidTheme.Space.md)
+                            .frame(height: RapidTheme.ControlHeight.small)
+                            // Deliberately `card`, not `brandPrimary`: the
+                            // composer's send disc is this surface's one amber
+                            // moment, and three glowing chips would take that
+                            // away from it.
+                            .background(RapidTheme.card)
+                            .clipShape(Capsule())
+                            .overlay(
+                                Capsule().stroke(RapidTheme.hairline, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!isEnabled)
+                    .help(isEnabled ? question : disabledTooltip)
+                    // Keyed on the index, never the text: the label is model
+                    // output, and an identifier that moves with it is not a
+                    // hook. Deliberately NOT prefixed `ChatView.Message.` —
+                    // `gui-golden-flows.sh`'s `transcript_only` scopes its
+                    // slice to that prefix, so a chip carrying it would drag
+                    // model-authored text into a frozen snapshot.
+                    .accessibilityIdentifier("ChatView.FollowUp.\(index)")
+                }
+            }
+        }
+        .transition(.opacity)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
@@ -226,8 +226,8 @@ struct BackgroundAssistGatingTests {
 
     // MARK: - Which turn gets a title
 
-    @Test("Only the first exchange is titled")
-    func onlyFirstExchangeIsTitled() {
+    @Test("The first exchange is recognisable")
+    func firstExchangeIsRecognisable() {
         #expect(ChatViewModel.isFirstExchange([ask, answer()]))
         #expect(!ChatViewModel.isFirstExchange([ask, answer(), ask, answer()]))
         #expect(!ChatViewModel.isFirstExchange([]))
@@ -261,9 +261,28 @@ struct BackgroundAssistGatingTests {
         #expect(!ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "vision", active: 0), alias: "m"))
     }
 
-    @Test("A busy model refuses")
-    func busyModelRefuses() {
-        #expect(!ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "text", active: 1), alias: "m"))
+    /// A busy text model is the normal case, not a reason to refuse.
+    ///
+    /// There was an `activeRequests > 0` clause here and it was wrong twice
+    /// over: continuous batching is why this feature is affordable, and the
+    /// only writer of `residency` polls every five seconds — so at a turn
+    /// boundary the freshest snapshot was taken *during* the answer, and any
+    /// reply streaming for five seconds or more looked busy. It silently
+    /// disabled both features on exactly the long answers follow-ups are for.
+    @Test("A busy text model still allows")
+    func busyTextModelAllows() {
+        #expect(ChatViewModel.laneAllowsBackgroundWork(
+            snapshot(modality: "text", active: 3), alias: "m"
+        ))
+    }
+
+    /// The serialised lane refuses whether it is busy or not — that clause is
+    /// the one carrying the rationale.
+    @Test("A serialised lane refuses even when idle")
+    func visionLaneRefusesWhenIdle() {
+        #expect(!ChatViewModel.laneAllowsBackgroundWork(
+            snapshot(modality: "vision", active: 0), alias: "m"
+        ))
     }
 
     /// A sidecar too old to report residency would otherwise disable both
@@ -294,17 +313,43 @@ struct BackgroundAssistGatingTests {
         model.devSeedMessages([ask, last])
         model.publishFollowUps("A one?\nB two?\nC three?", anchoredTo: last.id, excluding: "")
         #expect(model.followUp == .ready(["A one?", "B two?", "C three?"]))
+        // Both halves, or the rail would never mount: `ChatView` keys on the
+        // anchor, so a `.ready` state with no anchor is a combination the
+        // screen can never show.
+        #expect(model.followUpAnchorID == last.id)
     }
 
-    @Test("Nothing parseable leaves the rail empty")
-    func unparseableSuggestionsLeaveItEmpty() {
+    /// Starts from `.ready`, because the previous version of this test
+    /// asserted `.idle` on a model that was already `.idle` — it passed with
+    /// the entire body of `publishFollowUps` replaced by a no-op.
+    @Test("Nothing parseable puts the rail away")
+    func unparseableSuggestionsClearTheRail() {
         let model = ChatViewModel()
         let last = answer()
         model.devSeedMessages([ask, last])
+
+        model.publishFollowUps("A one?\nB two?\nC three?", anchoredTo: last.id, excluding: "")
+        #expect(model.followUp == .ready(["A one?", "B two?", "C three?"]))
+        #expect(model.followUpAnchorID == last.id)
+
         model.publishFollowUps("Here are some ideas for you.", anchoredTo: last.id, excluding: "")
         #expect(model.followUp == .idle)
+        // The anchor goes too: the rail is mounted on it and holds 40pt
+        // whatever it shows, so leaving it set is an empty band under the
+        // answer until the next turn.
+        #expect(model.followUpAnchorID == nil)
+    }
+
+    @Test("A nil reply puts the rail away")
+    func nilReplyClearsTheRail() {
+        let model = ChatViewModel()
+        let last = answer()
+        model.devSeedMessages([ask, last])
+        model.publishFollowUps("A one?\nB two?\nC three?", anchoredTo: last.id, excluding: "")
+        #expect(model.followUp != .idle)
         model.publishFollowUps(nil, anchoredTo: last.id, excluding: "")
         #expect(model.followUp == .idle)
+        #expect(model.followUpAnchorID == nil)
     }
 }
 
@@ -388,5 +433,60 @@ struct FollowUpSuggestionRailSourceTests {
         let text = try source("Sources/Rapid/Chat/BackgroundCompletionClient.swift")
         #expect(text.contains("enableThinking:false"))
         #expect(text.contains("tools:nil"))
+    }
+}
+
+/// Whether a conversation still wants a title.
+///
+/// The gate used to be "is this the first exchange", which forfeits the one
+/// chance permanently: `send` cancels the outstanding call, so a reader who
+/// replies within the fifteen-second deadline leaves the conversation on its
+/// derived title forever. `hasGeneratedTitle` already means "a title has
+/// landed", so gating on that keeps the once-per-conversation promise while
+/// letting a cancelled or failed attempt be retried on the next turn.
+@MainActor
+@Suite("Title retry")
+struct TitleRetryTests {
+
+    private func isolatedStore() throws -> (root: URL, file: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-title-retry-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (root, root.appendingPathComponent("conversations.json"))
+    }
+
+    @Test("A conversation whose first attempt failed is still eligible later")
+    func retriedAfterAFailedFirstAttempt() throws {
+        let store = try isolatedStore()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = ChatViewModel(conversationStoreURL: store.file)
+        model.send("first question", alias: "test-model")
+        model.stopAndPersist()
+        let id = model.activeConversationID
+
+        // The first attempt produced nothing — cancelled, or unparseable.
+        #expect(model.conversations.first { $0.id == id }?.hasGeneratedTitle == false)
+
+        // A second turn. The conversation is no longer a first exchange, but
+        // it still has no title, so it is still eligible.
+        model.send("second question", alias: "test-model")
+        model.stopAndPersist()
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+        #expect(model.conversations.first { $0.id == id }?.title == "Euler's theorem")
+    }
+
+    /// And once one lands, it is never asked for again.
+    @Test("A titled conversation stops being eligible")
+    func notRetriedOnceTitled() throws {
+        let store = try isolatedStore()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = ChatViewModel(conversationStoreURL: store.file)
+        model.send("first question", alias: "test-model")
+        model.stopAndPersist()
+        let id = model.activeConversationID
+
+        model.applyGeneratedTitle("First name", to: id)
+        model.applyGeneratedTitle("Second name", to: id)
+        #expect(model.conversations.first { $0.id == id }?.title == "First name")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
@@ -1,0 +1,392 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Who owns a conversation's name, and what happens when two owners disagree.
+///
+/// The derivation in ``ChatViewModel/persistActive`` re-reads the first user
+/// turn on *every* save, so any title that did not come from it needs a flag
+/// to survive the next streamed token. There are now two such flags with
+/// deliberately different meanings, and the interesting behaviour is all in
+/// how they interact.
+@MainActor
+@Suite("Generated conversation titles")
+struct GeneratedTitleTests {
+
+    private func isolatedStoreURL() throws -> (root: URL, file: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-generated-title-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (root, root.appendingPathComponent("conversations.json"))
+    }
+
+    /// One persisted single-turn conversation, the same way
+    /// ``SidebarConversationActionsTests`` builds one: the snapshot into
+    /// `conversations` hangs off the end of a turn, and `stopAndPersist`
+    /// cancels the unroutable request before it can stream.
+    private func seededModel(_ store: URL) -> ChatViewModel {
+        let model = ChatViewModel(conversationStoreURL: store)
+        model.send("how does euler's theorem work", alias: "test-model")
+        model.stopAndPersist()
+        return model
+    }
+
+    // MARK: - The flag earns its keep
+
+    /// The whole reason ``hasGeneratedTitle`` exists. Without it the next
+    /// persisted turn reverts a generated title to the opening words of the
+    /// user's prompt — the same regression ``hasCustomTitle`` was added for.
+    @Test("A generated title survives later saves")
+    func generatedTitleSurvivesLaterPersists() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+        #expect(model.conversations.first { $0.id == id }?.title == "Euler's theorem")
+
+        model.send("and fermat?", alias: "test-model")
+        model.stopAndPersist()
+
+        #expect(model.conversations.first { $0.id == id }?.title == "Euler's theorem")
+    }
+
+    // MARK: - The user always wins
+
+    @Test("A rename beats a title that arrives afterwards")
+    func renameBeatsLaterGeneratedTitle() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        #expect(model.renameConversation(id, to: "My notes"))
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+
+        #expect(model.conversations.first { $0.id == id }?.title == "My notes")
+    }
+
+    @Test("A rename beats a title that arrived before it")
+    func renameBeatsEarlierGeneratedTitle() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+        #expect(model.renameConversation(id, to: "My notes"))
+
+        model.send("more", alias: "test-model")
+        model.stopAndPersist()
+        #expect(model.conversations.first { $0.id == id }?.title == "My notes")
+    }
+
+    // MARK: - One shot, and quiet about it
+
+    @Test("A second generated title is ignored")
+    func secondGeneratedTitleIsIgnored() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        model.applyGeneratedTitle("First name", to: id)
+        model.applyGeneratedTitle("Second name", to: id)
+
+        #expect(model.conversations.first { $0.id == id }?.title == "First name")
+    }
+
+    @Test("Unparseable output leaves the derived title alone")
+    func unparseableTitleIsIgnored() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+        let derived = model.conversations.first { $0.id == id }?.title
+
+        model.applyGeneratedTitle("Sure! Here's a title for your conversation.", to: id)
+
+        #expect(model.conversations.first { $0.id == id }?.title == derived)
+        // And the door stays open — this was not the one shot.
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+        #expect(model.conversations.first { $0.id == id }?.title == "Euler's theorem")
+    }
+
+    @Test("A title for a conversation that no longer exists is dropped")
+    func titleForMissingConversationIsDropped() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let before = model.conversations
+        model.applyGeneratedTitle("Euler's theorem", to: UUID())
+        #expect(model.conversations == before)
+    }
+
+    // MARK: - Naming is not working on it
+
+    /// A rename does not bump `updatedAt`, and neither does this — otherwise
+    /// the sidebar reshuffles a second after the answer lands, moving a row
+    /// the reader is looking at for a reason they cannot see.
+    @Test("A generated title does not reorder the sidebar")
+    func generatedTitleDoesNotTouchUpdatedAt() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+        let before = model.conversations.first { $0.id == id }?.updatedAt
+        let order = model.conversations.map(\.id)
+
+        model.applyGeneratedTitle("Euler's theorem", to: id)
+
+        #expect(model.conversations.first { $0.id == id }?.updatedAt == before)
+        #expect(model.conversations.map(\.id) == order)
+    }
+
+    // MARK: - On-disk migration
+
+    /// History written before this shipped must decode, and must decode as
+    /// "still derived" so the row keeps behaving the way it always has.
+    @Test("History without the key decodes as not-yet-generated")
+    func legacyHistoryDecodes() throws {
+        let json = """
+            [{"id":"\(UUID().uuidString)","title":"Old chat","messages":[],
+              "createdAt":0,"updatedAt":0}]
+            """
+        let decoded = try JSONDecoder().decode(
+            [ChatConversation].self, from: Data(json.utf8)
+        )
+        #expect(decoded.first?.hasGeneratedTitle == false)
+        #expect(decoded.first?.hasCustomTitle == false)
+    }
+
+    @Test("The flag round-trips")
+    func flagRoundTrips() throws {
+        let original = ChatConversation(
+            id: UUID(), title: "Euler's theorem", messages: [],
+            createdAt: Date(), updatedAt: Date(), hasGeneratedTitle: true
+        )
+        let decoded = try JSONDecoder().decode(
+            ChatConversation.self, from: JSONEncoder().encode(original)
+        )
+        #expect(decoded.hasGeneratedTitle)
+        #expect(!decoded.hasCustomTitle)
+    }
+}
+
+/// When the app is allowed to ask the model something on its own account,
+/// and when a reply that arrives late is thrown away.
+@MainActor
+@Suite("Background assist gating")
+struct BackgroundAssistGatingTests {
+
+    private func answer(
+        _ content: String = "Because it scatters blue light.",
+        status: ChatMessage.Status = .complete,
+        errorMessage: String? = nil,
+        toolCalls: [ToolCall]? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            role: .assistant, content: content, status: status,
+            errorMessage: errorMessage, toolCalls: toolCalls
+        )
+    }
+
+    private let ask = ChatMessage(role: .user, content: "why is the sky blue")
+
+    // MARK: - Which turns qualify
+
+    @Test("A settled answer qualifies")
+    func settledAnswerQualifies() {
+        let turn = ChatViewModel.settledTurn([ask, answer()])
+        #expect(turn?.lastUserText == "why is the sky blue")
+    }
+
+    @Test("A turn that does not qualify", arguments: [
+        "streaming", "failed", "stopped", "empty", "tool-shell", "no-user", "user-last", "empty-transcript",
+    ])
+    func nonQualifyingTurns(_ shape: String) {
+        let messages: [ChatMessage]
+        switch shape {
+        case "streaming":  messages = [ask, answer(status: .streaming)]
+        case "failed":     messages = [ask, answer(status: .failed)]
+        // The marker ``finaliseCancellation`` writes. Suggesting more of an
+        // answer the reader just stopped is the opposite of listening.
+        case "stopped":    messages = [ask, answer(errorMessage: "Stopped.")]
+        case "empty":      messages = [ask, answer("   ")]
+        case "tool-shell": messages = [ask, answer("", toolCalls: [
+            ToolCall(id: "1", name: "web_search", arguments: "{}"),
+        ])]
+        case "no-user":    messages = [answer()]
+        case "user-last":  messages = [ask, answer(), ask]
+        default:           messages = []
+        }
+        #expect(ChatViewModel.settledTurn(messages) == nil, "\(shape) should not qualify")
+    }
+
+    // MARK: - Which turn gets a title
+
+    @Test("Only the first exchange is titled")
+    func onlyFirstExchangeIsTitled() {
+        #expect(ChatViewModel.isFirstExchange([ask, answer()]))
+        #expect(!ChatViewModel.isFirstExchange([ask, answer(), ask, answer()]))
+        #expect(!ChatViewModel.isFirstExchange([]))
+    }
+
+    // MARK: - Which lane will batch us
+
+    private func snapshot(modality: String, active: Int) -> ModelResidencySnapshot {
+        ModelResidencySnapshot(
+            memoryLimitBytes: 0, memoryUsedBytes: 0, memoryAvailableBytes: nil,
+            idleTTLSeconds: 0, loadsTotal: 0, evictionsTotal: 0,
+            models: [ResidentModelStatus(
+                id: "m", modelPath: "m", aliases: ["m"], modality: modality,
+                state: "ready", pinned: false, primary: true,
+                activeRequests: active, estimatedBytes: 0, measuredBytes: nil,
+                idleSeconds: 0
+            )]
+        )
+    }
+
+    @Test("The batched text lane allows background work")
+    func textLaneAllows() {
+        #expect(ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "text", active: 0), alias: "m"))
+    }
+
+    /// The `--mllm` lane runs one request at a time, so anything we send
+    /// there is not batched alongside the reader's turn — it is queued in
+    /// front of their next one.
+    @Test("A serialised lane refuses")
+    func visionLaneRefuses() {
+        #expect(!ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "vision", active: 0), alias: "m"))
+    }
+
+    @Test("A busy model refuses")
+    func busyModelRefuses() {
+        #expect(!ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "text", active: 1), alias: "m"))
+    }
+
+    /// A sidecar too old to report residency would otherwise disable both
+    /// features permanently. The cost of guessing wrong there is bounded by
+    /// max_tokens, the deadline, and cancel-on-send.
+    @Test("An unknown model allows")
+    func unknownModelAllows() {
+        #expect(ChatViewModel.laneAllowsBackgroundWork(.empty, alias: "m"))
+        #expect(ChatViewModel.laneAllowsBackgroundWork(snapshot(modality: "text", active: 0), alias: "other"))
+    }
+
+    // MARK: - Late replies
+
+    @Test("Suggestions for a turn that is no longer last are dropped")
+    func staleSuggestionsAreDropped() {
+        let model = ChatViewModel()
+        model.devSeedMessages([ask, answer()])
+        // Anchored to a row that is not the last one any more.
+        model.publishFollowUps("A?\nB?\nC?", anchoredTo: UUID(), excluding: "")
+        #expect(model.followUp == .idle)
+        #expect(model.followUpAnchorID == nil)
+    }
+
+    @Test("Suggestions for the visible turn are published")
+    func freshSuggestionsArePublished() {
+        let model = ChatViewModel()
+        let last = answer()
+        model.devSeedMessages([ask, last])
+        model.publishFollowUps("A one?\nB two?\nC three?", anchoredTo: last.id, excluding: "")
+        #expect(model.followUp == .ready(["A one?", "B two?", "C three?"]))
+    }
+
+    @Test("Nothing parseable leaves the rail empty")
+    func unparseableSuggestionsLeaveItEmpty() {
+        let model = ChatViewModel()
+        let last = answer()
+        model.devSeedMessages([ask, last])
+        model.publishFollowUps("Here are some ideas for you.", anchoredTo: last.id, excluding: "")
+        #expect(model.followUp == .idle)
+        model.publishFollowUps(nil, anchoredTo: last.id, excluding: "")
+        #expect(model.followUp == .idle)
+    }
+}
+
+/// Shape rules a SwiftUI body cannot be asked about from this target
+/// (ViewInspector is not linked — #1492), pinned by reading the source.
+@MainActor
+@Suite("Follow-up rail shape")
+struct FollowUpSuggestionRailSourceTests {
+
+    /// Comments stripped, because several of these rules are stated in prose
+    /// in the very file they govern — a naive grep for "brandPrimary" finds
+    /// the comment explaining why it is not used.
+    private func source(_ path: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // RapidTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // rapid-mac
+            .appendingPathComponent(path)
+        return CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(
+            try String(contentsOf: url, encoding: .utf8)
+        )
+    }
+
+    private let rail = "Sources/Rapid/UI/FollowUpSuggestionRail.swift"
+
+    /// The no-yank contract, in one line of source.
+    ///
+    /// The rail must hold a constant height in every state, because
+    /// ``TranscriptScrollPositionProbe`` follows any document growth while
+    /// the reader is pinned and its release valve is gated on `isStreaming`
+    /// — already false by the time chips could arrive. If filling the rail
+    /// ever changes its height, a pinned reader gets pulled down with
+    /// nothing to stop them.
+    @Test("The rail's height does not depend on its contents")
+    func heightIsConstant() throws {
+        let text = try source(rail)
+        #expect(text.contains(".frame(height:Self.reservedHeight"))
+        // One line, so the height cannot depend on the text a model wrote.
+        #expect(text.contains(".lineLimit(1)"))
+        #expect(text.contains("ScrollView(.horizontal"))
+    }
+
+    /// The composer's send disc is this surface's only amber moment
+    /// (`CoreWorkspaceVisualFoundationTests.composerControlsAreIntact`).
+    @Test("Chips do not compete with the send button")
+    func chipsAreNotBranded() throws {
+        #expect(!(try source(rail).contains("brandPrimary")))
+    }
+
+    /// Identifiers must not carry the `ChatView.Message.` prefix:
+    /// `gui-golden-flows.sh`'s `transcript_only` scopes its slice by it, and
+    /// a chip inside that slice would freeze model-authored text into a
+    /// baseline. They must also key on the index, never the label.
+    @Test("Chip identifiers stay out of the transcript slice")
+    func identifiersAreOutOfSlice() throws {
+        let text = try source(rail)
+        #expect(text.contains(#".accessibilityIdentifier("ChatView.FollowUp.\(index)")"#))
+        #expect(!text.contains("ChatView.Message."))
+        #expect(!text.contains("accessibilityIdentifier(question"))
+    }
+
+    /// Anything re-entering send from the view answers to the readiness gate
+    /// — `ChatViewModel.send` carries none of its own.
+    @Test("A chip send answers to the readiness gate")
+    func chipSendIsGated() throws {
+        let text = try source("Sources/Rapid/UI/ChatView.swift")
+        guard let start = text.range(of: "privatefuncsendSuggestion(") else {
+            Issue.record("sendSuggestion is gone")
+            return
+        }
+        let body = text[start.lowerBound...].prefix(600)
+        #expect(body.contains("acknowledgeIfNotReady()"))
+    }
+
+    /// Both background calls must keep thinking off and tools out: a hybrid
+    /// model with thinking on spends the whole budget on a reasoning trace
+    /// and returns empty content, and a call advertising tools can finish
+    /// with `tool_calls` and no text.
+    @Test("Background requests stay cheap and plain")
+    func backgroundRequestIsPlain() throws {
+        let text = try source("Sources/Rapid/Chat/BackgroundCompletionClient.swift")
+        #expect(text.contains("enableThinking:false"))
+        #expect(text.contains("tools:nil"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BackgroundAssistGatingTests.swift
@@ -351,6 +351,43 @@ struct BackgroundAssistGatingTests {
         #expect(model.followUp == .idle)
         #expect(model.followUpAnchorID == nil)
     }
+
+    // MARK: - Cancellation
+
+    /// Cancelling the assist has to put the rail away *synchronously*.
+    ///
+    /// A cancelled assist exits without publishing, so nothing downstream
+    /// clears the anchor — and ``ChatView`` mounts the rail on the anchor
+    /// alone, at a fixed height whatever it shows. The task's own
+    /// continuation does clear it, but only once it gets to run, and
+    /// ``stop()`` never cleared it at all.
+    ///
+    /// The routes are listed rather than folded into one case because the
+    /// defect was that three of the six cancellation sites remembered to put
+    /// the rail away and three did not — which a single-route test cannot
+    /// see.
+    @Test("Cancelling puts the rail away", arguments: [
+        "stop", "stopAndPersist", "newConversation",
+    ])
+    func cancellingClearsTheRail(_ route: String) {
+        let model = ChatViewModel()
+        let last = answer()
+        model.devSeedMessages([ask, last])
+        model.publishFollowUps("A one?\nB two?\nC three?", anchoredTo: last.id, excluding: "")
+        // The premise: there is a rail to strand. Without it the assertions
+        // below would hold on a model that never had one.
+        #expect(model.followUp == .ready(["A one?", "B two?", "C three?"]))
+        #expect(model.followUpAnchorID == last.id)
+
+        switch route {
+        case "stop": model.stop()
+        case "stopAndPersist": model.stopAndPersist()
+        default: model.newConversation()
+        }
+
+        #expect(model.followUp == .idle, "\(route) left the rail showing")
+        #expect(model.followUpAnchorID == nil, "\(route) left the anchor set")
+    }
 }
 
 /// Shape rules a SwiftUI body cannot be asked about from this target

--- a/apps/rapid-mac/Tests/RapidTests/BackgroundAssistParsingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BackgroundAssistParsingTests.swift
@@ -117,7 +117,6 @@ struct ConversationTitleSuggestionTests {
         ("Euler's theorem and modular arithmetic", "Euler's theorem and modular arithmetic"),
         ("Title: Euler's theorem", "Euler's theorem"),
         ("title：Euler's theorem", "Euler's theorem"),
-        ("标题：欧拉定理与模运算", "欧拉定理与模运算"),
         ("\"Euler's theorem\"", "Euler's theorem"),
         ("“Euler's theorem”", "Euler's theorem"),
         ("**Euler's theorem**", "Euler's theorem"),
@@ -146,7 +145,6 @@ struct ConversationTitleSuggestionTests {
         "| model | size | speed |",
         // A lead-in to a list names nothing.
         "Three things, in order:",
-        "接下来有三点：",
         // More than one sentence is the answer, not a name for it.
         "中文排版测试:这是一段中文回答,用来检查换行和字宽。 Emoji: 🎯",
         "Modular arithmetic. It comes up in cryptography.",
@@ -172,7 +170,6 @@ struct ConversationTitleSuggestionTests {
         "I can help with that! A good title would be Euler's theorem.",
         "Sure, here's a title for you",
         "Here is a title",
-        "好的，这个对话可以叫做欧拉定理",
         "New chat",
         "x",
         // Prose. Truncating this to 42 characters reads worse than the
@@ -336,5 +333,73 @@ struct BackgroundAssistFakeServerTests {
         for (name, text) in FakeServerReplies.all {
             #expect(FollowUpSuggestion.parse(text).isEmpty, "\(name) produced chips")
         }
+    }
+}
+
+/// Wrong-language chips, and the instruction-echoing that shipped in the
+/// first cut. Both were found by driving the bundled 1.2B model rather than
+/// by reading the prompt.
+@Suite("Background assist — measured against a small model")
+struct SmallModelBehaviourTests {
+
+    /// The reported defect: sending "hi" produced the title `3 to 6 words`.
+    ///
+    /// The old instruction was "Reply with ONLY the title: 3 to 6 words, no
+    /// quotes…", and the model handed the constraint back as the answer. Two
+    /// defences now: the instruction contains no noun phrase that could pass
+    /// for a title, and the parser refuses words that name the container
+    /// rather than the contents.
+    @Test("Instruction echoes are refused as titles", arguments: [
+        // The reported defect, verbatim.
+        "3 to 6 words",
+        // And the general form, so a reworded instruction cannot leak a new
+        // literal past a list of old ones.
+        "2 to 5 words", "5 to 8",
+        "Chat conversations", "Chat", "Chat topic",
+        "Conversation", "New chat", "Untitled",
+    ])
+    func instructionEchoesRefused(_ raw: String) {
+        #expect(ConversationTitleSuggestion.parse(raw) == nil)
+    }
+
+    /// The instruction must not contain a phrase a model could mistake for
+    /// the answer. This is the property that broke.
+    @Test("The title instruction offers nothing to copy")
+    func titleInstructionOffersNothingToCopy() {
+        let prompt = ConversationTitleSuggestion.systemPrompt
+        #expect(!prompt.contains("3 to 6"))
+        #expect(!prompt.lowercased().contains("the title"))
+    }
+
+    /// Naming a greeting as a greeting is a real answer about a real
+    /// exchange — a bigger model returns exactly that. Only words for the
+    /// container are refused.
+    @Test("A real but slight title is kept")
+    func slightTitleIsKept() {
+        #expect(ConversationTitleSuggestion.parse("Friendly greeting") == "Friendly greeting")
+    }
+
+    /// Measured: the language instruction was obeyed on 10 of 20 turns, and
+    /// 12 of 20 with a `CRITICAL:` clause. Three English chips under a
+    /// Chinese answer read as the app not having noticed — so a mismatch
+    /// throws the set away.
+    @Test("Chips in the wrong script are dropped")
+    func wrongScriptIsDropped() {
+        let english = "What is the proof?\nCan you give an example?\nHow is it used?"
+        let chinese = "证明是什么？\n能举个例子吗？\n它怎么用？"
+
+        #expect(FollowUpSuggestion.parse(english, excluding: "explain euler's theorem").count == 3)
+        #expect(FollowUpSuggestion.parse(chinese, excluding: "解释一下欧拉定理").count == 3)
+        // Crossed.
+        #expect(FollowUpSuggestion.parse(english, excluding: "解释一下欧拉定理").isEmpty)
+        #expect(FollowUpSuggestion.parse(chinese, excluding: "explain euler's theorem").isEmpty)
+    }
+
+    /// With nothing to compare against, the check must not veto.
+    @Test("An empty reference cannot veto")
+    func emptyReferenceDoesNotVeto() {
+        let english = "What is the proof?\nCan you give an example?\nHow is it used?"
+        #expect(FollowUpSuggestion.parse(english, excluding: "").count == 3)
+        #expect(FollowUpSuggestion.parse(english).count == 3)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/BackgroundAssistParsingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BackgroundAssistParsingTests.swift
@@ -1,0 +1,340 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The fake server's repertoire, verbatim from `scripts/fake-rapid-mlx.sh`.
+///
+/// The golden flows drive the app against that script, and a title request
+/// carries the user's original message — marker and all — so the fake picks
+/// the same shape for our background call that it picked for the answer.
+/// Whatever these parse to is what lands in `Tests/GUIGoldenFlows/__Snapshots__`,
+/// so it is pinned here where a failure names the cause instead of showing up
+/// as an unexplained baseline diff.
+enum FakeServerReplies {
+    static let `default` =
+        "Hello from the fake rapid-mlx mock. I return deterministic content "
+        + "so the smoke test has something to assert on."
+
+    static let code = """
+        Here is the function you asked for:
+
+        ```python
+        def fib(n):
+            a, b = 0, 1
+            for _ in range(n):
+                a, b = b, a + b
+            return a
+        ```
+
+        It runs in O(n) time and constant space.
+        """
+
+    static let table = """
+        | model | size | speed |
+        | --- | --- | --- |
+        | qwen3.5-9b | 5.2 GB | 74 tok/s |
+        | llama-3.1-8b | 4.5 GB | 68 tok/s |
+
+        Both fit comfortably in 16 GB.
+        """
+
+    static let math = """
+        The Gaussian integral is
+
+        $$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$$
+
+        and inline it reads $e^{i\\pi} + 1 = 0$.
+        """
+
+    static let list = """
+        Three things, in order:
+
+        1. First, read the prompt.
+        2. Second, plan the answer.
+           - a nested point
+        3. Third, write it down.
+        """
+
+    static let unicode =
+        "中文排版测试:这是一段中文回答,用来检查换行和字宽。 Emoji: 🎯🚀。 Right-to-left: مرحبا."
+
+    static let prose =
+        "The lighthouse keeper kept two logbooks. One recorded the weather, "
+        + "the ships, the hours of the lamp. The other recorded what he "
+        + "thought about while he watched them."
+
+    static let all: [(name: String, text: String)] = [
+        ("default", `default`), ("code", code), ("table", table),
+        ("math", math), ("list", list), ("unicode", unicode), ("prose", prose),
+    ]
+}
+
+@Suite("Conversation title suggestion")
+struct ConversationTitleSuggestionTests {
+
+    // MARK: - Prompt
+
+    @Test("The prompt carries both sides of the first exchange")
+    func promptCarriesFirstExchange() {
+        let transcript = [
+            ChatMessage(role: .user, content: "How does Euler's theorem work?"),
+            ChatMessage(role: .assistant, content: "For coprime a and n, a^φ(n) ≡ 1."),
+        ]
+        let built = ConversationTitleSuggestion.messages(forFirstExchange: transcript)
+        #expect(built?.count == 2)
+        #expect(built?.first?.role == .system)
+        #expect(built?.last?.content.contains("Euler's theorem") == true)
+        #expect(built?.last?.content.contains("a^φ(n)") == true)
+    }
+
+    @Test("Each side is capped so the call stays cheap")
+    func excerptsAreCapped() {
+        let transcript = [
+            ChatMessage(role: .user, content: String(repeating: "x", count: 5_000)),
+            ChatMessage(role: .assistant, content: String(repeating: "y", count: 5_000)),
+        ]
+        let prompt = ConversationTitleSuggestion.messages(forFirstExchange: transcript)?
+            .last?.content ?? ""
+        #expect(prompt.count < ConversationTitleSuggestion.excerptLimit * 2 + 200)
+    }
+
+    @Test("An exchange without an answer yet builds nothing")
+    func incompleteExchangeBuildsNothing() {
+        #expect(ConversationTitleSuggestion.messages(forFirstExchange: []) == nil)
+        #expect(ConversationTitleSuggestion.messages(forFirstExchange: [
+            ChatMessage(role: .user, content: "hi"),
+        ]) == nil)
+        // A placeholder assistant row with no prose is not an answer.
+        #expect(ConversationTitleSuggestion.messages(forFirstExchange: [
+            ChatMessage(role: .user, content: "hi"),
+            ChatMessage(role: .assistant, content: "   "),
+        ]) == nil)
+    }
+
+    // MARK: - Parsing what a small model actually returns
+
+    @Test("Wrapped and labelled titles are unwrapped", arguments: [
+        ("Euler's theorem and modular arithmetic", "Euler's theorem and modular arithmetic"),
+        ("Title: Euler's theorem", "Euler's theorem"),
+        ("title：Euler's theorem", "Euler's theorem"),
+        ("标题：欧拉定理与模运算", "欧拉定理与模运算"),
+        ("\"Euler's theorem\"", "Euler's theorem"),
+        ("“Euler's theorem”", "Euler's theorem"),
+        ("**Euler's theorem**", "Euler's theorem"),
+        ("「欧拉定理」", "欧拉定理"),
+        ("1. Euler's theorem", "Euler's theorem"),
+        ("- Euler's theorem", "Euler's theorem"),
+        ("Euler's theorem.", "Euler's theorem"),
+        ("欧拉定理。", "欧拉定理"),
+        ("```\nEuler's theorem\n```", "Euler's theorem"),
+        ("<think>hmm what to call it</think>\nEuler's theorem", "Euler's theorem"),
+        ("Euler's theorem\nAlso known as Fermat's little theorem", "Euler's theorem"),
+    ])
+    func unwrapsTitles(_ raw: String, _ expected: String) {
+        #expect(ConversationTitleSuggestion.parse(raw) == expected)
+    }
+
+    /// A question makes a fine title, so the trailing-stop strip must not
+    /// take the question mark with it.
+    @Test("A question mark survives")
+    func questionMarkSurvives() {
+        #expect(ConversationTitleSuggestion.parse("Why is the sky blue?") == "Why is the sky blue?")
+    }
+
+    @Test("Structure and prose are refused as titles", arguments: [
+        // A table row is a row whatever else it is.
+        "| model | size | speed |",
+        // A lead-in to a list names nothing.
+        "Three things, in order:",
+        "接下来有三点：",
+        // More than one sentence is the answer, not a name for it.
+        "中文排版测试:这是一段中文回答,用来检查换行和字宽。 Emoji: 🎯",
+        "Modular arithmetic. It comes up in cryptography.",
+    ])
+    func refusesStructureAndProse(_ raw: String) {
+        #expect(ConversationTitleSuggestion.parse(raw) == nil)
+    }
+
+    /// The multi-sentence rule is crude and takes abbreviations with it.
+    /// Pinned so the loss is a decision on the record rather than a surprise:
+    /// the fallback is the derived title, which is what the row shows today.
+    @Test("An abbreviation is collateral, and the fallback is benign")
+    func abbreviationIsCollateral() {
+        #expect(ConversationTitleSuggestion.parse("Dr. Who and the daleks") == nil)
+        // No space after the stop, so a version number is still a title.
+        #expect(ConversationTitleSuggestion.parse("Migrating to Swift 6.2") == "Migrating to Swift 6.2")
+    }
+
+    @Test("Non-titles are refused", arguments: [
+        "",
+        "   ",
+        "\n\n",
+        "I can help with that! A good title would be Euler's theorem.",
+        "Sure, here's a title for you",
+        "Here is a title",
+        "好的，这个对话可以叫做欧拉定理",
+        "New chat",
+        "x",
+        // Prose. Truncating this to 42 characters reads worse than the
+        // opening words of the user's own question, which is what the row
+        // already shows.
+        "This conversation is about the mathematical foundations of modular exponentiation",
+    ])
+    func refusesNonTitles(_ raw: String) {
+        #expect(ConversationTitleSuggestion.parse(raw) == nil)
+    }
+
+    /// A generated title obeys the same one-line budget as a derived one,
+    /// through the same function.
+    @Test("A long but valid title is capped exactly like a derived one")
+    func longTitleIsCapped() {
+        let raw = "Euler's theorem, modular arithmetic and Fermat"
+        let parsed = ConversationTitleSuggestion.parse(raw)
+        #expect(parsed == ConversationStore.capped(raw))
+        #expect(parsed?.count == 43)  // 42 + the ellipsis
+    }
+}
+
+@Suite("Follow-up suggestion")
+struct FollowUpSuggestionTests {
+
+    @Test("The prompt carries the last exchange")
+    func promptCarriesLastTurn() {
+        let transcript = [
+            ChatMessage(role: .user, content: "first"),
+            ChatMessage(role: .assistant, content: "first answer"),
+            ChatMessage(role: .user, content: "second"),
+            ChatMessage(role: .assistant, content: "second answer"),
+        ]
+        let prompt = FollowUpSuggestion.messages(forTurn: transcript)?.last?.content ?? ""
+        #expect(prompt.contains("second"))
+        #expect(prompt.contains("second answer"))
+        #expect(!prompt.contains("first answer"))
+    }
+
+    @Test("Clean output becomes three chips, in order")
+    func cleanOutput() {
+        let raw = """
+            Can you give a concrete example?
+            What is the proof?
+            How does it relate to Fermat?
+            """
+        #expect(FollowUpSuggestion.parse(raw) == [
+            "Can you give a concrete example?",
+            "What is the proof?",
+            "How does it relate to Fermat?",
+        ])
+    }
+
+    @Test("Numbering, bullets and quotes are stripped")
+    func decorationIsStripped() {
+        let raw = """
+            1. Can you give an example?
+            - What is the proof?
+            "How does it relate to Fermat?"
+            """
+        #expect(FollowUpSuggestion.parse(raw).count == 3)
+        #expect(FollowUpSuggestion.parse(raw).first == "Can you give an example?")
+    }
+
+    /// The single rule that does most of the work: a preamble does not end in
+    /// a question mark, so it disappears without a rule of its own.
+    @Test("A preamble line is dropped without a rule for preambles")
+    func preambleIsDropped() {
+        let raw = """
+            Here are three follow-up questions:
+            Can you give an example?
+            What is the proof?
+            How does it relate to Fermat?
+            """
+        #expect(FollowUpSuggestion.parse(raw).count == 3)
+        #expect(FollowUpSuggestion.parse(raw).first == "Can you give an example?")
+    }
+
+    @Test("Extra questions are trimmed to three")
+    func extrasAreTrimmed() {
+        let raw = "A?\nBB?\nCCC?\nDDDD?\nEEEEE?"
+        #expect(FollowUpSuggestion.parse(raw) == ["A?", "BB?", "CCC?"])
+    }
+
+    @Test("Fewer than three is nothing at all", arguments: [
+        "Can you give an example?\nWhat is the proof?",
+        "Can you give an example?",
+        "",
+        "Here are some follow-up questions:",
+        "I'm not sure what you would ask next.",
+    ])
+    func fewerThanThreeIsNothing(_ raw: String) {
+        #expect(FollowUpSuggestion.parse(raw).isEmpty)
+    }
+
+    @Test("The question just asked is not offered back")
+    func lastUserMessageIsExcluded() {
+        let raw = "What is the proof?\nCan you give an example?\nHow does it relate?"
+        let parsed = FollowUpSuggestion.parse(raw, excluding: "What is the proof?")
+        // Two survivors is fewer than three, so nothing renders.
+        #expect(parsed.isEmpty)
+    }
+
+    @Test("Duplicates are dropped case-insensitively")
+    func duplicatesAreDropped() {
+        let raw = "What is the proof?\nwhat is the PROOF?\nAn example?\nA third one?"
+        #expect(FollowUpSuggestion.parse(raw) == [
+            "What is the proof?", "An example?", "A third one?",
+        ])
+    }
+
+    @Test("CJK questions with a full-width mark are accepted")
+    func cjkQuestionsAccepted() {
+        let raw = "能举个例子吗？\n证明过程是什么？\n和费马小定理什么关系？"
+        #expect(FollowUpSuggestion.parse(raw).count == 3)
+    }
+
+    @Test("Structure that is not a question is refused", arguments: [
+        "| model | size | speed |\n| --- | --- | --- |\n| a | b | c |",
+        "```\ncode?\ncode?\ncode?\n```",
+        "---\n***\n___",
+    ])
+    func structureIsRefused(_ raw: String) {
+        #expect(FollowUpSuggestion.parse(raw).isEmpty)
+    }
+
+    @Test("A question too long to scan is refused")
+    func overlongQuestionRefused() {
+        let long = String(repeating: "word ", count: 30) + "?"
+        let raw = "Short one?\n\(long)\nAnother short?"
+        #expect(FollowUpSuggestion.parse(raw).isEmpty)
+    }
+}
+
+/// What the golden-flow fake server's answers do to both parsers.
+///
+/// Every case here is a fact about `scripts/fake-rapid-mlx.sh`, not a wish.
+/// A shape that parses to a title changes the sidebar row's `desc=` in
+/// `Tests/GUIGoldenFlows/__Snapshots__/chat-*.txt`; a shape that parses to
+/// three chips adds `AXButton` rows. Both are legitimate — the app's
+/// behaviour did change — but they must be *known*, and regenerated
+/// deliberately rather than discovered as a mystery diff.
+@Suite("Background assist against the fake server")
+struct BackgroundAssistFakeServerTests {
+
+    @Test("Which fake shapes yield a title")
+    func fakeShapeTitles() {
+        var titled: [String: String] = [:]
+        for (name, text) in FakeServerReplies.all {
+            if let title = ConversationTitleSuggestion.parse(text) {
+                titled[name] = title
+            }
+        }
+        // Pinned so a parser change that alters golden-flow output fails
+        // HERE, with a name, rather than as an unexplained baseline diff.
+        #expect(titled == ["math": "The Gaussian integral is"])
+    }
+
+    @Test("No fake shape yields follow-up chips")
+    func fakeShapesYieldNoChips() {
+        for (name, text) in FakeServerReplies.all {
+            #expect(FollowUpSuggestion.parse(text).isEmpty, "\(name) produced chips")
+        }
+    }
+}


### PR DESCRIPTION
Two cheap background completions at the end of a turn — the fourth item on the UX list.

**Titles.** The sidebar row is the first user message truncated to 42 characters. For "explain how euler's theorem works" that is a label you cannot pick out of a list of ten. After the first exchange the model now names the conversation instead — once, and never again.

**Follow-ups.** After every settled answer, three short questions the reader might ask next, as chips under that answer. Tapping one sends it.

Both are always on; neither is a setting.

## Titles need their own flag, not `hasCustomTitle`

`persistActive` re-derives the title from the first user turn on *every* save, so anything else needs a gate or the next streamed token reverts it — the regression `hasCustomTitle` was added for.

Reusing that flag was the obvious move and is wrong. It means the **user** owns the name. A generated title carrying it would be indistinguishable from a rename, and the generator could no longer tell "the reader named this, leave it" from "I named this, leave it". So `hasGeneratedTitle` is separate, and a rename still wins outright in both orderings.

## The parsers are generous going in, strict coming out

A small local model asked for a title returns it labelled, fenced, quoted, numbered, or buried in a paragraph. The first four are stripped. The last is refused: truncating prose to 42 characters reads worse than the reader's own opening words, which is what the row already shows.

Three rules beyond the obvious, each defensible on its own and not merely convenient:

- A markdown table row is a row whatever else it is.
- A trailing colon means the model wrote a lead-in to a list and stopped — "Three things, in order:" names nothing.
- More than one sentence is the answer, not a name for it. This is crude and takes `Dr. Who and the daleks` with it; that is an accepted loss, because a false reject keeps the derived title and a false accept puts a paragraph in the sidebar.

For follow-ups, **requiring every line to end in a question mark** is the highest-leverage decision here. One predicate removes preambles, markdown table rows, code, numbered-list residue and prose paragraphs, while compliant output passes by construction. Fewer than three survivors renders nothing — one lonely chip reads as a bug, and the whole feature is garnish.

## The rail holds its height before it has anything to show

`TranscriptScrollPositionProbe` follows any document growth while the reader is pinned, and its release valve `releaseIfAnswerOutgrewViewport` is gated on `isStreaming` — already false by the time a settled-turn footer could appear. Chips arriving a second after the answer would therefore yank a pinned reader with nothing to stop them, and the same growth flips `isPinnedToBottom` for a frame, popping the jump-to-bottom button and popping it back.

So the rail mounts at its final height in the same layout pass that adds the stats caption and the action row, and the chips fade in *inside* that reservation. Filling it changes no height, posts no frame notification, and cannot move anybody. **The probe needs no changes at all** — the hazard is gone by construction rather than guarded against.

That is also why the row scrolls sideways with `.lineLimit(1)` instead of flowing: a flowing layout makes the height depend on the text, and the text comes from a model.

## Not every lane will batch us

Skipped when the engine reports a non-text modality. The `--mllm` lane runs one request at a time, so a background call there is not batched alongside the reader's turn — it is queued in front of their next one.

The signal is `ModelResidencySnapshot.modality`, which is the engine's own answer per alias. `ModelBrandStyle.modelType(forAlias:)` is a second, name-based classifier already used to decide whether image parts go on the wire, but it treats the whole `qwen3.5-` and `gemma3-` families as vision — gating on it would have killed the feature on the most common models.

Two server constraints are satisfied by construction rather than by discipline: `ChatStreamClient.Request` cannot express a stop sequence, and the engine's batch-compatibility key is `(frozenset(stop_token_ids), bool(ignore_eos))` — a mismatch requeues behind the whole running batch. `enableThinking: false` is mandatory for the other reason `SamplingConfig` documents: thinking on spends the entire 24-token budget on a reasoning trace and returns empty content.

## Failure is silent, everywhere

No retry, no banner, no log the reader sees — the contract `ServerProfileFetcher` states for its own background fetch, for the same reason: there is nothing they could do about it. Every rejection leaves the derived title and an empty rail.

Cancelled on send, on conversation switch, on delete, on stop, and on termination. The five existing `inflight?.cancel(); inflight = nil` pairs are folded into one `cancelInflightWork()` — strictly less code than a registry, and it removes the "somebody added a third task and missed site four" class.

## Streaming, not a one-shot

`stream: true` stays hardcoded. A `stream: false` path would be the first desktop code to use the server's non-streaming branch, and `scripts/fake-rapid-mlx.sh` answers every chat request with `Content-Type: text/event-stream` and never reads the `stream` field — so a JSON-expecting client would decode-fail in the one harness that can drive this end to end, and fall back silently forever.

## Tests

41 new. Every guard was break-verified by reintroducing the defect and confirming the specific test fails: the title gate, both ownership guards, the one-shot guard, the follow-up anchor check, the `"Stopped."` clause, and the modality check.

**On golden-flow baselines.** The plan for this change asserted zero baseline churn on the grounds that the fake server's replies all fail the parsers. That reasoning was wrong — it checked two of the seven shapes. Measured, four of seven produced a title before the three quality rules above were added, and one (`math`) still does. `BackgroundAssistFakeServerTests` now pins exactly what each fake shape parses to, so a parser change that would move a baseline fails there first, with a name, instead of surfacing as a mystery diff.

Ran `chat-depth`, `math-rendering`, `message-actions` and `slow-stream-stop`: all pass, no baseline changes. `chat-restore` fails on `search-results`, but **it fails identically on a clean `main` build** (checked in a separate worktree) — the search panel moves in the AX tree, unrelated to this. `all` needs peekaboo, which is not installed here.

## Not in this change

- The fake server cannot produce a title or three questions on demand, so the harness cannot exercise the happy path. Teaching it a `shape:followups` marker plus a `flow_follow_ups` that presses `ChatView.FollowUp.0` introduces new baselines rather than mutating existing ones, which is a better second PR than a bigger first one.
- Chips do not participate in the streaming fade (`TextFadeAnimator` works on rendering attributes; these are not text).
- Identifiers are `ChatView.FollowUp.<index>`, deliberately **not** `ChatView.Message.` — `gui-golden-flows.sh`'s `transcript_only` scopes its slice by that prefix, and a chip inside it would freeze model-authored text into a snapshot.