### PR TITLE
[codex] Separate MLLM prefill and vision budgets

### DIFF
--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -160,6 +160,12 @@ the safe 8,192-token budget. This matters especially to Desktop users, because
 the GUI launches the alias without performance flags and receives both defaults
 automatically.
 
+Operator compatibility is source-aware. An explicit
+`--vision-prefill-token-budget` always wins; an explicit
+`--prefill-step-size` without that new flag preserves the historical shared
+limit for memory-constrained deployments. Only the zero-flag/profile path
+separates Gemma's 512 computation chunk from the 8,192 vision budget.
+
 A zero-flag service spot check used the same Desktop launch shape on the M2 Pro:
 `rapid-mlx serve gemma-4-12b-4bit`. Startup selected the profile's 512 chunk,
 and a 64×64 red PNG sent through `/v1/chat/completions` completed normally with

--- a/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
+++ b/docs/engineering/performance/2026-08-22-long-context-service-prefill.md
@@ -4,7 +4,8 @@
 
 Bench-verified text-model profiles should select their own prefill chunk in
 `rapid-mlx serve`: Qwen3.5 4B/9B 4-bit use 512; Qwen3.5 4B/9B 6/8-bit and
-27B 4-bit use 1,024. Against the previous universal
+27B 4-bit use 1,024; Gemma 4 12B 4-bit uses 512 with an independent 8,192-token
+vision admission budget. Against the previous universal
 2,048-token default, the original Qwen3.5 4B 4-bit result:
 
 - reduced a short request's TTFT under a concurrent long prefill by 51.1%;
@@ -152,12 +153,20 @@ single-repeat scout through mlx-vlm 0.6.15 found that 512 was promising:
 | 4K | 131.79 | 136.48 | +3.6% | -7.8% |
 | 16K | 125.38 | 130.12 | +3.8% | -13.3% |
 
-The later repeat-three direct-prefill matrix reproduced this result. It still
-does not justify a service default: on the multimodal path, the same setting is
-also the per-image admission budget. A 512 value can reject a token-dense image
-before generation. Gemma therefore remains at the MLLM default until the text
-chunk and image admission budget are separated, or repeated image-service tests
-prove a safe policy.
+The later repeat-three direct-prefill matrix reproduced this result. The runtime
+now keeps the language-model prefill chunk separate from the per-image admission
+budget: Gemma can use the measured 512 chunk while vision-bearing requests keep
+the safe 8,192-token budget. This matters especially to Desktop users, because
+the GUI launches the alias without performance flags and receives both defaults
+automatically.
+
+A zero-flag service spot check used the same Desktop launch shape on the M2 Pro:
+`rapid-mlx serve gemma-4-12b-4bit`. Startup selected the profile's 512 chunk,
+and a 64×64 red PNG sent through `/v1/chat/completions` completed normally with
+280 prompt tokens and the non-empty response `The image is dark red.` The
+admission regression test separately pins a representative 2,292-token image
+prompt as accepted by the 8,192 budget while proving it would have failed if
+the budget still followed the 512 chunk.
 
 ## Recurrent cross-model regression matrix
 
@@ -202,14 +211,14 @@ greater than 3% at either 4K or 16K, then prefer the smallest remaining chunk.
 | Qwen3.5 9B 6-bit | 1,024 | 1,024 | -0.8% | -1.2% | -7.0% | -10.1% |
 | Qwen3.5 9B 8-bit | 1,024 | 1,024 | -1.2% | -1.6% | -5.1% | -7.8% |
 | Qwen3.5 27B 4-bit | 1,024 | 1,024 | -0.6% | -0.5% | -6.6% | -8.9% |
-| Gemma 4 12B 4-bit | 512 | MLLM default | +3.3% | +3.8% | -7.8% | -13.3% |
+| Gemma 4 12B 4-bit | 512 | 512 | +3.3% | +3.8% | -7.8% | -13.3% |
 
 For the four 6/8-bit Qwen aliases, 512 regressed throughput by 3.9--7.5%, so
 1,024 is not merely a midpoint: it is the smallest candidate that stays within
 the regression budget. Qwen3.5 27B at 512 was acceptable at 4K (-2.5%) but
 missed at 16K (-3.3%), so it also uses 1,024. Gemma's repeat-three result
