### PR TITLE
feat(server): add model lifecycle control plane

### DIFF
--- a/docs/engineering/decisions/model-lifecycle-control-plane.md
+++ b/docs/engineering/decisions/model-lifecycle-control-plane.md
@@ -1,0 +1,40 @@
+# Server-owned model lifecycle control plane
+
+## Decision
+
+Request admission and model lifecycle drain state belong to the server. GUI,
+CLI, and external supervisors are clients of this control plane; they must not
+infer interruption safety from a non-atomic status snapshot.
+
+The server exposes authenticated lifecycle operations under
+`/v1/models/lifecycle`. Creating an operation and closing inference admission
+happen under one lock. The response reports the requests that were already
+active:
+
+- zero active requests: the operation is immediately `ready`;
+- one or more active requests: it is `awaiting_confirmation`;
+- confirmation moves it to `ready` without admitting new inference;
+- cancel, complete, supersession, or expiry reopens admission.
+
+An external process supervisor may terminate/restart `rapid-mlx serve` only
+after receiving a `ready` operation. The server cannot restart its own process,
+but it owns the admission barrier that makes that restart safe and explicit.
+
+## Compatibility
+
+Existing inference and `/v1/models/load` contracts are unchanged while no
+lifecycle operation is active. During a drain, authenticated new inference
+receives HTTP 409 with code `model_lifecycle_draining` and `Retry-After: 1`.
+Health, lifecycle status/transition routes, and existing control-plane routes
+remain reachable. Authentication still runs before lifecycle state is exposed.
+
+The ASGI middleware holds admission for the complete response body, including
+streaming responses. Operations expire after five minutes so an abandoned
+client cannot leave the server permanently drained.
+
+## Follow-up
+
+The Mac app should consume this API as a thin lifecycle client and process
+supervisor. Resident-engine replacement can later execute directly within the
+same operation, while process replacement uses the ready operation as a restart
+permit.

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -12,6 +12,7 @@ from vllm_mlx.middleware.model_lifecycle import ModelLifecycleMiddleware
 from vllm_mlx.runtime.model_lifecycle import (
     LifecycleAdmissionClosedError,
     LifecycleOperationConflictError,
+    LifecycleOperationNotFoundError,
     LifecyclePhase,
     ModelLifecycleManager,
 )
@@ -110,6 +111,21 @@ async def test_abandoned_operation_expires_and_reopens_admission():
     assert operation.phase is LifecyclePhase.EXPIRED
     async with manager.admit():
         pass
