### PR TITLE
fix(cli): preserve upgrade manager and daemon notices

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@
 | `rapid-mlx agents` | List, configure, and test agent integrations |
 | `rapid-mlx doctor` | Run self-diagnostic / regression harness |
 | `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
-| `rapid-mlx upgrade` | Upgrade rapid-mlx (brew / pip / install.sh) |
+| `rapid-mlx upgrade` | Upgrade rapid-mlx with its detected manager (brew / uv / pipx / pip / install.sh) |
 | `rapid-mlx version` | Show version number |
 | `rapid-mlx help <cmd>` | Show help for a subcommand |
 
@@ -473,7 +473,7 @@ flag always wins over its env-var fallback when both are set.
 | `RAPID_MLX_MODEL_MIRROR` | `https://models.rapidmlx.com` | Model download mirror base URL; set to an empty string to force downloads from Hugging Face |
 | `RAPID_MLX_EXTRA_MODEL_ROOTS` | unset | Extra local directories to resolve models from, separated by `os.pathsep` (`:` on macOS/Linux), or a JSON array of paths |
 | `RAPID_MLX_DEFAULT_MODEL` | `qwen3.5-4b-4bit` | Default model alias used by `rapid-mlx launch` when `--model` is not given |
-| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip the interactive new-version check |
+| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip new-version checks, including the passive `serve` startup-log notice |
 | `RAPID_MLX_TRUST_REMOTE_CODE` | unset | Set `0`/`false`/`no`/`off` to force `trust_remote_code=False` process-wide for tokenizer loading |
 | `VLLM_MLX_TEST_MODEL` | unset | Model for tests |
 | `HF_TOKEN` | unset | HuggingFace token for gated/private repos |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -400,7 +400,7 @@ flag always wins over its env-var fallback when both are set.
 | `RAPID_MLX_MODEL_MIRROR` | `https://models.rapidmlx.com` | Model download mirror base URL; set to an empty string to force downloads from Hugging Face |
 | `RAPID_MLX_EXTRA_MODEL_ROOTS` | unset | Extra local directories to resolve models from, separated by `os.pathsep` (`:` on macOS/Linux), or a JSON array of paths |
 | `RAPID_MLX_DEFAULT_MODEL` | `qwen3.5-4b-4bit` | Default model alias used by `rapid-mlx launch` when `--model` is not given |
-| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip the interactive new-version check |
+| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip new-version checks, including the passive `serve` startup-log notice |
 | `RAPID_MLX_TRUST_REMOTE_CODE` | unset | Set `0`/`false`/`no`/`off` to force `trust_remote_code=False` process-wide for tokenizer loading |
 | `VLLM_MLX_TEST_MODEL` | unset | Default model for tests |
 | `HF_TOKEN` | unset | HuggingFace authentication token |

--- a/tests/test_audio_route_registration_gate.py
+++ b/tests/test_audio_route_registration_gate.py
@@ -644,7 +644,8 @@ class TestCliServeCommandWiresEnableAudioFlag:
         )
         # Stub staleness banner so it doesn't print to stderr.
         monkeypatch.setattr(
-            "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+            "vllm_mlx._version_check.print_staleness_warning_if_any",
+            lambda **_kwargs: None,
         )
         # The ``main()`` alias resolver writes ``args._original_alias``;
         # we want to avoid hitting the real alias registry just to keep
