### PR TITLE
[codex] Auto-tune recurrent prefill chunks

### DIFF
--- a/.agents/handoffs/vector.md
+++ b/.agents/handoffs/vector.md
@@ -1,102 +1,28 @@
 # Vector handoff
 
-- Status: in progress; PR #2199 is technically complete and awaiting Atlas or
-  human review after the automated review loop reached its three-round cap
-- Active task: benchmark the 16--64 GB Mac model matrix against mlx-vlm,
-  oMLX, and applicable MLXFast/MTPLX implementations; optimize material
-  Rapid-MLX deficits and re-run the controlled matrix.
-- Branch or PR: `raullenchai/vector-desk`; https://github.com/raullenchai/Rapid-MLX/pull/2199
-- Host: final 16--32 GB claims must run on the M2 Pro 32 GB Mac mini at SSH
-  alias `mini`; large-model preflight and 48--64 GB-class experiments can run
-  on the M3 Ultra 256 GB Studio but must be labelled as Studio results.
+- Status: implementation and controlled mini verification complete; prepare PR
+- Active task: long-context prefill, HTTP prefix reuse, and mixed long/short
+  service contention
+- Branch: `raullenchai/vector-prefill-service-perf`
+- Host: M2 Pro 32 GB Mac mini (`mini`); local worktree for code/tests
 - Verified facts:
