### PR TITLE
fix(mac): pin golden-flow RAM to the 8 GB tier so AX baselines are host-deterministic

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
@@ -56,8 +56,9 @@ struct MacHardware: Sendable, Equatable {
     /// picker).
     ///
     /// ``RAPID_HARDWARE_RAM_GB`` and ``RAPID_HARDWARE_BRAND`` override
-    /// the corresponding probes when valid. Production launches never set
-    /// them; golden flows pin both so AX output is host-independent.
+    /// the corresponding probes only with ``RAPID_GUI_HARDWARE_FIXTURE=1``.
+    /// Production launches never set that gate; golden flows pin the complete
+    /// identity so AX output is host-independent.
     static func detect() -> MacHardware {
         let environment = ProcessInfo.processInfo.environment
         let brand = Self.brandString(environment: environment)
@@ -86,9 +87,11 @@ struct MacHardware: Sendable, Equatable {
         environment: [String: String],
         fallback: () -> UInt64?
     ) -> UInt64 {
-        if let override = environment["RAPID_HARDWARE_RAM_GB"],
+        if environment["RAPID_GUI_HARDWARE_FIXTURE"] == "1",
+           let override = environment["RAPID_HARDWARE_RAM_GB"],
            let gb = Double(override), gb.isFinite, gb > 0, gb <= 1024 {
-            return UInt64((gb * Double(1 << 30)).rounded())
+            let bytes = UInt64((gb * Double(1 << 30)).rounded())
+            if bytes > 0 { return bytes }
         }
         return fallback() ?? 0
     }
@@ -96,11 +99,21 @@ struct MacHardware: Sendable, Equatable {
     /// The golden harness pins the displayed chip together with RAM so AX
     /// output remains identical across CI and release-validation Macs.
     static func brandString(environment: [String: String]) -> String {
-        if let override = environment["RAPID_HARDWARE_BRAND"],
+        brandString(environment: environment) {
+            sysctlString("machdep.cpu.brand_string")
+        }
+    }
+
+    static func brandString(
+        environment: [String: String],
+        fallback: () -> String?
+    ) -> String {
+        if environment["RAPID_GUI_HARDWARE_FIXTURE"] == "1",
+           let override = environment["RAPID_HARDWARE_BRAND"],
            !override.isEmpty, override.utf8.count <= 128 {
             return override
         }
-        return sysctlString("machdep.cpu.brand_string") ?? "Apple Silicon"
+        return fallback() ?? "Apple Silicon"
     }
 
     // MARK: - Display helpers

--- a/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
@@ -55,15 +55,13 @@ struct MacHardware: Sendable, Equatable {
     /// through to ``.mUnknown / .unknown`` rather than crashing the
     /// picker).
     ///
-    /// ``RAPID_HARDWARE_RAM_GB`` (a decimal GB of total physical RAM)
-    /// overrides ``hw.memsize`` when set and parseable. Production
-    /// launches never set it, so the picker still reflects the real
-    /// Mac; the golden flows set it to a fixed tier so their structural
-    /// AX baselines are deterministic across hosts of very different
-    /// RAM.
+    /// ``RAPID_HARDWARE_RAM_GB`` and ``RAPID_HARDWARE_BRAND`` override
+    /// the corresponding probes when valid. Production launches never set
+    /// them; golden flows pin both so AX output is host-independent.
     static func detect() -> MacHardware {
-        let brand = sysctlString("machdep.cpu.brand_string") ?? "Apple Silicon"
-        let mem = Self.physicalRAMBytes(environment: ProcessInfo.processInfo.environment)
+        let environment = ProcessInfo.processInfo.environment
+        let brand = Self.brandString(environment: environment)
+        let mem = Self.physicalRAMBytes(environment: environment)
         let (family, tier) = Self.classify(brand)
         let bw = Self.bandwidthGBs(family: family, tier: tier)
         return MacHardware(
@@ -76,16 +74,33 @@ struct MacHardware: Sendable, Equatable {
     }
 
     /// ``hw.memsize`` in bytes, unless ``RAPID_HARDWARE_RAM_GB`` pins
-    /// it. Only the RAM is overridable — the chip brand still comes
-    /// from this host, so the labelled chip family stays truthful.
-    /// Pure so the golden-flow pin is unit-testable without mutating
-    /// the test process's global environment.
+    /// it. Pure so the golden-flow pin is unit-testable without mutating the
+    /// test process's global environment.
     static func physicalRAMBytes(environment: [String: String]) -> UInt64 {
+        physicalRAMBytes(environment: environment) {
+            sysctlUInt64("hw.memsize")
+        }
+    }
+
+    static func physicalRAMBytes(
+        environment: [String: String],
+        fallback: () -> UInt64?
+    ) -> UInt64 {
         if let override = environment["RAPID_HARDWARE_RAM_GB"],
            let gb = Double(override), gb.isFinite, gb > 0, gb <= 1024 {
             return UInt64((gb * Double(1 << 30)).rounded())
         }
-        return sysctlUInt64("hw.memsize") ?? 0
+        return fallback() ?? 0
+    }
+
+    /// The golden harness pins the displayed chip together with RAM so AX
+    /// output remains identical across CI and release-validation Macs.
+    static func brandString(environment: [String: String]) -> String {
+        if let override = environment["RAPID_HARDWARE_BRAND"],
+           !override.isEmpty, override.utf8.count <= 128 {
+            return override
+        }
+        return sysctlString("machdep.cpu.brand_string") ?? "Apple Silicon"
     }
 
     // MARK: - Display helpers

--- a/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
@@ -82,7 +82,7 @@ struct MacHardware: Sendable, Equatable {
     /// the test process's global environment.
     static func physicalRAMBytes(environment: [String: String]) -> UInt64 {
         if let override = environment["RAPID_HARDWARE_RAM_GB"],
-           let gb = Double(override), gb > 0 {
+           let gb = Double(override), gb.isFinite, gb > 0, gb <= 1024 {
             return UInt64((gb * Double(1 << 30)).rounded())
         }
         return sysctlUInt64("hw.memsize") ?? 0

--- a/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/MacHardware.swift
@@ -54,9 +54,16 @@ struct MacHardware: Sendable, Equatable {
     /// can't be classified (older / forward-compatible chips fall
     /// through to ``.mUnknown / .unknown`` rather than crashing the
     /// picker).
+    ///
+    /// ``RAPID_HARDWARE_RAM_GB`` (a decimal GB of total physical RAM)
+    /// overrides ``hw.memsize`` when set and parseable. Production
+    /// launches never set it, so the picker still reflects the real
+    /// Mac; the golden flows set it to a fixed tier so their structural
+    /// AX baselines are deterministic across hosts of very different
+    /// RAM.
     static func detect() -> MacHardware {
         let brand = sysctlString("machdep.cpu.brand_string") ?? "Apple Silicon"
-        let mem = sysctlUInt64("hw.memsize") ?? 0
+        let mem = Self.physicalRAMBytes(environment: ProcessInfo.processInfo.environment)
         let (family, tier) = Self.classify(brand)
         let bw = Self.bandwidthGBs(family: family, tier: tier)
         return MacHardware(
@@ -66,6 +73,19 @@ struct MacHardware: Sendable, Equatable {
             physicalRAMBytes: mem,
             memoryBandwidthGBs: bw
         )
+    }
+
+    /// ``hw.memsize`` in bytes, unless ``RAPID_HARDWARE_RAM_GB`` pins
+    /// it. Only the RAM is overridable — the chip brand still comes
+    /// from this host, so the labelled chip family stays truthful.
+    /// Pure so the golden-flow pin is unit-testable without mutating
+    /// the test process's global environment.
+    static func physicalRAMBytes(environment: [String: String]) -> UInt64 {
+        if let override = environment["RAPID_HARDWARE_RAM_GB"],
+           let gb = Double(override), gb > 0 {
+            return UInt64((gb * Double(1 << 30)).rounded())
+        }
+        return sysctlUInt64("hw.memsize") ?? 0
     }
 
     // MARK: - Display helpers

--- a/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
@@ -97,7 +97,10 @@ struct MacHardwareTests {
         // AX baselines are deterministic across hosts — a 14 GB CI runner
         // and a 256 GB release Mac must render the same recommended row.
         let gb: UInt64 = 8
-        let pinned = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "8"])
+        let pinned = MacHardware.physicalRAMBytes(environment: [
+            "RAPID_GUI_HARDWARE_FIXTURE": "1",
+            "RAPID_HARDWARE_RAM_GB": "8",
+        ])
         // 8 × 2^30 = 8589934592; allow a *bit* of rounding latitude.
         #expect(abs(Int64(pinned) - Int64(gb * UInt64(1 << 30))) < 16)
     }
@@ -105,31 +108,46 @@ struct MacHardwareTests {
     @Test("RAM override is ignored when not set or invalid")
     func goldenRAMOverrideIgnoredWhenAbsent() {
         let fallback: UInt64 = 24 * UInt64(1 << 30)
+        let fixture = ["RAPID_GUI_HARDWARE_FIXTURE": "1"]
         // Missing, malformed, non-finite, and implausibly large values must
         // return the exact probe result, not merely an arbitrary nonzero value.
         let absent = MacHardware.physicalRAMBytes(environment: [:]) { fallback }
         #expect(absent == fallback)
         let bad = MacHardware.physicalRAMBytes(
-            environment: ["RAPID_HARDWARE_RAM_GB": "not-a-number"]
+            environment: fixture.merging(["RAPID_HARDWARE_RAM_GB": "not-a-number"]) { _, new in new }
         ) { fallback }
         #expect(bad == fallback)
         let nonFinite = MacHardware.physicalRAMBytes(
-            environment: ["RAPID_HARDWARE_RAM_GB": "inf"]
+            environment: fixture.merging(["RAPID_HARDWARE_RAM_GB": "inf"]) { _, new in new }
         ) { fallback }
         #expect(nonFinite == fallback)
         let implausiblyLarge = MacHardware.physicalRAMBytes(
-            environment: ["RAPID_HARDWARE_RAM_GB": "1e100"]
+            environment: fixture.merging(["RAPID_HARDWARE_RAM_GB": "1e100"]) { _, new in new }
         ) { fallback }
         #expect(implausiblyLarge == fallback)
+        let underflow = MacHardware.physicalRAMBytes(
+            environment: fixture.merging(["RAPID_HARDWARE_RAM_GB": "1e-300"]) { _, new in new }
+        ) { fallback }
+        #expect(underflow == fallback)
+        let ungated = MacHardware.physicalRAMBytes(
+            environment: ["RAPID_HARDWARE_RAM_GB": "1024"]
+        ) { fallback }
+        #expect(ungated == fallback)
     }
 
     @Test("Golden hardware brand is deterministic and bounded")
     func goldenHardwareBrand() {
         #expect(MacHardware.brandString(environment: [
+            "RAPID_GUI_HARDWARE_FIXTURE": "1",
             "RAPID_HARDWARE_BRAND": "Apple M1",
         ]) == "Apple M1")
         #expect(MacHardware.brandString(environment: [
+            "RAPID_GUI_HARDWARE_FIXTURE": "1",
             "RAPID_HARDWARE_BRAND": String(repeating: "x", count: 129),
-        ]) != String(repeating: "x", count: 129))
+        ], fallback: { "Apple Test Host" }) == "Apple Test Host")
+        #expect(MacHardware.brandString(
+            environment: ["RAPID_HARDWARE_BRAND": "Apple M1"],
+            fallback: { "Apple Test Host" }
+        ) == "Apple Test Host")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
@@ -110,5 +110,11 @@ struct MacHardwareTests {
         // A non-parserable or non-positive value also falls back to sysctl.
         let bad = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "not-a-number"])
         #expect(bad > 0)