-confirmed the earlier scout, but is not deployed because the MLLM admission
-budget currently shares this setting.
+confirmed the earlier scout. It is deployed only after separating the 512
+language-model chunk from the 8,192-token vision admission budget.
 
 ### Desktop/GUI consumption audit
 
@@ -289,6 +298,6 @@ Land the profile-scoped 512 auto-default with the benchmark harness. Then:
 
 1. run the same HTTP workload against a calibrated oMLX deployment (none was
    installed on this mini during this run), including equivalent cache policy;
-2. repeat the Gemma 4 12B service A/B before considering a broader default;
+2. repeat the Gemma 4 12B image-service A/B before generalizing to other MLLMs;
 3. profile cache admission/eviction for multiple 16K--64K agent prefixes; and
 4. add a repeat-three service tier to scheduled Mac performance CI.

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -983,7 +983,9 @@ def _make_cap_request(uid: int, token_count: int) -> MLLMBatchRequest:
     )
 
 
-def _gen_with_prefill_cap(prefill_step_size: int) -> MLLMBatchGenerator:
+def _gen_with_prefill_cap(
+    prefill_step_size: int, *, vision_prefill_token_budget: int | None = None
+) -> MLLMBatchGenerator:
     """Generator with a tunable cap, no real model/processor needed.
 
     ``_process_prompts`` only reads ``self.prefill_step_size`` /
@@ -992,7 +994,11 @@ def _gen_with_prefill_cap(prefill_step_size: int) -> MLLMBatchGenerator:
     """
     gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
     gen.prefill_step_size = prefill_step_size
-    gen.vision_prefill_token_budget = prefill_step_size
+    gen.vision_prefill_token_budget = (
+        prefill_step_size
+        if vision_prefill_token_budget is None
+        else vision_prefill_token_budget
+    )
     gen.vision_cache = None
     gen.model = object()
     gen.language_model = object()
@@ -1215,6 +1221,23 @@ def test_per_batch_cap_does_not_fail_at_default_on_typical_screenshot(
         f"with the production MLLM default (8192), a 2292-token "
         f"single-request batch must pass the cap; got: {err_msg}"
     )
+
+
+def test_profile_chunk_uses_independent_vision_budget_in_process_prompts(
+    monkeypatch,
+):
+    """Exercise the production admission call site for the Gemma profile."""
+    gen = _gen_with_prefill_cap(
+        prefill_step_size=512,
+        vision_prefill_token_budget=8192,
+    )
+    monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
+    request = _make_vision_cap_request(uid=0, token_count=2292)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: BLE001 — bare model stub
+        MLLMBatchGenerator._process_prompts(gen, [request])
+
+    assert "exceeds the per-batch cap" not in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -1056,8 +1056,24 @@ def test_vision_admission_budget_is_independent_from_prefill_chunk():
 def test_vision_budget_keeps_safe_floor_and_larger_operator_value():
     from vllm_mlx.engine.batched import _resolve_mllm_vision_prefill_token_budget
 