-  - Google Chrome was closed with explicit human authorization before the run.
-  - The mini returned `No route to host` on 2026-08-21. A Wake-on-LAN packet
-    was sent to its known interface and six SSH retries still failed. It later
-    became reachable again (confirmed `MINI_OK` this campaign), so the final
-    16--32 GB claims are running through the controlled mini harness.
-  - The reusable local workspace is `~/mac-model-matrix`; raw preflight JSON
-    is under `results/` and is intentionally outside Git.
-  - Busy-Studio preflight, Qwen3.5-4B 4-bit: Rapid 175.2 decode tok/s and
-    2.65 GB peak MLX memory; mlx-vlm 165.9 tok/s and 3.73 GB. These are not
-    publication-grade numbers.
-  - Busy-Studio preflight, Gemma4-26B-A4B 4-bit: Rapid 116.6 decode tok/s and
-    14.40 GB peak MLX memory; mlx-vlm 113.4 tok/s and 15.55 GB. These are not
-    publication-grade numbers.
-  - On both preflights Rapid's reported short-prompt prefill rate was about
-    20% below mlx-vlm. The controlled Qwen3.5-4B cross-over subsequently found
-    the cause: keeping mlx-lm 0.31.3 and moving MLX/Metal 0.31.2 to 0.32.1
-    improved 1K/4K prefill by 22.3% (326.9/324.6 to 399.9/397.1 tok/s), closing
-    the mlx-vlm gap. Shipping this requires the #1248 full-family coherence gate
-    and Atlas approval because the dependency ceiling is deliberate.
-  - PyPI's latest mlx-lm remains 0.31.3. Official upstream main at `dfb5da1`
-    reports version 0.32.0 and removes MTP-presence as a sufficient reason to
-    shift Qwen3.5/3.6 RMSNorm weights. On Studio with Qwen3.6-35B-A3B-8bit and
-    MLX 0.32.1, main was exact on 8/8 64-token prompts versus 0.31.3, with
-    300.1 vs 277.4 prompt tok/s and 2.79 vs 7.53 seconds cached load. Upstream
-    VLM-MTP issue #1197 is still open, so its exact checkpoint layout was a
-    required coherence case for this dependency move.
-  - The exact #1197 layout subsequently passed 6/6 through Rapid's forced text
-    lane on MLX 0.32.1 + mlx-lm 0.31.3: Qwen3.6-35B-A3B-8bit snapshot
-    `e06a74e6236a60c8367e1a3214e83d8b61b637b0` contains a vision config, all
-    333 `vision_tower.*` tensors, `mtp_num_hidden_layers=1`, and
-    `model-mtp.safetensors`. Result SHA-256:
-    `58aa10fccb3d96de92d5fccb9b9ba084ff4b823211d43e6154977d39d8feaa68`.
-  - Issue #2165 follow-up on Qwen3.5-4B: mlx-lm main + MLX 0.32.1 improves
-    exact-token prefill over production by 21.8% at 8K (388.1 vs 318.6) and
-    20.8% at 16K (369.5 vs 306.0), with essentially unchanged peak memory.
-    The 8K-to-16K scaling loss remains. At 16K, increasing prefill step from
-    2K to 4K/8K/16K reduced throughput from 369.4 to 364.6/355.9/336.2 tok/s
-    and raised peak memory from 5.62 to 7.28/11.02/18.63 GB. Hybrid/GDN must
-    keep an architecture-specific smaller-step policy; do not promote a generic
-    largest-chunk-that-fits rule.
-  - Shipping candidate keeps released mlx-lm 0.31.3 and changes core to
-    `mlx>=0.32.1,<0.33`. Fresh resolver probes select MLX 0.32.1 for core.
-    Because mflux 0.18.1 requires `mlx<0.32`, `[image]` moves to
-    `mflux>=0.19.0,<0.20`; its metadata requires `mlx>=0.32,<0.33`, the image
-    resolver succeeds, and 88 image-lane plus 67 alias/dependency tests pass.
-  - Controlled mini prefill crossover extended to the two other large models.
-    Identical harness and stacks to the Qwen3.5 crossover (mlx-lm 0.31.3,
-    transformers 5.15.1, numpy 2.4.6, tokenizers 0.22.2; only
-    mlx/mlx-metal 0.31.2 -> 0.32.1). Gemma4-26B-A4B: 1K 294.4->394.9
-    (+34.1%) and 4K 288.3->379.3 (+31.6%) prompt tok/s, 15.05/15.96 GB peak.
-    Qwen3.8-27B (MTP checkpoint, plain AR prefill path): 1K 49.9->61.8
-    (+23.8%) and 4K 49.8->61.6 (+23.7%), 17.02/18.55 GB peak. Peak memory
-    unchanged in both. Added baseline venv `mlxlm-on-mlx0312` (mlx 0.31.2);
-    `mlxlm-on-mlx032` (mlx 0.32.1) already existed. Raw JSON and SHA-256 are
-    recorded in the mini performance report; publication-grade for this host.
-  - The MLX 0.32.1 candidate passed 6/6 blocking golden coherence cases for
-    every ordinary release family: Qwen3.5 4B, Qwen3.5 35B-A3B, Qwen3.6 27B,
-    Gemma4 12B, DeepSeek-R1-Distill 32B, and GPT-OSS 20B. The sweep now forces
-    `--disable-prefix-cache`: persisted KV tensors are not keyed by MLX runtime
-    and a stale DeepSeek cache initially caused a false failure; both its cold
-    rerun and the complete cold-cache release sweep passed. Hy3 snapshot
-    `8e4d56f18efd912b8c7581a8ccfa8b2a79ba3469` was staged on an external
-    1.8 TiB SSD and passed 6/6 on the M3 Ultra with only 13.69 MB swap used.
-    Artifact SHA-256:
-    `817969d4c78df19594d7c464990fa0b4e16beda3b8346e423161735ab8b9db72`.
-    The complete seven-family toolchain fleet therefore passed 42/42.
-  - Extra M2 Pro spot checks under the PR wheel: Qwen3.5-9B passed 6/6. LFM2.5
-    1.2B and Nemotron Diffusion 3B each scored 5/6, but repeated identically on
-    MLX 0.31.2 (same wrong LFM arithmetic token; same correct-but-verbose
-    Nemotron answer), ruling out an MLX 0.32.1 regression. An explicit Qwen9
-    `--ar-only` rerun produced 37.4165 median / 37.4258 pooled tok/s, 8/8 exact.
-  - Existing unarchived Qwen3.6-35B experiments under `~/qwen38-perf` suggest
-    Rapid AR around 91 tok/s, mlx-vlm AR around 83 tok/s, and Rapid MTP up to
-    120.9 tok/s on one coding prompt. Re-run with the common harness before
-    making claims.
-- Remaining matrix: Qwen3.5-4B, LFM2.5-8B-A1B, GPT-OSS-20B, Mistral Small
-  24B, Qwen3-Coder-30B-A3B, Nemotron 30B-A3B, Qwen3.6-35B-A3B,
-  Qwen3-Coder-Next-80B, plus Llama 8B, Phi-4 14B, Bonsai, and DeepSeek-Coder
-  compatibility baselines. Qwen3.8-27B and Gemma4-26B-A4B now have controlled
-  MLX 0.32.1 prefill crossovers on the mini (recorded above and in the report).
-- Risks: Studio currently has other CPU-active desktop processes; its
-  preflight data must not be published. Only about 137 GiB was available on
-  the Studio system volume, so uncached checkpoints need staged downloads or
-  explicit cache cleanup.
-- Next action: Atlas or a human reviewer should verify the round-3 AR-only
-  reproduction fix in `c7984227` and land PR #2199 after final CI. The automated
-  review loop stopped at its hard cap of three rounds without a post-fix LGTM;
-  its round-3 finding is addressed in the branch. The complete toolchain
-  coherence fleet, Hy3 Ultra, exact Qwen3.6 VLM+MTP layout, and extra mini spot
-  checks are complete. Continue the remaining performance matrix independently.
+  - Qwen3.5 4B direct 16K--96K throughput is within 0.7% at prefill chunks 512
+    and 2,048, while 512 reduces peak MLX memory by 27--29%.
+  - In the controlled service A/B, 512 reduces contended short-request TTFT
+    51.1% and total latency 64.4%; standalone latency is unchanged.
+  - Exact recurrent prefix reuse reduced a 22.5K prompt's TTFT from 62.48 s to
+    0.408 s and server counters confirmed 22,537 cached tokens.
+  - The candidate wheel auto-selected 512 without an explicit CLI flag and
+    reported that value in `/v1/status`.
+  - A single-repeat Gemma 4 12B mlx-vlm scout favored 512 by 3.6--3.8% and used
+    less memory, but it is not yet sufficient evidence to change dense models.
+  - Focused tests pass; raw artifacts and hashes are recorded in
+    `docs/engineering/performance/2026-08-22-long-context-service-prefill.md`.
+- Risks:
+  - Service A/B and Gemma scout are one repeat; treat them as scoped engineering
+    evidence, not publication-grade competitor claims.
+  - Bounded recurrent prefix snapshots reached 3.73 GB at 32K; larger cache
+    entry counts should not be enabled without multi-prefix pressure testing.
+- Receiving role: Atlas for compatibility/integration review.
+- Next action: run the full proportional test set, review the diff, commit,
+  push, open the PR, and complete the repository's review/CI flow.

--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -66,8 +66,15 @@ python bench_service_prefill.py \
 times the first visible content/reasoning/tool delta rather than the initial SSE
 role frame, records server-reported prompt/cached tokens, tests exact and
 partial prefix reuse, and submits a short request behind an active long prefill.
-It also stamps the result with a methodology hash. Use at least three repeats
-for publication claims; the one-repeat runs here are scoped engineering A/Bs.
+It polls `/v1/status` until the long request is server-confirmed as running
+before it submits the short request, rejects streams with no visible delta, and
+stamps the result with a methodology hash. Use at least three repeats for
+publication claims; the one-repeat runs here are scoped engineering A/Bs.
+
+The recorded A/B artifacts predate the enforced status poll; their server logs
+show the long request scheduled before the short request. The committed harness
+turns that observed ordering into a required precondition for future runs, so
+its methodology hash intentionally differs from those artifacts.
 
 ## Long-context scaling
 