+
+
+@pytest.mark.asyncio
+async def test_operation_history_is_bounded_without_evicting_current():
+    manager = ModelLifecycleManager(max_history=3)
+    operations = []
+    for index in range(10):
+        operations.append(
+            await manager.begin(target_model=str(index), reason="model_switch")
+        )
+
+    assert len(manager._history) == 3
+    assert operations[-1].id in manager._history
+    with pytest.raises(LifecycleOperationNotFoundError):
+        await manager.confirm(operations[0].id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.middleware.model_lifecycle import ModelLifecycleMiddleware
+from vllm_mlx.runtime.model_lifecycle import (
+    LifecycleAdmissionClosedError,
+    LifecycleOperationConflictError,
+    LifecyclePhase,
+    ModelLifecycleManager,
+)
+
+
+def test_lifecycle_routes_expose_status_and_preserve_auth_contract():
+    from vllm_mlx.routes.model_lifecycle import router
+
+    config = reset_config()
+    config.api_key = "secret"
+    config.lifecycle_manager = ModelLifecycleManager(clock=lambda: 42.0)
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        assert client.get("/v1/models/lifecycle").status_code == 401
+        headers = {"Authorization": "Bearer secret"}
+        initial = client.get("/v1/models/lifecycle", headers=headers)
+        assert initial.status_code == 200
+        assert initial.json() == {
+            "accepting_requests": True,
+            "active_requests": 0,
+            "operation": None,
+        }
+        created = client.post(
+            "/v1/models/lifecycle/operations",
+            headers=headers,
+            json={"target_model": "new", "reason": "model_switch"},
+        )
+        assert created.status_code == 201
+        assert created.json()["phase"] == "ready"
+        operation_id = created.json()["id"]
+        completed = client.post(
+            f"/v1/models/lifecycle/operations/{operation_id}/complete",
+            headers=headers,
+        )
+        assert completed.status_code == 200
+        assert completed.json()["phase"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_begin_atomically_closes_admission_and_reports_active_requests():
+    manager = ModelLifecycleManager(clock=lambda: 123.0)
+    release = asyncio.Event()
+
+    async def active_request():
+        async with manager.admit():
+            await release.wait()
+
+    request = asyncio.create_task(active_request())
+    await asyncio.sleep(0)
+    operation = await manager.begin(target_model="new", reason="model_switch")
+
+    assert operation.phase is LifecyclePhase.AWAITING_CONFIRMATION
+    assert operation.affected_requests == 1
+    with pytest.raises(LifecycleAdmissionClosedError) as closed:
+        async with manager.admit():
+            pass
+    assert closed.value.operation_id == operation.id
+
+    confirmed = await manager.confirm(operation.id)
+    assert confirmed.phase is LifecyclePhase.READY
+    release.set()
+    await request
+    assert (await manager.status())["active_requests"] == 0
+    completed = await manager.complete(operation.id)
+    assert completed.phase is LifecyclePhase.COMPLETED
+    assert (await manager.status())["accepting_requests"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_reopens_admission_and_new_operation_supersedes_old_token():
+    manager = ModelLifecycleManager()
+    first = await manager.begin(target_model="a", reason="model_switch")
+    second = await manager.begin(target_model="b", reason="model_switch")
+
+    assert first.phase is LifecyclePhase.SUPERSEDED
+    with pytest.raises(LifecycleOperationConflictError):
+        await manager.confirm(first.id)
+    await manager.cancel(second.id)
+    async with manager.admit():
+        assert (await manager.status())["active_requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_abandoned_operation_expires_and_reopens_admission():
+    now = 10.0
+    manager = ModelLifecycleManager(
+        clock=lambda: now,
+        operation_timeout_seconds=5,
+    )
+    operation = await manager.begin(target_model="new", reason="model_switch")
+    now = 16.0
+
+    assert (await manager.status())["accepting_requests"] is True
+    assert operation.phase is LifecyclePhase.EXPIRED
+    async with manager.admit():
+        pass
+
+
+@pytest.mark.asyncio
+async def test_asgi_middleware_counts_until_stream_body_finishes():
+    config = reset_config()
+    manager = ModelLifecycleManager()
+    config.lifecycle_manager = manager
+    body_release = asyncio.Event()
+    response_started = asyncio.Event()
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def streaming_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"one", "more_body": True})
+        response_started.set()
+        await body_release.wait()
+        await send({"type": "http.response.body", "body": b"two"})
+
+    middleware = ModelLifecycleMiddleware(streaming_app)
+    scope = {"type": "http", "path": "/v1/chat/completions", "method": "POST"}
+
+    task = asyncio.create_task(middleware(scope, None, send))
+    await response_started.wait()
+    assert (await manager.status())["active_requests"] == 1
+    operation = await manager.begin(target_model="new", reason="model_switch")
+    assert operation.affected_requests == 1
+    body_release.set()
+    await task
+    assert (await manager.status())["active_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_asgi_middleware_rejects_new_inference_but_not_control_plane():
+    config = reset_config()
+    manager = ModelLifecycleManager()
+    config.lifecycle_manager = manager
+    operation = await manager.begin(target_model="new", reason="model_switch")
+
+    calls = []
+
+    async def app(scope, receive, send):
+        calls.append(scope["path"])
+
+    middleware = ModelLifecycleMiddleware(app)
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(
+        {"type": "http", "path": "/v1/chat/completions", "method": "POST"},
+        None,
+        send,
+    )
+    assert calls == []
+    assert sent[0]["status"] == 409
+    payload = json.loads(sent[1]["body"])
+    assert payload["error"]["operation_id"] == operation.id
+
+    await middleware(
+        {"type": "http", "path": "/v1/models/lifecycle", "method": "GET"},
+        None,
+        send,
+    )
+    assert calls == ["/v1/models/lifecycle"]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_middleware_preserves_auth_before_drain_rejection():
+    config = reset_config()
+    config.api_key = "secret"
+    manager = ModelLifecycleManager()
+    config.lifecycle_manager = manager
+    await manager.begin(target_model="new", reason="model_switch")
+    calls = []
+
+    async def app(scope, receive, send):
+        calls.append(scope)
+
+    middleware = ModelLifecycleMiddleware(app)
+
+    await middleware(
+        {"type": "http", "path": "/v1/chat/completions", "headers": []},
+        None,
+        None,
+    )
+    assert len(calls) == 1
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(
+        {
+            "type": "http",
+            "path": "/v1/chat/completions",
+            "headers": [(b"authorization", b"Bearer secret")],
+        },
+        None,
+        send,
+    )
+    assert sent[0]["status"] == 409

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -198,6 +198,7 @@ PROTECTED_ROUTER_MODULES = (
     "vllm_mlx.routes.completions",
     "vllm_mlx.routes.embeddings",
     "vllm_mlx.routes.mcp_routes",
+    "vllm_mlx.routes.model_lifecycle",
     "vllm_mlx.routes.models",
     "vllm_mlx.routes.responses",
 )

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -45,6 +45,7 @@ class ServerConfig:
     # legacy ``engine`` fields remain the protected startup/default model;
     # request routes consult this manager for residency, eviction, and status.
     residency_manager: Any = None
+    lifecycle_manager: Any = None
     # True only after lifespan has finished engine.start(), warmup,
     # prefix-cache load_from_disk, and MCP init. Used by /health/ready
     # so callers (e.g. validation pipelines) can wait for a real

--- a/vllm_mlx/middleware/model_lifecycle.py
+++ b/vllm_mlx/middleware/model_lifecycle.py
@@ -1,0 +1,95 @@
+"""ASGI inference admission tied to the model lifecycle control plane."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import HTTPException
+
+from ..config import get_config
+from ..runtime.model_lifecycle import (
+    LifecycleAdmissionClosedError,
+    get_lifecycle_manager,
+)
+from .auth import _extract_bearer_token, _verify_api_key_values
+
+_INFERENCE_PATHS = frozenset(
+    {
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/v1/responses",
+        "/v1/messages",
+        "/v1/messages/count_tokens",
+        "/v1/embeddings",
+        "/v1/images/generations",
+        "/v1/images/edits",
+        "/v1/audio/transcriptions",
+        "/v1/audio/speech",
+        "/v1/audio/translations",
+        "/v1/audio/music",
+        "/v1/videos",
+    }
+)
+
+
+class ModelLifecycleMiddleware:
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope.get("type") != "http" or scope.get("path") not in _INFERENCE_PATHS:
+            await self.app(scope, receive, send)
+            return
+        if not _request_is_authenticated(scope):
+            # Preserve the route dependency's exact 401 envelope. Lifecycle
+            # state and operation ids must not be disclosed before auth.
+            await self.app(scope, receive, send)
+            return
+        manager = get_lifecycle_manager()
+        try:
+            async with manager.admit():
+                await self.app(scope, receive, send)
+        except LifecycleAdmissionClosedError as exc:
+            body = json.dumps(
+                {
+                    "error": {
+                        "code": "model_lifecycle_draining",
+                        "message": "The model server is preparing a lifecycle change.",
+                        "operation_id": exc.operation_id,
+                    }
+                },
+                separators=(",", ":"),
+            ).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 409,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"content-length", str(len(body)).encode()),
+                        (b"retry-after", b"1"),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+
+
+def install_model_lifecycle_middleware(app) -> None:
+    app.add_middleware(ModelLifecycleMiddleware)
+
+
+def _request_is_authenticated(scope) -> bool:
+    if get_config().api_key is None:
+        return True
+    headers: dict[bytes, list[str]] = {}
+    for name, value in scope.get("headers", []):
+        headers.setdefault(name.lower(), []).append(value.decode("latin-1"))
+    authorization = (headers.get(b"authorization") or [None])[0]
+    bearer = _extract_bearer_token(authorization)
+    keys: list[str | None] = [bearer]
+    if scope.get("path") in {"/v1/messages", "/v1/messages/count_tokens"}:
+        keys.extend(headers.get(b"x-api-key", []))
+    try:
+        return _verify_api_key_values(*keys)
+    except HTTPException:
+        return False

--- a/vllm_mlx/routes/model_lifecycle.py
+++ b/vllm_mlx/routes/model_lifecycle.py
@@ -1,0 +1,63 @@
+"""Authenticated model lifecycle drain permits and status."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..middleware.auth import verify_api_key
+from ..runtime.model_lifecycle import (
+    LifecycleOperationConflictError,
+    LifecycleOperationNotFoundError,
+    get_lifecycle_manager,
+)
+
+router = APIRouter(dependencies=[Depends(verify_api_key)])
+
+
+class LifecycleBeginRequest(BaseModel):
+    target_model: str | None = Field(default=None, min_length=1)
+    reason: str = Field(default="model_switch", min_length=1, max_length=64)
+
+
+def _manager():
+    return get_lifecycle_manager()
+
+
+@router.get("/v1/models/lifecycle")
+async def lifecycle_status():
+    return await _manager().status()
+
+
+@router.post("/v1/models/lifecycle/operations", status_code=201)
+async def begin_lifecycle_operation(request: LifecycleBeginRequest):
+    operation = await _manager().begin(
+        target_model=request.target_model,
+        reason=request.reason,
+    )
+    return operation.payload()
+
+
+async def _transition(operation_id: str, action: str):
+    try:
+        operation = await getattr(_manager(), action)(operation_id)
+    except LifecycleOperationNotFoundError as exc:
+        raise HTTPException(404, "Lifecycle operation not found") from exc
+    except LifecycleOperationConflictError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return operation.payload()
+
+
+@router.post("/v1/models/lifecycle/operations/{operation_id}/confirm")
+async def confirm_lifecycle_operation(operation_id: str):
+    return await _transition(operation_id, "confirm")
+
+
+@router.delete("/v1/models/lifecycle/operations/{operation_id}")
+async def cancel_lifecycle_operation(operation_id: str):
+    return await _transition(operation_id, "cancel")
+
+
+@router.post("/v1/models/lifecycle/operations/{operation_id}/complete")
+async def complete_lifecycle_operation(operation_id: str):
+    return await _transition(operation_id, "complete")

--- a/vllm_mlx/runtime/model_lifecycle.py
+++ b/vllm_mlx/runtime/model_lifecycle.py
@@ -1,0 +1,193 @@
+"""Authoritative request admission and model lifecycle operations."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class LifecyclePhase(StrEnum):
+    AWAITING_CONFIRMATION = "awaiting_confirmation"
+    READY = "ready"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    SUPERSEDED = "superseded"
+    EXPIRED = "expired"
+
+
+class LifecycleAdmissionClosedError(RuntimeError):
+    def __init__(self, operation_id: str) -> None:
+        super().__init__("model lifecycle operation is draining request admission")
+        self.operation_id = operation_id
+
+
+class LifecycleOperationNotFoundError(KeyError):
+    pass
+
+
+class LifecycleOperationConflictError(RuntimeError):
+    pass
+
+
+@dataclass
+class LifecycleOperation:
+    id: str
+    target_model: str | None
+    reason: str
+    phase: LifecyclePhase
+    affected_requests: int
+    created_at: float
+    expires_at: float
+
+    def payload(self) -> dict:
+        return {
+            "id": self.id,
+            "target_model": self.target_model,
+            "reason": self.reason,
+            "phase": self.phase.value,
+            "affected_requests": self.affected_requests,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "admission_closed": self.phase
+            in {LifecyclePhase.AWAITING_CONFIRMATION, LifecyclePhase.READY},
+        }
+
+
+class ModelLifecycleManager:
+    """Serialize drain permits with inference admission under one lock.
+
+    The permit does not kill or replace a process. It closes admission
+    atomically, reports the requests that were already active, and gives an
+    external supervisor an operation id it can confirm/cancel/complete.
+    """
+
+    def __init__(self, *, clock=time.time, operation_timeout_seconds: float = 300) -> None:
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        self._active_requests = 0
+        self._current: LifecycleOperation | None = None
+        self._history: dict[str, LifecycleOperation] = {}
+        self._operation_timeout_seconds = max(1.0, operation_timeout_seconds)
+
+    @asynccontextmanager
+    async def admit(self):
+        async with self._lock:
+            self._expire_locked()
+            current = self._current
+            if current is not None and current.phase in {
+                LifecyclePhase.AWAITING_CONFIRMATION,
+                LifecyclePhase.READY,
+            }:
+                raise LifecycleAdmissionClosedError(current.id)
+            self._active_requests += 1
+        try:
+            yield
+        finally:
+            async with self._lock:
+                self._active_requests = max(0, self._active_requests - 1)
+
+    async def begin(self, *, target_model: str | None, reason: str) -> LifecycleOperation:
+        async with self._lock:
+            self._expire_locked()
+            if self._current is not None and self._current.phase in {
+                LifecyclePhase.AWAITING_CONFIRMATION,
+                LifecyclePhase.READY,
+            }:
+                self._current.phase = LifecyclePhase.SUPERSEDED
+            created_at = self._clock()
+            operation = LifecycleOperation(
+                id=str(uuid.uuid4()),
+                target_model=target_model,
+                reason=reason,
+                phase=(
+                    LifecyclePhase.AWAITING_CONFIRMATION
+                    if self._active_requests > 0
+                    else LifecyclePhase.READY
+                ),
+                affected_requests=self._active_requests,
+                created_at=created_at,
+                expires_at=created_at + self._operation_timeout_seconds,
+            )
+            self._current = operation
+            self._history[operation.id] = operation
+            return operation
+
+    async def confirm(self, operation_id: str) -> LifecycleOperation:
+        async with self._lock:
+            self._expire_locked()
+            operation = self._lookup_current(operation_id)
+            if operation.phase is not LifecyclePhase.AWAITING_CONFIRMATION:
+                raise LifecycleOperationConflictError(
+                    f"operation cannot be confirmed from {operation.phase.value}"
+                )
+            operation.phase = LifecyclePhase.READY
+            return operation
+
+    async def cancel(self, operation_id: str) -> LifecycleOperation:
+        async with self._lock:
+            self._expire_locked()
+            operation = self._lookup_current(operation_id)
+            if operation.phase not in {
+                LifecyclePhase.AWAITING_CONFIRMATION,
+                LifecyclePhase.READY,
+            }:
+                raise LifecycleOperationConflictError(
+                    f"operation cannot be cancelled from {operation.phase.value}"
+                )
+            operation.phase = LifecyclePhase.CANCELLED
+            self._current = None
+            return operation
+
+    async def complete(self, operation_id: str) -> LifecycleOperation:
+        async with self._lock:
+            self._expire_locked()
+            operation = self._lookup_current(operation_id)
+            if operation.phase is not LifecyclePhase.READY:
+                raise LifecycleOperationConflictError(
+                    f"operation cannot be completed from {operation.phase.value}"
+                )
+            operation.phase = LifecyclePhase.COMPLETED
+            self._current = None
+            return operation
+
+    async def status(self) -> dict:
+        async with self._lock:
+            self._expire_locked()
+            return {
+                "accepting_requests": self._current is None,
+                "active_requests": self._active_requests,
+                "operation": self._current.payload() if self._current else None,
+            }
+
+    def _expire_locked(self) -> None:
+        if self._current is None:
+            return
+        if self._clock() < self._current.expires_at:
+            return
+        self._current.phase = LifecyclePhase.EXPIRED
+        self._current = None
+
+    def _lookup_current(self, operation_id: str) -> LifecycleOperation:
+        operation = self._history.get(operation_id)
+        if operation is None:
+            raise LifecycleOperationNotFoundError(operation_id)
+        if operation is not self._current:
+            raise LifecycleOperationConflictError(
+                f"operation is no longer current ({operation.phase.value})"
+            )
+        return operation
+
+
+def get_lifecycle_manager() -> ModelLifecycleManager:
+    """Return the config-scoped manager, recreating it after test resets."""
+
+    from ..config import get_config
+
+    config = get_config()
+    if config.lifecycle_manager is None:
+        config.lifecycle_manager = ModelLifecycleManager()
+    return config.lifecycle_manager

--- a/vllm_mlx/runtime/model_lifecycle.py
+++ b/vllm_mlx/runtime/model_lifecycle.py
@@ -97,7 +97,9 @@ class ModelLifecycleManager:
             async with self._lock:
                 self._active_requests = max(0, self._active_requests - 1)
 
-    async def begin(self, *, target_model: str | None, reason: str) -> LifecycleOperation:
+    async def begin(
+        self, *, target_model: str | None, reason: str
+    ) -> LifecycleOperation:
         async with self._lock:
             self._expire_locked()
             if self._current is not None and self._current.phase in {

--- a/vllm_mlx/runtime/model_lifecycle.py
+++ b/vllm_mlx/runtime/model_lifecycle.py
@@ -65,13 +65,20 @@ class ModelLifecycleManager:
     external supervisor an operation id it can confirm/cancel/complete.
     """
 
-    def __init__(self, *, clock=time.time, operation_timeout_seconds: float = 300) -> None:
+    def __init__(
+        self,
+        *,
+        clock=time.time,
+        operation_timeout_seconds: float = 300,
+        max_history: int = 256,
+    ) -> None:
         self._clock = clock
         self._lock = asyncio.Lock()
         self._active_requests = 0
         self._current: LifecycleOperation | None = None
         self._history: dict[str, LifecycleOperation] = {}
         self._operation_timeout_seconds = max(1.0, operation_timeout_seconds)
+        self._max_history = max(1, int(max_history))
 
     @asynccontextmanager
     async def admit(self):
@@ -114,6 +121,7 @@ class ModelLifecycleManager:
             )
             self._current = operation
             self._history[operation.id] = operation
+            self._trim_history_locked()
             return operation
 
     async def confirm(self, operation_id: str) -> LifecycleOperation:
@@ -170,6 +178,13 @@ class ModelLifecycleManager:
             return
         self._current.phase = LifecyclePhase.EXPIRED
         self._current = None
+
+    def _trim_history_locked(self) -> None:
+        while len(self._history) > self._max_history:
+            oldest_id = next(iter(self._history))
+            if self._current is not None and oldest_id == self._current.id:
+                break
+            self._history.pop(oldest_id, None)
 
     def _lookup_current(self, operation_id: str) -> LifecycleOperation:
         operation = self._history.get(operation_id)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -906,6 +906,12 @@ from .routes.images import install_image_body_limit_middleware  # noqa: E402
 
 install_image_body_limit_middleware(app)
 
+# Lifecycle admission wraps the complete ASGI response, including streaming
+# bodies, so active request counts do not drop when headers are first emitted.
+from .middleware.model_lifecycle import install_model_lifecycle_middleware  # noqa: E402
+
+install_model_lifecycle_middleware(app)
+
 # SECURITY: blanket request-body size cap across all /v1/* routes.
 # Defends against the DoS pattern documented in rapid-desktop#273 / #463
 # where a 10–100 MB JSON body silently runs full prefill (~60–90 s on a
@@ -2540,6 +2546,7 @@ from .routes.images import router as _images_router
 from .routes.mcp_routes import admin_router as _mcp_admin_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
+from .routes.model_lifecycle import router as _model_lifecycle_router
 from .routes.models import router as _models_router
 from .routes.residency import router as _residency_router
 from .routes.responses import router as _responses_router
@@ -2551,6 +2558,7 @@ app.include_router(_health_router)
 # ``X-Rapid-MLX-Internal: true`` gate ALSO applies when ``--api-key`` is unset.
 app.include_router(_health_admin_router)
 app.include_router(_metrics_router)
+app.include_router(_model_lifecycle_router)
 # Keep literal residency paths ahead of ``/v1/models/{model_id:path}`` so the
 # latter cannot consume ``residency`` as an ordinary model id.
 app.include_router(_residency_router)


### PR DESCRIPTION
## Summary
- make inference admission and lifecycle drain operations authoritative in the server
- expose authenticated lifecycle begin/status/confirm/cancel/complete APIs
- count active requests through complete streaming responses and reject new inference while draining
- preserve auth and existing load/inference behavior outside active lifecycle operations
- expire abandoned operations and document the server/supervisor responsibility boundary

## Compatibility
- existing `/v1/models/load` and inference contracts are unchanged when no lifecycle operation is active
- health and control-plane routes remain available during drain
- unauthenticated requests retain their existing auth path before lifecycle state is exposed

## Validation
- `python3.12 -m ruff check ...`
- `python3.12 -m pytest -q tests/test_model_lifecycle.py tests/test_resident_models.py tests/test_server_auth_ordering.py tests/test_config_and_middleware.py tests/test_server.py` (113 passed, 3 deselected)
- `git diff --check`