### PR TITLE
ci: add path-aware PR and full merge gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,72 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+  # Merge queue candidates are synthetic commits.  They need their own trigger
+  # or GitHub waits forever for the required `tests` check.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      engine: ${{ steps.policy.outputs.engine }}
+      desktop: ${{ steps.policy.outputs.desktop }}
+      docs_only: ${{ steps.policy.outputs.docs_only }}
+      full_gate: ${{ steps.policy.outputs.full_gate }}
+      l1_matrix: ${{ steps.policy.outputs.l1_matrix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify validation lanes
+        id: policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$FULL_CI" = true ]; then
+              # Empty input deliberately fails closed to every product lane.
+              python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
+              full_gate=true
+            else
+              git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
+              python scripts/classify_ci_changes.py \
+                --paths-file /tmp/changed-paths \
+                --github-output "$GITHUB_OUTPUT"
+              full_gate=false
+            fi
+            echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
+            if [ "$full_gate" = true ]; then
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
+            else
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # A merge-group commit may contain several independently classified
+            # PRs.  Validate the combined candidate in full. Push-to-main keeps
+            # the same coverage as before this policy was introduced.
+            {
+              echo 'engine=true'
+              echo 'desktop=true'
+              echo 'docs_only=false'
+              echo 'full_gate=true'
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -163,6 +224,8 @@ jobs:
         continue-on-error: true
 
   test-matrix:
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -209,6 +272,7 @@ jobs:
             tests/test_release_baselines.py \
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
+            tests/test_classify_ci_changes.py \
             tests/test_check_mlx_upstream_calls.py \
             tests/test_no_out_of_band_routing.py \
             tests/test_microbench_parsers.py \
@@ -234,6 +298,8 @@ jobs:
           fail_ci_if_error: false
 
   test-apple-silicon:
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -307,24 +373,15 @@ jobs:
     #
     # The aggregate ``tests`` job requires this matrix, so a contract failure is
     # release-blocking rather than an informational red check.
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
     runs-on: macos-14
     timeout-minutes: 20
     strategy:
       # Don't cancel the other legs when one family fails — we want to see
       # which families regressed, not just the first failure.
       fail-fast: false
-      matrix:
-        include:
-          - model: qwen3.5-4b-4bit  # hermes parser + GOLDEN coherence
-            contract_only: "0"
-          - model: llama3-3b-4bit  # llama parser + GOLDEN coherence
-            contract_only: "0"
-          - model: gemma3-4b-qat-4bit  # #1677 excluded G12 4B tier
-            contract_only: "1"
-          - model: qwen3-4b-instruct-2507-4bit
-            contract_only: "1"
-          - model: qwen3-4b-thinking-2507-4bit
-            contract_only: "1"
+      matrix: ${{ fromJSON(needs.changes.outputs.l1_matrix) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -364,12 +421,22 @@ jobs:
         run: bash scripts/l1_smoke.sh "${{ matrix.model }}"
 
   tests:
-    needs: [test-matrix, test-apple-silicon, l1-smoke]
+    needs: [changes, test-matrix, test-apple-silicon, l1-smoke]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check test results
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then
+            echo "PR gate passed; apply the full-ci label when this PR is ready to merge"
+            exit 1
+          fi
+          expected="${{ needs.changes.outputs.engine }}"
+          if [ "$expected" != "true" ]; then
+            echo "Engine lanes not required for this change"
+            exit 0
+          fi
           if [ "${{ needs.test-matrix.result }}" != "success" ]; then
             echo "Unit tests failed"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
               python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
               full_gate=true
             else
-              git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
+              # Disable rename folding so both the removed source path and the
+              # new destination participate in classification.
+              git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
               python scripts/classify_ci_changes.py \
                 --paths-file /tmp/changed-paths \
                 --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,14 @@ jobs:
         run: bash scripts/l1_smoke.sh "${{ matrix.model }}"
 
   tests:
-    needs: [changes, test-matrix, test-apple-silicon, l1-smoke]
+    needs:
+      - changes
+      - lint
+      - mlx-bound-guard
+      - type-check
+      - test-matrix
+      - test-apple-silicon
+      - l1-smoke
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -432,6 +439,19 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ] \
             && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then
             echo "PR gate passed; apply the full-ci label when this PR is ready to merge"
+            exit 1
+          fi
+          if [ "${{ needs.lint.result }}" != success ]; then
+            echo "Lint and static repository contracts failed"
+            exit 1
+          fi
+          if [ "${{ needs.type-check.result }}" != success ]; then
+            echo "Type-check job failed"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = pull_request ] \
+            && [ "${{ needs.mlx-bound-guard.result }}" != success ]; then
+            echo "MLX dependency-bound guard failed"
             exit 1
           fi
           expected="${{ needs.changes.outputs.engine }}"

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -65,7 +65,9 @@ jobs:
               echo 'full_gate=true'
             } >> "$GITHUB_OUTPUT"
           else
-            git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
+            # Disable rename folding so both the removed source path and the
+            # new destination participate in classification.
+            git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
             python scripts/classify_ci_changes.py \
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -190,6 +190,15 @@ jobs:
       - name: Fake sidecar catalog contract
         run: pytest tests/test_fake_sidecar_image_catalog.py -q
 
+      - name: GUI and XCUITest workflow contracts
+        run: |
+          pytest \
+            tests/test_ax_baseline.py \
+            tests/test_gui_control_behavior_contract.py \
+            tests/test_gui_walk_completeness.py \
+            tests/test_rapid_mac_xcui_target.py \
+            -q
+
   build:
     needs: changes
     if: needs.changes.outputs.desktop == 'true'

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -27,21 +27,9 @@ name: rapid-mac CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "apps/rapid-mac/**"
-      - ".github/workflows/rapid-mac-ci.yml"
-      # The gate script itself, so a change to the detector re-runs it...
-      - "scripts/check_rapid_mac_ax_identifiers.py"
-      # ...and its regression suite, which is the only thing that runs when a
-      # PR touches the detector but no Swift at all.
-      - "tests/test_rapid_mac_ax_identifiers.py"
-      # Same reasoning for the harness contract suites and the captured
-      # cross-OS dumps they assert against: a PR that edits only those must
-      # still run them.
-      - "tests/test_ax_baseline_os_variance.py"
-      - "tests/test_gui_preflight_contract.py"
-      - "tests/fixtures/ax_baseline/**"
-      - "tests/test_fake_sidecar_image_catalog.py"
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -52,11 +40,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      desktop: ${{ steps.policy.outputs.desktop }}
+      full_gate: ${{ steps.policy.outputs.full_gate }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify desktop lane
+        id: policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "merge_group" ] || [ "$FULL_CI" = true ]; then
+            # Empty input deliberately fails closed to every product lane.
+            python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
+            {
+              echo 'full_gate=true'
+            } >> "$GITHUB_OUTPUT"
+          else
+            git diff --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
+            python scripts/classify_ci_changes.py \
+              --paths-file /tmp/changed-paths \
+              --github-output "$GITHUB_OUTPUT"
+            echo 'full_gate=false' >> "$GITHUB_OUTPUT"
+          fi
+
   # Pure text lint over the diff — no Swift toolchain, no simulator, no app
   # build. It runs on ubuntu in ~15s beside the multi-minute macOS build rather
   # than inside it, so a missing identifier reads as its own red check with its
   # own log instead of hiding at the bottom of a compile job.
   accessibility-identifiers:
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -99,6 +121,8 @@ jobs:
   # to redden the tests without also taking down the gate that needs no
   # network at all.
   accessibility-identifier-tests:
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -136,6 +160,8 @@ jobs:
   #     nothing else notices, and the failure surfaces on a Mac, hours later,
   #     disguised as a product defect.
   gui-harness-contracts:
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -163,6 +189,8 @@ jobs:
         run: pytest tests/test_fake_sidecar_image_catalog.py -q
 
   build:
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
     # swift-tools-version and the release workflow's runner. macos-latest still
     # resolves to macos-14 (Swift 5.x) on GitHub-hosted runners.
@@ -235,6 +263,8 @@ jobs:
   # session so an .app can actually open a window. Both are image properties,
   # not promises — which is what the preflight step below is for.
   gui-golden-flows:
+    needs: changes
+    if: needs.changes.outputs.full_gate == 'true'
     # macos-15 for the same reason as the build job: Package.swift is
     # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
     runs-on: macos-15
@@ -606,5 +636,49 @@ jobs:
         run: |
           if [[ "$XCUI_OUTCOME" != success ]]; then
             echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
+            exit 1
+          fi
+
+  desktop-tests:
+    # Stable required-check facade. It is present even on non-desktop PRs,
+    # unlike workflow-level path filters, and upgrades merge-queue candidates
+    # to the complete GUI golden-flow gate.
+    needs:
+      - changes
+      - accessibility-identifiers
+      - accessibility-identifier-tests
+      - gui-harness-contracts
+      - build
+      - gui-golden-flows
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check desktop results
+        env:
+          DESKTOP_EXPECTED: ${{ needs.changes.outputs.desktop }}
+          FULL_GATE: ${{ needs.changes.outputs.full_gate }}
+          IDENTIFIERS: ${{ needs.accessibility-identifiers.result }}
+          IDENTIFIER_TESTS: ${{ needs.accessibility-identifier-tests.result }}
+          HARNESS_CONTRACTS: ${{ needs.gui-harness-contracts.result }}
+          BUILD: ${{ needs.build.result }}
+          GOLDEN_FLOWS: ${{ needs.gui-golden-flows.result }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = pull_request ] && [ "$FULL_GATE" != true ]; then
+            echo "PR gate passed; apply the full-ci label when this PR is ready to merge"
+            exit 1
+          fi
+          if [ "$DESKTOP_EXPECTED" != true ]; then
+            echo "Desktop lane not required for this PR"
+            exit 0
+          fi
+          for result in "$IDENTIFIERS" "$IDENTIFIER_TESTS" "$HARNESS_CONTRACTS" "$BUILD"; do
+            if [ "$result" != success ]; then
+              echo "A desktop PR gate failed: $result"
+              exit 1
+            fi
+          done
+          if [ "$FULL_GATE" = true ] && [ "$GOLDEN_FLOWS" != success ]; then
+            echo "GUI golden-flow merge gate failed: $GOLDEN_FLOWS"
             exit 1
           fi

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -1,0 +1,65 @@
+# Path-aware PR gates and merge queue
+
+Rapid-MLX uses two validation levels so concurrent pull requests do not each
+pay the full release-grade macOS cost.
+
+## PR gate
+
+`scripts/classify_ci_changes.py` assigns changed paths to the engine and desktop
+lanes. The policy fails closed: an empty diff, workflow change, or unknown
+product area selects all applicable lanes.
+
+- Engine changes run the Linux test matrix, the Apple Silicon test suite, and
+  one representative L1 model (`qwen3.5-4b-4bit`).
+- Desktop changes run the Swift build/test and the inexpensive GUI harness
+  contracts. They do not run engine model smokes.
+- Documentation-only changes run the common lightweight checks and stable
+  aggregate jobs, without allocating a macOS runner.
+
+The required checks are the stable aggregate jobs `tests` and `desktop-tests`.
+They must not be renamed or hidden behind workflow-level path filters without a
+matching branch-protection migration.
+
+## Merge gate
+
+Adding the `full-ci` label upgrades a pull request to the full five-model L1
+matrix and complete GUI golden-flow job. Apply it only when the PR is ready to
+merge; removing it returns subsequent commits to the path-aware PR gate.
+The stable aggregate checks intentionally remain non-successful until this
+label is present, so branch protection cannot accidentally bypass the merge
+gate.
+
+The workflows also subscribe to GitHub's `merge_group` event. After the
+repository becomes eligible for GitHub merge queues, every queue candidate will
+automatically receive the same full coverage against its synthetic candidate
+commit. This validates the combined state that will actually reach `main`,
+rather than repeatedly validating each PR against an obsolete base.
+
+Pushes to `main` retain the full engine coverage as a post-merge signal.
+
+## Repository configuration
+
+GitHub currently offers merge queues only to public repositories owned by an
+organization, or private repositories owned by an Enterprise Cloud
+organization. Rapid-MLX is a public repository owned by a personal account, so
+the queue cannot be enabled until ownership moves to an organization.
+
+After that eligibility change, and after the workflows containing
+`merge_group` support are present on `main`:
+
+1. Require `tests` and `desktop-tests` for `main`.
+2. Require branches to be up to date through the merge queue, rather than
+   asking authors or agents to rebase every open PR after each merge.
+3. Use squash as the merge method and start with a small queue batch. Increase
+   batching only after observing queue latency and failure isolation.
+
+Do not enable the queue before the workflow trigger reaches `main`: otherwise
+GitHub creates a merge-group commit whose required checks never start.
+
+## Rollback
+
+Disable the merge queue first, restore `full-ci` label-based merging, and leave
+the `merge_group` triggers in place. The triggers are harmless while the queue
+is disabled. If path classification is suspect, make its policy select both
+lanes for every PR; this restores the previous validation coverage without
+renaming required checks.

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -18,7 +18,9 @@ product area selects all applicable lanes.
 
 The required checks are the stable aggregate jobs `tests` and `desktop-tests`.
 They must not be renamed or hidden behind workflow-level path filters without a
-matching branch-protection migration.
+matching branch-protection migration. `tests` includes lint, type-check job
+health, the MLX dependency-bound guard on pull requests, and all selected engine
+test lanes; `desktop-tests` includes every selected Desktop lane.
 
 ## Merge gate
 

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -48,9 +48,13 @@ _DESKTOP_SUPPORT_PREFIXES = ("tests/fixtures/ax_baseline/",)
 _DESKTOP_SUPPORT = {
     "scripts/check_rapid_mac_ax_identifiers.py",
     "tests/test_rapid_mac_ax_identifiers.py",
+    "tests/test_rapid_mac_xcui_target.py",
+    "tests/test_ax_baseline.py",
     "tests/test_ax_baseline_os_variance.py",
+    "tests/test_gui_control_behavior_contract.py",
     "tests/test_gui_preflight_contract.py",
     "tests/test_gui_golden_ci_coverage.py",
+    "tests/test_gui_walk_completeness.py",
     "tests/test_fake_sidecar_image_catalog.py",
 }
 _DOC_ROOTS = {"docs"}

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Classify changed paths into stable CI lanes.
+
+The workflow deliberately keeps this policy in tested Python instead of a
+large, fragile GitHub Actions expression.  Unknown paths fail safe by selecting
+both product lanes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+
+@dataclass(frozen=True)
+class Lanes:
+    engine: bool
+    desktop: bool
+    docs_only: bool
+
+    def as_outputs(self) -> dict[str, str]:
+        return {
+            "engine": str(self.engine).lower(),
+            "desktop": str(self.desktop).lower(),
+            "docs_only": str(self.docs_only).lower(),
+        }
+
+
+_ENGINE_ROOTS = {
+    "vllm_mlx",
+    "tests",
+    "scripts",
+    "benchmarks",
+    "examples",
+}
+_ENGINE_FILES = {
+    "pyproject.toml",
+    "uv.lock",
+    "pytest.ini",
+    "requirements.txt",
+    "install.sh",
+}
+_DESKTOP_PREFIX = "apps/rapid-mac/"
+_DESKTOP_SUPPORT_PREFIXES = ("tests/fixtures/ax_baseline/",)
+_DESKTOP_SUPPORT = {
+    "scripts/check_rapid_mac_ax_identifiers.py",
+    "tests/test_rapid_mac_ax_identifiers.py",
+    "tests/test_ax_baseline_os_variance.py",
+    "tests/test_gui_preflight_contract.py",
+    "tests/test_gui_golden_ci_coverage.py",
+    "tests/test_fake_sidecar_image_catalog.py",
+}
+_DOC_ROOTS = {"docs"}
+_DOC_FILES = {
+    "README.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "LICENSE",
+}
+
+
+def classify(paths: Iterable[str]) -> Lanes:
+    normalized = {path.strip().removeprefix("./") for path in paths if path.strip()}
+    if not normalized:
+        # A missing/invalid diff must never turn validation into a no-op.
+        return Lanes(engine=True, desktop=True, docs_only=False)
+
+    engine = False
+    desktop = False
+    docs_only = True
+
+    for path in normalized:
+        pure = PurePosixPath(path)
+        root = pure.parts[0] if pure.parts else ""
+        is_doc = root in _DOC_ROOTS or path in _DOC_FILES or path.endswith(".md")
+        docs_only &= is_doc
+
+        if (
+            path.startswith(_DESKTOP_PREFIX)
+            or path.startswith(_DESKTOP_SUPPORT_PREFIXES)
+            or path in _DESKTOP_SUPPORT
+        ):
+            desktop = True
+            continue
+
+        if root == ".github":
+            # Workflow/policy changes validate every lane they can affect.
+            engine = True
+            desktop = True
+            continue
+
+        if root in _ENGINE_ROOTS or path in _ENGINE_FILES:
+            engine = True
+            continue
+
+        if not is_doc:
+            # Fail closed for new top-level product areas.
+            engine = True
+            desktop = True
+
+    return Lanes(engine=engine, desktop=desktop, docs_only=docs_only)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", help="Changed repository-relative paths")
+    parser.add_argument("--paths-file", type=argparse.FileType("r"))
+    parser.add_argument("--github-output", type=argparse.FileType("a"))
+    args = parser.parse_args()
+
+    paths = list(args.paths)
+    if args.paths_file:
+        paths.extend(args.paths_file.read().splitlines())
+    outputs = classify(paths).as_outputs()
+
+    if args.github_output:
+        for key, value in outputs.items():
+            print(f"{key}={value}", file=args.github_output)
+    else:
+        print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -77,7 +77,7 @@ def classify(paths: Iterable[str]) -> Lanes:
     for path in normalized:
         pure = PurePosixPath(path)
         root = pure.parts[0] if pure.parts else ""
-        is_doc = root in _DOC_ROOTS or path in _DOC_FILES or path.endswith(".md")
+        is_doc = root in _DOC_ROOTS or path in _DOC_FILES
         docs_only &= is_doc
 
         if (

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -1,3 +1,5 @@
+import pytest
+
 from scripts.classify_ci_changes import Lanes, classify
 
 
@@ -19,10 +21,24 @@ def test_engine_only_does_not_select_desktop():
     )
 
 
-def test_desktop_support_test_stays_in_desktop_lane():
-    assert classify(
-        ["tests/test_gui_preflight_contract.py", "tests/fixtures/ax_baseline/macos.txt"]
-    ) == Lanes(engine=False, desktop=True, docs_only=False)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "scripts/check_rapid_mac_ax_identifiers.py",
+        "tests/test_rapid_mac_ax_identifiers.py",
+        "tests/test_rapid_mac_xcui_target.py",
+        "tests/test_ax_baseline.py",
+        "tests/test_ax_baseline_os_variance.py",
+        "tests/test_gui_control_behavior_contract.py",
+        "tests/test_gui_preflight_contract.py",
+        "tests/test_gui_golden_ci_coverage.py",
+        "tests/test_gui_walk_completeness.py",
+        "tests/test_fake_sidecar_image_catalog.py",
+        "tests/fixtures/ax_baseline/macos.txt",
+    ],
+)
+def test_desktop_support_path_stays_in_desktop_lane(path):
+    assert classify([path]) == Lanes(engine=False, desktop=True, docs_only=False)
 
 
 def test_cross_cutting_change_selects_both_lanes():

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -1,0 +1,41 @@
+from scripts.classify_ci_changes import Lanes, classify
+
+
+def test_docs_only_selects_no_product_lane():
+    assert classify(["README.md", "docs/operations/ci.md"]) == Lanes(
+        engine=False, desktop=False, docs_only=True
+    )
+
+
+def test_desktop_only_does_not_select_engine():
+    assert classify(["apps/rapid-mac/Sources/App.swift"]) == Lanes(
+        engine=False, desktop=True, docs_only=False
+    )
+
+
+def test_engine_only_does_not_select_desktop():
+    assert classify(["vllm_mlx/server.py"]) == Lanes(
+        engine=True, desktop=False, docs_only=False
+    )
+
+
+def test_desktop_support_test_stays_in_desktop_lane():
+    assert classify(
+        ["tests/test_gui_preflight_contract.py", "tests/fixtures/ax_baseline/macos.txt"]
+    ) == Lanes(engine=False, desktop=True, docs_only=False)
+
+
+def test_cross_cutting_change_selects_both_lanes():
+    assert classify([".github/workflows/ci.yml"]) == Lanes(
+        engine=True, desktop=True, docs_only=False
+    )
+
+
+def test_unknown_product_area_fails_closed():
+    assert classify(["new-product/config.toml"]) == Lanes(
+        engine=True, desktop=True, docs_only=False
+    )
+
+
+def test_empty_diff_fails_closed():
+    assert classify([]) == Lanes(engine=True, desktop=True, docs_only=False)

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -32,8 +32,18 @@ def test_cross_cutting_change_selects_both_lanes():
 
 
 def test_unknown_product_area_fails_closed():