-    assert _resolve_mllm_vision_prefill_token_budget(512, mllm_default=8192) == 8192
-    assert _resolve_mllm_vision_prefill_token_budget(16384, mllm_default=8192) == 16384
+    assert (
+        _resolve_mllm_vision_prefill_token_budget(
+            512, configured=None, mllm_default=8192
+        )
+        == 8192
+    )
+    assert (
+        _resolve_mllm_vision_prefill_token_budget(
+            16384, configured=None, mllm_default=8192
+        )
+        == 16384
+    )
+    assert (
+        _resolve_mllm_vision_prefill_token_budget(
+            512, configured=256, mllm_default=8192
+        )
+        == 256
+    )
 
 
 def test_resolve_mllm_prefill_step_size_bumps_text_default_to_mllm_default():

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -992,6 +992,7 @@ def _gen_with_prefill_cap(prefill_step_size: int) -> MLLMBatchGenerator:
     """
     gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
     gen.prefill_step_size = prefill_step_size
+    gen.vision_prefill_token_budget = prefill_step_size
     gen.vision_cache = None
     gen.model = object()
     gen.language_model = object()
@@ -1008,9 +1009,8 @@ def _gen_with_prefill_cap(prefill_step_size: int) -> MLLMBatchGenerator:
     return gen
 
 
-def test_mllm_scheduler_config_default_prefill_step_size_covers_screenshot():
-    """``MLLMSchedulerConfig.prefill_step_size`` default must cover a
-    typical 1920×1080 screenshot's vision-token count.
+def test_mllm_scheduler_config_default_vision_budget_covers_screenshot():
+    """The independent vision budget must cover a typical screenshot.
 
     Pre-fix the default was 1024 — even an 800×600 image would have
     failed the cap on a direct ``MLLMSchedulerConfig()`` construction.
@@ -1023,11 +1023,35 @@ def test_mllm_scheduler_config_default_prefill_step_size_covers_screenshot():
     # 1920×1080 Qwen3-VL: ~2200 vision tokens + chat-template + text.
     # Default must be high enough that a single such request never
     # trips the cap on its own size (#682).
-    assert cfg.prefill_step_size >= 8192, (
-        f"MLLMSchedulerConfig.prefill_step_size default ({cfg.prefill_step_size}) "
+    assert cfg.vision_prefill_token_budget >= 8192, (
+        "MLLMSchedulerConfig.vision_prefill_token_budget default "
+        f"({cfg.vision_prefill_token_budget}) "
         f"must be at least 8192 to cover 1920×1080 screenshots without "
         f"tripping the per-batch cap (#682)."
     )
+
+
+def test_vision_admission_budget_is_independent_from_prefill_chunk():
+    """A profile-tuned 512 chunk must still admit a normal screenshot."""
+    from vllm_mlx.mllm_batch_generator import _prefill_cap_violation
+    from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+
+    cfg = MLLMSchedulerConfig(
+        prefill_step_size=512,
+        vision_prefill_token_budget=8192,
+    )
+    req = _make_vision_cap_request(uid=0, token_count=2292)
+
+    assert cfg.prefill_step_size == 512
+    assert _prefill_cap_violation([req], cfg.vision_prefill_token_budget) is None
+    assert _prefill_cap_violation([req], cfg.prefill_step_size) is not None
+
+
+def test_vision_budget_keeps_safe_floor_and_larger_operator_value():
+    from vllm_mlx.engine.batched import _resolve_mllm_vision_prefill_token_budget
+
+    assert _resolve_mllm_vision_prefill_token_budget(512, mllm_default=8192) == 8192
+    assert _resolve_mllm_vision_prefill_token_budget(16384, mllm_default=8192) == 16384
 
 
 def test_resolve_mllm_prefill_step_size_bumps_text_default_to_mllm_default():

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -257,6 +257,7 @@ class TestMLLMSchedulerConfig:
         # prefill_batch_size set equal to max_num_seqs to avoid batch extend issues
         assert config.prefill_batch_size == 16
         assert config.completion_batch_size == 16
+        assert config.vision_prefill_token_budget == 8192
         assert config.enable_vision_cache is True
         assert config.vision_cache_size == 100
 

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -270,7 +270,7 @@ class TestMLLMSchedulerConfig:
         )
         assert (
             MLLMSchedulerConfig(prefill_step_size=512).vision_prefill_token_budget
-            == 8192
+            == 512
         )
         assert (
             MLLMSchedulerConfig(

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -261,6 +261,25 @@ class TestMLLMSchedulerConfig:
         assert config.enable_vision_cache is True
         assert config.vision_cache_size == 100
 
+    def test_vision_budget_preserves_direct_large_prefill_compatibility(self):
+        from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+
+        assert (
+            MLLMSchedulerConfig(prefill_step_size=16_384).vision_prefill_token_budget
+            == 16_384
+        )
+        assert (
+            MLLMSchedulerConfig(prefill_step_size=512).vision_prefill_token_budget
+            == 8192
+        )
+        assert (
+            MLLMSchedulerConfig(
+                prefill_step_size=512,
+                vision_prefill_token_budget=12_000,
+            ).vision_prefill_token_budget
+            == 12_000
+        )
+
     def test_custom_config(self):
         """Test custom configuration."""
         from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -152,6 +152,33 @@ def test_real_profile_recommendations_reach_runtime_resolver():
     )
 
 
+def test_vision_budget_distinguishes_gui_profile_from_explicit_prefill():
+    assert (
+        cli._resolve_vision_prefill_token_budget(
+            configured=None,
+            prefill_step_size=512,
+            prefill_user_set_explicit=False,
+        )
+        == 8192
+    )
+    assert (
+        cli._resolve_vision_prefill_token_budget(
+            configured=None,
+            prefill_step_size=512,
+            prefill_user_set_explicit=True,
+        )
+        == 512
+    )
+    assert (
+        cli._resolve_vision_prefill_token_budget(
+            configured=4096,
+            prefill_step_size=512,
+            prefill_user_set_explicit=False,
+        )
+        == 4096
+    )
+
+
 def test_prefill_help_describes_profile_scoped_recommendation():
     serve_parser = next(
         action.choices["serve"]
@@ -165,3 +192,10 @@ def test_prefill_help_describes_profile_scoped_recommendation():
     )
     assert "bench-verified model profiles" in action.help
     assert "recurrent/linear-attention models auto-tune" not in action.help
+
+    vision_action = next(
+        action
+        for action in serve_parser._actions
+        if "--vision-prefill-token-budget" in action.option_strings
+    )
+    assert vision_action.default is None

--- a/tests/test_recurrent_prefill_auto_default.py
+++ b/tests/test_recurrent_prefill_auto_default.py
@@ -127,7 +127,9 @@ def test_only_bench_verified_profiles_opt_in():
     ):
         assert resolve_profile(alias).recommended_prefill_step_size == 1024
 
-    for alias in ("qwen3.5-35b-4bit", "gemma-4-12b-4bit"):
+    assert resolve_profile("gemma-4-12b-4bit").recommended_prefill_step_size == 512
+
+    for alias in ("qwen3.5-35b-4bit",):
         assert resolve_profile(alias).recommended_prefill_step_size is None
 
 
@@ -139,6 +141,14 @@ def test_real_profile_recommendations_reach_runtime_resolver():
             user_set_explicit=False,
         )
         == 1024
+    )
+    assert (
+        cli._resolve_prefill_step_size(
+            model_name="gemma-4-12b-4bit",
+            configured=2048,
+            user_set_explicit=False,
+        )
+        == 512
     )
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -682,6 +682,7 @@
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true,
+    "recommended_prefill_step_size": 512,
     "recommended_sampling": {
       "temperature": 1.0,
       "top_p": 0.95,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2676,6 +2676,21 @@ def _resolve_prefill_step_size(
     return resolved
 
 
+def _resolve_vision_prefill_token_budget(
+    *,
+    configured: int | None,
+    prefill_step_size: int,
+    prefill_user_set_explicit: bool,
+    mllm_default: int = 8192,
+) -> int:
+    """Resolve the independent MLLM vision admission budget."""
+    if configured is not None:
+        return configured
+    if prefill_user_set_explicit:
+        return prefill_step_size
+    return max(prefill_step_size, mllm_default)
+
+
 def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
     """Whether this model's cache can reuse prefixes but not trim exact hits."""
     from .model_aliases import resolve_profile as _resolve_alias