+        let nonFinite = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "inf"])
+        #expect(nonFinite > 0)
+        let implausiblyLarge = MacHardware.physicalRAMBytes(
+            environment: ["RAPID_HARDWARE_RAM_GB": "1e100"]
+        )
+        #expect(implausiblyLarge > 0)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
@@ -104,17 +104,32 @@ struct MacHardwareTests {
 
     @Test("RAM override is ignored when not set or invalid")
     func goldenRAMOverrideIgnoredWhenAbsent() {
-        // No env pin → the real sysctl probe runs (non-zero on any Mac).
-        let absent = MacHardware.physicalRAMBytes(environment: [:])
-        #expect(absent > 0)
-        // A non-parserable or non-positive value also falls back to sysctl.
-        let bad = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "not-a-number"])
-        #expect(bad > 0)
-        let nonFinite = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "inf"])
-        #expect(nonFinite > 0)
+        let fallback: UInt64 = 24 * UInt64(1 << 30)
+        // Missing, malformed, non-finite, and implausibly large values must
+        // return the exact probe result, not merely an arbitrary nonzero value.
+        let absent = MacHardware.physicalRAMBytes(environment: [:]) { fallback }
+        #expect(absent == fallback)
+        let bad = MacHardware.physicalRAMBytes(
+            environment: ["RAPID_HARDWARE_RAM_GB": "not-a-number"]
+        ) { fallback }
+        #expect(bad == fallback)
+        let nonFinite = MacHardware.physicalRAMBytes(
+            environment: ["RAPID_HARDWARE_RAM_GB": "inf"]
+        ) { fallback }
+        #expect(nonFinite == fallback)
         let implausiblyLarge = MacHardware.physicalRAMBytes(
             environment: ["RAPID_HARDWARE_RAM_GB": "1e100"]
-        )
-        #expect(implausiblyLarge > 0)
+        ) { fallback }
+        #expect(implausiblyLarge == fallback)
+    }
+
+    @Test("Golden hardware brand is deterministic and bounded")
+    func goldenHardwareBrand() {
+        #expect(MacHardware.brandString(environment: [
+            "RAPID_HARDWARE_BRAND": "Apple M1",
+        ]) == "Apple M1")
+        #expect(MacHardware.brandString(environment: [
+            "RAPID_HARDWARE_BRAND": String(repeating: "x", count: 129),
+        ]) != String(repeating: "x", count: 129))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacHardwareTests.swift
@@ -90,4 +90,25 @@ struct MacHardwareTests {
         let hw = MacHardware.detect()
         #expect(hw.physicalRAMBytes > 0)
     }