-    assert classify(["new-product/config.toml"]) == Lanes(
+    assert classify(["new-product/config.toml", "new-product/README.md"]) == Lanes(
         engine=True, desktop=True, docs_only=False
+    )
+
+
+def test_cross_lane_rename_selects_removed_product_lane():
+    # Workflows pass --no-renames, so a rename is represented by both paths.
+    assert classify(["vllm_mlx/server.py", "docs/server.md"]) == Lanes(
+        engine=True, desktop=False, docs_only=False
+    )
+    assert classify(["apps/rapid-mac/Sources/App.swift", "docs/App.swift.md"]) == Lanes(
+        engine=False, desktop=True, docs_only=False
     )
 
 


### PR DESCRIPTION
## Summary

- classify PR changes into engine, Desktop, docs-only, and fail-closed cross-cutting lanes
- run one representative L1 model during engine PR development, then all five models behind the `full-ci` merge gate
- move the complete GUI golden flow to the same merge gate while keeping Swift build/test on Desktop PRs
- add stable `tests` / `desktop-tests` aggregate behavior and `merge_group` triggers
- document rollout, GitHub account limitation, and rollback

## Why

Concurrent PRs currently enqueue six engine macOS jobs plus up to two Desktop macOS jobs per SHA. Rebases invalidate the whole set. This preserves release-grade coverage at merge time while making ordinary PR feedback path-aware.

GitHub merge queue cannot yet be enabled because GitHub only offers it to organization-owned repositories (Rapid-MLX is currently user-owned). The workflows are queue-ready; `full-ci` provides the enforceable merge gate until ownership moves to an organization.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/rapid-mac-ci.yml`
- `uv run pytest tests/test_classify_ci_changes.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/check_workflow_expressions.py`
- `uv run python scripts/check_gha_pinning.py`
- `git diff --check`
