### PR TITLE
fix(doctor): recognize the desktop audio dependency profile

### DIFF
--- a/tests/test_audio_desktop_extra.py
+++ b/tests/test_audio_desktop_extra.py
@@ -49,6 +49,10 @@ def test_doctor_desktop_audio_contract_matches_the_extra() -> None:
     """
     from vllm_mlx.doctor import env_health
 
+    assert env_health._AUDIO_DESKTOP_IMPORTS == (
+        ("mlx-audio", "mlx_audio"),
+        ("soundfile", "soundfile"),
+    )
     doctor_names = {dist for dist, _ in env_health._AUDIO_DESKTOP_IMPORTS}
     assert doctor_names == {
         _dependency_name(spec) for spec in _extras()["audio-desktop"]

--- a/tests/test_audio_desktop_extra.py
+++ b/tests/test_audio_desktop_extra.py
@@ -40,3 +40,16 @@ def test_full_audio_extra_remains_independent_and_complete() -> None:
 
     assert desktop_names <= full_names
     assert {"f5-tts-mlx", "misaki", "spacy", "phonemizer-fork"} <= full_names
+
+
+def test_doctor_desktop_audio_contract_matches_the_extra() -> None:
+    """``rapid-mlx doctor`` grades a bundled sidecar against
+    ``_AUDIO_DESKTOP_IMPORTS``. If this extra grows a dependency without the
+    doctor list growing too, doctor silently stops noticing it is missing.
+    """
+    from vllm_mlx.doctor import env_health
+
+    doctor_names = {dist for dist, _ in env_health._AUDIO_DESKTOP_IMPORTS}
+    assert doctor_names == {
+        _dependency_name(spec) for spec in _extras()["audio-desktop"]
+    }

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -265,6 +265,233 @@ def test_incomplete_audio_dependency_import_stack_marks_warning():
     assert broken.status is eh.CheckStatus.WARN
 
 
+def _stage_sidecar_bundle(tmp_path: Path, *, slot: str = "embedded") -> Path:
+    """Build the on-disk shape ``build-sidecar.sh`` produces and return the
+    interpreter.
+
+    ``slot`` picks which managed location it sits in — ``embedded`` mirrors
+    ``Rapid-MLX Desktop.app/Contents/Resources/rapid-mlx/`` and
+    ``runtime-override`` mirrors ``~/Library/Application Support/Rapid/
+    runtime-override/rapid-mlx/``. Both share the identical bundle layout.
+    """
+    parent = tmp_path / (
+        "runtime-override" if slot == "runtime-override" else "Resources"
+    )
+    root = parent / "rapid-mlx"
+    (root / "site-packages").mkdir(parents=True)
+    (root / "bin").mkdir(parents=True)
+    (root / "bin" / "rapid-mlx").write_text("#!/bin/sh\n")
+    exe = root / "python" / "bin" / "python3.12"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    return exe
+
+
+def test_bundled_sidecar_detected_from_layout(tmp_path: Path):
+    """The bundle is fingerprinted off ``sys.executable``'s directory shape."""
+    exe = _stage_sidecar_bundle(tmp_path)
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() == exe.parents[2].resolve()
+
+
+def test_ordinary_install_is_not_treated_as_bundled_sidecar(tmp_path: Path):
+    """A venv interpreter has no ``python/bin`` + ``site-packages`` sibling
+    shape, so CLI installs keep the full-extra contract."""
+    exe = tmp_path / "venv" / "bin" / "python3.12"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() is None
+
+
+def test_bundled_sidecar_grades_audio_against_desktop_extra(tmp_path: Path):
+    """RC 0.12.18: the signed bundle installs ``[audio-desktop]`` (mlx-audio +
+    soundfile only). Grading it against the full ``[audio]`` closure reported a
+    healthy build as incomplete."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    # Everything outside the audio-desktop extra is absent, exactly like the
+    # real bundle.
+    desktop_modules = {module for _, module in eh._AUDIO_DESKTOP_IMPORTS}
+    exe = _stage_sidecar_bundle(tmp_path)
+
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(
+            eh, "_module_available", side_effect=lambda m: m in desktop_modules
+        ),
+    ):
+        section = eh.section_optional_packages()
+
+    audio_row = next(c for c in section.checks if c.label.startswith("mlx-audio"))
+    assert audio_row.status is eh.CheckStatus.OK
+    assert "incomplete" not in audio_row.label
+
+
+def test_bundled_sidecar_never_recommends_pip_install(tmp_path: Path):
+    """Mutating a managed sidecar's Python environment is never the right
+    advice, so no row may hand the user a ``pip install`` line."""
+    exe = _stage_sidecar_bundle(tmp_path)
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", return_value=None),
+    ):
+        section = eh.section_optional_packages()
+
+    offenders = [
+        (c.label, c.detail)
+        for c in section.checks
+        if "pip install 'rapid-mlx[" in c.label + c.detail
+    ]
+    assert not offenders, offenders
+
+
+def test_bundle_does_not_ask_user_to_reinstall_for_an_extra_it_never_ships(
+    tmp_path: Path,
+):
+    """mlx-embeddings is outside the desktop product surface — ``build-
+    sidecar.sh`` never installs it. Flagging it ⚠ with a "reinstall" hint
+    reported a healthy bundle as broken and the warning would survive every
+    reinstall."""
+    exe = _stage_sidecar_bundle(tmp_path)
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", return_value=None),
+    ):
+        section = eh.section_optional_packages()
+
+    row = next(c for c in section.checks if c.label.startswith("mlx-embeddings"))
+    assert row.status is eh.CheckStatus.OK
+    assert "not bundled" in row.label
+    assert "reinstall" not in row.label.lower()
+
+
+def test_cli_install_still_warns_about_missing_embeddings(tmp_path: Path):
+    """The exclusion is bundle-only: an ordinary pip install that lacks
+    mlx-embeddings must still get the ⚠ + install hint."""
+    exe = tmp_path / "venv" / "bin" / "python3.12"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", return_value=None),
+    ):
+        section = eh.section_optional_packages()
+
+    row = next(c for c in section.checks if c.label.startswith("mlx-embeddings"))
+    assert row.status is eh.CheckStatus.WARN
+    assert "pip install 'rapid-mlx[embeddings]'" in row.label
+
+
+def test_embedded_bundle_hint_names_the_shipping_app(tmp_path: Path):
+    """``Rapid.app`` is a legacy name that release verification rejects; the
+    shipping product is ``Rapid-MLX Desktop.app``."""
+    exe = _stage_sidecar_bundle(tmp_path, slot="embedded")
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        hint = eh._sidecar_repair_hint(eh._bundled_sidecar_root())
+
+    assert "Rapid-MLX Desktop.app" in hint
+
+
+def test_runtime_override_is_not_told_to_reinstall_the_app(tmp_path: Path):
+    """The runtime override lives outside the app bundle, survives desktop
+    upgrades, and the bootstrapper skips its download while the cache exists —
+    so "reinstall the .app" alone repairs nothing."""
+    exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        root = eh._bundled_sidecar_root()
+        hint = eh._sidecar_repair_hint(root)
+
+    assert "outside the app bundle" in hint
+    # The step has to be actionable, so it names the exact directory to remove.
+    assert str(root) in hint
+
+
+def test_runtime_override_hint_avoids_the_nonexistent_update_entry_point(
+    tmp_path: Path,
+):
+    """Settings → check for updates hands off to Sparkle, which updates the app
+    bundle; ``UpdateChecker`` explicitly does not act on the manifest's
+    ``sidecar_*`` fields. Pointing users there for a broken runtime override is
+    a dead-end recovery flow."""
+    exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        hint = eh._sidecar_repair_hint(eh._bundled_sidecar_root())
+
+    assert "check for updates" not in hint.lower()
+
+
+def test_runtime_override_hint_does_not_promise_an_automatic_reinstall(
+    tmp_path: Path,
+):
+    """Nothing re-downloads a sidecar today: the bootstrapper module is not in
+    the source tree and the release workflow builds only the full DMG. A slim
+    install that merely deletes the override lands on the missing-runtime
+    overlay, whose only actions are Recheck and an *app* update download. So
+    the hint must order "install the app that ships a sidecar" BEFORE the
+    removal, and must not claim relaunching reinstalls the runtime."""
+    exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        root = eh._bundled_sidecar_root()
+        hint = eh._sidecar_repair_hint(root)
+
+    # No promise of self-repair.
+    assert "reinstalls it" not in hint
+    assert "then reinstalls" not in hint
+    # Install-first ordering: the app install must precede the removal step,
+    # otherwise a slim user is stranded with no sidecar at all.
+    assert hint.index("Rapid-MLX Desktop.app") < hint.index(f"remove {root}")
+
+
+def test_runtime_override_broken_audio_row_uses_the_runtime_hint(tmp_path: Path):
+    """End-to-end: a genuinely broken override bundle is still ⚠, and the
+    remediation the user reads is the runtime one, not the app one."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(
+            eh, "_module_available", side_effect=lambda m: m != "soundfile"
+        ),
+    ):
+        section = eh.section_optional_packages()
+
+    broken = next(c for c in section.checks if "soundfile" in c.label)
+    assert broken.status is eh.CheckStatus.WARN
+    assert "outside the app bundle" in broken.label
+
+
+def test_bundled_sidecar_still_flags_a_genuinely_broken_audio_install(
+    tmp_path: Path,
+):
+    """Narrowing the contract must not make the bundle unfalsifiable — a
+    missing soundfile is still inside the audio-desktop contract."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    exe = _stage_sidecar_bundle(tmp_path)
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(
+            eh, "_module_available", side_effect=lambda m: m != "soundfile"
+        ),
+    ):
+        section = eh.section_optional_packages()
+
+    broken = next(c for c in section.checks if "soundfile" in c.label)
+    assert broken.status is eh.CheckStatus.WARN
+    assert "reinstall Rapid-MLX Desktop.app" in broken.label
+
+
 # ---------------------------------------------------------------------------
 # Section: HuggingFace cache
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import plistlib
 from pathlib import Path
 from unittest import mock
 
@@ -274,9 +275,15 @@ def _stage_sidecar_bundle(tmp_path: Path, *, slot: str = "embedded") -> Path:
     ``runtime-override`` mirrors ``~/Library/Application Support/Rapid/
     runtime-override/rapid-mlx/``. Both share the identical bundle layout.
     """