@@ -746,7 +747,8 @@ class TestCliServeCommandWiresEnableAudioFlag:
             "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
         )
         monkeypatch.setattr(
-            "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+            "vllm_mlx._version_check.print_staleness_warning_if_any",
+            lambda **_kwargs: None,
         )
 
         monkeypatch.setattr(

--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -95,7 +95,8 @@ def _drive_serve_capturing_load_model_kwargs(argv_extra, monkeypatch):
         "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
     )
     monkeypatch.setattr(
-        "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
     )
     monkeypatch.setattr(
         sys,
@@ -473,7 +474,8 @@ with (
         "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
     ),
     mock.patch(
-        "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
     ),
     mock.patch(
         "vllm_mlx.utils.tokenizer._resolve_model_path",

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2523,7 +2523,8 @@ def test_server_main_no_mllm_skips_routing_config_fail_fast(monkeypatch):
         "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
     )
     monkeypatch.setattr(
-        "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
     )
     monkeypatch.setattr(
         "sys.argv",

--- a/tests/test_serve_image_gen_completeness.py
+++ b/tests/test_serve_image_gen_completeness.py
@@ -74,7 +74,8 @@ def _drive_serve(monkeypatch):
         "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
     )
     monkeypatch.setattr(
-        "vllm_mlx._version_check.print_staleness_warning_if_any", lambda: None
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
     )
     monkeypatch.setattr(sys, "argv", ["rapid-mlx", "serve", _ALIAS, "--port", "0"])
     cli.main()

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -251,7 +251,9 @@ def stub_heavy_serve_deps(monkeypatch):
     from vllm_mlx import server as server_mod
 
     monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", lambda: False)
-    monkeypatch.setattr(_version_check, "print_staleness_warning_if_any", lambda: None)
+    monkeypatch.setattr(
+        _version_check, "print_staleness_warning_if_any", lambda **_kwargs: None
+    )
     monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", lambda model: None)
     monkeypatch.setattr(cli_mod, "_check_memory_capacity", lambda *a, **kw: None)
     monkeypatch.setattr(cli_mod, "_check_disk_space", lambda *a, **kw: None)

--- a/tests/test_upgrade_cli.py
+++ b/tests/test_upgrade_cli.py
@@ -72,6 +72,43 @@ def test_non_dry_run_still_calls_subprocess(monkeypatch):
     assert exc.value.code == 0
 
 
+@pytest.mark.parametrize(
+    ("method", "command", "argv"),
+    [
+        ("uv", "uv tool upgrade rapid-mlx", ["uv", "tool", "upgrade", "rapid-mlx"]),
+        ("pipx", "pipx upgrade rapid-mlx", ["pipx", "upgrade", "rapid-mlx"]),
+    ],
+)
+def test_missing_manager_command_exits_cleanly(
+    monkeypatch, capsys, method, command, argv
+):
+    """A removed manager must produce an actionable error, not a traceback."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.9.3")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.9.4")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method=method,
+            binary_path=f"/manager/rapid-mlx/{method}/bin/rapid-mlx",
+            upgrade_command=command,
+            upgrade_argv=argv,
+        ),
+    )
+    missing = FileNotFoundError(2, "No such file or directory", argv[0])
+
+    with (
+        patch("subprocess.run", side_effect=missing),
+        pytest.raises(SystemExit) as exc,
+    ):
+        upgrade_command(SimpleNamespace(yes=True, dry_run=False))
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert f"Upgrade command not found: {argv[0]}" in out
+    assert f"Reinstall {method}" in out
+
+
 def test_dry_run_returns_silently_when_already_up_to_date(monkeypatch, capsys):
     """If current == latest, upgrade_command returns before consulting
     install method. --dry-run should not change that — still a clean

--- a/tests/test_upgrade_cli.py
+++ b/tests/test_upgrade_cli.py
@@ -109,6 +109,30 @@ def test_missing_manager_command_exits_cleanly(
     assert f"Reinstall {method}" in out
 
 
+def test_global_pipx_prints_manual_command_without_executing(monkeypatch, capsys):
+    """Global pipx needs sudo, so the CLI must never execute its empty argv."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.9.3")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.9.4")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="unknown",
+            binary_path="/opt/pipx/venvs/rapid-mlx/bin/rapid-mlx",
+            upgrade_command="sudo pipx upgrade --global rapid-mlx",
+            upgrade_argv=[],
+        ),
+    )
+
+    with patch("subprocess.run") as run:
+        upgrade_command(SimpleNamespace(yes=True, dry_run=False))
+
+    run.assert_not_called()
+    out = capsys.readouterr().out
+    assert "sudo pipx upgrade --global rapid-mlx" in out
+    assert "run the command above manually" in out
+
+
 def test_dry_run_returns_silently_when_already_up_to_date(monkeypatch, capsys):
     """If current == latest, upgrade_command returns before consulting
     install method. --dry-run should not change that — still a clean

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -760,6 +760,31 @@ def test_manager_like_path_outside_known_root_falls_back_to_pip(tmp_path, monkey
     assert info.upgrade_argv[:3] == [vc.sys.executable, "-m", "pip"]
 
 
+def test_manager_root_symlink_is_normalized_before_comparison(tmp_path, monkeypatch):
+    """Normalize both sides when a manager root itself is reached via symlink."""
+    home = tmp_path / "home"
+    binary = tmp_path / "uv-bin" / "rapid-mlx"
+    configured_root = tmp_path / "uv-tools"
+    venv = configured_root / "rapid-mlx"
+    expected = venv / "bin" / "rapid-mlx"
+    canonical = Path("/private") / expected.relative_to("/")
+    venv.mkdir(parents=True)
+    (venv / "uv-receipt.toml").write_text("managed")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: str(binary))
+
+    def fake_realpath(path):
+        return str(canonical) if Path(path) in {binary, expected} else str(path)
+
+    monkeypatch.setattr("os.path.realpath", fake_realpath)
+    monkeypatch.setenv("UV_TOOL_DIR", str(configured_root))
+
+    info = vc.detect_install_method()
+
+    assert info.method == "uv"
+    assert info.upgrade_argv == ["uv", "tool", "upgrade", "rapid-mlx"]
+
+
 def _run_install_sh_upgrade(
     tmp_path, monkeypatch, *, primary_ok, mirror_ok, primary_stall=False
 ):

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -662,11 +662,16 @@ def test_detects_tool_manager_from_resolved_launcher(
     home = tmp_path / "home"
     binary = home / ".local" / "bin" / "rapid-mlx"
     resolved = home.joinpath(*resolved_parts)
+    venv = resolved.parent.parent
+    venv.mkdir(parents=True)
+    receipt = "uv-receipt.toml" if manager == "uv" else "pipx_metadata.json"
+    (venv / receipt).write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: str(binary))
     monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
     monkeypatch.delenv("UV_TOOL_DIR", raising=False)
     monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
     info = vc.detect_install_method()
 
@@ -699,6 +704,10 @@ def test_detects_configured_tool_manager_root(
     binary = home / ".local" / "bin" / "rapid-mlx"
     manager_root = tmp_path / "custom-tools"
     resolved = manager_root.joinpath(*relative_parts, "bin", "rapid-mlx")
+    venv = resolved.parent.parent
+    venv.mkdir(parents=True)
+    receipt = "uv-receipt.toml" if manager == "uv" else "pipx_metadata.json"
+    (venv / receipt).write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: str(binary))
     monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
@@ -712,11 +721,13 @@ def test_detects_configured_tool_manager_root(
     assert info.upgrade_argv == expected_argv
 
 
-def test_detects_global_pipx_with_global_upgrade_flag(tmp_path, monkeypatch):
+def test_global_pipx_requires_manual_privileged_upgrade(tmp_path, monkeypatch):
     home = tmp_path / "home"
     binary = "/usr/local/bin/rapid-mlx"
     pipx_home = tmp_path / "global-pipx"
     resolved = pipx_home / "venvs" / "rapid-mlx" / "bin" / "rapid-mlx"
+    resolved.parent.parent.mkdir(parents=True)
+    (resolved.parent.parent / "pipx_metadata.json").write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: binary)
     monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
@@ -724,8 +735,29 @@ def test_detects_global_pipx_with_global_upgrade_flag(tmp_path, monkeypatch):
 
     info = vc.detect_install_method()
 
-    assert info.method == "pipx"
-    assert info.upgrade_argv == ["pipx", "upgrade", "--global", "rapid-mlx"]
+    assert info.method == "unknown"
+    assert info.upgrade_argv == []
+    assert info.upgrade_command == "sudo pipx upgrade --global rapid-mlx"
+
+
+def test_manager_like_path_outside_known_root_falls_back_to_pip(tmp_path, monkeypatch):
+    """Directory names and even a receipt are insufficient outside manager roots."""
+    home = tmp_path / "home"
+    binary = home / ".local" / "bin" / "rapid-mlx"
+    venv = tmp_path / "ordinary" / "uv" / "tools" / "rapid-mlx"
+    resolved = venv / "bin" / "rapid-mlx"
+    venv.mkdir(parents=True)
+    (venv / "uv-receipt.toml").write_text("coincidental")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: str(binary))
+    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    info = vc.detect_install_method()
+
+    assert info.method == "pip"
+    assert info.upgrade_argv[:3] == [vc.sys.executable, "-m", "pip"]
 
 
 def _run_install_sh_upgrade(
@@ -986,6 +1018,27 @@ def test_prompt_returns_false_when_upgrade_subprocess_fails(monkeypatch, interac
         # current installed version. The user sees the exit code and can
         # retry manually.
         assert vc.prompt_upgrade_if_available() is False
+
+
+def test_prompt_does_not_auto_run_privileged_global_pipx(monkeypatch, interactive):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.62")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="unknown",
+            upgrade_command="sudo pipx upgrade --global rapid-mlx",
+            upgrade_argv=[],
+        ),
+    )
+    with (
+        patch("builtins.input") as inp,
+        patch("subprocess.run") as run,
+    ):
+        assert vc.prompt_upgrade_if_available() is False
+        inp.assert_not_called()
+        run.assert_not_called()
 
 
 def test_prompt_returns_false_when_offline(monkeypatch, interactive):

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -668,7 +668,10 @@ def test_detects_tool_manager_from_resolved_launcher(
     (venv / receipt).write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: str(binary))
-    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.setattr(
+        "os.path.realpath",
+        lambda p: str(resolved) if Path(p) in {binary, resolved} else str(p),
+    )
     monkeypatch.delenv("UV_TOOL_DIR", raising=False)
     monkeypatch.delenv("PIPX_HOME", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
@@ -710,7 +713,10 @@ def test_detects_configured_tool_manager_root(
     (venv / receipt).write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: str(binary))
-    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.setattr(
+        "os.path.realpath",
+        lambda p: str(resolved) if Path(p) in {binary, resolved} else str(p),
+    )
     monkeypatch.delenv("UV_TOOL_DIR", raising=False)
     monkeypatch.delenv("PIPX_HOME", raising=False)
     monkeypatch.setenv(env_name, str(manager_root))
@@ -730,7 +736,10 @@ def test_global_pipx_requires_manual_privileged_upgrade(tmp_path, monkeypatch):
     (resolved.parent.parent / "pipx_metadata.json").write_text("managed")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: binary)
-    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.setattr(
+        "os.path.realpath",
+        lambda p: str(resolved) if Path(p) in {Path(binary), resolved} else str(p),
+    )
     monkeypatch.setenv("PIPX_GLOBAL_HOME", str(pipx_home))
 
     info = vc.detect_install_method()
@@ -750,7 +759,10 @@ def test_manager_like_path_outside_known_root_falls_back_to_pip(tmp_path, monkey
     (venv / "uv-receipt.toml").write_text("coincidental")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: str(binary))
-    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.setattr(
+        "os.path.realpath",
+        lambda p: str(resolved) if Path(p) in {binary, resolved} else str(p),
+    )
     monkeypatch.delenv("UV_TOOL_DIR", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
@@ -783,6 +795,31 @@ def test_manager_root_symlink_is_normalized_before_comparison(tmp_path, monkeypa
 
     assert info.method == "uv"
     assert info.upgrade_argv == ["uv", "tool", "upgrade", "rapid-mlx"]
+
+
+def test_install_sh_root_symlink_is_normalized_before_comparison(tmp_path, monkeypatch):
+    """Normalize the install.sh root as well as its resolved launcher."""
+    home = tmp_path / "home"
+    binary = home / ".local/bin/rapid-mlx"
+    expected_root = home / ".rapid-mlx"
+    canonical_root = Path("/private") / expected_root.relative_to("/")
+    canonical_binary = canonical_root / "bin/rapid-mlx"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: str(binary))
+
+    def fake_realpath(path):
+        if Path(path) == binary:
+            return str(canonical_binary)
+        if Path(path) == expected_root:
+            return str(canonical_root)
+        return str(path)
+
+    monkeypatch.setattr("os.path.realpath", fake_realpath)
+
+    info = vc.detect_install_method()
+
+    assert info.method == "install_sh"
+    assert info.upgrade_argv[:2] == ["bash", "-c"]
 
 
 def _run_install_sh_upgrade(

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the staleness-warning helper.
 
-The helper is opt-in (TTY+no-CI), cache-aware, and fail-silent on
-network errors. Tests pin those guarantees so a future "let's add a
-real call" change can't accidentally break the CLI on an offline
-laptop.
+The helper is TTY-gated for normal commands, while ``serve`` may emit a
+passive notice to non-TTY startup logs. Both paths are cache-aware,
+explicitly opt-out, and fail-silent on network errors. Tests pin those
+guarantees so a future "let's add a real call" change can't accidentally
+break the CLI on an offline laptop.
 """
 
 from __future__ import annotations
@@ -452,11 +453,70 @@ def test_disabled_in_ci(monkeypatch):
     assert vc._disabled() is True
 
 
+def test_non_tty_serve_warning_bypasses_only_tty_gate(monkeypatch):
+    """Daemon startup may check freshness, but explicit opt-outs still win."""
+    monkeypatch.setattr(vc, "_disabled", lambda: True)
+    monkeypatch.setattr(vc, "_explicitly_disabled", lambda: False)
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.14")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.6.16")
+
+    msg = vc.staleness_warning(allow_non_tty=True)
+
+    assert msg is not None
+    assert "0.6.14" in msg
+    assert "0.6.16" in msg
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["CI", "RAPID_MLX_DISABLE_VERSION_CHECK"],
+)
+def test_non_tty_serve_warning_respects_explicit_opt_out(monkeypatch, env_name):
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("RAPID_MLX_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setenv(env_name, "1")
+    monkeypatch.setattr(
+        vc,
+        "get_latest_version",
+        lambda force_refresh=False: pytest.fail("network leaked despite opt-out"),
+    )
+
+    assert vc.staleness_warning(allow_non_tty=True) is None
+
+
+def test_non_tty_serve_warning_prints_only_to_stderr(monkeypatch, capsys):
+    monkeypatch.setattr(
+        vc,
+        "staleness_warning",
+        lambda *, allow_non_tty=False: (
+            "daemon update notice" if allow_non_tty else None
+        ),
+    )
+
+    vc.print_staleness_warning_if_any(allow_non_tty=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "daemon update notice"
+
+
+def test_only_audio_and_text_serve_opt_into_non_tty_warning():
+    """Keep daemon logging scoped to both serve lanes, not every CLI command."""
+    cli_source = Path(vc.__file__).with_name("cli.py").read_text()
+    call = "print_staleness_warning_if_any(allow_non_tty=True)"
+
+    assert cli_source.count(call) == 2
+    audio_source = cli_source.split("def _serve_audio_mode", 1)[1].split("\ndef ", 1)[0]
+    text_source = cli_source.split("def serve_command", 1)[1].split("\ndef ", 1)[0]
+    assert call in audio_source
+    assert call in text_source
+
+
 # --- print_staleness_warning_if_any never raises ---------------------
 
 
 def test_print_helper_swallows_all_exceptions(monkeypatch, capsys):
-    def boom():
+    def boom(**_kwargs):
         raise RuntimeError("simulated GitHub outage")
 
     monkeypatch.setattr(vc, "staleness_warning", boom)
@@ -524,9 +584,12 @@ def test_detect_install_method_brew_linux(monkeypatch):
     assert info.method == "brew"
 
 
-def test_detect_install_method_install_sh(tmp_path, monkeypatch):
-    """install.sh drops the binary in ``~/.local/bin`` — re-running the
-    script is the only sane upgrade path for this install class.
+def test_local_bin_launcher_alone_does_not_imply_install_sh(tmp_path, monkeypatch):
+    """uv, pipx, and user-site pip all share ``~/.local/bin``.
+
+    A launcher located there but not resolving into a known managed venv must
+    conservatively use the running interpreter instead of letting install.sh
+    replace an unrelated tool manager's entry point.
     """
     home = tmp_path / "home"
     local_bin = home / ".local" / "bin"
@@ -537,25 +600,8 @@ def test_detect_install_method_install_sh(tmp_path, monkeypatch):
     monkeypatch.setattr("os.path.realpath", lambda p: p)
 
     info = vc.detect_install_method()
-    assert info.method == "install_sh"
-    assert "install.sh" in info.upgrade_command
-    # Upgrade prefers the canonical rapidmlx.com host and falls back to the
-    # raullenchai.github.io Pages mirror — both present, primary first, wired
-    # with ``||`` so the mirror is only reached if rapidmlx.com fails.
-    cmd = info.upgrade_command
-    assert "https://rapidmlx.com/install.sh" in cmd
-    assert "https://raullenchai.github.io/Rapid-MLX/install.sh" in cmd
-    assert cmd.index("rapidmlx.com") < cmd.index("github.io")
-    assert "||" in cmd
-    # Fetch to a temp file and run only a complete download (never ``| bash``):
-    # guards against a false-success on total outage and a partial/hybrid script.
-    assert "mktemp" in cmd
-    assert "set -e" in cmd
-    assert "| bash" not in cmd
-    # Bounded timeouts so a blackholed primary fails fast into the fallback
-    # instead of hanging forever.
-    assert "--connect-timeout" in cmd
-    assert "--max-time" in cmd
+    assert info.method == "pip"
+    assert info.upgrade_argv[:3] == [vc.sys.executable, "-m", "pip"]
 
 
 def test_detect_install_method_install_sh_via_symlink(tmp_path, monkeypatch):
@@ -595,6 +641,93 @@ def test_detect_install_method_install_sh_via_symlink(tmp_path, monkeypatch):
     assert argv_cmd.index("rapidmlx.com") < argv_cmd.index("github.io")
 
 
+@pytest.mark.parametrize(
+    "manager,resolved_parts,expected_argv",
+    [
+        (
+            "uv",
+            (".local", "share", "uv", "tools", "rapid-mlx", "bin", "rapid-mlx"),
+            ["uv", "tool", "upgrade", "rapid-mlx"],
+        ),
+        (
+            "pipx",
+            (".local", "share", "pipx", "venvs", "rapid-mlx", "bin", "rapid-mlx"),
+            ["pipx", "upgrade", "rapid-mlx"],
+        ),
+    ],
+)
+def test_detects_tool_manager_from_resolved_launcher(
+    tmp_path, monkeypatch, manager, resolved_parts, expected_argv
+):
+    home = tmp_path / "home"
+    binary = home / ".local" / "bin" / "rapid-mlx"
+    resolved = home.joinpath(*resolved_parts)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: str(binary))
+    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+
+    info = vc.detect_install_method()
+
+    assert info.method == manager
+    assert info.upgrade_argv == expected_argv
+    assert "install.sh" not in info.upgrade_command
+
+
+@pytest.mark.parametrize(
+    "manager,env_name,relative_parts,expected_argv",
+    [
+        (
+            "uv",
+            "UV_TOOL_DIR",
+            ("rapid-mlx",),
+            ["uv", "tool", "upgrade", "rapid-mlx"],
+        ),
+        (
+            "pipx",
+            "PIPX_HOME",
+            ("venvs", "rapid-mlx"),
+            ["pipx", "upgrade", "rapid-mlx"],
+        ),
+    ],
+)
+def test_detects_configured_tool_manager_root(
+    tmp_path, monkeypatch, manager, env_name, relative_parts, expected_argv
+):
+    home = tmp_path / "home"
+    binary = home / ".local" / "bin" / "rapid-mlx"
+    manager_root = tmp_path / "custom-tools"
+    resolved = manager_root.joinpath(*relative_parts, "bin", "rapid-mlx")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: str(binary))
+    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.setenv(env_name, str(manager_root))
+
+    info = vc.detect_install_method()
+
+    assert info.method == manager
+    assert info.upgrade_argv == expected_argv
+
+
+def test_detects_global_pipx_with_global_upgrade_flag(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    binary = "/usr/local/bin/rapid-mlx"
+    pipx_home = tmp_path / "global-pipx"
+    resolved = pipx_home / "venvs" / "rapid-mlx" / "bin" / "rapid-mlx"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: binary)
+    monkeypatch.setattr("os.path.realpath", lambda p: str(resolved))
+    monkeypatch.setenv("PIPX_GLOBAL_HOME", str(pipx_home))
+
+    info = vc.detect_install_method()
+
+    assert info.method == "pipx"
+    assert info.upgrade_argv == ["pipx", "upgrade", "--global", "rapid-mlx"]
+
+
 def _run_install_sh_upgrade(
     tmp_path, monkeypatch, *, primary_ok, mirror_ok, primary_stall=False
 ):
@@ -613,9 +746,12 @@ def _run_install_sh_upgrade(
     home = tmp_path / "home"
     (home / ".local" / "bin").mkdir(parents=True)
     fake_binary = str(home / ".local" / "bin" / "rapid-mlx")
+    fake_realpath = str(home / ".rapid-mlx" / "bin" / "rapid-mlx")
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.setattr("shutil.which", lambda _name: fake_binary)
-    monkeypatch.setattr("os.path.realpath", lambda p: p)
+    monkeypatch.setattr(
+        "os.path.realpath", lambda p: fake_realpath if p == fake_binary else p
+    )
     argv = vc.detect_install_method().upgrade_argv
 
     sentinel = tmp_path / "ran.txt"

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -542,7 +542,7 @@ def detect_install_method() -> InstallInfo:
             expected = venv / "bin" / "rapid-mlx"
             return (
                 os.path.normcase(normalized)
-                == os.path.normcase(os.path.normpath(str(expected)))
+                == os.path.normcase(os.path.realpath(expected))
                 and (venv / receipt).is_file()
             )
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -379,6 +379,9 @@ def prompt_upgrade_if_available() -> bool:
             f"(current: {installed_str})."
         )
         print(f"  Upgrade command: {info.upgrade_command}")
+        if info.method == "unknown":
+            print("  Automatic upgrade unavailable; run that command manually.\n")
+            return False
         try:
             answer = input("  Run it now? [Y/n] ").strip().lower()
         except (EOFError, KeyboardInterrupt):
@@ -440,7 +443,7 @@ class InstallInfo:
         upgrade_argv: list[str],
         binary_path: str | None = None,
     ) -> None:
-        self.method = method  # one of: brew, uv, pipx, pip, install_sh
+        self.method = method  # brew, uv, pipx, pip, install_sh, or unknown
         self.upgrade_command = upgrade_command
         self.upgrade_argv = upgrade_argv
         self.binary_path = binary_path
@@ -530,35 +533,33 @@ def detect_install_method() -> InstallInfo:
                 binary_path=binary,
             )
 
-        # uv and pipx both install console entry points into a shared user bin
-        # directory, but resolve those symlinks into manager-owned venvs. Use
-        # the target, including configured tool roots, so ``rapid-mlx upgrade``
-        # updates the environment that is actually running instead of replacing
-        # its launcher with an unrelated install.sh symlink.
-        normalized_path = Path(normalized)
-        normalized_parts = normalized_path.parts
-
-        def _has_sequence(parts: tuple[str, ...]) -> bool:
-            width = len(parts)
-            return any(
-                normalized_parts[i : i + width] == parts
-                for i in range(len(normalized_parts) - width + 1)
+        # uv and pipx both resolve their shared-bin launcher into a manager-owned
+        # venv. Require three signals before dispatching a manager command:
+        # known/configured root, exact ``rapid-mlx/bin/rapid-mlx`` target, and
+        # that manager's metadata receipt. A coincidentally named ordinary venv
+        # must fall back to the running interpreter instead.
+        def _is_managed_entry(venv: Path, receipt: str) -> bool:
+            expected = venv / "bin" / "rapid-mlx"
+            return (
+                os.path.normcase(normalized)
+                == os.path.normcase(os.path.normpath(str(expected)))
+                and (venv / receipt).is_file()
             )
 
-        def _under_configured_root(env_name: str, *relative: str) -> bool:
-            root = os.environ.get(env_name)
-            if not root:
-                return False
-            managed = Path(root).expanduser().joinpath(*relative)
-            try:
-                return os.path.commonpath(
-                    [normalized, str(managed)]
-                ) == os.path.normpath(str(managed))
-            except ValueError:
-                return False
-
-        if _under_configured_root("UV_TOOL_DIR", "rapid-mlx") or _has_sequence(
-            ("uv", "tools", "rapid-mlx")
+        uv_tool_dir = os.environ.get("UV_TOOL_DIR")
+        if uv_tool_dir:
+            uv_roots = [Path(uv_tool_dir).expanduser()]
+        else:
+            data_home = os.environ.get("XDG_DATA_HOME")
+            uv_data = (
+                Path(data_home).expanduser()
+                if data_home
+                else Path.home() / ".local/share"
+            )
+            uv_roots = [uv_data / "uv" / "tools"]
+        if any(
+            _is_managed_entry(root / "rapid-mlx", "uv-receipt.toml")
+            for root in uv_roots
         ):
             return InstallInfo(
                 method="uv",
@@ -567,26 +568,35 @@ def detect_install_method() -> InstallInfo:
                 binary_path=binary,
             )
 
-        is_global_pipx = _under_configured_root(
-            "PIPX_GLOBAL_HOME", "venvs", "rapid-mlx"
-        )
-        if not os.environ.get("PIPX_GLOBAL_HOME"):
-            try:
-                is_global_pipx = is_global_pipx or os.path.commonpath(
-                    [normalized, "/opt/pipx/venvs/rapid-mlx"]
-                ) == os.path.normpath("/opt/pipx/venvs/rapid-mlx")
-            except ValueError:
-                pass
-        if is_global_pipx:
+        global_pipx_home = Path(
+            os.environ.get("PIPX_GLOBAL_HOME", "/opt/pipx")
+        ).expanduser()
+        if _is_managed_entry(
+            global_pipx_home / "venvs" / "rapid-mlx", "pipx_metadata.json"
+        ):
             return InstallInfo(
-                method="pipx",
-                upgrade_command="pipx upgrade --global rapid-mlx",
-                upgrade_argv=["pipx", "upgrade", "--global", "rapid-mlx"],
+                method="unknown",
+                upgrade_command="sudo pipx upgrade --global rapid-mlx",
+                upgrade_argv=[],
                 binary_path=binary,
             )
 
-        if _under_configured_root("PIPX_HOME", "venvs", "rapid-mlx") or _has_sequence(
-            ("pipx", "venvs", "rapid-mlx")
+        pipx_home = os.environ.get("PIPX_HOME")
+        if pipx_home:
+            pipx_homes = [Path(pipx_home).expanduser()]
+        else:
+            data_home = os.environ.get("XDG_DATA_HOME")
+            pipx_homes = [
+                Path.home() / ".local/pipx",
+                Path.home() / ".local/share/pipx",
+            ]
+            if data_home:
+                pipx_homes.insert(0, Path(data_home).expanduser() / "pipx")
+            if sys.platform == "darwin":
+                pipx_homes.insert(0, Path.home() / "Library/Application Support/pipx")
+        if any(
+            _is_managed_entry(home / "venvs" / "rapid-mlx", "pipx_metadata.json")
+            for home in pipx_homes
         ):
             return InstallInfo(
                 method="pipx",

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -12,8 +12,10 @@ the same minor. Designed to fail completely silently on network / parse
 / sandbox errors — staleness warnings should never break the CLI.
 
 Cache: ``~/.cache/rapid-mlx/version_check.json`` with 24h TTL. Network
-fetch is opt-out via ``RAPID_MLX_DISABLE_VERSION_CHECK=1`` or any
-non-interactive context (``CI=1``, missing TTY).
+fetch is opt-out via ``RAPID_MLX_DISABLE_VERSION_CHECK=1`` or ``CI=1``.
+Interactive commands require a TTY; ``serve`` also writes the passive
+notice to non-interactive startup logs so launchd/daemon operators are
+not left on an old release with no signal.
 
 Behaviour matrix:
 
@@ -84,16 +86,21 @@ def _cache_path() -> Path:
     return Path(base) / "rapid-mlx" / "version_check.json"
 
 
-def _disabled() -> bool:
-    """Skip the check in non-interactive contexts.
+def _explicitly_disabled() -> bool:
+    """Return whether every version check is explicitly disabled.
 
-    Devs running tests, CI, scripts piped to other tools — none of them
-    benefit from a version warning. Only show when stderr is a TTY and
-    the user hasn't explicitly opted out.
+    These opt-outs also apply to the non-interactive ``serve`` log notice.
     """
     if os.environ.get("RAPID_MLX_DISABLE_VERSION_CHECK"):
         return True
     if os.environ.get("CI"):
+        return True
+    return False
+
+
+def _disabled() -> bool:
+    """Return whether the normal interactive warning should be skipped."""
+    if _explicitly_disabled():
         return True
     try:
         # ``stderr.isatty()`` matches where we'd print the warning.
@@ -259,12 +266,13 @@ def get_latest_version(force_refresh: bool = False) -> str | None:
     return latest
 
 
-def staleness_warning() -> str | None:
+def staleness_warning(*, allow_non_tty: bool = False) -> str | None:
     """Return a one-line warning string if the installed version is behind
     the latest release by ANY amount (patch, minor, or major). Returns
     None when no warning is warranted (current/ahead, or check disabled).
     """
-    if _disabled():
+    disabled = _explicitly_disabled() if allow_non_tty else _disabled()
+    if disabled:
         return None
     installed_str = _installed_version()
     if not installed_str:
@@ -299,10 +307,14 @@ def staleness_warning() -> str | None:
     )
 
 
-def print_staleness_warning_if_any() -> None:
-    """Best-effort: fetches + prints to stderr. Always silent on errors."""
+def print_staleness_warning_if_any(*, allow_non_tty: bool = False) -> None:
+    """Best-effort: fetches + prints to stderr. Always silent on errors.
+
+    ``allow_non_tty`` is reserved for ``serve`` startup logs. It keeps the
+    explicit environment/CI opt-outs but does not require stderr to be a TTY.
+    """
     try:
-        msg = staleness_warning()
+        msg = staleness_warning(allow_non_tty=allow_non_tty)
         if msg:
             print(msg, file=sys.stderr)
     except Exception:  # noqa: BLE001 — never break the CLI
@@ -428,7 +440,7 @@ class InstallInfo:
         upgrade_argv: list[str],
         binary_path: str | None = None,
     ) -> None:
-        self.method = method  # one of: brew, pip, install_sh
+        self.method = method  # one of: brew, uv, pipx, pip, install_sh
         self.upgrade_command = upgrade_command
         self.upgrade_argv = upgrade_argv
         self.binary_path = binary_path
@@ -441,10 +453,11 @@ def detect_install_method() -> InstallInfo:
       1. brew — ``rapid-mlx`` realpath under ``/Cellar/rapid-mlx``,
          ``/opt/homebrew/`` (macOS) or ``/home/linuxbrew/`` (Linux brew)
          triggers ``brew upgrade rapid-mlx`` (now in homebrew/core).
-      2. install.sh — binary under ``~/.local/bin`` (or realpath under
-         the install.sh venv at ``~/.rapid-mlx/``) triggers a re-run of
-         the install.sh script.
-      3. pip (default) — uses ``sys.executable -m pip install --upgrade``
+      2. install.sh — realpath under the install.sh venv at
+         ``~/.rapid-mlx/`` triggers a re-run of the install.sh script.
+      3. uv / pipx — realpath in that tool manager's isolated environment
+         triggers its native upgrade command.
+      4. pip (default) — uses ``sys.executable -m pip install --upgrade``
          so the upgrade lands in the same env that's currently running
          the CLI.
     """
@@ -461,13 +474,18 @@ def detect_install_method() -> InstallInfo:
                 upgrade_argv=["brew", "upgrade", "rapid-mlx"],
                 binary_path=binary,
             )
-        # install.sh creates ``~/.rapid-mlx`` (venv) and symlinks the
-        # entry point into ``~/.local/bin``. Match either side: the
-        # symlink path (binary) for fresh installs, the venv root
-        # (normalized) for installs where ``~/.local/bin`` was overridden.
-        local_bin = str(Path.home() / ".local" / "bin")
+        # install.sh creates ``~/.rapid-mlx`` (venv) and symlinks its entry
+        # point into ``~/.local/bin``. uv, pipx, and ``pip install --user``
+        # use that SAME bin directory, so the launcher path is not evidence of
+        # ownership. Only the resolved target identifies an install.sh venv.
         rapid_mlx_dir = str(Path.home() / ".rapid-mlx")
-        if binary.startswith(local_bin) or normalized.startswith(rapid_mlx_dir):
+        try:
+            is_install_sh = os.path.commonpath(
+                [normalized, rapid_mlx_dir]
+            ) == os.path.normpath(rapid_mlx_dir)
+        except ValueError:
+            is_install_sh = False
+        if is_install_sh:
             # Prefer the canonical rapidmlx.com host (the same domain the
             # website, docs, and the update poll ``CLI_UPDATE_ENDPOINT`` use),
             # falling back to the raullenchai.github.io Pages mirror when it
@@ -509,6 +527,71 @@ def detect_install_method() -> InstallInfo:
                 # ``shell=True`` (no ambient $SHELL coupling, no PATH-based
                 # shell-injection surface beyond the literal string we control).
                 upgrade_argv=["bash", "-c", install_sh_pipe],
+                binary_path=binary,
+            )
+
+        # uv and pipx both install console entry points into a shared user bin
+        # directory, but resolve those symlinks into manager-owned venvs. Use
+        # the target, including configured tool roots, so ``rapid-mlx upgrade``
+        # updates the environment that is actually running instead of replacing
+        # its launcher with an unrelated install.sh symlink.
+        normalized_path = Path(normalized)
+        normalized_parts = normalized_path.parts
+
+        def _has_sequence(parts: tuple[str, ...]) -> bool:
+            width = len(parts)
+            return any(
+                normalized_parts[i : i + width] == parts
+                for i in range(len(normalized_parts) - width + 1)
+            )
+
+        def _under_configured_root(env_name: str, *relative: str) -> bool:
+            root = os.environ.get(env_name)
+            if not root:
+                return False
+            managed = Path(root).expanduser().joinpath(*relative)
+            try:
+                return os.path.commonpath(
+                    [normalized, str(managed)]
+                ) == os.path.normpath(str(managed))
+            except ValueError:
+                return False
+
+        if _under_configured_root("UV_TOOL_DIR", "rapid-mlx") or _has_sequence(
+            ("uv", "tools", "rapid-mlx")
+        ):
+            return InstallInfo(
+                method="uv",
+                upgrade_command="uv tool upgrade rapid-mlx",
+                upgrade_argv=["uv", "tool", "upgrade", "rapid-mlx"],
+                binary_path=binary,
+            )
+
+        is_global_pipx = _under_configured_root(
+            "PIPX_GLOBAL_HOME", "venvs", "rapid-mlx"
+        )
+        if not os.environ.get("PIPX_GLOBAL_HOME"):
+            try:
+                is_global_pipx = is_global_pipx or os.path.commonpath(
+                    [normalized, "/opt/pipx/venvs/rapid-mlx"]
+                ) == os.path.normpath("/opt/pipx/venvs/rapid-mlx")
+            except ValueError:
+                pass
+        if is_global_pipx:
+            return InstallInfo(
+                method="pipx",
+                upgrade_command="pipx upgrade --global rapid-mlx",
+                upgrade_argv=["pipx", "upgrade", "--global", "rapid-mlx"],
+                binary_path=binary,
+            )
+
+        if _under_configured_root("PIPX_HOME", "venvs", "rapid-mlx") or _has_sequence(
+            ("pipx", "venvs", "rapid-mlx")
+        ):
+            return InstallInfo(
+                method="pipx",
+                upgrade_command="pipx upgrade rapid-mlx",
+                upgrade_argv=["pipx", "upgrade", "rapid-mlx"],
                 binary_path=binary,
             )
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -481,11 +481,12 @@ def detect_install_method() -> InstallInfo:
         # point into ``~/.local/bin``. uv, pipx, and ``pip install --user``
         # use that SAME bin directory, so the launcher path is not evidence of
         # ownership. Only the resolved target identifies an install.sh venv.
-        rapid_mlx_dir = str(Path.home() / ".rapid-mlx")
+        rapid_mlx_dir = os.path.normcase(os.path.realpath(Path.home() / ".rapid-mlx"))
         try:
-            is_install_sh = os.path.commonpath(
-                [normalized, rapid_mlx_dir]
-            ) == os.path.normpath(rapid_mlx_dir)
+            is_install_sh = (
+                os.path.commonpath([os.path.normcase(normalized), rapid_mlx_dir])
+                == rapid_mlx_dir
+            )
         except ValueError:
             is_install_sh = False
         if is_install_sh:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -851,7 +851,9 @@ def _serve_audio_mode(args, entry) -> None:
     from vllm_mlx._version_check import print_staleness_warning_if_any
     from vllm_mlx.config import get_config
 
-    print_staleness_warning_if_any()
+    # Audio servers are often launched by launchd or another supervisor. Keep
+    # the passive update notice in stderr startup logs even without a TTY.
+    print_staleness_warning_if_any(allow_non_tty=True)
     print()
 
     _cfg = get_config()
@@ -4363,7 +4365,9 @@ def serve_command(args):
         )
     from vllm_mlx._version_check import print_staleness_warning_if_any
 
-    print_staleness_warning_if_any()
+    # Long-lived launchd/daemon servers have no interactive prompt. Preserve
+    # the explicit opt-outs, but leave the passive notice in startup logs.
+    print_staleness_warning_if_any(allow_non_tty=True)
     print()
 
     # Stash the source of truth for the lifespan "Ready:" banner —

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8986,6 +8986,13 @@ def upgrade_command(args):
         # as shell separators. install.sh's pipe is wrapped as ``bash -c``
         # in upgrade_argv, so we still get the pipe semantics it needs.
         result = subprocess.run(info.upgrade_argv, check=False)
+    except FileNotFoundError as exc:
+        missing = exc.filename or info.upgrade_argv[0]
+        print(
+            f"\n  Upgrade command not found: {missing}\n"
+            f"  Reinstall {info.method} or run the command above manually.\n"
+        )
+        sys.exit(1)
     except KeyboardInterrupt:
         print("\n  Interrupted.\n")
         sys.exit(130)


### PR DESCRIPTION
## What does this PR do?

- detects install.sh only from the resolved `~/.rapid-mlx` target instead of treating every `~/.local/bin` launcher as install.sh
- routes uv, pipx, global pipx, pip, Homebrew, and install.sh upgrades through their owning manager
- lets text and audio `serve` write the existing passive staleness warning to non-TTY stderr startup logs
- keeps CI and `RAPID_MLX_DISABLE_VERSION_CHECK` as hard opt-outs and leaves stdout, exit codes, HTTP APIs, and automatic-upgrade behavior unchanged
- documents the expanded manager detection and daemon-log behavior

## Why is this needed?

uv, pipx, user-site pip, and install.sh can all expose `rapid-mlx` through `~/.local/bin`. The previous launcher-path heuristic classified all of them as install.sh, so `rapid-mlx upgrade` could replace a uv/pipx-owned launcher with a separate `~/.rapid-mlx` installation. Separately, launchd and daemon `serve` processes suppressed both the interactive prompt and passive warning, leaving operators with no upgrade signal in startup logs.

This change keeps upgrades inside the environment users actually installed and gives long-lived non-interactive servers a visible, non-disruptive update notice.

## AI assistance disclosure

Codex diagnosed, implemented, documented, and tested all files in this PR. The output was reviewed against the repository's install scripts plus the official uv and pipx storage/upgrade contracts. Verification covered the install-manager matrix, explicit opt-outs, stderr-only daemon notices, both serve lanes, upgrade CLI, doctor integration, and adjacent serve wiring.

## Test plan

- `python3.12 -m pytest -q tests/test_version_check.py tests/test_upgrade_cli.py tests/test_doctor_env_health.py tests/test_serve_stub_notice_wiring.py tests/test_serve_listen_fd.py tests/test_serve_image_gen_completeness.py tests/test_audio_route_registration_gate.py --disable-warnings` — 194 passed
- `python3.12 -m pytest -q tests/test_disk_stream_cli_wiring.py tests/test_no_mllm_flag.py --disable-warnings` — 56 passed
- `python3.12 -m pytest -q tests/test_version_check.py --disable-warnings` — 75 passed after final wiring assertion
- `python3.12 -m ruff check ...` — passed
- `python3.12 -m ruff format --check ...` — passed
- `git diff --check` — passed
- live local install detection still resolves the current install.sh-owned launcher as `install_sh`

- `PR_VALIDATE_NO_CODEX=1 PR_VALIDATE_NO_STRESS=1 python3.12 -m scripts.pr_validate.pr_validate 2221 --verbose` — MERGE-SAFE; 18,387 passed, 97 skipped, 22 deselected, 6 xfailed, 1 xpassed. Codex was skipped only in the final run after the same-SHA independent review reported no blocking findings; stress was skipped because this CLI-only change does not touch inference or performance.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>` — see [CONTRIBUTING.md](../CONTRIBUTING.md#self-validating-your-pr) (opt out heavy steps with `PR_VALIDATE_NO_CODEX=1 PR_VALIDATE_NO_STRESS=1` if you don't have the hardware / a codex login)
- [x] If new tests touch a critical code path (parser / scheduler / security), I've spot-checked that they fail when the corresponding production line is broken (not applicable; CLI maintenance path)
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API


