### PR TITLE
[codex] Scope recurrent prefill defaults to verified profiles

### DIFF
--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -2,17 +2,18 @@
 
 ## Outcome
 
-Qwen3.5 recurrent/GatedDeltaNet models should use a 512-token prefill chunk by
-default in `rapid-mlx serve`. Against the previous 2,048-token default, this:
+Bench-verified Qwen3.5 4B and 9B profiles should use a 512-token prefill chunk
+by default in `rapid-mlx serve`. Against the previous 2,048-token default, this:
 
 - reduced a short request's TTFT under a concurrent long prefill by 51.1%;
 - reduced that short request's end-to-end latency by 64.4%;
 - kept 16K--96K single-request prefill throughput within 0.7%; and
 - reduced peak MLX memory by 27--29% at 16K--96K.
 
-The change is architecture-scoped. An explicit `--prefill-step-size` always
-wins, and dense/sliding-window models retain 2,048 pending stronger service
-evidence.
+The change is profile-scoped, not architecture-scoped. Repeated follow-up
+measurements found that the same 512-token setting regresses Bonsai 8B,
+LFM2.5 2.6B, and Qwen3.5 35B-A3B by 6--16%. An explicit
+`--prefill-step-size` always wins; unverified profiles retain 2,048.
 
 ## Goal and constraints
 
@@ -154,6 +155,35 @@ Follow up with repeated Rapid service concurrency runs before changing the
 dense/sliding default. The current implementation deliberately does not use the
 broader "needs bounded prefix reuse" classifier, so Gemma is unaffected.
 
+## Recurrent cross-model regression matrix
+
+A repeat-three follow-up tested whether the Qwen3.5 4B result generalized to
+other recurrent/linear-attention models. Each cell is the median of three exact
+token-count prefills with one generated token. Qwen3.5 9B ran on the M2 Pro
+32 GB mini; the other rows ran on an M3 Ultra 256 GB Studio. Both used macOS,
+MLX 0.32.1, and mlx-lm 0.31.3. No competing inference process was active; an
+idle `mlx_audio.server` remained on the Studio.
+
+| Model | Prompt | 2,048 tok/s | 512 tok/s | Throughput delta | 2,048 GB | 512 GB | Memory delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Qwen3.5 9B 4-bit | 4K | 217.63 | 218.22 | +0.3% | 6.97 | 6.08 | -12.8% |
+| Qwen3.5 9B 4-bit | 16K | 209.32 | 209.51 | +0.1% | 8.18 | 6.75 | -17.5% |
+| Ternary-Bonsai 8B 2-bit | 4K | 1,153.24 | 1,087.78 | -5.7% | 3.66 | 3.54 | -3.2% |
+| Ternary-Bonsai 8B 2-bit | 16K | 929.66 | 853.79 | -8.2% | 5.32 | 5.26 | -1.2% |
+| LFM2.5 2.6B 4-bit | 4K | 3,444.45 | 3,168.61 | -8.0% | 2.81 | 2.44 | -13.1% |
+| LFM2.5 2.6B 4-bit | 16K | 3,194.98 | 2,912.64 | -8.8% | 2.97 | 2.57 | -13.4% |
+| Qwen3.5 35B-A3B 4-bit | 4K | 2,427.65 | 2,037.85 | -16.1% | 21.51 | 20.30 | -5.6% |
+| Qwen3.5 35B-A3B 4-bit | 16K | 2,159.47 | 1,806.38 | -16.4% | 22.55 | 20.73 | -8.1% |
+
+The 9B result reproduces the 4B tradeoff: effectively unchanged throughput
+with meaningfully lower peak memory. The other architectures save varying
+amounts of memory but exceed the predeclared 3% throughput-regression limit.
+Therefore recurrent config detection is not a safe default selector. The
+runtime uses an explicit `recommended_prefill_step_size` profile field only on
+the measured Qwen3.5 4B/9B 4-bit aliases; other quantizations, Bonsai, LFM,
+MoE/hybrid, bare local paths, and future aliases keep the general 2,048 default
+until measured.
+
 ## Artifacts
 
 SHA-256 checksums:
@@ -171,10 +201,22 @@ SHA-256 checksums:
 - Gemma 2,048 / 512 scouts:
   `9fdf433fe29ffd6d6fc6691f1e7081aac864c0fccf2e6c2746a4d45df168a323`,
   `5a39dc7ed674d6c056e2962ddedc75f46f1f16bc331b4c2f7fe973b642b7be51`
+- Qwen3.5 9B 2,048 / 512 repeat-three:
+  `f25d19a46a8a9aa5260cb15f0e2d3acdaeed21412ce4fa2df016540310cf642b`,
+  `7970ee9617db0fb0f211b5c310787987819e4eaa3f1ba22ed26def4646f939d1`
+- Bonsai 8B 2,048 / 512 repeat-three:
+  `300f379e3902b8d1ec1c4f627f687104ed3ef4e44469e0ac1ee99f9d7b7a5533`,
+  `3588e7cb0319eff3efc3ab0a827d323cd210c251875c13c2eaee2eb184b56c80`
+- LFM2.5 2.6B 2,048 / 512 repeat-three:
+  `5d5143f442bd098b3661acf6d19dd1f13cbed6d3f79a883ebff0795fae08305b`,
+  `763a7d3e4c196bafa88eaec706c72762b69bca81590cce3e53c260f7ca4202f5`
+- Qwen3.5 35B-A3B 2,048 / 512 repeat-three:
+  `d6b2459883bf0ce3a1a52d2cf8624f23315b7c9be5c47218286ba6977a4293a2`,
+  `35846b1024bc3ab2c5488c50ed96638b33a32c409fe252f1f44bebc0682a5ce0`
 
 ## Recommendation and next work
 
-Land the recurrent-only 512 auto-default with the benchmark harness. Then:
+Land the profile-scoped 512 auto-default with the benchmark harness. Then:
 
 1. run the same HTTP workload against a calibrated oMLX deployment (none was
    installed on this mini during this run), including equivalent cache policy;

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -70,6 +70,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "mtp_draft_model",
         "mtp_speculative_tokens",
         "default_max_tokens",
+        "recommended_prefill_step_size",
         "suffix_decoding_tier",
         "suffix_bench_speedup",
         "supports_dflash",

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -127,3 +127,18 @@ def test_only_bench_verified_qwen_profiles_opt_in():
         "qwen3.5-9b-8bit",
     ):
         assert resolve_profile(alias).recommended_prefill_step_size is None
+
+
+def test_prefill_help_describes_profile_scoped_recommendation():
+    serve_parser = next(
+        action.choices["serve"]
+        for action in cli.build_parser()._actions
+        if getattr(action, "choices", None) and "serve" in action.choices
+    )
+    action = next(
+        action
+        for action in serve_parser._actions
+        if "--prefill-step-size" in action.option_strings
+    )
+    assert "bench-verified model profiles" in action.help
+    assert "recurrent/linear-attention models auto-tune" not in action.help

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import vllm_mlx.cli as cli
+from vllm_mlx.model_aliases import resolve_profile
 
 
-def _profile(*, hybrid: bool, explicit: bool = False):
+def _profile(
+    *, hybrid: bool, explicit: bool = False, recommended_prefill_step_size=None
+):
     return SimpleNamespace(
         is_hybrid=hybrid,
         is_hybrid_explicit=explicit,
         hf_path="unused",
+        recommended_prefill_step_size=recommended_prefill_step_size,
     )
 
 
@@ -41,10 +45,12 @@ def test_mamba_and_recurrent_checkpoint_markers_are_detected():
     assert cli._config_declares_linear_attention({"model_type": "qwen3_next"})
 
 