-    parent = tmp_path / (
-        "runtime-override" if slot == "runtime-override" else "Resources"
-    )
+    if slot == "runtime-override":
+        parent = (
+            tmp_path / "Library" / "Application Support" / "Rapid" / "runtime-override"
+        )
+    else:
+        parent = tmp_path / "Rapid-MLX Desktop.app" / "Contents" / "Resources"
+        parent.parent.mkdir(parents=True)
+        with (parent.parent / "Info.plist").open("wb") as handle:
+            plistlib.dump({"CFBundleIdentifier": "com.rapidmlx.rapid"}, handle)
     root = parent / "rapid-mlx"
     (root / "site-packages").mkdir(parents=True)
     (root / "bin").mkdir(parents=True)
@@ -301,6 +308,58 @@ def test_ordinary_install_is_not_treated_as_bundled_sidecar(tmp_path: Path):
     exe.parent.mkdir(parents=True)
     exe.write_text("")
     with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() is None
+
+
+def test_custom_install_with_sidecar_shape_is_not_treated_as_desktop(
+    tmp_path: Path,
+):
+    """The three internal bundle paths are user-creatable and therefore do
+    not prove that Desktop owns the environment without a managed location."""
+    root = tmp_path / "custom-python" / "rapid-mlx"
+    (root / "site-packages").mkdir(parents=True)
+    (root / "bin").mkdir()
+    (root / "bin" / "rapid-mlx").write_text("#!/bin/sh\n")
+    exe = root / "python" / "bin" / "python3.12"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() is None
+
+
+def test_unrelated_app_with_sidecar_shape_is_not_treated_as_desktop(
+    tmp_path: Path,
+):
+    """A generic app-bundle suffix is not Rapid-MLX provenance."""
+    exe = _stage_sidecar_bundle(tmp_path)
+    info = exe.parents[4] / "Info.plist"
+    with info.open("wb") as handle:
+        plistlib.dump({"CFBundleIdentifier": "com.example.other-app"}, handle)
+
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() is None
+
+
+def test_non_mapping_info_plist_is_not_treated_as_desktop(tmp_path: Path):
+    """A valid plist may have a non-dictionary root and must not crash doctor."""
+    exe = _stage_sidecar_bundle(tmp_path)
+    info = exe.parents[4] / "Info.plist"
+    with info.open("wb") as handle:
+        plistlib.dump(["not", "a", "bundle", "dictionary"], handle)
+
+    with mock.patch.object(eh.sys, "executable", str(exe)):
+        assert eh._bundled_sidecar_root() is None
+
+
+def test_runtime_override_must_belong_to_active_home(tmp_path: Path):
+    """A matching suffix under another home is not Desktop provenance."""
+    foreign_home = tmp_path / "foreign-home"
+    exe = _stage_sidecar_bundle(foreign_home, slot="runtime-override")
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.dict(eh.os.environ, {"HOME": str(tmp_path / "active-home")}),
+    ):
         assert eh._bundled_sidecar_root() is None
 
 
