### PR TITLE
feat(mac): surface Ornith 1.5 in model UI

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelBrandStyle.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelBrandStyle.swift
@@ -35,6 +35,7 @@ enum ModelBrand: String, CaseIterable, Equatable, Sendable {
     case glm
     case smollm
     case hermes
+    case ornith
     case other
 
     /// The 2-character tile monogram for the recognised brands. `other`
@@ -52,6 +53,7 @@ enum ModelBrand: String, CaseIterable, Equatable, Sendable {
         case .glm:      return "GL"
         case .smollm:   return "Sm"
         case .hermes:   return "He"
+        case .ornith:   return "Or"
         case .other:    return "?"
         }
     }
@@ -77,6 +79,7 @@ enum ModelBrandStyle {
         if a.contains("glm") { return .glm }
         if a.contains("smollm") { return .smollm }
         if a.contains("hermes") { return .hermes }
+        if a.hasPrefix("ornith-1.5-") { return .ornith }
         return .other
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelInfoCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelInfoCatalog.swift
@@ -76,6 +76,7 @@ struct ModelInfo: Equatable, Sendable {
 /// - Phi-3 / 4: 4k / 16k
 /// - Mistral 3: 32k
 /// - Hermes 3: 128k
+/// - Ornith 1.5: 256k
 /// - SmolLM3: 8k
 enum ModelInfoCatalog {
     /// Resolve an alias to a `ModelInfo`. `hfRepo` is optional and just
@@ -186,6 +187,10 @@ enum ModelInfoCatalog {
         // Hermes
         if a.contains("hermes-3") || a.contains("hermes3") { return ("Hermes 3", 131_072) }
         if a.contains("hermes") { return ("Hermes", 32_768) }
+        // Ornith-1.5 official MLX checkpoints advertise 262144 through
+        // ``text_config.max_position_embeddings`` in both the 9B dense and
+        // 35B-A3B MoE configs. The live server value still wins when present.
+        if a.hasPrefix("ornith-1.5-") { return ("Ornith 1.5", 262_144) }
         // Bonsai (small / experimental)
         if a.contains("bonsai") { return ("Bonsai", 4_096) }
         return ("Unknown", nil)

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -382,6 +382,10 @@ enum ToolUseCapability {
         // works (continuous batching scales) and parser/family contour
         // matches verified 30B aliases (qwen3-coder-30b).
         KnownFamily(prefix: "nemotron", minSizeBillions: 3.0, note: "cycle-7 headline: engine + parser path verified at 30B scale"),
+        // ornith-1.5 — Qwen3.5-derived text family using the hermes parser.
+        // Studio dogfood on both official MLX checkpoints confirmed parsed
+        // tool calls: dense 9B and hybrid MoE 35B-A3B.
+        KnownFamily(prefix: "ornith-1.5-", minSizeBillions: 9.0, note: "Studio dogfood verified tool calls on official 9B dense and 35B-A3B MoE checkpoints; hermes parser"),
 
         // MARK: Gemma 4 e-series (efficient variants)
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -113,6 +113,13 @@ enum ToolUseConfidence: Sendable, Equatable {
 /// ``gemma-4-12b-qat`` / ``qwen3-coder-next-80b-a3b`` shapes.
 enum ToolUseCapability {
 
+    /// Individually dogfooded aliases whose evidence must not be widened to
+    /// arbitrary size siblings by a family rule.
+    static let exactKnownAliases: Set<String> = [
+        "ornith-1.5-9b-bf16",
+        "ornith-1.5-35b-a3b-bf16",
+    ]
+
     /// One family-level rule: "aliases whose name starts with
     /// ``prefix`` (case-insensitive) AND parse to a size
     /// >= ``minSizeBillions`` are ``.known``." The ``note`` field is
@@ -382,11 +389,6 @@ enum ToolUseCapability {
         // works (continuous batching scales) and parser/family contour
         // matches verified 30B aliases (qwen3-coder-30b).
         KnownFamily(prefix: "nemotron", minSizeBillions: 3.0, note: "cycle-7 headline: engine + parser path verified at 30B scale"),
-        // ornith-1.5 — Qwen3.5-derived text family using the hermes parser.
-        // Studio dogfood on both official MLX checkpoints confirmed parsed
-        // tool calls: dense 9B and hybrid MoE 35B-A3B.
-        KnownFamily(prefix: "ornith-1.5-", minSizeBillions: 9.0, note: "Studio dogfood verified tool calls on official 9B dense and 35B-A3B MoE checkpoints; hermes parser"),
-
         // MARK: Gemma 4 e-series (efficient variants)
 
         // gemma-4-e4b — efficient 4B variant of gemma-4 family; same
@@ -491,6 +493,13 @@ enum ToolUseCapability {
         // family root but multimodal tool-call surface is unverified.
         for override in unverifiedPrefixOverrides where needle.hasPrefix(override) {
             return .unknown
+        }
+
+        // Exact evidence takes precedence over family inference. Ornith 1.5
+        // currently has two verified official checkpoints; similarly named
+        // custom/future sizes remain unverified until they are dogfooded.
+        if exactKnownAliases.contains(needle) {
+            return .known
         }
 
         // Step 3: family + size guard. An alias is .known when its

--- a/apps/rapid-mac/Sources/Rapid/UI/BrandIcon.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/BrandIcon.swift
@@ -54,6 +54,7 @@ struct BrandIcon: View {
         case .glm:      return [hex(0x8E5BF0), hex(0x6D3DD6)] // violet
         case .smollm:   return [hex(0x1AA6B7), hex(0x14808C)] // teal
         case .hermes:   return [hex(0x9B59D0), hex(0x7B3FB0)] // purple
+        case .ornith:   return [hex(0x2F9E73), hex(0x237A59)] // forest green
         case .other:    return [hex(0x8A8A93), hex(0x6E6E77)] // graphite
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/ModelInfoCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelInfoCatalogTests.swift
@@ -45,6 +45,17 @@ struct ModelInfoCatalogTests {
         #expect(g3.contextWindow == 8_192)
     }
 
+    @Test("Ornith 1.5 reports the 256k window from both official model configs")
+    func ornithContext() {
+        for alias in ["ornith-1.5-9b-bf16", "ornith-1.5-35b-a3b-bf16"] {
+            let info = ModelInfoCatalog.info(for: alias, hfRepo: nil)
+            #expect(info.family == "Ornith 1.5")
+            #expect(info.contextWindow == 262_144)
+            #expect(info.contextLabel == "256k")
+        }
+        #expect(ModelInfoCatalog.info(for: "ornithology-9b", hfRepo: nil).family == "Unknown")
+    }
+
     @Test("Unknown alias families return nil context — meter shows '—', not a guess")
     func unknownFamily() {
         let mystery = ModelInfoCatalog.info(for: "totally-made-up-7b", hfRepo: nil)

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -28,6 +28,7 @@ struct ModelSurfaceRedesignTests {
         #expect(ModelBrandStyle.brand(forAlias: "glm-4.6-9b-4bit") == .glm)
         #expect(ModelBrandStyle.brand(forAlias: "smollm-1.7b") == .smollm)
         #expect(ModelBrandStyle.brand(forAlias: "hermes-3-8b") == .hermes)
+        #expect(ModelBrandStyle.brand(forAlias: "ornith-1.5-9b-bf16") == .ornith)
     }
 
     @Test("brand: the whole Mistral house resolves to .mistral")
@@ -47,6 +48,7 @@ struct ModelSurfaceRedesignTests {
     func brandOther() {
         #expect(ModelBrandStyle.brand(forAlias: "bonsai-2b-4bit") == .other)
         #expect(ModelBrandStyle.brand(forAlias: "some-unknown-model") == .other)
+        #expect(ModelBrandStyle.brand(forAlias: "ornithology-9b") == .other)
     }
 
     // MARK: - ModelBrandStyle.monogram
@@ -56,6 +58,7 @@ struct ModelSurfaceRedesignTests {
         #expect(ModelBrandStyle.monogram(forAlias: "qwen3.6-35b-4bit") == "Qw")
         #expect(ModelBrandStyle.monogram(forAlias: "gpt-oss-20b-4bit") == "GO")
         #expect(ModelBrandStyle.monogram(forAlias: "deepseek-v3-4bit") == "DS")
+        #expect(ModelBrandStyle.monogram(forAlias: "ornith-1.5-35b-a3b-bf16") == "Or")
     }
 
     @Test("monogram: .other derives the first two letters, upper-cased")
@@ -79,6 +82,8 @@ struct ModelSurfaceRedesignTests {
         #expect(ModelBrandStyle.modelType(forAlias: "gemma3-1b-4bit") == .chat)
         #expect(ModelBrandStyle.modelType(forAlias: "qwen3.6-35b-4bit") == .chat)
         #expect(ModelBrandStyle.modelType(forAlias: "gpt-oss-20b-4bit") == .chat)
+        #expect(ModelBrandStyle.modelType(forAlias: "ornith-1.5-9b-bf16") == .chat)
+        #expect(ModelBrandStyle.modelType(forAlias: "ornith-1.5-35b-a3b-bf16") == .chat)
     }
 
     // MARK: - ModelBrandStyle.displayFamily
@@ -89,6 +94,7 @@ struct ModelSurfaceRedesignTests {
         // ModelInfoCatalog returns "Unknown" — the brand layer fixes both.
         #expect(ModelBrandStyle.displayFamily(forAlias: "gpt-oss-20b-4bit") == "GPT-OSS")
         #expect(ModelBrandStyle.displayFamily(forAlias: "devstral-24b-4bit") == "Devstral")
+        #expect(ModelBrandStyle.displayFamily(forAlias: "ornith-1.5-9b-bf16") == "Ornith 1.5")
     }
 
     @Test("displayFamily: an entirely unknown alias reads 'Model', never 'Unknown'")

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
@@ -102,6 +102,12 @@ struct ToolUseCapabilityTests {
         #expect(ToolUseCapability.confidence(for: "ornith-1.5-35b-a3b-bf16") == .known)
     }
 
+    @Test("Unverified Ornith-1.5 size shapes remain .unknown")
+    func ornithUnverifiedSizesAreUnknown() {
+        #expect(ToolUseCapability.confidence(for: "ornith-1.5-19b") == .unknown)
+        #expect(ToolUseCapability.confidence(for: "ornith-1.5-135b") == .unknown)
+    }
+
     @Test("llama3-3b-4bit is .known — smallest empirically-good llama")
     func llama3_3bIsKnown() {
         #expect(ToolUseCapability.confidence(for: "llama3-3b-4bit") == .known)

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
@@ -96,6 +96,12 @@ struct ToolUseCapabilityTests {
         #expect(ToolUseCapability.confidence(for: "qwen3.6-35b-a3b-4bit") == .known)
     }
 
+    @Test("Ornith-1.5 official sizes are .known after Studio tool-call dogfood")
+    func ornithOfficialSizesAreKnown() {
+        #expect(ToolUseCapability.confidence(for: "ornith-1.5-9b-bf16") == .known)
+        #expect(ToolUseCapability.confidence(for: "ornith-1.5-35b-a3b-bf16") == .known)
+    }
+
     @Test("llama3-3b-4bit is .known — smallest empirically-good llama")
     func llama3_3bIsKnown() {
         #expect(ToolUseCapability.confidence(for: "llama3-3b-4bit") == .known)


### PR DESCRIPTION
## Summary

Complete the desktop GUI integration for the Ornith-1.5 aliases landed in #2197. The engine catalog already feeds both aliases into the dynamic picker; this adds the missing GUI metadata and verified capability treatment.

- render an Ornith `Or` brand tile with a distinct forest-green treatment
- label both aliases as `Ornith 1.5` with a 256k context fallback
- classify the official 9B dense and 35B-A3B MoE aliases as text chat models
- surface the Tools capability from the completed Studio dogfood on both checkpoints
- bound matching to the explicit `ornith-1.5-` prefix so unrelated `ornithology-*` names remain unknown

## Why

Without this desktop metadata, #2197 aliases appear in the GUI catalog but render as a generic model, lack a context fallback, and hide the empirically verified tool capability.

## Test plan

- [x] 85 focused Swift tests passed (`ModelInfoCatalog`, model surface, tool capability + catalog coverage)
- [x] `bash scripts/smoke.sh` passed
- [x] full release-mode local app build with bundled sidecar passed; strict codesign verification passed
- [x] bundled sidecar `models` and `ls` list both Ornith aliases as cached
- [x] real GUI DevSnapshot dogfood started `ornith-1.5-9b-bf16`, reached ready on port 8000, sent a chat turn, received a complete 114-character response with no error, and rendered the selected alias in the composer

Full `swift test` compiled and ran 2,692 tests but reported 10 pre-existing timing/concurrency failures outside this diff (HF cache monitor, approval timing, download cancellation, and throughput timing). The affected focused suites are green.