--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -1,0 +1,174 @@
+# Long-context and service-prefill study (M2 Pro, 2026-08-22)
+
+## Outcome
+
+Qwen3.5 recurrent/GatedDeltaNet models should use a 512-token prefill chunk by
+default in `rapid-mlx serve`. Against the previous 2,048-token default, this:
+
+- reduced a short request's TTFT under a concurrent long prefill by 51.1%;
+- reduced that short request's end-to-end latency by 64.4%;
+- kept 16K--96K single-request prefill throughput within 0.7%; and
+- reduced peak MLX memory by 27--29% at 16K--96K.
+
+The change is architecture-scoped. An explicit `--prefill-step-size` always
+wins, and dense/sliding-window models retain 2,048 pending stronger service
+evidence.
+
+## Goal and constraints
+
+- Owner: Vector (performance)
+- Host: M2 Pro Mac mini, 32 GB unified memory
+- OS: macOS 26.5.2
+- Base: Rapid-MLX `fc7f1635`; candidate branch
+  `raullenchai/vector-prefill-service-perf`
+- Runtime: MLX 0.32.1, mlx-lm 0.31.3, Rapid-MLX 0.12.18 candidate wheel
+- Primary model: `mlx-community/Qwen3.5-4B-MLX-4bit`
+- Verification: controlled direct prefill, OpenAI-compatible streaming HTTP,
+  exact/partial prefix reuse, mixed long/short concurrency, unit tests, and a
+  Gemma 4 12B dense/sliding spot check
+
+Chrome and competing model processes were not running. Raw JSON remains in
+`~/mac-model-matrix/results/` on the mini; it is intentionally not committed.
+
+## Reproduction
+
+Direct prefill:
+
+```bash
+python bench_prefill.py \
+  --engine rapid \
+  --model mlx-community/Qwen3.5-4B-MLX-4bit \
+  --lengths 16384 32768 65536 98304 \
+  --repeat 1 \
+  --prefill-step-size 512 \
+  --output results/qwen35-4b-prefill-step512-scout.json
+```
+
+Service workload:
+
+```bash
+rapid-mlx serve qwen3.5-4b-4bit \
+  --host 127.0.0.1 --port 18080 \
+  --enable-prefix-cache --pflash off --no-thinking
+
+python bench_service_prefill.py \
+  --url http://127.0.0.1:18080/v1 \
+  --model qwen3.5-4b-4bit \
+  --tokenizer mlx-community/Qwen3.5-4B-MLX-4bit \
+  --label rapid-auto512-branch \
+  --lengths 2048 --repeat 1 --max-tokens 1 \
+  --contention-length 32768 --contention-repeat 1 \
+  --contention-delay-ms 100 \
+  --output results/qwen35-4b-service-auto512-branch.json
+```
+
+`scripts/bench_service_prefill.py` clears the service cache before cold trials,
+times the first visible content/reasoning/tool delta rather than the initial SSE
+role frame, records server-reported prompt/cached tokens, tests exact and
+partial prefix reuse, and submits a short request behind an active long prefill.
+It also stamps the result with a methodology hash. Use at least three repeats
+for publication claims; the one-repeat runs here are scoped engineering A/Bs.
+
+## Long-context scaling
+
+With the old 2,048 chunk, prompt throughput scaled smoothly rather than falling
+off a discrete cliff:
+
+| Prompt | Prompt tok/s | Peak MLX GB |
+| ---: | ---: | ---: |
+| 2K | 400.47 | 4.21 |
+| 8K | 388.26 | 4.82 |
+| 16K | 369.72 | 5.62 |
+| 32K | 336.96 | 7.23 |
+| 64K | 285.90 | 10.45 |
+| 96K | 245.04 | 13.83 |
+
+The 96K rate is 38.8% below 2K, consistent with context-length cost. There was
+no swap and no abrupt regression boundary.
+
+## 512 versus 2,048 on recurrent prefill
+
+| Prompt | 2,048 tok/s | 512 tok/s | Throughput delta | 2,048 GB | 512 GB | Memory delta |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 16K | 369.72 | 370.02 | +0.1% | 5.62 | 4.10 | -27.1% |
+| 32K | 336.96 | 336.29 | -0.2% | 7.23 | 5.26 | -27.3% |
+| 64K | 285.90 | 283.96 | -0.7% | 10.45 | 7.49 | -28.3% |
+| 96K | 245.04 | 245.65 | +0.2% | 13.83 | 9.81 | -29.1% |
+
+For the controlled service A/B, both variants used identical prompts. The long
+request had 45,080 server-reported prompt tokens and the short request 2,840.
+
+| Metric | 2,048 | 512 | Delta |
+| --- | ---: | ---: | ---: |
+| Short standalone TTFT | 7.11 s | 7.08 s | -0.4% |
+| Contended short TTFT | 42.44 s | 20.77 s | **-51.1%** |
+| Contended short total | 84.76 s | 30.17 s | **-64.4%** |
+| Contended long TTFT | 157.17 s | 150.91 s | -4.0% |
+
+This isolates scheduler monopolization, not a faster math kernel: the smaller
+chunk gives waiting work more scheduling opportunities while leaving long
+request throughput intact.
+
+The candidate wheel, launched without a prefill override, logged the recurrent
+auto-selection and reported `adaptive_prefill.chunk_size=512`. With the fixed
+exact-token harness, cold 2K TTFT was 5.20 s, exact prefix reuse was 0.173 s
+(2,035 cached tokens), and a 2K request behind a 32K prefill reached its first
+visible token in 15.42 s. This is an end-to-end confirmation, not a cross-run
+comparison to the earlier differently-sized prompts.
+
+## Prefix-cache finding
+
+Prefix reuse is functioning for the recurrent model. On the 2,048-chunk
+baseline's 22,552-token prompt, an exact hit reused 22,537 tokens and reduced
+TTFT from 62.48 s to 0.408 s; a partial extension reused the same prefix and
+reached its first token in 0.416 s. The service auto-defaulted bounded recurrent
+snapshots to eight entries.
+
+The tradeoff is memory: recurrent snapshots can be large. The exact-token 32K
+candidate run reached 3.73 GB of prefix-cache memory before pressure eviction.
+Future concurrency work should measure cache-entry admission and eviction under
+agentic multi-prefix workloads rather than increasing the entry count blindly.
+
+## Dense/sliding spot check
+
+Gemma 4 12B (`mlx-community/gemma-4-12B-it-4bit`) must use the mlx-vlm/Gemma
+loader; mlx-lm 0.31.3 rejects its `gemma4_unified` model type. A single-repeat
+scout through mlx-vlm 0.6.15 found that 512 was promising but not yet sufficient
+evidence for a global default:
+
+| Prompt | 2,048 tok/s | 512 tok/s | Delta | Peak-memory delta |
+| ---: | ---: | ---: | ---: | ---: |
+| 4K | 131.79 | 136.48 | +3.6% | -7.8% |
+| 16K | 125.38 | 130.12 | +3.8% | -13.3% |
+
+Follow up with repeated Rapid service concurrency runs before changing the
+dense/sliding default. The current implementation deliberately does not use the
+broader "needs bounded prefix reuse" classifier, so Gemma is unaffected.
+
+## Artifacts
+
+SHA-256 checksums:
+
+- `qwen35-4b-prefill-mlx032-2k-96k-scout.json`:
+  `112fdbbe603b6dd87324395b60b4292a53f3eff6df0a8bb391e9a1d43f8370dd`
+- `qwen35-4b-prefill-step512-scout.json`:
+  `0182a37e30234c4075570ba64c34fff6246f1efca6ea2d25dc418eea8507b0de`
+- `qwen35-4b-service-prefill-r1.json`:
+  `997f674d95e53971d94a7932721907b1aede487e45f1feaca499c3561558bbd9`
+- `qwen35-4b-service-step512-r1.json`:
+  `8fff0413575b659a33fc7ad4a3e64d2b08688b7cd0bff9692755254450cbfbae`
+- `qwen35-4b-service-auto512-branch.json`:
+  `da73c19461ce719d84eb13c4d9338b808d5e6ace549b97897a576f0b97964107`
+- Gemma 2,048 / 512 scouts:
+  `9fdf433fe29ffd6d6fc6691f1e7081aac864c0fccf2e6c2746a4d45df168a323`,
+  `5a39dc7ed674d6c056e2962ddedc75f46f1f16bc331b4c2f7fe973b642b7be51`
+
+## Recommendation and next work
+
+Land the recurrent-only 512 auto-default with the benchmark harness. Then:
+
+1. run the same HTTP workload against a calibrated oMLX deployment (none was
+   installed on this mini during this run), including equivalent cache policy;
+2. repeat the Gemma 4 12B service A/B before considering a broader default;
+3. profile cache admission/eviction for multiple 16K--64K agent prefixes; and
+4. add a repeat-three service tier to scheduled Mac performance CI.

