### PR TITLE
fix(mac): default to the lowest image resolution option

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -72,7 +72,10 @@ final class ImageGenViewModel {
     // MARK: - Composed input
     var prompt: String = ""
     var aspect: Aspect = .square
-    var resolution: Resolution = .detailed
+    /// Defaults to the smallest preset: on-device diffusion cost scales with
+    /// pixel count, so 512² is the fastest first render and the least likely
+    /// to swap on a small-memory Mac. Users who want detail step up explicitly.
+    var resolution: Resolution = .compact
 
     var outputSize: String {
         aspect.size(for: resolution)

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true
           AXButton id="Images.Aspect.portrait" desc="3:4" enabled=true
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
-          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Load the model first" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -26,7 +26,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true
           AXButton id="Images.Aspect.portrait" desc="3:4" enabled=true
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
-          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -35,7 +35,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true
           AXButton id="Images.Aspect.portrait" desc="3:4" enabled=true
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
-          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Generate" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true
           AXButton id="Images.Aspect.portrait" desc="3:4" enabled=true
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
-          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -46,11 +46,11 @@ struct ImageGenerationResolutionTests {
         }
     }
 
-    @Test("A fresh view model still defaults to the pre-existing 1024x1024")
+    @Test("A fresh view model defaults to the lowest resolution preset")
     @MainActor
     func defaultOutputSize() {
         let viewModel = ImageGenViewModel(server: ServerManager())
-        #expect(viewModel.outputSize == "1024x1024")
+        #expect(viewModel.outputSize == "512x512")
     }
 
     @Test("Generated dimensions satisfy the image API contract")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3567,15 +3567,15 @@ flow_image_generation() {
     # And the rest of the payload. Without this the picker can show and load
     # the image alias while the request names something else entirely — the
     # tab would look right and render with the wrong model.
-    # `1024x1024` is what the default (square) aspect maps to. A shape-only
+    # `512x512` is what the default (square) aspect maps to. A shape-only
     # check like `^[0-9]+x[0-9]+$` passes `768x1024` — the PORTRAIT size — so
     # an aspect control wired to the wrong case would render the wrong shape
     # and the flow would call it correct.
     jq -s -e --arg alias "$FAKE_IMAGE_ALIAS" \
         'all(.[] | select(.event == "image_request");
-             .model == $alias and .n == 1 and .size == "1024x1024")' \
+             .model == $alias and .n == 1 and .size == "512x512")' \
         "$OUT/fake-events.jsonl" >/dev/null \
-        || die "an image request named the wrong model, asked for n != 1, or did not carry the square size 1024x1024: $(jq -s -c '[.[] | select(.event == "image_request") | {model, size, n}]' "$OUT/fake-events.jsonl")"
+        || die "an image request named the wrong model, asked for n != 1, or did not carry the square size 512x512: $(jq -s -c '[.[] | select(.event == "image_request") | {model, size, n}]' "$OUT/fake-events.jsonl")"
     # ...and the UI agreed that square was selected, so the two cannot drift
     # into agreeing on a wrong value together.
     # On `selected`, not on existence. All three ratio buttons carry the

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -9,6 +9,7 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+IMAGE_VIEW_MODEL = ROOT / "apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift"
 
 
 def test_audio_readiness_actions_start_the_selected_model_and_clear_the_gate():
@@ -40,6 +41,23 @@ def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
         1
     ]
     assert "image-generation audio-readiness" in diagnostic
+
+
+def test_image_generation_journey_asserts_the_product_default_request_size():
+    """Keep the shell E2E contract aligned with the Swift default.
+
+    The view-model test catches a wrong UI default, while the golden journey
+    catches a wrong request body. Pinning both sides here prevents changing
+    one literal and leaving the other to fail only in the 20-minute GUI job.
+    """
+    view_model = IMAGE_VIEW_MODEL.read_text()
+    flow = (
+        HARNESS.read_text().split("flow_image_generation() {", 1)[1].split("\n}", 1)[0]
+    )
+
+    assert "var resolution: Resolution = .compact" in view_model
+    assert '.size == "512x512"' in flow
+    assert "square size 512x512" in flow
 
 
 SNAPSHOTS = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__"


### PR DESCRIPTION
## Why

On-device diffusion cost and peak memory scale with pixel count. Starting at 512 × 512 gives a fresh user a substantially lighter first render and lowers swap/OOM risk on small-memory Macs; 1024 × 1024 remains one selection away for users who prefer detail.

## Change

The Images tab now defaults to the lowest resolution option (512 × 512) instead of 1024 × 1024.

## Validation

On the Mac Studio, the corrected default-value test fails against current `main` (`1024x1024`) and passes with this PR. All seven image-resolution contract tests pass.