@@ -401,7 +460,10 @@ def test_runtime_override_is_not_told_to_reinstall_the_app(tmp_path: Path):
     upgrades, and the bootstrapper skips its download while the cache exists —
     so "reinstall the .app" alone repairs nothing."""
     exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
-    with mock.patch.object(eh.sys, "executable", str(exe)):
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.dict(eh.os.environ, {"HOME": str(tmp_path)}),
+    ):
         root = eh._bundled_sidecar_root()
         hint = eh._sidecar_repair_hint(root)
 
@@ -418,7 +480,10 @@ def test_runtime_override_hint_avoids_the_nonexistent_update_entry_point(
     ``sidecar_*`` fields. Pointing users there for a broken runtime override is
     a dead-end recovery flow."""
     exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
-    with mock.patch.object(eh.sys, "executable", str(exe)):
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.dict(eh.os.environ, {"HOME": str(tmp_path)}),
+    ):
         hint = eh._sidecar_repair_hint(eh._bundled_sidecar_root())
 
     assert "check for updates" not in hint.lower()
@@ -434,7 +499,10 @@ def test_runtime_override_hint_does_not_promise_an_automatic_reinstall(
     the hint must order "install the app that ships a sidecar" BEFORE the
     removal, and must not claim relaunching reinstalls the runtime."""
     exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
-    with mock.patch.object(eh.sys, "executable", str(exe)):
+    with (
+        mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.dict(eh.os.environ, {"HOME": str(tmp_path)}),
+    ):
         root = eh._bundled_sidecar_root()
         hint = eh._sidecar_repair_hint(root)
 
@@ -456,6 +524,7 @@ def test_runtime_override_broken_audio_row_uses_the_runtime_hint(tmp_path: Path)
     exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
     with (
         mock.patch.object(eh.sys, "executable", str(exe)),
+        mock.patch.dict(eh.os.environ, {"HOME": str(tmp_path)}),
         mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
         mock.patch.object(
             eh, "_module_available", side_effect=lambda m: m != "soundfile"

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -24,6 +24,7 @@ import importlib.metadata as _im
 import importlib.util as _iu
 import os
 import platform
+import plistlib
 import shutil
 import subprocess
 import sys
@@ -230,7 +231,9 @@ def _bundled_sidecar_root() -> Path | None:
     We fingerprint that shape off ``sys.executable`` rather than trusting an
     env var: the desktop is not the only thing that spawns the sidecar (the
     user can run the shim by hand), so any env-var marker would be absent in
-    exactly the cases that matter.
+    exactly the cases that matter.  The shape alone is not provenance,
+    though: a custom Python installation can reproduce it.  Require one of
+    the two locations ``ServerLocator`` owns before changing doctor contracts.
     """
     try:
         exe = Path(sys.executable).resolve()
@@ -245,7 +248,50 @@ def _bundled_sidecar_root() -> Path | None:
         return None
     if not (root / "bin" / "rapid-mlx").exists():
         return None
-    return root
+
+    # Full DMG: <any app name>.app/Contents/Resources/rapid-mlx.  Users may
+    # rename the app after installation, so the stable macOS bundle suffix is
+    # the provenance signal rather than the display name.
+    embedded_shape = (
+        root.parent.name == "Resources"
+        and root.parents[1].name == "Contents"
+        and root.parents[2].suffix == ".app"
+    )
+    embedded = False
+    if embedded_shape:
+        try:
+            with (root.parents[1] / "Info.plist").open("rb") as handle:
+                plist = plistlib.load(handle)
+        except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
+            plist = None
+        bundle_id = plist.get("CFBundleIdentifier") if isinstance(plist, dict) else None
+        # Production is exact; dogfood isolation appends a suffix so multiple
+        # personas can coexist without sharing preferences.
+        embedded = isinstance(bundle_id, str) and (
+            bundle_id == "com.rapidmlx.rapid"
+            or bundle_id.startswith("com.rapidmlx.rapid.dogfood-")
+        )
+
+    # Runtime override: ApplicationSupportLocator may root this under a
+    # dogfood HOME, but the suffix below is invariant.  Match the complete
+    # product-owned suffix so an arbitrary ``runtime-override/rapid-mlx``
+    # directory is not enough to suppress ordinary CLI diagnostics.
+    runtime_override = False
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        try:
+            expected_override = (
+                Path(home).expanduser().resolve()
+                / "Library"
+                / "Application Support"
+                / "Rapid"
+                / "runtime-override"
+                / "rapid-mlx"
+            ).resolve()
+        except OSError:
+            expected_override = None
+        runtime_override = root == expected_override
+    return root if embedded or runtime_override else None
 
 
 def _sidecar_repair_hint(root: Path) -> str:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -139,6 +139,73 @@ _AUDIO_IMPORTS: tuple[tuple[str, str], ...] = (
     ("cn2an", "cn2an"),
 )
 
+# The macOS desktop sidecar deliberately installs ``rapid-mlx[audio-desktop]``
+# (``apps/rapid-mac/scripts/build-sidecar.sh``), a bounded extra that is just
+# ``mlx-audio`` + ``soundfile`` — the general-purpose TTS stack (f5-tts-mlx,
+# spaCy, misaki, numba, …) is excluded to stay under the bundle size gate.
+# Grading that bundle against ``_AUDIO_IMPORTS`` reported a perfectly healthy
+# signed 0.12.18 build as "incomplete — missing: f5-tts-mlx, numba, tiktoken,
+# …", i.e. the exact set difference between the two extras. Keep this aligned
+# with the ``audio-desktop`` extra in pyproject.toml (locked by
+# ``tests/test_audio_desktop_extra.py``).
+_AUDIO_DESKTOP_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("mlx-audio", "mlx_audio"),
+    ("soundfile", "soundfile"),
+)
+
+# Distributions the desktop sidecar deliberately does NOT ship. The bundle is
+# built to a hard size cap (``.github/workflows/rapid-mac-release.yml`` gates on
+# BUNDLE_SIZE_CAP_MB), so ``build-sidecar.sh`` installs the bounded
+# ``[audio-desktop]`` extra plus ``mlx-vlm --no-deps`` + Pillow, and nothing
+# else. ``mlx-embeddings`` is simply not part of the desktop product surface.
+# Reporting it as "not installed — reinstall the app" was doubly wrong: the
+# install is healthy, and reinstalling reproduces the identical warning
+# forever. These rows are informational, never ⚠.
+_DESKTOP_EXCLUDED_DISTS: frozenset[str] = frozenset({"mlx-embeddings"})
+
+# Where a bundled sidecar came from decides what "repair" even means, so the
+# two sources must not share one hint.
+#
+# * ``embedded`` — ``Rapid-MLX Desktop.app/Contents/Resources/rapid-mlx/``.
+#   Inside the code-signed, notarized app; pip-installing into it breaks the
+#   signature seal and Gatekeeper then rejects the app ("a sealed resource is
+#   missing or invalid"). Reinstalling the app genuinely replaces it.
+# * ``runtime-override`` — ``~/Library/Application Support/Rapid/
+#   runtime-override/rapid-mlx/``, written by the bootstrapper on first launch
+#   of the slim DMG. It lives OUTSIDE the app bundle and deliberately "survives
+#   desktop upgrades" (``ServerLocator.swift``), and the bootstrapper
+#   short-circuits its download while the cache is present
+#   (``build-bootstrapper-dmg.sh``). So "reinstall the .app" is actively wrong
+#   here — it typically changes nothing.
+#
+#   There is no in-app "repair the runtime" action to point at, and no
+#   automatic re-download either. Settings → check for updates hands off to
+#   Sparkle, which updates the *app* bundle, and ``UpdateChecker`` explicitly
+#   does not act on the manifest's ``sidecar_*`` fields. The bootstrapper that
+#   originally populated this slot is not part of the source tree any more, and
+#   the release workflow builds only the full DMG. So "remove it and relaunch"
+#   is NOT self-repairing on its own: with no bundled sidecar the desktop just
+#   lands on the missing-runtime overlay, whose only actions are Recheck and an
+#   app-update download.
+#
+#   What does work today, in this order: install the current
+#   Rapid-MLX Desktop.app — its DMG ships a sidecar at
+#   ``Contents/Resources/rapid-mlx/`` (``build.sh``) — and only then remove the
+#   override, so ``ServerLocator.find()`` resolves the bundled slot. Doing it
+#   the other way round leaves a slim install stranded. Note that reinstalling
+#   alone is not enough when the override's VERSION is equal or newer: it keeps
+#   winning over the bundled copy (``shouldPreferBundled``), which is exactly
+#   why the removal step is required.
+_EMBEDDED_REPAIR_HINT = (
+    "reinstall Rapid-MLX Desktop.app — the bundled sidecar's Python "
+    "environment is code-signed and must not be pip-installed into"
+)
+_RUNTIME_OVERRIDE_REPAIR_HINT_TEMPLATE = (
+    "this runtime at {root} lives outside the app bundle and no app update "
+    "replaces it — install the current Rapid-MLX Desktop.app (its DMG ships a "
+    "sidecar), then remove {root} and relaunch so the bundled sidecar is used"
+)
+
 
 def _module_available(module: str) -> bool:
     """Return whether *module* is discoverable, without importing it."""