--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -68,8 +68,10 @@ role frame, records server-reported prompt/cached tokens, tests exact and
 partial prefix reuse, and submits a short request behind an active long prefill.
 It polls `/v1/status` until the long request is server-confirmed as running
 before it submits the short request, rejects streams with no visible delta, and
-stamps the result with a methodology hash. Use at least three repeats for
-publication claims; the one-repeat runs here are scoped engineering A/Bs.
+rejects streams that omit prompt/completion/cached-token usage rather than
+silently treating missing counters as zero. It stamps the result with a
+methodology hash. Use at least three repeats for publication claims; the
+one-repeat runs here are scoped engineering A/Bs.
 
 The recorded A/B artifacts predate the enforced status poll; their server logs
 show the long request scheduled before the short request. The committed harness

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -46,6 +46,7 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_dflash.py",
         "bench_diffusion_gemma.py",
         "bench_engine_solo.py",
+        "bench_service_prefill.py",
         "bench_readme_refresh.py",
         "bench_suffix_decoding.py",
         "bench_suffix_decoding_integrated.py",

--- a/scripts/bench_service_prefill.py
+++ b/scripts/bench_service_prefill.py
@@ -154,12 +154,25 @@ def stream_request(
             "stream completed without a visible content, reasoning, or tool delta"
         )
     details = usage.get("prompt_tokens_details") or {}
+    required_usage = {
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "cached_tokens": details.get("cached_tokens"),
+        "completion_tokens": usage.get("completion_tokens"),
+    }
+    invalid_usage = [
+        name for name, value in required_usage.items() if not isinstance(value, int)
+    ]
+    if invalid_usage:
+        raise RuntimeError(
+            "stream completed without valid server usage metadata: "
+            + ", ".join(invalid_usage)
+        )
     return {
         "ttft_ms": round((first_visible - started) * 1000, 2),
         "total_ms": round((finished - started) * 1000, 2),
-        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
-        "cached_tokens": int(details.get("cached_tokens") or 0),
-        "completion_tokens": int(usage.get("completion_tokens") or 0),
+        "prompt_tokens": required_usage["prompt_tokens"],
+        "cached_tokens": required_usage["cached_tokens"],
+        "completion_tokens": required_usage["completion_tokens"],
         "visible_chunks": visible_chunks,
         "finish_reason": finish_reason,
     }