-def test_recurrent_alias_auto_defaults_to_512(monkeypatch):
+def test_bench_verified_alias_auto_defaults_to_512(monkeypatch):
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_profile",
-        lambda _name: _profile(hybrid=False, explicit=True),
+        lambda _name: _profile(
+            hybrid=False, explicit=True, recommended_prefill_step_size=512
+        ),
     )
     assert (
         cli._resolve_prefill_step_size(
@@ -57,7 +63,7 @@ def test_recurrent_alias_auto_defaults_to_512(monkeypatch):
 def test_explicit_prefill_step_size_always_wins(monkeypatch):
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_profile",
-        lambda _name: _profile(hybrid=True),
+        lambda _name: _profile(hybrid=True, recommended_prefill_step_size=512),
     )
     assert (
         cli._resolve_prefill_step_size(
@@ -87,11 +93,37 @@ def test_gemma_sliding_window_keeps_dense_default(monkeypatch):
     )
 
 
-def test_bare_linear_attention_checkpoint_is_detected(monkeypatch):
+def test_bare_linear_attention_checkpoint_keeps_general_default(monkeypatch):
     monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
     monkeypatch.setattr(
         cli,
         "_resolve_checkpoint_config",
         lambda _name, _profile: {"layer_types": ["linear_attention"]},
     )
-    assert cli._prefers_recurrent_prefill_chunks("/models/recurrent")
+    assert not cli._prefers_recurrent_prefill_chunks("/models/recurrent")
+    assert (
+        cli._resolve_prefill_step_size(
+            model_name="/models/recurrent",
+            configured=2048,
+            user_set_explicit=False,
+        )
+        == 2048
+    )
+
+
+def test_only_bench_verified_qwen_profiles_opt_in():
+    for alias in (
+        "qwen3.5-4b-4bit",
+        "qwen3.5-9b-4bit",
+    ):
+        assert resolve_profile(alias).recommended_prefill_step_size == 512
+
+    for alias in (
+        "qwen3.5-27b-4bit",
+        "qwen3.5-35b-4bit",
+        "qwen3.5-4b-6bit",
+        "qwen3.5-4b-8bit",
+        "qwen3.5-9b-6bit",
+        "qwen3.5-9b-8bit",
+    ):
+        assert resolve_profile(alias).recommended_prefill_step_size is None

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -23,6 +23,7 @@
     "supports_spec_decode": false,
     "mtp_draft_model": "mlx-community/Qwen3.5-4B-MTP-4bit",
     "mtp_speculative_tokens": 2,
+    "recommended_prefill_step_size": 512,
     "pflash_tier": "verified"
   },
   "qwen3.5-4b-8bit": {
@@ -57,6 +58,7 @@
     "supports_spec_decode": false,
     "mtp_draft_model": "mlx-community/Qwen3.5-9B-MTP-4bit",
     "mtp_speculative_tokens": 2,
+    "recommended_prefill_step_size": 512,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
   },

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2638,23 +2638,19 @@ def _config_declares_linear_attention(config: dict | None) -> bool:
 
 
 def _prefers_recurrent_prefill_chunks(model_name: str) -> bool:
-    """Whether smaller prefill chunks improve this recurrent architecture.
+    """Whether this model profile has a bench-verified smaller chunk.
 
-    Recurrent state has a much lower per-chunk memory floor than dense KV but
-    long chunks still monopolize the continuous-batching scheduler. Keep this
-    separate from ``_needs_bounded_trim_free_reuse``: sliding-window Gemma and
-    DeepSeek cache variants need bounded prefix snapshots, but are not evidence
-    for changing the prefill chunk size.
+    Do not infer this from recurrent/hybrid architecture.  Qwen3.5 4B/9B keeps
+    throughput while reducing memory at 512, but repeated measurements found
+    6--16% regressions on Bonsai, LFM2.5, and Qwen3.5 MoE.  Keep this explicit
+    and separate from ``_needs_bounded_trim_free_reuse``.
     """
     from .model_aliases import resolve_profile as _resolve_alias
 
     profile = _resolve_alias(model_name)
-    if profile is not None and (
-        profile.is_hybrid or (profile.is_hybrid_explicit and not profile.is_hybrid)
-    ):
-        return True
-    return _config_declares_linear_attention(
-        _resolve_checkpoint_config(model_name, profile)
+    return bool(
+        profile is not None
+        and getattr(profile, "recommended_prefill_step_size", None) is not None
     )
 
 
@@ -2666,10 +2662,14 @@ def _resolve_prefill_step_size(
 
     if user_set_explicit or not _prefers_recurrent_prefill_chunks(model_name):
         return configured
-    resolved = min(configured, _DEFAULT_RECURRENT_PREFILL_STEP_SIZE)
+    from .model_aliases import resolve_profile as _resolve_alias
+
+    profile = _resolve_alias(model_name)
+    recommendation = getattr(profile, "recommended_prefill_step_size", None)
+    resolved = min(configured, recommendation or _DEFAULT_RECURRENT_PREFILL_STEP_SIZE)
     if resolved != configured:
         _logging.getLogger(__name__).info(
-            "Recurrent/linear-attention model detected: auto-setting "
+            "Bench-verified model profile: auto-setting "
             "--prefill-step-size=%d (pass --prefill-step-size explicitly to override)",
             resolved,
         )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9893,8 +9893,8 @@ Examples:
         type=int,
         default=2048,
         help="Chunk size for prompt prefill processing. Larger values use more memory "
-        "but can improve prefill throughput. (default: 2048; recurrent/linear-attention "
-        "models auto-tune to 512 unless explicitly set)",
+        "but can improve prefill throughput. (default: 2048; bench-verified model "
+        "profiles may recommend a smaller value unless explicitly set)",
     )
     serve_parser.add_argument(
         "--vision-min-pixels",

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -176,6 +176,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "mtp_draft_model",
             "mtp_speculative_tokens",
             "default_max_tokens",
+            "recommended_prefill_step_size",
             "suffix_decoding_tier",
             "suffix_bench_speedup",
             "supports_dflash",
@@ -381,6 +382,9 @@ def _coerce(alias: str, value: object) -> AliasProfile:
 
     ddtree_speculative_tokens = _optional_positive_int("ddtree_speculative_tokens")
     ddtree_tree_budget = _optional_positive_int("ddtree_tree_budget")
+    recommended_prefill_step_size = _optional_positive_int(
+        "recommended_prefill_step_size"
+    )
 
     # ``min_memory_gb`` (codex #1069 round 3 [NIT #3]) — accepted as a
     # positive number (int or float). ``None`` = no hardware gate;
@@ -542,6 +546,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         mtp_draft_model=mtp_draft_model,
         mtp_speculative_tokens=mtp_speculative_tokens,
         default_max_tokens=value.get("default_max_tokens"),
+        recommended_prefill_step_size=recommended_prefill_step_size,
         suffix_decoding_tier=tier,
         suffix_bench_speedup=speedup,
         supports_dflash=supports_dflash,

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -165,6 +165,11 @@ class ModelProfile:
     mtp_draft_model: str | None = None
     mtp_speculative_tokens: int = 3
     default_max_tokens: int | None = None  # Per-model default when user omits
+    # Bench-verified service prefill chunk.  This is deliberately an explicit
+    # per-profile recommendation rather than an architecture inference:
+    # recurrent families have materially different chunk-overhead curves.
+    # ``None`` retains SchedulerConfig's general default.
+    recommended_prefill_step_size: int | None = None
 
     # SuffixDecoding eligibility — populated from cross-model bench (issue #269).
     # ``None`` for ``suffix_bench_speedup`` means "not benched yet"; the tier


### PR DESCRIPTION
## What changed

- replace architecture-wide recurrent prefill auto-detection with an explicit `recommended_prefill_step_size` model-profile field
- opt in only the repeat-tested Qwen3.5 4B/9B 4-bit aliases at 512 tokens
- leave 6/8-bit, 27B, MoE/hybrid, bare paths, and future profiles at the general 2,048-token default
- record the repeat-three cross-model regression matrix and artifact hashes

## Why

PR #2210 generalized the Qwen3.5 4B result to recurrent/linear-attention architectures. Repeat-three checks show that is unsafe: 512 regresses Bonsai 8B by 5.7--8.2%, LFM2.5 2.6B by 8.0--8.8%, and Qwen3.5 35B-A3B by 16.1--16.4%. Qwen3.5 9B reproduces the intended tradeoff: throughput is within +0.3% while peak memory falls 12.8--17.5%.

This turns the optimization into a conservative, auditable per-profile recommendation. Explicit `--prefill-step-size` still wins.

## Validation

- repeat-three 4K/16K direct prefill A/B on Qwen3.5 9B, Bonsai 8B, LFM2.5 2.6B, and Qwen3.5 35B-A3B
- `2917 passed`: recurrent-prefill and aliases contract suites
- `216 passed`: model aliases/profile SSOT, CLI config/alias, server load order/utils, routing guards
- Ruff passed on touched Python files
- JSON parse, compileall, and `git diff --check` passed
