### PR TITLE
fix(mac): confirm model switches with active requests

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -103,11 +103,14 @@ final class AudioViewModel {
         isLoadingVoices = true
         errorMessage = nil
         defer { isLoadingVoices = false }
-        guard await server.ensureServing(
+        let servingOutcome = await server.ensureServingOutcome(
             alias: entry.alias,
             hfPath: entry.hfRepo,
+            estimatedMemoryGB: nil,
             residencyEligible: false
-        ) else {
+        )
+        guard servingOutcome != .cancelled else { return false }
+        guard servingOutcome == .ready else {
             errorMessage = "The speech model couldn't start. Audio support may be unavailable in this app build."
             return false
         }
@@ -145,11 +148,14 @@ final class AudioViewModel {
         errorMessage = nil
         synthesizedAudio = nil
         defer { isSynthesizing = false }
-        guard await server.ensureServing(
+        let servingOutcome = await server.ensureServingOutcome(
             alias: entry.alias,
             hfPath: entry.hfRepo,
+            estimatedMemoryGB: nil,
             residencyEligible: false
-        ) else {
+        )
+        guard servingOutcome != .cancelled else { return }
+        guard servingOutcome == .ready else {
             errorMessage = "The speech model is no longer running. Load its voices and try again."
             return
         }
@@ -177,12 +183,14 @@ final class AudioViewModel {
         errorMessage = nil
         defer { previewingVoice = nil }
 
-        guard await server.ensureServing(
-                  alias: entry.alias,
-                  hfPath: entry.hfRepo,
-                  residencyEligible: false
-              ),
-              !Task.isCancelled else {
+        let servingOutcome = await server.ensureServingOutcome(
+            alias: entry.alias,
+            hfPath: entry.hfRepo,
+            estimatedMemoryGB: nil,
+            residencyEligible: false
+        )
+        guard servingOutcome != .cancelled else { return nil }
+        guard servingOutcome == .ready, !Task.isCancelled else {
             if !Task.isCancelled {
                 errorMessage = "The speech model is no longer running. Load its voices and try again."
             }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -833,7 +833,7 @@ final class ChatViewModel {
             // `ensureServing` short-circuits when we are already serving
             // this alias, so the warm path pays only a state read.
             if let server {
-                let ready = await server.ensureServing(
+                let servingOutcome = await server.ensureServingOutcome(
                     alias: alias,
                     hfPath: startupHFPath,
                     estimatedMemoryGB: nil,
@@ -851,7 +851,11 @@ final class ChatViewModel {
                     finishStartupCancellation(placeholderIndex: placeholderIndex, epoch: epoch)
                     return
                 }
-                guard ready else {
+                if servingOutcome == .cancelled {
+                    finishStartupCancellation(placeholderIndex: placeholderIndex, epoch: epoch)
+                    return
+                }
+                guard servingOutcome == .ready else {
                     finishWithStartupFailure(
                         placeholderIndex: placeholderIndex,
                         alias: alias,
@@ -1844,13 +1848,14 @@ final class ChatViewModel {
         let trimmed = newAlias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         if let server {
-            let ok = await server.ensureServing(
+            let servingOutcome = await server.ensureServingOutcome(
                 alias: trimmed,
                 hfPath: nil,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant
             )
-            guard ok else {
+            guard servingOutcome != .cancelled else { return }
+            guard servingOutcome == .ready else {
                 lastFailureKind = .modelLoadFailed
                 lastError = FailureDiagnoser.diagnosis(
                     for: .modelLoadFailed,

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -266,13 +266,15 @@ final class ImageGenViewModel {
         let size = outputSize
         guard !trimmed.isEmpty else { return }
         await withRequest {
-            guard await self.server.ensureServing(
+            let servingOutcome = await self.server.ensureServingOutcome(
                 alias: target.alias,
                 hfPath: target.hfPath,
                 estimatedMemoryGB: target.estimatedMemoryGB,
                 imageMode: .generation,
                 residencyEligible: false
-            ) else {
+            )
+            guard servingOutcome != .cancelled else { throw CancellationError() }
+            guard servingOutcome == .ready else {
                 throw ImageClientError.notReady
             }
             guard !self.cancelling else { throw CancellationError() }
@@ -300,13 +302,15 @@ final class ImageGenViewModel {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         await withRequest {
-            guard await self.server.ensureServing(
+            let servingOutcome = await self.server.ensureServingOutcome(
                 alias: target.alias,
                 hfPath: target.hfPath,
                 estimatedMemoryGB: target.estimatedMemoryGB,
                 imageMode: .editing,
                 residencyEligible: false
-            ) else {
+            )
+            guard servingOutcome != .cancelled else { throw CancellationError() }
+            guard servingOutcome == .ready else {
                 throw ImageClientError.notReady
             }
             guard !self.cancelling else { throw CancellationError() }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -360,6 +360,7 @@ struct RapidApp: App {
                 .environment(mcpApproval)
                 .environment(mcpTools)
                 .environment(perfConfig)
+                .activeRequestSwitchAlert()
                 .task {
                     // Dictation is a background service: arm it at launch so
                     // the hotkey works without ever opening the Audio tab.
@@ -517,6 +518,7 @@ struct RapidApp: App {
                 .environment(mcpApproval)
                 .environment(mcpTools)
                 .environment(perfConfig)
+                .activeRequestSwitchAlert()
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 720)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2,6 +2,48 @@ import Darwin
 import Foundation
 import Observation
 
+struct ActiveRequestSwitchWarning: Identifiable, Sendable, Equatable {
+    let id: UUID
+    let currentAlias: String
+    let targetAlias: String
+    let activeRequests: Int
+}
+
+struct ActiveRequestSwitchConfirmationQueue {
+    private struct Pending {
+        let warning: ActiveRequestSwitchWarning
+        let requestID: UUID
+    }
+
+    private var pending: [Pending] = []
+    private var decisions: [UUID: Bool] = [:]
+
+    var currentWarning: ActiveRequestSwitchWarning? { pending.first?.warning }
+
+    mutating func enqueue(_ warning: ActiveRequestSwitchWarning, requestID: UUID) {
+        pending.append(Pending(warning: warning, requestID: requestID))
+    }
+
+    func isPending(_ requestID: UUID) -> Bool {
+        pending.contains { $0.requestID == requestID }
+    }
+
+    mutating func resolveCurrent(_ warning: ActiveRequestSwitchWarning, confirmed: Bool) {
+        guard pending.first?.warning.id == warning.id else { return }
+        let item = pending.removeFirst()
+        decisions[item.requestID] = confirmed
+    }
+
+    mutating func takeDecision(for requestID: UUID) -> Bool? {
+        decisions.removeValue(forKey: requestID)
+    }
+
+    mutating func abandon(_ requestID: UUID) {
+        decisions.removeValue(forKey: requestID)
+        pending.removeAll { $0.requestID == requestID }
+    }
+}
+
 /// FIFO state machine for memory-risk confirmations. A request token is
 /// present for ``ensureServing`` callers that must await their own answer;
 /// direct ``start`` calls still queue a prompt but retain no result.
@@ -157,6 +199,12 @@ final class ServerManager {
     /// is answered. This prevents overlapping ``ensureServing`` calls from
     /// consuming one another's confirmation (#1463).
     private var memoryConfirmations = MemoryLoadConfirmationQueue()
+
+    var pendingActiveRequestSwitch: ActiveRequestSwitchWarning? {
+        activeRequestSwitchConfirmations.currentWarning
+    }
+
+    private var activeRequestSwitchConfirmations = ActiveRequestSwitchConfirmationQueue()
 
     /// Live-memory source. Production uses the host probe; tests replace it so
     /// launch auto-start semantics can be verified without depending on the
@@ -957,6 +1005,25 @@ final class ServerManager {
             return true
         }
 
+        // Switching a live serve process can terminate in-flight API streams.
+        // The residency endpoint already reports this count; refresh it at the
+        // decision point rather than relying on the last UI polling snapshot.
+        await refreshResidency()
+        let activeRequests = residency.activeRequestCount
+        if activeRequests > 0 {
+            let requestID = UUID()
+            let warning = ActiveRequestSwitchWarning(
+                id: UUID(),
+                currentAlias: servingAlias ?? residency.models.first(where: { $0.primary })?.displayName() ?? "the current model",
+                targetAlias: trimmed,
+                activeRequests: activeRequests
+            )
+            activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
+            guard await awaitActiveRequestSwitchDecision(for: requestID) == true else {
+                return false
+            }
+        }
+
         // Any fresh load attempt — resident, cold start, or the legacy
         // stop/start fallback — supersedes a stale rejection for THIS alias so
         // the surface stops showing last round's result while this load is in
@@ -1172,6 +1239,26 @@ final class ServerManager {
             }
         }
         return memoryConfirmations.takeDecision(for: requestID)
+    }
+
+    private func awaitActiveRequestSwitchDecision(for requestID: UUID) async -> Bool? {
+        while activeRequestSwitchConfirmations.isPending(requestID) {
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                activeRequestSwitchConfirmations.abandon(requestID)
+                return false
+            }
+        }
+        return activeRequestSwitchConfirmations.takeDecision(for: requestID)
+    }
+
+    func confirmActiveRequestSwitch(_ warning: ActiveRequestSwitchWarning) {
+        activeRequestSwitchConfirmations.resolveCurrent(warning, confirmed: true)
+    }
+
+    func cancelActiveRequestSwitch(_ warning: ActiveRequestSwitchWarning) {
+        activeRequestSwitchConfirmations.resolveCurrent(warning, confirmed: false)
     }
 
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1034,7 +1034,7 @@ final class ServerManager {
             ).first {
                 $0.alias.caseInsensitiveCompare(trimmed) == .orderedSame
             }
-            if Task.isCancelled || didSignalShutdown { return false }
+            if Task.isCancelled || didSignalShutdown { return .cancelled }
             requestedCatalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
                 forAlias: trimmed,
                 isBuiltinProfile: entry?.isBuiltinProfile,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -6,7 +6,17 @@ struct ActiveRequestSwitchWarning: Identifiable, Sendable, Equatable {
     let id: UUID
     let currentAlias: String
     let targetAlias: String
-    let activeRequests: Int
+    /// Nil when the decision-point status request failed. In that case the
+    /// switch still requires confirmation because an active stream may exist.
+    let activeRequests: Int?
+}
+
+enum EnsureServingOutcome: Equatable {
+    case ready
+    case cancelled
+    case failed
+
+    var isReady: Bool { self == .ready }
 }
 
 struct ActiveRequestSwitchConfirmationQueue {
@@ -249,16 +259,18 @@ final class ServerManager {
         isModelResident(alias) ? .ready(alias: alias) : state
     }
 
-    func refreshResidency() async {
+    @discardableResult
+    func refreshResidency() async -> Bool {
         guard case .ready = state else {
             residency = .empty
-            return
+            return true
         }
         guard let snapshot = await residencyClient.fetch(
             port: activePort,
             bearer: activeBearer
-        ) else { return }
+        ) else { return false }
         residency = snapshot
+        return true
     }
 
     /// Alias of the child that currently owns the runtime — for BOTH
@@ -961,8 +973,26 @@ final class ServerManager {
         imageMode: ResidentImageMode? = nil,
         residencyEligible: Bool = true
     ) async -> Bool {
+        await ensureServingOutcome(
+            alias: alias,
+            hfPath: hfPath,
+            estimatedMemoryGB: estimatedMemoryGB,
+            replacementGroup: replacementGroup,
+            imageMode: imageMode,
+            residencyEligible: residencyEligible
+        ).isReady
+    }
+
+    func ensureServingOutcome(
+        alias: String,
+        hfPath: String?,
+        estimatedMemoryGB: Double?,
+        replacementGroup: ResidentModelReplacementGroup? = nil,
+        imageMode: ResidentImageMode? = nil,
+        residencyEligible: Bool = true
+    ) async -> EnsureServingOutcome {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
+        guard !trimmed.isEmpty else { return .failed }
         let requestedPerformanceFlags = perfLaunchFlagsProvider?(trimmed) ?? []
         var requestedCatalogSupportsImageInput = false
         // Cold start delegates to `start`, which resolves the same metadata
@@ -998,19 +1028,19 @@ final class ServerManager {
         // chat send before the request can leave the app.
         if case .ready(let current) = state, current == trimmed,
            !speculativeSettingChanged, !requiresImageLaneRestart {
-            return true
+            return .ready
         }
         if replacementGroup == nil, isModelResident(trimmed),
            !speculativeSettingChanged, !requiresImageLaneRestart {
-            return true
+            return .ready
         }
 
         // Switching a live serve process can terminate in-flight API streams.
         // The residency endpoint already reports this count; refresh it at the
         // decision point rather than relying on the last UI polling snapshot.
-        await refreshResidency()
-        let activeRequests = residency.activeRequestCount
-        if activeRequests > 0 {
+        let residencyIsCurrent = await refreshResidency()
+        let activeRequests = residencyIsCurrent ? residency.activeRequestCount : nil
+        if activeRequests == nil || activeRequests! > 0 {
             let requestID = UUID()
             let warning = ActiveRequestSwitchWarning(
                 id: UUID(),
@@ -1020,7 +1050,7 @@ final class ServerManager {
             )
             activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
             guard await awaitActiveRequestSwitchDecision(for: requestID) == true else {
-                return false
+                return .cancelled
             }
         }
 
@@ -1104,7 +1134,7 @@ final class ServerManager {
                 if residentLoadAttemptTokens[trimmed] == attemptToken {
                     residentLoadFailures[trimmed] = nil
                 }
-                return true
+                return .ready
             case .unsupported:
                 break
             case .rejected(let message):
@@ -1122,7 +1152,7 @@ final class ServerManager {
                         message: LogScrubber.scrub(message)
                     )
                 }
-                return false
+                return .failed
             }
         }
         // Someone else — the picker's Start CTA, auto-start on launch,
@@ -1132,7 +1162,7 @@ final class ServerManager {
         // would re-enter a multi-gigabyte download. Wait for it.
         if case .starting(let current) = state, current == trimmed {
             await awaitStartupSettled(alias: trimmed)
-            return isServing(trimmed)
+            return isServing(trimmed) ? .ready : .failed
         }
         // Tear down whatever's there (a DIFFERENT alias, ready or
         // mid-``.starting``). ``stop()`` is a noop if child is nil, so
@@ -1168,7 +1198,7 @@ final class ServerManager {
         if case .starting(let current) = state, current == trimmed {
             await awaitStartupSettled(alias: trimmed)
         }
-        return isServing(trimmed)
+        return isServing(trimmed) ? .ready : .failed
     }
 
     /// Rebuild only the named resident engine with its current performance

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -52,6 +52,13 @@ struct ActiveRequestSwitchConfirmationQueue {
         decisions.removeValue(forKey: requestID)
         pending.removeAll { $0.requestID == requestID }
     }
+
+    mutating func cancelAll() {
+        for item in pending {
+            decisions[item.requestID] = false
+        }
+        pending.removeAll()
+    }
 }
 
 /// FIFO state machine for memory-risk confirmations. A request token is
@@ -1182,6 +1189,7 @@ final class ServerManager {
         if child != nil,
            await confirmActiveRequestSwitch(
                to: trimmed,
+               confirmWhenIdle: true,
                activeRequests: { $0.activeRequestCount }
            ) == false {
             return .cancelled
@@ -1238,11 +1246,12 @@ final class ServerManager {
         if child != nil,
            await confirmActiveRequestSwitch(
                to: trimmed,
+               confirmWhenIdle: true,
                activeRequests: { $0.activeRequestCount }
            ) == false {
             return .cancelled
         }
-        await stop()
+        await stop(preservingLastServedAlias: false)
         return await ensureServingOutcomeLocked(
             alias: trimmed,
             hfPath: hfPath,
@@ -1254,11 +1263,12 @@ final class ServerManager {
 
     private func confirmActiveRequestSwitch(
         to targetAlias: String,
+        confirmWhenIdle: Bool = false,
         activeRequests count: (ModelResidencySnapshot) -> Int
     ) async -> Bool {
         let residencyIsCurrent = await refreshResidency(timeoutInterval: 2)
         let activeRequests = residencyIsCurrent ? count(residency) : nil
-        if activeRequests == 0 { return true }
+        if activeRequests == 0, !confirmWhenIdle { return true }
         let requestID = UUID()
         let warning = ActiveRequestSwitchWarning(
             id: UUID(),
@@ -2268,6 +2278,9 @@ final class ServerManager {
     /// SIGKILL if still alive. State transitions to `.stopped` on
     /// success.
     func stop() async {
+        activeRequestSwitchConfirmations.cancelAll()
+        guard await acquireModelSwitchOperation() else { return }
+        defer { modelSwitchOperationInProgress = false }
         await stop(preservingLastServedAlias: false)
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -222,7 +222,7 @@ final class ServerManager {
     }
 
     private var activeRequestSwitchConfirmations = ActiveRequestSwitchConfirmationQueue()
-    private var modelSwitchOperationInProgress = false
+    private var modelSwitchOperationOwner: UUID?
 
     /// Live-memory source. Production uses the host probe; tests replace it so
     /// launch auto-start semantics can be verified without depending on the
@@ -1000,15 +1000,16 @@ final class ServerManager {
         imageMode: ResidentImageMode? = nil,
         residencyEligible: Bool = true
     ) async -> EnsureServingOutcome {
-        guard await acquireModelSwitchOperation() else { return .cancelled }
-        defer { modelSwitchOperationInProgress = false }
+        guard let operationID = await acquireModelSwitchOperation() else { return .cancelled }
+        defer { releaseModelSwitchOperation(operationID) }
         return await ensureServingOutcomeLocked(
             alias: alias,
             hfPath: hfPath,
             estimatedMemoryGB: estimatedMemoryGB,
             replacementGroup: replacementGroup,
             imageMode: imageMode,
-            residencyEligible: residencyEligible
+            residencyEligible: residencyEligible,
+            operationID: operationID
         )
     }
 
@@ -1018,7 +1019,8 @@ final class ServerManager {
         estimatedMemoryGB: Double?,
         replacementGroup: ResidentModelReplacementGroup? = nil,
         imageMode: ResidentImageMode? = nil,
-        residencyEligible: Bool = true
+        residencyEligible: Bool = true,
+        operationID: UUID
     ) async -> EnsureServingOutcome {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failed }
@@ -1034,7 +1036,8 @@ final class ServerManager {
             ).first {
                 $0.alias.caseInsensitiveCompare(trimmed) == .orderedSame
             }
-            if Task.isCancelled || didSignalShutdown { return .cancelled }
+            if Task.isCancelled || didSignalShutdown
+                || !ownsModelSwitchOperation(operationID) { return .cancelled }
             requestedCatalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
                 forAlias: trimmed,
                 isBuiltinProfile: entry?.isBuiltinProfile,
@@ -1104,6 +1107,7 @@ final class ServerManager {
                ) == false {
                 return .cancelled
             }
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
             // Publish before crossing the network await so SwiftUI replaces
             // the still-pressable CTA with an honest working state in the
             // same run-loop turn. Count rather than coalescing here: callers
@@ -1128,6 +1132,7 @@ final class ServerManager {
                 port: activePort,
                 bearer: activeBearer
             )
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
             switch result {
             case .loaded(let status):
                 if !residency.contains(status.id) {
@@ -1142,6 +1147,7 @@ final class ServerManager {
                     )
                 }
                 await refreshResidency()
+                guard ownsModelSwitchOperation(operationID) else { return .cancelled }
                 if replacementGroup != nil {
                     state = .ready(alias: trimmed)
                 }
@@ -1182,6 +1188,7 @@ final class ServerManager {
         // would re-enter a multi-gigabyte download. Wait for it.
         if case .starting(let current) = state, current == trimmed {
             await awaitStartupSettled(alias: trimmed)
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
             return isServing(trimmed) ? .ready : .failed
         }
         // Cold/modal starts and the legacy residency fallback replace the
@@ -1194,15 +1201,18 @@ final class ServerManager {
            ) == false {
             return .cancelled
         }
+        guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         // Tear down whatever's there (a DIFFERENT alias, ready or
         // mid-``.starting``). ``stop()`` is a noop if child is nil, so
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
         if child != nil {
             await stop(preservingLastServedAlias: true)
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         }
         let memoryRequestID = UUID()
         await start(alias: trimmed, hfPath: hfPath, memoryRequestID: memoryRequestID)
+        guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         // ``start`` also returns without spawning when the pre-load
         // memory guard parks the load on a confirmation prompt. Reading
         // ``isServing`` now would report "couldn't start the model"
@@ -1211,12 +1221,14 @@ final class ServerManager {
         // be marked failed and then silently dropped the moment the user
         // picks "Load anyway". Wait for the answer instead.
         if let decision = await awaitMemoryDecision(for: memoryRequestID) {
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
             if case .confirmed(let seq) = decision {
                 // Wait out the actual re-entered launch — no fixed bound,
                 // because it may legitimately sit on a background download.
                 // Bind to THIS confirmation so an unrelated later cancel
                 // cannot end the wait early.
                 await awaitConfirmedLaunch(seq)
+                guard ownsModelSwitchOperation(operationID) else { return .cancelled }
             }
         }
         // ``start`` returns silently when another caller already owns
@@ -1227,6 +1239,7 @@ final class ServerManager {
         // instead, exactly as in the short-circuit above.
         if case .starting(let current) = state, current == trimmed {
             await awaitStartupSettled(alias: trimmed)
+            guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         }
         return isServing(trimmed) ? .ready : .failed
     }
@@ -1241,8 +1254,8 @@ final class ServerManager {
     ) async -> EnsureServingOutcome {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failed }
-        guard await acquireModelSwitchOperation() else { return .cancelled }
-        defer { modelSwitchOperationInProgress = false }
+        guard let operationID = await acquireModelSwitchOperation() else { return .cancelled }
+        defer { releaseModelSwitchOperation(operationID) }
         if child != nil,
            await confirmActiveRequestSwitch(
                to: trimmed,
@@ -1251,13 +1264,16 @@ final class ServerManager {
            ) == false {
             return .cancelled
         }
+        guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         await stop(preservingLastServedAlias: false)
+        guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         return await ensureServingOutcomeLocked(
             alias: trimmed,
             hfPath: hfPath,
             estimatedMemoryGB: estimatedMemoryGB,
             imageMode: imageMode,
-            residencyEligible: residencyEligible
+            residencyEligible: residencyEligible,
+            operationID: operationID
         )
     }
 
@@ -1285,14 +1301,25 @@ final class ServerManager {
     /// Serialize the full check → confirmation → replacement transaction.
     /// A later switch re-enters only after the earlier operation has settled,
     /// so its decision-point fetch observes the newly serving model.
-    private func acquireModelSwitchOperation() async -> Bool {
-        while modelSwitchOperationInProgress {
-            guard !Task.isCancelled else { return false }
+    private func acquireModelSwitchOperation() async -> UUID? {
+        while modelSwitchOperationOwner != nil {
+            guard !Task.isCancelled else { return nil }
             try? await Task.sleep(for: .milliseconds(10))
         }
-        guard !Task.isCancelled else { return false }
-        modelSwitchOperationInProgress = true
-        return true
+        guard !Task.isCancelled else { return nil }
+        let operationID = UUID()
+        modelSwitchOperationOwner = operationID
+        return operationID
+    }
+
+    private func ownsModelSwitchOperation(_ operationID: UUID) -> Bool {
+        modelSwitchOperationOwner == operationID
+    }
+
+    private func releaseModelSwitchOperation(_ operationID: UUID) {
+        if modelSwitchOperationOwner == operationID {
+            modelSwitchOperationOwner = nil
+        }
     }
 
     /// Rebuild only the named resident engine with its current performance
@@ -2279,8 +2306,9 @@ final class ServerManager {
     /// success.
     func stop() async {
         activeRequestSwitchConfirmations.cancelAll()
-        guard await acquireModelSwitchOperation() else { return }
-        defer { modelSwitchOperationInProgress = false }
+        let stopOperationID = UUID()
+        modelSwitchOperationOwner = stopOperationID
+        defer { releaseModelSwitchOperation(stopOperationID) }
         await stop(preservingLastServedAlias: false)
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -19,6 +19,12 @@ enum EnsureServingOutcome: Equatable {
     var isReady: Bool { self == .ready }
 }
 
+private enum ActiveRequestSwitchDecision {
+    case proceed
+    case confirmed
+    case cancelled
+}
+
 struct ActiveRequestSwitchConfirmationQueue {
     private struct Pending {
         let warning: ActiveRequestSwitchWarning
@@ -1092,22 +1098,30 @@ final class ServerManager {
         // surface as a hard failure instead of the process swap they actually
         // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
         let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
-        if Self.residencyLoadApplies(
+        let residencyApplies = Self.residencyLoadApplies(
             residencyEligible: residencyEligible && !speculativeRequested
                 && !speculativeSettingChanged && !requiresImageLaneRestart,
             readyWithChild: readyWithChild
-        ) {
+        )
+        var processReplacementWasConfirmed = false
+        if residencyApplies, let replacementGroup {
             // An explicit assistant replacement evicts only text/VLM engines.
             // A bare resident admission does not evict siblings and therefore
             // must not warn merely because an unrelated engine is busy.
-            if let replacementGroup,
-               await confirmActiveRequestSwitch(
-                   to: trimmed,
-                   activeRequests: { $0.activeRequestCount(replacingGroup: replacementGroup) }
-               ) == false {
+            switch await confirmActiveRequestSwitch(
+                to: trimmed,
+                activeRequests: { $0.activeRequestCount(replacingGroup: replacementGroup) }
+            ) {
+            case .proceed:
+                break
+            case .confirmed:
+                processReplacementWasConfirmed = true
+            case .cancelled:
                 return .cancelled
             }
             guard ownsModelSwitchOperation(operationID) else { return .cancelled }
+        }
+        if residencyApplies, !processReplacementWasConfirmed {
             // Publish before crossing the network await so SwiftUI replaces
             // the still-pressable CTA with an honest working state in the
             // same run-loop turn. Count rather than coalescing here: callers
@@ -1163,6 +1177,22 @@ final class ServerManager {
                 return .ready
             case .unsupported:
                 break
+            case .busy:
+                // A request acquired a backend lease after our zero snapshot.
+                // The atomic resident replacement correctly refused to evict
+                // it; ask for interruption consent, then use process fallback.
+                switch await confirmActiveRequestSwitch(
+                    to: trimmed,
+                    confirmWhenIdle: true,
+                    activeRequests: { $0.activeRequestCount }
+                ) {
+                case .confirmed:
+                    processReplacementWasConfirmed = true
+                case .cancelled:
+                    return .cancelled
+                case .proceed:
+                    break
+                }
             case .rejected(let message):
                 appendLogLines(["Resident model load declined: \(message)"])
                 // Mirror the same redaction the log pane applies so a
@@ -1193,13 +1223,17 @@ final class ServerManager {
         }
         // Cold/modal starts and the legacy residency fallback replace the
         // process, so every resident engine is in the affected set.
-        if child != nil,
-           await confirmActiveRequestSwitch(
-               to: trimmed,
-               confirmWhenIdle: true,
-               activeRequests: { $0.activeRequestCount }
-           ) == false {
-            return .cancelled
+        if child != nil, !processReplacementWasConfirmed {
+            switch await confirmActiveRequestSwitch(
+                to: trimmed,
+                confirmWhenIdle: true,
+                activeRequests: { $0.activeRequestCount }
+            ) {
+            case .confirmed, .proceed:
+                break
+            case .cancelled:
+                return .cancelled
+            }
         }
         guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         // Tear down whatever's there (a DIFFERENT alias, ready or
@@ -1256,13 +1290,17 @@ final class ServerManager {
         guard !trimmed.isEmpty else { return .failed }
         guard let operationID = await acquireModelSwitchOperation() else { return .cancelled }
         defer { releaseModelSwitchOperation(operationID) }
-        if child != nil,
-           await confirmActiveRequestSwitch(
+        if child != nil {
+            switch await confirmActiveRequestSwitch(
                to: trimmed,
                confirmWhenIdle: true,
                activeRequests: { $0.activeRequestCount }
-           ) == false {
-            return .cancelled
+            ) {
+            case .confirmed, .proceed:
+                break
+            case .cancelled:
+                return .cancelled
+            }
         }
         guard ownsModelSwitchOperation(operationID) else { return .cancelled }
         await stop(preservingLastServedAlias: false)
@@ -1281,10 +1319,10 @@ final class ServerManager {
         to targetAlias: String,
         confirmWhenIdle: Bool = false,
         activeRequests count: (ModelResidencySnapshot) -> Int
-    ) async -> Bool {
+    ) async -> ActiveRequestSwitchDecision {
         let residencyIsCurrent = await refreshResidency(timeoutInterval: 2)
         let activeRequests = residencyIsCurrent ? count(residency) : nil
-        if activeRequests == 0, !confirmWhenIdle { return true }
+        if activeRequests == 0, !confirmWhenIdle { return .proceed }
         let requestID = UUID()
         let warning = ActiveRequestSwitchWarning(
             id: UUID(),
@@ -1296,6 +1334,8 @@ final class ServerManager {
         )
         activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
         return await awaitActiveRequestSwitchDecision(for: requestID) == true
+            ? .confirmed
+            : .cancelled
     }
 
     /// Serialize the full check → confirmation → replacement transaction.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1035,25 +1035,6 @@ final class ServerManager {
             return .ready
         }
 
-        // Switching a live serve process can terminate in-flight API streams.
-        // The residency endpoint already reports this count; refresh it at the
-        // decision point rather than relying on the last UI polling snapshot.
-        let residencyIsCurrent = await refreshResidency()
-        let activeRequests = residencyIsCurrent ? residency.activeRequestCount : nil
-        if activeRequests == nil || activeRequests! > 0 {
-            let requestID = UUID()
-            let warning = ActiveRequestSwitchWarning(
-                id: UUID(),
-                currentAlias: servingAlias ?? residency.models.first(where: { $0.primary })?.displayName() ?? "the current model",
-                targetAlias: trimmed,
-                activeRequests: activeRequests
-            )
-            activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
-            guard await awaitActiveRequestSwitchDecision(for: requestID) == true else {
-                return .cancelled
-            }
-        }
-
         // Any fresh load attempt — resident, cold start, or the legacy
         // stop/start fallback — supersedes a stale rejection for THIS alias so
         // the surface stops showing last round's result while this load is in
@@ -1084,6 +1065,16 @@ final class ServerManager {
                 && !speculativeSettingChanged && !requiresImageLaneRestart,
             readyWithChild: readyWithChild
         ) {
+            // An explicit assistant replacement evicts only text/VLM engines.
+            // A bare resident admission does not evict siblings and therefore
+            // must not warn merely because an unrelated engine is busy.
+            if let replacementGroup,
+               await confirmActiveRequestSwitch(
+                   to: trimmed,
+                   activeRequests: { $0.activeRequestCount(replacingGroup: replacementGroup) }
+               ) == false {
+                return .cancelled
+            }
             // Publish before crossing the network await so SwiftUI replaces
             // the still-pressable CTA with an honest working state in the
             // same run-loop turn. Count rather than coalescing here: callers
@@ -1164,6 +1155,15 @@ final class ServerManager {
             await awaitStartupSettled(alias: trimmed)
             return isServing(trimmed) ? .ready : .failed
         }
+        // Cold/modal starts and the legacy residency fallback replace the
+        // process, so every resident engine is in the affected set.
+        if child != nil,
+           await confirmActiveRequestSwitch(
+               to: trimmed,
+               activeRequests: { $0.activeRequestCount }
+           ) == false {
+            return .cancelled
+        }
         // Tear down whatever's there (a DIFFERENT alias, ready or
         // mid-``.starting``). ``stop()`` is a noop if child is nil, so
         // the idle/stopped/missing cases just fall through to
@@ -1199,6 +1199,53 @@ final class ServerManager {
             await awaitStartupSettled(alias: trimmed)
         }
         return isServing(trimmed) ? .ready : .failed
+    }
+
+    /// Restart a model without exposing a stop-before-confirm race to views.
+    func restartServingOutcome(
+        alias: String,
+        hfPath: String?,
+        estimatedMemoryGB: Double? = nil,
+        imageMode: ResidentImageMode? = nil,
+        residencyEligible: Bool = true
+    ) async -> EnsureServingOutcome {
+        let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failed }
+        if child != nil,
+           await confirmActiveRequestSwitch(
+               to: trimmed,
+               activeRequests: { $0.activeRequestCount }
+           ) == false {
+            return .cancelled
+        }
+        await stop()
+        return await ensureServingOutcome(
+            alias: trimmed,
+            hfPath: hfPath,
+            estimatedMemoryGB: estimatedMemoryGB,
+            imageMode: imageMode,
+            residencyEligible: residencyEligible
+        )
+    }
+
+    private func confirmActiveRequestSwitch(
+        to targetAlias: String,
+        activeRequests count: (ModelResidencySnapshot) -> Int
+    ) async -> Bool {
+        let residencyIsCurrent = await refreshResidency()
+        let activeRequests = residencyIsCurrent ? count(residency) : nil
+        if activeRequests == 0 { return true }
+        let requestID = UUID()
+        let warning = ActiveRequestSwitchWarning(
+            id: UUID(),
+            currentAlias: servingAlias
+                ?? residency.models.first(where: { $0.primary })?.displayName()
+                ?? "the current model",
+            targetAlias: targetAlias,
+            activeRequests: activeRequests
+        )
+        activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
+        return await awaitActiveRequestSwitchDecision(for: requestID) == true
     }
 
     /// Rebuild only the named resident engine with its current performance

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -215,6 +215,7 @@ final class ServerManager {
     }
 
     private var activeRequestSwitchConfirmations = ActiveRequestSwitchConfirmationQueue()
+    private var modelSwitchOperationInProgress = false
 
     /// Live-memory source. Production uses the host probe; tests replace it so
     /// launch auto-start semantics can be verified without depending on the
@@ -260,14 +261,15 @@ final class ServerManager {
     }
 
     @discardableResult
-    func refreshResidency() async -> Bool {
+    func refreshResidency(timeoutInterval: TimeInterval? = nil) async -> Bool {
         guard case .ready = state else {
             residency = .empty
             return true
         }
         guard let snapshot = await residencyClient.fetch(
             port: activePort,
-            bearer: activeBearer
+            bearer: activeBearer,
+            timeoutInterval: timeoutInterval
         ) else { return false }
         residency = snapshot
         return true
@@ -991,6 +993,26 @@ final class ServerManager {
         imageMode: ResidentImageMode? = nil,
         residencyEligible: Bool = true
     ) async -> EnsureServingOutcome {
+        guard await acquireModelSwitchOperation() else { return .cancelled }
+        defer { modelSwitchOperationInProgress = false }
+        return await ensureServingOutcomeLocked(
+            alias: alias,
+            hfPath: hfPath,
+            estimatedMemoryGB: estimatedMemoryGB,
+            replacementGroup: replacementGroup,
+            imageMode: imageMode,
+            residencyEligible: residencyEligible
+        )
+    }
+
+    private func ensureServingOutcomeLocked(
+        alias: String,
+        hfPath: String?,
+        estimatedMemoryGB: Double?,
+        replacementGroup: ResidentModelReplacementGroup? = nil,
+        imageMode: ResidentImageMode? = nil,
+        residencyEligible: Bool = true
+    ) async -> EnsureServingOutcome {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failed }
         let requestedPerformanceFlags = perfLaunchFlagsProvider?(trimmed) ?? []
@@ -1211,6 +1233,8 @@ final class ServerManager {
     ) async -> EnsureServingOutcome {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failed }
+        guard await acquireModelSwitchOperation() else { return .cancelled }
+        defer { modelSwitchOperationInProgress = false }
         if child != nil,
            await confirmActiveRequestSwitch(
                to: trimmed,
@@ -1219,7 +1243,7 @@ final class ServerManager {
             return .cancelled
         }
         await stop()
-        return await ensureServingOutcome(
+        return await ensureServingOutcomeLocked(
             alias: trimmed,
             hfPath: hfPath,
             estimatedMemoryGB: estimatedMemoryGB,
@@ -1232,7 +1256,7 @@ final class ServerManager {
         to targetAlias: String,
         activeRequests count: (ModelResidencySnapshot) -> Int
     ) async -> Bool {
-        let residencyIsCurrent = await refreshResidency()
+        let residencyIsCurrent = await refreshResidency(timeoutInterval: 2)
         let activeRequests = residencyIsCurrent ? count(residency) : nil
         if activeRequests == 0 { return true }
         let requestID = UUID()
@@ -1246,6 +1270,19 @@ final class ServerManager {
         )
         activeRequestSwitchConfirmations.enqueue(warning, requestID: requestID)
         return await awaitActiveRequestSwitchDecision(for: requestID) == true
+    }
+
+    /// Serialize the full check → confirmation → replacement transaction.
+    /// A later switch re-enters only after the earlier operation has settled,
+    /// so its decision-point fetch observes the newly serving model.
+    private func acquireModelSwitchOperation() async -> Bool {
+        while modelSwitchOperationInProgress {
+            guard !Task.isCancelled else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        guard !Task.isCancelled else { return false }
+        modelSwitchOperationInProgress = true
+        return true
     }
 
     /// Rebuild only the named resident engine with its current performance

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1278,9 +1278,15 @@ final class ServerManager {
     /// Speculative decoding is installed while the process-owning engine
     /// starts, unlike the resident API's per-engine KV/prefix knobs. Rebuild
     /// one setting changes; conversations and downloaded weights remain.
-    func restartForSpeculativePerformance(alias: String, hfPath: String? = nil) async -> Bool {
-        await stop()
-        return await ensureServing(alias: alias, hfPath: hfPath, residencyEligible: false)
+    func restartForSpeculativePerformance(
+        alias: String,
+        hfPath: String? = nil
+    ) async -> EnsureServingOutcome {
+        await restartServingOutcome(
+            alias: alias,
+            hfPath: hfPath,
+            residencyEligible: false
+        )
     }
 
     /// True when the child is serving exactly this alias.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -215,8 +215,13 @@ struct ServerResidencyClient {
         return request
     }
 
-    func fetch(port: Int, bearer: String?) async -> ModelResidencySnapshot? {
-        let request = request(path: "/v1/models/residency", port: port, bearer: bearer)
+    func fetch(
+        port: Int,
+        bearer: String?,
+        timeoutInterval: TimeInterval? = nil
+    ) async -> ModelResidencySnapshot? {
+        var request = request(path: "/v1/models/residency", port: port, bearer: bearer)
+        if let timeoutInterval { request.timeoutInterval = timeoutInterval }
         guard let (data, response) = try? await session.data(for: request),
               let http = response as? HTTPURLResponse,
               (200...299).contains(http.statusCode)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -129,6 +129,18 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
             .reduce(0) { $0 + max(0, $1.activeRequests) }
     }
 
+    func activeRequestCount(replacingGroup group: ResidentModelReplacementGroup) -> Int {
+        models.lazy
+            .filter { model in
+                guard model.state != "evicting" else { return false }
+                switch group {
+                case .assistant:
+                    return model.modality == "text" || model.modality == "mllm"
+                }
+            }
+            .reduce(0) { $0 + max(0, $1.activeRequests) }
+    }
+
     /// Pick the resident text model that can host chat-only subsystems such
     /// as MCP. The process-owning alias may be an audio model after a user
     /// visits Speech, even while a text engine is resident in that process.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -122,6 +122,13 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
         models.contains { $0.matches(alias) && $0.state != "evicting" }
     }
 
+    /// Requests that would be interrupted by replacing the serving process.
+    var activeRequestCount: Int {
+        models.lazy
+            .filter { $0.state != "evicting" }
+            .reduce(0) { $0 + max(0, $1.activeRequests) }
+    }
+
     /// Pick the resident text model that can host chat-only subsystems such
     /// as MCP. The process-owning alias may be an audio model after a user
     /// visits Speech, even while a text engine is resident in that process.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -158,6 +158,7 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
 enum ResidentModelLoadResult: Sendable, Equatable {
     case loaded(ResidentModelStatus)
     case unsupported
+    case busy(String)
     case rejected(String)
 }
 
@@ -270,6 +271,10 @@ struct ServerResidencyClient {
                 return .unsupported
             }
             let detail = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data))?.detail
+            if http.statusCode == 409, let detail,
+               detail.localizedCaseInsensitiveContains("active request") {
+                return .busy(detail)
+            }
             return .rejected(detail ?? "The model could not be kept resident (HTTP \(http.statusCode)).")
         } catch {
             return .rejected("The model server could not load another resident model.")

--- a/apps/rapid-mac/Sources/Rapid/UI/ActiveRequestSwitchAlert.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ActiveRequestSwitchAlert.swift
@@ -1,0 +1,57 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the process-switch confirmation on whichever Rapid window is active.
+/// The manager is app-scoped, so anchoring this only in ContentView strands a
+/// Settings-initiated restart when the main window is closed.
+private struct ActiveRequestSwitchAlertModifier: ViewModifier {
+    @Environment(ServerManager.self) private var server
+    @State private var hostWindow: NSWindow?
+
+    func body(content: Content) -> some View {
+        let displayedWarning = server.pendingActiveRequestSwitch
+        content
+            .background {
+                WindowAccessor { window in hostWindow = window }
+                    .frame(width: 0, height: 0)
+            }
+            .alert(
+                "Switch models?",
+                isPresented: Binding(
+                    get: {
+                        displayedWarning != nil
+                            && (hostWindow?.isKeyWindow == true || NSApp.keyWindow == nil)
+                    },
+                    set: {
+                        if !$0, let warning = displayedWarning {
+                            server.cancelActiveRequestSwitch(warning)
+                        }
+                    }
+                ),
+                presenting: displayedWarning
+            ) { warning in
+                Button("Cancel", role: .cancel) {
+                    server.cancelActiveRequestSwitch(warning)
+                }
+                .accessibilityIdentifier("ActiveRequestSwitch.Cancel")
+                Button("Switch model", role: .destructive) {
+                    server.confirmActiveRequestSwitch(warning)
+                }
+                .accessibilityIdentifier("ActiveRequestSwitch.Confirm")
+            } message: { warning in
+                if warning.activeRequests == 0 {
+                    Text("Switching from \(warning.currentAlias) to \(warning.targetAlias) briefly stops the current server. New requests may be interrupted during the handoff.")
+                } else if let count = warning.activeRequests {
+                    Text("\(count) active request\(count == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(count == 1 ? "it" : "them").")
+                } else {
+                    Text("Rapid couldn't verify whether requests are active. Switching from \(warning.currentAlias) to \(warning.targetAlias) may interrupt clients using the server.")
+                }
+            }
+    }
+}
+
+extension View {
+    func activeRequestSwitchAlert() -> some View {
+        modifier(ActiveRequestSwitchAlertModifier())
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -546,13 +546,27 @@ struct AudioView: View {
         case .start(let alias), .retry(let alias):
             Task { await loadAudioModel(alias) }
         case .restart(let alias):
-            Task {
-                await server.stop()
-                await loadAudioModel(alias)
-            }
+            Task { await restartAudioModel(alias) }
         case .openModelManagement:
             openModelManagement()
         }
+    }
+
+    private func restartAudioModel(_ alias: String) async {
+        guard let entry = viewModel.audioModels.first(where: { $0.alias == alias }) else { return }
+        let outcome = await server.restartServingOutcome(
+            alias: alias,
+            hfPath: entry.hfRepo,
+            estimatedMemoryGB: ModelSizing.residentEstimateGB(
+                alias: alias,
+                sizeText: entry.sizeOnDisk
+            ),
+            residencyEligible: false
+        )
+        if outcome == .failed {
+            viewModel.errorMessage = "The audio model couldn't restart."
+        }
+        await viewModel.refreshCatalog()
     }
 
     private func loadAudioModel(_ alias: String) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -199,7 +199,7 @@ struct ContentView: View {
             Text(warning.message)
         }
         .alert(
-            "Switch models while requests are active?",
+            "Switch models?",
             isPresented: Binding(
                 get: { server.pendingActiveRequestSwitch != nil },
                 set: {
@@ -219,7 +219,9 @@ struct ContentView: View {
             }
             .accessibilityIdentifier("ActiveRequestSwitch.Confirm")
         } message: { warning in
-            if let count = warning.activeRequests {
+            if warning.activeRequests == 0 {
+                Text("Switching from \(warning.currentAlias) to \(warning.targetAlias) briefly stops the current server. New requests may be interrupted during the handoff.")
+            } else if let count = warning.activeRequests {
                 Text("\(count) active request\(count == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(count == 1 ? "it" : "them").")
             } else {
                 Text("Rapid couldn't verify whether requests are active. Switching from \(warning.currentAlias) to \(warning.targetAlias) may interrupt clients using the server.")

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -219,7 +219,11 @@ struct ContentView: View {
             }
             .accessibilityIdentifier("ActiveRequestSwitch.Confirm")
         } message: { warning in
-            Text("\(warning.activeRequests) active request\(warning.activeRequests == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(warning.activeRequests == 1 ? "it" : "them").")
+            if let count = warning.activeRequests {
+                Text("\(count) active request\(count == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(count == 1 ? "it" : "them").")
+            } else {
+                Text("Rapid couldn't verify whether requests are active. Switching from \(warning.currentAlias) to \(warning.targetAlias) may interrupt clients using the server.")
+            }
         }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -675,8 +675,7 @@ struct ContentView: View {
     private func restartModel(_ target: String) {
         let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
         Task {
-            await server.stop()
-            _ = await server.ensureServing(alias: target, hfPath: hfPath)
+            _ = await server.restartServingOutcome(alias: target, hfPath: hfPath)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -75,6 +75,7 @@ struct ContentView: View {
         // callback must not cancel a newer warning that has reached the queue
         // head in the meantime (#1463).
         let displayedMemoryWarning = server.pendingMemoryWarning
+        let displayedActiveRequestSwitch = server.pendingActiveRequestSwitch
         // Ollama-style layout: a left sidebar (New Chat / Launch / — later —
         // history) + a detail pane. No top model-control bar; the model
         // picker lives inline in the compose box (see ChatView) and the
@@ -196,6 +197,29 @@ struct ContentView: View {
             .accessibilityIdentifier("MemoryWarning.Confirm")
         } message: { warning in
             Text(warning.message)
+        }
+        .alert(
+            "Switch models while requests are active?",
+            isPresented: Binding(
+                get: { server.pendingActiveRequestSwitch != nil },
+                set: {
+                    if !$0, let warning = displayedActiveRequestSwitch {
+                        server.cancelActiveRequestSwitch(warning)
+                    }
+                }
+            ),
+            presenting: displayedActiveRequestSwitch
+        ) { warning in
+            Button("Cancel", role: .cancel) {
+                server.cancelActiveRequestSwitch(warning)
+            }
+            .accessibilityIdentifier("ActiveRequestSwitch.Cancel")
+            Button("Switch model", role: .destructive) {
+                server.confirmActiveRequestSwitch(warning)
+            }
+            .accessibilityIdentifier("ActiveRequestSwitch.Confirm")
+        } message: { warning in
+            Text("\(warning.activeRequests) active request\(warning.activeRequests == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(warning.activeRequests == 1 ? "it" : "them").")
         }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -75,7 +75,6 @@ struct ContentView: View {
         // callback must not cancel a newer warning that has reached the queue
         // head in the meantime (#1463).
         let displayedMemoryWarning = server.pendingMemoryWarning
-        let displayedActiveRequestSwitch = server.pendingActiveRequestSwitch
         // Ollama-style layout: a left sidebar (New Chat / Launch / — later —
         // history) + a detail pane. No top model-control bar; the model
         // picker lives inline in the compose box (see ChatView) and the
@@ -197,35 +196,6 @@ struct ContentView: View {
             .accessibilityIdentifier("MemoryWarning.Confirm")
         } message: { warning in
             Text(warning.message)
-        }
-        .alert(
-            "Switch models?",
-            isPresented: Binding(
-                get: { server.pendingActiveRequestSwitch != nil },
-                set: {
-                    if !$0, let warning = displayedActiveRequestSwitch {
-                        server.cancelActiveRequestSwitch(warning)
-                    }
-                }
-            ),
-            presenting: displayedActiveRequestSwitch
-        ) { warning in
-            Button("Cancel", role: .cancel) {
-                server.cancelActiveRequestSwitch(warning)
-            }
-            .accessibilityIdentifier("ActiveRequestSwitch.Cancel")
-            Button("Switch model", role: .destructive) {
-                server.confirmActiveRequestSwitch(warning)
-            }
-            .accessibilityIdentifier("ActiveRequestSwitch.Confirm")
-        } message: { warning in
-            if warning.activeRequests == 0 {
-                Text("Switching from \(warning.currentAlias) to \(warning.targetAlias) briefly stops the current server. New requests may be interrupted during the handoff.")
-            } else if let count = warning.activeRequests {
-                Text("\(count) active request\(count == 1 ? " is" : "s are") using \(warning.currentAlias). Switching to \(warning.targetAlias) will interrupt \(count == 1 ? "it" : "them").")
-            } else {
-                Text("Rapid couldn't verify whether requests are active. Switching from \(warning.currentAlias) to \(warning.targetAlias) may interrupt clients using the server.")
-            }
         }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -281,8 +281,18 @@ struct ImagesView: View {
         case .restart(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
             Task {
-                await server.stop()
-                await loadImageModel(target, hfPath: hf)
+                let entry = viewModel.imageModels.first { $0.alias == target }
+                _ = await server.restartServingOutcome(
+                    alias: target,
+                    hfPath: hf,
+                    estimatedMemoryGB: ModelSizing.residentEstimateGB(
+                        alias: target,
+                        sizeText: entry?.sizeOnDisk
+                    ),
+                    imageMode: viewModel.isEditing ? .editing : .generation,
+                    residencyEligible: false
+                )
+                await viewModel.refreshCatalog()
             }
         case .openModelManagement:
             settingsRouter.route(.openModelManagement) {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -333,8 +333,11 @@ struct SettingsConnectorsPanel: View {
         ) else { return }
         isRestarting = true
         Task {
-            await server.stop()
-            await server.start(alias: alias)
+            _ = await server.restartServingOutcome(
+                alias: alias,
+                hfPath: nil,
+                residencyEligible: false
+            )
             // The fresh child publishes its connector state on /healthz; the
             // ready transition in ContentView refreshes the catalog, but this
             // panel may be the only thing on screen — refresh here too so the

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -408,13 +408,13 @@ struct SettingsPerformancePanel: View {
             let speculativeChanged = (perf.config(forAlias: alias).speculativePreset != nil)
                 != server.hasAppliedSpeculativeDecoding(forAlias: alias)
             if speculativeChanged {
-                let restarted = await server.restartForSpeculativePerformance(
+                let restartOutcome = await server.restartForSpeculativePerformance(
                     alias: alias,
                     hfPath: entry?.hfRepo
                 )
-                if restarted {
+                if restartOutcome == .ready {
                     launchedFlags = perf.launchFlags(forAlias: alias)
-                } else {
+                } else if restartOutcome == .failed {
                     applyError = "Could not restart this model with its speculative-decoding setting."
                 }
                 isReloading = false

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -240,6 +240,48 @@ struct ModelResidencyTests {
         #expect(server.state == .ready(alias: "current"))
     }
 
+    @Test("Overlapping switches revalidate after the preceding decision")
+    func overlappingSwitchesRevalidate() async throws {
+        OverlappingResidencyProtocol.fetchCount = 0
+        OverlappingResidencyProtocol.lastTimeout = nil
+        let server = makeSwitchServer(protocolClass: OverlappingResidencyProtocol.self)
+        let firstTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "first", hfPath: nil, estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+        let secondTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "second", hfPath: nil, estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let firstWarning = try #require(server.pendingActiveRequestSwitch)
+        #expect(OverlappingResidencyProtocol.fetchCount == 1)
+        #expect(OverlappingResidencyProtocol.lastTimeout == 2)
+        // Stand in for the first transaction installing B while it still owns
+        // the operation gate; the second transaction must observe B afterward.
+        server._testSetState(.ready(alias: "replacement"))
+        server.cancelActiveRequestSwitch(firstWarning)
+        #expect(await firstTask.value == .cancelled)
+
+        // The queued operation fetches again and describes the current process,
+        // rather than reusing the first transaction's A-era warning.
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let secondWarning = try #require(server.pendingActiveRequestSwitch)
+        #expect(secondWarning.currentAlias == "replacement")
+        #expect(OverlappingResidencyProtocol.fetchCount == 2)
+        server.cancelActiveRequestSwitch(secondWarning)
+        #expect(await secondTask.value == .cancelled)
+    }
+
     @Test("Production restart surfaces use the confirmation-aware manager API")
     func restartSurfacesDoNotStopDirectly() throws {
         let rapidMacRoot = URL(fileURLWithPath: #filePath)
@@ -490,6 +532,18 @@ private final class ActiveResidencyProtocol: ResidencySnapshotProtocol, @uncheck
 }
 
 private final class IdleResidencyProtocol: ResidencySnapshotProtocol, @unchecked Sendable {}
+
+private final class OverlappingResidencyProtocol: ResidencySnapshotProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var fetchCount = 0
+    nonisolated(unsafe) static var lastTimeout: TimeInterval?
+    override class var activeRequests: Int { 1 }
+
+    override func startLoading() {
+        Self.fetchCount += 1
+        Self.lastTimeout = request.timeoutInterval
+        super.startLoading()
+    }
+}
 
 private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var capturedBody: Data?

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -251,7 +251,7 @@ struct ModelResidencyTests {
         #expect(server.state == .stopped)
     }
 
-    @Test("Explicit stop preempts a confirmed resident load")
+    @Test("Explicit stop preempts an in-flight resident load")
     func stopPreemptsResidentLoad() async throws {
         SlowResidentLoadProtocol.loadStarted = false
         let server = makeSwitchServer(protocolClass: SlowResidentLoadProtocol.self)
@@ -261,11 +261,6 @@ struct ModelResidencyTests {
                 replacementGroup: .assistant
             )
         }
-        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        let warning = try #require(server.pendingActiveRequestSwitch)
-        server.confirmActiveRequestSwitch(warning)
         for _ in 0..<100 where !SlowResidentLoadProtocol.loadStarted {
             try await Task.sleep(for: .milliseconds(10))
         }
@@ -277,6 +272,31 @@ struct ModelResidencyTests {
         #expect(server.state == .stopped)
         #expect(await switchTask.value == .cancelled)
         #expect(server.state == .stopped)
+    }
+
+    @Test("Backend busy replacement falls back after explicit confirmation")
+    func backendBusyFallsBackAfterConfirmation() async throws {
+        BusyResidentLoadProtocol.fetchCount = 0
+        BusyResidentLoadProtocol.loadAttempted = false
+        let server = makeSwitchServer(protocolClass: BusyResidentLoadProtocol.self)
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        #expect(BusyResidentLoadProtocol.loadAttempted)
+        #expect(warning.activeRequests == 1)
+        server.confirmActiveRequestSwitch(warning)
+
+        // No binary is installed in the harness, so process fallback reaches
+        // its normal cold-start failure after replacing the old child.
+        #expect(await switchTask.value == .failed)
+        #expect(server.pendingActiveRequestSwitch == nil)
     }
 
     @Test("Speculative restart cancellation preserves the active server")
@@ -615,7 +635,7 @@ private final class OverlappingResidencyProtocol: ResidencySnapshotProtocol, @un
 
 private final class SlowResidentLoadProtocol: ResidencySnapshotProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var loadStarted = false
-    override class var activeRequests: Int { 1 }
+    override class var activeRequests: Int { 0 }
 
     override func startLoading() {
         guard request.httpMethod == "POST" else {
@@ -627,6 +647,31 @@ private final class SlowResidentLoadProtocol: ResidencySnapshotProtocol, @unchec
         let payload = #"{"id":"target","model_path":"target","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":0,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}"#.data(using: .utf8)!
         let response = HTTPURLResponse(
             url: request.url!, statusCode: 200,
+            httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}
+
+private final class BusyResidentLoadProtocol: ResidencySnapshotProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var fetchCount = 0
+    nonisolated(unsafe) static var loadAttempted = false
+    override class var activeRequests: Int {
+        BusyResidentLoadProtocol.fetchCount == 1 ? 0 : 1
+    }
+
+    override func startLoading() {
+        guard request.httpMethod == "POST" else {
+            Self.fetchCount += 1
+            super.startLoading()
+            return
+        }
+        Self.loadAttempted = true
+        let payload = #"{"detail":"model is serving an active request"}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 409,
             httpVersion: "HTTP/1.1", headerFields: nil
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -113,6 +113,13 @@ struct ModelResidencyTests {
         #expect(snapshot.activeRequestCount == 3)
     }
 
+    @Test("Assistant replacement counts only text and VLM requests")
+    func assistantReplacementRequestCount() {
+        let snapshot = requestSnapshot(textRequests: 2, imageRequests: 5)
+        #expect(snapshot.activeRequestCount == 7)
+        #expect(snapshot.activeRequestCount(replacingGroup: .assistant) == 2)
+    }
+
     @Test("Active-request switch confirmations resolve in FIFO order")
     func activeRequestSwitchConfirmationFIFO() {
         var queue = ActiveRequestSwitchConfirmationQueue()
@@ -165,6 +172,55 @@ struct ModelResidencyTests {
 
         server.cancelActiveRequestSwitch(warning)
         #expect(await switchTask.value == .cancelled)
+        #expect(server.state == .ready(alias: "current"))
+    }
+
+    @Test("A current active request can be confirmed before process replacement")
+    func activeRequestConfirmationContinuesSwitch() async throws {
+        let server = makeSwitchServer(protocolClass: ActiveResidencyProtocol.self)
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        #expect(warning.activeRequests == 2)
+        server.confirmActiveRequestSwitch(warning)
+
+        // There is intentionally no binary in this harness, so reaching a
+        // normal startup failure proves confirmation continued past the gate.
+        #expect(await switchTask.value == .failed)
+        #expect(server.pendingActiveRequestSwitch == nil)
+    }
+
+    @Test("A current zero-request snapshot does not prompt")
+    func zeroActiveRequestsDoNotPrompt() async {
+        let server = makeSwitchServer(protocolClass: IdleResidencyProtocol.self)
+        let outcome = await server.ensureServingOutcome(
+            alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+            residencyEligible: false
+        )
+        #expect(outcome == .failed)
+        #expect(server.pendingActiveRequestSwitch == nil)
+    }
+
+    @Test("Restart confirms before stopping an active server")
+    func restartCancellationPreservesServer() async throws {
+        let server = makeSwitchServer(protocolClass: ActiveResidencyProtocol.self)
+        let restartTask = Task { @MainActor in
+            await server.restartServingOutcome(alias: "current", hfPath: nil)
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        server.cancelActiveRequestSwitch(warning)
+
+        #expect(await restartTask.value == .cancelled)
         #expect(server.state == .ready(alias: "current"))
     }
 
@@ -332,6 +388,36 @@ struct ModelResidencyTests {
             memoryBandwidthGBs: 150
         )
     }
+
+    private func makeSwitchServer(protocolClass: AnyClass) -> ServerManager {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [protocolClass]
+        var client = ServerResidencyClient()
+        client.session = URLSession(configuration: configuration)
+        let server = ServerManager(testingState: .ready(alias: "current"))
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+        return server
+    }
+
+    private func requestSnapshot(textRequests: Int, imageRequests: Int) -> ModelResidencySnapshot {
+        func status(_ id: String, modality: String, requests: Int) -> ResidentModelStatus {
+            ResidentModelStatus(
+                id: id, modelPath: id, aliases: [], modality: modality,
+                state: "resident", pinned: false, primary: modality == "text",
+                activeRequests: requests, estimatedBytes: 1,
+                measuredBytes: nil, idleSeconds: 0
+            )
+        }
+        return ModelResidencySnapshot(
+            memoryLimitBytes: 1, memoryUsedBytes: 1, memoryAvailableBytes: 0,
+            idleTTLSeconds: 1, loadsTotal: 1, evictionsTotal: 0,
+            models: [
+                status("text", modality: "text", requests: textRequests),
+                status("image", modality: "image-gen", requests: imageRequests),
+            ]
+        )
+    }
 }
 
 private final class ResidencyFetchFailureProtocol: URLProtocol, @unchecked Sendable {
@@ -344,6 +430,30 @@ private final class ResidencyFetchFailureProtocol: URLProtocol, @unchecked Senda
 
     override func stopLoading() {}
 }
+
+private class ResidencySnapshotProtocol: URLProtocol, @unchecked Sendable {
+    class var activeRequests: Int { 0 }
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let payload = #"{"memory_limit_bytes":1,"memory_used_bytes":1,"memory_available_bytes":0,"idle_ttl_seconds":1,"loads_total":1,"evictions_total":0,"models":[{"id":"current","model_path":"current","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":\#(Self.activeRequests),"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}]}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class ActiveResidencyProtocol: ResidencySnapshotProtocol, @unchecked Sendable {
+    override class var activeRequests: Int { 2 }
+}
+
+private final class IdleResidencyProtocol: ResidencySnapshotProtocol, @unchecked Sendable {}
 
 private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var capturedBody: Data?

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -224,6 +224,42 @@ struct ModelResidencyTests {
         #expect(server.state == .ready(alias: "current"))
     }
 
+    @Test("Speculative restart cancellation preserves the active server")
+    func speculativeRestartCancellationPreservesServer() async throws {
+        let server = makeSwitchServer(protocolClass: ActiveResidencyProtocol.self)
+        let restartTask = Task { @MainActor in
+            await server.restartForSpeculativePerformance(alias: "current")
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        server.cancelActiveRequestSwitch(warning)
+
+        #expect(await restartTask.value == .cancelled)
+        #expect(server.state == .ready(alias: "current"))
+    }
+
+    @Test("Production restart surfaces use the confirmation-aware manager API")
+    func restartSurfacesDoNotStopDirectly() throws {
+        let rapidMacRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        for relativePath in [
+            "Sources/Rapid/UI/AudioView.swift",
+            "Sources/Rapid/UI/ImagesView.swift",
+            "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
+        ] {
+            let source = try String(
+                contentsOf: rapidMacRoot.appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            #expect(!source.contains("await server.stop()"), "Direct stop bypass in \(relativePath)")
+            #expect(source.contains("restartServingOutcome"))
+        }
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -251,6 +251,34 @@ struct ModelResidencyTests {
         #expect(server.state == .stopped)
     }
 
+    @Test("Explicit stop preempts a confirmed resident load")
+    func stopPreemptsResidentLoad() async throws {
+        SlowResidentLoadProtocol.loadStarted = false
+        let server = makeSwitchServer(protocolClass: SlowResidentLoadProtocol.self)
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        server.confirmActiveRequestSwitch(warning)
+        for _ in 0..<100 where !SlowResidentLoadProtocol.loadStarted {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(SlowResidentLoadProtocol.loadStarted)
+
+        let startedAt = Date()
+        await server.stop()
+        #expect(Date().timeIntervalSince(startedAt) < 0.5)
+        #expect(server.state == .stopped)
+        #expect(await switchTask.value == .cancelled)
+        #expect(server.state == .stopped)
+    }
+
     @Test("Speculative restart cancellation preserves the active server")
     func speculativeRestartCancellationPreservesServer() async throws {
         let server = makeSwitchServer(protocolClass: ActiveResidencyProtocol.self)
@@ -582,6 +610,28 @@ private final class OverlappingResidencyProtocol: ResidencySnapshotProtocol, @un
         Self.fetchCount += 1
         Self.lastTimeout = request.timeoutInterval
         super.startLoading()
+    }
+}
+
+private final class SlowResidentLoadProtocol: ResidencySnapshotProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var loadStarted = false
+    override class var activeRequests: Int { 1 }
+
+    override func startLoading() {
+        guard request.httpMethod == "POST" else {
+            super.startLoading()
+            return
+        }
+        Self.loadStarted = true
+        Thread.sleep(forTimeInterval: 0.7)
+        let payload = #"{"id":"target","model_path":"target","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":0,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200,
+            httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -139,6 +139,35 @@ struct ModelResidencyTests {
         #expect(queue.currentWarning == nil)
     }
 
+    @Test("A failed decision-point refresh fails safe and cancellation is distinct")
+    func failedRefreshPromptsAndReturnsCancellation() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ResidencyFetchFailureProtocol.self]
+        var client = ServerResidencyClient()
+        client.session = URLSession(configuration: configuration)
+        let server = ServerManager(testingState: .ready(alias: "current"))
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target",
+                hfPath: nil,
+                estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        #expect(warning.activeRequests == nil)
+
+        server.cancelActiveRequestSwitch(warning)
+        #expect(await switchTask.value == .cancelled)
+        #expect(server.state == .ready(alias: "current"))
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(
@@ -303,6 +332,17 @@ struct ModelResidencyTests {
             memoryBandwidthGBs: 150
         )
     }
+}
+
+private final class ResidencyFetchFailureProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: URLError(.timedOut))
+    }
+
+    override func stopLoading() {}
 }
 
 private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendable {

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -78,6 +78,67 @@ struct ModelResidencyTests {
         #expect(status.displayName(preferredAlias: "qwen3.5-4b-4bit") == "qwen3.5-4b-4bit")
     }
 
+    @Test("Active request count ignores evicting engines and invalid negative values")
+    func activeRequestCount() {
+        func status(_ id: String, state: String, active: Int) -> ResidentModelStatus {
+            ResidentModelStatus(
+                id: id,
+                modelPath: id,
+                aliases: [],
+                modality: "text",
+                state: state,
+                pinned: false,
+                primary: false,
+                activeRequests: active,
+                estimatedBytes: 1,
+                measuredBytes: nil,
+                idleSeconds: 0
+            )
+        }
+        let snapshot = ModelResidencySnapshot(
+            memoryLimitBytes: 1,
+            memoryUsedBytes: 1,
+            memoryAvailableBytes: 0,
+            idleTTLSeconds: 1,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [
+                status("primary", state: "resident", active: 2),
+                status("secondary", state: "loading", active: 1),
+                status("leaving", state: "evicting", active: 9),
+                status("invalid", state: "resident", active: -4),
+            ]
+        )
+
+        #expect(snapshot.activeRequestCount == 3)
+    }
+
+    @Test("Active-request switch confirmations resolve in FIFO order")
+    func activeRequestSwitchConfirmationFIFO() {
+        var queue = ActiveRequestSwitchConfirmationQueue()
+        let firstRequest = UUID()
+        let secondRequest = UUID()
+        let first = ActiveRequestSwitchWarning(
+            id: UUID(), currentAlias: "a", targetAlias: "b", activeRequests: 1
+        )
+        let second = ActiveRequestSwitchWarning(
+            id: UUID(), currentAlias: "a", targetAlias: "c", activeRequests: 2
+        )
+
+        queue.enqueue(first, requestID: firstRequest)
+        queue.enqueue(second, requestID: secondRequest)
+        #expect(queue.currentWarning == first)
+
+        queue.resolveCurrent(second, confirmed: true)
+        #expect(queue.currentWarning == first)
+        queue.resolveCurrent(first, confirmed: false)
+        #expect(queue.takeDecision(for: firstRequest) == false)
+        #expect(queue.currentWarning == second)
+        queue.resolveCurrent(second, confirmed: true)
+        #expect(queue.takeDecision(for: secondRequest) == true)
+        #expect(queue.currentWarning == nil)
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -197,15 +197,22 @@ struct ModelResidencyTests {
         #expect(server.pendingActiveRequestSwitch == nil)
     }
 
-    @Test("A current zero-request snapshot does not prompt")
-    func zeroActiveRequestsDoNotPrompt() async {
+    @Test("A process replacement confirms even after an idle snapshot")
+    func idleProcessReplacementStillConfirms() async throws {
         let server = makeSwitchServer(protocolClass: IdleResidencyProtocol.self)
-        let outcome = await server.ensureServingOutcome(
-            alias: "target", hfPath: nil, estimatedMemoryGB: nil,
-            residencyEligible: false
-        )
-        #expect(outcome == .failed)
-        #expect(server.pendingActiveRequestSwitch == nil)
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let warning = try #require(server.pendingActiveRequestSwitch)
+        #expect(warning.activeRequests == 0)
+        server.cancelActiveRequestSwitch(warning)
+        #expect(await switchTask.value == .cancelled)
     }
 
     @Test("Restart confirms before stopping an active server")
@@ -222,6 +229,26 @@ struct ModelResidencyTests {
 
         #expect(await restartTask.value == .cancelled)
         #expect(server.state == .ready(alias: "current"))
+    }
+
+    @Test("Explicit stop cancels a pending switch and remains authoritative")
+    func stopCancelsPendingSwitch() async throws {
+        let server = makeSwitchServer(protocolClass: ActiveResidencyProtocol.self)
+        let switchTask = Task { @MainActor in
+            await server.ensureServingOutcome(
+                alias: "target", hfPath: nil, estimatedMemoryGB: nil,
+                residencyEligible: false
+            )
+        }
+        for _ in 0..<100 where server.pendingActiveRequestSwitch == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let stopTask = Task { @MainActor in await server.stop() }
+
+        #expect(await switchTask.value == .cancelled)
+        await stopTask.value
+        #expect(server.pendingActiveRequestSwitch == nil)
+        #expect(server.state == .stopped)
     }
 
     @Test("Speculative restart cancellation preserves the active server")

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -329,6 +329,19 @@ struct ModelResidencyTests {
         }
     }
 
+    @Test("Main and Settings windows both host switch confirmation")
+    func appWindowsHostSwitchConfirmation() throws {
+        let rapidMacRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: rapidMacRoot.appendingPathComponent("Sources/Rapid/RapidApp.swift"),
+            encoding: .utf8
+        )
+        #expect(source.components(separatedBy: ".activeRequestSwitchAlert()").count - 1 == 2)
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(


### PR DESCRIPTION
## Summary
- derive the current active request count from decoded server residency data
- require explicit confirmation before switching models while requests are active
- serialize concurrent confirmation requests and make cancellation safe
- cover request counting and confirmation ordering with unit tests

## Validation
- `swift test --package-path apps/rapid-mac --filter ModelResidencyTests`
- `swift build --package-path apps/rapid-mac`
- `git diff --check origin/main...HEAD`