--- a/scripts/bench_service_prefill.py
+++ b/scripts/bench_service_prefill.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Benchmark cold, cached, and contended prefill through an OpenAI API.
+
+The benchmark records server-reported prompt and cached-token counts instead
+of inferring cache hits from latency.  It also distinguishes first visible
+content/reasoning from role-only SSE frames, which is required for honest TTFT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import platform
+import statistics
+import time
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:
+    from bench_metadata import write_bench_json
+
+
+FILLER = "Deterministic prefill benchmark sentence with stable repeated words. "
+
+
+def token_count(encoded: Any) -> int:
+    """Count token ids from list- or BatchEncoding-shaped tokenizer output."""
+    if isinstance(encoded, Mapping):
+        encoded = encoded.get("input_ids", ())
+    if hasattr(encoded, "tolist"):
+        encoded = encoded.tolist()
+    if (
+        isinstance(encoded, Sequence)
+        and encoded
+        and isinstance(encoded[0], Sequence)
+        and not isinstance(encoded[0], (str, bytes))
+    ):
+        encoded = encoded[0]
+    return len(encoded)
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    rank = fraction * (len(ordered) - 1)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return ordered[low] * (1 - weight) + ordered[high] * weight
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, float]:
+    ttfts = [float(row["ttft_ms"]) for row in rows]
+    totals = [float(row["total_ms"]) for row in rows]
+    return {
+        "ttft_p50_ms": round(statistics.median(ttfts), 2),
+        "ttft_p95_ms": round(percentile(ttfts, 0.95), 2),
+        "total_p50_ms": round(statistics.median(totals), 2),
+        "total_p95_ms": round(percentile(totals, 0.95), 2),
+    }
+
+
+def make_messages(tokenizer: Any, target_tokens: int, suffix: str = "") -> list[dict]:
+    """Build a deterministic chat prompt close to ``target_tokens`` tokens."""
+    system = "You are a concise benchmark assistant."
+    content = FILLER * max(1, target_tokens // 8)
+
+    def count(text: str) -> int:
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": text + suffix},
+        ]
+        try:
+            rendered = tokenizer.apply_chat_template(
+                messages, tokenize=True, add_generation_prompt=True
+            )
+            return token_count(rendered)
+        except (AttributeError, TypeError, ValueError):
+            return token_count(tokenizer.encode(system + "\n" + text + suffix))
+
+    # Character-space binary search avoids assumptions about tokenizer word
+    # boundaries while keeping the API payload valid text.
+    low, high = 0, len(content)
+    while low < high:
+        mid = (low + high + 1) // 2
+        if count(content[:mid]) <= target_tokens:
+            low = mid
+        else:
+            high = mid - 1
+    text = content[:low]
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": text + suffix},
+    ]
+
+
+def stream_request(
+    client: httpx.Client,
+    base_url: str,
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "enable_thinking": False,
+    }
+    started = time.perf_counter()
+    first_visible: float | None = None
+    usage: dict[str, Any] = {}
+    finish_reason = None
+    visible_chunks = 0
+    with client.stream(
+        "POST", f"{base_url}/chat/completions", json=payload
+    ) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            chunk = json.loads(line[6:])
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+            choices = chunk.get("choices") or []
+            if not choices:
+                continue
+            choice = choices[0]
+            delta = choice.get("delta") or {}
+            if (
+                delta.get("content")
+                or delta.get("reasoning_content")
+                or delta.get("tool_calls")
+            ):
+                visible_chunks += 1
+                if first_visible is None:
+                    first_visible = time.perf_counter()
+            if choice.get("finish_reason") is not None:
+                finish_reason = choice["finish_reason"]
+    finished = time.perf_counter()
+    details = usage.get("prompt_tokens_details") or {}
+    return {
+        "ttft_ms": round(((first_visible or finished) - started) * 1000, 2),
+        "total_ms": round((finished - started) * 1000, 2),
+        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+        "cached_tokens": int(details.get("cached_tokens") or 0),
+        "completion_tokens": int(usage.get("completion_tokens") or 0),
+        "visible_chunks": visible_chunks,
+        "finish_reason": finish_reason,
+    }
+
+
+def clear_prefix_cache(client: httpx.Client, root_url: str) -> dict[str, Any]:
+    response = client.post(f"{root_url}/v1/cache/clear")
+    response.raise_for_status()
+    return response.json()
+
+
+def get_status(client: httpx.Client, root_url: str) -> dict[str, Any]:
+    response = client.get(f"{root_url}/v1/status")
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8000/v1")
+    parser.add_argument("--model")
+    parser.add_argument("--tokenizer")
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--lengths", nargs="+", type=int, default=[2048, 8192, 16384])
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--contention-length", type=int, default=32768)
+    parser.add_argument("--contention-repeat", type=int, default=3)
+    parser.add_argument("--contention-delay-ms", type=float, default=25.0)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from transformers import AutoTokenizer
+
+    root_url = args.url.removesuffix("/v1")
+    timeout = httpx.Timeout(900.0, connect=30.0)
+    with httpx.Client(timeout=timeout) as client:
+        model = args.model or client.get(f"{args.url}/models").json()["data"][0]["id"]
+        tokenizer_id = args.tokenizer or model
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, trust_remote_code=True)
+        client.get(f"{root_url}/health").raise_for_status()
+
+        cold: dict[str, list[dict[str, Any]]] = {}
+        for target in args.lengths:
+            messages = make_messages(tokenizer, target)
+            rows = []
+            for repeat in range(args.repeat):
+                clear_prefix_cache(client, root_url)
+                row = stream_request(client, args.url, model, messages, args.max_tokens)
+                row.update(target_tokens=target, repeat=repeat)
+                rows.append(row)
+            cold[str(target)] = rows
+
+        cache_target = args.lengths[-1]
+        base_messages = make_messages(tokenizer, cache_target)
+        clear_prefix_cache(client, root_url)
+        populate = stream_request(
+            client, args.url, model, base_messages, args.max_tokens
+        )
+        exact = [
+            stream_request(client, args.url, model, base_messages, args.max_tokens)
+            for _ in range(args.repeat)
+        ]
+        partial_messages = [*base_messages]
+        partial_messages[-1] = {
+            "role": "user",
+            "content": base_messages[-1]["content"] + "\nReturn only the word done.",
+        }
+        partial = [
+            stream_request(client, args.url, model, partial_messages, args.max_tokens)
+            for _ in range(args.repeat)
+        ]
+
+        long_messages = make_messages(tokenizer, args.contention_length)
+        short_messages = make_messages(tokenizer, min(args.lengths))
+        contention_runs = []
+        for repeat in range(args.contention_repeat):
+            clear_prefix_cache(client, root_url)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                long_future = executor.submit(
+                    stream_request,
+                    client,
+                    args.url,
+                    model,
+                    long_messages,
+                    args.max_tokens,
+                )
+                time.sleep(args.contention_delay_ms / 1000)
+                short_future = executor.submit(
+                    stream_request,
+                    client,
+                    args.url,
+                    model,
+                    short_messages,
+                    args.max_tokens,
+                )
+                contention_runs.append(
+                    {
+                        "repeat": repeat,
+                        "long": long_future.result(),
+                        "short": short_future.result(),
+                    }
+                )
+        contention = {
+            "long_target_tokens": args.contention_length,
+            "short_target_tokens": min(args.lengths),
+            "submit_delay_ms": args.contention_delay_ms,
+            "short_summary": summarize([row["short"] for row in contention_runs]),
+            "long_summary": summarize([row["long"] for row in contention_runs]),
+            "runs": contention_runs,
+        }
+
+        status = get_status(client, root_url)
+
+    payload = {
+        "label": args.label,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "client_platform": platform.platform(),
+        "base_url": args.url,
+        "model": model,
+        "tokenizer": tokenizer_id,
+        "repeat": args.repeat,
+        "max_tokens": args.max_tokens,
+        "cold": {
+            key: {"summary": summarize(rows), "runs": rows}
+            for key, rows in cold.items()
+        },
+        "cache": {
+            "target_tokens": cache_target,
+            "populate": populate,
+            "exact": {"summary": summarize(exact), "runs": exact},
+            "partial": {"summary": summarize(partial), "runs": partial},
+        },
+        "contention": contention,
+        "server_status": status,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    write_bench_json(args.output, payload, __file__)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_service_prefill.py
+++ b/scripts/bench_service_prefill.py
@@ -149,9 +149,13 @@ def stream_request(
             if choice.get("finish_reason") is not None:
                 finish_reason = choice["finish_reason"]
     finished = time.perf_counter()
+    if first_visible is None:
+        raise RuntimeError(
+            "stream completed without a visible content, reasoning, or tool delta"
+        )
     details = usage.get("prompt_tokens_details") or {}
     return {
-        "ttft_ms": round(((first_visible or finished) - started) * 1000, 2),
+        "ttft_ms": round((first_visible - started) * 1000, 2),
         "total_ms": round((finished - started) * 1000, 2),
         "prompt_tokens": int(usage.get("prompt_tokens") or 0),
         "cached_tokens": int(details.get("cached_tokens") or 0),
@@ -171,6 +175,26 @@ def get_status(client: httpx.Client, root_url: str) -> dict[str, Any]:
     response = client.get(f"{root_url}/v1/status")
     response.raise_for_status()
     return response.json()
+
+
+def wait_for_running_request(
+    client: httpx.Client,
+    root_url: str,
+    *,
+    timeout_seconds: float = 30.0,
+    poll_seconds: float = 0.01,
+) -> dict[str, Any]:
+    """Wait until the service confirms that a request is actively scheduled."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = get_status(client, root_url)
+        if int(status.get("num_running") or 0) > 0:
+            return status
+        time.sleep(poll_seconds)
+    raise TimeoutError(
+        f"no running request observed at {root_url}/v1/status "
+        f"within {timeout_seconds:.1f}s"
+    )
 
 
 def main() -> int:
@@ -243,6 +267,7 @@ def main() -> int:
                     long_messages,
                     args.max_tokens,
                 )
+                wait_for_running_request(client, root_url)
                 time.sleep(args.contention_delay_ms / 1000)
                 short_future = executor.submit(
                     stream_request,

--- a/tests/test_bench_service_prefill.py
+++ b/tests/test_bench_service_prefill.py
@@ -1,3 +1,8 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts import bench_service_prefill as bench
 from scripts.bench_service_prefill import percentile, summarize, token_count
 
 
@@ -23,3 +28,31 @@ def test_summary_reports_ttft_and_total_p50_p95():
         "total_p50_ms": 30.0,
         "total_p95_ms": 39.0,
     }
+
+
+def test_wait_for_running_request_polls_server_state(monkeypatch):
+    statuses = iter([{"num_running": 0}, {"num_running": 1}])
+    monkeypatch.setattr(bench, "get_status", lambda _client, _url: next(statuses))
+    monkeypatch.setattr(bench.time, "sleep", lambda _seconds: None)
+
+    observed = bench.wait_for_running_request(
+        MagicMock(), "http://rapid", timeout_seconds=1
+    )
+
+    assert observed["num_running"] == 1
+
+
+def test_stream_request_rejects_stream_without_visible_delta(monkeypatch):
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_lines.return_value = [
+        'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":4}}',
+        "data: [DONE]",
+    ]
+    client = MagicMock()
+    client.stream.return_value = response
+    monkeypatch.setattr(bench.time, "perf_counter", MagicMock(side_effect=[1.0, 2.0]))
+
+    with pytest.raises(RuntimeError, match="without a visible"):
+        bench.stream_request(client, "http://rapid/v1", "model", [], 1)

--- a/tests/test_bench_service_prefill.py
+++ b/tests/test_bench_service_prefill.py
@@ -56,3 +56,20 @@ def test_stream_request_rejects_stream_without_visible_delta(monkeypatch):
 
     with pytest.raises(RuntimeError, match="without a visible"):
         bench.stream_request(client, "http://rapid/v1", "model", [], 1)
+
+
+def test_stream_request_rejects_missing_server_usage(monkeypatch):
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_lines.return_value = [
+        'data: {"choices":[{"delta":{"content":"done"}}]}',
+        "data: [DONE]",
+    ]
+    client = MagicMock()
+    client.stream.return_value = response
+    monkeypatch.setattr(
+        bench.time, "perf_counter", MagicMock(side_effect=[1.0, 1.5, 2.0])
+    )
+
+    with pytest.raises(RuntimeError, match="server usage metadata"):
+        bench.stream_request(client, "http://rapid/v1", "model", [], 1)

--- a/tests/test_bench_service_prefill.py
+++ b/tests/test_bench_service_prefill.py
@@ -1,0 +1,25 @@
+from scripts.bench_service_prefill import percentile, summarize, token_count
+
+
+def test_token_count_handles_batch_encoding_shape():
+    assert token_count({"input_ids": [1, 2, 3]}) == 3
+    assert token_count({"input_ids": [[1, 2, 3]]}) == 3
+
+
+def test_percentile_interpolates_small_samples():
+    assert percentile([10.0, 20.0, 30.0], 0.5) == 20.0
+    assert percentile([10.0, 20.0], 0.95) == 19.5
+
+
+def test_summary_reports_ttft_and_total_p50_p95():
+    rows = [
+        {"ttft_ms": 10, "total_ms": 20},
+        {"ttft_ms": 30, "total_ms": 40},
+        {"ttft_ms": 20, "total_ms": 30},
+    ]
+    assert summarize(rows) == {
+        "ttft_p50_ms": 20.0,
+        "ttft_p95_ms": 29.0,
+        "total_p50_ms": 30.0,
+        "total_p95_ms": 39.0,
+    }

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -1,0 +1,87 @@
+"""Architecture-aware prefill chunk defaults for recurrent language models."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import vllm_mlx.cli as cli
+
+
+def _profile(*, hybrid: bool, explicit: bool = False):
+    return SimpleNamespace(
+        is_hybrid=hybrid,
+        is_hybrid_explicit=explicit,
+        hf_path="unused",
+    )
+
+
+def test_linear_attention_config_is_detected_at_language_backbone():
+    assert cli._config_declares_linear_attention(
+        {
+            "text_config": {"layer_types": ["linear_attention", "full_attention"]},
+            "layer_types": ["full_attention"],
+        }
+    )
+
+
+def test_dense_and_sliding_attention_are_not_recurrent():
+    assert not cli._config_declares_linear_attention(
+        {"layer_types": ["sliding_attention", "full_attention"]}
+    )
+    assert not cli._config_declares_linear_attention(None)
+
+
+def test_recurrent_alias_auto_defaults_to_512(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_profile",
+        lambda _name: _profile(hybrid=False, explicit=True),
+    )
+    assert (
+        cli._resolve_prefill_step_size(
+            model_name="qwen3.5-4b-4bit", configured=2048, user_set_explicit=False
+        )
+        == cli._DEFAULT_RECURRENT_PREFILL_STEP_SIZE
+    )
+
+
+def test_explicit_prefill_step_size_always_wins(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_profile",
+        lambda _name: _profile(hybrid=True),
+    )
+    assert (
+        cli._resolve_prefill_step_size(
+            model_name="hybrid", configured=2048, user_set_explicit=True
+        )
+        == 2048
+    )
+
+
+def test_gemma_sliding_window_keeps_dense_default(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_profile",
+        lambda _name: _profile(hybrid=False),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_resolve_checkpoint_config",
+        lambda _name, _profile: {
+            "layer_types": ["sliding_attention", "full_attention"]
+        },
+    )
+    assert (
+        cli._resolve_prefill_step_size(
+            model_name="gemma-4-12b", configured=2048, user_set_explicit=False
+        )
+        == 2048
+    )
+
+
+def test_bare_linear_attention_checkpoint_is_detected(monkeypatch):
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_checkpoint_config",
+        lambda _name, _profile: {"layer_types": ["linear_attention"]},
+    )
+    assert cli._prefers_recurrent_prefill_chunks("/models/recurrent")

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -31,6 +31,16 @@ def test_dense_and_sliding_attention_are_not_recurrent():
     assert not cli._config_declares_linear_attention(None)
 
 
+def test_mamba_and_recurrent_checkpoint_markers_are_detected():
+    assert cli._config_declares_linear_attention(
+        {"layer_types": ["mamba", "full_attention"]}
+    )
+    assert cli._config_declares_linear_attention(
+        {"text_config": {"model_type": "recurrent_gemma"}}
+    )
+    assert cli._config_declares_linear_attention({"model_type": "qwen3_next"})
+
+
 def test_recurrent_alias_auto_defaults_to_512(monkeypatch):
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_profile",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2607,16 +2607,33 @@ def _resolve_checkpoint_config(model_name: str, profile) -> dict | None:
 
 
 def _config_declares_linear_attention(config: dict | None) -> bool:
-    """Whether the language backbone declares recurrent/linear attention."""
+    """Whether the language backbone declares recurrent/linear attention.
+
+    Keep the checkpoint signals aligned with ``mllm_backbone_is_hybrid``: this
+    variant accepts an already-resolved config so aliases and bare local paths
+    can share the serve prefill policy without another metadata lookup.
+    """
     if not isinstance(config, dict):
         return False
 
     text_config = config.get("text_config")
     language_config = text_config if isinstance(text_config, dict) else config
     layer_types = language_config.get("layer_types") or []
-    return any(
-        isinstance(layer_type, str) and "linear" in layer_type.lower()
+    if any(
+        isinstance(layer_type, str)
+        and any(
+            marker in layer_type.lower() for marker in ("linear", "mamba", "recurrent")
+        )
         for layer_type in layer_types
+    ):
+        return True
+    return any(
+        isinstance(model_type, str)
+        and any(
+            marker in model_type.lower()
+            for marker in ("mamba", "recurrent", "qwen3_next")
+        )
+        for model_type in (language_config.get("model_type"), config.get("model_type"))
     )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2489,6 +2489,7 @@ def _preflight_ddtree_or_exit(args):
 
 
 _DEFAULT_HYBRID_CACHE_ENTRIES = 8
+_DEFAULT_RECURRENT_PREFILL_STEP_SIZE = 512
 
 
 def _resolve_hybrid_cache_entries(
@@ -2603,6 +2604,59 @@ def _resolve_checkpoint_config(model_name: str, profile) -> dict | None:
         if metadata is not None and metadata.config:
             return metadata.config
     return None
+
+
+def _config_declares_linear_attention(config: dict | None) -> bool:
+    """Whether the language backbone declares recurrent/linear attention."""
+    if not isinstance(config, dict):
+        return False
+
+    text_config = config.get("text_config")
+    language_config = text_config if isinstance(text_config, dict) else config
+    layer_types = language_config.get("layer_types") or []
+    return any(
+        isinstance(layer_type, str) and "linear" in layer_type.lower()
+        for layer_type in layer_types
+    )
+
+
+def _prefers_recurrent_prefill_chunks(model_name: str) -> bool:
+    """Whether smaller prefill chunks improve this recurrent architecture.
+
+    Recurrent state has a much lower per-chunk memory floor than dense KV but
+    long chunks still monopolize the continuous-batching scheduler. Keep this
+    separate from ``_needs_bounded_trim_free_reuse``: sliding-window Gemma and
+    DeepSeek cache variants need bounded prefix snapshots, but are not evidence
+    for changing the prefill chunk size.
+    """
+    from .model_aliases import resolve_profile as _resolve_alias
+
+    profile = _resolve_alias(model_name)
+    if profile is not None and (
+        profile.is_hybrid or (profile.is_hybrid_explicit and not profile.is_hybrid)
+    ):
+        return True
+    return _config_declares_linear_attention(
+        _resolve_checkpoint_config(model_name, profile)
+    )
+
+
+def _resolve_prefill_step_size(
+    *, model_name: str, configured: int, user_set_explicit: bool
+) -> int:
+    """Resolve the architecture-aware serve prefill chunk size."""
+    import logging as _logging
+
+    if user_set_explicit or not _prefers_recurrent_prefill_chunks(model_name):
+        return configured
+    resolved = min(configured, _DEFAULT_RECURRENT_PREFILL_STEP_SIZE)
+    if resolved != configured:
+        _logging.getLogger(__name__).info(
+            "Recurrent/linear-attention model detected: auto-setting "
+            "--prefill-step-size=%d (pass --prefill-step-size explicitly to override)",
+            resolved,
+        )
+    return resolved
 
 
 def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
@@ -3809,6 +3863,12 @@ def serve_command(args):
         or any(a.startswith("--hybrid-cache-entries=") for a in sys.argv),
         model_name=getattr(args, "_original_alias", None) or args.model,
     )
+    _prefill_step_size = _resolve_prefill_step_size(
+        model_name=getattr(args, "_original_alias", None) or args.model,
+        configured=args.prefill_step_size,
+        user_set_explicit="--prefill-step-size" in sys.argv
+        or any(a.startswith("--prefill-step-size=") for a in sys.argv),
+    )
 
     # 0.9.13 PR-A codex round-E blocker #2: resolve model_type on the
     # CLI's asyncio thread and thread it down through SchedulerConfig
@@ -3867,7 +3927,7 @@ def serve_command(args):
         # reads it off scheduler_config only; the legacy load_model kwarg was
         # accepted but never used. See #400 and the CLI ↔ Config fidelity
         # audit at scripts/audit_cli_config_fidelity.py.
-        prefill_step_size=args.prefill_step_size,
+        prefill_step_size=_prefill_step_size,
         vision_min_pixels=getattr(args, "vision_min_pixels", 0),
         vision_max_pixels=getattr(args, "vision_max_pixels", 0),
         # Speculative decoding selection.
@@ -9816,7 +9876,8 @@ Examples:
         type=int,
         default=2048,
         help="Chunk size for prompt prefill processing. Larger values use more memory "
-        "but can improve prefill throughput. (default: 2048)",
+        "but can improve prefill throughput. (default: 2048; recurrent/linear-attention "
+        "models auto-tune to 512 unless explicitly set)",
     )
     serve_parser.add_argument(
         "--vision-min-pixels",


### PR DESCRIPTION
## What changed

- auto-select a 512-token serve prefill chunk for recurrent/linear-attention language backbones while preserving every explicit `--prefill-step-size`
- add an OpenAI streaming service benchmark for cold prefill, exact/partial prefix reuse, and mixed long/short contention
- record the controlled M2 Pro long-context and service A/B, artifact hashes, limitations, and follow-up work

## Why

The previous 2,048-token default lets a long recurrent prefill monopolize more scheduler time than necessary. On Qwen3.5 4B, reducing the chunk to 512 kept 16K--96K direct prefill throughput within 0.7%, reduced peak MLX memory by 27--29%, and cut a contended short request's TTFT by 51.1%.

The policy is intentionally recurrent-only. Dense/sliding models retain the existing default, and an explicit CLI value always wins.

## User impact

Concurrent short requests become substantially more responsive while a Qwen3.5/GDN long prompt is prefilling, without a measured single-request throughput penalty. Operators can reproduce or override the old behavior explicitly.

## Validation

- 179 focused scheduler, adaptive-prefill, cache, alias, CLI, and benchmark tests passed
- ruff clean and `git diff --check` clean
- candidate wheel tested on M2 Pro 32 GB mini with MLX 0.32.1 / mlx-lm 0.31.3
- no-override server boot logged and reported the effective 512-token chunk
- exact prefix hit verified with server-reported cached-token counts
