### PR TITLE
fix(mac): remove first-run GUI friction

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -255,7 +255,8 @@ final class ImageGenViewModel {
                 alias: target.alias,
                 hfPath: target.hfPath,
                 estimatedMemoryGB: target.estimatedMemoryGB,
-                imageMode: .generation
+                imageMode: .generation,
+                residencyEligible: false
             ) else {
                 throw ImageClientError.notReady
             }
@@ -288,7 +289,8 @@ final class ImageGenViewModel {
                 alias: target.alias,
                 hfPath: target.hfPath,
                 estimatedMemoryGB: target.estimatedMemoryGB,
-                imageMode: .editing
+                imageMode: .editing,
+                residencyEligible: false
             ) else {
                 throw ImageClientError.notReady
             }

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -206,9 +206,9 @@ final class ImageGenViewModel {
 
     /// Load the image-gen alias catalog (safe to call repeatedly).
     func refreshCatalog() async {
-        guard let binary = server.binaryPath else { return }
         catalogRefreshGeneration &+= 1
         let refreshGeneration = catalogRefreshGeneration
+        guard let binary = server.binaryPath else { return }
         let loaded = await catalogLoader(binary)
         guard !Task.isCancelled,
               refreshGeneration == catalogRefreshGeneration else { return }

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -168,9 +168,19 @@ final class ImageGenViewModel {
 
     private let client = ImageClient()
     private let server: ServerManager
+    @ObservationIgnored
+    private let catalogLoader: (URL) async -> [ModelEntry]
+    @ObservationIgnored
+    private var catalogRefreshGeneration: UInt = 0
 
-    init(server: ServerManager) {
+    init(
+        server: ServerManager,
+        catalogLoader: @escaping (URL) async -> [ModelEntry] = {
+            await ModelCatalog.imageEntries(binary: $0)
+        }
+    ) {
         self.server = server
+        self.catalogLoader = catalogLoader
     }
 
     var canSubmit: Bool {
@@ -197,7 +207,12 @@ final class ImageGenViewModel {
     /// Load the image-gen alias catalog (safe to call repeatedly).
     func refreshCatalog() async {
         guard let binary = server.binaryPath else { return }
-        imageModels = await ModelCatalog.imageEntries(binary: binary)
+        catalogRefreshGeneration &+= 1
+        let refreshGeneration = catalogRefreshGeneration
+        let loaded = await catalogLoader(binary)
+        guard !Task.isCancelled,
+              refreshGeneration == catalogRefreshGeneration else { return }
+        imageModels = loaded
         catalogLoaded = true
         resolveAlias()
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -83,6 +83,10 @@ final class DownloadManager {
     @Observable
     final class Job: Identifiable, Equatable {
         let id: String  // == alias
+        /// Stable identity for this particular attempt. Unlike
+        /// ``ObjectIdentifier``, this cannot be reused after ARC releases an
+        /// earlier job with the same alias.
+        let instanceID = UUID()
         let alias: String
         let progress: DownloadProgress
         fileprivate(set) var status: Status

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -201,9 +201,13 @@ final class DownloadProgress {
     /// total, bytes and rate are all known.
     var etaText: String? {
         guard let total = totalBytes, let bytes = bytesDownloaded,
-              let speed = bytesPerSecond, speed > 0, total > bytes,
+              let etaSeconds, etaSeconds > 0, total > bytes,
               etaEstimateIsStable else { return nil }
-        return Self.formatETA(bytesRemaining: total - bytes, bytesPerSecond: speed)
+        let remaining = total - bytes
+        return Self.formatETA(
+            bytesRemaining: remaining,
+            bytesPerSecond: Double(remaining) / etaSeconds
+        )
     }
 
     /// ETA is intentionally delayed while the connection ramps up. Two early
@@ -229,6 +233,11 @@ final class DownloadProgress {
     private var rateSamplingStartedAt: Date?
     private var rateSamplingBaselineBytes: Int64?
     private var lastGrowingSample: (at: Date, bytes: Int64)?
+    /// Smoothed prediction used for user-facing copy. A brief rate dip may
+    /// raise the estimate by at most 25% per observation, preventing a
+    /// settled ETA from jumping several-fold in one frame while still
+    /// converging when a slowdown persists.
+    private(set) var etaSeconds: Double?
     private nonisolated static let minimumETASampleSpan: TimeInterval = 8
     private nonisolated static let minimumETAGrowthBytes: Int64 = 16 * 1024 * 1024
 
@@ -286,6 +295,7 @@ final class DownloadProgress {
         rateSamplingBaselineBytes = nil
         lastGrowingSample = nil
         bytesPerSecond = nil
+        etaSeconds = nil
     }
 
     /// Set the catalog-known total weight size. Called once when a job
@@ -345,6 +355,7 @@ final class DownloadProgress {
         lastTickAt = now
         recordRateSample(at: now, bytes: bytes)
         bytesPerSecond = computeRate(now: now)
+        updateETAEstimate()
     }
 
     /// Append a sample, drop anything older than ``rateWindowSeconds``
@@ -361,6 +372,7 @@ final class DownloadProgress {
             // ticks cannot preserve a stale stability epoch.
             rateSamplingStartedAt = now
             rateSamplingBaselineBytes = bytes
+            etaSeconds = nil
         }
         if rateSamplingStartedAt == nil {
             rateSamplingStartedAt = now
@@ -393,6 +405,23 @@ final class DownloadProgress {
         let delta = newest.bytes - oldest.bytes
         guard delta > 0 else { return nil }
         return Double(delta) / span
+    }
+
+    private func updateETAEstimate() {
+        guard etaEstimateIsStable,
+              let total = totalBytes,
+              let bytes = bytesDownloaded,
+              let speed = bytesPerSecond,
+              speed > 0, total > bytes else {
+            etaSeconds = nil
+            return
+        }
+        let raw = Double(total - bytes) / speed
+        if let previous = etaSeconds, raw > previous {
+            etaSeconds = min(raw, previous * 1.25)
+        } else {
+            etaSeconds = raw
+        }
     }
 
     /// Ingest one stdout/stderr line from the child. Returns ``true`` if

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -343,7 +343,14 @@ final class DownloadProgress {
     /// behind the newest one, and enforce ``maxRateSamples``. Called
     /// only from ``applyDiskObservation(bytes:at:)``.
     private func recordRateSample(at now: Date, bytes: Int64) {
-        if rateSamplingStartedAt == nil { rateSamplingStartedAt = now }
+        // A resumed transfer needs a fresh settling period. Otherwise the
+        // epoch from before a long stall survives after every old rate sample
+        // has been evicted, and two new chunks can immediately publish the
+        // same volatile ETA we intentionally suppress on first start.
+        if rateSamplingStartedAt == nil
+            || rateSamples.last.map({ now.timeIntervalSince($0.at) > Self.rateStaleSeconds }) == true {
+            rateSamplingStartedAt = now
+        }
         rateSamples.append((at: now, bytes: bytes))
         let cutoff = now.addingTimeInterval(-Self.rateWindowSeconds)
         while let first = rateSamples.first, first.at < cutoff {

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -201,8 +201,18 @@ final class DownloadProgress {
     /// total, bytes and rate are all known.
     var etaText: String? {
         guard let total = totalBytes, let bytes = bytesDownloaded,
-              let speed = bytesPerSecond, speed > 0, total > bytes else { return nil }
+              let speed = bytesPerSecond, speed > 0, total > bytes,
+              etaEstimateIsStable else { return nil }
         return Self.formatETA(bytesRemaining: total - bytes, bytesPerSecond: speed)
+    }
+
+    /// ETA is intentionally delayed while the connection ramps up. Two early
+    /// chunks can produce a mathematically valid but wildly misleading answer
+    /// (for example 1 minute, then 12 minutes). Speed remains visible during
+    /// this settling period; only the predictive copy is withheld.
+    private var etaEstimateIsStable: Bool {
+        guard let first = rateSamplingStartedAt, let newest = rateSamples.last else { return false }
+        return newest.at.timeIntervalSince(first) >= Self.minimumETASampleSpan
     }
 
     /// Recent ``(timestamp, bytes)`` samples accumulated from
@@ -213,6 +223,8 @@ final class DownloadProgress {
     /// against the OLDEST in-window sample on each call — simpler to
     /// reason about than recursive EMA and easier to test.
     private var rateSamples: [(at: Date, bytes: Int64)] = []
+    private var rateSamplingStartedAt: Date?
+    private nonisolated static let minimumETASampleSpan: TimeInterval = 8
 
     /// Most recent rate estimate in bytes/second, or ``nil`` if we
     /// don't have a fresh enough window to derive one. Recomputed on
@@ -264,6 +276,7 @@ final class DownloadProgress {
         baselineDiskBytes = nil
         hasObservedGrowth = false
         rateSamples.removeAll(keepingCapacity: true)
+        rateSamplingStartedAt = nil
         bytesPerSecond = nil
     }
 
@@ -330,6 +343,7 @@ final class DownloadProgress {
     /// behind the newest one, and enforce ``maxRateSamples``. Called
     /// only from ``applyDiskObservation(bytes:at:)``.
     private func recordRateSample(at now: Date, bytes: Int64) {
+        if rateSamplingStartedAt == nil { rateSamplingStartedAt = now }
         rateSamples.append((at: now, bytes: bytes))
         let cutoff = now.addingTimeInterval(-Self.rateWindowSeconds)
         while let first = rateSamples.first, first.at < cutoff {
@@ -822,7 +836,8 @@ final class DownloadProgress {
                 parts.append("\(Self.formatBytes(bytes)) / \(Self.formatBytes(total)) · \(clamped)%")
                 if let speed = bytesPerSecond {
                     parts.append(Self.formatSpeed(bytesPerSecond: speed))
-                    if let eta = Self.formatETA(bytesRemaining: total - bytes, bytesPerSecond: speed) {
+                    if etaEstimateIsStable,
+                       let eta = Self.formatETA(bytesRemaining: total - bytes, bytesPerSecond: speed) {
                         parts.append(eta)
                     }
                 }

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -211,8 +211,11 @@ final class DownloadProgress {
     /// (for example 1 minute, then 12 minutes). Speed remains visible during
     /// this settling period; only the predictive copy is withheld.
     private var etaEstimateIsStable: Bool {
-        guard let first = rateSamplingStartedAt, let newest = rateSamples.last else { return false }
+        guard let first = rateSamplingStartedAt,
+              let baseline = rateSamplingBaselineBytes,
+              let newest = rateSamples.last else { return false }
         return newest.at.timeIntervalSince(first) >= Self.minimumETASampleSpan
+            && newest.bytes - baseline >= Self.minimumETAGrowthBytes
     }
 
     /// Recent ``(timestamp, bytes)`` samples accumulated from
@@ -224,8 +227,10 @@ final class DownloadProgress {
     /// reason about than recursive EMA and easier to test.
     private var rateSamples: [(at: Date, bytes: Int64)] = []
     private var rateSamplingStartedAt: Date?
+    private var rateSamplingBaselineBytes: Int64?
     private var lastGrowingSample: (at: Date, bytes: Int64)?
     private nonisolated static let minimumETASampleSpan: TimeInterval = 8
+    private nonisolated static let minimumETAGrowthBytes: Int64 = 16 * 1024 * 1024
 
     /// Most recent rate estimate in bytes/second, or ``nil`` if we
     /// don't have a fresh enough window to derive one. Recomputed on
@@ -278,6 +283,7 @@ final class DownloadProgress {
         hasObservedGrowth = false
         rateSamples.removeAll(keepingCapacity: true)
         rateSamplingStartedAt = nil
+        rateSamplingBaselineBytes = nil
         lastGrowingSample = nil
         bytesPerSecond = nil
     }
@@ -354,8 +360,12 @@ final class DownloadProgress {
             // actually MOVED, not the latest heartbeat, so those liveness
             // ticks cannot preserve a stale stability epoch.
             rateSamplingStartedAt = now
+            rateSamplingBaselineBytes = bytes
         }
-        if rateSamplingStartedAt == nil { rateSamplingStartedAt = now }
+        if rateSamplingStartedAt == nil {
+            rateSamplingStartedAt = now
+            rateSamplingBaselineBytes = bytes
+        }
         if grew { lastGrowingSample = (now, bytes) }
         rateSamples.append((at: now, bytes: bytes))
         let cutoff = now.addingTimeInterval(-Self.rateWindowSeconds)

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -888,8 +888,7 @@ final class DownloadProgress {
                 parts.append("\(Self.formatBytes(bytes)) / \(Self.formatBytes(total)) · \(clamped)%")
                 if let speed = bytesPerSecond {
                     parts.append(Self.formatSpeed(bytesPerSecond: speed))
-                    if etaEstimateIsStable,
-                       let eta = Self.formatETA(bytesRemaining: total - bytes, bytesPerSecond: speed) {
+                    if let eta = etaText {
                         parts.append(eta)
                     }
                 }

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -224,6 +224,7 @@ final class DownloadProgress {
     /// reason about than recursive EMA and easier to test.
     private var rateSamples: [(at: Date, bytes: Int64)] = []
     private var rateSamplingStartedAt: Date?
+    private var lastGrowingSample: (at: Date, bytes: Int64)?
     private nonisolated static let minimumETASampleSpan: TimeInterval = 8
 
     /// Most recent rate estimate in bytes/second, or ``nil`` if we
@@ -277,6 +278,7 @@ final class DownloadProgress {
         hasObservedGrowth = false
         rateSamples.removeAll(keepingCapacity: true)
         rateSamplingStartedAt = nil
+        lastGrowingSample = nil
         bytesPerSecond = nil
     }
 
@@ -343,14 +345,18 @@ final class DownloadProgress {
     /// behind the newest one, and enforce ``maxRateSamples``. Called
     /// only from ``applyDiskObservation(bytes:at:)``.
     private func recordRateSample(at now: Date, bytes: Int64) {
-        // A resumed transfer needs a fresh settling period. Otherwise the
-        // epoch from before a long stall survives after every old rate sample
-        // has been evicted, and two new chunks can immediately publish the
-        // same volatile ETA we intentionally suppress on first start.
-        if rateSamplingStartedAt == nil
-            || rateSamples.last.map({ now.timeIntervalSince($0.at) > Self.rateStaleSeconds }) == true {
+        let grew = lastGrowingSample.map { bytes > $0.bytes } ?? true
+        if grew,
+           let lastGrowth = lastGrowingSample,
+           now.timeIntervalSince(lastGrowth.at) > Self.rateStaleSeconds {
+            // Cache monitors keep reporting unchanged byte counts during a
+            // network stall. Measure recovery from the last sample that
+            // actually MOVED, not the latest heartbeat, so those liveness
+            // ticks cannot preserve a stale stability epoch.
             rateSamplingStartedAt = now
         }
+        if rateSamplingStartedAt == nil { rateSamplingStartedAt = now }
+        if grew { lastGrowingSample = (now, bytes) }
         rateSamples.append((at: now, bytes: bytes))
         let cutoff = now.addingTimeInterval(-Self.rateWindowSeconds)
         while let first = rateSamples.first, first.at < cutoff {

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -46,6 +46,8 @@ struct ConnectToolsView: View {
     var readiness: ModelReadiness? = nil
     var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
     @State private var integrationTargets: [IntegrationTarget] = []
+    @State private var showsConnectionDetails = false
+    @State private var showsMoreIntegrations = false
 
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
@@ -160,16 +162,57 @@ struct ConnectToolsView: View {
             // and unlike the old local sentence it carries the action
             // that resolves the problem.
             if let readiness, !readiness.isReady {
-                ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
+                VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                    SectionHeader(
+                        "Start here",
+                        subtitle: "Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands."
+                    )
+                    ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
+                }
             } else if !configReady {
                 // Either no readiness was supplied (dev snapshot), or the
                 // model is up but a value is still missing — a narrow
                 // case, but silence there would leave a half-filled
                 // config looking complete.
                 InlineNotice(message: readinessMessage, tone: .info)
+                endpointSection
+                toolsSection(tools)
+            } else {
+                toolsSection(Array(tools.prefix(3)), title: "Popular integrations")
+                Button {
+                    showsConnectionDetails.toggle()
+                } label: {
+                    disclosureLabel(
+                        "Advanced connection details",
+                        systemImage: "network",
+                        expanded: showsConnectionDetails
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("ConnectTools.AdvancedDetails")
+                if showsConnectionDetails {
+                    endpointSection.padding(.top, RapidTheme.Space.sm)
+                }
+
+                let remaining = Array(tools.dropFirst(3))
+                if !remaining.isEmpty {
+                    Button {
+                        showsMoreIntegrations.toggle()
+                    } label: {
+                        disclosureLabel(
+                            "More integrations (\(remaining.count))",
+                            systemImage: "ellipsis.circle",
+                            expanded: showsMoreIntegrations
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("ConnectTools.MoreIntegrations")
+                    if showsMoreIntegrations {
+                        toolsSection(remaining, title: "More integrations")
+                            .padding(.top, RapidTheme.Space.sm)
+                    }
+                }
             }
-            endpointSection
-            toolsSection
         }
         .frame(maxWidth: RapidTheme.Layout.pageMaxWidth, alignment: .leading)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -241,11 +284,14 @@ struct ConnectToolsView: View {
         }
     }
 
-    private var toolsSection: some View {
+    private func toolsSection(
+        _ displayedTools: [ConnectTool],
+        title: String = "Editors and agents"
+    ) -> some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
-            SectionHeader("Editors and agents")
+            SectionHeader(title)
             VStack(spacing: 0) {
-                ForEach(Array(tools.enumerated()), id: \.element.id) { index, tool in
+                ForEach(Array(displayedTools.enumerated()), id: \.element.id) { index, tool in
                     if index > 0 { rowDivider }
                     ConnectToolRow(tool: tool, isReady: configReady)
                 }
@@ -259,6 +305,21 @@ struct ConnectToolsView: View {
             .fill(RapidTheme.hairline)
             .frame(height: 1)
             .padding(.leading, RapidTheme.Space.md)
+    }
+
+    private func disclosureLabel(
+        _ title: String,
+        systemImage: String,
+        expanded: Bool
+    ) -> some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                .frame(width: 12)
+            Label(title, systemImage: systemImage)
+                .font(RapidFont.secondary)
+            Spacer()
+        }
+        .contentShape(Rectangle())
     }
 
     // MARK: - Tool definitions

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -50,9 +50,6 @@ struct ContentView: View {
     /// by the onboarding completion transaction so the user lands in their
     /// first chat with the caret already in the message field.
     @State private var composerFocusRequest: Int = 0
-    @State private var showOnboardingCompletePrompt = false
-    @AppStorage(GitHubCommunity.didShowOnboardingPromptKey)
-    private var didShowOnboardingCompletePrompt = false
     @Environment(SettingsRouter.self) private var settingsRouter
     /// #223: launch-time auto-start "needs download" state — the empty
     /// state names the pending pull when non-nil.
@@ -110,20 +107,6 @@ struct ContentView: View {
         .overlay {
             if showConversationSearch {
                 conversationSearchOverlay
-            }
-        }
-        .overlay(alignment: .bottomTrailing) {
-            if showOnboardingCompletePrompt {
-                OnboardingCompletePrompt {
-                    withAnimation(RapidMotion.resolve(
-                        RapidMotion.standard,
-                        reduceMotion: reduceMotion
-                    )) {
-                        showOnboardingCompletePrompt = false
-                    }
-                }
-                .padding(20)
-                .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
         .onChange(of: server.state) { _, newState in
@@ -362,7 +345,14 @@ struct ContentView: View {
             }
             // Background pulls are process-wide, not chat-only.  Keep their
             // progress visible whichever sidebar destination is selected.
-            DownloadStrip(downloads: downloads)
+            DownloadStrip(
+                downloads: downloads,
+                isResident: { alias in
+                    if server.residency.contains(alias) { return true }
+                    if case .ready(let readyAlias) = server.state { return readyAlias == alias }
+                    return false
+                }
+            )
             if showLogs {
                 LogDrawer(server: server)
                     .frame(minHeight: 100, idealHeight: 150, maxHeight: 220)
@@ -769,17 +759,6 @@ struct ContentView: View {
         section = .chat
         VoiceOverAnnouncer.announce("Setup complete. Opening your first chat.")
         composerFocusRequest &+= 1
-        let prompt = GitHubStarPromptCompletion.completingOnboarding(
-            hasShown: didShowOnboardingCompletePrompt
-        )
-        didShowOnboardingCompletePrompt = prompt.hasShown
-        guard prompt.shouldPresent else { return }
-        withAnimation(RapidMotion.resolve(
-            RapidMotion.standard,
-            reduceMotion: reduceMotion
-        )) {
-            showOnboardingCompletePrompt = true
-        }
     }
 
     /// True when the Quickstart card should render in place of the chat

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -61,9 +61,16 @@ struct DownloadStrip: View {
     }
 
     private var completedCleanupKey: String {
-        downloads.jobs.values.compactMap { job -> String? in
+        Self.completedCleanupKey(jobs: downloads.jobs, isResident: isResident)
+    }
+
+    static func completedCleanupKey(
+        jobs: [String: DownloadManager.Job],
+        isResident: (String) -> Bool
+    ) -> String {
+        jobs.values.compactMap { job -> String? in
             guard case .completed = job.status else { return nil }
-            return "\(job.alias):\(isResident(job.alias) ? "resident" : "cached")"
+            return "\(job.alias):\(job.instanceID):\(isResident(job.alias) ? "resident" : "cached")"
         }.sorted().joined(separator: "|")
     }
 
@@ -79,9 +86,9 @@ struct DownloadStrip: View {
 
     static func isSameCompletedJob(
         _ job: DownloadManager.Job?,
-        as expectedID: ObjectIdentifier
+        as expectedID: UUID
     ) -> Bool {
-        guard let job, ObjectIdentifier(job) == expectedID else { return false }
+        guard let job, job.instanceID == expectedID else { return false }
         if case .completed = job.status { return true }
         return false
     }
@@ -109,9 +116,9 @@ struct DownloadStrip: View {
             ) {
                 downloads.dismissJob(alias: alias)
             }
-            let delayed = completed.compactMap { alias -> (String, ObjectIdentifier)? in
+            let delayed = completed.compactMap { alias -> (String, UUID)? in
                 guard !isResident(alias), let job = downloads.job(for: alias) else { return nil }
-                return (alias, ObjectIdentifier(job))
+                return (alias, job.instanceID)
             }
             guard !delayed.isEmpty else { return }
             try? await Task.sleep(for: .seconds(8))

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -77,6 +77,15 @@ struct DownloadStrip: View {
         }.sorted()
     }
 
+    static func isSameCompletedJob(
+        _ job: DownloadManager.Job?,
+        as expectedID: ObjectIdentifier
+    ) -> Bool {
+        guard let job, ObjectIdentifier(job) == expectedID else { return false }
+        if case .completed = job.status { return true }
+        return false
+    }
+
     var body: some View {
         Group {
             if !orderedJobs.isEmpty {
@@ -100,12 +109,15 @@ struct DownloadStrip: View {
             ) {
                 downloads.dismissJob(alias: alias)
             }
-            let delayed = completed.filter { !isResident($0) }
+            let delayed = completed.compactMap { alias -> (String, ObjectIdentifier)? in
+                guard !isResident(alias), let job = downloads.job(for: alias) else { return nil }
+                return (alias, ObjectIdentifier(job))
+            }
             guard !delayed.isEmpty else { return }
             try? await Task.sleep(for: .seconds(8))
             guard !Task.isCancelled else { return }
-            for alias in delayed {
-                if case .completed = downloads.job(for: alias)?.status {
+            for (alias, originalID) in delayed {
+                if Self.isSameCompletedJob(downloads.job(for: alias), as: originalID) {
                     downloads.dismissJob(alias: alias)
                 }
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -21,6 +21,7 @@ import SwiftUI
 /// "[Dismiss]" clears a finished job from the row.
 struct DownloadStrip: View {
     @Bindable var downloads: DownloadManager
+    var isResident: (String) -> Bool = { _ in false }
 
     /// Deep-link channel into Settings, resolved optionally so the strip still
     /// renders in a host that never injected one (previews, the snapshot
@@ -37,7 +38,11 @@ struct DownloadStrip: View {
     /// dictionary is small (typically 0-2 entries; 5+ would be
     /// pathological on a single Mac).
     private var orderedJobs: [DownloadManager.Job] {
-        let pairs = downloads.jobs.values.map { job -> (DownloadManager.Job, Int) in
+        let visible = downloads.jobs.values.filter { job in
+            if case .completed = job.status { return !isResident(job.alias) }
+            return true
+        }
+        let pairs = visible.map { job -> (DownloadManager.Job, Int) in
             // Sort key: running before terminal. Within each bucket,
             // alphabetical alias gives a stable order so newly added
             // jobs don't jump around mid-scroll.
@@ -60,6 +65,12 @@ struct DownloadStrip: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(orderedJobs) { job in
                     jobRow(job)
+                        .task(id: terminalDismissKey(for: job)) {
+                            guard case .completed = job.status else { return }
+                            try? await Task.sleep(for: .seconds(8))
+                            guard !Task.isCancelled else { return }
+                            downloads.dismissJob(alias: job.alias)
+                        }
                 }
             }
             .padding(.horizontal, 18)
@@ -157,7 +168,7 @@ struct DownloadStrip: View {
                     : nil
             )
         case .completed:
-            return "Downloaded — ready to load"
+            return "Downloaded — start from the model picker"
         case .cancelled:
             return "Cancelled"
         case .failed(let message):
@@ -227,8 +238,10 @@ struct DownloadStrip: View {
                 downloads.cancelDownload(alias: job.alias)
             } label: {
                 Image(systemName: "xmark.circle")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                    .frame(width: 24, height: 24)
+                    .background(RapidTheme.brandPrimaryTint, in: Circle())
             }
             .buttonStyle(.plain)
             .help("Cancel download (partial files stay in the HuggingFace cache and can resume on retry).")
@@ -246,6 +259,15 @@ struct DownloadStrip: View {
             .help("Dismiss")
             .accessibilityLabel("Dismiss \(job.alias) status")
             .accessibilityIdentifier("DownloadStrip.Dismiss.\(job.alias)")
+        }
+    }
+
+    private func terminalDismissKey(for job: DownloadManager.Job) -> String {
+        switch job.status {
+        case .completed: return "\(job.alias):completed"
+        case .cancelled: return "\(job.alias):cancelled"
+        case .failed: return "\(job.alias):failed"
+        case .running: return "\(job.alias):running"
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -60,23 +60,55 @@ struct DownloadStrip: View {
             .map { $0.0 }
     }
 
+    private var completedCleanupKey: String {
+        downloads.jobs.values.compactMap { job -> String? in
+            guard case .completed = job.status else { return nil }
+            return "\(job.alias):\(isResident(job.alias) ? "resident" : "cached")"
+        }.sorted().joined(separator: "|")
+    }
+
+    static func completedResidentAliases(
+        jobs: [String: DownloadManager.Job],
+        isResident: (String) -> Bool
+    ) -> [String] {
+        jobs.values.compactMap { job in
+            guard case .completed = job.status, isResident(job.alias) else { return nil }
+            return job.alias
+        }.sorted()
+    }
+
     var body: some View {
-        if !orderedJobs.isEmpty {
-            VStack(alignment: .leading, spacing: 4) {
-                ForEach(orderedJobs) { job in
-                    jobRow(job)
-                        .task(id: terminalDismissKey(for: job)) {
-                            guard case .completed = job.status else { return }
-                            try? await Task.sleep(for: .seconds(8))
-                            guard !Task.isCancelled else { return }
-                            downloads.dismissJob(alias: job.alias)
-                        }
+        Group {
+            if !orderedJobs.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(orderedJobs) { job in jobRow(job) }
+                }
+                .padding(.horizontal, 18)
+                .padding(.vertical, 6)
+                .background(.bar)
+                .overlay(Divider(), alignment: .bottom)
+            }
+        }
+        .task(id: completedCleanupKey) {
+            let completed = downloads.jobs.values.compactMap { job -> String? in
+                guard case .completed = job.status else { return nil }
+                return job.alias
+            }
+            for alias in Self.completedResidentAliases(
+                jobs: downloads.jobs,
+                isResident: isResident
+            ) {
+                downloads.dismissJob(alias: alias)
+            }
+            let delayed = completed.filter { !isResident($0) }
+            guard !delayed.isEmpty else { return }
+            try? await Task.sleep(for: .seconds(8))
+            guard !Task.isCancelled else { return }
+            for alias in delayed {
+                if case .completed = downloads.job(for: alias)?.status {
+                    downloads.dismissJob(alias: alias)
                 }
             }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 6)
-            .background(.bar)
-            .overlay(Divider(), alignment: .bottom)
         }
     }
 
@@ -262,12 +294,4 @@ struct DownloadStrip: View {
         }
     }
 
-    private func terminalDismissKey(for job: DownloadManager.Job) -> String {
-        switch job.status {
-        case .completed: return "\(job.alias):completed"
-        case .cancelled: return "\(job.alias):cancelled"
-        case .failed: return "\(job.alias):failed"
-        case .running: return "\(job.alias):running"
-        }
-    }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -2,16 +2,9 @@ import SwiftUI
 
 enum GitHubCommunity {
     static let repositoryURL = URL(string: "https://github.com/raullenchai/Rapid-MLX")!
+    /// Retained so re-onboarding can clear the preference written by older
+    /// builds, even though completion no longer presents an overlay.
     static let didShowOnboardingPromptKey = "Rapid.didShowOnboardingGitHubStarPrompt"
-}
-
-struct GitHubStarPromptCompletion: Equatable {
-    let hasShown: Bool
-    let shouldPresent: Bool
-
-    static func completingOnboarding(hasShown: Bool) -> Self {
-        Self(hasShown: true, shouldPresent: !hasShown)
-    }
 }
 
 struct GitHubStarButton: View {
@@ -43,65 +36,5 @@ struct GitHubStarButton: View {
         .contentShape(Capsule(style: .continuous))
         .accessibilityIdentifier(accessibilityIdentifier)
         .accessibilityHint("Opens the Rapid-MLX repository in your browser")
-    }
-}
-
-struct OnboardingCompletePrompt: View {
-    let onDismiss: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.green)
-                    .accessibilityHidden(true)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Onboarding complete")
-                        .font(.system(size: 14, weight: .semibold))
-                    Text("You’re ready to chat locally with Rapid-MLX.")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 8)
-
-                Button(action: onDismiss) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .semibold))
-                        .frame(width: 22, height: 22)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Dismiss onboarding completion")
-                .accessibilityIdentifier("OnboardingComplete.Close")
-            }
-
-            HStack(spacing: 8) {
-                GitHubStarButton(
-                    onOpen: onDismiss,
-                    accessibilityIdentifier: "OnboardingComplete.Star"
-                )
-                Spacer(minLength: 0)
-                Button("Later", action: onDismiss)
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 7)
-                    .accessibilityIdentifier("OnboardingComplete.Later")
-            }
-        }
-        .padding(16)
-        .frame(width: 342)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(.primary.opacity(0.1), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("OnboardingComplete.Prompt")
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -30,7 +30,10 @@ struct ImagesView: View {
             composer
         }
         .background(RapidTheme.surfaceCanvas)
-        .task { await viewModel.refreshCatalog() }
+        // A download can finish while this tab remains mounted. Re-read the
+        // catalog on DownloadManager's authoritative cache generation so the
+        // Download button becomes Start without requiring an app restart.
+        .task(id: downloads.cacheGeneration) { await viewModel.refreshCatalog() }
     }
 
     // MARK: - Stage + history
@@ -135,8 +138,10 @@ struct ImagesView: View {
             title: "Draw anything",
             message: readiness.isReady
                 ? "Describe what you want to see, then press Generate."
-                : readiness.emptyStateSubtitle,
-            hint: readiness.isReady ? nil : readiness.emptyStateHint,
+                : "Create images locally, then keep generating offline.",
+            hint: readiness.isReady
+                ? nil
+                : "Pick a starter below while Rapid gets the model ready.",
             markDiameter: aspectPreviewSize.height,
             marksOnBackplate: false,
             mark: { aspectPreview },
@@ -249,7 +254,7 @@ struct ImagesView: View {
     }
 
     /// The banner's next-step action: start the sidecar or load the selected
-    /// image engine into the already-running process.
+    /// image engine in the modal sidecar process.
     private func handleReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:
@@ -266,10 +271,6 @@ struct ImagesView: View {
             )
         case .start(let target), .retry(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
-            // Same shared helper as Chat: ``ensureServing`` (not ``start``),
-            // because the user is almost always switching FROM a running chat
-            // model TO the image model, and cold-start ``start`` would no-op
-            // while that model is resident. See ``ReadinessModelStart``.
             Task { await loadImageModel(target, hfPath: hf) }
         case .restart(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
@@ -293,7 +294,10 @@ struct ImagesView: View {
                 alias: alias,
                 sizeText: entry?.sizeOnDisk
             ),
-            imageMode: viewModel.isEditing ? .editing : .generation
+            imageMode: viewModel.isEditing ? .editing : .generation,
+            // mflux is a modal engine, like TTS: it cannot be admitted through
+            // the chat sidecar's resident /v1/models/load endpoint.
+            residencyEligible: false
         )
         // A cold resident load can change the cache while the sidecar stays
         // globally ready. Refresh this surface so its cached/downloaded copy
@@ -685,24 +689,31 @@ struct ImagesView: View {
     }
 
     private var starters: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 7) {
-                ForEach(Array(ImageGenViewModel.starters.enumerated()), id: \.offset) { index, starter in
-                    Button {
-                        viewModel.use(starter: starter)
-                    } label: {
-                        Text(starter)
-                            .font(.caption)
-                            .lineLimit(1)
-                            .padding(.horizontal, 11)
-                            .padding(.vertical, 6)
-                            .background(RapidTheme.card)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(RapidTheme.hairline, lineWidth: 1))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("Images.Starter.\(index)")
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible())],
+            alignment: .leading,
+            spacing: 7
+        ) {
+            ForEach(Array(ImageGenViewModel.starters.enumerated()), id: \.offset) { index, starter in
+                Button {
+                    viewModel.use(starter: starter)
+                } label: {
+                    Text(starter)
+                        .font(.caption)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, minHeight: 30, alignment: .leading)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 6)
+                        .background(RapidTheme.card)
+                        .clipShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.button))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: RapidTheme.Radius.button)
+                                .stroke(RapidTheme.hairline, lineWidth: 1)
+                        )
                 }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("Images.Starter.\(index)")
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -3,6 +3,10 @@ import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct ImageCatalogRefreshKey: Hashable {
+    let cacheGeneration: UInt
+}
+
 /// The Images tab. Deliberately mirrors ``ChatView``: a scrollable results
 /// area on top and, at the bottom, the *same* compose box — a `surfaceRaised`
 /// rounded field with the model picker + submit button clustered at its
@@ -33,7 +37,9 @@ struct ImagesView: View {
         // A download can finish while this tab remains mounted. Re-read the
         // catalog on DownloadManager's authoritative cache generation so the
         // Download button becomes Start without requiring an app restart.
-        .task(id: downloads.cacheGeneration) { await viewModel.refreshCatalog() }
+        .task(id: ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)) {
+            await viewModel.refreshCatalog()
+        }
     }
 
     // MARK: - Stage + history

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -3481,11 +3481,15 @@ struct QuickstartView: View {
                 selectionAlias: coordinator.selection.alias,
                 alreadyRequested: cancelRequestedAlias == coordinator.selection.alias
             ) {
-                Button("Cancel download") {
+                Button {
                     cancelRequestedAlias = cancelAlias
                     downloads.cancelDownload(alias: cancelAlias)
+                } label: {
+                    Label("Cancel download", systemImage: "xmark.circle")
                 }
-                .buttonStyle(.onboardingQuiet)
+                .buttonStyle(.bordered)
+                .tint(RapidTheme.textSecondary)
+                .controlSize(.regular)
                 .padding(.top, 26)
             // Deliberately NO keyboard shortcut.
             //

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -12,11 +12,12 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText id="Images.EmptyState" value=text enabled=true
           AXStaticText id="Images.EmptyState" value=text enabled=true
+          AXStaticText id="Images.EmptyState" value=text enabled=true
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="Readiness.Action" desc="Start" enabled=true
-          AXScrollArea
+          AXOpaqueProviderGroup subrole=AXOpaqueProviderGrid enabled=true
             AXButton id="Images.Starter.0" desc="A cozy ramen shop at night in the rain, neon, steam, 35mm" enabled=true
             AXButton id="Images.Starter.1" desc="Studio portrait of an elderly fisherman, dramatic side light" enabled=true
             AXButton id="Images.Starter.2" desc="A minimalist product shot of a ceramic mug on linen" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -24,7 +24,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="Images.Gallery.Thumb.1" desc="Image 1, replace the couch with a blue armchair, selected" enabled=true
             AXButton id="Images.Gallery.Thumb.2" desc="Image 2, the same cheetah, at night" enabled=true
             AXButton id="Images.Gallery.Thumb.3" desc="Image 3, a cheetah on a red couch" enabled=true
-          AXScrollArea
+          AXOpaqueProviderGroup subrole=AXOpaqueProviderGrid enabled=true
             AXButton id="Images.Starter.0" desc="A cozy ramen shop at night in the rain, neon, steam, 35mm" enabled=true
             AXButton id="Images.Starter.1" desc="Studio portrait of an elderly fisherman, dramatic side light" enabled=true
             AXButton id="Images.Starter.2" desc="A minimalist product shot of a ceramic mug on linen" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -12,80 +12,11 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
           AXScrollArea
+            AXHeading desc="Start here, Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands." enabled=true
             AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
               AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Start" enabled=true
-            AXHeading desc="Endpoint" enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="ConnectTools.Copy.OpenAI base URL" desc="Copy OpenAI base URL" help="Copy OpenAI base URL" enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="ConnectTools.Copy.Anthropic base URL" desc="Copy Anthropic base URL" help="Copy Anthropic base URL" enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="ConnectTools.Copy.API key" desc="Copy API key" help="Start a model to generate a valid key and configuration." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="ConnectTools.Copy.Model" desc="Copy Model" help="Copy Model" enabled=true
-            AXHeading desc="Editors and agents" enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.continue-dev" desc="Copy Continue.dev command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.cursor" desc="Copy Cursor command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.hermes" desc="Copy Hermes Agent command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.kilo-code" desc="Copy Kilo Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.langchain" desc="Copy LangChain command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.opencode" desc="Copy OpenCode command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.openhands" desc="Copy OpenHands command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.pydanticai" desc="Copy PydanticAI command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.qwen-code" desc="Copy Qwen Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.smolagents" desc="Copy smolagents command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -435,6 +435,22 @@ struct DownloadManagerTests {
 @Suite("DownloadStrip — phase caption formatting")
 struct DownloadStripCaptionTests {
 
+    @Test("A completed resident job is removed while its row is hidden")
+    func completedResidentCleanupDoesNotResurface() {
+        let downloads = DownloadManager()
+        _ = downloads._testingSeedJob(alias: "image-model")
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        #expect(downloads.job(for: "image-model")?.status == .completed)
+
+        let resident = DownloadStrip.completedResidentAliases(
+            jobs: downloads.jobs,
+            isResident: { $0 == "image-model" }
+        )
+        #expect(resident == ["image-model"])
+        resident.forEach { downloads.dismissJob(alias: $0) }
+        #expect(downloads.job(for: "image-model") == nil)
+    }
+
     @Test("Idle phase reads as 'Starting…' — the strip never shows raw enum names")
     func idleReadsAsStarting() {
         #expect(DownloadStrip.detail(phase: .idle) == "Starting…")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -452,8 +452,8 @@ struct DownloadStripCaptionTests {
             )
         )
         host.layoutSubtreeIfNeeded()
-        for _ in 0..<20 where downloads.job(for: "image-model") != nil {
-            try await Task.sleep(for: .milliseconds(10))
+        for _ in 0..<100 where downloads.job(for: "image-model") != nil {
+            try await Task.sleep(for: .milliseconds(20))
         }
         #expect(downloads.job(for: "image-model") == nil)
         _ = host

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import SwiftUI
 import Testing
 @testable import Rapid
 
@@ -436,19 +437,26 @@ struct DownloadManagerTests {
 struct DownloadStripCaptionTests {
 
     @Test("A completed resident job is removed while its row is hidden")
-    func completedResidentCleanupDoesNotResurface() {
+    func completedResidentCleanupDoesNotResurface() async throws {
         let downloads = DownloadManager()
         _ = downloads._testingSeedJob(alias: "image-model")
         downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
         #expect(downloads.job(for: "image-model")?.status == .completed)
 
-        let resident = DownloadStrip.completedResidentAliases(
-            jobs: downloads.jobs,
-            isResident: { $0 == "image-model" }
+        // Mount the real view so its `.task(id:)` lifecycle performs the
+        // hidden-resident cleanup; do not duplicate that task in the test.
+        let host = NSHostingView(
+            rootView: DownloadStrip(
+                downloads: downloads,
+                isResident: { $0 == "image-model" }
+            )
         )
-        #expect(resident == ["image-model"])
-        resident.forEach { downloads.dismissJob(alias: $0) }
+        host.layoutSubtreeIfNeeded()
+        for _ in 0..<20 where downloads.job(for: "image-model") != nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
         #expect(downloads.job(for: "image-model") == nil)
+        _ = host
     }
 
     @Test("A delayed cleanup cannot dismiss a newer job reusing the alias")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -451,6 +451,24 @@ struct DownloadStripCaptionTests {
         #expect(downloads.job(for: "image-model") == nil)
     }
 
+    @Test("A delayed cleanup cannot dismiss a newer job reusing the alias")
+    func delayedCleanupIsScopedToJobIdentity() {
+        let downloads = DownloadManager()
+        let original = downloads._testingSeedJob(alias: "image-model")
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        let originalID = ObjectIdentifier(original)
+        downloads.dismissJob(alias: "image-model")
+
+        let replacement = downloads._testingSeedJob(alias: "image-model")
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        #expect(ObjectIdentifier(replacement) != originalID)
+        #expect(!DownloadStrip.isSameCompletedJob(
+            downloads.job(for: "image-model"),
+            as: originalID
+        ))
+        #expect(downloads.job(for: "image-model") === replacement)
+    }
+
     @Test("Idle phase reads as 'Starting…' — the strip never shows raw enum names")
     func idleReadsAsStarting() {
         #expect(DownloadStrip.detail(phase: .idle) == "Starting…")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -437,6 +437,7 @@ struct DownloadManagerTests {
 struct DownloadStripCaptionTests {
 
     @Test("A completed resident job is removed while its row is hidden")
+    @MainActor
     func completedResidentCleanupDoesNotResurface() async throws {
         let downloads = DownloadManager()
         _ = downloads._testingSeedJob(alias: "image-model")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -456,17 +456,38 @@ struct DownloadStripCaptionTests {
         let downloads = DownloadManager()
         let original = downloads._testingSeedJob(alias: "image-model")
         downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
-        let originalID = ObjectIdentifier(original)
+        let originalID = original.instanceID
         downloads.dismissJob(alias: "image-model")
 
         let replacement = downloads._testingSeedJob(alias: "image-model")
         downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
-        #expect(ObjectIdentifier(replacement) != originalID)
+        #expect(replacement.instanceID != originalID)
         #expect(!DownloadStrip.isSameCompletedJob(
             downloads.job(for: "image-model"),
             as: originalID
         ))
         #expect(downloads.job(for: "image-model") === replacement)
+    }
+
+    @Test("A completed replacement under the same alias reschedules cleanup")
+    func completedReplacementChangesCleanupKey() {
+        let downloads = DownloadManager()
+        _ = downloads._testingSeedJob(alias: "image-model")
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        let originalKey = DownloadStrip.completedCleanupKey(
+            jobs: downloads.jobs,
+            isResident: { _ in false }
+        )
+        downloads.dismissJob(alias: "image-model")
+
+        _ = downloads._testingSeedJob(alias: "image-model")
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        let replacementKey = DownloadStrip.completedCleanupKey(
+            jobs: downloads.jobs,
+            isResident: { _ in false }
+        )
+
+        #expect(originalKey != replacementKey)
     }
 
     @Test("Idle phase reads as 'Starting…' — the strip never shows raw enum names")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -834,21 +834,27 @@ struct DownloadProgressTests {
     /// gains the speed + ETA suffix in the order documented in the
     /// header comment. This is the production read-out the user will
     /// see; if this test passes the UX works.
-    @Test("v0.7.12: progressSubtitle gains speed + ETA suffix once the rate is known")
+    @Test("ETA waits for a stable sample span while speed appears immediately")
     func progressSubtitleSpeedETA() {
         let progress = DownloadProgress()
         let t0 = Date(timeIntervalSince1970: 6_000_000)
-        // Two heartbeats one second apart, 1 MB delta on a 10 MB target.
+        // Early samples publish speed but deliberately withhold a prediction.
         progress.setTotalBytes(10 * 1024 * 1024)
         progress.applyDiskObservation(bytes: 1 * 1024 * 1024, at: t0)
         progress.applyDiskObservation(bytes: 2 * 1024 * 1024, at: t0.addingTimeInterval(1.0))
-        let subtitle = progress.progressSubtitle ?? ""
-        // Bytes branch reflects the LATEST observation (2 MiB of 10 MiB
-        // → 20%), then the speed token, then the ETA, joined by " · ".
-        #expect(subtitle.contains("2.0 MB / 10.0 MB"))
-        #expect(subtitle.contains("20%"))
-        #expect(subtitle.contains("MB/s") || subtitle.contains("KB/s"))
-        #expect(subtitle.contains("left"))
+        let early = progress.progressSubtitle ?? ""
+        #expect(early.contains("MB/s") || early.contains("KB/s"))
+        #expect(!early.contains("left"))
+        #expect(progress.etaText == nil)
+
+        // After eight seconds of observations the prediction is allowed.
+        progress.applyDiskObservation(bytes: 3 * 1024 * 1024, at: t0.addingTimeInterval(4.0))
+        progress.applyDiskObservation(bytes: 4 * 1024 * 1024, at: t0.addingTimeInterval(8.0))
+        let stable = progress.progressSubtitle ?? ""
+        #expect(stable.contains("4.0 MB / 10.0 MB"))
+        #expect(stable.contains("40%"))
+        #expect(stable.contains("left"))
+        #expect(progress.etaText != nil)
     }
 
     /// When the total is unknown (HF didn't expose sizes), the subtitle

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -868,9 +868,12 @@ struct DownloadProgressTests {
         progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(8))
         #expect(progress.etaText != nil)
 
-        // More than the freshness window passes with no observations. The
-        // first two chunks after recovery can show speed, but must not inherit
-        // the old epoch and immediately claim a stable ETA.
+        // The production cache monitor keeps publishing unchanged totals every
+        // few seconds during a network stall. Those liveness observations must
+        // not preserve the old stability epoch.
+        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(11))
+        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(14))
+        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(17))
         progress.applyDiskObservation(bytes: 4 * mb, at: t0.addingTimeInterval(20))
         progress.applyDiskObservation(bytes: 5 * mb, at: t0.addingTimeInterval(21))
         let resumed = progress.progressSubtitle ?? ""

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -857,6 +857,28 @@ struct DownloadProgressTests {
         #expect(progress.etaText != nil)
     }
 
+    @Test("ETA settles again after a stalled download resumes")
+    func resumedDownloadRestartsETAStabilityEpoch() {
+        let progress = DownloadProgress()
+        let mb: Int64 = 1024 * 1024
+        let t0 = Date(timeIntervalSince1970: 6_100_000)
+        progress.setTotalBytes(20 * mb)
+        progress.applyDiskObservation(bytes: 1 * mb, at: t0)
+        progress.applyDiskObservation(bytes: 2 * mb, at: t0.addingTimeInterval(4))
+        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(8))
+        #expect(progress.etaText != nil)
+
+        // More than the freshness window passes with no observations. The
+        // first two chunks after recovery can show speed, but must not inherit
+        // the old epoch and immediately claim a stable ETA.
+        progress.applyDiskObservation(bytes: 4 * mb, at: t0.addingTimeInterval(20))
+        progress.applyDiskObservation(bytes: 5 * mb, at: t0.addingTimeInterval(21))
+        let resumed = progress.progressSubtitle ?? ""
+        #expect(resumed.contains("MB/s") || resumed.contains("KB/s"))
+        #expect(!resumed.contains("left"))
+        #expect(progress.etaText == nil)
+    }
+
     /// When the total is unknown (HF didn't expose sizes), the subtitle
     /// falls through to "X downloaded" — but the speed readout still
     /// helps the user feel things are alive, so we append it even

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -839,19 +839,19 @@ struct DownloadProgressTests {
         let progress = DownloadProgress()
         let t0 = Date(timeIntervalSince1970: 6_000_000)
         // Early samples publish speed but deliberately withhold a prediction.
-        progress.setTotalBytes(10 * 1024 * 1024)
-        progress.applyDiskObservation(bytes: 1 * 1024 * 1024, at: t0)
-        progress.applyDiskObservation(bytes: 2 * 1024 * 1024, at: t0.addingTimeInterval(1.0))
+        progress.setTotalBytes(100 * 1024 * 1024)
+        progress.applyDiskObservation(bytes: 10 * 1024 * 1024, at: t0)
+        progress.applyDiskObservation(bytes: 20 * 1024 * 1024, at: t0.addingTimeInterval(1.0))
         let early = progress.progressSubtitle ?? ""
         #expect(early.contains("MB/s") || early.contains("KB/s"))
         #expect(!early.contains("left"))
         #expect(progress.etaText == nil)
 
         // After eight seconds of observations the prediction is allowed.
-        progress.applyDiskObservation(bytes: 3 * 1024 * 1024, at: t0.addingTimeInterval(4.0))
-        progress.applyDiskObservation(bytes: 4 * 1024 * 1024, at: t0.addingTimeInterval(8.0))
+        progress.applyDiskObservation(bytes: 30 * 1024 * 1024, at: t0.addingTimeInterval(4.0))
+        progress.applyDiskObservation(bytes: 40 * 1024 * 1024, at: t0.addingTimeInterval(8.0))
         let stable = progress.progressSubtitle ?? ""
-        #expect(stable.contains("4.0 MB / 10.0 MB"))
+        #expect(stable.contains("40.0 MB / 100 MB"))
         #expect(stable.contains("40%"))
         #expect(stable.contains("left"))
         #expect(progress.etaText != nil)
@@ -862,20 +862,20 @@ struct DownloadProgressTests {
         let progress = DownloadProgress()
         let mb: Int64 = 1024 * 1024
         let t0 = Date(timeIntervalSince1970: 6_100_000)
-        progress.setTotalBytes(20 * mb)
-        progress.applyDiskObservation(bytes: 1 * mb, at: t0)
-        progress.applyDiskObservation(bytes: 2 * mb, at: t0.addingTimeInterval(4))
-        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(8))
+        progress.setTotalBytes(200 * mb)
+        progress.applyDiskObservation(bytes: 10 * mb, at: t0)
+        progress.applyDiskObservation(bytes: 20 * mb, at: t0.addingTimeInterval(4))
+        progress.applyDiskObservation(bytes: 30 * mb, at: t0.addingTimeInterval(8))
         #expect(progress.etaText != nil)
 
         // The production cache monitor keeps publishing unchanged totals every
         // few seconds during a network stall. Those liveness observations must
         // not preserve the old stability epoch.
-        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(11))
-        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(14))
-        progress.applyDiskObservation(bytes: 3 * mb, at: t0.addingTimeInterval(17))
-        progress.applyDiskObservation(bytes: 4 * mb, at: t0.addingTimeInterval(20))
-        progress.applyDiskObservation(bytes: 5 * mb, at: t0.addingTimeInterval(21))
+        progress.applyDiskObservation(bytes: 30 * mb, at: t0.addingTimeInterval(11))
+        progress.applyDiskObservation(bytes: 30 * mb, at: t0.addingTimeInterval(14))
+        progress.applyDiskObservation(bytes: 30 * mb, at: t0.addingTimeInterval(17))
+        progress.applyDiskObservation(bytes: 40 * mb, at: t0.addingTimeInterval(20))
+        progress.applyDiskObservation(bytes: 50 * mb, at: t0.addingTimeInterval(21))
         let resumed = progress.progressSubtitle ?? ""
         #expect(resumed.contains("MB/s") || resumed.contains("KB/s"))
         #expect(!resumed.contains("left"))

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -874,6 +874,8 @@ struct DownloadProgressTests {
         let slowed = try! #require(progress.etaSeconds)
         #expect(slowed <= settled * 1.25)
         #expect(slowed > settled)
+        let visibleETA = try! #require(progress.etaText)
+        #expect(progress.progressSubtitle?.contains(visibleETA) == true)
     }
 
     @Test("ETA settles again after a stalled download resumes")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadProgressTests.swift
@@ -857,6 +857,25 @@ struct DownloadProgressTests {
         #expect(progress.etaText != nil)
     }
 
+    @Test("A brief slowdown cannot make a settled ETA jump several-fold")
+    func settledETASmoothsTransientSlowdown() {
+        let progress = DownloadProgress()
+        let mb: Int64 = 1024 * 1024
+        let t0 = Date(timeIntervalSince1970: 6_050_000)
+        progress.setTotalBytes(1_000 * mb)
+        progress.applyDiskObservation(bytes: 10 * mb, at: t0)
+        progress.applyDiskObservation(bytes: 20 * mb, at: t0.addingTimeInterval(4))
+        progress.applyDiskObservation(bytes: 30 * mb, at: t0.addingTimeInterval(8))
+        let settled = try! #require(progress.etaSeconds)
+
+        // The rolling four-second rate now sees only 1 MiB/s instead of
+        // 2.5 MiB/s. Raw ETA would jump by more than 2x in one heartbeat.
+        progress.applyDiskObservation(bytes: 31 * mb, at: t0.addingTimeInterval(9))
+        let slowed = try! #require(progress.etaSeconds)
+        #expect(slowed <= settled * 1.25)
+        #expect(slowed > settled)
+    }
+
     @Test("ETA settles again after a stalled download resumes")
     func resumedDownloadRestartsETAStabilityEpoch() {
         let progress = DownloadProgress()

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -21,36 +21,13 @@ struct GitHubStarPromptTests {
                 "https://github.com/raullenchai/Rapid-MLX")
     }
 
-    @Test("First-run prompt owns a stable persistence key")
-    func stablePromptPersistenceKey() {
-        #expect(GitHubCommunity.didShowOnboardingPromptKey ==
-                "Rapid.didShowOnboardingGitHubStarPrompt")
-    }
-
-    @Test("Completion prompt presents once and records that presentation")
-    func oneShotCompletionTransition() {
-        let first = GitHubStarPromptCompletion.completingOnboarding(hasShown: false)
-        #expect(first == GitHubStarPromptCompletion(
-            hasShown: true,
-            shouldPresent: true
-        ))
-
-        let repeated = GitHubStarPromptCompletion.completingOnboarding(
-            hasShown: first.hasShown
-        )
-        #expect(repeated == GitHubStarPromptCompletion(
-            hasShown: true,
-            shouldPresent: false
-        ))
-    }
-
-    @Test("Star entry is mounted in Chat and the completion overlay")
+    @Test("Star entry stays in Chat and onboarding never covers the composer")
     func productionWiring() throws {
         let chat = try Self.source("ChatView.swift")
         let content = try Self.source("ContentView.swift")
 
         #expect(chat.contains("GitHubStarButton()"))
-        #expect(content.contains("OnboardingCompletePrompt"))
-        #expect(content.contains("GitHubStarPromptCompletion.completingOnboarding"))
+        #expect(!content.contains("OnboardingCompletePrompt"))
+        #expect(!content.contains("showOnboardingCompletePrompt"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -40,7 +40,7 @@ struct ImageGenerationResolutionTests {
                 "Both generation and editing must use the modal process-swap path.")
     }
 
-    @Test("A completed image pull invalidates the mounted catalog and changes Download to Start")
+    @Test("A completed image pull changes the catalog key and view-model readiness to Start")
     @MainActor
     func completedPullInvalidatesCatalogReadiness() async {
         let binary = URL(fileURLWithPath: "/tmp/rapid-test-sidecar")

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import Rapid
 
@@ -42,7 +43,7 @@ struct ImageGenerationResolutionTests {
 
     @Test("A completed image pull changes the catalog key and view-model readiness to Start")
     @MainActor
-    func completedPullInvalidatesCatalogReadiness() async {
+    func completedPullInvalidatesCatalogReadiness() async throws {
         let binary = URL(fileURLWithPath: "/tmp/rapid-test-sidecar")
         let server = ServerManager(testingState: .idle, binaryPath: binary)
         let downloads = DownloadManager()
@@ -54,9 +55,18 @@ struct ImageGenerationResolutionTests {
             )
         }
         let viewModel = ImageGenViewModel(server: server) { _ in [entry(cached)] }
+        let host = NSHostingView(
+            rootView: ImagesView(viewModel: viewModel, server: server)
+                .environment(SettingsRouter())
+                .environment(downloads)
+        )
+        host.layoutSubtreeIfNeeded()
 
         let beforeKey = ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)
-        await viewModel.refreshCatalog()
+        for _ in 0..<100 where viewModel.imageModels.isEmpty {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(viewModel.imageModels.count == 1)
         let before = ModelReadiness.resolve(
             serverState: .idle,
             alias: "image-model",
@@ -71,7 +81,11 @@ struct ImageGenerationResolutionTests {
         let afterKey = ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)
         #expect(afterKey != beforeKey, "A successful pull must restart the view's keyed task.")
 
-        await viewModel.refreshCatalog()
+        // The mounted ImagesView must observe cacheGeneration and refresh its
+        // catalog without a test-side call to refreshCatalog().
+        for _ in 0..<100 where viewModel.imageModels.first?.cached != true {
+            try await Task.sleep(for: .milliseconds(20))
+        }
         let after = ModelReadiness.resolve(
             serverState: .idle,
             alias: "image-model",
@@ -79,6 +93,7 @@ struct ImageGenerationResolutionTests {
             sizeText: "1 GiB"
         )
         #expect(after.action == .start(alias: "image-model"))
+        _ = host
     }
 
     @Test("A cancelled older catalog refresh cannot overwrite the newest result")

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -4,6 +4,35 @@ import Testing
 
 @Suite("Image generation resolution")
 struct ImageGenerationResolutionTests {
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func source(_ path: String) throws -> String {
+        try String(contentsOf: packageRoot.appendingPathComponent(path), encoding: .utf8)
+    }
+
+    @Test("Images refreshes cache state live and modal engines bypass residency")
+    func liveDownloadAndModalLaunchWiring() throws {
+        let view = try Self.source("Sources/Rapid/UI/ImagesView.swift")
+        let model = try Self.source("Sources/Rapid/Images/ImageGenViewModel.swift")
+
+        #expect(view.contains(".task(id: downloads.cacheGeneration)"))
+        #expect(view.contains("residencyEligible: false"))
+        #expect(model.components(separatedBy: "residencyEligible: false").count - 1 == 2,
+                "Both generation and editing must use the modal process-swap path.")
+    }
+
+    @Test("Image starters wrap instead of clipping in a horizontal rail")
+    func startersRemainReadable() throws {
+        let view = try Self.source("Sources/Rapid/UI/ImagesView.swift")
+        #expect(view.contains("private var starters: some View {\n        LazyVGrid("))
+        #expect(!view.contains("private var starters: some View {\n        ScrollView(.horizontal"))
+    }
+
     @Test("Every aspect and resolution maps to the expected API size")
     func outputSizes() {
         let expected: [ImageGenViewModel.Resolution: [ImageGenViewModel.Aspect: String]] = [

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -34,10 +34,51 @@ struct ImageGenerationResolutionTests {
         let view = try Self.source("Sources/Rapid/UI/ImagesView.swift")
         let model = try Self.source("Sources/Rapid/Images/ImageGenViewModel.swift")
 
-        #expect(view.contains(".task(id: downloads.cacheGeneration)"))
+        #expect(view.contains("ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)"))
         #expect(view.contains("residencyEligible: false"))
         #expect(model.components(separatedBy: "residencyEligible: false").count - 1 == 2,
                 "Both generation and editing must use the modal process-swap path.")
+    }
+
+    @Test("A completed image pull invalidates the mounted catalog and changes Download to Start")
+    @MainActor
+    func completedPullInvalidatesCatalogReadiness() async {
+        let binary = URL(fileURLWithPath: "/tmp/rapid-test-sidecar")
+        let server = ServerManager(testingState: .idle, binaryPath: binary)
+        let downloads = DownloadManager()
+        var cached = false
+        let entry: (Bool) -> ModelEntry = { isCached in
+            ModelEntry(
+                alias: "image-model", hfRepo: "example/image", sizeOnDisk: "1 GiB",
+                cached: isCached, kind: .image, imageCapability: .generation
+            )
+        }
+        let viewModel = ImageGenViewModel(server: server) { _ in [entry(cached)] }
+
+        let beforeKey = ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)
+        await viewModel.refreshCatalog()
+        let before = ModelReadiness.resolve(
+            serverState: .idle,
+            alias: "image-model",
+            cacheState: viewModel.imageModels[0].cached ? .onDisk : .notOnDisk,
+            sizeText: "1 GiB"
+        )
+        #expect(before.action == .download(alias: "image-model"))
+
+        _ = downloads._testingSeedJob(alias: "image-model")
+        cached = true
+        downloads._testingFinish(alias: "image-model", status: 0, reason: .exit)
+        let afterKey = ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)
+        #expect(afterKey != beforeKey, "A successful pull must restart the view's keyed task.")
+
+        await viewModel.refreshCatalog()
+        let after = ModelReadiness.resolve(
+            serverState: .idle,
+            alias: "image-model",
+            cacheState: viewModel.imageModels[0].cached ? .onDisk : .notOnDisk,
+            sizeText: "1 GiB"
+        )
+        #expect(after.action == .start(alias: "image-model"))
     }
 
     @Test("A cancelled older catalog refresh cannot overwrite the newest result")

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -4,6 +4,20 @@ import Testing
 
 @Suite("Image generation resolution")
 struct ImageGenerationResolutionTests {
+    @MainActor
+    private final class ControlledCatalogLoader {
+        private var continuations: [CheckedContinuation<[ModelEntry], Never>] = []
+        var requestCount: Int { continuations.count }
+
+        func load(_: URL) async -> [ModelEntry] {
+            await withCheckedContinuation { continuations.append($0) }
+        }
+
+        func finish(_ index: Int, with entries: [ModelEntry]) {
+            continuations[index].resume(returning: entries)
+        }
+    }
+
     private static var packageRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -24,6 +38,36 @@ struct ImageGenerationResolutionTests {
         #expect(view.contains("residencyEligible: false"))
         #expect(model.components(separatedBy: "residencyEligible: false").count - 1 == 2,
                 "Both generation and editing must use the modal process-swap path.")
+    }
+
+    @Test("A cancelled older catalog refresh cannot overwrite the newest result")
+    @MainActor
+    func overlappingCatalogRefreshesKeepNewestResult() async {
+        let binary = URL(fileURLWithPath: "/tmp/rapid-test-sidecar")
+        let server = ServerManager(testingState: .idle, binaryPath: binary)
+        let loader = ControlledCatalogLoader()
+        let viewModel = ImageGenViewModel(server: server, catalogLoader: loader.load)
+        let fresh = ModelEntry(
+            alias: "fresh-image", hfRepo: "example/fresh", sizeOnDisk: "1 GiB",
+            cached: true, kind: .image, imageCapability: .generation
+        )
+
+        let older = Task { await viewModel.refreshCatalog() }
+        while loader.requestCount < 1 { await Task.yield() }
+        older.cancel()
+        let newer = Task { await viewModel.refreshCatalog() }
+        while loader.requestCount < 2 { await Task.yield() }
+
+        loader.finish(1, with: [fresh])
+        await newer.value
+        #expect(viewModel.imageModels.map(\.alias) == ["fresh-image"])
+
+        // The cancelled subprocess may still unwind later with an empty or
+        // partial result. It must not commit after the newer generation.
+        loader.finish(0, with: [])
+        await older.value
+        #expect(viewModel.imageModels.map(\.alias) == ["fresh-image"])
+        #expect(viewModel.catalogLoaded)
     }
 
     @Test("Image starters wrap instead of clipping in a horizontal rail")

--- a/apps/rapid-mac/Tests/RapidTests/MountedRecoverySurfacesTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MountedRecoverySurfacesTests.swift
@@ -23,7 +23,8 @@ struct MountedRecoverySurfacesTests {
     func contentViewMountsWindowLevelSurfaces() throws {
         let content = try source("UI/ContentView.swift")
         #expect(content.contains("FailedReplaceBanner()"))
-        #expect(content.contains("DownloadStrip(downloads: downloads)"))
+        #expect(content.contains("DownloadStrip("))
+        #expect(content.contains("downloads: downloads"))
         #expect(content.contains("LogDrawer(server: server)"))
         #expect(content.contains("ServerStatusPill(state: server.state)"))
     }

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -1100,6 +1100,11 @@ def main():
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
 
+    if _setting("FAKE_REJECT_IMAGE_SIDECAR") == "1" and args.alias == FAKE_IMAGE_ALIAS:
+        _event("server_start_rejected", alias=args.alias, pid=os.getpid())
+        print(FAKE_REJECTION_DETAIL, file=sys.stderr, flush=True)
+        sys.exit(1)
+
     # The residency snapshot reports the served alias as resident, which is
     # what keeps the GUI on the in-process /v1/models/load path (#1838).
     # The assignment must use ``global``: the handler methods read the

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3943,14 +3943,14 @@ flow_resident_load_rejected() {
         see_main "$OUT/rlr-shown.json"
         if jq -e '[.data.ui_elements[]?]
                   | map(((.title // "") | tostring) + " " + ((.value // "") | tostring) + " " + ((.description // "") | tostring) + " " + ((.help // "") | tostring))
-                  | join(" ") | test("rapid-mlx\\[image\\]")' \
+                  | join(" ") | test("couldn.t load|Check the model files|choose another model"; "i")' \
                "$OUT/rlr-shown.json" >/dev/null 2>&1; then
             shown=1; break
         fi
         sleep 0.25
     done
     [[ "$shown" == 1 ]] \
-        || die "the image-sidecar failure never appeared on the Images surface"
+        || die "the actionable image-sidecar diagnosis never appeared on the Images surface"
     jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
         "$OUT/rlr-shown.json" >/dev/null \
         || die "the Images failure offered no recovery action"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3862,7 +3862,7 @@ flow_image_generation() {
     log "  image-generation OK"
 }
 flow_resident_load_rejected() {
-    start_persona resident-load-rejected
+    start_persona resident-load-rejected FAKE_REJECT_IMAGE_SIDECAR=1
 
     dismiss_first_run
 
@@ -3930,11 +3930,30 @@ flow_resident_load_rejected() {
     press "$OUT/rlr-ig-readiness.json" Readiness.Action "$OUT/rlr-ig-start.json" \
         || die "Images Readiness.Action is not pressable - the load button is dead"
 
-    wait_fake_event ".event == \"server_started\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
-        "the Images action never started its dedicated image sidecar"
+    wait_fake_event ".event == \"server_start_rejected\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
+        "the fake never rejected the dedicated image sidecar"
     if jq -e 'select(.event == "model_load")' "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
         die "Images incorrectly issued an in-process /v1/models/load"
     fi
+
+    # The dedicated process failure must remain actionable on the Images
+    # surface, not disappear into logs after avoiding the resident 500.
+    local i shown=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/rlr-shown.json"
+        if jq -e '[.data.ui_elements[]?]
+                  | map(((.title // "") | tostring) + " " + ((.value // "") | tostring) + " " + ((.description // "") | tostring) + " " + ((.help // "") | tostring))
+                  | join(" ") | test("rapid-mlx\\[image\\]")' \
+               "$OUT/rlr-shown.json" >/dev/null 2>&1; then
+            shown=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$shown" == 1 ]] \
+        || die "the image-sidecar failure never appeared on the Images surface"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
+        "$OUT/rlr-shown.json" >/dev/null \
+        || die "the Images failure offered no recovery action"
 
     log "  resident-load-rejected OK"
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3862,8 +3862,7 @@ flow_image_generation() {
     log "  image-generation OK"
 }
 flow_resident_load_rejected() {
-    start_persona resident-load-rejected FAKE_REJECT_IMAGE_LOAD=1 \
-        FAKE_RESIDENT_LOAD_DELAY_MS=1500
+    start_persona resident-load-rejected
 
     dismiss_first_run
 
@@ -3923,52 +3922,19 @@ flow_resident_load_rejected() {
     jq -e '.data.ui_elements[]? | select(.identifier == "Images.Aspect.square")' "$OUT/rlr-ig-empty.json" >/dev/null \
         || die "Images.Aspect is missing - the picker did not finish resolving"
 
-    # 3. The readiness action routes through ensureServing and hits the
-    #    in-process /v1/models/load endpoint, not a process restart.
+    # 3. Image models are deliberately not residency-eligible. Starting one
+    #    must replace the chat sidecar instead of sending the incompatible
+    #    image architecture through the chat server's /v1/models/load path.
     wait_identifier Readiness.Action "$OUT/rlr-ig-readiness.json" \
         || die "Images readiness has no action to load its model"
     press "$OUT/rlr-ig-readiness.json" Readiness.Action "$OUT/rlr-ig-start.json" \
         || die "Images Readiness.Action is not pressable - the load button is dead"
 
-    # 4. The wire must show the load was ATTEMPTED in-process and REJECTED.
-    wait_fake_event '.event == "model_load"' \
-        "the Images action never issued an in-process /v1/models/load"
-
-    # The request is deliberately held open: the tap must immediately replace
-    # the CTA with a working state. Before this regression fix HF was already
-    # writing the checkpoint while the UI still said "isn't downloaded yet"
-    # and kept showing a pressable Download & start button.
-    see_main "$OUT/rlr-in-flight.json"
-    jq -e '[.data.ui_elements[]? | .value? | strings] | any(contains("Downloading or loading the image model"))' \
-        "$OUT/rlr-in-flight.json" >/dev/null \
-        || die "resident image download started without visible working feedback"
-    if jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
-        "$OUT/rlr-in-flight.json" >/dev/null; then
-        die "Download & start remained pressable while its resident load was in flight"
+    wait_fake_event ".event == \"server_started\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
+        "the Images action never started its dedicated image sidecar"
+    if jq -e 'select(.event == "model_load")' "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
+        die "Images incorrectly issued an in-process /v1/models/load"
     fi
-    wait_fake_event '.event == "model_load_rejected"' \
-        "the fake did not reject the in-process image load (FAKE_REJECT_IMAGE_LOAD not applied)"
-
-    # 5. The rejection's actionable reason must be VISIBLE on the Images
-    #    surface (the readiness banner), not only in the log drawer.
-    local i shown=0
-    for ((i=0; i<80; i++)); do
-        see_main "$OUT/rlr-shown.json"
-        if jq -e '[.data.ui_elements[]?]
-                  | map(((.title // "") | tostring) + " " + ((.value // "") | tostring) + " " + ((.description // "") | tostring) + " " + ((.help // "") | tostring))
-                  | join(" ") | test("rapid-mlx\\[image\\]")' \
-               "$OUT/rlr-shown.json" >/dev/null 2>&1; then
-            shown=1; break
-        fi
-        sleep 0.25
-    done
-    [[ "$shown" == 1 ]] \
-        || die "the engine's rejection reason never appeared on the Images surface - it was swallowed into the log (#1838)"
-
-    # 6. The surface offers a recovery action, not a dead button.
-    jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
-        "$OUT/rlr-shown.json" >/dev/null \
-        || die "the Images readiness banner did not offer a recovery action after the rejection"
 
     log "  resident-load-rejected OK"
 }
@@ -4319,24 +4285,22 @@ flow_audio_readiness() {
     # nor remain copyable while their selected chat model is not serving.
     press "$OUT/speech-resident.json" Sidebar.Launch "$OUT/launch-from-audio.json" \
         || die "Sidebar.Launch is not pressable from an Audio residency"
-    local launch_copy_count=0
+    local launch_copy_count=0 launch_ready=0
     for ((i=0; i<40; i++)); do
         see_main "$OUT/launch-from-audio.json"
         launch_copy_count="$(jq '[.data.ui_elements[]?
                                   | (.identifier // "")
                                   | select(startswith("Launch.Integration.Copy."))]
                                  | unique | length' "$OUT/launch-from-audio.json")"
-        [[ "$launch_copy_count" == 14 ]] && break
+        if [[ "$launch_copy_count" == 0 ]] &&
+           jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
+              "$OUT/launch-from-audio.json" >/dev/null; then
+            launch_ready=1; break
+        fi
         sleep 0.25
     done
-    [[ "$launch_copy_count" == 14 ]] \
-        || die "Launch did not finish loading integrations from Audio"
-    if jq -e '[.data.ui_elements[]?
-               | select(((.identifier // "") | startswith("Launch.Integration.Copy."))
-                        and .enabled == true)] | length > 0' \
-            "$OUT/launch-from-audio.json" >/dev/null; then
-        die "Launch enabled agent commands while an Audio model was serving"
-    fi
+    [[ "$launch_ready" == 1 ]] \
+        || die "Launch exposed dead commands or no chat-model start action from Audio"
     if jq -e '[.data.ui_elements[]? | .value? | strings]
               | any(contains("fake-qwen3-tts")
                     and (contains("--model")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3979,52 +3979,15 @@ flow_launch_integrations() {
     dismiss_first_run
     see_main "$OUT/main.json"
     press "$OUT/main.json" Sidebar.Launch "$OUT/launch.json"
+    wait_tree_text "Connect your agents" "$OUT/launch.json" 40
 
-    # The engine-owned registry currently resolves to fourteen distinct
-    # products after the overlapping Claude Code and Continue entries are
-    # merged. Count the actual per-row action, not a container: putting the id
-    # on the row propagates it to the Copy button in SwiftUI and makes the
-    # button look addressable while preventing it from having its own stable
-    # identity.
-    for _ in {1..40}; do
-        see_main "$OUT/launch.json"
-        count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration.Copy."))] | unique | length' "$OUT/launch.json")"
-        [[ "$count" == 14 ]] && break
-        sleep 0.25
-    done
-    [[ "$count" == 14 ]] || die "Launch rendered $count integrations; engine registry exposes 14 (#1715)"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.cline")' "$OUT/launch.json" >/dev/null \
-        || die "Launch omitted config-writing target Cline"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.smolagents")' "$OUT/launch.json" >/dev/null \
-        || die "Launch omitted adapter profile smolagents"
-    # The two one-session launch commands are the useful fast path, not an
-    # implementation-detail registry order. Keep them first and in the product
-    # order promised by the Launch page.
-    local first_two
-    first_two="$(jq -r '[.data.ui_elements[]?
-                         | select((.identifier // "")
-                                  | startswith("Launch.Integration.Copy."))
-                         | .identifier]
-                        | .[0:2]
-                        | join(",")' "$OUT/launch.json")"
-    [[ "$first_two" == "Launch.Integration.Copy.claude-code,Launch.Integration.Copy.codex" ]] \
-        || die "Launch did not lead with Claude Code then Codex (got: $first_two)"
-    # The card itself is not the action. Every visible row must publish a
-    # distinct Copy button so AX/keyboard users can invoke the same command a
-    # pointer user can, and every one is disabled honestly until a live model
-    # has minted a usable endpoint/key.
-    local copy_count enabled_copy_count
-    copy_count="$(jq '[.data.ui_elements[]?
-                       | (.identifier // "")
-                       | select(startswith("Launch.Integration.Copy."))]
-                      | unique | length' "$OUT/launch.json")"
-    [[ "$copy_count" == 14 ]] \
-        || die "Launch rendered $copy_count addressable Copy buttons for 14 integrations"
-    enabled_copy_count="$(jq '[.data.ui_elements[]?
-                               | select(((.identifier // "") | startswith("Launch.Integration.Copy."))
-                                        and .enabled == true)] | length' "$OUT/launch.json")"
-    [[ "$enabled_copy_count" == 0 ]] \
-        || die "Launch enabled $enabled_copy_count copy commands before a model was ready"
+    # Cold Launch is a beginner path, not a wall of dead commands. It should
+    # offer the same actionable readiness banner as Chat and reveal no setup
+    # snippets until the endpoint/key actually exist.
+    count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration.Copy."))] | unique | length' "$OUT/launch.json")"
+    [[ "$count" == 0 ]] || die "Cold Launch rendered $count dead integration commands"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' "$OUT/launch.json" >/dev/null \
+        || die "Cold Launch offered no primary model-start action"
     baseline launch-integrations.complete "$OUT/launch.json"
 
     press "$OUT/launch.json" Sidebar.NewChat "$OUT/launch-chat.json" \
@@ -4032,7 +3995,21 @@ flow_launch_integrations() {
     start_model
     see_main "$OUT/launch-model-ready.json"
     press "$OUT/launch-model-ready.json" Sidebar.Launch "$OUT/launch-ready-open.json"
-    local i ready_copies=0
+    # Ready Launch leads with three common choices. The registry remains fully
+    # reachable behind one explicit disclosure instead of occupying the page by
+    # default.
+    wait_identifier ConnectTools.MoreIntegrations "$OUT/launch-ready.json"
+    local ready_copies
+    ready_copies="$(jq '[.data.ui_elements[]?
+                         | select(((.identifier // "")
+                                   | startswith("Launch.Integration.Copy."))
+                                  and .enabled == true)] | length' "$OUT/launch-ready.json")"
+    [[ "$ready_copies" == 3 ]] \
+        || die "Ready Launch should lead with 3 common integrations, got $ready_copies"
+    press "$OUT/launch-ready.json" ConnectTools.MoreIntegrations \
+        "$OUT/launch-more-press.json" \
+        || die "More integrations disclosure is not pressable"
+    local i
     for ((i=0; i<80; i++)); do
         see_main "$OUT/launch-ready.json"
         ready_copies="$(jq '[.data.ui_elements[]?
@@ -4045,6 +4022,19 @@ flow_launch_integrations() {
     done
     [[ "$ready_copies" == 14 ]] \
         || die "Launch enabled $ready_copies of 14 copy commands after the chat model was ready"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.cline")' "$OUT/launch-ready.json" >/dev/null \
+        || die "Expanded Launch omitted config-writing target Cline"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.smolagents")' "$OUT/launch-ready.json" >/dev/null \
+        || die "Expanded Launch omitted adapter profile smolagents"
+    local first_two
+    first_two="$(jq -r '[.data.ui_elements[]?
+                         | select((.identifier // "")
+                                  | startswith("Launch.Integration.Copy."))
+                         | .identifier]
+                        | .[0:2]
+                        | join(",")' "$OUT/launch-ready.json")"
+    [[ "$first_two" == "Launch.Integration.Copy.claude-code,Launch.Integration.Copy.codex" ]] \
+        || die "Launch did not lead with Claude Code then Codex (got: $first_two)"
     local integration_id copied_command
     while IFS= read -r integration_id; do
         pbcopy < /dev/null

--- a/docs/engineering/operations/2026-08-22-first-run-gui-friction.md
+++ b/docs/engineering/operations/2026-08-22-first-run-gui-friction.md
@@ -1,0 +1,150 @@
+# First-run GUI friction dogfood — 2026-08-22
+
+## Scope and environment
+
+- Source: `origin/main` at `365a29dd`
+- Host: Studio, Apple M3 Ultra, 256 GB unified memory
+- Install surface: locally assembled release DMG
+- Persona: isolated bundle identifier, fresh preferences, fresh Application
+  Support, and a cold Hugging Face cache
+- Journey: DMG install, telemetry consent, onboarding, first model download,
+  chat, tools, documents, Images, Text to Speech, restart, Launch, and Settings
+
+This document records the nine dogfood findings selected for the first-run GUI
+friction pass. It intentionally keeps the evidence and acceptance criteria in
+the repository instead of relying on a chat transcript.
+
+## Findings and acceptance criteria
+
+### F1 — Images download completion leaves contradictory state
+
+After the 4.3 GiB `flux2-klein-4b` download completed, the download strip said
+`Downloaded — ready to load`, while Images still said the model was not
+downloaded, kept the `Download` action, and disabled Generate. Waiting and
+pressing Download again did not recover; restarting the app did.
+
+Acceptance:
+
+- A successful image-model download immediately invalidates the cached model
+  inventory and transitions Images to `Start` without an app restart.
+- A completed download cannot coexist with a `not downloaded` readiness state.
+- Regression coverage exercises the real completion notification/state path.
+
+### F2 — Images start fails with an opaque resident HTTP 500
+
+After restart recognized the model, `Start` consistently failed with
+`The model could not be kept resident (HTTP 500)` on a 256 GB machine. Retry
+produced the same result. The message exposed transport detail and offered no
+actionable diagnosis.
+
+Acceptance:
+
+- Image models use the image-generation runtime instead of the text-model
+  residency endpoint.
+- The default image model can start and generate pixels from the bundled
+  sidecar in a cold persona.
+- Any remaining start failure is translated into an actionable user message;
+  raw HTTP status may appear only as secondary detail.
+
+### F9 — Download ETA is unstable during early sampling
+
+The 633 MB onboarding download jumped between approximately 1 and 12 minutes
+remaining as the first few speed samples arrived.
+
+Acceptance:
+
+- ETA is hidden until enough time and bytes have been sampled for a stable
+  estimate.
+- Once shown, short-lived throughput drops do not cause multi-fold ETA jumps.
+- Bytes and current speed remain visible while ETA is calibrating.
+
+### F10 — Cancel download looks disabled
+
+The onboarding `Cancel download` action used low-contrast secondary styling
+that visually resembled disabled text.
+
+Acceptance:
+
+- Cancel is visibly interactive, keyboard accessible, and destructive without
+  visually competing with the primary download progress.
+- AX label/help continue to describe the consequence.
+
+### F11 — Completed download strip contradicts resident state
+
+The chat model remained represented as `Downloaded — ready to load` even while
+the sidebar and footer reported it Resident/Ready. Completed strips also piled
+up after image and TTS downloads.
+
+Acceptance:
+
+- Completed strips disappear when their alias becomes the running model.
+- Non-running successful downloads may remain briefly as a useful `Start`
+  affordance, then auto-dismiss.
+- Multiple completed jobs do not permanently consume the bottom of the app.
+
+### F12 — Onboarding completion prompt blocks the first message
+
+The completion prompt appeared over the composer/model picker immediately
+after the first model became ready and asked the user to star the repository.
+
+Acceptance:
+
+- The first chat composer is unobstructed and focused after onboarding.
+- Repository-star promotion moves to a non-blocking empty-state or delayed
+  moment and is never layered over the composer.
+
+### F19 — Image starter prompts are clipped without discoverability
+
+Four one-line starter pills overflowed horizontally. The final prompts were
+clipped, with no visible scroll affordance.
+
+Acceptance:
+
+- Every starter prompt is readable without hidden horizontal scrolling at the
+  minimum supported window width.
+- Layout wraps or uses a grid while retaining semantic AX identifiers.
+
+### F20 — Images repeats download messaging instead of explaining value
+
+The empty state repeated the model name, 4.3 GiB size, and download requirement
+across the center stage, readiness banner, and disabled composer. It did not
+explain expected generation time, local/offline behavior, or what the starter
+model is good at.
+
+Acceptance:
+
+- One primary readiness surface owns download/start status and size.
+- The empty state explains the outcome in plain language and avoids duplicate
+  model/runtime jargon.
+- The disabled composer gives a short action-oriented reason only.
+
+### F27 — Launch exposes an expert wall at top-level navigation
+
+Launch presented base URLs, API keys, and a long list of shell commands for
+Claude Code, Codex, Cline, Continue, Cursor, LangChain, and others in one view.
+When the selected chat model was stopped by TTS, every integration action was
+disabled and the page became a dense dead end.
+
+Acceptance:
+
+- Launch opens with a beginner-readable purpose statement and a short set of
+  common clients.
+- Advanced endpoint/key details and the full integration catalog require an
+  explicit disclosure action.
+- When no chat model is running, the primary action is `Start <model>` and
+  disabled command walls are not rendered.
+
+## Verification journey
+
+The post-fix dogfood must repeat the same cold-persona sequence:
+
+1. Mount the release DMG and inspect the install surface.
+2. Complete telemetry and onboarding; download the starter model.
+3. Verify stable progress, visible cancel, unobstructed first composer, and no
+   contradictory completed strip.
+4. Download `flux2-klein-4b`; verify immediate `Start`, start it, generate a
+   512×512 image, and verify non-empty pixels.
+5. Return to chat, switch/start a text model, and verify history survives.
+6. Open Launch with and without a running chat model and inspect both beginner
+   and advanced disclosure states.
+7. Run focused Swift tests plus the relevant GUI golden flows.


### PR DESCRIPTION
## Summary

- keep Images cache/readiness live after background downloads and launch modal image engines through the correct process-swap path
- stabilize first-run progress and actions: delay volatile ETA, strengthen cancel affordances, retire misleading completed strips, and remove the onboarding overlay
- make image starters readable and Launch progressive: no dead command wall before startup, 3 common integrations first, full registry behind disclosure
- record the nine dogfood findings and acceptance criteria in durable operations notes

## Validation

- local release `.app` build succeeded (`apps/rapid-mac/scripts/build.sh`)
- `swift test --package-path apps/rapid-mac --filter DownloadProgressTests`
- focused image, GitHub prompt, mounted recovery, integration ordering, and accessibility identifier suites
- `python3 -m pytest -q tests/test_gui_control_behavior_contract.py tests/test_gui_preflight_contract.py` (17 passed)
- GUI golden `image-generation` PASS
- GUI golden `launch-integrations` PASS; cold state has no dead commands, ready state expands and copies 14/14 integrations
- full Swift run: 2691 tests executed; related suites passed, 7 existing timing-sensitive issues observed under parallel load and retained for prvalidation rerun

No release action is included or authorized.
