### PR TITLE
feat(mac): explain speech-to-text model choices

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -276,8 +276,8 @@ final class AudioViewModel {
         case "parakeet-v3", "parakeet-tdt-0.6b-v3":
             return .init(
                 displayName: "Parakeet TDT v3",
-                badge: "25 languages",
-                summary: "Highest accuracy for 25 European languages, with punctuation and timestamps.",
+                badge: "English",
+                summary: "Fast English transcription with improved accuracy over v2 and automatic punctuation.",
                 isRecommended: false
             )
         case "parakeet", "parakeet-tdt-0.6b", "parakeet-tdt-0.6b-v2":

--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -4,6 +4,13 @@ import Observation
 @MainActor
 @Observable
 final class AudioViewModel {
+    struct TranscriptionModelDetails: Equatable, Sendable {
+        let displayName: String
+        let badge: String
+        let summary: String
+        let isRecommended: Bool
+    }
+
     enum Mode: String, CaseIterable, Identifiable {
         case dictation
         case speech
@@ -54,10 +61,11 @@ final class AudioViewModel {
     }
 
     var transcriptionModels: [ModelEntry] {
-        audioModels.filter {
+        let candidates = audioModels.filter {
             $0.audioCapability?.supportsTranscription == true
                 && ModelCatalog.isDesktopAudioAliasVisible($0.alias)
         }
+        return Self.deduplicatedTranscriptionModels(candidates)
     }
 
     var speechModels: [ModelEntry] {
@@ -216,6 +224,148 @@ final class AudioViewModel {
         case "ono_anna": return "Japanese · Female"
         case "sohee": return "Korean · Female"
         default: return "Multilingual"
+        }
+    }
+
+    /// Product-facing guidance for the Speech to Text picker. The engine's
+    /// alias catalog is deliberately technical; this layer answers the user's
+    /// actual question: which model fits my language and speed/quality needs?
+    /// Keep the fallback useful so a newly added engine alias never lands in
+    /// the UI as an unexplained name.
+    static func transcriptionDetails(
+        alias: String,
+        family: String?
+    ) -> TranscriptionModelDetails {
+        let normalized = alias.lowercased()
+        switch normalized {
+        case "whisper", "whisper-1", "whisper-large-v3":
+            return .init(
+                displayName: "Whisper Large v3",
+                badge: "best quality",
+                summary: "Highest-accuracy Whisper model. Supports 99+ languages and difficult accents.",
+                isRecommended: false
+            )
+        case "whisper-large-v3-turbo":
+            return .init(
+                displayName: "Whisper Large v3 Turbo",
+                badge: "balanced",
+                summary: "Near Large v3 accuracy with much faster transcription. Supports 99+ languages.",
+                isRecommended: true
+            )
+        case "whisper-medium":
+            return .init(
+                displayName: "Whisper Medium",
+                badge: "multilingual",
+                summary: "Good multilingual accuracy with lower memory use than the Large models.",
+                isRecommended: false
+            )
+        case "whisper-small":
+            return .init(
+                displayName: "Whisper Small",
+                badge: "fast",
+                summary: "Fast, lightweight multilingual transcription for everyday dictation.",
+                isRecommended: false
+            )
+        case "whisper-base":
+            return .init(
+                displayName: "Whisper Base",
+                badge: "low memory",
+                summary: "A compact multilingual model for older Macs. Faster, with lower accuracy.",
+                isRecommended: false
+            )
+        case "parakeet-v3", "parakeet-tdt-0.6b-v3":
+            return .init(
+                displayName: "Parakeet TDT v3",
+                badge: "25 languages",
+                summary: "Highest accuracy for 25 European languages, with punctuation and timestamps.",
+                isRecommended: false
+            )
+        case "parakeet", "parakeet-tdt-0.6b", "parakeet-tdt-0.6b-v2":
+            return .init(
+                displayName: "Parakeet TDT v2",
+                badge: "English",
+                summary: "English-only transcription. Very fast with strong punctuation and capitalization.",
+                isRecommended: false
+            )
+        case "qwen3-asr", "qwen3-asr-1.7b":
+            return .init(
+                displayName: "Qwen3 ASR 1.7B",
+                badge: "code-switching",
+                summary: "Strong Chinese and English code-switching, punctuation, and custom vocabulary hints.",
+                isRecommended: false
+            )
+        case "qwen3-asr-0.6b":
+            return .init(
+                displayName: "Qwen3 ASR 0.6B",
+                badge: "fast",
+                summary: "A smaller, faster Chinese and English model with a modest accuracy tradeoff.",
+                isRecommended: false
+            )
+        case "sensevoice", "sensevoice-small":
+            return .init(
+                displayName: "SenseVoice Small",
+                badge: "Asian languages",
+                summary: "Fast Chinese, Cantonese, Japanese, Korean, and English recognition with sound-event tags.",
+                isRecommended: false
+            )
+        default:
+            let familyName = family?
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized ?? "Speech"
+            return .init(
+                displayName: alias,
+                badge: familyName,
+                summary: "Local speech-to-text model. Runs offline after its first download.",
+                isRecommended: false
+            )
+        }
+    }
+
+    /// The engine exposes compatibility aliases for API and CLI callers, but
+    /// a visual picker should not show the same checkpoint three times. Group
+    /// by HF repo and keep the explicit product alias where one exists.
+    static func deduplicatedTranscriptionModels(_ entries: [ModelEntry]) -> [ModelEntry] {
+        var order: [String] = []
+        var representative: [String: ModelEntry] = [:]
+
+        for entry in entries {
+            let key = entry.hfRepo?.lowercased() ?? "alias:\(entry.alias.lowercased())"
+            guard let current = representative[key] else {
+                order.append(key)
+                representative[key] = entry
+                continue
+            }
+            if transcriptionAliasPriority(entry.alias)
+                < transcriptionAliasPriority(current.alias) {
+                representative[key] = entry
+            }
+        }
+        let position = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($1, $0) })
+        return order.compactMap { representative[$0] }.sorted { lhs, rhs in
+            let lhsRecommended = transcriptionDetails(
+                alias: lhs.alias, family: lhs.audioFamily
+            ).isRecommended
+            let rhsRecommended = transcriptionDetails(
+                alias: rhs.alias, family: rhs.audioFamily
+            ).isRecommended
+            if lhsRecommended != rhsRecommended { return lhsRecommended }
+            if lhs.cached != rhs.cached { return lhs.cached }
+            let lhsKey = lhs.hfRepo?.lowercased() ?? "alias:\(lhs.alias.lowercased())"
+            let rhsKey = rhs.hfRepo?.lowercased() ?? "alias:\(rhs.alias.lowercased())"
+            return position[lhsKey, default: .max] < position[rhsKey, default: .max]
+        }
+    }
+
+    private static func transcriptionAliasPriority(_ alias: String) -> Int {
+        switch alias.lowercased() {
+        case "whisper-large-v3", "parakeet", "parakeet-v3", "qwen3-asr", "sensevoice":
+            return 0
+        case "whisper", "whisper-1", "parakeet-tdt-0.6b",
+             "parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3",
+             "qwen3-asr-1.7b", "sensevoice-small":
+            return 2
+        default:
+            return 1
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -15,6 +15,7 @@ struct DictationView: View {
 
     @State private var newTerm = ""
     @State private var fixTarget: DictationHistory.Entry?
+    @State private var showModelPicker = false
 
     private let contentMaxWidth = RapidTheme.Layout.contentMaxWidth
 
@@ -175,36 +176,22 @@ struct DictationView: View {
                 done: controller.readinessSnapshot.modelSelected
                     && controller.readinessSnapshot.modelOnDisk
             ) {
-                Menu {
-                    Picker("", selection: $controller.modelAlias) {
-                        Text("Choose…").tag("")
-                        ForEach(viewModel.transcriptionModels, id: \.alias) { entry in
-                            // Same menu grammar as the Audio tabs' pickers:
-                            // the cache glyph says up front which choices are
-                            // a download and which are ready now.
-                            Label(
-                                entry.alias,
-                                systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
-                            )
-                            .tag(entry.alias)
-                        }
-                    }
-                    .accessibilityIdentifier("Dictation.Model.Options")
-                    .pickerStyle(.inline)
-                    .labelsHidden()
+                Button {
+                    showModelPicker.toggle()
                 } label: {
                     PopupControlChrome(
-                        title: controller.modelAlias.isEmpty ? "Choose…" : controller.modelAlias,
+                        title: selectedModelDetails?.displayName ?? "Choose…",
                         width: 260
                     )
                 }
-                .menuStyle(.button)
                 .buttonStyle(.plain)
-                .menuIndicator(.hidden)
                 .disabled(controller.phase != .off && controller.phase != .idle)
                 .accessibilityLabel("Model")
                 .accessibilityValue(controller.modelAlias)
                 .accessibilityIdentifier("Dictation.Model")
+                .popover(isPresented: $showModelPicker, arrowEdge: .top) {
+                    transcriptionModelPicker
+                }
             } detail: {
                 Text(modelDetail)
             }
@@ -312,7 +299,56 @@ struct DictationView: View {
     }
 
     private var selectedModelEntry: ModelEntry? {
-        viewModel.transcriptionModels.first { $0.alias == controller.modelAlias }
+        viewModel.audioModels.first {
+            $0.alias == controller.modelAlias
+                && $0.audioCapability?.supportsTranscription == true
+        }
+    }
+
+    /// Compatibility aliases hidden by the picker still resolve to the same
+    /// canonical row. Existing users keep a truthful selected state without a
+    /// forced model restart; choosing that row later migrates the stored alias.
+    private func isSelectedModel(_ entry: ModelEntry) -> Bool {
+        guard let selectedModelEntry else { return false }
+        if selectedModelEntry.alias == entry.alias { return true }
+        guard let selectedRepo = selectedModelEntry.hfRepo,
+              let entryRepo = entry.hfRepo else { return false }
+        return selectedRepo.caseInsensitiveCompare(entryRepo) == .orderedSame
+    }
+
+    private var selectedModelDetails: AudioViewModel.TranscriptionModelDetails? {
+        guard let entry = selectedModelEntry else { return nil }
+        return AudioViewModel.transcriptionDetails(
+            alias: entry.alias,
+            family: entry.audioFamily
+        )
+    }
+
+    private var transcriptionModelPicker: some View {
+        ScrollView {
+            LazyVStack(spacing: RapidTheme.Space.xs) {
+                ForEach(viewModel.transcriptionModels, id: \.alias) { entry in
+                    TranscriptionModelOptionRow(
+                        entry: entry,
+                        details: AudioViewModel.transcriptionDetails(
+                            alias: entry.alias,
+                            family: entry.audioFamily
+                        ),
+                        isSelected: isSelectedModel(entry)
+                    ) {
+                        controller.modelAlias = entry.alias
+                        showModelPicker = false
+                    }
+                }
+            }
+            .padding(RapidTheme.Space.sm)
+            .accessibilityIdentifier("Dictation.Model.Options")
+        }
+        .frame(width: 410, height: transcriptionModelPopoverHeight)
+    }
+
+    private var transcriptionModelPopoverHeight: CGFloat {
+        min(max(CGFloat(viewModel.transcriptionModels.count) * 76 + 16, 92), 460)
     }
 
     /// Alias + job status folded into one value so `.task(id:)` re-fires on
@@ -356,7 +392,7 @@ struct DictationView: View {
     private func handleModelReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .download(let alias), .retry(let alias):
-            guard let entry = viewModel.transcriptionModels.first(where: { $0.alias == alias }),
+            guard let entry = viewModel.audioModels.first(where: { $0.alias == alias }),
                   !downloads.isDownloading(alias) else { return }
             if case .failed = downloads.job(for: alias)?.status {
                 downloads.dismissJob(alias: alias)
@@ -684,6 +720,91 @@ struct DictationView: View {
             }
         }
         .padding(RapidTheme.Space.lg)
+    }
+}
+
+private struct TranscriptionModelOptionRow: View {
+    let entry: ModelEntry
+    let details: AudioViewModel.TranscriptionModelDetails
+    let isSelected: Bool
+    let select: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: select) {
+            HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .opacity(isSelected ? 1 : 0)
+                    .frame(width: 14, height: 18)
+
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
+                    HStack(spacing: RapidTheme.Space.xs) {
+                        Text(details.displayName)
+                            .font(RapidFont.body)
+                            .lineLimit(1)
+                        pickerBadge("offline")
+                        pickerBadge(details.badge)
+                        if details.isRecommended {
+                            pickerBadge("recommended", emphasized: true)
+                        }
+                        Spacer(minLength: RapidTheme.Space.xs)
+                        if let size = entry.sizeOnDisk {
+                            Text(size)
+                                .font(RapidFont.caption)
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                        }
+                        Image(systemName: ModelPickerBar.cacheGlyph(cached: entry.cached))
+                            .font(.caption)
+                            .foregroundStyle(entry.cached ? RapidTheme.green : .secondary)
+                            .accessibilityHidden(true)
+                    }
+                    Text(details.summary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .padding(.horizontal, RapidTheme.Space.sm)
+            .padding(.vertical, RapidTheme.Space.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                .fill(isSelected || hovering ? RapidTheme.hoverFill : .clear)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous))
+        .onHover { hovering = $0 }
+        .rapidAnimation(RapidMotion.quick, value: hovering)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier("Dictation.Model.Option.\(entry.alias)")
+    }
+
+    private func pickerBadge(_ text: String, emphasized: Bool = false) -> some View {
+        Text(text)
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(emphasized ? RapidTheme.green : Color.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                Capsule().fill(emphasized ? RapidTheme.green.opacity(0.12) : RapidTheme.hoverFill)
+            )
+            .lineLimit(1)
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [details.displayName, details.badge]
+        if details.isRecommended { parts.append("Recommended") }
+        parts.append(entry.cached ? "Downloaded" : "Not downloaded")
+        if let size = entry.sizeOnDisk { parts.append(size) }
+        parts.append(details.summary)
+        return parts.joined(separator: ", ")
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -61,7 +61,9 @@ struct AudioCatalogTests {
             family: "parakeet"
         )
         #expect(parakeet.displayName == "Parakeet TDT v3")
-        #expect(parakeet.badge == "25 languages")
+        #expect(parakeet.badge == "English")
+        #expect(parakeet.summary.contains("English"))
+        #expect(!parakeet.summary.contains("25"))
         #expect(parakeet.summary.contains("punctuation"))
 
         let qwen = AudioViewModel.transcriptionDetails(

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -45,6 +45,68 @@ struct AudioCatalogTests {
         #expect(AudioViewModel.previewText(for: "Sohee").hasPrefix("안녕하세요"))
     }
 
+    @Test("speech-to-text model guidance explains language and tradeoffs")
+    @MainActor
+    func transcriptionModelGuidance() {
+        let recommended = AudioViewModel.transcriptionDetails(
+            alias: "whisper-large-v3-turbo",
+            family: "whisper"
+        )
+        #expect(recommended.displayName == "Whisper Large v3 Turbo")
+        #expect(recommended.isRecommended)
+        #expect(recommended.summary.contains("99+ languages"))
+
+        let parakeet = AudioViewModel.transcriptionDetails(
+            alias: "parakeet-v3",
+            family: "parakeet"
+        )
+        #expect(parakeet.displayName == "Parakeet TDT v3")
+        #expect(parakeet.badge == "25 languages")
+        #expect(parakeet.summary.contains("punctuation"))
+
+        let qwen = AudioViewModel.transcriptionDetails(
+            alias: "qwen3-asr",
+            family: "qwen3_asr"
+        )
+        #expect(qwen.summary.contains("code-switching"))
+
+        let unknown = AudioViewModel.transcriptionDetails(
+            alias: "future-stt",
+            family: "future_family"
+        )
+        #expect(unknown.displayName == "future-stt")
+        #expect(unknown.summary.contains("Runs offline"))
+    }
+
+    @Test("speech-to-text picker collapses compatibility aliases by checkpoint")
+    @MainActor
+    func transcriptionPickerDeduplicatesAliases() {
+        let duplicateRepo = "mlx-community/whisper-large-v3-mlx"
+        let rows = [
+            audioEntry(alias: "whisper", capability: .transcription, family: "whisper", repo: duplicateRepo),
+            audioEntry(alias: "whisper-1", capability: .transcription, family: "whisper", repo: duplicateRepo),
+            audioEntry(alias: "whisper-large-v3", capability: .transcription, family: "whisper", repo: duplicateRepo),
+            audioEntry(alias: "whisper-small", capability: .transcription, family: "whisper"),
+            audioEntry(alias: "whisper-large-v3-turbo", capability: .transcription, family: "whisper"),
+        ]
+
+        let visible = AudioViewModel.deduplicatedTranscriptionModels(rows)
+        #expect(visible.map(\.alias) == [
+            "whisper-large-v3-turbo", "whisper-large-v3", "whisper-small",
+        ])
+    }
+
+    @Test("speech-to-text picker renders explanatory rows instead of a native alias menu")
+    func transcriptionPickerUsesRichRows() throws {
+        let source = try String(contentsOf: Self.dictationViewURL, encoding: .utf8)
+
+        #expect(source.contains("TranscriptionModelOptionRow("))
+        #expect(source.contains("details.summary"))
+        #expect(source.contains("pickerBadge(\"recommended\""))
+        #expect(source.contains(".popover(isPresented: $showModelPicker"))
+        #expect(!source.contains("Picker(\"\", selection: $controller.modelAlias)"))
+    }
+
     @Test("parser extracts audio rows and preserves subtype, family, size, and repo")
     func parsesRows() {
         let rows = ModelCatalog.parseAudioRows(Self.sample)
@@ -268,11 +330,12 @@ struct AudioCatalogTests {
     private func audioEntry(
         alias: String,
         capability: AudioModelCapability,
-        family: String
+        family: String,
+        repo: String? = nil
     ) -> ModelEntry {
         ModelEntry(
             alias: alias,
-            hfRepo: "mlx-community/\(alias)",
+            hfRepo: repo ?? "mlx-community/\(alias)",
             sizeOnDisk: nil,
             cached: false,
             kind: .audio,
@@ -287,5 +350,9 @@ struct AudioCatalogTests {
             .deletingLastPathComponent() // Tests
             .deletingLastPathComponent() // rapid-mac
             .appendingPathComponent("Sources/Rapid/UI/AudioView.swift")
+    }
+
+    private static var dictationViewURL: URL {
+        audioViewURL.deletingLastPathComponent().appendingPathComponent("DictationView.swift")
     }
 }


### PR DESCRIPTION
## Summary

- replace the native Speech to Text alias menu with a scrollable rich model picker
- explain each model's language coverage and speed/quality tradeoff, including recommendation, offline state, size, and cache state
- collapse compatibility aliases that resolve to the same Hugging Face checkpoint while preserving existing saved selections
- keep unknown future STT aliases useful with a safe fallback description

## User benefit

Users can choose a transcription model without looking up technical aliases, and the picker drops from roughly 15 alias rows to 10 genuinely different checkpoints.

## Validation

- `swift test --filter AudioCatalogTests` — 16 passed
- `swift test --no-parallel` — 2,736 passed across 236 suites
- `git diff --check`