@@ -146,6 +213,59 @@ def _module_available(module: str) -> bool:
         return _iu.find_spec(module) is not None
     except (ImportError, AttributeError, ValueError):
         return False
+
+
+def _bundled_sidecar_root() -> Path | None:
+    """Return the sidecar bundle root when doctor is running from a managed
+    sidecar's embedded interpreter, else ``None``.
+
+    The bundle layout produced by ``build-sidecar.sh`` is fixed, and both
+    managed slots share it (``ServerLocator.swift`` resolves each through the
+    same ``rapid-mlx/bin/rapid-mlx`` suffix)::
+
+        <root>/bin/rapid-mlx        # shell shim (sidecar-shim.sh)
+        <root>/python/bin/python3.12
+        <root>/site-packages/
+
+    We fingerprint that shape off ``sys.executable`` rather than trusting an
+    env var: the desktop is not the only thing that spawns the sidecar (the
+    user can run the shim by hand), so any env-var marker would be absent in
+    exactly the cases that matter.
+    """
+    try:
+        exe = Path(sys.executable).resolve()
+    except OSError:
+        return None
+    if len(exe.parents) < 3:
+        return None
+    if exe.parent.name != "bin" or exe.parents[1].name != "python":
+        return None
+    root = exe.parents[2]
+    if not (root / "site-packages").is_dir():
+        return None
+    if not (root / "bin" / "rapid-mlx").exists():
+        return None
+    return root
+
+
+def _sidecar_repair_hint(root: Path) -> str:
+    """Pick the repair hint matching which managed slot *root* sits in.
+
+    ``runtime-override`` is detected by its parent directory name rather than
+    by a full absolute-path match against ``~/Library/Application Support`` —
+    the desktop resolves Application Support through ``ApplicationSupportLocator``
+    which honours an overridden ``$HOME`` (dogfood / test launches), so a
+    hardcoded home-relative path would misclassify exactly those runs. Anything
+    that is not the override slot is the in-bundle copy.
+
+    The override hint embeds the resolved path because doctor already knows it
+    exactly and the recovery is a manual removal — a generic "remove the cached
+    runtime" would leave the user guessing at a location that moves with
+    ``$HOME``.
+    """
+    if root.parent.name == "runtime-override":
+        return _RUNTIME_OVERRIDE_REPAIR_HINT_TEMPLATE.format(root=root)
+    return _EMBEDDED_REPAIR_HINT
 
 
 # ---------------------------------------------------------------------------
