### PR TITLE
fix(mac): bundle MLX-compatible mflux

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -72,7 +72,7 @@ struct SidecarBuildScriptTests {
     func imageStackIsPinnedAndProvenTorchFree() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
 
-        #expect(script.contains("'mflux==0.18.1'"),
+        #expect(script.contains("'mflux==0.19.0'"),
                 "The no-deps sidecar install must never float within a range.")
         // The Images tab is only shippable because mflux's module-level
         // `import torch` is deferred into the three torch-only loading modes —

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -332,7 +332,7 @@ echo "==> bundling mflux --no-deps + platformdirs/piexif/toml (Images tab image-
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    'mflux==0.18.1' \
+    'mflux==0.19.0' \
     'platformdirs>=4.0,<5.0' \
     'piexif>=1.1.3,<2.0' \
     'toml>=0.10.2,<1.0'


### PR DESCRIPTION
## Summary

- align the Rapid Mac sidecar exact pin with the already coherence-gated `mflux>=0.19.0,<0.20` package metadata
- update the fail-closed Swift source guard to require mflux 0.19.0
- restore full Release app builds after the core MLX 0.32.1 upgrade

## Release blocker

`apps/rapid-mac/scripts/build.sh` failed its bundled-distribution compatibility audit because the sidecar still installed mflux 0.18.1 (`mlx<0.32`) next to core mlx 0.32.1. mflux 0.19.0 is the repository-documented first compatible line.

## Test plan

- [x] `swift test --filter SidecarBuildScriptTests` (6 passed)
- [x] full `bash scripts/build.sh` with bundled sidecar
- [x] sidecar compatibility audit accepts mlx 0.32.1 + mflux 0.19.0
- [x] torch-deferral/import proof remains fail-closed and passes
- [x] final app assembled and ad-hoc codesigned