### PR TITLE
fix(cache): isolate persisted KV by model revision

### DIFF
--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -28,6 +28,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+# A direct ``python scripts/release_fleet.py`` puts ``scripts/`` rather than
+# the checkout root on sys.path. The documented release command must work from
+# a bare checkout without requiring an editable install or manual PYTHONPATH.
+_CHECKOUT_ROOT = Path(__file__).resolve().parents[1]
+if str(_CHECKOUT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CHECKOUT_ROOT))
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -32,8 +32,9 @@ from typing import Any
 # the checkout root on sys.path. The documented release command must work from
 # a bare checkout without requiring an editable install or manual PYTHONPATH.
 _CHECKOUT_ROOT = Path(__file__).resolve().parents[1]
-if str(_CHECKOUT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_CHECKOUT_ROOT))
+_checkout_root_str = str(_CHECKOUT_ROOT)
+sys.path[:] = [entry for entry in sys.path if entry != _checkout_root_str]
+sys.path.insert(0, _checkout_root_str)
 
 try:
     import tomllib

--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -721,14 +721,14 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     monkeypatch.setattr(tok, "repair_byte_level_decoder", _fake_repair_decoder)
     monkeypatch.setattr(tok, "_post_load_ubc_evict", lambda name: None)
 
-    model, tokenizer, config = tok.load_model_with_fallback(
-        model_name, lazy=True, return_config=True
+    model, tokenizer, config, checkpoint_source = tok.load_model_with_fallback(
+        model_name, lazy=True, return_config=True, return_source=True
     )
 
     assert model is fake_model
     assert tokenizer is fake_tokenizer
     assert config == {"model_type": "qwen2_moe"}
-    assert fake_model._rapid_mlx_loaded_checkpoint_source == resolved_name
+    assert checkpoint_source == resolved_name
     assert order == [
         "_neutralize_unbundled_template_types",
         "mlx_lm.load",

--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -714,9 +714,7 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     monkeypatch.setattr(tok, "_neutralize_unbundled_template_types", _fake_neutralize)
     monkeypatch.setattr(tok, "_try_inject_mtp_post_load", _fake_inject_mtp)
     monkeypatch.setattr(tok, "_apply_chat_template_sidecar", _fake_sidecar)
-    monkeypatch.setattr(
-        tok, "_resolve_model_path", lambda name: resolved_name
-    )
+    monkeypatch.setattr(tok, "_resolve_model_path", lambda name: resolved_name)
     monkeypatch.setattr(
         tok, "augment_eos_token_ids_from_generation_config", _fake_augment_eos
     )

--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -669,12 +669,14 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     from vllm_mlx.utils import tokenizer as tok
 
     order: list[str] = []
-    fake_model = object()
+    fake_model = SimpleNamespace()
     fake_tokenizer = SimpleNamespace(chat_template=None)
     model_name = "mlx-community/fake-qwen2-moe-checkpoint-4bit"
+    resolved_name = "/fake/disk-stream-checkpoint"
 
     def _fake_mlx_lm_load(path_or_hf_repo, tokenizer_config=None, **kwargs):
         order.append("mlx_lm.load")
+        assert path_or_hf_repo == resolved_name
         assert kwargs.get("lazy") is True
         assert tokenizer_config == {"neutralized": True}, (
             "mlx_lm.load must see the tokenizer_config AFTER "
@@ -687,13 +689,13 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
 
     def _fake_neutralize(name, tokenizer_config):
         order.append("_neutralize_unbundled_template_types")
-        assert name == model_name
+        assert name == resolved_name
         return {"neutralized": True}
 
     def _fake_inject_mtp(model, name):
         order.append("_try_inject_mtp_post_load")
         assert model is fake_model
-        assert name == model_name
+        assert name == resolved_name
 
     def _fake_sidecar(model_path, tokenizer):
         order.append("_apply_chat_template_sidecar")
@@ -702,7 +704,7 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     def _fake_augment_eos(tokenizer, name):
         order.append("augment_eos_token_ids_from_generation_config")
         assert tokenizer is fake_tokenizer
-        assert name == model_name
+        assert name == resolved_name
 
     def _fake_repair_decoder(tokenizer):
         order.append("repair_byte_level_decoder")
@@ -713,7 +715,7 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     monkeypatch.setattr(tok, "_try_inject_mtp_post_load", _fake_inject_mtp)
     monkeypatch.setattr(tok, "_apply_chat_template_sidecar", _fake_sidecar)
     monkeypatch.setattr(
-        tok, "_resolve_model_path", lambda name: "/fake/disk-stream-checkpoint"
+        tok, "_resolve_model_path", lambda name: resolved_name
     )
     monkeypatch.setattr(
         tok, "augment_eos_token_ids_from_generation_config", _fake_augment_eos
@@ -728,6 +730,7 @@ def test_lazy_load_runs_generic_post_load_tokenizer_fixups(monkeypatch):
     assert model is fake_model
     assert tokenizer is fake_tokenizer
     assert config == {"model_type": "qwen2_moe"}
+    assert fake_model._rapid_mlx_loaded_checkpoint_source == resolved_name
     assert order == [
         "_neutralize_unbundled_template_types",
         "mlx_lm.load",

--- a/tests/test_model_file_guard.py
+++ b/tests/test_model_file_guard.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -132,7 +131,11 @@ def test_shared_loader_pins_concrete_snapshot_on_loaded_model(
 
     snapshot = tmp_path / "snapshots" / "immutable-revision"
     snapshot.mkdir(parents=True)
-    model = SimpleNamespace()
+
+    class ImmutableModel:
+        __slots__ = ()
+
+    model = ImmutableModel()
     expected = (model, object())
     loaded = []
 
@@ -147,6 +150,7 @@ def test_shared_loader_pins_concrete_snapshot_on_loaded_model(
     )
     monkeypatch.setattr(tokenizer, "_post_load_ubc_evict", lambda name: None)
 
-    assert tokenizer.load_model_with_fallback("org/model") is expected
+    result = tokenizer.load_model_with_fallback("org/model", return_source=True)
+    assert result[:2] == expected
+    assert result[2] == str(snapshot)
     assert loaded == [str(snapshot)]
-    assert model._rapid_mlx_loaded_checkpoint_source == str(snapshot)

--- a/tests/test_model_file_guard.py
+++ b/tests/test_model_file_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -117,7 +118,35 @@ def test_shared_loader_validates_before_dispatch(
             expected,
         )[1],
     )
+    monkeypatch.setattr(tokenizer, "_resolve_model_path", lambda model_name: None)
     monkeypatch.setattr(tokenizer, "_post_load_ubc_evict", lambda model_name: None)
 
     assert tokenizer.load_model_with_fallback("local-model") is expected
     assert events == [("validate", "local-model"), ("load", "local-model")]
+
+
+def test_shared_loader_pins_concrete_snapshot_on_loaded_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from vllm_mlx.utils import tokenizer
+
+    snapshot = tmp_path / "snapshots" / "immutable-revision"
+    snapshot.mkdir(parents=True)
+    model = SimpleNamespace()
+    expected = (model, object())
+    loaded = []
+
+    monkeypatch.setattr(tokenizer, "_local_snapshot_if_cached", lambda name: name)
+    monkeypatch.setattr(tokenizer, "_resolve_model_path", lambda name: snapshot)
+    monkeypatch.setattr(tokenizer, "validate_local_model_file", lambda name: None)
+    monkeypatch.setattr(tokenizer, "_model_requires_remote_code", lambda name: False)
+    monkeypatch.setattr(
+        tokenizer,
+        "_load_model_with_fallback_impl",
+        lambda name, tokenizer_config=None: (loaded.append(name), expected)[1],
+    )
+    monkeypatch.setattr(tokenizer, "_post_load_ubc_evict", lambda name: None)
+
+    assert tokenizer.load_model_with_fallback("org/model") is expected
+    assert loaded == [str(snapshot)]
+    assert model._rapid_mlx_loaded_checkpoint_source == str(snapshot)

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1179,13 +1179,14 @@ def test_start_llm_calls_apply_mtp_dispatch():
     engine._engine_started = False
 
     # 2. Stub the model loader so we don't touch HF / MLX weights.
-    def _fake_load(model_name, tokenizer_config=None):
+    def _fake_load(model_name, tokenizer_config=None, *, return_source=False):
         # Return a duck-typed model + tokenizer; the real code just
         # stashes them on ``self`` and hands the model to the
         # dispatch helper.
         fake_model = object()
         fake_tokenizer = SimpleNamespace(eos_token_id=0)
-        return fake_model, fake_tokenizer
+        result = (fake_model, fake_tokenizer)
+        return (*result, "/fake/immutable-snapshot") if return_source else result
 
     monkeypatch = _MonkeypatchScope()
     try:

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -116,6 +116,44 @@ def test_distinct_model_revisions_get_distinct_cache_dirs():
     assert first != second
 
 
+def test_loaded_engine_pins_revision_identity_for_load_and_save():
+    cfg = _patched_cfg("org/model", "int8")
+    cfg.engine = SimpleNamespace(
+        scheduler=SimpleNamespace(config=SimpleNamespace(kv_cache_dtype="int8"))
+    )
+    with (
+        patch("vllm_mlx.runtime.cache.get_config", return_value=cfg),
+        patch(
+            "vllm_mlx.runtime.cache._cached_model_revision",
+            side_effect=["revision-at-load", "revision-after-external-update"],
+        ) as revision,
+    ):
+        load_path = get_cache_dir()
+        save_path = get_cache_dir()
+    assert load_path == save_path
+    revision.assert_called_once_with("org/model")
+
+
+def test_new_engine_recaptures_updated_revision_identity():
+    cfg = _patched_cfg("org/model", "int8")
+    cfg.engine = SimpleNamespace(
+        scheduler=SimpleNamespace(config=SimpleNamespace(kv_cache_dtype="int8"))
+    )
+    with (
+        patch("vllm_mlx.runtime.cache.get_config", return_value=cfg),
+        patch(
+            "vllm_mlx.runtime.cache._cached_model_revision",
+            side_effect=["revision-a", "revision-b"],
+        ),
+    ):
+        first = get_cache_dir()
+        cfg.engine = SimpleNamespace(
+            scheduler=SimpleNamespace(config=SimpleNamespace(kv_cache_dtype="int8"))
+        )
+        second = get_cache_dir()
+    assert first != second
+
+
 def test_builtin_alias_resolves_to_underlying_hf_repo():
     assert (
         _resolved_model_source("deepseek-r1-32b-4bit")

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -84,6 +84,24 @@ def test_distinct_kv_dtypes_get_distinct_cache_dirs():
     )
 
 
+def test_live_scheduler_dtype_wins_over_server_config_fallback():
+    cfg = _patched_cfg("org/model", "bf16")
+    cfg.engine = SimpleNamespace(
+        scheduler=SimpleNamespace(config=SimpleNamespace(kv_cache_dtype="int8"))
+    )
+    with (
+        patch("vllm_mlx.runtime.cache.get_config", return_value=cfg),
+        patch("vllm_mlx.runtime.cache._cached_model_revision", return_value="rev-a"),
+    ):
+        programmatic = get_cache_dir()
+    assert os.path.basename(programmatic) == os.path.basename(
+        _resolve_with_dtype("org/model", "int8")
+    )
+    assert os.path.basename(programmatic) != os.path.basename(
+        _resolve_with_dtype("org/model", "bf16")
+    )
+
+
 def test_distinct_model_revisions_get_distinct_cache_dirs():
     cfg = _patched_cfg("org/model", "int8")
     with patch("vllm_mlx.runtime.cache.get_config", return_value=cfg):
@@ -112,6 +130,20 @@ def test_local_checkpoint_fingerprint_changes_when_weights_change(tmp_path):
     first = _cached_model_revision(str(tmp_path))
 
     weights.write_bytes(b"replacement-weights")
+    second = _cached_model_revision(str(tmp_path))
+    assert first != second
+
+
+def test_local_checkpoint_same_size_preserved_mtime_still_invalidates(tmp_path):
+    weights = tmp_path / "model.safetensors"
+    weights.write_bytes(b"first-weights")
+    original = weights.stat()
+    first = _cached_model_revision(str(tmp_path))
+
+    weights.write_bytes(b"other-weights")  # same byte length
+    os.utime(weights, ns=(original.st_atime_ns, original.st_mtime_ns))
+    assert weights.stat().st_size == original.st_size
+    assert weights.stat().st_mtime_ns == original.st_mtime_ns
     second = _cached_model_revision(str(tmp_path))
     assert first != second
 

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -61,7 +61,7 @@ def test_normal_hf_name_resolves_under_prefix_cache_root():
     stable hash suffix for collision protection."""
     p = _resolve("mlx-community/Qwen3-0.6B-8bit")
     leaf = os.path.basename(p)
-    # ``mlx-community--Qwen3-0.6B-8bit--<8 hex>``
+    # ``mlx-community--Qwen3-0.6B-8bit--<16 hex>``
     assert leaf.startswith("mlx-community--Qwen3-0.6B-8bit--")
     assert p.startswith(_root() + os.sep)
     # Same input → same output (deterministic hash).

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -14,7 +14,11 @@ import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from vllm_mlx.runtime.cache import get_cache_dir
+from vllm_mlx.runtime.cache import (
+    _cached_model_revision,
+    _resolved_model_source,
+    get_cache_dir,
+)
 
 
 def _patched_cfg(name: str, kv_cache_dtype: str = "bf16"):
@@ -91,6 +95,24 @@ def test_distinct_model_revisions_get_distinct_cache_dirs():
             "vllm_mlx.runtime.cache._cached_model_revision", return_value="rev-b"
         ):
             second = get_cache_dir()
+    assert first != second
+
+
+def test_builtin_alias_resolves_to_underlying_hf_repo():
+    assert (
+        _resolved_model_source("deepseek-r1-32b-4bit")
+        == "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit"
+    )
+
+
+def test_local_checkpoint_fingerprint_changes_when_weights_change(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type":"test"}')
+    weights = tmp_path / "model.safetensors"
+    weights.write_bytes(b"first")
+    first = _cached_model_revision(str(tmp_path))
+
+    weights.write_bytes(b"replacement-weights")
+    second = _cached_model_revision(str(tmp_path))
     assert first != second
 
 

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -239,6 +239,20 @@ def test_local_custom_model_code_change_invalidates(tmp_path):
     assert first != second
 
 
+def test_local_custom_model_arbitrary_asset_change_invalidates(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "custom", "model_file": "model.py"})
+    )
+    (tmp_path / "model.py").write_text("# reads params.table\n")
+    asset = tmp_path / "params.table"
+    asset.write_bytes(b"semantic-version-one")
+    first = _cached_model_revision(str(tmp_path))
+
+    asset.write_bytes(b"semantic-version-two")
+    second = _cached_model_revision(str(tmp_path))
+    assert first != second
+
+
 def test_traversal_double_dot_does_not_escape_root():
     """A name with ``..`` must NOT escape the prefix-cache root."""
     p = _resolve("../evil")

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -11,24 +11,36 @@ don't permit ``..``.
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from vllm_mlx.runtime.cache import get_cache_dir
 
 
-def _patched_cfg(name: str):
+def _patched_cfg(name: str, kv_cache_dtype: str = "bf16"):
     """Stub config object with model_path/model_name set for the test."""
 
-    class _Cfg:
-        model_path = None
-        model_name = name
-        engine = None
-
-    return _Cfg()
+    return SimpleNamespace(
+        model_path=None,
+        model_name=name,
+        engine=None,
+        kv_cache_dtype=kv_cache_dtype,
+    )
 
 
 def _resolve(name: str) -> str:
     with patch("vllm_mlx.runtime.cache.get_config", return_value=_patched_cfg(name)):
+        return os.path.realpath(get_cache_dir())
+
+
+def _resolve_with_dtype(name: str, dtype: str) -> str:
+    with (
+        patch(
+            "vllm_mlx.runtime.cache.get_config",
+            return_value=_patched_cfg(name, dtype),
+        ),
+        patch("vllm_mlx.runtime.cache._cached_model_revision", return_value="rev-a"),
+    ):
         return os.path.realpath(get_cache_dir())
 
 
@@ -60,6 +72,26 @@ def test_distinct_models_get_distinct_dirs_even_when_sanitized_clash():
     # Both leaves should still START with the same sanitized prefix.
     assert os.path.basename(p_slash).startswith("a--b--")
     assert os.path.basename(p_dash).startswith("a--b--")
+
+
+def test_distinct_kv_dtypes_get_distinct_cache_dirs():
+    assert _resolve_with_dtype("org/model", "bf16") != _resolve_with_dtype(
+        "org/model", "int8"
+    )
+
+
+def test_distinct_model_revisions_get_distinct_cache_dirs():
+    cfg = _patched_cfg("org/model", "int8")
+    with patch("vllm_mlx.runtime.cache.get_config", return_value=cfg):
+        with patch(
+            "vllm_mlx.runtime.cache._cached_model_revision", return_value="rev-a"
+        ):
+            first = get_cache_dir()
+        with patch(
+            "vllm_mlx.runtime.cache._cached_model_revision", return_value="rev-b"
+        ):
+            second = get_cache_dir()
+    assert first != second
 
 
 def test_traversal_double_dot_does_not_escape_root():

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -18,6 +18,7 @@ from vllm_mlx.runtime.cache import (
     _cached_model_revision,
     _resolved_model_source,
     get_cache_dir,
+    pin_prefix_cache_identity,
 )
 
 
@@ -132,6 +133,26 @@ def test_loaded_engine_pins_revision_identity_for_load_and_save():
         save_path = get_cache_dir()
     assert load_path == save_path
     revision.assert_called_once_with("org/model")
+
+
+def test_explicit_engine_pin_never_rereads_mutable_remote_ref():
+    engine = SimpleNamespace()
+    pin_prefix_cache_identity(
+        engine,
+        raw_model_name="org/model",
+        checkpoint_source="/cache/snapshots/immutable-revision",
+        kv_dtype="int8",
+    )
+    cfg = _patched_cfg("org/model", "int8")
+    cfg.engine = engine
+    with (
+        patch("vllm_mlx.runtime.cache.get_config", return_value=cfg),
+        patch(
+            "vllm_mlx.runtime.cache._cached_model_revision",
+            side_effect=AssertionError("must use the pre-pinned identity"),
+        ),
+    ):
+        assert get_cache_dir() == get_cache_dir()
 
 
 def test_new_engine_recaptures_updated_revision_identity():

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -10,6 +10,7 @@ don't permit ``..``.
 
 from __future__ import annotations
 
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -203,6 +204,21 @@ def test_local_checkpoint_same_size_preserved_mtime_still_invalidates(tmp_path):
     os.utime(weights, ns=(original.st_atime_ns, original.st_mtime_ns))
     assert weights.stat().st_size == original.st_size
     assert weights.stat().st_mtime_ns == original.st_mtime_ns
+    second = _cached_model_revision(str(tmp_path))
+    assert first != second
+
+
+def test_local_indexed_nested_shard_change_invalidates(tmp_path):
+    shard_dir = tmp_path / "weights"
+    shard_dir.mkdir()
+    shard = shard_dir / "model-00001-of-00001.safetensors"
+    shard.write_bytes(b"first-shard")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"model.weight": str(shard.relative_to(tmp_path))}})
+    )
+    first = _cached_model_revision(str(tmp_path))
+
+    shard.write_bytes(b"replacement-shard")
     second = _cached_model_revision(str(tmp_path))
     assert first != second
 

--- a/tests/test_runtime_cache_path.py
+++ b/tests/test_runtime_cache_path.py
@@ -223,6 +223,22 @@ def test_local_indexed_nested_shard_change_invalidates(tmp_path):
     assert first != second
 
 
+def test_local_custom_model_code_change_invalidates(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "custom", "model_file": "code/model.py"})
+    )
+    code_dir = tmp_path / "code"
+    code_dir.mkdir()
+    model_file = code_dir / "model.py"
+    model_file.write_text("MODEL_VERSION = 1\n")
+    (tmp_path / "model.safetensors").write_bytes(b"unchanged-weights")
+    first = _cached_model_revision(str(tmp_path))
+
+    model_file.write_text("MODEL_VERSION = 2\n")
+    second = _cached_model_revision(str(tmp_path))
+    assert first != second
+
+
 def test_traversal_double_dot_does_not_escape_root():
     """A name with ``..`` must NOT escape the prefix-cache root."""
     p = _resolve("../evil")

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -52,12 +52,14 @@ def _load_lazy_and_install_disk_stream(
     from .. import disk_stream_patch
     from ..utils.tokenizer import _resolve_model_path, load_model_with_fallback
 
-    model, tokenizer, config = load_model_with_fallback(
-        model_name, tokenizer_config, lazy=True, return_config=True
+    model, tokenizer, config, checkpoint_source = load_model_with_fallback(
+        model_name,
+        tokenizer_config,
+        lazy=True,
+        return_config=True,
+        return_source=True,
     )
-    checkpoint_path = _resolve_model_path(
-        getattr(model, "_rapid_mlx_loaded_checkpoint_source", model_name)
-    )
+    checkpoint_path = _resolve_model_path(checkpoint_source)
     if checkpoint_path is None:
         raise ValueError(
             f"--disk-stream: could not resolve a local checkpoint path for "
@@ -69,7 +71,7 @@ def _load_lazy_and_install_disk_stream(
         checkpoint_path,
         cache_budget_gb=cache_budget_gb,
     )
-    return model, tokenizer
+    return model, tokenizer, checkpoint_source
 
 
 # Harmony's chat template ends its generation prompt immediately after
@@ -1294,23 +1296,28 @@ class BatchedEngine(BaseEngine):
             # combination and lazy loading bypasses
             # load_model_with_fallback's fallback branches entirely (see
             # its docstring).
-            self._model, self._tokenizer = self._model_load_executor.submit(
-                _load_lazy_and_install_disk_stream,
-                self._model_name,
-                tokenizer_config,
-                getattr(self, "_disk_stream_cache_gb", 1.0),
-            ).result()
+            self._model, self._tokenizer, checkpoint_source = (
+                self._model_load_executor.submit(
+                    _load_lazy_and_install_disk_stream,
+                    self._model_name,
+                    tokenizer_config,
+                    getattr(self, "_disk_stream_cache_gb", 1.0),
+                ).result()
+            )
         else:
             load_kwargs = {"tokenizer_config": tokenizer_config}
             if self._scheduler_config is not None and (
                 getattr(self._scheduler_config, "spec_decode", "none") == "dspark"
             ):
                 load_kwargs["enable_dspark"] = True
-            self._model, self._tokenizer = self._model_load_executor.submit(
-                load_model_with_fallback,
-                self._model_name,
-                **load_kwargs,
-            ).result()
+            self._model, self._tokenizer, checkpoint_source = (
+                self._model_load_executor.submit(
+                    load_model_with_fallback,
+                    self._model_name,
+                    return_source=True,
+                    **load_kwargs,
+                ).result()
+            )
 
             # Fuse MoE gate+up expert projections: one gather_qmm launch
             # instead of two per MoE layer per token, bit-exact (see
@@ -1347,9 +1354,6 @@ class BatchedEngine(BaseEngine):
         # receive the same single, immutable namespace.
         from ..runtime.cache import pin_prefix_cache_identity
 
-        checkpoint_source = getattr(
-            self._model, "_rapid_mlx_loaded_checkpoint_source", self._model_name
-        )
         kv_dtype = str(
             getattr(self._scheduler_config, "kv_cache_dtype", None) or "bf16"
         )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -55,7 +55,9 @@ def _load_lazy_and_install_disk_stream(
     model, tokenizer, config = load_model_with_fallback(
         model_name, tokenizer_config, lazy=True, return_config=True
     )
-    checkpoint_path = _resolve_model_path(model_name)
+    checkpoint_path = _resolve_model_path(
+        getattr(model, "_rapid_mlx_loaded_checkpoint_source", model_name)
+    )
     if checkpoint_path is None:
         raise ValueError(
             f"--disk-stream: could not resolve a local checkpoint path for "
@@ -1337,6 +1339,26 @@ class BatchedEngine(BaseEngine):
                 from ..gdn_in_proj_fusion import fuse_gdn_in_proj
 
                 self._model_load_executor.submit(fuse_gdn_in_proj, self._model).result()
+
+        # Capture persistence identity from the exact immutable snapshot
+        # selected by the loader before this engine is published through
+        # ServerConfig and concurrent cache load/save tasks can observe it.
+        # This is deliberately outside the eager branch so disk-stream engines
+        # receive the same single, immutable namespace.
+        from ..runtime.cache import pin_prefix_cache_identity
+
+        checkpoint_source = getattr(
+            self._model, "_rapid_mlx_loaded_checkpoint_source", self._model_name
+        )
+        kv_dtype = str(
+            getattr(self._scheduler_config, "kv_cache_dtype", None) or "bf16"
+        )
+        pin_prefix_cache_identity(
+            self,
+            raw_model_name=self._model_name,
+            checkpoint_source=checkpoint_source,
+            kv_dtype=kv_dtype,
+        )
 
         # 0.9.13 PR-A: new-arch MTP inject dispatcher (Gemma 4 external
         # assistant / Qwen3.5 baked-in MTP). Runs BEFORE the scheduler is

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -425,6 +425,19 @@ def _semantic_cache_identity(cfg, raw_model_name: str) -> str:
     return identity
 
 
+def pin_prefix_cache_identity(
+    engine, *, raw_model_name: str, checkpoint_source: str, kv_dtype: str
+) -> str:
+    """Pin cache identity before a loaded engine becomes concurrently visible."""
+    revision = _cached_model_revision(checkpoint_source)
+    identity = (
+        f"{raw_model_name}\0prefix-cache-v{_PREFIX_CACHE_NAMESPACE_VERSION}"
+        f"\0kv={kv_dtype}\0revision={revision}"
+    )
+    engine._rapid_mlx_prefix_cache_identity = identity
+    return identity
+
+
 def _file_identity(stat: os.stat_result) -> str:
     """Metadata identity that changes on content replacement.
 

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -356,16 +356,44 @@ def get_cache_dir() -> str:
 
 def _cached_model_revision(model_name: str) -> str:
     """Return a stable, network-free identity for the selected weights."""
-    candidate = Path(model_name).expanduser()
+    source = _resolved_model_source(model_name)
+    candidate = Path(source).expanduser()
     if candidate.exists():
         try:
-            return str(candidate.resolve())
+            resolved = candidate.resolve()
         except OSError:
-            return str(candidate)
+            resolved = candidate
+        if resolved.is_dir():
+            digest = hashlib.sha256(str(resolved).encode("utf-8"))
+            tracked = [
+                resolved / "config.json",
+                resolved / "model.safetensors.index.json",
+            ]
+            tracked.extend(sorted(resolved.glob("*.safetensors")))
+            for path in tracked:
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                digest.update(path.name.encode("utf-8"))
+                digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode("ascii"))
+                # Config/index files are small and encode architecture/shard
+                # identity. Hash their bytes; large weight files use metadata.
+                if path.suffix == ".json":
+                    try:
+                        digest.update(path.read_bytes())
+                    except OSError:
+                        pass
+            return f"local-{digest.hexdigest()[:16]}"
+        try:
+            stat = resolved.stat()
+            return f"local-file-{stat.st_size}-{stat.st_mtime_ns}"
+        except OSError:
+            return str(resolved)
     try:
         from huggingface_hub import try_to_load_from_cache
 
-        cached = try_to_load_from_cache(model_name, "config.json")
+        cached = try_to_load_from_cache(source, "config.json")
         if isinstance(cached, str):
             path = Path(cached)
             if path.parent.parent.name == "snapshots":
@@ -374,4 +402,14 @@ def _cached_model_revision(model_name: str) -> str:
         # Prefix persistence is best-effort and must not make startup depend on
         # optional Hugging Face cache metadata.
         pass
-    return model_name
+    return source
+
+
+def _resolved_model_source(model_name: str) -> str:
+    """Resolve a built-in/user alias to the checkpoint source it names."""
+    try:
+        from ..model_aliases import resolve_model
+
+        return resolve_model(model_name) or model_name
+    except Exception:
+        return model_name

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -337,7 +337,7 @@ def get_cache_dir() -> str:
     # Persisted KV tensors are reusable only for the exact model revision and
     # effective KV dtype that produced them. Tensor shape/type validation cannot
     # prove that semantic identity, so keep those axes in the directory key.
-    kv_dtype = str(getattr(cfg, "kv_cache_dtype", None) or "bf16")
+    kv_dtype = _effective_kv_cache_dtype(cfg)
     revision = _cached_model_revision(raw)
     identity = (
         f"{raw}\0prefix-cache-v{_PREFIX_CACHE_NAMESPACE_VERSION}"
@@ -376,7 +376,7 @@ def _cached_model_revision(model_name: str) -> str:
                 except OSError:
                     continue
                 digest.update(path.name.encode("utf-8"))
-                digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode("ascii"))
+                digest.update(_file_identity(stat).encode("ascii"))
                 # Config/index files are small and encode architecture/shard
                 # identity. Hash their bytes; large weight files use metadata.
                 if path.suffix == ".json":
@@ -387,7 +387,7 @@ def _cached_model_revision(model_name: str) -> str:
             return f"local-{digest.hexdigest()[:16]}"
         try:
             stat = resolved.stat()
-            return f"local-file-{stat.st_size}-{stat.st_mtime_ns}"
+            return f"local-file-{_file_identity(stat)}"
         except OSError:
             return str(resolved)
     try:
@@ -403,6 +403,26 @@ def _cached_model_revision(model_name: str) -> str:
         # optional Hugging Face cache metadata.
         pass
     return source
+
+
+def _file_identity(stat: os.stat_result) -> str:
+    """Metadata identity that changes on content replacement.
+
+    ``ctime_ns`` cannot be restored with ``utime`` after an in-place write, and
+    ``st_ino`` changes for atomic replace deployments. Together they cover the
+    same-size/preserved-mtime case without reading tens of GB of weights during
+    every server boot.
+    """
+    return f"{stat.st_size}:{stat.st_mtime_ns}:{stat.st_ctime_ns}:{stat.st_ino}"
+
+
+def _effective_kv_cache_dtype(cfg) -> str:
+    """Read the canonical live scheduler dtype, falling back pre-load."""
+    engine = getattr(cfg, "engine", None)
+    scheduler = _resolve_scheduler(engine) if engine is not None else None
+    scheduler_cfg = getattr(scheduler, "config", None)
+    live = getattr(scheduler_cfg, "kv_cache_dtype", None)
+    return str(live or getattr(cfg, "kv_cache_dtype", None) or "bf16")
 
 
 def _resolved_model_source(model_name: str) -> str:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -337,12 +337,7 @@ def get_cache_dir() -> str:
     # Persisted KV tensors are reusable only for the exact model revision and
     # effective KV dtype that produced them. Tensor shape/type validation cannot
     # prove that semantic identity, so keep those axes in the directory key.
-    kv_dtype = _effective_kv_cache_dtype(cfg)
-    revision = _cached_model_revision(raw)
-    identity = (
-        f"{raw}\0prefix-cache-v{_PREFIX_CACHE_NAMESPACE_VERSION}"
-        f"\0kv={kv_dtype}\0revision={revision}"
-    )
+    identity = _semantic_cache_identity(cfg, raw)
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:8]
     leaf = f"{safe_name}--{digest}"
     # ~/.cache/rapid-mlx/ (was ~/.cache/vllm-mlx/ pre-rename). The cache is
@@ -403,6 +398,31 @@ def _cached_model_revision(model_name: str) -> str:
         # optional Hugging Face cache metadata.
         pass
     return source
+
+
+def _semantic_cache_identity(cfg, raw_model_name: str) -> str:
+    """Capture immutable cache identity for one loaded engine lifetime."""
+    engine = getattr(cfg, "engine", None)
+    attr = "_rapid_mlx_prefix_cache_identity"
+    if engine is not None:
+        captured = getattr(engine, attr, None)
+        if isinstance(captured, str) and captured:
+            return captured
+
+    kv_dtype = _effective_kv_cache_dtype(cfg)
+    revision = _cached_model_revision(raw_model_name)
+    identity = (
+        f"{raw_model_name}\0prefix-cache-v{_PREFIX_CACHE_NAMESPACE_VERSION}"
+        f"\0kv={kv_dtype}\0revision={revision}"
+    )
+    if engine is not None:
+        try:
+            setattr(engine, attr, identity)
+        except (AttributeError, TypeError):
+            # Foreign immutable engine wrappers still get a safe identity for
+            # this call; production BatchedEngine supports the lifetime pin.
+            pass
+    return identity
 
 
 def _file_identity(stat: os.stat_result) -> str:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -360,17 +360,28 @@ def _cached_model_revision(model_name: str) -> str:
             resolved = candidate
         if resolved.is_dir():
             digest = hashlib.sha256(str(resolved).encode("utf-8"))
-            tracked = [
-                resolved / "config.json",
-                resolved / "model.safetensors.index.json",
-            ]
-            tracked.extend(sorted(resolved.glob("*.safetensors")))
-            for path in tracked:
+            # Model implementations in the shared/vendored loaders may use
+            # indexed shards, nested files, or MLX/torch weight containers.
+            # Track all supported weight suffixes recursively, plus every
+            # index manifest. The manifest bytes also capture its weight_map.
+            weight_suffixes = {".safetensors", ".npz", ".bin", ".pt", ".pth"}
+            tracked = {resolved / "config.json"}
+            tracked.update(resolved.rglob("*.index.json"))
+            tracked.update(
+                path
+                for path in resolved.rglob("*")
+                if path.is_file() and path.suffix.lower() in weight_suffixes
+            )
+            for path in sorted(tracked):
                 try:
                     stat = path.stat()
                 except OSError:
                     continue
-                digest.update(path.name.encode("utf-8"))
+                try:
+                    relative = path.relative_to(resolved)
+                except ValueError:
+                    continue
+                digest.update(str(relative).encode("utf-8"))
                 digest.update(_file_identity(stat).encode("ascii"))
                 # Config/index files are small and encode architecture/shard
                 # identity. Hash their bytes; large weight files use metadata.

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -367,6 +367,11 @@ def _cached_model_revision(model_name: str) -> str:
             weight_suffixes = {".safetensors", ".npz", ".bin", ".pt", ".pth"}
             tracked = {resolved / "config.json"}
             tracked.update(resolved.rglob("*.index.json"))
+            # A config.json::model_file can change model semantics with
+            # identical tensors, and may import sibling modules. Hash all
+            # checkpoint-local Python sources so that custom architectures
+            # cannot inherit a KV namespace across code revisions.
+            tracked.update(resolved.rglob("*.py"))
             tracked.update(
                 path
                 for path in resolved.rglob("*")
@@ -383,9 +388,9 @@ def _cached_model_revision(model_name: str) -> str:
                     continue
                 digest.update(str(relative).encode("utf-8"))
                 digest.update(_file_identity(stat).encode("ascii"))
-                # Config/index files are small and encode architecture/shard
-                # identity. Hash their bytes; large weight files use metadata.
-                if path.suffix == ".json":
+                # Config/index/code files are small and encode architecture /
+                # shard identity. Hash their bytes; large weights use metadata.
+                if path.suffix in {".json", ".py"}:
                     try:
                         digest.update(path.read_bytes())
                     except OSError:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -332,13 +332,13 @@ def get_cache_dir() -> str:
     safe_name = (
         raw.replace("/", "--").replace("\\", "--").replace("..", "--").lstrip(".")
     ) or "default"
-    # 8 hex chars of SHA-256 — 32 bits, collision-resistant for the
-    # tens-of-models-per-user scale we'd ever see in practice.
+    # 16 hex chars of SHA-256 (64 bits) make accidental semantic namespace
+    # collisions negligible even across large fleets and long-lived caches.
     # Persisted KV tensors are reusable only for the exact model revision and
     # effective KV dtype that produced them. Tensor shape/type validation cannot
     # prove that semantic identity, so keep those axes in the directory key.
     identity = _semantic_cache_identity(cfg, raw)
-    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:8]
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
     leaf = f"{safe_name}--{digest}"
     # ~/.cache/rapid-mlx/ (was ~/.cache/vllm-mlx/ pre-rename). The cache is
     # best-effort and silently rebuilds, so the moved location just costs a
@@ -366,17 +366,17 @@ def _cached_model_revision(model_name: str) -> str:
             # index manifest. The manifest bytes also capture its weight_map.
             weight_suffixes = {".safetensors", ".npz", ".bin", ".pt", ".pth"}
             tracked = {resolved / "config.json"}
-            tracked.update(resolved.rglob("*.index.json"))
-            # A config.json::model_file can change model semantics with
-            # identical tensors, and may import sibling modules. Hash all
-            # checkpoint-local Python sources so that custom architectures
-            # cannot inherit a KV namespace across code revisions.
-            tracked.update(resolved.rglob("*.py"))
-            tracked.update(
-                path
-                for path in resolved.rglob("*")
-                if path.is_file() and path.suffix.lower() in weight_suffixes
-            )
+            # One traversal covers manifests, custom model code (including
+            # sibling imports), and supported weight containers.
+            for path in resolved.rglob("*"):
+                if not path.is_file():
+                    continue
+                if (
+                    path.name.endswith(".index.json")
+                    or path.suffix == ".py"
+                    or path.suffix.lower() in weight_suffixes
+                ):
+                    tracked.add(path)
             for path in sorted(tracked):
                 try:
                     stat = path.stat()

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -360,23 +360,13 @@ def _cached_model_revision(model_name: str) -> str:
             resolved = candidate
         if resolved.is_dir():
             digest = hashlib.sha256(str(resolved).encode("utf-8"))
-            # Model implementations in the shared/vendored loaders may use
-            # indexed shards, nested files, or MLX/torch weight containers.
-            # Track all supported weight suffixes recursively, plus every
-            # index manifest. The manifest bytes also capture its weight_map.
-            weight_suffixes = {".safetensors", ".npz", ".bin", ".pt", ".pth"}
-            tracked = {resolved / "config.json"}
-            # One traversal covers manifests, custom model code (including
-            # sibling imports), and supported weight containers.
-            for path in resolved.rglob("*"):
-                if not path.is_file():
-                    continue
-                if (
-                    path.name.endswith(".index.json")
-                    or path.suffix == ".py"
-                    or path.suffix.lower() in weight_suffixes
-                ):
-                    tracked.add(path)
+            # Custom model code can read arbitrary checkpoint-local assets, so
+            # an extension allowlist cannot define semantic identity safely.
+            # Build a complete regular-file manifest in one traversal. Every
+            # file gets replacement-sensitive metadata; reasonably small files
+            # also get a byte hash without forcing startup to stream huge
+            # weight shards from disk.
+            tracked = [path for path in resolved.rglob("*") if path.is_file()]
             for path in sorted(tracked):
                 try:
                     stat = path.stat()
@@ -388,9 +378,7 @@ def _cached_model_revision(model_name: str) -> str:
                     continue
                 digest.update(str(relative).encode("utf-8"))
                 digest.update(_file_identity(stat).encode("ascii"))
-                # Config/index/code files are small and encode architecture /
-                # shard identity. Hash their bytes; large weights use metadata.
-                if path.suffix in {".json", ".py"}:
+                if stat.st_size <= 8 * 1024 * 1024:
                     try:
                         digest.update(path.read_bytes())
                     except OSError:

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import time
+from pathlib import Path
 
 from ..config import get_config
 
@@ -35,6 +36,12 @@ _DEFAULT_SHUTDOWN_BUDGET_SEC = 3.5
 # entry-count fixtures + leaves ~600 ms of slack under a 5 s SIGTERM
 # grace for ``engine.stop()`` and uvicorn teardown.
 _COMMIT_HEADROOM_SEC = 0.4
+
+# Bump whenever persisted KV semantics change in a way the safetensors schema
+# alone cannot detect. Version 2 closes a release-blocking corruption found by
+# the v0.12.19 dogfood: a cache written for an older checkpoint / KV dtype was
+# structurally loadable but produced token-id-0-style garbage after restart.
+_PREFIX_CACHE_NAMESPACE_VERSION = 2
 
 
 def _shutdown_budget_sec() -> float:
@@ -327,7 +334,16 @@ def get_cache_dir() -> str:
     ) or "default"
     # 8 hex chars of SHA-256 — 32 bits, collision-resistant for the
     # tens-of-models-per-user scale we'd ever see in practice.
-    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    # Persisted KV tensors are reusable only for the exact model revision and
+    # effective KV dtype that produced them. Tensor shape/type validation cannot
+    # prove that semantic identity, so keep those axes in the directory key.
+    kv_dtype = str(getattr(cfg, "kv_cache_dtype", None) or "bf16")
+    revision = _cached_model_revision(raw)
+    identity = (
+        f"{raw}\0prefix-cache-v{_PREFIX_CACHE_NAMESPACE_VERSION}"
+        f"\0kv={kv_dtype}\0revision={revision}"
+    )
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:8]
     leaf = f"{safe_name}--{digest}"
     # ~/.cache/rapid-mlx/ (was ~/.cache/vllm-mlx/ pre-rename). The cache is
     # best-effort and silently rebuilds, so the moved location just costs a
@@ -336,3 +352,26 @@ def get_cache_dir() -> str:
     return os.path.join(
         os.path.expanduser("~"), ".cache", "rapid-mlx", "prefix_cache", leaf
     )
+
+
+def _cached_model_revision(model_name: str) -> str:
+    """Return a stable, network-free identity for the selected weights."""
+    candidate = Path(model_name).expanduser()
+    if candidate.exists():
+        try:
+            return str(candidate.resolve())
+        except OSError:
+            return str(candidate)
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(model_name, "config.json")
+        if isinstance(cached, str):
+            path = Path(cached)
+            if path.parent.parent.name == "snapshots":
+                return path.parent.name
+    except Exception:
+        # Prefix persistence is best-effort and must not make startup depend on
+        # optional Hugging Face cache metadata.
+        pass
+    return model_name

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1143,6 +1143,14 @@ def load_model_with_fallback(
     # cache or an already-local path (see the helper).
     model_name = _local_snapshot_if_cached(model_name)
 
+    # Pin remote repositories to the concrete snapshot that THIS load will
+    # consume. Persisted KV identity must never be derived later from mutable
+    # refs/main state, which can advance while the server is running.
+    if not Path(model_name).is_dir():
+        resolved_snapshot = _resolve_model_path(model_name)
+        if resolved_snapshot is not None:
+            model_name = str(resolved_snapshot)
+
     # ``mlx_lm.load`` may import config.json::model_file.  Validate that
     # caller-supplied local path once at this shared boundary before any native
     # or fallback loader runs.  Remote repository ids are intentionally a no-op
@@ -1239,7 +1247,7 @@ def load_model_with_fallback(
         # branches would ever fire for a checkpoint this code path is
         # actually used for.
         _post_load_ubc_evict(model_name)
-        return result
+        return _annotate_loaded_checkpoint_source(result, model_name)
     if enable_dspark:
         result = _load_model_with_fallback_impl(
             model_name, tokenizer_config, enable_dspark=True
@@ -1258,6 +1266,16 @@ def load_model_with_fallback(
     # mirror worth evicting after the inner loader succeeded.
     # No-op on non-Darwin.
     _post_load_ubc_evict(model_name)
+    return _annotate_loaded_checkpoint_source(result, model_name)
+
+
+def _annotate_loaded_checkpoint_source(result, source: str):
+    """Attach the immutable source selected by the shared loader."""
+    model = result[0]
+    try:
+        model._rapid_mlx_loaded_checkpoint_source = str(source)
+    except (AttributeError, TypeError):
+        pass
     return result
 
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1128,8 +1128,10 @@ def load_model_with_fallback(
             without requiring the returned model object to accept attributes.
 
     Returns:
-        Tuple of (model, tokenizer), or (model, tokenizer, config) when
-        ``return_config=True``.
+        ``(model, tokenizer)`` by default; ``(model, tokenizer, config)``
+        with ``return_config=True``; ``(model, tokenizer, source)`` with
+        ``return_source=True``; or ``(model, tokenizer, config, source)``
+        when both flags are true.
     """
     # Publishers who ship one repo per model with a folder per quant
     # (``LiquidAI/LFM2.5-2.6B-MLX`` → ``4bit/``, ``8bit/``, ``bf16/`` …)

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1093,6 +1093,7 @@ def load_model_with_fallback(
     enable_dspark: bool = False,
     lazy: bool = False,
     return_config: bool = False,
+    return_source: bool = False,
 ):
     """
     Load model and tokenizer with fallback for non-standard tokenizers.
@@ -1122,6 +1123,9 @@ def load_model_with_fallback(
             (needed to read ``model_type`` for
             ``disk_stream_patch.install``) — passed straight through to
             ``mlx_lm.load(..., return_config=True)``.
+        return_source: Append the concrete checkpoint source selected for this
+            load. Engine startup uses this to pin persisted-cache identity
+            without requiring the returned model object to accept attributes.
 
     Returns:
         Tuple of (model, tokenizer), or (model, tokenizer, config) when
@@ -1247,7 +1251,7 @@ def load_model_with_fallback(
         # branches would ever fire for a checkpoint this code path is
         # actually used for.
         _post_load_ubc_evict(model_name)
-        return _annotate_loaded_checkpoint_source(result, model_name)
+        return (*result, str(model_name)) if return_source else result
     if enable_dspark:
         result = _load_model_with_fallback_impl(
             model_name, tokenizer_config, enable_dspark=True
@@ -1266,17 +1270,7 @@ def load_model_with_fallback(
     # mirror worth evicting after the inner loader succeeded.
     # No-op on non-Darwin.
     _post_load_ubc_evict(model_name)
-    return _annotate_loaded_checkpoint_source(result, model_name)
-
-
-def _annotate_loaded_checkpoint_source(result, source: str):
-    """Attach the immutable source selected by the shared loader."""
-    model = result[0]
-    try:
-        model._rapid_mlx_loaded_checkpoint_source = str(source)
-    except (AttributeError, TypeError):
-        pass
-    return result
+    return (*result, str(model_name)) if return_source else result
 
 
 # mlx-lm's tokenizer loader (``mlx_lm.tokenizer_utils.load``) imports a


### PR DESCRIPTION
## Summary

- namespace persisted prefix caches by cache ABI, effective KV dtype, and cached model revision
- prevent structurally valid but semantically stale KV tensors from corrupting generation after model/config changes
- make `release_fleet.py` import the checkout directly so the documented bare-worktree release command works without manual `PYTHONPATH`

## Release-blocker reproduction

During next-release dogfood, `make release-check-m3` loaded an older DeepSeek-R1-Distill 32B prefix cache and produced token-id-0-style `!` output. G0 failed 3/6 cases. The same checkpoint was correct under upstream `mlx_lm`; Rapid with an empty cache was also correct under both bf16 and int8 KV, isolating the failure to persisted-cache reuse.

## Validation

- [x] `python3.12 -m pytest -q tests/test_runtime_cache_path.py tests/test_prefix_cache_persistence.py tests/test_release_fleet.py tests/test_coherence.py` — 185 passed
- [x] `python3.12 -m ruff check ...` and `ruff format --check ...`
- [x] bare-checkout `env -u PYTHONPATH python3.12 scripts/release_fleet.py is-reasoning-distill deepseek-r1-32b-4bit`
- [x] real Studio sweep: `MODELS=deepseek-r1-32b-4bit PORT=8402 bash scripts/coherence_sweep.sh` — 6/6 passed
- [x] upstream/control A/B documented above

## Test plan

- [x] Different KV dtypes resolve to different persistence directories
- [x] Different model revisions resolve to different persistence directories
- [x] Existing sanitization/collision contracts remain green
- [x] DeepSeek real serve-path coherence passes from the new namespace
- [x] No model weights or user caches are deleted