### PR TITLE
docs(perf): record 0.12.18 release gate

### DIFF
--- a/docs/engineering/performance/2026-08-22-release-0.12.18-perf-gate.md
+++ b/docs/engineering/performance/2026-08-22-release-0.12.18-perf-gate.md
@@ -1,0 +1,119 @@
+# Rapid-MLX 0.12.18 performance release gate
+
+Date: 2026-08-22
+
+## Outcome
+
+The release-candidate runtime passed focused Apple Silicon checks for the two
+new per-model prefill defaults and the unprofiled-model fallback:
+
+- Qwen3.5 9B 4-bit selected a 512-token prefill step automatically and served
+  long text prompts without output corruption.
+- Gemma 4 12B 4-bit selected a 512-token prefill step automatically and served
+  a real image request without an admission or runtime error.
+- LFM2.5 1.2B 4-bit, which has no model-specific recommendation, retained the
+  safe 2048-token fallback.
+- An explicit `--prefill-step-size 2048` overrode the Qwen recommendation, as
+  required by the runtime precedence contract.
+
+This is a one-repeat release regression gate, not a publishable engine
+comparison. Use the linked model reports for repeat-controlled competitor
+claims.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Machine | Mac mini, Apple M2 Pro, 32 GB unified memory |
+| OS | macOS 26.5.2 (25F84), arm64 |
+| Tested Git commit | `df10340b6cd88a446f5492326efe5f6fc5b2a2a4` |
+| Verified integration commit | `a8d970153791f3109bbbe87c0f451c42261a2cc4` |
+| Tested runtime tree (`vllm_mlx`) | `9502d72391fe9df4f439fc26f106958675985fad` |
+| Python | `~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python` |
+| MLX | 0.32.1 |
+| mlx-lm | 0.31.3 |
+| mlx-vlm | 0.6.15 |
+| transformers | 5.12.1 |
+| Rapid-MLX package metadata | 0.12.18 |
+| pflash | disabled for the text-service measurements |
+
+The repository source was selected with
+`PYTHONPATH=~/release-perf-0.12.18`; the installed package metadata therefore
+does not identify the runtime source by itself.
+
+## Reproduction
+
+Start the text server without setting a prefill step:
+
+```bash
+cd ~/release-perf-0.12.18
+PYTHONPATH="$PWD" ~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python \
+  -m vllm_mlx.cli serve qwen3.5-9b-4bit \
+  --host 127.0.0.1 --port 18080 --pflash off --no-thinking
+```
+
+Verify the effective configuration at `GET /v1/status`, then run:
+
+```bash
+PYTHONPATH="$PWD" ~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python \
+  scripts/bench_service_prefill.py \
+  --base-url http://127.0.0.1:18080/v1 \
+  --model qwen3.5-9b-4bit \
+  --tokenizer mlx-community/Qwen3.5-9B-4bit \
+  --lengths 4096 16384 --repeat 1 --max-tokens 4 \
+  --contention-length 16384 --contention-repeat 1 \
+  --contention-delay-ms 100 \
+  --output /tmp/release-0.12.18-qwen9.json
+```
+
+The LFM check used the same command with model `lfm2.5-1b-4bit`, tokenizer
+`mlx-community/LFM2.5-1.2B-Instruct-4bit`, a single 4096-token length, and a
+4096-token contention length. For override precedence, restart Qwen with
+`--prefill-step-size 2048` and inspect `/v1/status`.
+
+For Gemma, start the server without a prefill-step flag:
+
+```bash
+PYTHONPATH="$PWD" ~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python \
+  -m vllm_mlx.cli serve gemma-4-12b-4bit \
+  --host 127.0.0.1 --port 18080
+```
+
+Then send one OpenAI-compatible chat-completions request containing both text
+and `https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/docs/assets/logo.png`
+as an `image_url`. The startup log and `/v1/status` must show a 512-token step;
+the response must contain non-empty text and no scheduler/admission error.
+
+## Results
+
+| Model and path | Effective step | Workload | Result | Peak MLX memory |
+| --- | ---: | --- | --- | ---: |
+| Qwen3.5 9B 4-bit, automatic | 512 | cold 4,098 prompt tokens | TTFT 20.165 s; ~203.2 prompt tok/s | 10.28 GB |
+| Qwen3.5 9B 4-bit, automatic | 512 | cold 16,386 prompt tokens | TTFT 77.715 s; ~210.8 prompt tok/s | 10.28 GB |
+| Qwen3.5 9B 4-bit, exact prefix | 512 | 16,371 cached tokens | TTFT 1.185 s | 10.28 GB |
+| Qwen3.5 9B 4-bit, partial prefix | 512 | 16,371 cached tokens | TTFT 0.877 s | 10.28 GB |
+| Qwen3.5 9B 4-bit, explicit override | 2048 | configuration check | override honored | n/a |
+| LFM2.5 1.2B 4-bit, unprofiled fallback | 2048 | cold 4,097 prompt tokens | TTFT 2.967 s; ~1,380.7 prompt tok/s | 3.06 GB |
+| Gemma 4 12B 4-bit, image request | 512 | 278 prompt + 21 completion tokens | valid response; 47.98 prompt tok/s; 24.31 generation tok/s | 7.48 GB |
+
+The Qwen and LFM JSON summaries had SHA-256 values
+`ff945827f6274761db549005f29d3239c73c92e14a2c847f816f50dcc7efe527`
+and `8eb8462015a1f5e8d0f2dc760ab0e2d8ec624696c8b00beb3f711a41a69b301d`
+respectively. They remain local benchmark artifacts; the commands and summary
+above are the durable reproduction record.
+
+## Interpretation and limitations
+
+- One repeat is sufficient for a release smoke but not for detecting small
+  throughput changes. Treat the numbers as pass/fail evidence only.
+- The Gemma result checks multimodal correctness and memory admission. Its short
+  prompt is not a meaningful prefill throughput comparison.
+- LFM prefix-cache hits were zero because this model path is not currently
+  prefix-trimmable; that behavior was outside this gate.
+- Contention was sampled once and is intentionally excluded from release claims.
+- Before tagging, compare the final release commit's `vllm_mlx` tree hash with
+  the tested tree above. Any runtime-tree change requires rerunning this gate.
+
+The integration commit listed above was checked after PR #2220 merged: both its
+`vllm_mlx` tree and benchmark-script blob matched the tested commit. No model
+rerun was required for that integration change.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -8,3 +8,4 @@ summary statistics, and limitations.
 
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)
 - [Qwen3.5-9B engine comparison on M2 Pro](2026-08-21-qwen3.5-9b-engine-comparison.md)
+- [Rapid-MLX 0.12.18 performance release gate](2026-08-22-release-0.12.18-perf-gate.md)


### PR DESCRIPTION
## Summary
- record the focused M2 Pro release performance gate for Qwen3.5 9B, Gemma 4 12B, and the unprofiled LFM fallback
- document environment, exact reproduction commands, results, artifact hashes, and limitations
- index the report in the performance knowledge README

## Verification
- `git diff --check`
- benchmarked commit `df10340b6cd88a446f5492326efe5f6fc5b2a2a4` on the M2 Pro mini
- PR #2220 head has the identical `vllm_mlx` tree (`9502d72391fe9df4f439fc26f106958675985fad`) and benchmark-script blob (`4a3a73b2c1901c716337452ec467246cb29d6d3a`)

## Scope
Documentation only. The measurements are explicitly labeled as a one-repeat release regression gate, not a competitor-performance claim.