@@ -3880,11 +3895,18 @@ def serve_command(args):
         or any(a.startswith("--hybrid-cache-entries=") for a in sys.argv),
         model_name=getattr(args, "_original_alias", None) or args.model,
     )
+    _prefill_user_set_explicit = "--prefill-step-size" in sys.argv or any(
+        a.startswith("--prefill-step-size=") for a in sys.argv
+    )
     _prefill_step_size = _resolve_prefill_step_size(
         model_name=getattr(args, "_original_alias", None) or args.model,
         configured=args.prefill_step_size,
-        user_set_explicit="--prefill-step-size" in sys.argv
-        or any(a.startswith("--prefill-step-size=") for a in sys.argv),
+        user_set_explicit=_prefill_user_set_explicit,
+    )
+    _vision_prefill_token_budget = _resolve_vision_prefill_token_budget(
+        configured=getattr(args, "vision_prefill_token_budget", None),
+        prefill_step_size=_prefill_step_size,
+        prefill_user_set_explicit=_prefill_user_set_explicit,
     )
 
     # 0.9.13 PR-A codex round-E blocker #2: resolve model_type on the
@@ -3945,6 +3967,7 @@ def serve_command(args):
         # accepted but never used. See #400 and the CLI ↔ Config fidelity
         # audit at scripts/audit_cli_config_fidelity.py.
         prefill_step_size=_prefill_step_size,
