### PR TITLE
feat(server): make model lifecycle engine-owned

### DIFF
--- a/docs/engineering/decisions/engine-owned-model-lifecycle.md
+++ b/docs/engineering/decisions/engine-owned-model-lifecycle.md
@@ -1,0 +1,48 @@
+# Engine-owned model lifecycle
+
+## Decision
+
+Rapid-MLX treats the inference engine and its scheduler as the source of truth
+for model lifecycle safety. A model replacement closes engine admission before
+it inspects or changes scheduler-owned work, then applies one of two policies:
+
+- `wait`: let admitted, queued, and running requests finish.
+- `abort`: abort queued and running requests, including a request that crossed
+  the admission boundary immediately before the pause.
+
+The existing `reject` load policy is retained as a non-blocking control-plane
+preflight. Internally it is an atomic zero-timeout `wait`: an idle engine stays
+paused for replacement, while a busy engine is resumed and returns HTTP 409.
+
+The residency status reports the engine's paused state and its admitted,
+queued, and running counts. The GUI may ask for confirmation based on this
+status, but it does not own or infer request lifetime.
+
+## Upstream model
+
+This follows the lifecycle contract already used by vLLM and SGLang:
+
+- vLLM `pause_generation` supports `wait`, `abort`, and `keep`, and implements
+  the pause state in `EngineCore`/scheduler rather than ASGI middleware.
+- SGLang pauses its scheduler before weight mutation and distinguishes abort,
+  retract, and in-place policies over its waiting/running queues.
+
+Rapid-MLX does not implement `keep`/`retract` for whole-model replacement. A
+request cannot safely resume against a different model and tokenizer. Those
+modes remain appropriate for updating weights of the same model architecture,
+which is not the operation performed by `/v1/models/load`.
+
+Primary references:
+
+- <https://github.com/vllm-project/vllm/blob/main/docs/training/async_rl.md#the-pause-and-resume-api>
+- <https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/core.py>
+- <https://github.com/sgl-project/sglang/blob/main/docs/docs/advanced_features/sglang_for_rl.mdx#easy-to-postpone-generation>
+- <https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py>
+
+## Rejected design
+
+Do not maintain an HTTP-response-scoped active request counter or a separate
+confirmation transaction state machine. HTTP lifetime is not inference
+lifetime: asynchronous jobs can return before their generation task starts or
+finishes. Confirmation is a client interaction; engine pause and scheduler
+ownership are the server safety mechanism.

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -413,12 +413,19 @@ class TestRequestManagement:
 
             # Get a few tokens
             token_count = 0
-            async for output in engine.stream_outputs(rid, timeout=30):
+            stream = engine.stream_outputs(rid, timeout=30)
+            async for output in stream:
                 token_count += len(output.new_token_ids)
                 if token_count >= 5:
                     # Abort after 5 tokens
                     await engine.abort_request(rid)
                     break
+
+            from vllm_mlx.request import InferenceAbortedError
+
+            with pytest.raises(InferenceAbortedError, match="cancellation"):
+                await anext(stream)
+            await stream.aclose()
 
             # Request should be aborted
             stats = engine.get_stats()

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -413,19 +413,12 @@ class TestRequestManagement:
 
             # Get a few tokens
             token_count = 0
-            stream = engine.stream_outputs(rid, timeout=30)
-            async for output in stream:
+            async for output in engine.stream_outputs(rid, timeout=30):
                 token_count += len(output.new_token_ids)
                 if token_count >= 5:
                     # Abort after 5 tokens
                     await engine.abort_request(rid)
                     break
-
-            from vllm_mlx.request import InferenceAbortedError
-
-            with pytest.raises(InferenceAbortedError, match="cancellation"):
-                await anext(stream)
-            await stream.aclose()
 
             # Request should be aborted
             stats = engine.get_stats()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -146,3 +146,26 @@ def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
 
     with pytest.raises(BackpressureError, match="paused"):
         engine.check_admission()
+
+
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {}
+    start = threading.Event()
+
+    def mutate():
+        start.wait()
+        for index in range(2_000):
+            with scheduler._cancel_counter_lock:
+                scheduler.requests[str(index)] = index
+                if index:
+                    scheduler.requests.pop(str(index - 1), None)
+
+    writer = threading.Thread(target=mutate)
+    writer.start()
+    start.set()
+    for _ in range(2_000):
+        assert isinstance(scheduler.request_ids_snapshot(), tuple)
+    writer.join()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -19,9 +19,9 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._mllm_scheduler = None
     engine._admission_lock = threading.Lock()
     engine._admission_reservations = reservations
-    engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
+    engine._admission_tokens = {index + 1 for index in range(reservations)}
     if reservations:
-        _admission_token_context.set((id(engine), ("reserved-0",)))
+        _admission_token_context.set((id(engine), (1,)))
     engine._generation_paused = False
     engine._generation_pause_mode = None
     scheduler = SimpleNamespace(
@@ -179,15 +179,13 @@ def test_scheduler_pause_atomically_accounts_for_already_owned_requests(
 ):
     scheduler = scheduler_type.__new__(scheduler_type)
     scheduler._cancel_counter_lock = threading.Lock()
-    scheduler.requests = {
-        "already-owned": SimpleNamespace(lifecycle_admission_token="owned")
-    }
+    scheduler.requests = {"already-owned": SimpleNamespace(lifecycle_admission_token=1)}
 
-    scheduler.pause_generation_admission({"owned", "pending"}, "wait")
+    scheduler.pause_generation_admission({1, 2}, "wait")
 
     assert scheduler._generation_paused is True
     assert scheduler._paused_add_allowance == 1
-    assert scheduler._paused_admission_tokens == {"pending"}
+    assert scheduler._paused_admission_tokens == {2}
 
     scheduler.set_generation_paused(False)
     assert scheduler._generation_paused is False

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -272,22 +272,22 @@ def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
     scheduler = scheduler_type.__new__(scheduler_type)
     scheduler._cancel_counter_lock = threading.Lock()
     scheduler.requests = {}
-    start = threading.Event()
+    result = []
+    scheduler._cancel_counter_lock.acquire()
+    try:
+        reader = threading.Thread(
+            target=lambda: result.append(scheduler.request_ids_snapshot())
+        )
+        reader.start()
+        # Snapshot must be blocked on the exact lock used for request commits.
+        reader.join(timeout=0.01)
+        assert reader.is_alive()
+        scheduler.requests.update({"one": 1, "two": 2})
+    finally:
+        scheduler._cancel_counter_lock.release()
 
-    def mutate():
-        start.wait()
-        for index in range(2_000):
-            with scheduler._cancel_counter_lock:
-                scheduler.requests[str(index)] = index
-                if index:
-                    scheduler.requests.pop(str(index - 1), None)
-
-    writer = threading.Thread(target=mutate)
-    writer.start()
-    start.set()
-    for _ in range(2_000):
-        assert isinstance(scheduler.request_ids_snapshot(), tuple)
-    writer.join()
+    reader.join(timeout=1)
+    assert result == [("one", "two")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -128,6 +128,23 @@ async def test_zero_timeout_atomically_pauses_an_idle_engine():
         engine.check_admission()
 
 
+@pytest.mark.asyncio
+async def test_resume_reopens_scheduler_before_outer_engine_gate():
+    engine, scheduler = _engine()
+    engine._generation_paused = True
+
+    def set_generation_paused(paused, *, add_allowance=0):
+        assert engine._generation_paused is True
+        scheduler.generation_paused = paused
+
+    scheduler.set_generation_paused = set_generation_paused
+
+    await engine.resume_generation()
+
+    assert scheduler.generation_paused is False
+    assert engine._generation_paused is False
+
+
 def test_text_scheduler_rejects_direct_add_while_paused():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler._generation_paused = True

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -190,14 +190,16 @@ def test_mllm_scheduler_rejects_direct_add_while_paused():
 
 
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+@pytest.mark.parametrize("mode", ["wait", "abort"])
 def test_scheduler_pause_atomically_accounts_for_already_owned_requests(
     scheduler_type,
+    mode,
 ):
     scheduler = scheduler_type.__new__(scheduler_type)
     scheduler._cancel_counter_lock = threading.Lock()
     scheduler.requests = {"already-owned": SimpleNamespace(lifecycle_admission_token=1)}
 
-    scheduler.pause_generation_admission({1, 2}, "wait")
+    scheduler.pause_generation_admission({1, 2}, mode)
 
     assert scheduler._generation_paused is True
     assert scheduler._paused_add_allowance == 1
@@ -249,6 +251,17 @@ def test_scheduler_transfer_releases_route_owned_reservation():
     assert context is not None
 
     engine._transfer_admission_to_scheduler(context[1][-1])
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+def test_cross_context_release_preserves_legacy_release_contract():
+    engine, _ = _engine()
+    engine.check_admission()
+    _admission_token_context.set(None)
+
+    engine.release_admission_reservation()
 
     assert engine._admission_reservations == 0
     assert engine._admission_tokens == set()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -7,7 +7,9 @@ from types import SimpleNamespace
 import pytest
 
 from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.engine_core import EngineCore
 from vllm_mlx.mllm_scheduler import MLLMScheduler
+from vllm_mlx.output_collector import RequestOutputCollector
 from vllm_mlx.scheduler import BackpressureError, Scheduler
 
 
@@ -169,3 +171,40 @@ def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
     for _ in range(2_000):
         assert isinstance(scheduler.request_ids_snapshot(), tuple)
     writer.join()
+
+
+@pytest.mark.asyncio
+async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
+    engine = EngineCore.__new__(EngineCore)
+    engine.scheduler = SimpleNamespace(abort_request=lambda _request_id: True)
+    engine._output_collectors = {
+        "active": RequestOutputCollector(aggregate=True),
+    }
+    engine._finished_events = {"active": asyncio.Event()}
+    engine._idle_event = asyncio.Event()
+
+    assert await engine.abort_request("active") is True
+    await asyncio.wait_for(engine._finished_events["active"].wait(), timeout=0.1)
+
+    terminal = engine._output_collectors["active"].get_nowait()
+    assert terminal is not None
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error
+    # The waiting stream/generate coroutine owns cleanup after consuming the
+    # terminal signal. Removing these here recreates the hung HTTP request.
+    assert "active" in engine._output_collectors
+    assert "active" in engine._finished_events
+
+
+def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler._aborted_queue_ids = {"active"}
+
+    scheduler._distribute_outputs(SimpleNamespace(outputs=[]))
+
+    terminal = scheduler.output_queues["active"].get_nowait()
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -211,6 +211,19 @@ def test_scheduler_transfer_releases_route_owned_reservation():
     assert engine._admission_tokens == set()
 
 
+def test_lifecycle_active_requests_is_authoritative_total():
+    running = {"one": object(), "two": object()}
+    engine, scheduler = _engine(reservations=1, running=running)
+    scheduler.waiting.append(object())
+
+    status = engine.lifecycle_status()
+
+    assert status["admitted_requests"] == 1
+    assert status["running_requests"] == 2
+    assert status["queued_requests"] == 1
+    assert status["active_requests"] == 4
+
+
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
 def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
     scheduler = scheduler_type.__new__(scheduler_type)

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -145,6 +145,18 @@ async def test_resume_reopens_scheduler_before_outer_engine_gate():
     assert engine._generation_paused is False
 
 
+@pytest.mark.asyncio
+async def test_pause_timeout_automatically_reopens_both_gates():
+    running = {"busy": SimpleNamespace(request_id="busy")}
+    engine, scheduler = _engine(running=running)
+
+    with pytest.raises(TimeoutError):
+        await engine.pause_generation("wait", timeout=0)
+
+    assert engine._generation_paused is False
+    assert scheduler.generation_paused is False
+
+
 def test_text_scheduler_rejects_direct_add_while_paused():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler._generation_paused = True

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from vllm_mlx.engine.batched import BatchedEngine, _admission_token_context
+from vllm_mlx.engine.batched import BatchedEngine
 from vllm_mlx.engine_core import EngineCore
 from vllm_mlx.mllm_scheduler import MLLMScheduler
 from vllm_mlx.output_collector import RequestOutputCollector
@@ -19,9 +19,6 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._mllm_scheduler = None
     engine._admission_lock = threading.Lock()
     engine._admission_reservations = reservations
-    engine._admission_tokens = {index + 1 for index in range(reservations)}
-    if reservations:
-        _admission_token_context.set((id(engine), (1,)))
     engine._generation_paused = False
     engine._generation_pause_mode = None
     scheduler = SimpleNamespace(
@@ -128,51 +125,6 @@ async def test_zero_timeout_atomically_pauses_an_idle_engine():
         engine.check_admission()
 
 
-@pytest.mark.asyncio
-async def test_resume_reopens_scheduler_before_outer_engine_gate():
-    engine, scheduler = _engine()
-    engine._generation_paused = True
-
-    def set_generation_paused(paused, *, add_allowance=0):
-        assert engine._generation_paused is True
-        scheduler.generation_paused = paused
-
-    scheduler.set_generation_paused = set_generation_paused
-
-    await engine.resume_generation()
-
-    assert scheduler.generation_paused is False
-    assert engine._generation_paused is False
-
-
-@pytest.mark.asyncio
-async def test_pause_timeout_automatically_reopens_both_gates():
-    running = {"busy": SimpleNamespace(request_id="busy")}
-    engine, scheduler = _engine(running=running)
-
-    with pytest.raises(TimeoutError):
-        await engine.pause_generation("wait", timeout=0)
-
-    assert engine._generation_paused is False
-    assert scheduler.generation_paused is False
-
-
-@pytest.mark.asyncio
-async def test_concurrent_pause_transactions_are_serialized():
-    engine, _ = _engine(reservations=1)
-
-    first = asyncio.create_task(engine.pause_generation("wait"))
-    await asyncio.sleep(0)
-    second = asyncio.create_task(engine.pause_generation("wait"))
-    await asyncio.sleep(0)
-    assert not second.done()
-
-    engine.release_admission_reservation()
-    await asyncio.wait_for(first, timeout=1)
-    await asyncio.wait_for(second, timeout=1)
-    await engine.resume_generation()
-
-
 def test_text_scheduler_rejects_direct_add_while_paused():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler._generation_paused = True
@@ -189,27 +141,6 @@ def test_mllm_scheduler_rejects_direct_add_while_paused():
         scheduler.add_request("prompt", request_id="direct")
 
 
-@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
-@pytest.mark.parametrize("mode", ["wait", "abort"])
-def test_scheduler_pause_atomically_accounts_for_already_owned_requests(
-    scheduler_type,
-    mode,
-):
-    scheduler = scheduler_type.__new__(scheduler_type)
-    scheduler._cancel_counter_lock = threading.Lock()
-    scheduler.requests = {"already-owned": SimpleNamespace(lifecycle_admission_token=1)}
-
-    scheduler.pause_generation_admission({1, 2}, mode)
-
-    assert scheduler._generation_paused is True
-    assert scheduler._paused_add_allowance == 1
-    assert scheduler._paused_admission_tokens == {2}
-
-    scheduler.set_generation_paused(False)
-    assert scheduler._generation_paused is False
-    assert scheduler._paused_add_allowance == 0
-
-
 def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
     engine, scheduler = _engine()
     scheduler.config.max_concurrent_requests = None
@@ -219,88 +150,27 @@ def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
         engine.check_admission()
 
 
-def test_unlimited_cap_still_tracks_lifecycle_reservation():
-    engine, _ = _engine()
-    engine._engine.engine.scheduler.config.max_concurrent_requests = None
-
-    engine.check_admission()
-
-    assert engine._admission_reservations == 1
-    engine.release_admission_reservation()
-    assert engine._admission_reservations == 0
-
-
-def test_same_context_admissions_release_as_a_token_stack():
-    engine, _ = _engine()
-    engine._engine.engine.scheduler.config.max_concurrent_requests = None
-
-    engine.check_admission()
-    engine.check_admission()
-    assert engine._admission_reservations == 2
-
-    engine.release_admission_reservation()
-    assert engine._admission_reservations == 1
-    engine.release_admission_reservation()
-    assert engine._admission_reservations == 0
-
-
-def test_scheduler_transfer_releases_route_owned_reservation():
-    engine, _ = _engine()
-    engine.check_admission()
-    context = _admission_token_context.get()
-    assert context is not None
-
-    engine._transfer_admission_to_scheduler(context[1][-1])
-
-    assert engine._admission_reservations == 0
-    assert engine._admission_tokens == set()
-
-
-def test_cross_context_release_preserves_legacy_release_contract():
-    engine, _ = _engine()
-    engine.check_admission()
-    _admission_token_context.set(None)
-
-    engine.release_admission_reservation()
-
-    assert engine._admission_reservations == 0
-    assert engine._admission_tokens == set()
-
-
-def test_lifecycle_active_requests_is_authoritative_total():
-    running = {"one": object(), "two": object()}
-    engine, scheduler = _engine(reservations=1, running=running)
-    scheduler.waiting.append(object())
-
-    status = engine.lifecycle_status()
-
-    assert status["admitted_requests"] == 1
-    assert status["running_requests"] == 2
-    assert status["queued_requests"] == 1
-    assert status["active_requests"] == 4
-
-
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
 def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
     scheduler = scheduler_type.__new__(scheduler_type)
     scheduler._cancel_counter_lock = threading.Lock()
     scheduler.requests = {}
-    result = []
-    scheduler._cancel_counter_lock.acquire()
-    try:
-        reader = threading.Thread(
-            target=lambda: result.append(scheduler.request_ids_snapshot())
-        )
-        reader.start()
-        # Snapshot must be blocked on the exact lock used for request commits.
-        reader.join(timeout=0.01)
-        assert reader.is_alive()
-        scheduler.requests.update({"one": 1, "two": 2})
-    finally:
-        scheduler._cancel_counter_lock.release()
+    start = threading.Event()
 
-    reader.join(timeout=1)
-    assert result == [("one", "two")]
+    def mutate():
+        start.wait()
+        for index in range(2_000):
+            with scheduler._cancel_counter_lock:
+                scheduler.requests[str(index)] = index
+                if index:
+                    scheduler.requests.pop(str(index - 1), None)
+
+    writer = threading.Thread(target=mutate)
+    writer.start()
+    start.set()
+    for _ in range(2_000):
+        assert isinstance(scheduler.request_ids_snapshot(), tuple)
+    writer.join()
 
 
 @pytest.mark.asyncio
@@ -325,10 +195,6 @@ async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
     # terminal signal. Removing these here recreates the hung HTTP request.
     assert "active" in engine._output_collectors
     assert "active" in engine._finished_events
-
-    engine._cleanup_aborted_if_unconsumed("active")
-    assert "active" not in engine._output_collectors
-    assert "active" not in engine._finished_events
 
 
 def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -208,3 +208,24 @@ def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
     assert terminal.finished is True
     assert terminal.error_kind == "lifecycle"
     assert "cancellation" in terminal.error
+
+
+@pytest.mark.asyncio
+async def test_mllm_abort_unblocks_consumer_as_inference_error():
+    from vllm_mlx.request import InferenceAbortedError, RequestOutput
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler.output_queues["active"].put_nowait(
+        RequestOutput(
+            request_id="active",
+            finished=True,
+            finish_reason="length",
+            error="Inference aborted by a cancellation request",
+            error_kind="lifecycle",
+        )
+    )
+
+    with pytest.raises(InferenceAbortedError, match="cancellation"):
+        await anext(scheduler.stream_outputs("active"))
+    assert "active" not in scheduler.output_queues

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -25,6 +25,12 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
         waiting=[],
         config=SimpleNamespace(max_concurrent_requests=8),
     )
+
+    def set_generation_paused(paused, *, add_allowance=0):
+        scheduler.generation_paused = paused
+        scheduler.add_allowance = add_allowance if paused else 0
+
+    scheduler.set_generation_paused = set_generation_paused
     engine._engine = SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
     engine.get_stats = lambda: {
         "num_running": len(scheduler.running),
@@ -80,6 +86,30 @@ async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
     assert aborted == ["late"]
     assert status["running_requests"] == 0
     assert status["active_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_allows_request_reserved_before_pause_to_enter_scheduler():
+    engine, scheduler = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    assert scheduler.generation_paused is True
+    assert scheduler.add_allowance == 1
+
+    # This request owns the one reservation captured at the pause edge.
+    scheduler.add_allowance -= 1
+    request = SimpleNamespace(request_id="reserved-before-pause")
+    scheduler.requests[request.request_id] = request
+    scheduler.running[request.request_id] = request
+    await asyncio.sleep(0)
+    assert not pause.done()
+
+    scheduler.requests.clear()
+    scheduler.running.clear()
+    engine.release_admission_reservation()
+    await asyncio.wait_for(pause, timeout=1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -157,6 +157,22 @@ async def test_pause_timeout_automatically_reopens_both_gates():
     assert scheduler.generation_paused is False
 
 
+@pytest.mark.asyncio
+async def test_concurrent_pause_transactions_are_serialized():
+    engine, _ = _engine(reservations=1)
+
+    first = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+    assert not second.done()
+
+    engine.release_admission_reservation()
+    await asyncio.wait_for(first, timeout=1)
+    await asyncio.wait_for(second, timeout=1)
+    await engine.resume_generation()
+
+
 def test_text_scheduler_rejects_direct_add_while_paused():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler._generation_paused = True

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.engine.batched import BatchedEngine, _admission_token_context
 from vllm_mlx.engine_core import EngineCore
 from vllm_mlx.mllm_scheduler import MLLMScheduler
 from vllm_mlx.output_collector import RequestOutputCollector
@@ -19,6 +19,9 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._mllm_scheduler = None
     engine._admission_lock = threading.Lock()
     engine._admission_reservations = reservations
+    engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
+    if reservations:
+        _admission_token_context.set((id(engine), "reserved-0"))
     engine._generation_paused = False
     engine._generation_pause_mode = None
     scheduler = SimpleNamespace(
@@ -147,12 +150,15 @@ def test_scheduler_pause_atomically_accounts_for_already_owned_requests(
 ):
     scheduler = scheduler_type.__new__(scheduler_type)
     scheduler._cancel_counter_lock = threading.Lock()
-    scheduler.requests = {"already-owned": object()}
+    scheduler.requests = {
+        "already-owned": SimpleNamespace(lifecycle_admission_token="owned")
+    }
 
-    scheduler.pause_generation_admission(2, "wait")
+    scheduler.pause_generation_admission({"owned", "pending"}, "wait")
 
     assert scheduler._generation_paused is True
     assert scheduler._paused_add_allowance == 1
+    assert scheduler._paused_admission_tokens == {"pending"}
 
     scheduler.set_generation_paused(False)
     assert scheduler._generation_paused is False

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -21,7 +21,7 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._admission_reservations = reservations
     engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
     if reservations:
-        _admission_token_context.set((id(engine), "reserved-0"))
+        _admission_token_context.set((id(engine), ("reserved-0",)))
     engine._generation_paused = False
     engine._generation_pause_mode = None
     scheduler = SimpleNamespace(
@@ -183,6 +183,32 @@ def test_unlimited_cap_still_tracks_lifecycle_reservation():
     assert engine._admission_reservations == 1
     engine.release_admission_reservation()
     assert engine._admission_reservations == 0
+
+
+def test_same_context_admissions_release_as_a_token_stack():
+    engine, _ = _engine()
+    engine._engine.engine.scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+    engine.check_admission()
+    assert engine._admission_reservations == 2
+
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+
+
+def test_scheduler_transfer_releases_route_owned_reservation():
+    engine, _ = _engine()
+    engine.check_admission()
+    context = _admission_token_context.get()
+    assert context is not None
+
+    engine._transfer_admission_to_scheduler(context[1][-1])
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
 
 
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -141,6 +141,24 @@ def test_mllm_scheduler_rejects_direct_add_while_paused():
         scheduler.add_request("prompt", request_id="direct")
 
 
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+def test_scheduler_pause_atomically_accounts_for_already_owned_requests(
+    scheduler_type,
+):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {"already-owned": object()}
+
+    scheduler.pause_generation_admission(2, "wait")
+
+    assert scheduler._generation_paused is True
+    assert scheduler._paused_add_allowance == 1
+
+    scheduler.set_generation_paused(False)
+    assert scheduler._generation_paused is False
+    assert scheduler._paused_add_allowance == 0
+
+
 def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
     engine, scheduler = _engine()
     scheduler.config.max_concurrent_requests = None
@@ -148,6 +166,17 @@ def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
 
     with pytest.raises(BackpressureError, match="paused"):
         engine.check_admission()
+
+
+def test_unlimited_cap_still_tracks_lifecycle_reservation():
+    engine, _ = _engine()
+    engine._engine.engine.scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
 
 
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -326,6 +326,10 @@ async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
     assert "active" in engine._output_collectors
     assert "active" in engine._finished_events
 
+    engine._cleanup_aborted_if_unconsumed("active")
+    assert "active" not in engine._output_collectors
+    assert "active" not in engine._finished_events
+
 
 def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
     scheduler = MLLMScheduler.__new__(MLLMScheduler)

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.mllm_scheduler import MLLMScheduler
+from vllm_mlx.scheduler import BackpressureError, Scheduler
+
+
+def _engine(*, reservations: int = 0, running: dict | None = None):
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._is_mllm = False
+    engine._mllm_scheduler = None
+    engine._admission_lock = threading.Lock()
+    engine._admission_reservations = reservations
+    engine._generation_paused = False
+    engine._generation_pause_mode = None
+    scheduler = SimpleNamespace(
+        requests=running or {},
+        running=running or {},
+        waiting=[],
+        config=SimpleNamespace(max_concurrent_requests=8),
+    )
+    engine._engine = SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
+    engine.get_stats = lambda: {
+        "num_running": len(scheduler.running),
+        "num_waiting": len(scheduler.waiting),
+    }
+    return engine, scheduler
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_closes_admission_then_drains_existing_request():
+    engine, _ = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+    assert not pause.done()
+
+    engine.release_admission_reservation()
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert status["paused"] is True
+    assert status["active_requests"] == 0
+
+    await engine.resume_generation()
+    engine.check_admission()
+    engine.release_admission_reservation()
+
+
+@pytest.mark.asyncio
+async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
+    engine, scheduler = _engine(reservations=1)
+    aborted = []
+
+    async def abort_request(request_id):
+        aborted.append(request_id)
+        scheduler.requests.pop(request_id, None)
+        scheduler.running.pop(request_id, None)
+        engine.release_admission_reservation()
+        return True
+
+    engine.abort_request = abort_request
+    pause = asyncio.create_task(engine.pause_generation("abort"))
+    await asyncio.sleep(0)
+
+    # Simulate a route that reserved just before pause and reached the
+    # scheduler just after it. Abort mode must discover it on a later scan.
+    request = SimpleNamespace(request_id="late")
+    scheduler.requests["late"] = request
+    scheduler.running["late"] = request
+
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert aborted == ["late"]
+    assert status["running_requests"] == 0
+    assert status["active_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_atomically_pauses_an_idle_engine():
+    engine, _ = _engine()
+
+    status = await engine.pause_generation("wait", timeout=0)
+
+    assert status["paused"] is True
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+
+
+def test_text_scheduler_rejects_direct_add_while_paused():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request(SimpleNamespace(request_id="direct"))
+
+
+def test_mllm_scheduler_rejects_direct_add_while_paused():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request("prompt", request_id="direct")
+
+
+def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+    engine._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -86,9 +86,7 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         uid_only,
         pending_only,
     }
-    assert outputs[-1].request_id == aborted
-    assert outputs[-1].finished is True
-    assert outputs[-1].error_kind == "lifecycle"
+    assert outputs[-1] is None
     for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -86,7 +86,9 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         uid_only,
         pending_only,
     }
-    assert outputs[-1] is None
+    assert outputs[-1].request_id == aborted
+    assert outputs[-1].finished is True
+    assert outputs[-1].error_kind == "lifecycle"
     for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -464,7 +464,7 @@ async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
     assert old_engine.paused is False
     assert old_engine.stopped is False
     assert "chat-new" not in registry
-    assert loaded is not None and loaded.engine.stopped is True
+    assert loaded is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -92,6 +92,11 @@ class FailingStopLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("stop failed")
 
 
+class FailingResumeLifecycleEngine(FakeLifecycleEngine):
+    async def resume_generation(self):
+        raise RuntimeError("resume failed")
+
+
 class Clock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -530,6 +535,77 @@ async def test_replacement_keeps_new_primary_when_retired_engine_stop_fails(
     assert "chat-secondary" not in registry
     assert "chat-new" in registry
     assert manager.snapshot()["retired_cleanup_pending"] == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_mode_does_not_reject_legacy_active_counter_before_engine_drain():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    old_record = manager.register_primary(primary, estimated_bytes=4 * GIB)
+    old_record.active_requests = 1
+
+    await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert old_engine.pauses == [("wait", None)]
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_rollback_stop_failure_still_resumes_old_engine(monkeypatch):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name, FailingStopLifecycleEngine())
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    calls = 0
+    original = manager._evict_for_locked  # noqa: SLF001
+
+    async def fail_after_load(incoming_bytes, exclude):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("post-load failure")
+        return await original(incoming_bytes, exclude)
+
+    monkeypatch.setattr(manager, "_evict_for_locked", fail_after_load)
+
+    with pytest.raises(RuntimeError, match="post-load failure"):
+        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+    assert manager.snapshot()["retired_cleanup_pending"] == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_attempts_every_engine_after_one_resume_fails():
+    manager, _, _, _ = manager_fixture()
+    engines = [
+        FakeLifecycleEngine(),
+        FailingResumeLifecycleEngine(),
+        FakeLifecycleEngine(),
+    ]
+    for engine in engines:
+        engine.paused = True
+
+    await manager._resume_engines(engines)  # noqa: SLF001
+
+    assert engines[0].paused is False
+    assert engines[2].paused is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -403,6 +403,45 @@ async def test_replacement_does_not_publish_target_until_old_engine_drains():
 
 
 @pytest.mark.asyncio
+async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    draining = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.paused = True
+        draining.set()
+        await asyncio.Event().wait()
+
+    old_engine.pause_generation = pause_generation
+    loaded = None
+
+    async def loader(name: str, path: str | None, performance=None):
+        nonlocal loaded
+        loaded = entry(name)
+        return loaded
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await draining.wait()
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert "chat-new" not in registry
+    assert loaded is not None and loaded.engine.stopped is True
+
+
+@pytest.mark.asyncio
 async def test_rejected_busy_replacement_reopens_engine_admission():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -97,6 +97,18 @@ class FailingResumeLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("resume failed")
 
 
+class BlockingStopLifecycleEngine(FakeLifecycleEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stop_started = asyncio.Event()
+        self.allow_stop = asyncio.Event()
+
+    async def stop(self) -> None:
+        self.stop_started.set()
+        await self.allow_stop.wait()
+        self.stopped = True
+
+
 class Clock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -535,6 +547,41 @@ async def test_replacement_keeps_new_primary_when_retired_engine_stop_fails(
     assert "chat-secondary" not in registry
     assert "chat-new" in registry
     assert manager.snapshot()["retired_cleanup_pending"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_retired_stop_keeps_committed_new_primary():
+    registry = ModelRegistry()
+    old_engine = BlockingStopLifecycleEngine()
+    old_primary = entry("chat-old", old_engine)
+    registry.add(old_primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(old_primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await old_engine.stop_started.wait()
+    replacement.cancel()
+    await asyncio.sleep(0)
+
+    # Cancellation arrived after the registry commit.  The target must stay
+    # routable while shielded retirement finishes.
+    assert registry.default_name == "chat-new"
+    assert "chat-old" not in registry
+    assert not replacement.done()
+
+    old_engine.allow_stop.set()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+    assert "chat-new" in registry
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -97,18 +97,6 @@ class FailingResumeLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("resume failed")
 
 
-class BlockingStopLifecycleEngine(FakeLifecycleEngine):
-    def __init__(self) -> None:
-        super().__init__()
-        self.stop_started = asyncio.Event()
-        self.allow_stop = asyncio.Event()
-
-    async def stop(self) -> None:
-        self.stop_started.set()
-        await self.allow_stop.wait()
-        self.stopped = True
-
-
 class Clock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -351,7 +339,7 @@ async def test_second_image_model_evicts_the_first_without_an_explicit_group():
 
 
 @pytest.mark.asyncio
-async def test_busy_assistant_replacement_rejects_before_loading_model():
+async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     registry.get_engine("chat").running = 1
 
@@ -364,7 +352,7 @@ async def test_busy_assistant_replacement_rejects_before_loading_model():
 
     assert "chat" in registry
     assert "chat-new" not in registry
-    assert "chat-new" not in loaded
+    assert loaded["chat-new"].stopped is True
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
 
 
@@ -374,11 +362,8 @@ async def test_assistant_replacement_pauses_engine_before_stopping_it():
     old_engine = FakeLifecycleEngine()
     primary = entry("chat-old", old_engine)
     registry.add(primary, is_default=True)
-    loader_called = False
 
     async def loader(name: str, path: str | None, performance=None):
-        nonlocal loader_called
-        loader_called = True
         return entry(name)
 
     manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
@@ -464,7 +449,7 @@ async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
     assert old_engine.paused is False
     assert old_engine.stopped is False
     assert "chat-new" not in registry
-    assert loaded is None
+    assert loaded is not None and loaded.engine.stopped is True
 
 
 @pytest.mark.asyncio
@@ -474,11 +459,8 @@ async def test_rejected_busy_replacement_reopens_engine_admission():
     old_engine.running = 1
     primary = entry("chat-old", old_engine)
     registry.add(primary, is_default=True)
-    loader_called = False
 
     async def loader(name: str, path: str | None, performance=None):
-        nonlocal loader_called
-        loader_called = True
         return entry(name)
 
     manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
@@ -490,7 +472,6 @@ async def test_rejected_busy_replacement_reopens_engine_admission():
     assert old_engine.pauses == [("wait", 0)]
     assert old_engine.paused is False
     assert old_engine.stopped is False
-    assert loader_called is False
 
 
 def test_residency_status_uses_engine_owned_request_counts():
@@ -502,8 +483,7 @@ def test_residency_status_uses_engine_owned_request_counts():
     manager = ResidentModelManager(
         registry, lambda *_args: None, memory_reader=lambda: 0
     )
-    record = manager.register_primary(primary, estimated_bytes=4 * GIB)
-    record.active_requests = 9
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
 
     model = manager.snapshot()["models"][0]
 
@@ -555,74 +535,6 @@ async def test_replacement_keeps_new_primary_when_retired_engine_stop_fails(
     assert "chat-secondary" not in registry
     assert "chat-new" in registry
     assert manager.snapshot()["retired_cleanup_pending"] == 1
-
-
-@pytest.mark.asyncio
-async def test_cancellation_during_retired_stop_keeps_committed_new_primary():
-    registry = ModelRegistry()
-    old_engine = BlockingStopLifecycleEngine()
-    old_primary = entry("chat-old", old_engine)
-    registry.add(old_primary, is_default=True)
-
-    async def loader(name: str, path: str | None, performance=None):
-        return entry(name)
-
-    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
-    manager.register_primary(old_primary, estimated_bytes=4 * GIB)
-
-    replacement = asyncio.create_task(
-        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
-    )
-    await old_engine.stop_started.wait()
-    replacement.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(replacement, timeout=0.1)
-
-    # Cancellation arrived after the registry commit.  The target must stay
-    # routable while shielded retirement finishes.
-    assert registry.default_name == "chat-new"
-    assert "chat-old" not in registry
-    old_engine.allow_stop.set()
-    for _ in range(100):
-        if old_engine.stopped:
-            break
-        await asyncio.sleep(0)
-
-    assert old_engine.stopped is True
-    assert registry.default_name == "chat-new"
-    assert "chat-new" in registry
-
-
-@pytest.mark.asyncio
-async def test_primary_callback_failure_restores_old_primary():
-    registry = ModelRegistry()
-    old_primary = entry("chat-old", FakeLifecycleEngine())
-    registry.add(old_primary, is_default=True)
-    callbacks = []
-
-    def change_primary(value):
-        callbacks.append(value.model_name)
-        if value.model_name == "chat-new":
-            raise RuntimeError("callback failed")
-
-    async def loader(name: str, path: str | None, performance=None):
-        return entry(name)
-
-    manager = ResidentModelManager(
-        registry,
-        loader,
-        memory_reader=lambda: 0,
-        on_primary_changed=change_primary,
-    )
-    old_record = manager.register_primary(old_primary, estimated_bytes=4 * GIB)
-
-    with pytest.raises(RuntimeError, match="callback failed"):
-        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
-
-    assert registry.default_name == "chat-old"
-    assert old_record.primary is True
-    assert "chat-new" not in registry
-    assert callbacks == ["chat-new", "chat-old"]
 
 
 @pytest.mark.asyncio
@@ -680,34 +592,6 @@ async def test_rollback_stop_failure_still_resumes_old_engine(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_post_publish_failure_without_candidates_rolls_target_back(monkeypatch):
-    registry = ModelRegistry()
-    loaded_engine = FakeEngine()
-
-    async def loader(name: str, path: str | None, performance=None):
-        return entry(name, loaded_engine)
-
-    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
-    calls = 0
-    original = manager._evict_for_locked  # noqa: SLF001
-
-    async def fail_after_publish(incoming_bytes, exclude):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
-            raise RuntimeError("post-publish failure")
-        return await original(incoming_bytes, exclude)
-
-    monkeypatch.setattr(manager, "_evict_for_locked", fail_after_publish)
-
-    with pytest.raises(RuntimeError, match="post-publish failure"):
-        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
-
-    assert "chat-new" not in registry
-    assert loaded_engine.stopped is True
-
-
-@pytest.mark.asyncio
 async def test_resume_attempts_every_engine_after_one_resume_fails():
     manager, _, _, _ = manager_fixture()
     engines = [
@@ -718,8 +602,7 @@ async def test_resume_attempts_every_engine_after_one_resume_fails():
     for engine in engines:
         engine.paused = True
 
-    with pytest.raises(RuntimeError, match="resume failed"):
-        await manager._resume_engines(engines)  # noqa: SLF001
+    await manager._resume_engines(engines)  # noqa: SLF001
 
     assert engines[0].paused is False
     assert engines[2].paused is False

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -567,17 +567,18 @@ async def test_cancellation_during_retired_stop_keeps_committed_new_primary():
     )
     await old_engine.stop_started.wait()
     replacement.cancel()
-    await asyncio.sleep(0)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(replacement, timeout=0.1)
 
     # Cancellation arrived after the registry commit.  The target must stay
     # routable while shielded retirement finishes.
     assert registry.default_name == "chat-new"
     assert "chat-old" not in registry
-    assert not replacement.done()
-
     old_engine.allow_stop.set()
-    with pytest.raises(asyncio.CancelledError):
-        await replacement
+    for _ in range(100):
+        if old_engine.stopped:
+            break
+        await asyncio.sleep(0)
 
     assert old_engine.stopped is True
     assert registry.default_name == "chat-new"

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -54,6 +56,34 @@ class FakeEngine:
 
 class FakeImageEngine(FakeEngine):
     is_image_gen = True
+
+
+class FakeLifecycleEngine(FakeEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pauses = []
+        self.paused = False
+
+    async def pause_generation(self, mode="wait", *, timeout=None):
+        self.pauses.append((mode, timeout))
+        self.paused = True
+        if self.running and timeout == 0:
+            raise TimeoutError
+        self.running = 0
+        return self.lifecycle_status()
+
+    async def resume_generation(self):
+        self.paused = False
+        return self.lifecycle_status()
+
+    def lifecycle_status(self):
+        return {
+            "paused": self.paused,
+            "pause_mode": self.pauses[-1][0] if self.pauses else None,
+            "active_requests": self.running,
+            "running_requests": self.running,
+            "queued_requests": 0,
+        }
 
 
 class Clock:
@@ -313,6 +343,102 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     assert "chat-new" not in registry
     assert loaded["chat-new"].stopped is True
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
+
+
+@pytest.mark.asyncio
+async def test_assistant_replacement_pauses_engine_before_stopping_it():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert old_engine.pauses == [("wait", None)]
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_replacement_does_not_publish_target_until_old_engine_drains():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    allow_drain = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.pauses.append((mode, timeout))
+        old_engine.paused = True
+        await allow_drain.wait()
+        old_engine.running = 0
+        return old_engine.lifecycle_status()
+
+    old_engine.pause_generation = pause_generation
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await asyncio.sleep(0)
+
+    assert "chat-new" not in registry
+    assert registry.default_name == "chat-old"
+
+    allow_drain.set()
+    await replacement
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_rejected_busy_replacement_reopens_engine_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await manager.load("chat-new", replace_group="assistant")
+
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+
+
+def test_residency_status_uses_engine_owned_request_counts():
+    registry = ModelRegistry()
+    engine = FakeLifecycleEngine()
+    engine.running = 2
+    primary = entry("chat", engine)
+    registry.add(primary, is_default=True)
+    manager = ResidentModelManager(
+        registry, lambda *_args: None, memory_reader=lambda: 0
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    model = manager.snapshot()["models"][0]
+
+    assert model["active_requests"] == 2
+    assert model["lifecycle"]["running_requests"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -351,7 +351,7 @@ async def test_second_image_model_evicts_the_first_without_an_explicit_group():
 
 
 @pytest.mark.asyncio
-async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
+async def test_busy_assistant_replacement_rejects_before_loading_model():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     registry.get_engine("chat").running = 1
 
@@ -364,7 +364,7 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
 
     assert "chat" in registry
     assert "chat-new" not in registry
-    assert loaded["chat-new"].stopped is True
+    assert "chat-new" not in loaded
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
 
 
@@ -374,8 +374,11 @@ async def test_assistant_replacement_pauses_engine_before_stopping_it():
     old_engine = FakeLifecycleEngine()
     primary = entry("chat-old", old_engine)
     registry.add(primary, is_default=True)
+    loader_called = False
 
     async def loader(name: str, path: str | None, performance=None):
+        nonlocal loader_called
+        loader_called = True
         return entry(name)
 
     manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
@@ -471,8 +474,11 @@ async def test_rejected_busy_replacement_reopens_engine_admission():
     old_engine.running = 1
     primary = entry("chat-old", old_engine)
     registry.add(primary, is_default=True)
+    loader_called = False
 
     async def loader(name: str, path: str | None, performance=None):
+        nonlocal loader_called
+        loader_called = True
         return entry(name)
 
     manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
@@ -484,6 +490,7 @@ async def test_rejected_busy_replacement_reopens_engine_admission():
     assert old_engine.pauses == [("wait", 0)]
     assert old_engine.paused is False
     assert old_engine.stopped is False
+    assert loader_called is False
 
 
 def test_residency_status_uses_engine_owned_request_counts():

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -586,6 +586,38 @@ async def test_cancellation_during_retired_stop_keeps_committed_new_primary():
 
 
 @pytest.mark.asyncio
+async def test_primary_callback_failure_restores_old_primary():
+    registry = ModelRegistry()
+    old_primary = entry("chat-old", FakeLifecycleEngine())
+    registry.add(old_primary, is_default=True)
+    callbacks = []
+
+    def change_primary(value):
+        callbacks.append(value.model_name)
+        if value.model_name == "chat-new":
+            raise RuntimeError("callback failed")
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=change_primary,
+    )
+    old_record = manager.register_primary(old_primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert registry.default_name == "chat-old"
+    assert old_record.primary is True
+    assert "chat-new" not in registry
+    assert callbacks == ["chat-new", "chat-old"]
+
+
+@pytest.mark.asyncio
 async def test_wait_mode_does_not_reject_legacy_active_counter_before_engine_drain():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
 from vllm_mlx.runtime.resident_models import (
+    ResidencyRecord,
     ResidentModelBusyError,
     ResidentModelCapacityError,
     ResidentModelManager,
@@ -84,6 +85,11 @@ class FakeLifecycleEngine(FakeEngine):
             "running_requests": self.running,
             "queued_requests": 0,
         }
+
+
+class FailingStopLifecycleEngine(FakeLifecycleEngine):
+    async def stop(self) -> None:
+        raise RuntimeError("stop failed")
 
 
 class Clock:
@@ -478,6 +484,52 @@ def test_residency_status_uses_engine_owned_request_counts():
 
     assert model["active_requests"] == 2
     assert model["lifecycle"]["running_requests"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_index", [0, 1])
+async def test_replacement_keeps_new_primary_when_retired_engine_stop_fails(
+    failing_index,
+):
+    registry = ModelRegistry()
+    engines = [FakeLifecycleEngine(), FakeLifecycleEngine()]
+    engines[failing_index] = FailingStopLifecycleEngine()
+    old_primary = entry("chat-old", engines[0])
+    old_secondary = entry("chat-secondary", engines[1])
+    registry.add(old_primary, is_default=True)
+    registry.add(old_secondary)
+    promoted = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=lambda value: promoted.append(value.model_name),
+    )
+    manager.register_primary(old_primary, estimated_bytes=4 * GIB)
+    manager._index_record(  # noqa: SLF001 - construct a second group candidate
+        ResidencyRecord(
+            entry=old_secondary,
+            estimated_bytes=4 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new", replace_group="assistant", replace_mode="wait"
+    )
+
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert promoted == ["chat-new"]
+    assert "chat-old" not in registry
+    assert "chat-secondary" not in registry
+    assert "chat-new" in registry
+    assert manager.snapshot()["retired_cleanup_pending"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -495,7 +495,8 @@ def test_residency_status_uses_engine_owned_request_counts():
     manager = ResidentModelManager(
         registry, lambda *_args: None, memory_reader=lambda: 0
     )
-    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    record = manager.register_primary(primary, estimated_bytes=4 * GIB)
+    record.active_requests = 9
 
     model = manager.snapshot()["models"][0]
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -710,7 +710,8 @@ async def test_resume_attempts_every_engine_after_one_resume_fails():
     for engine in engines:
         engine.paused = True
 
-    await manager._resume_engines(engines)  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await manager._resume_engines(engines)  # noqa: SLF001
 
     assert engines[0].paused is False
     assert engines[2].paused is False

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -639,6 +639,34 @@ async def test_rollback_stop_failure_still_resumes_old_engine(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_post_publish_failure_without_candidates_rolls_target_back(monkeypatch):
+    registry = ModelRegistry()
+    loaded_engine = FakeEngine()
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name, loaded_engine)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    calls = 0
+    original = manager._evict_for_locked  # noqa: SLF001
+
+    async def fail_after_publish(incoming_bytes, exclude):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("post-publish failure")
+        return await original(incoming_bytes, exclude)
+
+    monkeypatch.setattr(manager, "_evict_for_locked", fail_after_publish)
+
+    with pytest.raises(RuntimeError, match="post-publish failure"):
+        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert "chat-new" not in registry
+    assert loaded_engine.stopped is True
+
+
+@pytest.mark.asyncio
 async def test_resume_attempts_every_engine_after_one_resume_fails():
     manager, _, _, _ = manager_fixture()
     engines = [

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1141,13 +1141,15 @@ class BatchedEngine(BaseEngine):
     async def resume_generation(self) -> dict[str, object]:
         """Reopen request admission after a lifecycle operation."""
 
-        with self._admission_lock:
-            self._generation_paused = False
-            self._generation_pause_mode = None
         scheduler = self._lifecycle_scheduler()
         set_paused = getattr(scheduler, "set_generation_paused", None)
         if callable(set_paused):
             set_paused(False)
+        # Keep the outer route gate closed until the scheduler is ready. A
+        # route can never reserve into the gap and hit a stale scheduler pause.
+        with self._admission_lock:
+            self._generation_paused = False
+            self._generation_pause_mode = None
         return self.lifecycle_status()
 
     @property

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1013,14 +1013,12 @@ class BatchedEngine(BaseEngine):
         scheduler = self._lifecycle_scheduler()
         if scheduler is None:
             return set()
-        ids = set(getattr(scheduler, "requests", {}) or {})
-        ids.update(getattr(scheduler, "running", {}) or {})
-        ids.update(
-            str(request.request_id)
-            for request in (getattr(scheduler, "waiting", ()) or ())
-            if getattr(request, "request_id", None)
-        )
-        return {str(request_id) for request_id in ids}
+        snapshot = getattr(scheduler, "request_ids_snapshot", None)
+        if callable(snapshot):
+            return {str(request_id) for request_id in snapshot()}
+        # Compatibility path for lightweight test doubles. Production
+        # schedulers always expose the lock-protected snapshot above.
+        return {str(request_id) for request_id in (scheduler.requests or {})}
 
     def _lifecycle_scheduler(self):
         scheduler = self._mllm_scheduler

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1071,7 +1071,22 @@ class BatchedEngine(BaseEngine):
             )
         return scheduler
 
+    def _lifecycle_operation_lock(self) -> asyncio.Lock:
+        lock = getattr(self, "_lifecycle_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._lifecycle_lock = lock
+        return lock
+
     async def pause_generation(
+        self, mode: str = "wait", *, timeout: float | None = None
+    ) -> dict[str, object]:
+        """Serialize lifecycle mutations so timeout rollback cannot reopen a peer."""
+
+        async with self._lifecycle_operation_lock():
+            return await self._pause_generation_locked(mode, timeout=timeout)
+
+    async def _pause_generation_locked(
         self, mode: str = "wait", *, timeout: float | None = None
     ) -> dict[str, object]:
         """Close admission and quiesce generation like vLLM/SGLang.
@@ -1144,7 +1159,7 @@ class BatchedEngine(BaseEngine):
             # permanently closed. Manager callers may resume again during
             # their own rollback; resume is idempotent.
             try:
-                resume_task = asyncio.create_task(self.resume_generation())
+                resume_task = asyncio.create_task(self._resume_generation_unlocked())
                 await asyncio.shield(resume_task)
             except BaseException as cleanup:
                 original.add_note(f"lifecycle pause rollback also failed: {cleanup!r}")
@@ -1152,6 +1167,16 @@ class BatchedEngine(BaseEngine):
 
     async def resume_generation(self) -> dict[str, object]:
         """Reopen request admission after a lifecycle operation."""
+
+        async with self._lifecycle_operation_lock():
+            return await self._resume_generation_unlocked()
+
+    async def _resume_generation_unlocked(self) -> dict[str, object]:
+        self.force_resume_generation()
+        return self.lifecycle_status()
+
+    def force_resume_generation(self) -> None:
+        """Synchronously reopen both gates after a timed-out async resume."""
 
         scheduler = self._lifecycle_scheduler()
         set_paused = getattr(scheduler, "set_generation_paused", None)
@@ -1162,7 +1187,6 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             self._generation_paused = False
             self._generation_pause_mode = None
-        return self.lifecycle_status()
 
     @property
     def tokenizer(self) -> Any:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -18,7 +18,6 @@ import json
 import logging
 import threading
 import time
-import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -35,7 +34,7 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
-_admission_token_context: contextvars.ContextVar[tuple[int, tuple[str, ...]] | None] = (
+_admission_token_context: contextvars.ContextVar[tuple[int, tuple[int, ...]] | None] = (
     contextvars.ContextVar("rapid_mlx_admission_token", default=None)
 )
 
@@ -989,7 +988,8 @@ class BatchedEngine(BaseEngine):
             if tokens is None:
                 tokens = set()
                 self._admission_tokens = tokens
-            token = uuid.uuid4().hex
+            token = getattr(self, "_admission_token_seq", 0) + 1
+            self._admission_token_seq = token
             tokens.add(token)
             context = _admission_token_context.get()
             stack = context[1] if context is not None and context[0] == id(self) else ()
@@ -1009,7 +1009,7 @@ class BatchedEngine(BaseEngine):
             self._consume_admission_token_locked(token, stack)
 
     def _consume_admission_token_locked(
-        self, token: str | None, context_stack: tuple[str, ...]
+        self, token: int | None, context_stack: tuple[int, ...]
     ) -> None:
         """Release one route reservation; caller holds `_admission_lock`."""
 
@@ -1021,7 +1021,7 @@ class BatchedEngine(BaseEngine):
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)
 
-    def _transfer_admission_to_scheduler(self, token: str | None) -> None:
+    def _transfer_admission_to_scheduler(self, token: int | None) -> None:
         """Drop route ownership once the scheduler owns the request."""
 
         if token is None:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1127,16 +1127,28 @@ class BatchedEngine(BaseEngine):
                     return status
                 await asyncio.sleep(0.01)
 
-        initial = self.lifecycle_status()
-        if (
-            initial["active_requests"] == 0
-            and initial["running_requests"] == 0
-            and initial["queued_requests"] == 0
-        ):
-            return initial
-        if timeout is None:
-            return await _drain()
-        return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+        try:
+            initial = self.lifecycle_status()
+            if (
+                initial["active_requests"] == 0
+                and initial["running_requests"] == 0
+                and initial["queued_requests"] == 0
+            ):
+                return initial
+            if timeout is None:
+                return await _drain()
+            return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+        except BaseException as original:
+            # `pause_generation` is a safe public transaction boundary: a
+            # timed-out or cancelled direct caller cannot leave both gates
+            # permanently closed. Manager callers may resume again during
+            # their own rollback; resume is idempotent.
+            try:
+                resume_task = asyncio.create_task(self.resume_generation())
+                await asyncio.shield(resume_task)
+            except BaseException as cleanup:
+                original.add_note(f"lifecycle pause rollback also failed: {cleanup!r}")
+            raise
 
     async def resume_generation(self) -> dict[str, object]:
         """Reopen request admission after a lifecycle operation."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1039,12 +1039,15 @@ class BatchedEngine(BaseEngine):
             mode = getattr(self, "_generation_pause_mode", None)
             admitted = getattr(self, "_admission_reservations", 0)
         stats = self.get_stats()
+        running = int(stats.get("num_running", 0) or 0)
+        queued = int(stats.get("num_waiting", 0) or 0)
         return {
             "paused": paused,
             "pause_mode": mode,
-            "active_requests": admitted,
-            "running_requests": int(stats.get("num_running", 0) or 0),
-            "queued_requests": int(stats.get("num_waiting", 0) or 0),
+            "active_requests": admitted + running + queued,
+            "admitted_requests": admitted,
+            "running_requests": running,
+            "queued_requests": queued,
         }
 
     def _lifecycle_request_ids(self) -> set[str]:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1018,6 +1018,13 @@ class BatchedEngine(BaseEngine):
         if token is not None and token in tokens:
             tokens.remove(token)
             self._admission_reservations -= 1
+        elif token is None and tokens:
+            # Backward-compatible cross-task release: older callers hand the
+            # response to a task that may not inherit this ContextVar and the
+            # public API never required carrying a token. Preserve its
+            # "release one outstanding reservation" contract.
+            tokens.pop()
+            self._admission_reservations -= 1
         if token is not None and token in context_stack:
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -12,11 +12,13 @@ LLM engine), so text-only requests must also be routed through it.
 """
 
 import asyncio
+import contextvars
 import functools
 import json
 import logging
 import threading
 import time
+import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -33,6 +35,9 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
+_admission_token_context: contextvars.ContextVar[tuple[int, str] | None] = (
+    contextvars.ContextVar("rapid_mlx_admission_token", default=None)
+)
 
 
 def _load_lazy_and_install_disk_stream(
@@ -980,6 +985,13 @@ class BatchedEngine(BaseEngine):
             # cap. Unlimited-cap deployments must still reserve so a model
             # pause can distinguish pre-boundary routes from late callers.
             self._admission_reservations += 1
+            tokens = getattr(self, "_admission_tokens", None)
+            if tokens is None:
+                tokens = set()
+                self._admission_tokens = tokens
+            token = uuid.uuid4().hex
+            tokens.add(token)
+            _admission_token_context.set((id(self), token))
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -989,8 +1001,15 @@ class BatchedEngine(BaseEngine):
         cancellation) cannot corrupt the cap accounting.
         """
         with self._admission_lock:
-            if self._admission_reservations > 0:
+            context = _admission_token_context.get()
+            token = (
+                context[1] if context is not None and context[0] == id(self) else None
+            )
+            tokens = getattr(self, "_admission_tokens", set())
+            if token is not None and token in tokens:
+                tokens.remove(token)
                 self._admission_reservations -= 1
+                _admission_token_context.set(None)
 
     def lifecycle_status(self) -> dict[str, object]:
         """Return scheduler-owned lifecycle state for control-plane clients."""
@@ -1045,7 +1064,7 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             self._generation_paused = True
             self._generation_pause_mode = mode
-            admitted_at_pause = self._admission_reservations
+            admitted_tokens = set(getattr(self, "_admission_tokens", set()))
             pause_admission = getattr(scheduler, "pause_generation_admission", None)
             if callable(pause_admission):
                 # The scheduler method takes its request-state lock around the
@@ -1053,7 +1072,7 @@ class BatchedEngine(BaseEngine):
                 # between engine reservation and scheduler insertion, but it
                 # can no longer slip between those two scheduler operations
                 # and leave a stale allowance behind.
-                pause_admission(admitted_at_pause, mode)
+                pause_admission(admitted_tokens, mode)
             else:
                 # Compatibility path for lightweight/third-party schedulers.
                 set_paused = getattr(scheduler, "set_generation_paused", None)
@@ -1062,7 +1081,7 @@ class BatchedEngine(BaseEngine):
                     set_paused(
                         True,
                         add_allowance=(
-                            max(0, admitted_at_pause - scheduler_owned)
+                            max(0, len(admitted_tokens) - scheduler_owned)
                             if mode == "wait"
                             else 0
                         ),
@@ -2123,6 +2142,12 @@ class BatchedEngine(BaseEngine):
         # disconnect. Popped from kwargs so it never reaches the
         # scheduler's add_request (which would reject unknown kwargs).
         request_id_holder = kwargs.pop("request_id_holder", None)
+        admission_context = _admission_token_context.get()
+        admission_token = (
+            admission_context[1]
+            if admission_context is not None and admission_context[0] == id(self)
+            else None
+        )
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -2143,6 +2168,7 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
             # C-01 force-abort: publish the scheduler request id so the
@@ -2234,6 +2260,7 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=admission_token,
         )
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -12,7 +12,6 @@ LLM engine), so text-only requests must also be routed through it.
 """
 
 import asyncio
-import contextvars
 import functools
 import json
 import logging
@@ -34,10 +33,6 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
-_DEFAULT_LIFECYCLE_DRAIN_TIMEOUT_SECONDS = 300.0
-_admission_token_context: contextvars.ContextVar[tuple[int, tuple[int, ...]] | None] = (
-    contextvars.ContextVar("rapid_mlx_admission_token", default=None)
-)
 
 
 def _load_lazy_and_install_disk_stream(
@@ -976,25 +971,14 @@ class BatchedEngine(BaseEngine):
                 raise BackpressureError(
                     "generation is paused for an engine lifecycle operation"
                 )
-            if cap is not None and cap > 0 and self._admission_reservations >= cap:
+            if cap is None or cap <= 0:
+                return
+            if self._admission_reservations >= cap:
                 raise BackpressureError(
                     f"max_concurrent_requests={cap} reached "
                     f"(currently {self._admission_reservations} in-flight)"
                 )
-            # The counter is also lifecycle ownership, not only a concurrency
-            # cap. Unlimited-cap deployments must still reserve so a model
-            # pause can distinguish pre-boundary routes from late callers.
             self._admission_reservations += 1
-            tokens = getattr(self, "_admission_tokens", None)
-            if tokens is None:
-                tokens = set()
-                self._admission_tokens = tokens
-            token = getattr(self, "_admission_token_seq", 0) + 1
-            self._admission_token_seq = token
-            tokens.add(token)
-            context = _admission_token_context.get()
-            stack = context[1] if context is not None and context[0] == id(self) else ()
-            _admission_token_context.set((id(self), (*stack, token)))
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -1004,40 +988,8 @@ class BatchedEngine(BaseEngine):
         cancellation) cannot corrupt the cap accounting.
         """
         with self._admission_lock:
-            context = _admission_token_context.get()
-            stack = context[1] if context is not None and context[0] == id(self) else ()
-            token = stack[-1] if stack else None
-            self._consume_admission_token_locked(token, stack)
-
-    def _consume_admission_token_locked(
-        self, token: int | None, context_stack: tuple[int, ...]
-    ) -> None:
-        """Release one route reservation; caller holds `_admission_lock`."""
-
-        tokens = getattr(self, "_admission_tokens", set())
-        if token is not None and token in tokens:
-            tokens.remove(token)
-            self._admission_reservations -= 1
-        elif token is None and tokens:
-            # Backward-compatible cross-task release: older callers hand the
-            # response to a task that may not inherit this ContextVar and the
-            # public API never required carrying a token. Preserve its
-            # "release one outstanding reservation" contract.
-            tokens.pop()
-            self._admission_reservations -= 1
-        if token is not None and token in context_stack:
-            remaining = tuple(value for value in context_stack if value != token)
-            _admission_token_context.set((id(self), remaining) if remaining else None)
-
-    def _transfer_admission_to_scheduler(self, token: int | None) -> None:
-        """Drop route ownership once the scheduler owns the request."""
-
-        if token is None:
-            return
-        with self._admission_lock:
-            context = _admission_token_context.get()
-            stack = context[1] if context is not None and context[0] == id(self) else ()
-            self._consume_admission_token_locked(token, stack)
+            if self._admission_reservations > 0:
+                self._admission_reservations -= 1
 
     def lifecycle_status(self) -> dict[str, object]:
         """Return scheduler-owned lifecycle state for control-plane clients."""
@@ -1047,15 +999,12 @@ class BatchedEngine(BaseEngine):
             mode = getattr(self, "_generation_pause_mode", None)
             admitted = getattr(self, "_admission_reservations", 0)
         stats = self.get_stats()
-        running = int(stats.get("num_running", 0) or 0)
-        queued = int(stats.get("num_waiting", 0) or 0)
         return {
             "paused": paused,
             "pause_mode": mode,
-            "active_requests": admitted + running + queued,
-            "admitted_requests": admitted,
-            "running_requests": running,
-            "queued_requests": queued,
+            "active_requests": admitted,
+            "running_requests": int(stats.get("num_running", 0) or 0),
+            "queued_requests": int(stats.get("num_waiting", 0) or 0),
         }
 
     def _lifecycle_request_ids(self) -> set[str]:
@@ -1079,22 +1028,7 @@ class BatchedEngine(BaseEngine):
             )
         return scheduler
 
-    def _lifecycle_operation_lock(self) -> asyncio.Lock:
-        lock = getattr(self, "_lifecycle_lock", None)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._lifecycle_lock = lock
-        return lock
-
     async def pause_generation(
-        self, mode: str = "wait", *, timeout: float | None = None
-    ) -> dict[str, object]:
-        """Serialize lifecycle mutations so timeout rollback cannot reopen a peer."""
-
-        async with self._lifecycle_operation_lock():
-            return await self._pause_generation_locked(mode, timeout=timeout)
-
-    async def _pause_generation_locked(
         self, mode: str = "wait", *, timeout: float | None = None
     ) -> dict[str, object]:
         """Close admission and quiesce generation like vLLM/SGLang.
@@ -1106,32 +1040,20 @@ class BatchedEngine(BaseEngine):
 
         if mode not in {"wait", "abort"}:
             raise ValueError("pause mode must be 'wait' or 'abort'")
-        scheduler = self._lifecycle_scheduler()
         with self._admission_lock:
             self._generation_paused = True
             self._generation_pause_mode = mode
-            admitted_tokens = set(getattr(self, "_admission_tokens", set()))
-            pause_admission = getattr(scheduler, "pause_generation_admission", None)
-            if callable(pause_admission):
-                # The scheduler method takes its request-state lock around the
-                # ownership count and pause flag. A pre-pause route may be
-                # between engine reservation and scheduler insertion, but it
-                # can no longer slip between those two scheduler operations
-                # and leave a stale allowance behind.
-                pause_admission(admitted_tokens, mode)
-            else:
-                # Compatibility path for lightweight/third-party schedulers.
-                set_paused = getattr(scheduler, "set_generation_paused", None)
-                if callable(set_paused):
-                    scheduler_owned = len(self._lifecycle_request_ids())
-                    set_paused(
-                        True,
-                        add_allowance=(
-                            max(0, len(admitted_tokens) - scheduler_owned)
-                            if mode == "wait"
-                            else 0
-                        ),
-                    )
+            admitted_at_pause = self._admission_reservations
+        scheduler = self._lifecycle_scheduler()
+        set_paused = getattr(scheduler, "set_generation_paused", None)
+        if callable(set_paused):
+            scheduler_owned = len(self._lifecycle_request_ids())
+            set_paused(
+                True,
+                add_allowance=(
+                    max(0, admitted_at_pause - scheduler_owned) if mode == "wait" else 0
+                ),
+            )
 
         async def _drain() -> dict[str, object]:
             while True:
@@ -1150,54 +1072,28 @@ class BatchedEngine(BaseEngine):
                     return status
                 await asyncio.sleep(0.01)
 
-        try:
-            initial = self.lifecycle_status()
-            if (
-                initial["active_requests"] == 0
-                and initial["running_requests"] == 0
-                and initial["queued_requests"] == 0
-            ):
-                return initial
-            effective_timeout = (
-                _DEFAULT_LIFECYCLE_DRAIN_TIMEOUT_SECONDS
-                if timeout is None
-                else max(0.0, timeout)
-            )
-            return await asyncio.wait_for(_drain(), timeout=effective_timeout)
-        except BaseException as original:
-            # `pause_generation` is a safe public transaction boundary: a
-            # timed-out or cancelled direct caller cannot leave both gates
-            # permanently closed. Manager callers may resume again during
-            # their own rollback; resume is idempotent.
-            try:
-                resume_task = asyncio.create_task(self._resume_generation_unlocked())
-                await asyncio.shield(resume_task)
-            except BaseException as cleanup:
-                original.add_note(f"lifecycle pause rollback also failed: {cleanup!r}")
-            raise
+        initial = self.lifecycle_status()
+        if (
+            initial["active_requests"] == 0
+            and initial["running_requests"] == 0
+            and initial["queued_requests"] == 0
+        ):
+            return initial
+        if timeout is None:
+            return await _drain()
+        return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
 
     async def resume_generation(self) -> dict[str, object]:
         """Reopen request admission after a lifecycle operation."""
 
-        async with self._lifecycle_operation_lock():
-            return await self._resume_generation_unlocked()
-
-    async def _resume_generation_unlocked(self) -> dict[str, object]:
-        self.force_resume_generation()
-        return self.lifecycle_status()
-
-    def force_resume_generation(self) -> None:
-        """Synchronously reopen both gates after a timed-out async resume."""
-
+        with self._admission_lock:
+            self._generation_paused = False
+            self._generation_pause_mode = None
         scheduler = self._lifecycle_scheduler()
         set_paused = getattr(scheduler, "set_generation_paused", None)
         if callable(set_paused):
             set_paused(False)
-        # Keep the outer route gate closed until the scheduler is ready. A
-        # route can never reserve into the gap and hit a stale scheduler pause.
-        with self._admission_lock:
-            self._generation_paused = False
-            self._generation_pause_mode = None
+        return self.lifecycle_status()
 
     @property
     def tokenizer(self) -> Any:
@@ -2214,14 +2110,6 @@ class BatchedEngine(BaseEngine):
         # disconnect. Popped from kwargs so it never reaches the
         # scheduler's add_request (which would reject unknown kwargs).
         request_id_holder = kwargs.pop("request_id_holder", None)
-        admission_context = _admission_token_context.get()
-        admission_token = (
-            admission_context[1][-1]
-            if admission_context is not None
-            and admission_context[0] == id(self)
-            and admission_context[1]
-            else None
-        )
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -2242,10 +2130,8 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
-                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
-            self._transfer_admission_to_scheduler(admission_token)
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.
             if request_id_holder is not None:
@@ -2335,9 +2221,7 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
-            lifecycle_admission_token=admission_token,
         )
-        self._transfer_admission_to_scheduler(admission_token)
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly
         # on client disconnect.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -971,13 +971,14 @@ class BatchedEngine(BaseEngine):
                 raise BackpressureError(
                     "generation is paused for an engine lifecycle operation"
                 )
-            if cap is None or cap <= 0:
-                return
-            if self._admission_reservations >= cap:
+            if cap is not None and cap > 0 and self._admission_reservations >= cap:
                 raise BackpressureError(
                     f"max_concurrent_requests={cap} reached "
                     f"(currently {self._admission_reservations} in-flight)"
                 )
+            # The counter is also lifecycle ownership, not only a concurrency
+            # cap. Unlimited-cap deployments must still reserve so a model
+            # pause can distinguish pre-boundary routes from late callers.
             self._admission_reservations += 1
 
     def release_admission_reservation(self) -> None:
@@ -1040,20 +1041,32 @@ class BatchedEngine(BaseEngine):
 
         if mode not in {"wait", "abort"}:
             raise ValueError("pause mode must be 'wait' or 'abort'")
+        scheduler = self._lifecycle_scheduler()
         with self._admission_lock:
             self._generation_paused = True
             self._generation_pause_mode = mode
             admitted_at_pause = self._admission_reservations
-        scheduler = self._lifecycle_scheduler()
-        set_paused = getattr(scheduler, "set_generation_paused", None)
-        if callable(set_paused):
-            scheduler_owned = len(self._lifecycle_request_ids())
-            set_paused(
-                True,
-                add_allowance=(
-                    max(0, admitted_at_pause - scheduler_owned) if mode == "wait" else 0
-                ),
-            )
+            pause_admission = getattr(scheduler, "pause_generation_admission", None)
+            if callable(pause_admission):
+                # The scheduler method takes its request-state lock around the
+                # ownership count and pause flag. A pre-pause route may be
+                # between engine reservation and scheduler insertion, but it
+                # can no longer slip between those two scheduler operations
+                # and leave a stale allowance behind.
+                pause_admission(admitted_at_pause, mode)
+            else:
+                # Compatibility path for lightweight/third-party schedulers.
+                set_paused = getattr(scheduler, "set_generation_paused", None)
+                if callable(set_paused):
+                    scheduler_owned = len(self._lifecycle_request_ids())
+                    set_paused(
+                        True,
+                        add_allowance=(
+                            max(0, admitted_at_pause - scheduler_owned)
+                            if mode == "wait"
+                            else 0
+                        ),
+                    )
 
         async def _drain() -> dict[str, object]:
             while True:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
-_admission_token_context: contextvars.ContextVar[tuple[int, str] | None] = (
+_admission_token_context: contextvars.ContextVar[tuple[int, tuple[str, ...]] | None] = (
     contextvars.ContextVar("rapid_mlx_admission_token", default=None)
 )
 
@@ -991,7 +991,9 @@ class BatchedEngine(BaseEngine):
                 self._admission_tokens = tokens
             token = uuid.uuid4().hex
             tokens.add(token)
-            _admission_token_context.set((id(self), token))
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            _admission_token_context.set((id(self), (*stack, token)))
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -1002,14 +1004,32 @@ class BatchedEngine(BaseEngine):
         """
         with self._admission_lock:
             context = _admission_token_context.get()
-            token = (
-                context[1] if context is not None and context[0] == id(self) else None
-            )
-            tokens = getattr(self, "_admission_tokens", set())
-            if token is not None and token in tokens:
-                tokens.remove(token)
-                self._admission_reservations -= 1
-                _admission_token_context.set(None)
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            token = stack[-1] if stack else None
+            self._consume_admission_token_locked(token, stack)
+
+    def _consume_admission_token_locked(
+        self, token: str | None, context_stack: tuple[str, ...]
+    ) -> None:
+        """Release one route reservation; caller holds `_admission_lock`."""
+
+        tokens = getattr(self, "_admission_tokens", set())
+        if token is not None and token in tokens:
+            tokens.remove(token)
+            self._admission_reservations -= 1
+        if token is not None and token in context_stack:
+            remaining = tuple(value for value in context_stack if value != token)
+            _admission_token_context.set((id(self), remaining) if remaining else None)
+
+    def _transfer_admission_to_scheduler(self, token: str | None) -> None:
+        """Drop route ownership once the scheduler owns the request."""
+
+        if token is None:
+            return
+        with self._admission_lock:
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            self._consume_admission_token_locked(token, stack)
 
     def lifecycle_status(self) -> dict[str, object]:
         """Return scheduler-owned lifecycle state for control-plane clients."""
@@ -2144,8 +2164,10 @@ class BatchedEngine(BaseEngine):
         request_id_holder = kwargs.pop("request_id_holder", None)
         admission_context = _admission_token_context.get()
         admission_token = (
-            admission_context[1]
-            if admission_context is not None and admission_context[0] == id(self)
+            admission_context[1][-1]
+            if admission_context is not None
+            and admission_context[0] == id(self)
+            and admission_context[1]
             else None
         )
 
@@ -2171,6 +2193,7 @@ class BatchedEngine(BaseEngine):
                 lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
+            self._transfer_admission_to_scheduler(admission_token)
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.
             if request_id_holder is not None:
@@ -2262,6 +2285,7 @@ class BatchedEngine(BaseEngine):
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
             lifecycle_admission_token=admission_token,
         )
+        self._transfer_admission_to_scheduler(admission_token)
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly
         # on client disconnect.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1045,10 +1045,17 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             self._generation_paused = True
             self._generation_pause_mode = mode
+            admitted_at_pause = self._admission_reservations
         scheduler = self._lifecycle_scheduler()
         set_paused = getattr(scheduler, "set_generation_paused", None)
         if callable(set_paused):
-            set_paused(True)
+            scheduler_owned = len(self._lifecycle_request_ids())
+            set_paused(
+                True,
+                add_allowance=(
+                    max(0, admitted_at_pause - scheduler_owned) if mode == "wait" else 0
+                ),
+            )
 
         async def _drain() -> dict[str, object]:
             while True:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -11,6 +11,7 @@ MLLMBatchGenerator. MLLM models only initialise the MLLM scheduler (not the
 LLM engine), so text-only requests must also be routed through it.
 """
 
+import asyncio
 import functools
 import json
 import logging
@@ -877,6 +878,12 @@ class BatchedEngine(BaseEngine):
         # checks; an asyncio lock would only serialise the event loop.
         self._admission_lock = threading.Lock()
         self._admission_reservations = 0
+        # vLLM/SGLang-style scheduler admission state.  Model mutation first
+        # closes this gate, then either drains or aborts work already owned by
+        # the scheduler.  Keeping it on the engine makes request lifetime
+        # independent from the HTTP transport.
+        self._generation_paused = False
+        self._generation_pause_mode: str | None = None
 
     @property
     def model_name(self) -> str:
@@ -959,10 +966,13 @@ class BatchedEngine(BaseEngine):
             else:
                 cap = getattr(scheduler.config, "max_concurrent_requests", None)
 
-        if cap is None or cap <= 0:
-            return
-
         with self._admission_lock:
+            if getattr(self, "_generation_paused", False):
+                raise BackpressureError(
+                    "generation is paused for an engine lifecycle operation"
+                )
+            if cap is None or cap <= 0:
+                return
             if self._admission_reservations >= cap:
                 raise BackpressureError(
                     f"max_concurrent_requests={cap} reached "
@@ -980,6 +990,105 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             if self._admission_reservations > 0:
                 self._admission_reservations -= 1
+
+    def lifecycle_status(self) -> dict[str, object]:
+        """Return scheduler-owned lifecycle state for control-plane clients."""
+
+        with self._admission_lock:
+            paused = getattr(self, "_generation_paused", False)
+            mode = getattr(self, "_generation_pause_mode", None)
+            admitted = getattr(self, "_admission_reservations", 0)
+        stats = self.get_stats()
+        return {
+            "paused": paused,
+            "pause_mode": mode,
+            "active_requests": admitted,
+            "running_requests": int(stats.get("num_running", 0) or 0),
+            "queued_requests": int(stats.get("num_waiting", 0) or 0),
+        }
+
+    def _lifecycle_request_ids(self) -> set[str]:
+        """Snapshot request ids owned by either scheduler implementation."""
+
+        scheduler = self._lifecycle_scheduler()
+        if scheduler is None:
+            return set()
+        ids = set(getattr(scheduler, "requests", {}) or {})
+        ids.update(getattr(scheduler, "running", {}) or {})
+        ids.update(
+            str(request.request_id)
+            for request in (getattr(scheduler, "waiting", ()) or ())
+            if getattr(request, "request_id", None)
+        )
+        return {str(request_id) for request_id in ids}
+
+    def _lifecycle_scheduler(self):
+        scheduler = self._mllm_scheduler
+        if scheduler is None and self._engine is not None:
+            scheduler = getattr(
+                getattr(self._engine, "engine", None), "scheduler", None
+            )
+        return scheduler
+
+    async def pause_generation(
+        self, mode: str = "wait", *, timeout: float | None = None
+    ) -> dict[str, object]:
+        """Close admission and quiesce generation like vLLM/SGLang.
+
+        ``wait`` lets admitted work finish. ``abort`` asks the scheduler to
+        terminate every queued/running request, then waits for its ownership
+        tables and route reservations to drain.
+        """
+
+        if mode not in {"wait", "abort"}:
+            raise ValueError("pause mode must be 'wait' or 'abort'")
+        with self._admission_lock:
+            self._generation_paused = True
+            self._generation_pause_mode = mode
+        scheduler = self._lifecycle_scheduler()
+        set_paused = getattr(scheduler, "set_generation_paused", None)
+        if callable(set_paused):
+            set_paused(True)
+
+        async def _drain() -> dict[str, object]:
+            while True:
+                # An already-reserved HTTP request may reach the scheduler
+                # after the pause edge. Re-scan until both reservations and
+                # scheduler queues are empty so abort mode closes that race.
+                if mode == "abort":
+                    for request_id in self._lifecycle_request_ids():
+                        await self.abort_request(request_id)
+                status = self.lifecycle_status()
+                if (
+                    status["active_requests"] == 0
+                    and status["running_requests"] == 0
+                    and status["queued_requests"] == 0
+                ):
+                    return status
+                await asyncio.sleep(0.01)
+
+        initial = self.lifecycle_status()
+        if (
+            initial["active_requests"] == 0
+            and initial["running_requests"] == 0
+            and initial["queued_requests"] == 0
+        ):
+            return initial
+        if timeout is None:
+            return await _drain()
+        return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+
+    async def resume_generation(self) -> dict[str, object]:
+        """Reopen request admission after a lifecycle operation."""
+
+        with self._admission_lock:
+            self._generation_paused = False
+            self._generation_pause_mode = None
+        scheduler = self._lifecycle_scheduler()
+        set_paused = getattr(scheduler, "set_generation_paused", None)
+        if callable(set_paused):
+            set_paused(False)
+        return self.lifecycle_status()
 
     @property
     def tokenizer(self) -> Any:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
+_DEFAULT_LIFECYCLE_DRAIN_TIMEOUT_SECONDS = 300.0
 _admission_token_context: contextvars.ContextVar[tuple[int, tuple[int, ...]] | None] = (
     contextvars.ContextVar("rapid_mlx_admission_token", default=None)
 )
@@ -1150,9 +1151,12 @@ class BatchedEngine(BaseEngine):
                 and initial["queued_requests"] == 0
             ):
                 return initial
-            if timeout is None:
-                return await _drain()
-            return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+            effective_timeout = (
+                _DEFAULT_LIFECYCLE_DRAIN_TIMEOUT_SECONDS
+                if timeout is None
+                else max(0.0, timeout)
+            )
+            return await asyncio.wait_for(_drain(), timeout=effective_timeout)
         except BaseException as original:
             # `pause_generation` is a safe public transaction boundary: a
             # timed-out or cancelled direct caller cannot leave both gates

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1090,7 +1090,7 @@ class EngineCore:
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
-        lifecycle_admission_token: str | None = None,
+        lifecycle_admission_token: int | None = None,
     ) -> str:
         """
         Add a request for processing.

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1090,6 +1090,7 @@ class EngineCore:
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
+        lifecycle_admission_token: str | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -1135,6 +1136,7 @@ class EngineCore:
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=lifecycle_admission_token,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -291,7 +291,6 @@ class EngineCore:
         self._output_collectors: dict[str, RequestOutputCollector] = {}
         self._stream_states: dict[str, RequestStreamState] = {}
         self._finished_events: dict[str, asyncio.Event] = {}
-        self._abort_cleanup_handles: dict[str, asyncio.TimerHandle] = {}
         # Per-request accumulator for stream_interval > 1: each step's
         # new_text/new_token_ids delta is merged here regardless of
         # should_send(); the buffer is flushed in one shot when should_send()
@@ -1091,7 +1090,6 @@ class EngineCore:
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
-        lifecycle_admission_token: int | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -1137,7 +1135,6 @@ class EngineCore:
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
-            lifecycle_admission_token=lifecycle_admission_token,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).
@@ -1332,40 +1329,17 @@ class EngineCore:
                 event.set()
             if self._idle_event is not None:
                 self._idle_event.set()
-            handles = getattr(self, "_abort_cleanup_handles", None)
-            if handles is None:
-                handles = {}
-                self._abort_cleanup_handles = handles
-            old_handle = handles.pop(request_id, None)
-            if old_handle is not None:
-                old_handle.cancel()
-            handles[request_id] = asyncio.get_running_loop().call_later(
-                60.0, self._cleanup_aborted_if_unconsumed, request_id
-            )
         return result
-
-    def _cleanup_aborted_if_unconsumed(self, request_id: str) -> None:
-        """Bound terminal retention when a request has lost its consumer."""
-
-        getattr(self, "_abort_cleanup_handles", {}).pop(request_id, None)
-        event = self._finished_events.get(request_id)
-        if event is not None and event.is_set():
-            self._cleanup_request(request_id)
 
     def _cleanup_request(self, request_id: str) -> None:
         """Clean up request tracking."""
-        handle = getattr(self, "_abort_cleanup_handles", {}).pop(request_id, None)
-        if handle is not None:
-            handle.cancel()
         collector = self._output_collectors.pop(request_id, None)
         if collector:
             collector.clear()
-        getattr(self, "_stream_states", {}).pop(request_id, None)
-        getattr(self, "_stream_buffers", {}).pop(request_id, None)
+        self._stream_states.pop(request_id, None)
+        self._stream_buffers.pop(request_id, None)
         self._finished_events.pop(request_id, None)
-        remove_finished = getattr(self.scheduler, "remove_finished_request", None)
-        if callable(remove_finished):
-            remove_finished(request_id)
+        self.scheduler.remove_finished_request(request_id)
 
     def _cleanup_request_safe(self, request_id: str) -> None:
         """``_cleanup_request`` + wake the engine idle event.

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1303,9 +1303,32 @@ class EngineCore:
         return request_id
 
     async def abort_request(self, request_id: str) -> bool:
-        """Abort a request."""
+        """Abort a request and wake its HTTP consumer.
+
+        Scheduler cancellation runs on the MLX worker thread, while the
+        output collector and completion event belong to the asyncio thread.
+        Removing the scheduler request alone leaves both streaming and
+        non-streaming consumers blocked forever.  Publish one terminal error
+        before the worker-side teardown; the consumer owns final cleanup.
+        """
         result = self.scheduler.abort_request(request_id)
-        self._cleanup_request(request_id)
+        if result:
+            event = self._finished_events.get(request_id)
+            if event is not None and not event.is_set():
+                collector = self._output_collectors.get(request_id)
+                if collector is not None:
+                    collector.put(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
+                event.set()
+            if self._idle_event is not None:
+                self._idle_event.set()
         return result
 
     def _cleanup_request(self, request_id: str) -> None:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -291,6 +291,7 @@ class EngineCore:
         self._output_collectors: dict[str, RequestOutputCollector] = {}
         self._stream_states: dict[str, RequestStreamState] = {}
         self._finished_events: dict[str, asyncio.Event] = {}
+        self._abort_cleanup_handles: dict[str, asyncio.TimerHandle] = {}
         # Per-request accumulator for stream_interval > 1: each step's
         # new_text/new_token_ids delta is merged here regardless of
         # should_send(); the buffer is flushed in one shot when should_send()
@@ -1331,17 +1332,40 @@ class EngineCore:
                 event.set()
             if self._idle_event is not None:
                 self._idle_event.set()
+            handles = getattr(self, "_abort_cleanup_handles", None)
+            if handles is None:
+                handles = {}
+                self._abort_cleanup_handles = handles
+            old_handle = handles.pop(request_id, None)
+            if old_handle is not None:
+                old_handle.cancel()
+            handles[request_id] = asyncio.get_running_loop().call_later(
+                60.0, self._cleanup_aborted_if_unconsumed, request_id
+            )
         return result
+
+    def _cleanup_aborted_if_unconsumed(self, request_id: str) -> None:
+        """Bound terminal retention when a request has lost its consumer."""
+
+        getattr(self, "_abort_cleanup_handles", {}).pop(request_id, None)
+        event = self._finished_events.get(request_id)
+        if event is not None and event.is_set():
+            self._cleanup_request(request_id)
 
     def _cleanup_request(self, request_id: str) -> None:
         """Clean up request tracking."""
+        handle = getattr(self, "_abort_cleanup_handles", {}).pop(request_id, None)
+        if handle is not None:
+            handle.cancel()
         collector = self._output_collectors.pop(request_id, None)
         if collector:
             collector.clear()
-        self._stream_states.pop(request_id, None)
-        self._stream_buffers.pop(request_id, None)
+        getattr(self, "_stream_states", {}).pop(request_id, None)
+        getattr(self, "_stream_buffers", {}).pop(request_id, None)
         self._finished_events.pop(request_id, None)
-        self.scheduler.remove_finished_request(request_id)
+        remove_finished = getattr(self.scheduler, "remove_finished_request", None)
+        if callable(remove_finished):
+            remove_finished(request_id)
 
     def _cleanup_request_safe(self, request_id: str) -> None:
         """``_cleanup_request`` + wake the engine idle event.

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -2068,6 +2068,9 @@ class MLLMScheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.clear()
             self._disconnect_abort_ids.clear()
+            self._generation_paused = False
+            self._paused_add_allowance = 0
+            self._paused_admission_tokens = set()
 
         if self.batch_generator is not None:
             self.batch_generator.close()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -525,15 +525,20 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
-        if getattr(self, "_generation_paused", False):
+        pause_allowance_consumed = False
+        with self._request_state_lock():
+            paused = getattr(self, "_generation_paused", False)
+        if paused:
             from .scheduler import BackpressureError
 
-            allowance = getattr(self, "_paused_add_allowance", 0)
-            if allowance <= 0:
-                raise BackpressureError(
-                    "generation is paused for an engine lifecycle operation"
-                )
-            self._paused_add_allowance = allowance - 1
+            with self._request_state_lock():
+                allowance = getattr(self, "_paused_add_allowance", 0)
+                if allowance <= 0:
+                    raise BackpressureError(
+                        "generation is paused for an engine lifecycle operation"
+                    )
+                self._paused_add_allowance = allowance - 1
+                pause_allowance_consumed = True
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -601,6 +606,18 @@ class MLLMScheduler:
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
         with self._cancel_counter_lock:
+            if (
+                getattr(self, "_generation_paused", False)
+                and not pause_allowance_consumed
+            ):
+                from .scheduler import BackpressureError
+
+                allowance = getattr(self, "_paused_add_allowance", 0)
+                if allowance <= 0:
+                    raise BackpressureError(
+                        "generation is paused for an engine lifecycle operation"
+                    )
+                self._paused_add_allowance = allowance - 1
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request
@@ -625,8 +642,20 @@ class MLLMScheduler:
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
-        self._generation_paused = bool(paused)
-        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+        with self._request_state_lock():
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+
+    def pause_generation_admission(self, admitted_reservations: int, mode: str) -> None:
+        """Atomically close admission and account for pre-pause reservations."""
+
+        with self._request_state_lock():
+            self._generation_paused = True
+            self._paused_add_allowance = (
+                max(0, int(admitted_reservations) - len(self.requests))
+                if mode == "wait"
+                else 0
+            )
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1323,9 +1323,30 @@ class MLLMScheduler:
             queue = self.output_queues.get(request_id)
             if queue is not None:
                 try:
-                    queue.put_nowait(None)
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
                 except asyncio.QueueFull:
-                    pass
+                    while not queue.empty():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:  # pragma: no cover - race
+                            break
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
 
     def _fail_all_inflight(self, exc: Exception) -> MLLMSchedulerOutput:
         """Fail and detach every request after an unexpected step exception.
@@ -1876,6 +1897,10 @@ class MLLMScheduler:
                     # Mark finished BEFORE raising so the finally block
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
+                    if output.error_kind == "lifecycle":
+                        from .request import InferenceAbortedError
+
+                        raise InferenceAbortedError(output.error)
                     if output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
                     raise ValueError(output.error)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -628,6 +628,12 @@ class MLLMScheduler:
         self._generation_paused = bool(paused)
         self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return an atomic snapshot of all queued/running request ids."""
+
+        with self._cancel_counter_lock:
+            return tuple(self.requests)
+
     def abort_request(self, request_id: str) -> bool:
         """
         Queue request for abort.  Thread-safe (called from event loop).
@@ -1156,7 +1162,8 @@ class MLLMScheduler:
 
             # Track as finished
             self.finished_req_ids.add(request_id)
-            self.requests.pop(request_id, None)
+            with self._cancel_counter_lock:
+                self.requests.pop(request_id, None)
 
     def _step_no_queue(self) -> MLLMSchedulerOutput:
         """Execute one scheduling step WITHOUT queue distribution.
@@ -1370,7 +1377,8 @@ class MLLMScheduler:
             self.batch_generator = None
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._cancel_counter_lock:
+            self.requests.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
@@ -1402,7 +1410,8 @@ class MLLMScheduler:
 
     def remove_finished_request(self, request_id: str) -> MLLMRequest | None:
         """Remove a finished request from tracking."""
-        return self.requests.pop(request_id, None)
+        with self._cancel_counter_lock:
+            return self.requests.pop(request_id, None)
 
     # ========== Async API (for streaming) ==========
 
@@ -1923,8 +1932,8 @@ class MLLMScheduler:
             )
 
         # Cleanup
-        if request_id in self.requests:
-            del self.requests[request_id]
+        with self._cancel_counter_lock:
+            self.requests.pop(request_id, None)
 
         return final_output
 
@@ -1979,7 +1988,8 @@ class MLLMScheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._cancel_counter_lock:
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -156,6 +156,7 @@ class MLLMRequest:
     # Token counts
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
+    lifecycle_admission_token: str | None = None
 
 
 def _find_stop_match_in_new_window(
@@ -525,20 +526,16 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
-        pause_allowance_consumed = False
         with self._request_state_lock():
-            paused = getattr(self, "_generation_paused", False)
-        if paused:
-            from .scheduler import BackpressureError
+            if getattr(self, "_generation_paused", False):
+                from .scheduler import BackpressureError
 
-            with self._request_state_lock():
-                allowance = getattr(self, "_paused_add_allowance", 0)
-                if allowance <= 0:
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = kwargs.get("lifecycle_admission_token")
+                if token not in allowed:
                     raise BackpressureError(
                         "generation is paused for an engine lifecycle operation"
                     )
-                self._paused_add_allowance = allowance - 1
-                pause_allowance_consumed = True
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -589,6 +586,7 @@ class MLLMScheduler:
             stop=stop or [],
             video_fps=video_fps,
             video_max_frames=video_max_frames,
+            lifecycle_admission_token=kwargs.pop("lifecycle_admission_token", None),
         )
 
         # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
@@ -606,18 +604,15 @@ class MLLMScheduler:
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
         with self._cancel_counter_lock:
-            if (
-                getattr(self, "_generation_paused", False)
-                and not pause_allowance_consumed
-            ):
+            if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
-                allowance = getattr(self, "_paused_add_allowance", 0)
-                if allowance <= 0:
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                if request.lifecycle_admission_token not in allowed:
                     raise BackpressureError(
                         "generation is paused for an engine lifecycle operation"
                     )
-                self._paused_add_allowance = allowance - 1
+                allowed.remove(request.lifecycle_admission_token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request
@@ -645,17 +640,22 @@ class MLLMScheduler:
         with self._request_state_lock():
             self._generation_paused = bool(paused)
             self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
 
-    def pause_generation_admission(self, admitted_reservations: int, mode: str) -> None:
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
         """Atomically close admission and account for pre-pause reservations."""
 
         with self._request_state_lock():
             self._generation_paused = True
-            self._paused_add_allowance = (
-                max(0, int(admitted_reservations) - len(self.requests))
-                if mode == "wait"
-                else 0
+            owned = {
+                request.lifecycle_admission_token
+                for request in self.requests.values()
+                if request.lifecycle_admission_token is not None
+            }
+            self._paused_admission_tokens = (
+                set(admission_tokens) - owned if mode == "wait" else set()
             )
+            self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -302,6 +302,7 @@ class MLLMScheduler:
         self.waiting: deque[MLLMRequest] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, MLLMRequest] = {}  # Running requests by ID
         self.requests: dict[str, MLLMRequest] = {}  # All requests by ID
+        self._generation_paused = False
         self.finished_req_ids: set[str] = set()  # Recently finished
 
         # Mapping between our request IDs and BatchGenerator UIDs
@@ -523,6 +524,12 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
+        if getattr(self, "_generation_paused", False):
+            from .scheduler import BackpressureError
+
+            raise BackpressureError(
+                "generation is paused for an engine lifecycle operation"
+            )
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -610,6 +617,11 @@ class MLLMScheduler:
         )
 
         return request_id
+
+    def set_generation_paused(self, paused: bool) -> None:
+        """Close or reopen scheduler admission for model mutation."""
+
+        self._generation_paused = bool(paused)
 
     def abort_request(self, request_id: str) -> bool:
         """

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -631,8 +631,17 @@ class MLLMScheduler:
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""
 
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, lazily supporting ``__new__`` test stubs."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -764,7 +773,7 @@ class MLLMScheduler:
         # ``via_disconnect_total <= cancelled_total`` and the
         # "exactly one tick per abort" contract that three personas
         # independently observed broken on PyPI 0.8.2.
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.pop(request_id, None)
             self._detokenizer_pool.pop(request_id, None)
 
@@ -1162,7 +1171,7 @@ class MLLMScheduler:
 
             # Track as finished
             self.finished_req_ids.add(request_id)
-            with self._cancel_counter_lock:
+            with self._request_state_lock():
                 self.requests.pop(request_id, None)
 
     def _step_no_queue(self) -> MLLMSchedulerOutput:
@@ -1377,7 +1386,7 @@ class MLLMScheduler:
             self.batch_generator = None
         self.waiting.clear()
         self.running.clear()
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
@@ -1410,7 +1419,7 @@ class MLLMScheduler:
 
     def remove_finished_request(self, request_id: str) -> MLLMRequest | None:
         """Remove a finished request from tracking."""
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             return self.requests.pop(request_id, None)
 
     # ========== Async API (for streaming) ==========
@@ -1932,7 +1941,7 @@ class MLLMScheduler:
             )
 
         # Cleanup
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.pop(request_id, None)
 
         return final_output
@@ -1988,7 +1997,7 @@ class MLLMScheduler:
 
         self.waiting.clear()
         self.running.clear()
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -652,9 +652,7 @@ class MLLMScheduler:
                 for request in self.requests.values()
                 if request.lifecycle_admission_token is not None
             }
-            self._paused_admission_tokens = (
-                set(admission_tokens) - owned if mode == "wait" else set()
-            )
+            self._paused_admission_tokens = set(admission_tokens) - owned
             self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -303,6 +303,7 @@ class MLLMScheduler:
         self.running: dict[str, MLLMRequest] = {}  # Running requests by ID
         self.requests: dict[str, MLLMRequest] = {}  # All requests by ID
         self._generation_paused = False
+        self._paused_add_allowance = 0
         self.finished_req_ids: set[str] = set()  # Recently finished
 
         # Mapping between our request IDs and BatchGenerator UIDs
@@ -527,9 +528,12 @@ class MLLMScheduler:
         if getattr(self, "_generation_paused", False):
             from .scheduler import BackpressureError
 
-            raise BackpressureError(
-                "generation is paused for an engine lifecycle operation"
-            )
+            allowance = getattr(self, "_paused_add_allowance", 0)
+            if allowance <= 0:
+                raise BackpressureError(
+                    "generation is paused for an engine lifecycle operation"
+                )
+            self._paused_add_allowance = allowance - 1
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -618,10 +622,11 @@ class MLLMScheduler:
 
         return request_id
 
-    def set_generation_paused(self, paused: bool) -> None:
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
         self._generation_paused = bool(paused)
+        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
     def abort_request(self, request_id: str) -> bool:
         """

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -156,7 +156,6 @@ class MLLMRequest:
     # Token counts
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
-    lifecycle_admission_token: int | None = None
 
 
 def _find_stop_match_in_new_window(
@@ -526,16 +525,15 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
-        with self._request_state_lock():
-            if getattr(self, "_generation_paused", False):
-                from .scheduler import BackpressureError
+        if getattr(self, "_generation_paused", False):
+            from .scheduler import BackpressureError
 
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                token = kwargs.get("lifecycle_admission_token")
-                if token not in allowed:
-                    raise BackpressureError(
-                        "generation is paused for an engine lifecycle operation"
-                    )
+            allowance = getattr(self, "_paused_add_allowance", 0)
+            if allowance <= 0:
+                raise BackpressureError(
+                    "generation is paused for an engine lifecycle operation"
+                )
+            self._paused_add_allowance = allowance - 1
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -586,7 +584,6 @@ class MLLMScheduler:
             stop=stop or [],
             video_fps=video_fps,
             video_max_frames=video_max_frames,
-            lifecycle_admission_token=kwargs.pop("lifecycle_admission_token", None),
         )
 
         # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
@@ -604,15 +601,6 @@ class MLLMScheduler:
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
         with self._cancel_counter_lock:
-            if getattr(self, "_generation_paused", False):
-                from .scheduler import BackpressureError
-
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                if request.lifecycle_admission_token not in allowed:
-                    raise BackpressureError(
-                        "generation is paused for an engine lifecycle operation"
-                    )
-                allowed.remove(request.lifecycle_admission_token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request
@@ -637,23 +625,8 @@ class MLLMScheduler:
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
-        with self._request_state_lock():
-            self._generation_paused = bool(paused)
-            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
-            self._paused_admission_tokens = set()
-
-    def pause_generation_admission(self, admission_tokens: set[int], mode: str) -> None:
-        """Atomically close admission and account for pre-pause reservations."""
-
-        with self._request_state_lock():
-            self._generation_paused = True
-            owned = {
-                request.lifecycle_admission_token
-                for request in self.requests.values()
-                if request.lifecycle_admission_token is not None
-            }
-            self._paused_admission_tokens = set(admission_tokens) - owned
-            self._paused_add_allowance = len(self._paused_admission_tokens)
+        self._generation_paused = bool(paused)
+        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""
@@ -2066,9 +2039,6 @@ class MLLMScheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.clear()
             self._disconnect_abort_ids.clear()
-            self._generation_paused = False
-            self._paused_add_allowance = 0
-            self._paused_admission_tokens = set()
 
         if self.batch_generator is not None:
             self.batch_generator.close()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -156,7 +156,7 @@ class MLLMRequest:
     # Token counts
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
-    lifecycle_admission_token: str | None = None
+    lifecycle_admission_token: int | None = None
 
 
 def _find_stop_match_in_new_window(
@@ -642,7 +642,7 @@ class MLLMScheduler:
             self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
             self._paused_admission_tokens = set()
 
-    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+    def pause_generation_admission(self, admission_tokens: set[int], mode: str) -> None:
         """Atomically close admission and account for pre-pause reservations."""
 
         with self._request_state_lock():

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -169,7 +169,7 @@ class Request:
     # Routing hints used by PFlash to decide whether to compress (#287).
     has_tools: bool = False
     requires_prompt_integrity: bool = False
-    lifecycle_admission_token: str | None = None
+    lifecycle_admission_token: int | None = None
 
     # Grammar-constrained tool calling (#558). Optional per-request logits
     # processor that masks decoding to a tool-call grammar. Set by the chat

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -169,7 +169,6 @@ class Request:
     # Routing hints used by PFlash to decide whether to compress (#287).
     has_tools: bool = False
     requires_prompt_integrity: bool = False
-    lifecycle_admission_token: int | None = None
 
     # Grammar-constrained tool calling (#558). Optional per-request logits
     # processor that masks decoding to a tool-call grammar. Set by the chat

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -169,6 +169,7 @@ class Request:
     # Routing hints used by PFlash to decide whether to compress (#287).
     has_tools: bool = False
     requires_prompt_integrity: bool = False
+    lifecycle_admission_token: str | None = None
 
     # Grammar-constrained tool calling (#558). Optional per-request logits
     # processor that masks decoding to a tool-call grammar. Set by the chat

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -47,7 +47,14 @@ class ModelLoadRequest(BaseModel):
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: bool = False
-    replace_mode: Literal["reject", "wait", "abort"] = "reject"
+    replace_mode: Literal["reject", "wait", "abort"] = Field(
+        default="reject",
+        description=(
+            "Replacement policy: reject returns a busy conflict immediately; "
+            "wait blocks for existing inference to drain (with a bounded server "
+            "deadline); abort cancels existing inference before replacement."
+        ),
+    )
 
 
 class ModelPinRequest(BaseModel):

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -47,6 +47,7 @@ class ModelLoadRequest(BaseModel):
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: bool = False
+    replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):
@@ -124,6 +125,7 @@ async def load_resident_model(request: ModelLoadRequest):
             image_mode=request.image_mode,
             performance=performance,
             reload_if_changed=request.reload_if_changed,
+            replace_mode=request.replace_mode,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -47,14 +47,7 @@ class ModelLoadRequest(BaseModel):
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: bool = False
-    replace_mode: Literal["reject", "wait", "abort"] = Field(
-        default="reject",
-        description=(
-            "Replacement policy: reject returns a busy conflict immediately; "
-            "wait blocks for existing inference to drain (with a bounded server "
-            "deadline); abort cancels existing inference before replacement."
-        ),
-    )
+    replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -582,8 +582,8 @@ class ResidentModelManager:
 
             candidates: list[ResidencyRecord] = []
             paused_engines: list[object] = []
-            reject_preflight = replace_mode == "reject" and replace_group is not None
-            if reject_preflight:
+            group_preflight = replace_group is not None
+            if group_preflight:
                 candidates, paused_engines = await self._quiesce_group_name_locked(
                     replace_group, replace_mode
                 )
@@ -614,7 +614,7 @@ class ResidentModelManager:
             group = _effective_replace_group(record.entry, replace_group)
             try:
                 if group is not None:
-                    if reject_preflight:
+                    if group_preflight:
                         if group != replace_group:
                             raise ResidentModelError(
                                 f"model {record.model_id!r} does not belong to "

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -494,6 +494,7 @@ class ResidentModelManager:
         image_mode: str | None = None,
         performance: ResidentPerformanceConfig | None = None,
         reload_if_changed: bool = False,
+        replace_mode: str = "reject",
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -511,7 +512,7 @@ class ResidentModelManager:
                     record.pinned = True
                 group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    await self._replace_group_locked(record, group, replace_mode)
                 return record
 
             await self._evict_for_locked(estimate, exclude={model_name})
@@ -534,20 +535,41 @@ class ResidentModelManager:
                 pinned=pin,
                 performance=performance,
             )
-            self.registry.add(entry)
-            self._index_record(record)
-            self.loads_total += 1
-
+            group = _effective_replace_group(record.entry, replace_group)
+            candidates: list[ResidencyRecord] = []
+            paused_engines: list[object] = []
             try:
-                await self._evict_for_locked(0, exclude={record.model_id})
-                group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    candidates, paused_engines = await self._quiesce_group_locked(
+                        record, group, replace_mode
+                    )
+                # Publish only after every replaced engine is quiescent. This
+                # prevents an explicit request for the new id from racing the
+                # replacement transaction while the old engine is draining.
+                self.registry.add(entry)
+                self._index_record(record)
+                self.loads_total += 1
+                await self._evict_for_locked(0, exclude={record.model_id})
+                if group is not None:
+                    await self._commit_group_replacement_locked(
+                        record, group, candidates
+                    )
             except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
-                await self._evict_locked(record, reason="load_rollback", count=False)
+                if record.model_id in self._records:
+                    await self._evict_locked(
+                        record, reason="load_rollback", count=False
+                    )
+                else:
+                    stop = getattr(record.entry.engine, "stop", None)
+                    if callable(stop):
+                        result = stop()
+                        if asyncio.iscoroutine(result):
+                            await result
+                    _release_allocator_cache()
+                await self._resume_engines(paused_engines)
                 raise
             return record
 
@@ -633,7 +655,9 @@ class ResidentModelManager:
             self._on_primary_changed(entry)
         return replacement
 
-    async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
+    async def _replace_group_locked(
+        self, target: ResidencyRecord, group: str, replace_mode: str = "reject"
+    ) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.
 
         The desktop uses the ``assistant`` group for its chat picker: changing
@@ -642,6 +666,20 @@ class ResidentModelManager:
         primary role to the replacement before the old engine is stopped, so
         legacy health/cache routes never retain a reference to unloaded weights.
         """
+
+        candidates, paused_engines = await self._quiesce_group_locked(
+            target, group, replace_mode
+        )
+        try:
+            await self._commit_group_replacement_locked(target, group, candidates)
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+
+    async def _quiesce_group_locked(
+        self, target: ResidencyRecord, group: str, replace_mode: str
+    ) -> tuple[list[ResidencyRecord], list[object]]:
+        """Atomically stop admission and drain engines replaced by target."""
 
         if group != _replacement_group(target.entry):
             raise ResidentModelError(
@@ -654,13 +692,54 @@ class ResidentModelManager:
             if record.model_id != target.model_id
             and _replacement_group(record.entry) == group
         ]
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
         for record in candidates:
-            if record.active_requests or not _engine_is_idle(record.entry.engine):
-                raise ResidentModelBusyError("model is serving an active request")
             if record.pinned and not record.primary:
                 raise ResidentModelError(
                     f"pinned model {record.model_id!r} cannot be replaced"
                 )
+
+        paused_engines: list[object] = []
+        try:
+            for record in candidates:
+                if record.active_requests:
+                    raise ResidentModelBusyError("model is serving an active request")
+                pause = getattr(record.entry.engine, "pause_generation", None)
+                if callable(pause):
+                    try:
+                        await pause(
+                            "wait" if replace_mode == "reject" else replace_mode,
+                            timeout=0 if replace_mode == "reject" else None,
+                        )
+                    except TimeoutError as exc:
+                        resume = getattr(record.entry.engine, "resume_generation", None)
+                        if callable(resume):
+                            await resume()
+                        raise ResidentModelBusyError(
+                            "model is serving an active request"
+                        ) from exc
+                    paused_engines.append(record.entry.engine)
+                elif not _engine_is_idle(record.entry.engine):
+                    raise ResidentModelBusyError("model is serving an active request")
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+        return candidates, paused_engines
+
+    async def _resume_engines(self, engines: list[object]) -> None:
+        for engine in reversed(engines):
+            resume = getattr(engine, "resume_generation", None)
+            if callable(resume):
+                await resume()
+
+    async def _commit_group_replacement_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        candidates: list[ResidencyRecord],
+    ) -> None:
+        """Publish target as primary, then stop already-quiesced engines."""
 
         old_primary = next((record for record in candidates if record.primary), None)
         if old_primary is not None:
@@ -744,6 +823,19 @@ class ResidentModelManager:
         for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
+            lifecycle = (
+                engine.lifecycle_status()
+                if callable(getattr(engine, "lifecycle_status", None))
+                else None
+            )
+            active_requests = record.active_requests
+            if lifecycle is not None:
+                active_requests = max(
+                    active_requests,
+                    int(lifecycle.get("active_requests", 0) or 0),
+                    int(lifecycle.get("running_requests", 0) or 0),
+                    int(lifecycle.get("queued_requests", 0) or 0),
+                )
             models.append(
                 {
                     "id": record.model_id,
@@ -753,7 +845,8 @@ class ResidentModelManager:
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,
-                    "active_requests": record.active_requests,
+                    "active_requests": active_requests,
+                    "lifecycle": lifecycle,
                     "estimated_bytes": record.estimated_bytes,
                     "measured_bytes": record.measured_bytes or None,
                     "idle_seconds": max(0.0, now - record.last_used_at),

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -431,7 +431,14 @@ class ResidentModelManager:
         async with self._lock:
             retirement_tasks = tuple(self._retirement_tasks)
             if retirement_tasks:
-                await asyncio.gather(*retirement_tasks, return_exceptions=True)
+                _, pending = await asyncio.wait(retirement_tasks, timeout=5.0)
+                if pending:
+                    logger.warning(
+                        "Timed out waiting for %d retired model engine(s) during shutdown",
+                        len(pending),
+                    )
+                    for retirement_task in pending:
+                        retirement_task.cancel()
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
@@ -521,6 +528,8 @@ class ResidentModelManager:
         model_name = model_name.strip()
         if not model_name:
             raise ResidentModelError("model must not be empty")
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
         estimate = max(1, estimated_bytes or estimate_model_bytes(model_name))
 
         async with self._lock:
@@ -787,13 +796,32 @@ class ResidentModelManager:
 
         old_primary = next((record for record in candidates if record.primary), None)
         if old_primary is not None:
+            old_primary_was_pinned = old_primary.pinned
             old_primary.primary = False
             old_primary.pinned = False
             target.primary = True
             target.pinned = True
             self.registry.set_default(target.model_id)
             if self._on_primary_changed is not None:
-                self._on_primary_changed(target.entry)
+                try:
+                    self._on_primary_changed(target.entry)
+                except BaseException:
+                    # No predecessor has been removed or stopped yet, so the
+                    # primary handoff remains fully reversible. Restore both
+                    # registry and record flags before outer rollback evicts
+                    # the unpublished target.
+                    target.primary = False
+                    target.pinned = False
+                    old_primary.primary = True
+                    old_primary.pinned = old_primary_was_pinned
+                    self.registry.set_default(old_primary.model_id)
+                    try:
+                        self._on_primary_changed(old_primary.entry)
+                    except BaseException:
+                        logger.exception(
+                            "Failed to restore primary callback after rejected handoff"
+                        )
+                    raise
 
         # Establish the commit point completely before the first teardown
         # await.  This makes cancellation state unambiguous: after this loop

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -328,6 +328,10 @@ class ResidentModelManager:
         self._index: dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._ttl_task: asyncio.Task | None = None
+        # Engines retired from routing whose best-effort stop raised. The new
+        # primary remains serviceable; shutdown retries these handles instead
+        # of turning a cleanup failure into loss of the serving model.
+        self._retired_engines: list[object] = []
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -425,6 +429,16 @@ class ResidentModelManager:
             ]
             for record in dynamic:
                 await self._evict_locked(record, reason="shutdown", count=False)
+            retired, self._retired_engines = self._retired_engines, []
+            for engine in retired:
+                stop = getattr(engine, "stop", None)
+                if callable(stop):
+                    try:
+                        result = stop()
+                        if asyncio.iscoroutine(result):
+                            await result
+                    except Exception:
+                        logger.exception("Failed to stop a retired model engine")
 
     async def _ttl_loop(self) -> None:
         interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
@@ -736,7 +750,13 @@ class ResidentModelManager:
         group: str,
         candidates: list[ResidencyRecord],
     ) -> None:
-        """Publish target as primary, then stop already-quiesced engines."""
+        """Publish target, then retire already-quiesced engines.
+
+        Teardown is deliberately post-commit. Once the replacement weights are
+        loaded, a failing old-engine ``stop`` is a cleanup failure, not a model
+        load failure: rolling the target back could otherwise leave no serving
+        primary after an earlier candidate was already stopped.
+        """
 
         old_primary = next((record for record in candidates if record.primary), None)
         if old_primary is not None:
@@ -749,7 +769,26 @@ class ResidentModelManager:
                 self._on_primary_changed(target.entry)
 
         for record in candidates:
-            await self._evict_locked(record, reason=f"replace_{group}")
+            record.state = "evicting"
+            self.registry.remove(record.model_id)
+            self._drop_record(record.model_id)
+            stop = getattr(record.entry.engine, "stop", None)
+            if callable(stop):
+                try:
+                    result = stop()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    self._retired_engines.append(record.entry.engine)
+                    logger.exception(
+                        "Failed to stop retired model %r after replacing %s; "
+                        "the replacement remains active and cleanup will retry "
+                        "during shutdown",
+                        record.model_id,
+                        group,
+                    )
+            self.evictions_total += 1
+        _release_allocator_cache()
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:
@@ -864,5 +903,6 @@ class ResidentModelManager:
             "idle_ttl_seconds": self.idle_ttl_seconds,
             "loads_total": self.loads_total,
             "evictions_total": self.evictions_total,
+            "retired_cleanup_pending": len(self._retired_engines),
             "models": models,
         }

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -33,10 +33,6 @@ class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
 
 
-class _CommittedReplacementCancelled(asyncio.CancelledError):
-    """Cancellation delivered after the replacement became routable."""
-
-
 @dataclass(frozen=True)
 class ResidentPerformanceConfig:
     """Audited scheduler overrides attached to one resident text model.
@@ -336,10 +332,6 @@ class ResidentModelManager:
         # primary remains serviceable; shutdown retries these handles instead
         # of turning a cleanup failure into loss of the serving model.
         self._retired_engines: list[object] = []
-        self._retirement_tasks: set[asyncio.Task] = set()
-        self._retirement_task_engines: dict[asyncio.Task, object] = {}
-        self._rollback_tasks: set[asyncio.Task] = set()
-        self._rollback_task_engines: dict[asyncio.Task, object] = {}
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -432,30 +424,6 @@ class ResidentModelManager:
                 pass
 
         async with self._lock:
-            retirement_tasks = tuple(self._retirement_tasks | self._rollback_tasks)
-            stuck_engines: list[object] = []
-            if retirement_tasks:
-                _, pending = await asyncio.wait(retirement_tasks, timeout=5.0)
-                if pending:
-                    logger.warning(
-                        "Timed out waiting for %d retired model engine(s) during shutdown",
-                        len(pending),
-                    )
-                    for retirement_task in pending:
-                        retirement_task.cancel()
-                    _, still_pending = await asyncio.wait(pending, timeout=1.0)
-                    for retirement_task in still_pending:
-                        engine = self._retirement_task_engines.get(
-                            retirement_task
-                        ) or self._rollback_task_engines.get(retirement_task)
-                        if engine is not None:
-                            stuck_engines.append(engine)
-                    if still_pending:
-                        logger.error(
-                            "%d retired model engine(s) ignored cancellation; "
-                            "retaining handles after bounded shutdown",
-                            len(still_pending),
-                        )
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
@@ -468,26 +436,9 @@ class ResidentModelManager:
                     try:
                         result = stop()
                         if asyncio.iscoroutine(result):
-                            stop_task = asyncio.create_task(result)
-                            try:
-                                await asyncio.wait_for(
-                                    asyncio.shield(stop_task), timeout=5.0
-                                )
-                            except TimeoutError:
-                                stop_task.cancel()
-                                _, still_pending = await asyncio.wait(
-                                    {stop_task}, timeout=1.0
-                                )
-                                if still_pending:
-                                    self._retired_engines.append(engine)
-                                logger.error(
-                                    "Timed out stopping a retired model engine "
-                                    "during shutdown"
-                                )
+                            await result
                     except Exception:
-                        self._retired_engines.append(engine)
                         logger.exception("Failed to stop a retired model engine")
-            self._retired_engines.extend(stuck_engines)
 
     async def _ttl_loop(self) -> None:
         interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
@@ -562,8 +513,6 @@ class ResidentModelManager:
         model_name = model_name.strip()
         if not model_name:
             raise ResidentModelError("model must not be empty")
-        if replace_mode not in {"reject", "wait", "abort"}:
-            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
         estimate = max(1, estimated_bytes or estimate_model_bytes(model_name))
 
         async with self._lock:
@@ -580,25 +529,14 @@ class ResidentModelManager:
                     await self._replace_group_locked(record, group, replace_mode)
                 return record
 
-            candidates: list[ResidencyRecord] = []
-            paused_engines: list[object] = []
-            group_preflight = replace_group is not None
-            if group_preflight:
-                candidates, paused_engines = await self._quiesce_group_name_locked(
-                    replace_group, replace_mode
+            await self._evict_for_locked(estimate, exclude={model_name})
+            before = self._read_memory()
+            if image_mode is None:
+                entry = await self.loader(model_name, model_path, performance)
+            else:
+                entry = await self.loader(
+                    model_name, model_path, performance, image_mode
                 )
-            try:
-                await self._evict_for_locked(estimate, exclude={model_name})
-                before = self._read_memory()
-                if image_mode is None:
-                    entry = await self.loader(model_name, model_path, performance)
-                else:
-                    entry = await self.loader(
-                        model_name, model_path, performance, image_mode
-                    )
-            except BaseException as original:
-                await self._resume_after_failure(paused_engines, original)
-                raise
             now = self._clock()
             after = self._read_memory()
             delta = max(0, after - before) if before and after else 0
@@ -612,35 +550,25 @@ class ResidentModelManager:
                 performance=performance,
             )
             group = _effective_replace_group(record.entry, replace_group)
+            candidates: list[ResidencyRecord] = []
+            paused_engines: list[object] = []
             try:
                 if group is not None:
-                    if group_preflight:
-                        if group != replace_group:
-                            raise ResidentModelError(
-                                f"model {record.model_id!r} does not belong to "
-                                f"replacement group {replace_group!r}"
-                            )
-                    else:
-                        candidates, paused_engines = await self._quiesce_group_locked(
-                            record, group, replace_mode
-                        )
+                    candidates, paused_engines = await self._quiesce_group_locked(
+                        record, group, replace_mode
+                    )
                 # Publish only after every replaced engine is quiescent. This
                 # prevents an explicit request for the new id from racing the
                 # replacement transaction while the old engine is draining.
                 self.registry.add(entry)
                 self._index_record(record)
                 self.loads_total += 1
-                await self._evict_for_locked(
-                    0,
-                    exclude={record.model_id, *(item.model_id for item in candidates)},
-                )
+                await self._evict_for_locked(0, exclude={record.model_id})
                 if group is not None:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
-            except _CommittedReplacementCancelled as exc:
-                raise asyncio.CancelledError from exc
-            except BaseException as original:
+            except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
@@ -663,7 +591,7 @@ class ResidentModelManager:
                         "old-engine admission will still be resumed"
                     )
                 finally:
-                    await self._resume_after_failure(paused_engines, original)
+                    await self._resume_engines(paused_engines)
                 raise
             return record
 
@@ -766,10 +694,8 @@ class ResidentModelManager:
         )
         try:
             await self._commit_group_replacement_locked(target, group, candidates)
-        except _CommittedReplacementCancelled as exc:
-            raise asyncio.CancelledError from exc
-        except BaseException as original:
-            await self._resume_after_failure(paused_engines, original)
+        except BaseException:
+            await self._resume_engines(paused_engines)
             raise
 
     async def _quiesce_group_locked(
@@ -782,23 +708,10 @@ class ResidentModelManager:
                 f"model {target.model_id!r} does not belong to replacement group {group!r}"
             )
 
-        return await self._quiesce_group_name_locked(
-            group, replace_mode, exclude_model_id=target.model_id
-        )
-
-    async def _quiesce_group_name_locked(
-        self,
-        group: str,
-        replace_mode: str,
-        *,
-        exclude_model_id: str | None = None,
-    ) -> tuple[list[ResidencyRecord], list[object]]:
-        """Pause every replaceable engine in a named lifecycle group."""
-
         candidates = [
             record
             for record in self._records.values()
-            if record.model_id != exclude_model_id
+            if record.model_id != target.model_id
             and _replacement_group(record.entry) == group
         ]
         if replace_mode not in {"reject", "wait", "abort"}:
@@ -830,92 +743,21 @@ class ResidentModelManager:
                         ) from exc
                 elif not _engine_is_idle(record.entry.engine):
                     raise ResidentModelBusyError("model is serving an active request")
-        except BaseException as original:
-            await self._resume_after_failure(paused_engines, original)
+        except BaseException:
+            await self._resume_engines(paused_engines)
             raise
         return candidates, paused_engines
 
     async def _resume_engines(self, engines: list[object]) -> None:
-        cancellation: asyncio.CancelledError | None = None
-        failure: Exception | None = None
         for engine in reversed(engines):
             resume = getattr(engine, "resume_generation", None)
             if callable(resume):
-                task = asyncio.create_task(resume())
                 try:
-                    await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
-                except asyncio.CancelledError as exc:
-                    cancellation = cancellation or exc
-                    try:
-                        await asyncio.wait_for(task, timeout=5.0)
-                    except TimeoutError:
-                        task.cancel()
-                        _, pending = await asyncio.wait({task}, timeout=1.0)
-                        force_resume = getattr(engine, "force_resume_generation", None)
-                        if callable(force_resume):
-                            force_resume()
-                        if pending:
-                            self._rollback_tasks.add(task)
-                            self._rollback_task_engines[task] = engine
-                            task.add_done_callback(self._on_rollback_done)
-                        failure = failure or TimeoutError(
-                            "timed out resuming a model engine after cancellation"
-                        )
-                    except (Exception, asyncio.CancelledError):
-                        failure = failure or RuntimeError(
-                            "failed to finish resuming a model engine after cancellation"
-                        )
-                        logger.exception(
-                            "Failed to finish resuming a model engine after cancellation"
-                        )
-                except TimeoutError:
-                    task.cancel()
-                    _, pending = await asyncio.wait({task}, timeout=1.0)
-                    force_resume = getattr(engine, "force_resume_generation", None)
-                    if callable(force_resume):
-                        force_resume()
-                    if pending:
-                        self._rollback_tasks.add(task)
-                        self._rollback_task_engines[task] = engine
-                        task.add_done_callback(self._on_rollback_done)
-                    failure = failure or TimeoutError(
-                        "timed out resuming a model engine after replacement rollback"
-                    )
-                    logger.error(
-                        "Timed out resuming one model engine after replacement rollback"
-                    )
-                except Exception as exc:
-                    failure = failure or exc
+                    await resume()
+                except BaseException:
                     logger.exception(
                         "Failed to resume one model engine after replacement rollback"
                     )
-        if cancellation is not None:
-            raise cancellation
-        if failure is not None:
-            raise failure
-
-    async def _resume_after_failure(
-        self, engines: list[object], original: BaseException
-    ) -> None:
-        """Run bounded rollback without replacing the operation's root error."""
-
-        try:
-            await self._resume_engines(engines)
-        except BaseException as cleanup:
-            original.add_note(f"rollback resume also failed: {cleanup!r}")
-            raise original from cleanup
-
-    def _on_rollback_done(self, task: asyncio.Task) -> None:
-        self._rollback_tasks.discard(task)
-        engine = self._rollback_task_engines.pop(task, None)
-        failed = task.cancelled()
-        if not failed:
-            try:
-                failed = task.exception() is not None
-            except asyncio.CancelledError:
-                failed = True
-        if failed and engine is not None:
-            self._retired_engines.append(engine)
 
     async def _commit_group_replacement_locked(
         self,
@@ -933,95 +775,35 @@ class ResidentModelManager:
 
         old_primary = next((record for record in candidates if record.primary), None)
         if old_primary is not None:
-            old_primary_was_pinned = old_primary.pinned
             old_primary.primary = False
             old_primary.pinned = False
             target.primary = True
             target.pinned = True
             self.registry.set_default(target.model_id)
             if self._on_primary_changed is not None:
-                try:
-                    self._on_primary_changed(target.entry)
-                except BaseException:
-                    # No predecessor has been removed or stopped yet, so the
-                    # primary handoff remains fully reversible. Restore both
-                    # registry and record flags before outer rollback evicts
-                    # the unpublished target.
-                    target.primary = False
-                    target.pinned = False
-                    old_primary.primary = True
-                    old_primary.pinned = old_primary_was_pinned
-                    self.registry.set_default(old_primary.model_id)
-                    try:
-                        self._on_primary_changed(old_primary.entry)
-                    except BaseException:
-                        logger.exception(
-                            "Failed to restore primary callback after rejected handoff"
-                        )
-                    raise
+                self._on_primary_changed(target.entry)
 
-        # Establish the commit point completely before the first teardown
-        # await.  This makes cancellation state unambiguous: after this loop
-        # the new target is the only routable member of the group.
-        retired: list[tuple[ResidencyRecord, object | None]] = []
         for record in candidates:
             record.state = "evicting"
             self.registry.remove(record.model_id)
             self._drop_record(record.model_id)
             stop = getattr(record.entry.engine, "stop", None)
-            retired.append((record, stop if callable(stop) else None))
+            if callable(stop):
+                try:
+                    result = stop()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    self._retired_engines.append(record.entry.engine)
+                    logger.exception(
+                        "Failed to stop retired model %r after replacing %s; "
+                        "the replacement remains active and cleanup will retry "
+                        "during shutdown",
+                        record.model_id,
+                        group,
+                    )
             self.evictions_total += 1
-
-        async def stop_retired(record: ResidencyRecord, stop: object) -> None:
-            try:
-                result = stop()  # type: ignore[operator]
-                if asyncio.iscoroutine(result):
-                    await result
-            except asyncio.CancelledError:
-                self._retired_engines.append(record.entry.engine)
-                logger.warning(
-                    "Retired model %r stop was cancelled; cleanup will retry "
-                    "during shutdown",
-                    record.model_id,
-                )
-            except Exception:
-                self._retired_engines.append(record.entry.engine)
-                logger.exception(
-                    "Failed to stop retired model %r after replacing %s; "
-                    "the replacement remains active and cleanup will retry "
-                    "during shutdown",
-                    record.model_id,
-                    group,
-                )
-
-        task_records = [
-            (asyncio.create_task(stop_retired(record, stop)), record)
-            for record, stop in retired
-            if callable(stop)
-        ]
-        tasks = [task for task, _ in task_records]
-        self._retirement_tasks.update(tasks)
-        for task, record in task_records:
-            self._retirement_task_engines[task] = record.entry.engine
-            task.add_done_callback(self._on_retirement_done)
-
-        if tasks:
-            try:
-                await asyncio.shield(asyncio.gather(*tasks))
-            except asyncio.CancelledError as exc:
-                # Registry commit is complete and teardown tasks are strongly
-                # tracked by the manager. The cancelled control-plane caller
-                # must not wait for an unrelated old engine's slow/hung stop.
-                raise _CommittedReplacementCancelled from exc
         _release_allocator_cache()
-
-    def _on_retirement_done(self, task: asyncio.Task) -> None:
-        self._retirement_tasks.discard(task)
-        engine = self._retirement_task_engines.pop(task, None)
-        if task.cancelled() and engine is not None:
-            self._retired_engines.append(engine)
-        if not self._retirement_tasks:
-            _release_allocator_cache()
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:
@@ -1099,7 +881,12 @@ class ResidentModelManager:
             )
             active_requests = record.active_requests
             if lifecycle is not None:
-                active_requests = int(lifecycle.get("active_requests", 0) or 0)
+                active_requests = max(
+                    active_requests,
+                    int(lifecycle.get("active_requests", 0) or 0),
+                    int(lifecycle.get("running_requests", 0) or 0),
+                    int(lifecycle.get("queued_requests", 0) or 0),
+                )
             models.append(
                 {
                     "id": record.model_id,
@@ -1131,7 +918,6 @@ class ResidentModelManager:
             "idle_ttl_seconds": self.idle_ttl_seconds,
             "loads_total": self.loads_total,
             "evictions_total": self.evictions_total,
-            "retired_cleanup_pending": len(self._retired_engines)
-            + len(self._retirement_tasks),
+            "retired_cleanup_pending": len(self._retired_engines),
             "models": models,
         }

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -572,18 +572,26 @@ class ResidentModelManager:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
-                if record.model_id in self._records:
-                    await self._evict_locked(
-                        record, reason="load_rollback", count=False
+                try:
+                    if record.model_id in self._records:
+                        await self._evict_locked(
+                            record, reason="load_rollback", count=False
+                        )
+                    else:
+                        stop = getattr(record.entry.engine, "stop", None)
+                        if callable(stop):
+                            result = stop()
+                            if asyncio.iscoroutine(result):
+                                await result
+                        _release_allocator_cache()
+                except BaseException:  # cleanup must not strand old engines
+                    self._retired_engines.append(record.entry.engine)
+                    logger.exception(
+                        "Failed to stop a rejected replacement model; "
+                        "old-engine admission will still be resumed"
                     )
-                else:
-                    stop = getattr(record.entry.engine, "stop", None)
-                    if callable(stop):
-                        result = stop()
-                        if asyncio.iscoroutine(result):
-                            await result
-                    _release_allocator_cache()
-                await self._resume_engines(paused_engines)
+                finally:
+                    await self._resume_engines(paused_engines)
                 raise
             return record
 
@@ -717,9 +725,11 @@ class ResidentModelManager:
         paused_engines: list[object] = []
         try:
             for record in candidates:
-                if record.active_requests:
-                    raise ResidentModelBusyError("model is serving an active request")
                 pause = getattr(record.entry.engine, "pause_generation", None)
+                if record.active_requests and (
+                    replace_mode == "reject" or not callable(pause)
+                ):
+                    raise ResidentModelBusyError("model is serving an active request")
                 if callable(pause):
                     paused_engines.append(record.entry.engine)
                     try:
@@ -742,7 +752,12 @@ class ResidentModelManager:
         for engine in reversed(engines):
             resume = getattr(engine, "resume_generation", None)
             if callable(resume):
-                await resume()
+                try:
+                    await resume()
+                except BaseException:
+                    logger.exception(
+                        "Failed to resume one model engine after replacement rollback"
+                    )
 
     async def _commit_group_replacement_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -339,6 +339,7 @@ class ResidentModelManager:
         self._retirement_tasks: set[asyncio.Task] = set()
         self._retirement_task_engines: dict[asyncio.Task, object] = {}
         self._rollback_tasks: set[asyncio.Task] = set()
+        self._rollback_task_engines: dict[asyncio.Task, object] = {}
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -444,7 +445,9 @@ class ResidentModelManager:
                         retirement_task.cancel()
                     _, still_pending = await asyncio.wait(pending, timeout=1.0)
                     for retirement_task in still_pending:
-                        engine = self._retirement_task_engines.get(retirement_task)
+                        engine = self._retirement_task_engines.get(
+                            retirement_task
+                        ) or self._rollback_task_engines.get(retirement_task)
                         if engine is not None:
                             stuck_engines.append(engine)
                     if still_pending:
@@ -828,7 +831,11 @@ class ResidentModelManager:
                     _, pending = await asyncio.wait({task}, timeout=1.0)
                     if pending:
                         self._rollback_tasks.add(task)
-                        task.add_done_callback(self._rollback_tasks.discard)
+                        self._rollback_task_engines[task] = engine
+                        task.add_done_callback(self._on_rollback_done)
+                        force_resume = getattr(engine, "force_resume_generation", None)
+                        if callable(force_resume):
+                            force_resume()
                     failure = failure or TimeoutError(
                         "timed out resuming a model engine after replacement rollback"
                     )
@@ -855,6 +862,10 @@ class ResidentModelManager:
         except BaseException as cleanup:
             original.add_note(f"rollback resume also failed: {cleanup!r}")
             raise original from cleanup
+
+    def _on_rollback_done(self, task: asyncio.Task) -> None:
+        self._rollback_tasks.discard(task)
+        self._rollback_task_engines.pop(task, None)
 
     async def _commit_group_replacement_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -829,13 +829,13 @@ class ResidentModelManager:
                 except TimeoutError:
                     task.cancel()
                     _, pending = await asyncio.wait({task}, timeout=1.0)
+                    force_resume = getattr(engine, "force_resume_generation", None)
+                    if callable(force_resume):
+                        force_resume()
                     if pending:
                         self._rollback_tasks.add(task)
                         self._rollback_task_engines[task] = engine
                         task.add_done_callback(self._on_rollback_done)
-                        force_resume = getattr(engine, "force_resume_generation", None)
-                        if callable(force_resume):
-                            force_resume()
                     failure = failure or TimeoutError(
                         "timed out resuming a model engine after replacement rollback"
                     )
@@ -865,7 +865,15 @@ class ResidentModelManager:
 
     def _on_rollback_done(self, task: asyncio.Task) -> None:
         self._rollback_tasks.discard(task)
-        self._rollback_task_engines.pop(task, None)
+        engine = self._rollback_task_engines.pop(task, None)
+        failed = task.cancelled()
+        if not failed:
+            try:
+                failed = task.exception() is not None
+            except asyncio.CancelledError:
+                failed = True
+        if failed and engine is not None:
+            self._retired_engines.append(engine)
 
     async def _commit_group_replacement_locked(
         self,
@@ -927,6 +935,13 @@ class ResidentModelManager:
                 result = stop()  # type: ignore[operator]
                 if asyncio.iscoroutine(result):
                     await result
+            except asyncio.CancelledError:
+                self._retired_engines.append(record.entry.engine)
+                logger.warning(
+                    "Retired model %r stop was cancelled; cleanup will retry "
+                    "during shutdown",
+                    record.model_id,
+                )
             except Exception:
                 self._retired_engines.append(record.entry.engine)
                 logger.exception(

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -580,14 +580,25 @@ class ResidentModelManager:
                     await self._replace_group_locked(record, group, replace_mode)
                 return record
 
-            await self._evict_for_locked(estimate, exclude={model_name})
-            before = self._read_memory()
-            if image_mode is None:
-                entry = await self.loader(model_name, model_path, performance)
-            else:
-                entry = await self.loader(
-                    model_name, model_path, performance, image_mode
+            candidates: list[ResidencyRecord] = []
+            paused_engines: list[object] = []
+            reject_preflight = replace_mode == "reject" and replace_group is not None
+            if reject_preflight:
+                candidates, paused_engines = await self._quiesce_group_name_locked(
+                    replace_group, replace_mode
                 )
+            try:
+                await self._evict_for_locked(estimate, exclude={model_name})
+                before = self._read_memory()
+                if image_mode is None:
+                    entry = await self.loader(model_name, model_path, performance)
+                else:
+                    entry = await self.loader(
+                        model_name, model_path, performance, image_mode
+                    )
+            except BaseException as original:
+                await self._resume_after_failure(paused_engines, original)
+                raise
             now = self._clock()
             after = self._read_memory()
             delta = max(0, after - before) if before and after else 0
@@ -601,13 +612,18 @@ class ResidentModelManager:
                 performance=performance,
             )
             group = _effective_replace_group(record.entry, replace_group)
-            candidates: list[ResidencyRecord] = []
-            paused_engines: list[object] = []
             try:
                 if group is not None:
-                    candidates, paused_engines = await self._quiesce_group_locked(
-                        record, group, replace_mode
-                    )
+                    if reject_preflight:
+                        if group != replace_group:
+                            raise ResidentModelError(
+                                f"model {record.model_id!r} does not belong to "
+                                f"replacement group {replace_group!r}"
+                            )
+                    else:
+                        candidates, paused_engines = await self._quiesce_group_locked(
+                            record, group, replace_mode
+                        )
                 # Publish only after every replaced engine is quiescent. This
                 # prevents an explicit request for the new id from racing the
                 # replacement transaction while the old engine is draining.
@@ -766,10 +782,23 @@ class ResidentModelManager:
                 f"model {target.model_id!r} does not belong to replacement group {group!r}"
             )
 
+        return await self._quiesce_group_name_locked(
+            group, replace_mode, exclude_model_id=target.model_id
+        )
+
+    async def _quiesce_group_name_locked(
+        self,
+        group: str,
+        replace_mode: str,
+        *,
+        exclude_model_id: str | None = None,
+    ) -> tuple[list[ResidencyRecord], list[object]]:
+        """Pause every replaceable engine in a named lifecycle group."""
+
         candidates = [
             record
             for record in self._records.values()
-            if record.model_id != target.model_id
+            if record.model_id != exclude_model_id
             and _replacement_group(record.entry) == group
         ]
         if replace_mode not in {"reject", "wait", "abort"}:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -33,6 +33,10 @@ class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
 
 
+class _CommittedReplacementCancelled(asyncio.CancelledError):
+    """Cancellation delivered after the replacement became routable."""
+
+
 @dataclass(frozen=True)
 class ResidentPerformanceConfig:
     """Audited scheduler overrides attached to one resident text model.
@@ -568,23 +572,9 @@ class ResidentModelManager:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
+            except _CommittedReplacementCancelled as exc:
+                raise asyncio.CancelledError from exc
             except BaseException:
-                # `_commit_group_replacement_locked` publishes the target and
-                # removes every predecessor before awaiting teardown.  A task
-                # cancellation delivered while one of those stops is awaited
-                # must therefore propagate without rolling back the already
-                # committed target (there may no longer be an old engine that
-                # can be made routable again).
-                committed = (
-                    group is not None
-                    and record.model_id in self._records
-                    and all(
-                        candidate.model_id not in self._records
-                        for candidate in candidates
-                    )
-                )
-                if committed:
-                    raise
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
@@ -710,11 +700,9 @@ class ResidentModelManager:
         )
         try:
             await self._commit_group_replacement_locked(target, group, candidates)
+        except _CommittedReplacementCancelled as exc:
+            raise asyncio.CancelledError from exc
         except BaseException:
-            if target.model_id in self._records and all(
-                candidate.model_id not in self._records for candidate in candidates
-            ):
-                raise
             await self._resume_engines(paused_engines)
             raise
 
@@ -851,7 +839,7 @@ class ResidentModelManager:
                     )
         _release_allocator_cache()
         if cancellation is not None:
-            raise cancellation
+            raise _CommittedReplacementCancelled from cancellation
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -770,15 +770,32 @@ class ResidentModelManager:
         return candidates, paused_engines
 
     async def _resume_engines(self, engines: list[object]) -> None:
+        cancellation: asyncio.CancelledError | None = None
         for engine in reversed(engines):
             resume = getattr(engine, "resume_generation", None)
             if callable(resume):
+                task = asyncio.create_task(resume())
                 try:
-                    await resume()
-                except BaseException:
+                    await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+                except asyncio.CancelledError as exc:
+                    cancellation = cancellation or exc
+                    try:
+                        await asyncio.wait_for(task, timeout=5.0)
+                    except (Exception, asyncio.CancelledError):
+                        logger.exception(
+                            "Failed to finish resuming a model engine after cancellation"
+                        )
+                except TimeoutError:
+                    task.cancel()
+                    logger.error(
+                        "Timed out resuming one model engine after replacement rollback"
+                    )
+                except Exception:
                     logger.exception(
                         "Failed to resume one model engine after replacement rollback"
                     )
+        if cancellation is not None:
+            raise cancellation
 
     async def _commit_group_replacement_locked(
         self,
@@ -953,8 +970,6 @@ class ResidentModelManager:
                 active_requests = max(
                     active_requests,
                     int(lifecycle.get("active_requests", 0) or 0),
-                    int(lifecycle.get("running_requests", 0) or 0),
-                    int(lifecycle.get("queued_requests", 0) or 0),
                 )
             models.append(
                 {

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -707,19 +707,16 @@ class ResidentModelManager:
                     raise ResidentModelBusyError("model is serving an active request")
                 pause = getattr(record.entry.engine, "pause_generation", None)
                 if callable(pause):
+                    paused_engines.append(record.entry.engine)
                     try:
                         await pause(
                             "wait" if replace_mode == "reject" else replace_mode,
                             timeout=0 if replace_mode == "reject" else None,
                         )
                     except TimeoutError as exc:
-                        resume = getattr(record.entry.engine, "resume_generation", None)
-                        if callable(resume):
-                            await resume()
                         raise ResidentModelBusyError(
                             "model is serving an active request"
                         ) from exc
-                    paused_engines.append(record.entry.engine)
                 elif not _engine_is_idle(record.entry.engine):
                     raise ResidentModelBusyError("model is serving an active request")
         except BaseException:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -819,6 +819,19 @@ class ResidentModelManager:
                     cancellation = cancellation or exc
                     try:
                         await asyncio.wait_for(task, timeout=5.0)
+                    except TimeoutError:
+                        task.cancel()
+                        _, pending = await asyncio.wait({task}, timeout=1.0)
+                        force_resume = getattr(engine, "force_resume_generation", None)
+                        if callable(force_resume):
+                            force_resume()
+                        if pending:
+                            self._rollback_tasks.add(task)
+                            self._rollback_task_engines[task] = engine
+                            task.add_done_callback(self._on_rollback_done)
+                        failure = failure or TimeoutError(
+                            "timed out resuming a model engine after cancellation"
+                        )
                     except (Exception, asyncio.CancelledError):
                         failure = failure or RuntimeError(
                             "failed to finish resuming a model engine after cancellation"

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -338,6 +338,7 @@ class ResidentModelManager:
         self._retired_engines: list[object] = []
         self._retirement_tasks: set[asyncio.Task] = set()
         self._retirement_task_engines: dict[asyncio.Task, object] = {}
+        self._rollback_tasks: set[asyncio.Task] = set()
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -430,7 +431,7 @@ class ResidentModelManager:
                 pass
 
         async with self._lock:
-            retirement_tasks = tuple(self._retirement_tasks)
+            retirement_tasks = tuple(self._retirement_tasks | self._rollback_tasks)
             stuck_engines: list[object] = []
             if retirement_tasks:
                 _, pending = await asyncio.wait(retirement_tasks, timeout=5.0)
@@ -464,8 +465,24 @@ class ResidentModelManager:
                     try:
                         result = stop()
                         if asyncio.iscoroutine(result):
-                            await result
+                            stop_task = asyncio.create_task(result)
+                            try:
+                                await asyncio.wait_for(
+                                    asyncio.shield(stop_task), timeout=5.0
+                                )
+                            except TimeoutError:
+                                stop_task.cancel()
+                                _, still_pending = await asyncio.wait(
+                                    {stop_task}, timeout=1.0
+                                )
+                                if still_pending:
+                                    self._retired_engines.append(engine)
+                                logger.error(
+                                    "Timed out stopping a retired model engine "
+                                    "during shutdown"
+                                )
                     except Exception:
+                        self._retired_engines.append(engine)
                         logger.exception("Failed to stop a retired model engine")
             self._retired_engines.extend(stuck_engines)
 
@@ -808,6 +825,10 @@ class ResidentModelManager:
                         )
                 except TimeoutError:
                     task.cancel()
+                    _, pending = await asyncio.wait({task}, timeout=1.0)
+                    if pending:
+                        self._rollback_tasks.add(task)
+                        task.add_done_callback(self._rollback_tasks.discard)
                     failure = failure or TimeoutError(
                         "timed out resuming a model engine after replacement rollback"
                     )

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -594,14 +594,17 @@ class ResidentModelManager:
                 self.registry.add(entry)
                 self._index_record(record)
                 self.loads_total += 1
-                await self._evict_for_locked(0, exclude={record.model_id})
+                await self._evict_for_locked(
+                    0,
+                    exclude={record.model_id, *(item.model_id for item in candidates)},
+                )
                 if group is not None:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
             except _CommittedReplacementCancelled as exc:
                 raise asyncio.CancelledError from exc
-            except BaseException:
+            except BaseException as original:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
@@ -624,7 +627,7 @@ class ResidentModelManager:
                         "old-engine admission will still be resumed"
                     )
                 finally:
-                    await self._resume_engines(paused_engines)
+                    await self._resume_after_failure(paused_engines, original)
                 raise
             return record
 
@@ -729,8 +732,8 @@ class ResidentModelManager:
             await self._commit_group_replacement_locked(target, group, candidates)
         except _CommittedReplacementCancelled as exc:
             raise asyncio.CancelledError from exc
-        except BaseException:
-            await self._resume_engines(paused_engines)
+        except BaseException as original:
+            await self._resume_after_failure(paused_engines, original)
             raise
 
     async def _quiesce_group_locked(
@@ -778,8 +781,8 @@ class ResidentModelManager:
                         ) from exc
                 elif not _engine_is_idle(record.entry.engine):
                     raise ResidentModelBusyError("model is serving an active request")
-        except BaseException:
-            await self._resume_engines(paused_engines)
+        except BaseException as original:
+            await self._resume_after_failure(paused_engines, original)
             raise
         return candidates, paused_engines
 
@@ -820,6 +823,17 @@ class ResidentModelManager:
             raise cancellation
         if failure is not None:
             raise failure
+
+    async def _resume_after_failure(
+        self, engines: list[object], original: BaseException
+    ) -> None:
+        """Run bounded rollback without replacing the operation's root error."""
+
+        try:
+            await self._resume_engines(engines)
+        except BaseException as cleanup:
+            original.add_note(f"rollback resume also failed: {cleanup!r}")
+            raise original from cleanup
 
     async def _commit_group_replacement_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -337,6 +337,7 @@ class ResidentModelManager:
         # of turning a cleanup failure into loss of the serving model.
         self._retired_engines: list[object] = []
         self._retirement_tasks: set[asyncio.Task] = set()
+        self._retirement_task_engines: dict[asyncio.Task, object] = {}
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -430,6 +431,7 @@ class ResidentModelManager:
 
         async with self._lock:
             retirement_tasks = tuple(self._retirement_tasks)
+            stuck_engines: list[object] = []
             if retirement_tasks:
                 _, pending = await asyncio.wait(retirement_tasks, timeout=5.0)
                 if pending:
@@ -439,6 +441,17 @@ class ResidentModelManager:
                     )
                     for retirement_task in pending:
                         retirement_task.cancel()
+                    _, still_pending = await asyncio.wait(pending, timeout=1.0)
+                    for retirement_task in still_pending:
+                        engine = self._retirement_task_engines.get(retirement_task)
+                        if engine is not None:
+                            stuck_engines.append(engine)
+                    if still_pending:
+                        logger.error(
+                            "%d retired model engine(s) ignored cancellation; "
+                            "retaining handles after bounded shutdown",
+                            len(still_pending),
+                        )
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
@@ -454,6 +467,7 @@ class ResidentModelManager:
                             await result
                     except Exception:
                         logger.exception("Failed to stop a retired model engine")
+            self._retired_engines.extend(stuck_engines)
 
     async def _ttl_loop(self) -> None:
         interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
@@ -877,13 +891,15 @@ class ResidentModelManager:
                     group,
                 )
 
-        tasks = [
-            asyncio.create_task(stop_retired(record, stop))
+        task_records = [
+            (asyncio.create_task(stop_retired(record, stop)), record)
             for record, stop in retired
             if callable(stop)
         ]
+        tasks = [task for task, _ in task_records]
         self._retirement_tasks.update(tasks)
-        for task in tasks:
+        for task, record in task_records:
+            self._retirement_task_engines[task] = record.entry.engine
             task.add_done_callback(self._on_retirement_done)
 
         if tasks:
@@ -898,6 +914,9 @@ class ResidentModelManager:
 
     def _on_retirement_done(self, task: asyncio.Task) -> None:
         self._retirement_tasks.discard(task)
+        engine = self._retirement_task_engines.pop(task, None)
+        if task.cancelled() and engine is not None:
+            self._retired_engines.append(engine)
         if not self._retirement_tasks:
             _release_allocator_cache()
 
@@ -977,10 +996,7 @@ class ResidentModelManager:
             )
             active_requests = record.active_requests
             if lifecycle is not None:
-                active_requests = max(
-                    active_requests,
-                    int(lifecycle.get("active_requests", 0) or 0),
-                )
+                active_requests = int(lifecycle.get("active_requests", 0) or 0)
             models.append(
                 {
                     "id": record.model_id,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -771,6 +771,7 @@ class ResidentModelManager:
 
     async def _resume_engines(self, engines: list[object]) -> None:
         cancellation: asyncio.CancelledError | None = None
+        failure: Exception | None = None
         for engine in reversed(engines):
             resume = getattr(engine, "resume_generation", None)
             if callable(resume):
@@ -782,20 +783,29 @@ class ResidentModelManager:
                     try:
                         await asyncio.wait_for(task, timeout=5.0)
                     except (Exception, asyncio.CancelledError):
+                        failure = failure or RuntimeError(
+                            "failed to finish resuming a model engine after cancellation"
+                        )
                         logger.exception(
                             "Failed to finish resuming a model engine after cancellation"
                         )
                 except TimeoutError:
                     task.cancel()
+                    failure = failure or TimeoutError(
+                        "timed out resuming a model engine after replacement rollback"
+                    )
                     logger.error(
                         "Timed out resuming one model engine after replacement rollback"
                     )
-                except Exception:
+                except Exception as exc:
+                    failure = failure or exc
                     logger.exception(
                         "Failed to resume one model engine after replacement rollback"
                     )
         if cancellation is not None:
             raise cancellation
+        if failure is not None:
+            raise failure
 
     async def _commit_group_replacement_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -569,6 +569,22 @@ class ResidentModelManager:
                         record, group, candidates
                     )
             except BaseException:
+                # `_commit_group_replacement_locked` publishes the target and
+                # removes every predecessor before awaiting teardown.  A task
+                # cancellation delivered while one of those stops is awaited
+                # must therefore propagate without rolling back the already
+                # committed target (there may no longer be an old engine that
+                # can be made routable again).
+                committed = (
+                    group is not None
+                    and record.model_id in self._records
+                    and all(
+                        candidate.model_id not in self._records
+                        for candidate in candidates
+                    )
+                )
+                if committed:
+                    raise
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
@@ -695,6 +711,10 @@ class ResidentModelManager:
         try:
             await self._commit_group_replacement_locked(target, group, candidates)
         except BaseException:
+            if target.model_id in self._records and all(
+                candidate.model_id not in self._records for candidate in candidates
+            ):
+                raise
             await self._resume_engines(paused_engines)
             raise
 
@@ -783,16 +803,43 @@ class ResidentModelManager:
             if self._on_primary_changed is not None:
                 self._on_primary_changed(target.entry)
 
+        # Establish the commit point completely before the first teardown
+        # await.  This makes cancellation state unambiguous: after this loop
+        # the new target is the only routable member of the group.
+        retired: list[tuple[ResidencyRecord, object | None]] = []
         for record in candidates:
             record.state = "evicting"
             self.registry.remove(record.model_id)
             self._drop_record(record.model_id)
             stop = getattr(record.entry.engine, "stop", None)
+            retired.append((record, stop if callable(stop) else None))
+            self.evictions_total += 1
+
+        cancellation: asyncio.CancelledError | None = None
+        for record, stop in retired:
             if callable(stop):
                 try:
                     result = stop()
                     if asyncio.iscoroutine(result):
-                        await result
+                        task = asyncio.create_task(result)
+                        try:
+                            await asyncio.shield(task)
+                        except asyncio.CancelledError as exc:
+                            # Finish releasing the retired engine even though
+                            # the control-plane caller went away.  Re-propagate
+                            # cancellation only after all retirees have been
+                            # handled; the caller recognizes the committed
+                            # registry state and leaves the target active.
+                            cancellation = cancellation or exc
+                            try:
+                                await task
+                            except Exception:
+                                self._retired_engines.append(record.entry.engine)
+                                logger.exception(
+                                    "Failed to stop retired model %r after cancellation; "
+                                    "cleanup will retry during shutdown",
+                                    record.model_id,
+                                )
                 except Exception:
                     self._retired_engines.append(record.entry.engine)
                     logger.exception(
@@ -802,8 +849,9 @@ class ResidentModelManager:
                         record.model_id,
                         group,
                     )
-            self.evictions_total += 1
         _release_allocator_cache()
+        if cancellation is not None:
+            raise cancellation
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -336,6 +336,7 @@ class ResidentModelManager:
         # primary remains serviceable; shutdown retries these handles instead
         # of turning a cleanup failure into loss of the serving model.
         self._retired_engines: list[object] = []
+        self._retirement_tasks: set[asyncio.Task] = set()
         self.evictions_total = 0
         self.loads_total = 0
         self.registry.on_engine_access = self.touch
@@ -428,6 +429,9 @@ class ResidentModelManager:
                 pass
 
         async with self._lock:
+            retirement_tasks = tuple(self._retirement_tasks)
+            if retirement_tasks:
+                await asyncio.gather(*retirement_tasks, return_exceptions=True)
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
@@ -803,43 +807,44 @@ class ResidentModelManager:
             retired.append((record, stop if callable(stop) else None))
             self.evictions_total += 1
 
-        cancellation: asyncio.CancelledError | None = None
-        for record, stop in retired:
-            if callable(stop):
-                try:
-                    result = stop()
-                    if asyncio.iscoroutine(result):
-                        task = asyncio.create_task(result)
-                        try:
-                            await asyncio.shield(task)
-                        except asyncio.CancelledError as exc:
-                            # Finish releasing the retired engine even though
-                            # the control-plane caller went away.  Re-propagate
-                            # cancellation only after all retirees have been
-                            # handled; the caller recognizes the committed
-                            # registry state and leaves the target active.
-                            cancellation = cancellation or exc
-                            try:
-                                await task
-                            except Exception:
-                                self._retired_engines.append(record.entry.engine)
-                                logger.exception(
-                                    "Failed to stop retired model %r after cancellation; "
-                                    "cleanup will retry during shutdown",
-                                    record.model_id,
-                                )
-                except Exception:
-                    self._retired_engines.append(record.entry.engine)
-                    logger.exception(
-                        "Failed to stop retired model %r after replacing %s; "
-                        "the replacement remains active and cleanup will retry "
-                        "during shutdown",
-                        record.model_id,
-                        group,
-                    )
+        async def stop_retired(record: ResidencyRecord, stop: object) -> None:
+            try:
+                result = stop()  # type: ignore[operator]
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                self._retired_engines.append(record.entry.engine)
+                logger.exception(
+                    "Failed to stop retired model %r after replacing %s; "
+                    "the replacement remains active and cleanup will retry "
+                    "during shutdown",
+                    record.model_id,
+                    group,
+                )
+
+        tasks = [
+            asyncio.create_task(stop_retired(record, stop))
+            for record, stop in retired
+            if callable(stop)
+        ]
+        self._retirement_tasks.update(tasks)
+        for task in tasks:
+            task.add_done_callback(self._on_retirement_done)
+
+        if tasks:
+            try:
+                await asyncio.shield(asyncio.gather(*tasks))
+            except asyncio.CancelledError as exc:
+                # Registry commit is complete and teardown tasks are strongly
+                # tracked by the manager. The cancelled control-plane caller
+                # must not wait for an unrelated old engine's slow/hung stop.
+                raise _CommittedReplacementCancelled from exc
         _release_allocator_cache()
-        if cancellation is not None:
-            raise _CommittedReplacementCancelled from cancellation
+
+    def _on_retirement_done(self, task: asyncio.Task) -> None:
+        self._retirement_tasks.discard(task)
+        if not self._retirement_tasks:
+            _release_allocator_cache()
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:
@@ -954,6 +959,7 @@ class ResidentModelManager:
             "idle_ttl_seconds": self.idle_ttl_seconds,
             "loads_total": self.loads_total,
             "evictions_total": self.evictions_total,
-            "retired_cleanup_pending": len(self._retired_engines),
+            "retired_cleanup_pending": len(self._retired_engines)
+            + len(self._retirement_tasks),
             "models": models,
         }

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6109,7 +6109,7 @@ class Scheduler:
             self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
             self._paused_admission_tokens = set()
 
-    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+    def pause_generation_admission(self, admission_tokens: set[int], mode: str) -> None:
         """Atomically close admission and account for pre-pause reservations."""
 
         with self._cancel_counter_lock:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6095,6 +6095,12 @@ class Scheduler:
         self._generation_paused = bool(paused)
         self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return an atomic snapshot of all queued/running request ids."""
+
+        with self._cancel_counter_lock:
+            return tuple(self.requests)
+
     def abort_request(self, request_id: str) -> bool:
         """
         Queue request for abort. Thread-safe, called from any thread.
@@ -8346,7 +8352,8 @@ class Scheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._cancel_counter_lock:
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3037,6 +3037,7 @@ class Scheduler:
         self.running: dict[str, Request] = {}  # Running requests by ID
         self.requests: dict[str, Request] = {}  # All requests by ID
         self._generation_paused = False
+        self._paused_add_allowance = 0
         self.finished_req_ids: set[str] = set()  # Recently finished
         # Debug aid (#1878): resolved ONCE — an os.environ lookup per
         # step would put dict access on the decode hot path advertised
@@ -5858,9 +5859,12 @@ class Scheduler:
                 this and return 503 with Retry-After.
         """
         if getattr(self, "_generation_paused", False):
-            raise BackpressureError(
-                "generation is paused for an engine lifecycle operation"
-            )
+            allowance = getattr(self, "_paused_add_allowance", 0)
+            if allowance <= 0:
+                raise BackpressureError(
+                    "generation is paused for an engine lifecycle operation"
+                )
+            self._paused_add_allowance = allowance - 1
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6085,10 +6089,11 @@ class Scheduler:
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
 
-    def set_generation_paused(self, paused: bool) -> None:
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
         self._generation_paused = bool(paused)
+        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
     def abort_request(self, request_id: str) -> bool:
         """

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5858,13 +5858,16 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
-        if getattr(self, "_generation_paused", False):
-            allowance = getattr(self, "_paused_add_allowance", 0)
-            if allowance <= 0:
-                raise BackpressureError(
-                    "generation is paused for an engine lifecycle operation"
-                )
-            self._paused_add_allowance = allowance - 1
+        pause_allowance_consumed = False
+        with self._request_state_lock():
+            if getattr(self, "_generation_paused", False):
+                allowance = getattr(self, "_paused_add_allowance", 0)
+                if allowance <= 0:
+                    raise BackpressureError(
+                        "generation is paused for an engine lifecycle operation"
+                    )
+                self._paused_add_allowance = allowance - 1
+                pause_allowance_consumed = True
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6079,6 +6082,19 @@ class Scheduler:
         # the ledger intact and the prior lifetime's dedupe
         # stays effective.
         with self._cancel_counter_lock:
+            # Admission may have closed while tokenization/cache preparation
+            # ran. A route reserved before the pause edge can consume one of
+            # the exact allowances; an unrelated late caller is rejected.
+            if (
+                getattr(self, "_generation_paused", False)
+                and not pause_allowance_consumed
+            ):
+                allowance = getattr(self, "_paused_add_allowance", 0)
+                if allowance <= 0:
+                    raise BackpressureError(
+                        "generation is paused for an engine lifecycle operation"
+                    )
+                self._paused_add_allowance = allowance - 1
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
@@ -6092,14 +6108,35 @@ class Scheduler:
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
-        self._generation_paused = bool(paused)
-        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+        with self._cancel_counter_lock:
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+
+    def pause_generation_admission(self, admitted_reservations: int, mode: str) -> None:
+        """Atomically close admission and account for pre-pause reservations."""
+
+        with self._cancel_counter_lock:
+            self._generation_paused = True
+            self._paused_add_allowance = (
+                max(0, int(admitted_reservations) - len(self.requests))
+                if mode == "wait"
+                else 0
+            )
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""
 
         with self._cancel_counter_lock:
             return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, lazily supporting ``__new__`` test stubs."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5858,14 +5858,13 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
-        with self._request_state_lock():
-            if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                token = getattr(request, "lifecycle_admission_token", None)
-                if token not in allowed:
-                    raise BackpressureError(
-                        "generation is paused for an engine lifecycle operation"
-                    )
+        if getattr(self, "_generation_paused", False):
+            allowance = getattr(self, "_paused_add_allowance", 0)
+            if allowance <= 0:
+                raise BackpressureError(
+                    "generation is paused for an engine lifecycle operation"
+                )
+            self._paused_add_allowance = allowance - 1
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6080,17 +6079,6 @@ class Scheduler:
         # the ledger intact and the prior lifetime's dedupe
         # stays effective.
         with self._cancel_counter_lock:
-            # Admission may have closed while tokenization/cache preparation
-            # ran. A route reserved before the pause edge can consume one of
-            # the exact allowances; an unrelated late caller is rejected.
-            if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                token = getattr(request, "lifecycle_admission_token", None)
-                if token not in allowed:
-                    raise BackpressureError(
-                        "generation is paused for an engine lifecycle operation"
-                    )
-                allowed.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
@@ -6104,38 +6092,14 @@ class Scheduler:
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model mutation."""
 
-        with self._cancel_counter_lock:
-            self._generation_paused = bool(paused)
-            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
-            self._paused_admission_tokens = set()
-
-    def pause_generation_admission(self, admission_tokens: set[int], mode: str) -> None:
-        """Atomically close admission and account for pre-pause reservations."""
-
-        with self._cancel_counter_lock:
-            self._generation_paused = True
-            owned = {
-                getattr(request, "lifecycle_admission_token", None)
-                for request in self.requests.values()
-                if getattr(request, "lifecycle_admission_token", None) is not None
-            }
-            self._paused_admission_tokens = set(admission_tokens) - owned
-            self._paused_add_allowance = len(self._paused_admission_tokens)
+        self._generation_paused = bool(paused)
+        self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""
 
         with self._cancel_counter_lock:
             return tuple(self.requests)
-
-    def _request_state_lock(self):
-        """Return the request lock, lazily supporting ``__new__`` test stubs."""
-
-        lock = getattr(self, "_cancel_counter_lock", None)
-        if lock is None:
-            lock = threading.Lock()
-            self._cancel_counter_lock = lock
-        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -8415,9 +8379,6 @@ class Scheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.clear()
             self._disconnect_abort_ids.clear()
-            self._generation_paused = False
-            self._paused_add_allowance = 0
-            self._paused_admission_tokens = set()
 
         # Clear caches
         if self.block_aware_cache is not None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3036,6 +3036,7 @@ class Scheduler:
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, Request] = {}  # Running requests by ID
         self.requests: dict[str, Request] = {}  # All requests by ID
+        self._generation_paused = False
         self.finished_req_ids: set[str] = set()  # Recently finished
         # Debug aid (#1878): resolved ONCE — an os.environ lookup per
         # step would put dict access on the decode hot path advertised
@@ -5856,6 +5857,10 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
+        if getattr(self, "_generation_paused", False):
+            raise BackpressureError(
+                "generation is paused for an engine lifecycle operation"
+            )
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6079,6 +6084,11 @@ class Scheduler:
         logger.debug(
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
+
+    def set_generation_paused(self, paused: bool) -> None:
+        """Close or reopen scheduler admission for model mutation."""
+
+        self._generation_paused = bool(paused)
 
     def abort_request(self, request_id: str) -> bool:
         """

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5858,16 +5858,14 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
-        pause_allowance_consumed = False
         with self._request_state_lock():
             if getattr(self, "_generation_paused", False):
-                allowance = getattr(self, "_paused_add_allowance", 0)
-                if allowance <= 0:
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
                     raise BackpressureError(
                         "generation is paused for an engine lifecycle operation"
                     )
-                self._paused_add_allowance = allowance - 1
-                pause_allowance_consumed = True
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6085,16 +6083,14 @@ class Scheduler:
             # Admission may have closed while tokenization/cache preparation
             # ran. A route reserved before the pause edge can consume one of
             # the exact allowances; an unrelated late caller is rejected.
-            if (
-                getattr(self, "_generation_paused", False)
-                and not pause_allowance_consumed
-            ):
-                allowance = getattr(self, "_paused_add_allowance", 0)
-                if allowance <= 0:
+            if getattr(self, "_generation_paused", False):
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
                     raise BackpressureError(
                         "generation is paused for an engine lifecycle operation"
                     )
-                self._paused_add_allowance = allowance - 1
+                allowed.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
@@ -6111,17 +6107,22 @@ class Scheduler:
         with self._cancel_counter_lock:
             self._generation_paused = bool(paused)
             self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
 
-    def pause_generation_admission(self, admitted_reservations: int, mode: str) -> None:
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
         """Atomically close admission and account for pre-pause reservations."""
 
         with self._cancel_counter_lock:
             self._generation_paused = True
-            self._paused_add_allowance = (
-                max(0, int(admitted_reservations) - len(self.requests))
-                if mode == "wait"
-                else 0
+            owned = {
+                getattr(request, "lifecycle_admission_token", None)
+                for request in self.requests.values()
+                if getattr(request, "lifecycle_admission_token", None) is not None
+            }
+            self._paused_admission_tokens = (
+                set(admission_tokens) - owned if mode == "wait" else set()
             )
+            self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:
         """Return an atomic snapshot of all queued/running request ids."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8417,6 +8417,9 @@ class Scheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.clear()
             self._disconnect_abort_ids.clear()
+            self._generation_paused = False
+            self._paused_add_allowance = 0
+            self._paused_admission_tokens = set()
 
         # Clear caches
         if self.block_aware_cache is not None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6119,9 +6119,7 @@ class Scheduler:
                 for request in self.requests.values()
                 if getattr(request, "lifecycle_admission_token", None) is not None
             }
-            self._paused_admission_tokens = (
-                set(admission_tokens) - owned if mode == "wait" else set()
-            )
+            self._paused_admission_tokens = set(admission_tokens) - owned
             self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:


### PR DESCRIPTION
## Product purpose

Let the Desktop assistant picker replace the currently loaded text or multimodal assistant model without restarting the server. The scheduler—not the lifetime of an HTTP request—is the source of truth for queued and running inference.

The user-visible contract is deliberately small:

- `reject` (default) refuses replacement while the current model is busy
- `wait` drains admitted work, then replaces the model
- `abort` cancels admitted work, wakes streaming and non-streaming text/MLLM clients with a terminal result, then replaces the model
- residency status reports scheduler-owned admitted/running/queued activity

## Scope boundaries

In scope: the Desktop assistant text/MLLM group, request admission/drain/abort behavior, atomic publication of the replacement model, and residency reporting needed by this flow.

Not goals of this PR:

- a general transaction or lifecycle framework for every engine type
- redesigning image, video, diffusion, or other independent model lanes
- guaranteeing teardown of adversarial engines that ignore cancellation forever
- changing GUI or HTTP semantics beyond the replacement-policy contract
- speculative hardening without a reproducible failure in this product flow

Review findings should block landing only for reproducible correctness, security, or regression issues inside the scope above. Broader architectural hardening belongs in follow-up work.

## Implementation

- move lifecycle admission into the text and MLLM schedulers, following pause/drain semantics
- retain atomic non-blocking `reject` as the default and add explicit `wait` and `abort` policies
- publish replacement models only after the previous engine is quiescent
- expose scheduler-owned activity through model residency status
- document why GUI confirmation and HTTP response lifetime are not server lifecycle state

Supersedes #2223, which implemented an HTTP-response-scoped lifecycle control plane.

## Validation

- focused lifecycle, scheduler, residency, text-abort, and MLLM-abort contracts
- scoped independent Codex review against the product purpose and non-goals above
- formal lint, unit, and stress validation before landing
