### PR TITLE
test(mac): confirm fake vision model memory warning [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3621,18 +3621,21 @@ flow_image_generation() {
 
     # The in-flight card. Asserted BEFORE the result so a render that returns
     # instantly (or a card that never appears) is a failure rather than a frame
-    # nobody looked at.
+    # nobody looked at.  SwiftUI mounts Cancel one layout pass before the
+    # indeterminate indicator the baseline owns; require both so the snapshot
+    # cannot race that valid intermediate tree.
     local inflight=0
     for ((i=0; i<80; i++)); do
         see_main "$OUT/ig-inflight.json"
-        if jq -e '.data.ui_elements[]? | select(.identifier == "Images.Cancel")' \
+        if jq -e 'any(.data.ui_elements[]?; .identifier == "Images.Cancel")
+                  and any(.data.ui_elements[]?; .role == "AXBusyIndicator")' \
                "$OUT/ig-inflight.json" >/dev/null; then
             inflight=1; break
         fi
         sleep 0.1
     done
     [[ "$inflight" == 1 ]] \
-        || die "no in-flight progress card: Images.Cancel never appeared during a render"
+        || die "no settled in-flight progress card with Cancel and busy indicator"
     baseline image-generation.inflight "$OUT/ig-inflight.json"
 
     # Sampling completion is followed by VAE decode / encoding. That tail must

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1069,8 +1069,8 @@ start_model() {
             if jq -e '.data.ui_elements[]?
                       | select(.identifier == "MemoryWarning.Confirm" and .enabled == true)' \
                 "$OUT/readiness-after-start.json" >/dev/null; then
-                press "$OUT/readiness-after-start.json" MemoryWarning.Confirm \
-                    "$OUT/readiness-memory-confirm.json"
+                "$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm \
+                    > "$OUT/readiness-memory-confirm.json"
                 memory_confirmed=1
                 log "  confirmed hosted-runner memory warning for fake sidecar"
             fi

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1055,8 +1055,26 @@ start_model() {
     # Hosted macOS runners can spend more than 30 seconds cold-starting the
     # bundled fake sidecar after a full release build. Keep the event-based
     # readiness proof, but allow 60 seconds before declaring startup broken.
+    local memory_confirmed=0
     for _ in {1..240}; do
         grep -q '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null && break
+        # Authoritative aliases retain their production footprint estimate
+        # even though this journey launches the zero-weight fake sidecar.  A
+        # memory-constrained hosted runner can therefore present the real
+        # safety confirmation after Start.  Confirm only when that explicit
+        # sheet exists; this keeps the product gate covered without leaving a
+        # fake-model GUI journey dependent on the runner's ambient pressure.
+        if [[ "$memory_confirmed" == 0 ]]; then
+            see_main "$OUT/readiness-after-start.json"
+            if jq -e '.data.ui_elements[]?
+                      | select(.identifier == "MemoryWarning.Confirm" and .enabled == true)' \
+                "$OUT/readiness-after-start.json" >/dev/null; then
+                press "$OUT/readiness-after-start.json" MemoryWarning.Confirm \
+                    "$OUT/readiness-memory-confirm.json"
+                memory_confirmed=1
+                log "  confirmed hosted-runner memory warning for fake sidecar"
+            fi
+        fi
         sleep 0.25
     done
     grep -q '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null \

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -111,7 +111,7 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
+    fail("usage: rapid-ax <dump|press|click-center|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
@@ -389,6 +389,20 @@ switch command {
 case "press":
     let result = AXUIElementPerformAction(target, kAXPressAction as CFString)
     guard result == .success else { fail("AXPress \(identifier) failed: \(result.rawValue)") }
+case "click-center":
+    guard let origin = point(target, kAXPositionAttribute as CFString),
+          let extent = size(target, kAXSizeAttribute as CFString),
+          extent.width > 0, extent.height > 0
+    else { fail("click-center \(identifier) has no usable AX bounds") }
+    let center = CGPoint(x: origin.x + extent.width / 2, y: origin.y + extent.height / 2)
+    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
+                             mouseCursorPosition: center, mouseButton: .left),
+          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
+                           mouseCursorPosition: center, mouseButton: .left)
+    else { fail("could not create click-center events for \(identifier)") }
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+    usleep(150_000)
 case "set-scroll-value":
     guard CommandLine.arguments.count > 3,
           let value = Double(CommandLine.arguments[3]),

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -163,7 +163,13 @@ func string(_ element: AXUIElement, _ name: CFString) -> String? {
 func jsonValue(_ value: AnyObject?) -> Any? {
     switch value {
     case let text as String: return text
-    case let number as NSNumber: return number
+    case let number as NSNumber:
+        // AX occasionally publishes ±infinity for transient progress/range
+        // values. Foundation raises an Objective-C exception when such an
+        // NSNumber reaches JSONSerialization, taking down the whole driver.
+        // The value carries no stable assertion signal, so omit only the
+        // non-finite representation and keep ordinary integers/bools/floats.
+        return number.doubleValue.isFinite ? number : nil
     default: return nil
     }
 }
@@ -231,7 +237,9 @@ func walk(_ element: AXUIElement, depth: Int) {
     if let help = string(element, kAXHelpAttribute as CFString), !help.isEmpty { record["help"] = help }
     if let value = jsonValue(attribute(element, kAXValueAttribute as CFString)) { record["value"] = value }
     if let origin = point(element, kAXPositionAttribute as CFString),
-       let extent = size(element, kAXSizeAttribute as CFString) {
+       let extent = size(element, kAXSizeAttribute as CFString),
+       origin.x.isFinite, origin.y.isFinite,
+       extent.width.isFinite, extent.height.isFinite {
         record["bounds"] = [
             "x": origin.x, "y": origin.y,
             "width": extent.width, "height": extent.height

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -180,7 +180,14 @@ def test_start_model_waits_for_an_interactive_readiness_action():
         'press "$OUT/readiness-start.json" Readiness.Action'
     )
     assert 'identifier == "MemoryWarning.Confirm" and .enabled == true' in helper
-    assert 'press "$OUT/readiness-after-start.json" MemoryWarning.Confirm' in helper
+    assert '"$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm' in helper
+
+    driver = DRIVER.read_text()
+    click = driver.split('case "click-center":', 1)[1].split(
+        'case "set-scroll-value":', 1
+    )[0]
+    assert "kAXPositionAttribute" in click and "kAXSizeAttribute" in click
+    assert ".leftMouseDown" in click and ".leftMouseUp" in click
 
 
 def test_audio_baseline_waits_for_residency_poll_to_settle():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -54,6 +54,16 @@ def test_trust_success_requires_all_three_signals():
     assert "screenLocked" in line
 
 
+def test_ax_dump_omits_non_finite_numbers_before_json_serialization():
+    source = DRIVER.read_text()
+    json_value = source.split("func jsonValue", 1)[1].split("\n}", 1)[0]
+    assert "number.doubleValue.isFinite ? number : nil" in json_value
+    bounds = source.split('record["bounds"]', 1)[0].rsplit("if let origin = point", 1)[
+        1
+    ]
+    assert "origin.x.isFinite" in bounds and "extent.height.isFinite" in bounds
+
+
 def test_each_fault_fails_with_its_own_message():
     source = DRIVER.read_text()
     assert source.count("fail(") >= 4

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -179,6 +179,8 @@ def test_start_model_waits_for_an_interactive_readiness_action():
     assert helper.index("wait_identifier_enabled Readiness.Action") < helper.index(
         'press "$OUT/readiness-start.json" Readiness.Action'
     )
+    assert 'identifier == "MemoryWarning.Confirm" and .enabled == true' in helper
+    assert 'press "$OUT/readiness-after-start.json" MemoryWarning.Confirm' in helper
 
 
 def test_audio_baseline_waits_for_residency_poll_to_settle():


### PR DESCRIPTION
## Summary
- make the shared GUI `start_model` helper detect the real memory-warning sheet before waiting for fake sidecar readiness
- explicitly confirm only that sheet for zero-weight fake-sidecar journeys
- pin the enabled confirmation behavior with a static harness contract

## Why
PR #2201 exposed that hosted macOS runners retain the authoritative Qwen-VL production footprint estimate even when the GUI journey uses the fake sidecar. Pressing Start can therefore show `MemoryWarning.Confirm`; without handling it, no `serve` process starts and the multimodal attachment flow times out. Product memory protection remains unchanged.

## Verification
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `pytest -q tests/test_gui_preflight_contract.py tests/test_fake_sidecar_image_catalog.py tests/test_gui_golden_ci_coverage.py` (22 passed)
- Mini release-app `chat-multimodal-attachments` flow passed on the parent fixture changes
- hosted Mac full golden gate required before landing