+        vision_prefill_token_budget=_vision_prefill_token_budget,
         vision_min_pixels=getattr(args, "vision_min_pixels", 0),
         vision_max_pixels=getattr(args, "vision_max_pixels", 0),
         # Speculative decoding selection.
@@ -9895,6 +9918,16 @@ Examples:
         help="Chunk size for prompt prefill processing. Larger values use more memory "
         "but can improve prefill throughput. (default: 2048; bench-verified model "
         "profiles may recommend a smaller value unless explicitly set)",
+    )
+    serve_parser.add_argument(
+        "--vision-prefill-token-budget",
+        type=positive_int,
+        default=None,
+        help=(
+            "Advanced: maximum prompt tokens per vision-bearing request. "
+            "Defaults to 8192 for automatic profiles; an explicit "
+            "--prefill-step-size preserves the legacy shared limit."
+        ),
     )
     serve_parser.add_argument(
         "--vision-min-pixels",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -667,6 +667,13 @@ def _resolve_mllm_prefill_step_size(
     return user_value
 
 
+def _resolve_mllm_vision_prefill_token_budget(
+    prefill_step_size: int, *, mllm_default: int
+) -> int:
+    """Keep vision admission safe without limiting larger operator budgets."""
+    return max(prefill_step_size, mllm_default)
+
+
 def _compute_metal_cache_limit(soft_limit_bytes: int) -> int:
     """Pick a Metal free-cache size that scales with the device's working set.
 
@@ -1224,6 +1231,10 @@ class BatchedEngine(BaseEngine):
             prefill_batch_size=prefill_batch_size,
             completion_batch_size=completion_batch_size,
             prefill_step_size=prefill_step_size,
+            vision_prefill_token_budget=_resolve_mllm_vision_prefill_token_budget(
+                prefill_step_size,
+                mllm_default=_MLLM_DEFAULT_PREFILL_STEP_SIZE,
+            ),
             enable_vision_cache=True,
             vision_cache_size=100,
             max_concurrent_requests=max_concurrent_requests,
@@ -1245,7 +1256,10 @@ class BatchedEngine(BaseEngine):
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
-            f"completion_batch={completion_batch_size}, vision_min_pixels="
+            f"completion_batch={completion_batch_size}, "
+            f"prefill_step_size={prefill_step_size}, "
+            f"vision_prefill_token_budget="
+            f"{mllm_config.vision_prefill_token_budget}, vision_min_pixels="
             f"{vision_min_pixels or 'model-default'}, vision_max_pixels="
             f"{vision_max_pixels or 'model-default'}"
         )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -668,9 +668,14 @@ def _resolve_mllm_prefill_step_size(
 
 
 def _resolve_mllm_vision_prefill_token_budget(
-    prefill_step_size: int, *, mllm_default: int
+    prefill_step_size: int,
+    *,
+    configured: int | None,
+    mllm_default: int,
 ) -> int:
     """Keep vision admission safe without limiting larger operator budgets."""
+    if configured is not None:
+        return configured
     return max(prefill_step_size, mllm_default)
 
 
@@ -1233,6 +1238,9 @@ class BatchedEngine(BaseEngine):
             prefill_step_size=prefill_step_size,
             vision_prefill_token_budget=_resolve_mllm_vision_prefill_token_budget(
                 prefill_step_size,
+                configured=getattr(
+                    self._scheduler_config, "vision_prefill_token_budget", None
+                ),
                 mllm_default=_MLLM_DEFAULT_PREFILL_STEP_SIZE,
             ),
             enable_vision_cache=True,

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -579,11 +579,11 @@ class MLLMBatchGenerator:
         completion_batch_size: int = 16,  # Can be larger for text generation
         allow_arrays_cache: bool = False,
         prefill_step_size: int = 1024,
-        vision_prefill_token_budget: int = 8192,
         enable_vision_cache: bool = True,
         vision_cache_size: int = 100,
         vision_min_pixels: int = 0,
         vision_max_pixels: int = 0,
+        vision_prefill_token_budget: int = 8192,
     ):
         """
         Initialize MLLM batch generator.
@@ -599,12 +599,13 @@ class MLLMBatchGenerator:
             completion_batch_size: Max requests for completion batching
             allow_arrays_cache: Permit mlx-lm ArraysCache in serialized mode
             prefill_step_size: Tokens to process per prefill step
-            vision_prefill_token_budget: Per-image-request admission budget;
-                independent from the language-model prefill chunk
             enable_vision_cache: Enable vision embedding caching
             vision_cache_size: Max entries in vision cache
             vision_min_pixels: Optional processor-side minimum image pixels
             vision_max_pixels: Optional processor-side maximum image pixels
+            vision_prefill_token_budget: Per-image-request admission budget;
+                independent from the language-model prefill chunk. Appended to
+                preserve positional compatibility with existing callers.
         """
         self.model = model
         self.processor = processor

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -265,7 +265,7 @@ def _prefill_cap_violation(requests, prefill_step_size: int):
     if vision_tokens > max_batch_tokens:
         return (
             f"Vision-request prompt tokens ({vision_tokens}) exceeds the "
-            f"per-batch cap ({max_batch_tokens} = prefill_step_size "
+            f"per-batch cap ({max_batch_tokens} = vision token budget "
             f"{prefill_step_size} × {num_vision} vision request(s)). "
             f"For image inputs, downscale the image; for text inputs, "
             f"shorten the prompt or restart the server with "
@@ -579,6 +579,7 @@ class MLLMBatchGenerator:
         completion_batch_size: int = 16,  # Can be larger for text generation
         allow_arrays_cache: bool = False,
         prefill_step_size: int = 1024,
+        vision_prefill_token_budget: int = 8192,
         enable_vision_cache: bool = True,
         vision_cache_size: int = 100,
         vision_min_pixels: int = 0,
@@ -598,6 +599,8 @@ class MLLMBatchGenerator:
             completion_batch_size: Max requests for completion batching
             allow_arrays_cache: Permit mlx-lm ArraysCache in serialized mode
             prefill_step_size: Tokens to process per prefill step
+            vision_prefill_token_budget: Per-image-request admission budget;
+                independent from the language-model prefill chunk
             enable_vision_cache: Enable vision embedding caching
             vision_cache_size: Max entries in vision cache
             vision_min_pixels: Optional processor-side minimum image pixels
@@ -606,6 +609,7 @@ class MLLMBatchGenerator:
         self.model = model
         self.processor = processor
         self.mm_processor = mm_processor
+        self.vision_prefill_token_budget = vision_prefill_token_budget
 
         # Get language model for text generation
         self.language_model = getattr(model, "language_model", model)
@@ -1355,7 +1359,7 @@ class MLLMBatchGenerator:
         # vision-encoding path and do not contribute vision tokens, so they
         # are exempt from the cap (#1848) — a >8k text-only prompt must not
         # be rejected just because ``prefill_step_size`` defaults to 8192.
-        _cap_help = _prefill_cap_violation(requests, self.prefill_step_size)
+        _cap_help = _prefill_cap_violation(requests, self.vision_prefill_token_budget)
         if _cap_help is not None:
             raise ClientRequestError(_cap_help)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -101,7 +101,7 @@ class MLLMSchedulerConfig:
 
     def __post_init__(self) -> None:
         if self.vision_prefill_token_budget is None:
-            self.vision_prefill_token_budget = max(self.prefill_step_size, 8192)
+            self.vision_prefill_token_budget = self.prefill_step_size
         elif self.vision_prefill_token_budget <= 0:
             raise ValueError("vision_prefill_token_budget must be positive")
         if self.vision_min_pixels < 0 or self.vision_max_pixels < 0:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -76,7 +76,7 @@ class MLLMSchedulerConfig:
     # must remain aligned with their placeholder tokens. Keep their admission
     # budget independent from the language-model prefill chunk so a measured
     # small chunk (for example Gemma 4 at 512) does not reject normal images.
-    vision_prefill_token_budget: int = 8192
+    vision_prefill_token_budget: int | None = None
     # Optional image-resolution bounds forwarded to dynamic-resolution
     # processors (Qwen2.5/3-VL). Zero leaves model defaults unchanged.
     vision_min_pixels: int = 0
@@ -100,6 +100,10 @@ class MLLMSchedulerConfig:
     allow_arrays_cache: bool = False
 
     def __post_init__(self) -> None:
+        if self.vision_prefill_token_budget is None:
+            self.vision_prefill_token_budget = max(self.prefill_step_size, 8192)
+        elif self.vision_prefill_token_budget <= 0:
+            raise ValueError("vision_prefill_token_budget must be positive")
         if self.vision_min_pixels < 0 or self.vision_max_pixels < 0:
             raise ValueError("vision pixel bounds must be non-negative")
         if (
@@ -465,6 +469,8 @@ class MLLMScheduler:
 
             # Default sampler (can be overridden per-request in future)
             sampler = make_sampler(temp=0.7, top_p=0.9)
+            vision_prefill_token_budget = self.config.vision_prefill_token_budget
+            assert vision_prefill_token_budget is not None
 
             self.batch_generator = MLLMBatchGenerator(
                 model=self.model,
@@ -477,7 +483,7 @@ class MLLMScheduler:
                 completion_batch_size=self.config.completion_batch_size,
                 allow_arrays_cache=self.config.allow_arrays_cache,
                 prefill_step_size=self.config.prefill_step_size,
-                vision_prefill_token_budget=self.config.vision_prefill_token_budget,
+                vision_prefill_token_budget=vision_prefill_token_budget,
                 vision_min_pixels=self.config.vision_min_pixels,
                 vision_max_pixels=self.config.vision_max_pixels,
             )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -68,15 +68,15 @@ class MLLMSchedulerConfig:
     prefill_batch_size: int = 16
     # Completion batch size
     completion_batch_size: int = 16
-    # Prefill step size — per-request prompt-token budget. Vision tokens
-    # balloon the prompt size on VLMs (a 1920×1080 screenshot alone is
-    # ~2200 tokens on Qwen3-VL), so the MLLM-side default is 8192 to
-    # cover typical desktop screenshots and small multi-image messages
-    # out-of-the-box. ``BatchedEngine._start_mllm`` applies a bump-policy
-    # (see ``_resolve_mllm_prefill_step_size``) so a SchedulerConfig
-    # carrying the text-LLM default (2048) gets bumped to 8192, while
-    # any explicit operator-set value is honored as-is (#682, codex r2).
+    # Language-model prefill chunk. ``BatchedEngine._start_mllm`` applies a
+    # compatibility bump to the direct MLLM default, while measured model
+    # profiles may select a smaller value.
     prefill_step_size: int = 8192
+    # Vision-bearing prompts cannot always be chunked because image features
+    # must remain aligned with their placeholder tokens. Keep their admission
+    # budget independent from the language-model prefill chunk so a measured
+    # small chunk (for example Gemma 4 at 512) does not reject normal images.
+    vision_prefill_token_budget: int = 8192
     # Optional image-resolution bounds forwarded to dynamic-resolution
     # processors (Qwen2.5/3-VL). Zero leaves model defaults unchanged.
     vision_min_pixels: int = 0
@@ -477,6 +477,7 @@ class MLLMScheduler:
                 completion_batch_size=self.config.completion_batch_size,
                 allow_arrays_cache=self.config.allow_arrays_cache,
                 prefill_step_size=self.config.prefill_step_size,
+                vision_prefill_token_budget=self.config.vision_prefill_token_budget,
                 vision_min_pixels=self.config.vision_min_pixels,
                 vision_max_pixels=self.config.vision_max_pixels,
             )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -514,7 +514,18 @@ class SchedulerConfig:
     # RAPID_MLX_IDLE_CACHE_CLEAR_SECONDS; 0 explicitly disables it.
     idle_cache_clear_seconds: float | None = None
 
+    # Independent MLLM vision admission budget. ``None`` preserves legacy
+    # programmatic behavior by letting BatchedEngine use prefill_step_size.
+    # CLI frontends always resolve this explicitly so profile-selected chunks
+    # can retain the safe MLLM default without taking control from operators.
+    vision_prefill_token_budget: int | None = None
+
     def __post_init__(self) -> None:
+        if (
+            self.vision_prefill_token_budget is not None
+            and self.vision_prefill_token_budget <= 0
+        ):
+            raise ValueError("vision_prefill_token_budget must be positive")
         if self.vision_min_pixels < 0 or self.vision_max_pixels < 0:
             raise ValueError("vision pixel bounds must be non-negative")
         if (

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2878,6 +2878,15 @@ Examples:
         "Larger values may improve TTFT on Apple Silicon with sufficient memory.",
     )
     parser.add_argument(
+        "--vision-prefill-token-budget",
+        type=int,
+        default=None,
+        help=(
+            "Advanced per-vision-request admission budget. Defaults to 8192; "
+            "explicit --prefill-step-size keeps the legacy shared limit."
+        ),
+    )
+    parser.add_argument(
         "--vision-min-pixels",
         type=int,
         default=0,
@@ -3157,8 +3166,22 @@ Examples:
     ):
         parser.error("--vision-min-pixels must not exceed --vision-max-pixels")
 
+    import sys
+
+    prefill_user_set_explicit = "--prefill-step-size" in sys.argv or any(
+        value.startswith("--prefill-step-size=") for value in sys.argv
+    )
+    vision_prefill_token_budget = args.vision_prefill_token_budget
+    if vision_prefill_token_budget is None:
+        vision_prefill_token_budget = (
+            args.prefill_step_size if prefill_user_set_explicit else 8192
+        )
+    if vision_prefill_token_budget <= 0:
+        parser.error("--vision-prefill-token-budget must be positive")
+
     scheduler_config = SchedulerConfig(
         prefill_step_size=args.prefill_step_size,
+        vision_prefill_token_budget=vision_prefill_token_budget,
         vision_min_pixels=args.vision_min_pixels,
         vision_max_pixels=args.vision_max_pixels,
         pflash_config=server_pflash_config,


### PR DESCRIPTION
## Summary

- separates language-model prefill chunking from the MLLM vision admission budget
- enables the measured 512-token default for Gemma 4 12B 4-bit without rejecting normal image prompts
- preserves larger explicit operator values and adds startup observability for both effective values
- records the zero-flag Desktop-equivalent service spot check and benchmark rationale

## User impact

A non-technical Rapid Desktop user only selects Gemma 4 12B and starts it. The backend automatically chooses the measured 512 chunk while retaining an 8192-token image safety budget; no GUI performance controls are required.

## Validation

- 3,183 focused MLLM, profile, alias, CLI, and server tests passed
- zero-flag Gemma service startup reported prefill_step_size=512 and vision_prefill_token_budget=8192
- a real 64x64 PNG request returned HTTP 200 with non-empty model output
- Ruff, JSON parsing, formatting, and diff checks passed