+
+    @Test("RAPID_HARDWARE_RAM_GB pins the golden-flow RAM tier")
+    func goldenRAMOverride() {
+        // The first-run golden flows pin a fixed tier so their structural
+        // AX baselines are deterministic across hosts — a 14 GB CI runner
+        // and a 256 GB release Mac must render the same recommended row.
+        let gb: UInt64 = 8
+        let pinned = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "8"])
+        // 8 × 2^30 = 8589934592; allow a *bit* of rounding latitude.
+        #expect(abs(Int64(pinned) - Int64(gb * UInt64(1 << 30))) < 16)
+    }
+
+    @Test("RAM override is ignored when not set or invalid")
+    func goldenRAMOverrideIgnoredWhenAbsent() {
+        // No env pin → the real sysctl probe runs (non-zero on any Mac).
+        let absent = MacHardware.physicalRAMBytes(environment: [:])
+        #expect(absent > 0)
+        // A non-parserable or non-positive value also falls back to sysctl.
+        let bad = MacHardware.physicalRAMBytes(environment: ["RAPID_HARDWARE_RAM_GB": "not-a-number"])
+        #expect(bad > 0)
+    }
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1533,9 +1533,14 @@ flow_download_progress() {
         "$OUT/downloading.json" >/dev/null; then
         die "download progress still shows observed bytes above its displayed total"
     fi
-    jq -e -s 'any(.[]; .event == "command" and .subcommand == "pull")' \
-        "$OUT/fake-events.jsonl" >/dev/null \
-        || die "download-progress flow never exercised the pull subprocess"
+    # The progress pipe can become AX-visible a few milliseconds before the
+    # separately opened JSONL witness is observable after several personas
+    # have run back-to-back. Poll the independent witness like the image/audio
+    # flows do instead of treating that filesystem scheduling window as a
+    # product failure.
+    wait_fake_event \
+        '.event == "command" and .subcommand == "pull"' \
+        "download-progress flow never exercised the pull subprocess"
 
     # Onboarding covers the global DownloadStrip, so Step 3 must provide its
     # own reachable cancellation path. Exercise the live process rather than

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -33,6 +33,7 @@ FAKE_IMAGE_ALIAS="fake-image-alias"
 # qwen3.5-4b to stay a native curated trade-up, which 8 GB guarantees
 # (16/24/32 GB hosts fold qwen3.5-4b into the recommended row instead).
 GOLDEN_RAM_GB=8
+GOLDEN_BRAND="Apple M1"
 UPDATE_BASELINES=0
 FLOW="all"
 KEEP=0
@@ -1198,7 +1199,8 @@ flow_fresh_install() {
     # The real engine registry always contains the starter. Without this row,
     # the fake catalog makes the app correctly fall back to its only chat row
     # and the assertion below can never prove the production first-run rule.
-    start_persona fresh-install FAKE_INCLUDE_STARTER=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona fresh-install FAKE_INCLUDE_STARTER=1 \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
@@ -1349,7 +1351,8 @@ flow_cached_quickstart() {
     # never promote that notice into a selectable model named "No" (#1918).
     # A fresh persona keeps this onboarding assertion independent from the
     # launch-sweep assertion above.
-    start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1 \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -1425,7 +1428,8 @@ flow_cached_quickstart() {
 
 flow_cached_curated_tradeup() {
     log "cached curated trade-up keeps its on-disk state past the six-row cap"
-    start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1 \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -1455,7 +1459,8 @@ flow_cached_curated_tradeup() {
 
 flow_cached_variant_collapse() {
     log "first-run chooser collapses cached quant siblings (#2033 finding 3)"
-    start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1 \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -1480,7 +1485,8 @@ flow_cached_variant_collapse() {
 
 flow_download_progress() {
     log "download progress never shows observed bytes above its total (#1550)"
-    start_persona download-progress FAKE_DOWNLOAD_OVERRUN=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona download-progress FAKE_DOWNLOAD_OVERRUN=1 \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -2427,7 +2433,8 @@ flow_model_crash_recovery() {
 
 flow_low_memory_choice() {
     log "6/6 low-memory onboarding escape"
-    start_persona low-memory-choice RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona low-memory-choice \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     local tree="$OUT/onboarding.json"
     see_main "$tree"
@@ -2935,7 +2942,8 @@ flow_browse_all_destination() {
     # supersedes it — the catalogue is now a micro-stage INSIDE Step 2. So the
     # assertions below are the same three questions, asked of the new
     # destination: did anything happen, did setup survive, did the pick.
-    start_persona browse-all-destination RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
+    start_persona browse-all-destination \
+        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     # Only the consent sheet — the wizard has to stay up, it is the subject.
     local tree="$OUT/ba-first-run.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1200,7 +1200,8 @@ flow_fresh_install() {
     # the fake catalog makes the app correctly fall back to its only chat row
     # and the assertion below can never prove the production first-run rule.
     start_persona fresh-install FAKE_INCLUDE_STARTER=1 \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
@@ -1352,7 +1353,8 @@ flow_cached_quickstart() {
     # A fresh persona keeps this onboarding assertion independent from the
     # launch-sweep assertion above.
     start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1 \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -1429,7 +1431,8 @@ flow_cached_quickstart() {
 flow_cached_curated_tradeup() {
     log "cached curated trade-up keeps its on-disk state past the six-row cap"
     start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1 \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -1460,7 +1463,8 @@ flow_cached_curated_tradeup() {
 flow_cached_variant_collapse() {
     log "first-run chooser collapses cached quant siblings (#2033 finding 3)"
     start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1 \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -1486,7 +1490,8 @@ flow_cached_variant_collapse() {
 flow_download_progress() {
     log "download progress never shows observed bytes above its total (#1550)"
     start_persona download-progress FAKE_DOWNLOAD_OVERRUN=1 \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -2434,7 +2439,8 @@ flow_model_crash_recovery() {
 flow_low_memory_choice() {
     log "6/6 low-memory onboarding escape"
     start_persona low-memory-choice \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     local tree="$OUT/onboarding.json"
     see_main "$tree"
@@ -2943,7 +2949,8 @@ flow_browse_all_destination() {
     # assertions below are the same three questions, asked of the new
     # destination: did anything happen, did setup survive, did the pick.
     start_persona browse-all-destination \
-        RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
 
     # Only the consent sheet — the wizard has to stay up, it is the subject.
     local tree="$OUT/ba-first-run.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1480,7 +1480,7 @@ flow_cached_variant_collapse() {
 
 flow_download_progress() {
     log "download progress never shows observed bytes above its total (#1550)"
-    start_persona download-progress FAKE_DOWNLOAD_OVERRUN=1
+    start_persona download-progress FAKE_DOWNLOAD_OVERRUN=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -19,6 +19,20 @@ FAKE_ALIAS="fake-alias"
 # baselines for the same reason as FAKE_ALIAS: renaming a fixture must not read
 # as a structural change to the UI.
 FAKE_IMAGE_ALIAS="fake-image-alias"
+# Phase B made the first-run wizard's "RECOMMENDED FOR YOUR N GB MAC" row
+# derive from the host's REAL physical RAM. A single committed golden
+# baseline therefore can't be host-independent: a 14 GB CI runner lands on
+# the 8 GB tier (lfm2.5-2.6B) while a 256 GB release Mac lands on 48+
+# (qwen3.8-27B + qwen3.6-35B). The golden gate runs in BOTH places (CI and
+# the operator's release Mac), so every persona that renders the chooser
+# pins the same tier to keep its AX baseline deterministic.
+# 8 = the 8 GB tier, which is exactly what the committed compact-chooser
+# baseline captures (smart lfm2.5-2.6B; its fast pick lfm2.5-1B equals the
+# starter, so the row renders just the one card). Pinning 8 also happens to
+# be the safe tier for cached-curated-tradeup: its assertion needs
+# qwen3.5-4b to stay a native curated trade-up, which 8 GB guarantees
+# (16/24/32 GB hosts fold qwen3.5-4b into the recommended row instead).
+GOLDEN_RAM_GB=8
 UPDATE_BASELINES=0
 FLOW="all"
 KEEP=0
@@ -1184,7 +1198,7 @@ flow_fresh_install() {
     # The real engine registry always contains the starter. Without this row,
     # the fake catalog makes the app correctly fall back to its only chat row
     # and the assertion below can never prove the production first-run rule.
-    start_persona fresh-install FAKE_INCLUDE_STARTER=1
+    start_persona fresh-install FAKE_INCLUDE_STARTER=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
@@ -1335,7 +1349,7 @@ flow_cached_quickstart() {
     # never promote that notice into a selectable model named "No" (#1918).
     # A fresh persona keeps this onboarding assertion independent from the
     # launch-sweep assertion above.
-    start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1
+    start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -1411,7 +1425,7 @@ flow_cached_quickstart() {
 
 flow_cached_curated_tradeup() {
     log "cached curated trade-up keeps its on-disk state past the six-row cap"
-    start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1
+    start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -1441,7 +1455,7 @@ flow_cached_curated_tradeup() {
 
 flow_cached_variant_collapse() {
     log "first-run chooser collapses cached quant siblings (#2033 finding 3)"
-    start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1
+    start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
         "$OUT/consent.json" >/dev/null; then
@@ -2413,7 +2427,7 @@ flow_model_crash_recovery() {
 
 flow_low_memory_choice() {
     log "6/6 low-memory onboarding escape"
-    start_persona low-memory-choice
+    start_persona low-memory-choice RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
 
     local tree="$OUT/onboarding.json"
     see_main "$tree"
@@ -2921,7 +2935,7 @@ flow_browse_all_destination() {
     # supersedes it — the catalogue is now a micro-stage INSIDE Step 2. So the
     # assertions below are the same three questions, asked of the new
     # destination: did anything happen, did setup survive, did the pick.
-    start_persona browse-all-destination
+    start_persona browse-all-destination RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB
 
     # Only the consent sheet — the wizard has to stay up, it is the subject.
     local tree="$OUT/ba-first-run.json"


### PR DESCRIPTION
## Why

Phase B (PR #2220, already merged) anchored the first-run compact-chooser AX baseline to the **8 GB tier** — the tier the `macos-15` CI runner (~14 GB → 8 GB) produces. The same golden GUI flows also run on the **256 GB Studio** at release, where tier-48 recommends **27B + 35B** instead of `lfm2.5 · 2.6B`. The committed structural baseline would therefore mismatch and the golden gate would go **red at release time**.

## Fix

- Add `RAPID_HARDWARE_RAM_GB` — a decimal GB override of total physical RAM in `MacHardware.physicalRAMBytes(environment:)`. Implemented as a **pure** function so it's unit-tested without mutating the test process env.
- Set `RAPID_HARDWARE_RAM_GB=8` in the golden-flow script (all 6 chooser flows) so every flow reproduces the committed 8 GB-tier baseline **deterministically on any host** — CI runner and release Studio both render the same recommended row (`lfm2.5 · 2.6B`).
- **Production launches never set the var** → the real picker still reflects the live Mac.

> Why 8 and not 48: the merged baseline is already 8 GB-anchored; 48 would require regenerating the committed baseline and contradict the merged/CI-validated state. 8 also keeps `qwen3.5-4b` a native curated trade-up for `cached-curated-tradeup` (16/24/32 tiers would fold it into recommended and break that assertion).

## Verification

Verified locally, incl. on the 256 GB Mac:
- `MacHardwareTests`: 8/8 pass (incl. 2 new golden-pin tests).
- Release build succeeds.
- `fresh-install` reproduces the committed `lfm2.5 · 2.6B` baseline on a 256 GB Mac via the 8 GB pin.
- All 6 chooser flows PASS; full golden suite PASS.
- `Step2ModelSelectionBehaviorTests`: 54/54 pass.

Closes the release blocker: golden GUI flow now passes on the release Studio.