@@ -609,8 +729,30 @@ def section_updates(
 
 def section_optional_packages() -> Section:
     s = Section("Optional Packages")
-    for dist, label, hint in OPTIONAL_PACKAGES:
+    # RC 0.12.18: the signed desktop bundle installs the bounded
+    # ``[audio-desktop]`` extra, but doctor graded it against the full
+    # ``[audio]`` contract and reported a healthy build as "incomplete", then
+    # told the user to pip-install into a code-signed app. Detect the managed
+    # sidecar once and swap the contract, the remediation hint, and the
+    # treatment of extras the bundle intentionally omits.
+    sidecar_root = _bundled_sidecar_root()
+    bundled = sidecar_root is not None
+    audio_contract = _AUDIO_DESKTOP_IMPORTS if bundled else _AUDIO_IMPORTS
+    repair_hint = _sidecar_repair_hint(sidecar_root) if sidecar_root else None
+    for dist, label, install_hint in OPTIONAL_PACKAGES:
+        hint = repair_hint if repair_hint else install_hint
         ver = _safe_version(dist)
+        if bundled and not ver and dist in _DESKTOP_EXCLUDED_DISTS:
+            # Not a defect: this extra is outside the desktop product surface,
+            # so there is nothing for the user to repair. ⚠ + "reinstall" here
+            # would survive any reinstall and train users to ignore the
+            # section.
+            s.add(
+                f"{label} not bundled with Rapid-MLX Desktop (not required)",
+                CheckStatus.OK,
+                detail=f"distribution={dist} bundled=false reason=excluded-from-desktop",
+            )
+            continue
         if ver:
             # #1255: mlx-vlm can install mlx-audio transitively without
             # respecting Rapid-MLX's supported audio range. Presence alone
@@ -632,7 +774,7 @@ def section_optional_packages() -> Section:
             if dist == "mlx-audio":
                 missing = [
                     distribution
-                    for distribution, module in _AUDIO_IMPORTS
+                    for distribution, module in audio_contract
                     if not _module_available(module)
                 ]
                 if missing:
@@ -643,7 +785,8 @@ def section_optional_packages() -> Section:
                         CheckStatus.WARN,
                         detail=(
                             f"distribution={dist} version={ver} "
-                            f"missing={missing_text} hint={hint}"
+                            f"missing={missing_text} hint={hint} "
+                            f"contract={'audio-desktop' if bundled else 'audio'}"
                         ),
                     )
                     continue
@@ -681,7 +824,14 @@ def section_optional_packages() -> Section:
     # it cannot say "you have mlx-vlm but it's too old for [dflash]". This
     # extra row makes the gate explicit so a fresh-install user knows whether
     # `pip install 'rapid-mlx[dflash]'` will actually work.
+    #
+    # The desktop bundle DOES ship mlx-vlm (pinned 0.6.3, ``--no-deps`` + Pillow
+    # — the gemma-4 family needs it even in text-only mode), so unlike
+    # mlx-embeddings this row is a real contract on a bundled sidecar and stays
+    # gradeable; only the remediation wording changes.
     dflash_min = (0, 5, 0)
+    dflash_hint = repair_hint or "pip install 'rapid-mlx[dflash]'"
+    vision_hint = repair_hint or "pip install 'rapid-mlx[vision]'"
     vlm_ver = _safe_version("mlx-vlm")
     if vlm_ver and _version_at_least(vlm_ver, dflash_min):
         # #1126: same PIL honesty as the vision row — a version-adequate
@@ -694,7 +844,7 @@ def section_optional_packages() -> Section:
                 CheckStatus.WARN,
                 detail=(
                     f"distribution=mlx-vlm version={vlm_ver} "
-                    "pil=missing-or-broken hint=pip install 'rapid-mlx[vision]'"
+                    f"pil=missing-or-broken hint={vision_hint}"
                 ),
             )
         else:
@@ -709,7 +859,7 @@ def section_optional_packages() -> Section:
             f"mlx-vlm 0.5.0+ (dflash extras) not installed or too old "
             f"(current: {current}, need: 0.5.0+)",
             CheckStatus.WARN,
-            detail="pip install 'rapid-mlx[dflash]'",
+            detail=dflash_hint,
         )
 
     return s


### PR DESCRIPTION
   Teach `rapid-mlx doctor` to recognize the managed desktop sidecar and validate its audio installation against the intentional `audio-desktop` dependency profile instead of the full `audio` extra.

  The change:

  - checks desktop audio dependencies against `mlx-audio` and `soundfile`;
  - preserves the full audio-extra validation for ordinary CLI installations;
  - avoids recommending `pip install` inside managed desktop environments;
  - provides repair guidance appropriate to embedded and runtime-override sidecars;
  - treats optional dependencies intentionally excluded from the desktop bundle as not required;
  - adds regression tests locking the doctor contract to the `audio-desktop` extra.

  Fixes #2185.

  The signed/notarized desktop bundle intentionally installs `rapid-mlx[audio-desktop]`, but `rapid-mlx doctor` evaluated it against the full `rapid-mlx[audio]` dependency set. As a result, healthy desktop installations were reported as incomplete and users were told to mutate the app's managed Python environment with `pip install`.

  Doctor should reflect the dependency contract of the environment it is inspecting while retaining the existing full-extra diagnostics for regular CLI installations.