### PR TITLE
feat: surface agent health and re-run setup

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -755,7 +755,8 @@ struct SettingsView: View {
         ) {
             Button("Restart into setup", role: .destructive) { restartIntoSetup() }
                 .accessibilityIdentifier("Settings.App.ConfirmRunSetupAgain")
-            Button("Cancel", role: .cancel) {}
+            Button("Cancel", role: .cancel) { confirmingSetupRestart = false }
+                .accessibilityIdentifier("Settings.App.CancelRunSetupAgain")
         } message: {
             Text(ReonboardingReset.confirmation(for: .onboarding).message)
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -41,6 +41,9 @@ struct SettingsView: View {
     /// without re-triggering the one-time prompt, plus a "Reset
     /// onboarding alerts" affordance that brings the prompt back.
     @Environment(DockVisibilityPromptStore.self) private var dockPromptStore
+    @Environment(QuickstartCoordinator.self) private var quickstart
+    @State private var confirmingSetupRestart = false
+    @State private var restartingSetup = false
 
     /// Stable reference shared by the sidebar and detail canvas. Keeping the
     /// frequently-mutated category outside this large view's value state means
@@ -742,7 +745,43 @@ struct SettingsView: View {
             }
 
             diagnosticsSection
+            setupSection
             dockVisibilitySection
+        }
+        .confirmationDialog(
+            ReonboardingReset.confirmation(for: .onboarding).title,
+            isPresented: $confirmingSetupRestart,
+            titleVisibility: .visible
+        ) {
+            Button("Restart into setup", role: .destructive) { restartIntoSetup() }
+                .accessibilityIdentifier("Settings.App.ConfirmRunSetupAgain")
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(ReonboardingReset.confirmation(for: .onboarding).message)
+        }
+    }
+
+    @ViewBuilder
+    private var setupSection: some View {
+        SettingsSection(
+            "Setup",
+            subtitle: "Run the guided model setup again. Your settings, conversations, downloaded models, and telemetry choice stay untouched."
+        ) {
+            HStack {
+                Spacer(minLength: 0)
+                Button("Run setup again…") { confirmingSetupRestart = true }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .disabled(restartingSetup)
+                    .accessibilityIdentifier("Settings.App.RunSetupAgain")
+            }
+        }
+    }
+
+    private func restartIntoSetup() {
+        restartingSetup = true
+        Task { @MainActor in
+            await ReonboardingReset.perform(scope: .onboarding, quickstart: quickstart)
+            ReonboardingReset.relaunch()
         }
     }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -85,6 +85,8 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
         AXHeading desc="Diagnostics, Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data." enabled=true
         AXButton id="Settings.App.ExportDiagnostics" desc="Export diagnostics…" enabled=true
+        AXHeading desc="Setup, Run the guided model setup again. Your settings, conversations, downloaded models, and telemetry choice stay untouched." enabled=true
+        AXButton id="Settings.App.RunSetupAgain" desc="Run setup again…" enabled=true
         AXHeading desc="Window, Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible." enabled=true
         AXCheckBox subrole=AXToggle id="Settings.App.HideDockOnCloseToggle" desc="Hide Dock icon when closing window" help="Rapid-MLX remains available from the menu bar." value=bool:false enabled=true
         AXButton id="Settings.App.ResetDockOnboardingCTA" desc="Reset onboarding alerts" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
@@ -79,6 +79,8 @@ AXApplication title="Rapid-MLX"
         AXStaticText id="Settings.App.AheadOfManifest" value=text enabled=true
         AXHeading desc="Diagnostics, Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data." enabled=true
         AXButton id="Settings.App.ExportDiagnostics" desc="Export diagnostics…" enabled=true
+        AXHeading desc="Setup, Run the guided model setup again. Your settings, conversations, downloaded models, and telemetry choice stay untouched." enabled=true
+        AXButton id="Settings.App.RunSetupAgain" desc="Run setup again…" enabled=true
         AXHeading desc="Window, Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible." enabled=true
         AXCheckBox subrole=AXToggle id="Settings.App.HideDockOnCloseToggle" desc="Hide Dock icon when closing window" help="Rapid-MLX remains available from the menu bar." value=bool:false enabled=true
         AXButton id="Settings.App.ResetDockOnboardingCTA" desc="Reset onboarding alerts" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -82,6 +82,8 @@ AXApplication title="Rapid-MLX"
         AXButton id="Settings.App.RecheckCTA" desc="Check for updates" enabled=true
         AXHeading desc="Diagnostics, Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data." enabled=true
         AXButton id="Settings.App.ExportDiagnostics" desc="Export diagnostics…" enabled=true
+        AXHeading desc="Setup, Run the guided model setup again. Your settings, conversations, downloaded models, and telemetry choice stay untouched." enabled=true
+        AXButton id="Settings.App.RunSetupAgain" desc="Run setup again…" enabled=true
         AXHeading desc="Window, Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible." enabled=true
         AXCheckBox subrole=AXToggle id="Settings.App.HideDockOnCloseToggle" desc="Hide Dock icon when closing window" help="Rapid-MLX remains available from the menu bar." value=bool:false enabled=true
         AXButton id="Settings.App.ResetDockOnboardingCTA" desc="Reset onboarding alerts" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -24,6 +24,19 @@ import Testing
 @Suite("Accessibility identifier inventory")
 struct AccessibilityIdentifierInventoryTests {
 
+    @Test("Settings → App names the re-onboarding confirmation controls")
+    func settingsAppReonboardingIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Settings.App.RunSetupAgain""#,
+                #""Settings.App.ConfirmRunSetupAgain""#,
+                #""Settings.App.CancelRunSetupAgain""#,
+            ],
+            in: "Sources/Rapid/UI/SettingsView.swift",
+            surface: "Settings → App setup"
+        )
+    }
+
     private static var sourceRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // RapidTests

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -29,6 +29,7 @@ from unittest import mock
 import pytest
 
 from vllm_mlx.doctor import env_health as eh
+from vllm_mlx.launch import cline
 
 
 class _HTTPResponse:
@@ -255,6 +256,29 @@ def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
     ]
     assert roots[0].as_posix() in cline[0].detail
     assert roots[1].as_posix() in cline[1].detail
+
+
+def test_doctor_discovers_the_exact_config_written_by_cline_launcher(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "vscode-globalStorage"
+    launcher_path = (
+        root / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
+    )
+    launcher_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(cline, "_candidate_settings_roots", lambda: [root])
+    cline.write_or_patch_config(
+        "http://127.0.0.1:8000", "model", config_path=launcher_path
+    )
+
+    # Doctor's macOS Stable root resolves to the same relative destination.
+    doctor_root = tmp_path / "Library/Application Support/Code/User/globalStorage"
+    doctor_path = doctor_root / launcher_path.relative_to(root)
+    doctor_path.parent.mkdir(parents=True)
+    doctor_path.write_bytes(launcher_path.read_bytes())
+
+    configured = eh._configured_agent_urls(tmp_path)
+    assert configured == [("Cline", doctor_path, "http://127.0.0.1:8000/v1")]
 
 
 def test_agent_integration_non_http_service_is_reported_unresponsive(tmp_path):

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -179,11 +179,14 @@ def test_agent_integrations_probe_each_configured_server(tmp_path):
         / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
     )
     cline.parent.mkdir(parents=True)
-    cline.write_text('{"openAiBaseUrl":"http://localhost:8001/v1"}')
+    cline.write_text(
+        '{"apiProvider":"openai","openAiBaseUrl":"http://localhost:8001/v1"}'
+    )
     cont = tmp_path / ".continue/config.json"
     cont.parent.mkdir(parents=True)
     cont.write_text(
-        '{"models":[{"title":"rapid-mlx","apiBase":"http://localhost:8002/v1"}]}'
+        '{"models":[{"title":"rapid-mlx","provider":"openai",'
+        '"apiBase":"http://localhost:8002/v1"}]}'
     )
 
     requested = []
@@ -241,7 +244,9 @@ def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
     for index, root in enumerate(roots):
         path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
         path.parent.mkdir(parents=True)
-        path.write_text(f'{{"openAiBaseUrl":"http://localhost:800{index}/v1"}}')
+        path.write_text(
+            f'{{"apiProvider":"openai","openAiBaseUrl":"http://localhost:800{index}/v1"}}'
+        )
 
     def open_url(request, *, timeout):
         if ":8001/" in request.full_url:
@@ -279,6 +284,50 @@ def test_doctor_discovers_the_exact_config_written_by_cline_launcher(
 
     configured = eh._configured_agent_urls(tmp_path)
     assert configured == [("Cline", doctor_path, "http://127.0.0.1:8000/v1")]
+
+
+def test_stale_inactive_provider_urls_are_not_probed(tmp_path):
+    cline_path = (
+        tmp_path
+        / "Library/Application Support/Code/User/globalStorage"
+        / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    )
+    cline_path.parent.mkdir(parents=True)
+    cline_path.write_text(
+        '{"apiProvider":"anthropic","openAiBaseUrl":"http://localhost:8000/v1"}'
+    )
+    cont = tmp_path / ".continue/config.json"
+    cont.parent.mkdir(parents=True)
+    cont.write_text(
+        '{"models":[{"title":"rapid-mlx","provider":"anthropic",'
+        '"apiBase":"http://localhost:8001/v1"}]}'
+    )
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: pytest.fail("stale URL was probed"),
+    )
+    assert len(section.checks) == 2
+    assert all(check.status is eh.CheckStatus.WARN for check in section.checks)
+
+
+def test_agent_integration_details_redact_url_secrets(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text(
+        '{"env":{"ANTHROPIC_BASE_URL":'
+        '"https://user:password@localhost:8000/v1?token=secret#fragment"}}'
+    )
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: _HTTPResponse(),
+    )
+    detail = section.checks[0].detail
+    assert "https://localhost:8000/v1" in detail
+    assert all(
+        secret not in detail for secret in ("user", "password", "token", "secret")
+    )
 
 
 def test_agent_integration_non_http_service_is_reported_unresponsive(tmp_path):

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -39,6 +39,7 @@ class _HTTPResponse:
     def __exit__(self, *_args):
         return None
 
+
 # ---------------------------------------------------------------------------
 # Section: System
 # ---------------------------------------------------------------------------
@@ -168,9 +169,7 @@ def test_agent_integrations_are_quiet_when_no_client_is_configured(tmp_path):
 def test_agent_integrations_probe_each_configured_server(tmp_path):
     claude = tmp_path / ".claude/settings.json"
     claude.parent.mkdir(parents=True)
-    claude.write_text(
-        '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}'
-    )
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
     cline = (
         tmp_path
         / "Library/Application Support/Code/User/globalStorage"
@@ -216,6 +215,44 @@ def test_agent_integration_malformed_or_unrelated_config_warns(tmp_path):
     assert len(section.checks) == 2
     assert all(check.status is eh.CheckStatus.WARN for check in section.checks)
     assert all("no Rapid-MLX server" in check.label for check in section.checks)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_agent_integration_auth_response_proves_server_is_alive(tmp_path, status):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
+
+    def open_url(request, *, timeout):
+        raise urllib.error.HTTPError(request.full_url, status, "auth", {}, None)
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    assert section.checks[0].status is eh.CheckStatus.OK
+
+
+def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
+    roots = [
+        tmp_path / "Library/Application Support/Code/User/globalStorage",
+        tmp_path / "Library/Application Support/VSCodium/User/globalStorage",
+    ]
+    for index, root in enumerate(roots):
+        path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(f'{{"openAiBaseUrl":"http://localhost:800{index}/v1"}}')
+
+    def open_url(request, *, timeout):
+        if ":8001/" in request.full_url:
+            raise urllib.error.URLError("offline")
+        return _HTTPResponse()
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    cline = [check for check in section.checks if check.label.startswith("Cline")]
+    assert [check.status for check in cline] == [
+        eh.CheckStatus.OK,
+        eh.CheckStatus.WARN,
+    ]
+    assert roots[0].as_posix() in cline[0].detail
+    assert roots[1].as_posix() in cline[1].detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -24,6 +24,7 @@ import os
 import plistlib
 import time
 import urllib.error
+from io import BytesIO
 from pathlib import Path
 from unittest import mock
 
@@ -444,11 +445,15 @@ def test_agent_integration_details_redact_url_secrets(tmp_path):
         '"https://user:password@localhost:8000/v1?token=secret#fragment"}}'
     )
 
-    section = eh.section_agent_integrations(
-        home=tmp_path,
-        open_url=lambda *_args, **_kwargs: _HTTPResponse(),
-    )
+    requested = []
+
+    def open_url(request, *, timeout):
+        requested.append(request.full_url)
+        return _HTTPResponse()
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
     detail = section.checks[0].detail
+    assert requested == ["https://localhost:8000/healthz"]
     assert "https://localhost:8000/v1" in detail
     assert all(
         secret not in detail for secret in ("user", "password", "token", "secret")
@@ -477,6 +482,27 @@ def test_agent_integration_config_read_is_size_bounded(tmp_path):
         Path, "read_text", side_effect=AssertionError("must not read")
     ):
         section = eh.section_agent_integrations(home=tmp_path)
+
+    assert section.checks[0].status is eh.CheckStatus.WARN
+    assert "no Rapid-MLX server" in section.checks[0].label
+
+
+def test_agent_integration_config_growth_during_read_is_size_bounded(
+    tmp_path, monkeypatch
+):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text("{}")
+    oversized = BytesIO(b" " * (eh._AGENT_CONFIG_MAX_BYTES + 1))
+    original_open = Path.open
+
+    def open_file(path, *args, **kwargs):
+        if path == claude:
+            return oversized
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", open_file)
+    section = eh.section_agent_integrations(home=tmp_path)
 
     assert section.checks[0].status is eh.CheckStatus.WARN
     assert "no Rapid-MLX server" in section.checks[0].label

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -340,7 +340,27 @@ def test_doctor_discovers_the_exact_config_written_by_cline_launcher(
     doctor_path.write_bytes(launcher_path.read_bytes())
 
     configured = eh._configured_agent_urls(tmp_path)
-    assert configured == [("Cline", doctor_path, "http://127.0.0.1:8000/v1")]
+    assert configured == [("Cline", doctor_path, "http://127.0.0.1:8000/v1", "sk-noop")]
+
+
+def test_agent_integration_authenticates_ddtree_health_probe(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text(
+        '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000/v1",'
+        '"ANTHROPIC_API_KEY":"secret-key"}}'
+    )
+
+    def open_url(request, *, timeout):
+        assert request.get_header("Authorization") == "Bearer secret-key"
+        return _HTTPResponse(
+            payload={"engine": "ddtree", "status": "ok", "ready": True}
+        )
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+
+    assert section.checks[0].status is eh.CheckStatus.OK
+    assert "secret-key" not in section.checks[0].detail
 
 
 def test_stale_inactive_provider_urls_are_not_probed(tmp_path):
@@ -442,12 +462,11 @@ def test_agent_integration_probe_has_a_shared_hard_deadline():
         return _HTTPResponse()
 
     started = time.monotonic()
-    result = eh._probe_agent_urls(
-        ["http://slow.invalid:8000"], open_url=open_url, deadline=0.1
-    )
+    endpoint = ("http://slow.invalid:8000", None)
+    result = eh._probe_agent_urls([endpoint], open_url=open_url, deadline=0.1)
     elapsed = time.monotonic() - started
 
-    assert result == {"http://slow.invalid:8000": False}
+    assert result == {endpoint: False}
     assert elapsed < 0.3, f"probe exceeded its deadline in {elapsed:.3f}s"
 
 

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import http.client
 import importlib
+import json
 import os
 import plistlib
 import time
@@ -33,14 +34,22 @@ from vllm_mlx.launch import cline
 
 
 class _HTTPResponse:
-    def __init__(self, status: int = 200):
+    def __init__(self, status: int = 200, payload: dict | None = None):
         self.status = status
+        self.payload = payload or {
+            "status": "healthy",
+            "ready": True,
+            "model_loaded": True,
+        }
 
     def __enter__(self):
         return self
 
     def __exit__(self, *_args):
         return None
+
+    def read(self, _limit: int = -1):
+        return json.dumps(self.payload).encode()
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +233,9 @@ def test_agent_integration_malformed_or_unrelated_config_warns(tmp_path):
 
 
 @pytest.mark.parametrize("status", [401, 403])
-def test_agent_integration_auth_response_proves_server_is_alive(tmp_path, status):
+def test_agent_integration_auth_response_is_not_mistaken_for_rapid_mlx(
+    tmp_path, status
+):
     claude = tmp_path / ".claude/settings.json"
     claude.parent.mkdir(parents=True)
     claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
@@ -233,6 +244,33 @@ def test_agent_integration_auth_response_proves_server_is_alive(tmp_path, status
         raise urllib.error.HTTPError(request.full_url, status, "auth", {}, None)
 
     section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    assert section.checks[0].status is eh.CheckStatus.WARN
+    assert "could not be verified" in section.checks[0].label
+
+
+def test_agent_integration_rejects_unrelated_2xx_health_payload(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: _HTTPResponse(payload={"status": "ok"}),
+    )
+    assert section.checks[0].status is eh.CheckStatus.WARN
+
+
+def test_agent_integration_accepts_ddtree_health_payload(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: _HTTPResponse(
+            payload={"status": "loading", "engine": "ddtree", "ready": False}
+        ),
+    )
     assert section.checks[0].status is eh.CheckStatus.OK
 
 
@@ -340,7 +378,7 @@ def test_agent_integration_non_http_service_is_reported_unresponsive(tmp_path):
 
     section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
     assert section.checks[0].status is eh.CheckStatus.WARN
-    assert "not responding" in section.checks[0].label
+    assert "could not be verified" in section.checks[0].label
 
 
 def test_agent_integration_config_read_is_size_bounded(tmp_path):

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -52,6 +52,15 @@ class _HTTPResponse:
         return json.dumps(self.payload).encode()
 
 
+class _RawHTTPResponse(_HTTPResponse):
+    def __init__(self, body: bytes, status: int = 200):
+        self.status = status
+        self.body = body
+
+    def read(self, _limit: int = -1):
+        return self.body
+
+
 # ---------------------------------------------------------------------------
 # Section: System
 # ---------------------------------------------------------------------------
@@ -257,6 +266,19 @@ def test_agent_integration_rejects_unrelated_2xx_health_payload(tmp_path):
         home=tmp_path,
         open_url=lambda *_args, **_kwargs: _HTTPResponse(payload={"status": "ok"}),
     )
+    assert section.checks[0].status is eh.CheckStatus.WARN
+
+
+def test_agent_integration_invalid_utf8_health_payload_warns(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: _RawHTTPResponse(b"\xff"),
+    )
+
     assert section.checks[0].status is eh.CheckStatus.WARN
 
 

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -17,50 +17,15 @@ mutation) so the suite runs identically on every Python and every OS.
 
 from __future__ import annotations
 
-import http.client
 import importlib
-import json
 import os
 import plistlib
-import time
-import urllib.error
-from io import BytesIO
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from vllm_mlx.doctor import env_health as eh
-from vllm_mlx.launch import cline
-
-
-class _HTTPResponse:
-    def __init__(self, status: int = 200, payload: dict | None = None):
-        self.status = status
-        self.payload = payload or {
-            "status": "healthy",
-            "ready": True,
-            "model_loaded": True,
-        }
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_args):
-        return None
-
-    def read(self, _limit: int = -1):
-        return json.dumps(self.payload).encode()
-
-
-class _RawHTTPResponse(_HTTPResponse):
-    def __init__(self, body: bytes, status: int = 200):
-        self.status = status
-        self.body = body
-
-    def read(self, _limit: int = -1):
-        return self.body
-
 
 # ---------------------------------------------------------------------------
 # Section: System
@@ -181,17 +146,49 @@ def test_install_location_reported():
 # ---------------------------------------------------------------------------
 
 
+class _Connection:
+    def close(self):
+        pass
+
+
 def test_agent_integrations_are_quiet_when_no_client_is_configured(tmp_path):
     section = eh.section_agent_integrations(home=tmp_path)
-    assert len(section.checks) == 1
     assert section.checks[0].status is eh.CheckStatus.OK
-    assert "No Claude Code" in section.checks[0].label
 
 
-def test_agent_integrations_probe_each_configured_server(tmp_path):
+def test_agent_integrations_report_config_and_server_reachability(tmp_path):
     claude = tmp_path / ".claude/settings.json"
     claude.parent.mkdir(parents=True)
     claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
+    cont = tmp_path / ".continue/config.json"
+    cont.parent.mkdir(parents=True)
+    cont.write_text(
+        '{"models":[{"title":"rapid-mlx","provider":"openai",'
+        '"apiBase":"http://localhost:8001/v1"}]}'
+    )
+
+    def connect(address, *, timeout):
+        assert timeout == 0.25
+        if address[1] == 8001:
+            raise ConnectionRefusedError
+        return _Connection()
+
+    section = eh.section_agent_integrations(home=tmp_path, connect=connect)
+
+    assert [check.status for check in section.checks] == [
+        eh.CheckStatus.OK,
+        eh.CheckStatus.WARN,
+    ]
+    assert [check.label for check in section.checks] == [
+        "Claude Code server is reachable",
+        "Continue.dev server is not reachable",
+    ]
+
+
+def test_agent_integrations_warn_for_malformed_or_inactive_config(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text("not json")
     cline = (
         tmp_path
         / "Library/Application Support/Code/User/globalStorage"
@@ -199,349 +196,16 @@ def test_agent_integrations_probe_each_configured_server(tmp_path):
     )
     cline.parent.mkdir(parents=True)
     cline.write_text(
-        '{"apiProvider":"openai","openAiBaseUrl":"http://localhost:8001/v1"}'
-    )
-    cont = tmp_path / ".continue/config.json"
-    cont.parent.mkdir(parents=True)
-    cont.write_text(
-        '{"models":[{"title":"rapid-mlx","provider":"openai",'
-        '"apiBase":"http://localhost:8002/v1"}]}'
-    )
-
-    requested = []
-
-    def open_url(request, *, timeout):
-        requested.append((request.full_url, timeout))
-        if ":8001/" in request.full_url:
-            raise urllib.error.URLError("offline")
-        return _HTTPResponse()
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    by_name = {check.label.split()[0]: check for check in section.checks}
-    assert by_name["Claude"].status is eh.CheckStatus.OK
-    assert by_name["Cline"].status is eh.CheckStatus.WARN
-    assert by_name["Continue.dev"].status is eh.CheckStatus.OK
-    assert {url for url, _ in requested} == {
-        "http://127.0.0.1:8000/healthz",
-        "http://localhost:8001/healthz",
-        "http://localhost:8002/healthz",
-    }
-
-
-def test_agent_integration_malformed_or_unrelated_config_warns(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text("not json")
-    cont = tmp_path / ".continue/config.json"
-    cont.parent.mkdir(parents=True)
-    cont.write_text('{"models":[{"title":"cloud","apiBase":"https://example.com"}]}')
-
-    section = eh.section_agent_integrations(home=tmp_path)
-    assert len(section.checks) == 2
-    assert all(check.status is eh.CheckStatus.WARN for check in section.checks)
-    assert all("no Rapid-MLX server" in check.label for check in section.checks)
-
-
-@pytest.mark.parametrize("status", [401, 403])
-def test_agent_integration_auth_response_is_not_mistaken_for_rapid_mlx(
-    tmp_path, status
-):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
-
-    def open_url(request, *, timeout):
-        raise urllib.error.HTTPError(request.full_url, status, "auth", {}, None)
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    assert section.checks[0].status is eh.CheckStatus.WARN
-    assert "could not be verified" in section.checks[0].label
-
-
-def test_agent_integration_rejects_unrelated_2xx_health_payload(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
-
-    section = eh.section_agent_integrations(
-        home=tmp_path,
-        open_url=lambda *_args, **_kwargs: _HTTPResponse(payload={"status": "ok"}),
-    )
-    assert section.checks[0].status is eh.CheckStatus.WARN
-
-
-def test_agent_integration_invalid_utf8_health_payload_warns(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
-
-    section = eh.section_agent_integrations(
-        home=tmp_path,
-        open_url=lambda *_args, **_kwargs: _RawHTTPResponse(b"\xff"),
-    )
-
-    assert section.checks[0].status is eh.CheckStatus.WARN
-
-
-def test_agent_integration_accepts_ddtree_health_payload(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
-
-    section = eh.section_agent_integrations(
-        home=tmp_path,
-        open_url=lambda *_args, **_kwargs: _HTTPResponse(
-            payload={"status": "loading", "engine": "ddtree", "ready": False}
-        ),
-    )
-    assert section.checks[0].status is eh.CheckStatus.OK
-
-
-def test_agent_integration_accepts_dflash_health_payload(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
-
-    section = eh.section_agent_integrations(
-        home=tmp_path,
-        open_url=lambda *_args, **_kwargs: _HTTPResponse(
-            payload={
-                "status": "ok",
-                "engine": "dflash",
-                "mode": "single-user-serial",
-                "drafter": "mlx-community/drafter",
-            }
-        ),
-    )
-    assert section.checks[0].status is eh.CheckStatus.OK
-
-
-def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
-    roots = [
-        tmp_path / "Library/Application Support/Code/User/globalStorage",
-        tmp_path / "Library/Application Support/VSCodium/User/globalStorage",
-    ]
-    for index, root in enumerate(roots):
-        path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
-        path.parent.mkdir(parents=True)
-        path.write_text(
-            f'{{"apiProvider":"openai","openAiBaseUrl":"http://localhost:800{index}/v1"}}'
-        )
-
-    def open_url(request, *, timeout):
-        if ":8001/" in request.full_url:
-            raise urllib.error.URLError("offline")
-        return _HTTPResponse()
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    cline = [check for check in section.checks if check.label.startswith("Cline")]
-    assert [check.status for check in cline] == [
-        eh.CheckStatus.OK,
-        eh.CheckStatus.WARN,
-    ]
-    assert roots[0].as_posix() in cline[0].detail
-    assert roots[1].as_posix() in cline[1].detail
-
-
-def test_doctor_discovers_the_exact_config_written_by_cline_launcher(
-    tmp_path, monkeypatch
-):
-    root = tmp_path / "vscode-globalStorage"
-    launcher_path = (
-        root / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
-    )
-    launcher_path.parent.mkdir(parents=True)
-    monkeypatch.setattr(cline, "_candidate_settings_roots", lambda: [root])
-    cline.write_or_patch_config(
-        "http://127.0.0.1:8000", "model", config_path=launcher_path
-    )
-
-    # Doctor's macOS Stable root resolves to the same relative destination.
-    doctor_root = tmp_path / "Library/Application Support/Code/User/globalStorage"
-    doctor_path = doctor_root / launcher_path.relative_to(root)
-    doctor_path.parent.mkdir(parents=True)
-    doctor_path.write_bytes(launcher_path.read_bytes())
-
-    configured = eh._configured_agent_urls(tmp_path)
-    assert configured == [("Cline", doctor_path, "http://127.0.0.1:8000/v1", "sk-noop")]
-
-
-def test_agent_integration_authenticates_ddtree_health_probe(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text(
-        '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000/v1",'
-        '"ANTHROPIC_API_KEY":"secret-key"}}'
-    )
-
-    def open_url(request, *, timeout):
-        assert request.get_header("Authorization") == "Bearer secret-key"
-        return _HTTPResponse(
-            payload={"engine": "ddtree", "status": "ok", "ready": True}
-        )
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-
-    assert section.checks[0].status is eh.CheckStatus.OK
-    assert "secret-key" not in section.checks[0].detail
-
-
-def test_agent_health_probe_disables_redirects_before_sending_api_key(monkeypatch):
-    class FakeOpener:
-        def open(self, request, *, timeout):
-            assert request.get_header("Authorization") == "Bearer secret-key"
-            return _HTTPResponse()
-
-    def build_opener(handler):
-        assert isinstance(handler, eh._NoAgentProbeRedirects)
-        assert (
-            handler.redirect_request(
-                None,
-                None,
-                302,
-                "Found",
-                {},
-                "https://attacker.example/steal",
-            )
-            is None
-        )
-        return FakeOpener()
-
-    monkeypatch.setattr(eh.urllib.request, "build_opener", build_opener)
-
-    assert eh._agent_server_alive("http://127.0.0.1:8000", api_key="secret-key")
-
-
-def test_stale_inactive_provider_urls_are_not_probed(tmp_path):
-    cline_path = (
-        tmp_path
-        / "Library/Application Support/Code/User/globalStorage"
-        / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
-    )
-    cline_path.parent.mkdir(parents=True)
-    cline_path.write_text(
         '{"apiProvider":"anthropic","openAiBaseUrl":"http://localhost:8000/v1"}'
     )
-    cont = tmp_path / ".continue/config.json"
-    cont.parent.mkdir(parents=True)
-    cont.write_text(
-        '{"models":[{"title":"rapid-mlx","provider":"anthropic",'
-        '"apiBase":"http://localhost:8001/v1"}]}'
-    )
 
     section = eh.section_agent_integrations(
         home=tmp_path,
-        open_url=lambda *_args, **_kwargs: pytest.fail("stale URL was probed"),
+        connect=lambda *_args, **_kwargs: pytest.fail("must not connect"),
     )
+
     assert len(section.checks) == 2
     assert all(check.status is eh.CheckStatus.WARN for check in section.checks)
-
-
-def test_agent_integration_details_redact_url_secrets(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text(
-        '{"env":{"ANTHROPIC_BASE_URL":'
-        '"https://user:password@localhost:8000/v1?token=secret#fragment"}}'
-    )
-
-    requested = []
-
-    def open_url(request, *, timeout):
-        requested.append(request.full_url)
-        return _HTTPResponse()
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    detail = section.checks[0].detail
-    assert requested == ["https://localhost:8000/healthz"]
-    assert "https://localhost:8000/v1" in detail
-    assert all(
-        secret not in detail for secret in ("user", "password", "token", "secret")
-    )
-
-
-def test_agent_integration_non_http_service_is_reported_unresponsive(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
-
-    def open_url(request, *, timeout):
-        raise http.client.BadStatusLine("SSH-2.0")
-
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    assert section.checks[0].status is eh.CheckStatus.WARN
-    assert "could not be verified" in section.checks[0].label
-
-
-def test_agent_integration_config_read_is_size_bounded(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_bytes(b" " * (eh._AGENT_CONFIG_MAX_BYTES + 1))
-
-    with mock.patch.object(
-        Path, "read_text", side_effect=AssertionError("must not read")
-    ):
-        section = eh.section_agent_integrations(home=tmp_path)
-
-    assert section.checks[0].status is eh.CheckStatus.WARN
-    assert "no Rapid-MLX server" in section.checks[0].label
-
-
-def test_agent_integration_config_growth_during_read_is_size_bounded(
-    tmp_path, monkeypatch
-):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text("{}")
-    oversized = BytesIO(b" " * (eh._AGENT_CONFIG_MAX_BYTES + 1))
-    original_open = Path.open
-
-    def open_file(path, *args, **kwargs):
-        if path == claude:
-            return oversized
-        return original_open(path, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "open", open_file)
-    section = eh.section_agent_integrations(home=tmp_path)
-
-    assert section.checks[0].status is eh.CheckStatus.WARN
-    assert "no Rapid-MLX server" in section.checks[0].label
-
-
-def test_agent_integration_probes_run_concurrently(tmp_path):
-    claude = tmp_path / ".claude/settings.json"
-    claude.parent.mkdir(parents=True)
-    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
-    cont = tmp_path / ".continue/config.json"
-    cont.parent.mkdir(parents=True)
-    cont.write_text(
-        '{"models":[{"title":"rapid-mlx","apiBase":"http://localhost:8001/v1"}]}'
-    )
-
-    def open_url(request, *, timeout):
-        time.sleep(0.15)
-        raise urllib.error.URLError("timeout")
-
-    started = time.monotonic()
-    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
-    elapsed = time.monotonic() - started
-
-    assert len(section.checks) == 2
-    assert elapsed < 0.25, f"probes ran serially in {elapsed:.3f}s"
-
-
-def test_agent_integration_probe_has_a_shared_hard_deadline():
-    def open_url(request, *, timeout):
-        time.sleep(2)
-        return _HTTPResponse()
-
-    started = time.monotonic()
-    endpoint = ("http://slow.invalid:8000", None)
-    result = eh._probe_agent_urls([endpoint], open_url=open_url, deadline=0.1)
-    elapsed = time.monotonic() - started
-
-    assert result == {endpoint: False}
-    assert elapsed < 0.3, f"probe exceeded its deadline in {elapsed:.3f}s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -17,9 +17,11 @@ mutation) so the suite runs identically on every Python and every OS.
 
 from __future__ import annotations
 
+import http.client
 import importlib
 import os
 import plistlib
+import time
 import urllib.error
 from pathlib import Path
 from unittest import mock
@@ -253,6 +255,55 @@ def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
     ]
     assert roots[0].as_posix() in cline[0].detail
     assert roots[1].as_posix() in cline[1].detail
+
+
+def test_agent_integration_non_http_service_is_reported_unresponsive(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
+
+    def open_url(request, *, timeout):
+        raise http.client.BadStatusLine("SSH-2.0")
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    assert section.checks[0].status is eh.CheckStatus.WARN
+    assert "not responding" in section.checks[0].label
+
+
+def test_agent_integration_config_read_is_size_bounded(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_bytes(b" " * (eh._AGENT_CONFIG_MAX_BYTES + 1))
+
+    with mock.patch.object(
+        Path, "read_text", side_effect=AssertionError("must not read")
+    ):
+        section = eh.section_agent_integrations(home=tmp_path)
+
+    assert section.checks[0].status is eh.CheckStatus.WARN
+    assert "no Rapid-MLX server" in section.checks[0].label
+
+
+def test_agent_integration_probes_run_concurrently(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}')
+    cont = tmp_path / ".continue/config.json"
+    cont.parent.mkdir(parents=True)
+    cont.write_text(
+        '{"models":[{"title":"rapid-mlx","apiBase":"http://localhost:8001/v1"}]}'
+    )
+
+    def open_url(request, *, timeout):
+        time.sleep(0.15)
+        raise urllib.error.URLError("timeout")
+
+    started = time.monotonic()
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    elapsed = time.monotonic() - started
+
+    assert len(section.checks) == 2
+    assert elapsed < 0.25, f"probes ran serially in {elapsed:.3f}s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -363,6 +363,32 @@ def test_agent_integration_authenticates_ddtree_health_probe(tmp_path):
     assert "secret-key" not in section.checks[0].detail
 
 
+def test_agent_health_probe_disables_redirects_before_sending_api_key(monkeypatch):
+    class FakeOpener:
+        def open(self, request, *, timeout):
+            assert request.get_header("Authorization") == "Bearer secret-key"
+            return _HTTPResponse()
+
+    def build_opener(handler):
+        assert isinstance(handler, eh._NoAgentProbeRedirects)
+        assert (
+            handler.redirect_request(
+                None,
+                None,
+                302,
+                "Found",
+                {},
+                "https://attacker.example/steal",
+            )
+            is None
+        )
+        return FakeOpener()
+
+    monkeypatch.setattr(eh.urllib.request, "build_opener", build_opener)
+
+    assert eh._agent_server_alive("http://127.0.0.1:8000", api_key="secret-key")
+
+
 def test_stale_inactive_provider_urls_are_not_probed(tmp_path):
     cline_path = (
         tmp_path

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -306,6 +306,21 @@ def test_agent_integration_probes_run_concurrently(tmp_path):
     assert elapsed < 0.25, f"probes ran serially in {elapsed:.3f}s"
 
 
+def test_agent_integration_probe_has_a_shared_hard_deadline():
+    def open_url(request, *, timeout):
+        time.sleep(2)
+        return _HTTPResponse()
+
+    started = time.monotonic()
+    result = eh._probe_agent_urls(
+        ["http://slow.invalid:8000"], open_url=open_url, deadline=0.1
+    )
+    elapsed = time.monotonic() - started
+
+    assert result == {"http://slow.invalid:8000": False}
+    assert elapsed < 0.3, f"probe exceeded its deadline in {elapsed:.3f}s"
+
+
 # ---------------------------------------------------------------------------
 # Section: Required + optional packages
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -274,6 +274,25 @@ def test_agent_integration_accepts_ddtree_health_payload(tmp_path):
     assert section.checks[0].status is eh.CheckStatus.OK
 
 
+def test_agent_integration_accepts_dflash_health_payload(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text('{"env":{"ANTHROPIC_BASE_URL":"http://localhost:8000"}}')
+
+    section = eh.section_agent_integrations(
+        home=tmp_path,
+        open_url=lambda *_args, **_kwargs: _HTTPResponse(
+            payload={
+                "status": "ok",
+                "engine": "dflash",
+                "mode": "single-user-serial",
+                "drafter": "mlx-community/drafter",
+            }
+        ),
+    )
+    assert section.checks[0].status is eh.CheckStatus.OK
+
+
 def test_agent_integrations_probe_every_existing_cline_config(tmp_path):
     roots = [
         tmp_path / "Library/Application Support/Code/User/globalStorage",

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -185,10 +185,13 @@ def test_agent_integrations_report_config_and_server_reachability(tmp_path):
     ]
 
 
-def test_agent_integrations_warn_for_malformed_or_inactive_config(tmp_path):
+@pytest.mark.parametrize("claude_config", ["not json", "null", "[]"])
+def test_agent_integrations_warn_for_malformed_or_inactive_config(
+    tmp_path, claude_config
+):
     claude = tmp_path / ".claude/settings.json"
     claude.parent.mkdir(parents=True)
-    claude.write_text("not json")
+    claude.write_text(claude_config)
     cline = (
         tmp_path
         / "Library/Application Support/Code/User/globalStorage"

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -20,12 +20,24 @@ from __future__ import annotations
 import importlib
 import os
 import plistlib
+import urllib.error
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from vllm_mlx.doctor import env_health as eh
+
+
+class _HTTPResponse:
+    def __init__(self, status: int = 200):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
 
 # ---------------------------------------------------------------------------
 # Section: System
@@ -139,6 +151,71 @@ def test_install_location_reported():
     # Second row is always the install-location classifier.
     loc_row = section.checks[1]
     assert "Install location" in loc_row.label
+
+
+# ---------------------------------------------------------------------------
+# Section: Agent integrations
+# ---------------------------------------------------------------------------
+
+
+def test_agent_integrations_are_quiet_when_no_client_is_configured(tmp_path):
+    section = eh.section_agent_integrations(home=tmp_path)
+    assert len(section.checks) == 1
+    assert section.checks[0].status is eh.CheckStatus.OK
+    assert "No Claude Code" in section.checks[0].label
+
+
+def test_agent_integrations_probe_each_configured_server(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text(
+        '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8000"}}'
+    )
+    cline = (
+        tmp_path
+        / "Library/Application Support/Code/User/globalStorage"
+        / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    )
+    cline.parent.mkdir(parents=True)
+    cline.write_text('{"openAiBaseUrl":"http://localhost:8001/v1"}')
+    cont = tmp_path / ".continue/config.json"
+    cont.parent.mkdir(parents=True)
+    cont.write_text(
+        '{"models":[{"title":"rapid-mlx","apiBase":"http://localhost:8002/v1"}]}'
+    )
+
+    requested = []
+
+    def open_url(request, *, timeout):
+        requested.append((request.full_url, timeout))
+        if ":8001/" in request.full_url:
+            raise urllib.error.URLError("offline")
+        return _HTTPResponse()
+
+    section = eh.section_agent_integrations(home=tmp_path, open_url=open_url)
+    by_name = {check.label.split()[0]: check for check in section.checks}
+    assert by_name["Claude"].status is eh.CheckStatus.OK
+    assert by_name["Cline"].status is eh.CheckStatus.WARN
+    assert by_name["Continue.dev"].status is eh.CheckStatus.OK
+    assert {url for url, _ in requested} == {
+        "http://127.0.0.1:8000/healthz",
+        "http://localhost:8001/healthz",
+        "http://localhost:8002/healthz",
+    }
+
+
+def test_agent_integration_malformed_or_unrelated_config_warns(tmp_path):
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir(parents=True)
+    claude.write_text("not json")
+    cont = tmp_path / ".continue/config.json"
+    cont.parent.mkdir(parents=True)
+    cont.write_text('{"models":[{"title":"cloud","apiBase":"https://example.com"}]}')
+
+    section = eh.section_agent_integrations(home=tmp_path)
+    assert len(section.checks) == 2
+    assert all(check.status is eh.CheckStatus.WARN for check in section.checks)
+    assert all("no Rapid-MLX server" in check.label for check in section.checks)
 
 
 # ---------------------------------------------------------------------------
@@ -841,6 +918,7 @@ def test_run_all_returns_all_sections():
         "Network",
         "Shell Integration",
         "Optional Tools",
+        "Agent Integrations",
     ]
     assert titles == expected, (
         f"sections drifted from spec order. got {titles}, expected {expected}"

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1266,6 +1266,9 @@ def _agent_integrations(home: Path) -> list[tuple[str, Path, str | None]]:
         url = None
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                integrations.append((name, path, None))
+                continue
             if name == "Claude Code" and isinstance(data.get("env"), dict):
                 url = data["env"].get("ANTHROPIC_BASE_URL")
             elif name == "Continue.dev" and isinstance(data.get("models"), list):

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1290,7 +1290,7 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
         home / ".config/VSCodium/User/globalStorage",
     )
     for root in cline_roots:
-        path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+        path = root / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
         if path.exists():
             candidates.append(("Cline", path, lambda data: data.get("openAiBaseUrl")))
 

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -21,6 +21,7 @@ Tests in ``tests/test_doctor_env_health.py`` cover each section's probe.
 
 from __future__ import annotations
 
+import http.client
 import importlib.metadata as _im
 import importlib.util as _iu
 import json
@@ -34,6 +35,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -123,6 +125,8 @@ OPTIONAL_PACKAGES: list[tuple[str, str, str]] = [
         "pip install 'rapid-mlx[embeddings]'",
     ),
 ]
+
+_AGENT_CONFIG_MAX_BYTES = 1024 * 1024
 
 # ``find_spec`` checks discoverability without importing heavyweight audio
 # packages such as scipy, numba, and spaCy.  Keep this aligned with the
@@ -1294,6 +1298,9 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
         if not path.is_file():
             continue
         try:
+            if path.stat().st_size > _AGENT_CONFIG_MAX_BYTES:
+                configured.append((name, path, None))
+                continue
             data = json.loads(path.read_text(encoding="utf-8"))
             url = extract(data) if isinstance(data, dict) else None
             configured.append((name, path, url if isinstance(url, str) else None))
@@ -1327,7 +1334,13 @@ def _agent_server_alive(
         # Authentication proves that a server answered. Some supported
         # serving modes intentionally protect even their health endpoint.
         return error.code in {401, 403}
-    except (OSError, TypeError, urllib.error.URLError, ValueError):
+    except (
+        OSError,
+        TypeError,
+        http.client.HTTPException,
+        urllib.error.URLError,
+        ValueError,
+    ):
         return False
 
 
@@ -1343,6 +1356,15 @@ def section_agent_integrations(
         s.add("No Claude Code, Cline, or Continue.dev config found", CheckStatus.OK)
         return s
 
+    urls = [url for _, _, url in integrations if url]
+    with ThreadPoolExecutor(max_workers=min(len(urls), 8) or 1) as pool:
+        alive_by_url = dict(
+            zip(
+                urls,
+                pool.map(lambda url: _agent_server_alive(url, open_url=open_url), urls),
+            )
+        )
+
     for name, path, url in integrations:
         if not url:
             s.add(
@@ -1350,7 +1372,7 @@ def section_agent_integrations(
                 CheckStatus.WARN,
                 detail=f"path={path}",
             )
-        elif _agent_server_alive(url, open_url=open_url):
+        elif alive_by_url[url]:
             s.add(
                 f"{name} config points to a live server",
                 CheckStatus.OK,

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1252,23 +1252,27 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
         (
             "Claude Code",
             home / ".claude/settings.json",
-            lambda data: data.get("env", {}).get("ANTHROPIC_BASE_URL")
-            if isinstance(data.get("env"), dict)
-            else None,
+            lambda data: (
+                data.get("env", {}).get("ANTHROPIC_BASE_URL")
+                if isinstance(data.get("env"), dict)
+                else None
+            ),
         ),
         (
             "Continue.dev",
             home / ".continue/config.json",
-            lambda data: next(
-                (
-                    entry.get("apiBase")
-                    for entry in data.get("models", [])
-                    if isinstance(entry, dict) and entry.get("title") == "rapid-mlx"
-                ),
-                None,
-            )
-            if isinstance(data.get("models"), list)
-            else None,
+            lambda data: (
+                next(
+                    (
+                        entry.get("apiBase")
+                        for entry in data.get("models", [])
+                        if isinstance(entry, dict) and entry.get("title") == "rapid-mlx"
+                    ),
+                    None,
+                )
+                if isinstance(data.get("models"), list)
+                else None
+            ),
         ),
     ]
 
@@ -1284,7 +1288,6 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
         path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
         if path.exists():
             candidates.append(("Cline", path, lambda data: data.get("openAiBaseUrl")))
-            break
 
     configured: list[tuple[str, Path, str | None]] = []
     for name, path, extract in candidates:
@@ -1320,6 +1323,10 @@ def _agent_server_alive(
     try:
         with opener(request, timeout=timeout) as response:  # noqa: S310
             return 200 <= int(response.status) < 300
+    except urllib.error.HTTPError as error:
+        # Authentication proves that a server answered. Some supported
+        # serving modes intentionally protect even their health endpoint.
+        return error.code in {401, 403}
     except (OSError, TypeError, urllib.error.URLError, ValueError):
         return False
 

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1271,7 +1271,9 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
                     (
                         entry.get("apiBase")
                         for entry in data.get("models", [])
-                        if isinstance(entry, dict) and entry.get("title") == "rapid-mlx"
+                        if isinstance(entry, dict)
+                        and entry.get("title") == "rapid-mlx"
+                        and entry.get("provider") == "openai"
                     ),
                     None,
                 )
@@ -1292,7 +1294,17 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
     for root in cline_roots:
         path = root / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
         if path.exists():
-            candidates.append(("Cline", path, lambda data: data.get("openAiBaseUrl")))
+            candidates.append(
+                (
+                    "Cline",
+                    path,
+                    lambda data: (
+                        data.get("openAiBaseUrl")
+                        if data.get("apiProvider") == "openai"
+                        else None
+                    ),
+                )
+            )
 
     configured: list[tuple[str, Path, str | None]] = []
     for name, path, extract in candidates:
@@ -1380,6 +1392,21 @@ def _probe_agent_urls(
         return {url: results.get(url, False) for url in unique_urls}
 
 
+def _redacted_server_url(url: str) -> str:
+    """Render an endpoint without credentials, query values, or fragments."""
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        host = parsed.hostname or ""
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        return urllib.parse.urlunsplit(
+            (parsed.scheme, host + port, parsed.path, "", "")
+        )
+    except ValueError:
+        return "<invalid URL>"
+
+
 def section_agent_integrations(
     *,
     home: Path | None = None,
@@ -1406,13 +1433,13 @@ def section_agent_integrations(
             s.add(
                 f"{name} config points to a live server",
                 CheckStatus.OK,
-                detail=f"path={path} server={url}",
+                detail=f"path={path} server={_redacted_server_url(url)}",
             )
         else:
             s.add(
                 f"{name} config points to a server that is not responding",
                 CheckStatus.WARN,
-                detail=f"path={path} server={url}",
+                detail=f"path={path} server={_redacted_server_url(url)}",
             )
     return s
 

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -7,7 +7,8 @@ optional dev tools. The user runs ``rapid-mlx doctor`` to answer one question
 — "is my install/env broken?" — so every probe must:
 
 * run in well under a second (no model load, no engine init, no server boot);
-* never escalate to sudo or read user data outside ``~/.cache/huggingface``;
+* never escalate to sudo; only read the documented cache, shell, and supported
+  agent-integration config paths needed to diagnose the user's setup;
 * report a deterministic status (✓ / ⚠ / ✗) with a one-line label.
 
 Total wall-clock for ``rapid-mlx doctor`` ≤ 5 s on a warm cache, dominated by
@@ -22,6 +23,7 @@ from __future__ import annotations
 
 import importlib.metadata as _im
 import importlib.util as _iu
+import json
 import os
 import platform
 import plistlib
@@ -29,11 +31,13 @@ import shutil
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -1233,6 +1237,128 @@ def section_optional_tools(
 
 
 # ---------------------------------------------------------------------------
+# Section: Agent Integrations
+# ---------------------------------------------------------------------------
+
+
+def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
+    """Return configured Rapid-MLX endpoints from supported agent clients.
+
+    Missing files are intentionally omitted: agent integrations are optional,
+    and installing Rapid-MLX must not make ``doctor`` warn about clients the
+    user has never used.
+    """
+    candidates: list[tuple[str, Path, Callable[[dict[str, Any]], str | None]]] = [
+        (
+            "Claude Code",
+            home / ".claude/settings.json",
+            lambda data: data.get("env", {}).get("ANTHROPIC_BASE_URL")
+            if isinstance(data.get("env"), dict)
+            else None,
+        ),
+        (
+            "Continue.dev",
+            home / ".continue/config.json",
+            lambda data: next(
+                (
+                    entry.get("apiBase")
+                    for entry in data.get("models", [])
+                    if isinstance(entry, dict) and entry.get("title") == "rapid-mlx"
+                ),
+                None,
+            )
+            if isinstance(data.get("models"), list)
+            else None,
+        ),
+    ]
+
+    cline_roots = (
+        home / "Library/Application Support/Code/User/globalStorage",
+        home / "Library/Application Support/Code - Insiders/User/globalStorage",
+        home / "Library/Application Support/VSCodium/User/globalStorage",
+        home / ".config/Code/User/globalStorage",
+        home / ".config/Code - Insiders/User/globalStorage",
+        home / ".config/VSCodium/User/globalStorage",
+    )
+    for root in cline_roots:
+        path = root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+        if path.exists():
+            candidates.append(("Cline", path, lambda data: data.get("openAiBaseUrl")))
+            break
+
+    configured: list[tuple[str, Path, str | None]] = []
+    for name, path, extract in candidates:
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            url = extract(data) if isinstance(data, dict) else None
+            configured.append((name, path, url if isinstance(url, str) else None))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            configured.append((name, path, None))
+    return configured
+
+
+def _agent_server_alive(
+    base_url: str,
+    *,
+    open_url: Callable[..., Any] | None = None,
+    timeout: float = 0.5,
+) -> bool:
+    """Probe the unauthenticated Rapid-MLX liveness endpoint."""
+    root = base_url.rstrip("/")
+    if root.endswith("/v1"):
+        root = root[:-3]
+    try:
+        parsed = urllib.parse.urlsplit(root)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return False
+        request = urllib.request.Request(root + "/healthz", method="GET")  # noqa: S310
+    except ValueError:
+        return False
+    opener = open_url or urllib.request.urlopen
+    try:
+        with opener(request, timeout=timeout) as response:  # noqa: S310
+            return 200 <= int(response.status) < 300
+    except (OSError, TypeError, urllib.error.URLError, ValueError):
+        return False
+
+
+def section_agent_integrations(
+    *,
+    home: Path | None = None,
+    open_url: Callable[..., Any] | None = None,
+) -> Section:
+    """Show configured IDE/agent clients and verify their target is alive."""
+    s = Section("Agent Integrations")
+    integrations = _configured_agent_urls(home or Path.home())
+    if not integrations:
+        s.add("No Claude Code, Cline, or Continue.dev config found", CheckStatus.OK)
+        return s
+
+    for name, path, url in integrations:
+        if not url:
+            s.add(
+                f"{name} config found, but no Rapid-MLX server is configured",
+                CheckStatus.WARN,
+                detail=f"path={path}",
+            )
+        elif _agent_server_alive(url, open_url=open_url):
+            s.add(
+                f"{name} config points to a live server",
+                CheckStatus.OK,
+                detail=f"path={path} server={url}",
+            )
+        else:
+            s.add(
+                f"{name} config points to a server that is not responding",
+                CheckStatus.WARN,
+                detail=f"path={path} server={url}",
+            )
+    return s
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -1250,6 +1376,7 @@ _SECTION_BUILDERS = (
     section_network,
     section_shell_integration,
     section_optional_tools,
+    section_agent_integrations,
 )
 
 

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1336,6 +1336,13 @@ def _configured_agent_urls(
     return configured
 
 
+class _NoAgentProbeRedirects(urllib.request.HTTPRedirectHandler):
+    """Keep configured API keys on the exact origin the user selected."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def _agent_server_alive(
     base_url: str,
     *,
@@ -1357,7 +1364,9 @@ def _agent_server_alive(
         )
     except ValueError:
         return False
-    opener = open_url or urllib.request.urlopen
+    opener = open_url
+    if opener is None:
+        opener = urllib.request.build_opener(_NoAgentProbeRedirects()).open
     try:
         with opener(request, timeout=timeout) as response:  # noqa: S310
             if not 200 <= int(response.status) < 300:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1318,10 +1318,12 @@ def _configured_agent_urls(
         if not path.is_file():
             continue
         try:
-            if path.stat().st_size > _AGENT_CONFIG_MAX_BYTES:
+            with path.open("rb") as config_file:
+                raw_config = config_file.read(_AGENT_CONFIG_MAX_BYTES + 1)
+            if len(raw_config) > _AGENT_CONFIG_MAX_BYTES:
                 configured.append((name, path, None, None))
                 continue
-            data = json.loads(path.read_text(encoding="utf-8"))
+            data = json.loads(raw_config)
             url, api_key = extract(data) if isinstance(data, dict) else (None, None)
             configured.append(
                 (
@@ -1351,16 +1353,23 @@ def _agent_server_alive(
     timeout: float = 0.5,
 ) -> bool:
     """Probe Rapid-MLX liveness, authenticating from the client config."""
-    root = base_url.rstrip("/")
-    if root.endswith("/v1"):
-        root = root[:-3]
     try:
-        parsed = urllib.parse.urlsplit(root)
+        parsed = urllib.parse.urlsplit(base_url)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             return False
+        path = parsed.path.rstrip("/")
+        if path.endswith("/v1"):
+            path = path[:-3]
+        host = parsed.hostname or ""
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        health_url = urllib.parse.urlunsplit(
+            (parsed.scheme, host + port, path + "/healthz", "", "")
+        )
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         request = urllib.request.Request(  # noqa: S310
-            root + "/healthz", headers=headers, method="GET"
+            health_url, headers=headers, method="GET"
         )
     except ValueError:
         return False

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1398,6 +1398,7 @@ def _agent_server_alive(
     except (
         OSError,
         TypeError,
+        UnicodeError,
         http.client.HTTPException,
         urllib.error.URLError,
         ValueError,

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -31,11 +31,12 @@ import plistlib
 import shutil
 import subprocess
 import sys
+import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -1344,6 +1345,41 @@ def _agent_server_alive(
         return False
 
 
+def _probe_agent_urls(
+    urls: list[str],
+    *,
+    open_url: Callable[..., Any] | None = None,
+    deadline: float = 0.75,
+) -> dict[str, bool]:
+    """Probe endpoints concurrently without ever waiting past ``deadline``.
+
+    ``urlopen(timeout=...)`` does not cover DNS resolution on every platform.
+    Daemon workers let the short-lived doctor process return its diagnosis even
+    if libc's resolver remains blocked. Late results only mutate this function's
+    private dictionary and are discarded.
+    """
+    unique_urls = list(dict.fromkeys(urls))
+    results: dict[str, bool] = {}
+    lock = threading.Lock()
+
+    def probe(url: str) -> None:
+        alive = _agent_server_alive(url, open_url=open_url)
+        with lock:
+            results[url] = alive
+
+    workers = [
+        threading.Thread(target=probe, args=(url,), daemon=True) for url in unique_urls
+    ]
+    expires = time.monotonic() + deadline
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=max(0.0, expires - time.monotonic()))
+
+    with lock:
+        return {url: results.get(url, False) for url in unique_urls}
+
+
 def section_agent_integrations(
     *,
     home: Path | None = None,
@@ -1357,13 +1393,7 @@ def section_agent_integrations(
         return s
 
     urls = [url for _, _, url in integrations if url]
-    with ThreadPoolExecutor(max_workers=min(len(urls), 8) or 1) as pool:
-        alive_by_url = dict(
-            zip(
-                urls,
-                pool.map(lambda url: _agent_server_alive(url, open_url=open_url), urls),
-            )
-        )
+    alive_by_url = _probe_agent_urls(urls, open_url=open_url)
 
     for name, path, url in integrations:
         if not url:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -7,8 +7,7 @@ optional dev tools. The user runs ``rapid-mlx doctor`` to answer one question
 — "is my install/env broken?" — so every probe must:
 
 * run in well under a second (no model load, no engine init, no server boot);
-* never escalate to sudo; only read the documented cache, shell, and supported
-  agent-integration config paths needed to diagnose the user's setup;
+* never escalate to sudo or read user data outside ``~/.cache/huggingface``;
 * report a deterministic status (✓ / ⚠ / ✗) with a one-line label.
 
 Total wall-clock for ``rapid-mlx doctor`` ≤ 5 s on a warm cache, dominated by
@@ -21,7 +20,6 @@ Tests in ``tests/test_doctor_env_health.py`` cover each section's probe.
 
 from __future__ import annotations
 
-import http.client
 import importlib.metadata as _im
 import importlib.util as _iu
 import json
@@ -29,10 +27,9 @@ import os
 import platform
 import plistlib
 import shutil
+import socket
 import subprocess
 import sys
-import threading
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -40,7 +37,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -126,8 +122,6 @@ OPTIONAL_PACKAGES: list[tuple[str, str, str]] = [
         "pip install 'rapid-mlx[embeddings]'",
     ),
 ]
-
-_AGENT_CONFIG_MAX_BYTES = 1024 * 1024
 
 # ``find_spec`` checks discoverability without importing heavyweight audio
 # packages such as scipy, numba, and spaCy.  Keep this aligned with the
@@ -1246,50 +1240,12 @@ def section_optional_tools(
 # ---------------------------------------------------------------------------
 
 
-def _configured_agent_urls(
-    home: Path,
-) -> list[tuple[str, Path, str | None, str | None]]:
-    """Return configured Rapid-MLX endpoints from supported agent clients.
-
-    Missing files are intentionally omitted: agent integrations are optional,
-    and installing Rapid-MLX must not make ``doctor`` warn about clients the
-    user has never used.
-    """
-    candidates: list[
-        tuple[str, Path, Callable[[dict[str, Any]], tuple[str | None, str | None]]]
-    ] = [
-        (
-            "Claude Code",
-            home / ".claude/settings.json",
-            lambda data: (
-                (
-                    data.get("env", {}).get("ANTHROPIC_BASE_URL"),
-                    data.get("env", {}).get("ANTHROPIC_API_KEY"),
-                )
-                if isinstance(data.get("env"), dict)
-                else (None, None)
-            ),
-        ),
-        (
-            "Continue.dev",
-            home / ".continue/config.json",
-            lambda data: (
-                next(
-                    (
-                        (entry.get("apiBase"), entry.get("apiKey"))
-                        for entry in data.get("models", [])
-                        if isinstance(entry, dict)
-                        and entry.get("title") == "rapid-mlx"
-                        and entry.get("provider") == "openai"
-                    ),
-                    (None, None),
-                )
-                if isinstance(data.get("models"), list)
-                else (None, None)
-            ),
-        ),
+def _agent_integrations(home: Path) -> list[tuple[str, Path, str | None]]:
+    """Read the local endpoint selected by each supported agent client."""
+    configs = [
+        ("Claude Code", home / ".claude/settings.json"),
+        ("Continue.dev", home / ".continue/config.json"),
     ]
-
     cline_roots = (
         home / "Library/Application Support/Code/User/globalStorage",
         home / "Library/Application Support/Code - Insiders/User/globalStorage",
@@ -1298,210 +1254,93 @@ def _configured_agent_urls(
         home / ".config/Code - Insiders/User/globalStorage",
         home / ".config/VSCodium/User/globalStorage",
     )
-    for root in cline_roots:
-        path = root / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
-        if path.exists():
-            candidates.append(
-                (
-                    "Cline",
-                    path,
-                    lambda data: (
-                        (data.get("openAiBaseUrl"), data.get("openAiApiKey"))
-                        if data.get("apiProvider") == "openai"
-                        else (None, None)
-                    ),
-                )
-            )
+    configs.extend(
+        ("Cline", root / "saoudrizwan.claude-dev/settings/cline_mcp_settings.json")
+        for root in cline_roots
+    )
 
-    configured: list[tuple[str, Path, str | None, str | None]] = []
-    for name, path, extract in candidates:
+    integrations = []
+    for name, path in configs:
         if not path.is_file():
             continue
+        url = None
         try:
-            with path.open("rb") as config_file:
-                raw_config = config_file.read(_AGENT_CONFIG_MAX_BYTES + 1)
-            if len(raw_config) > _AGENT_CONFIG_MAX_BYTES:
-                configured.append((name, path, None, None))
-                continue
-            data = json.loads(raw_config)
-            url, api_key = extract(data) if isinstance(data, dict) else (None, None)
-            configured.append(
-                (
-                    name,
-                    path,
-                    url if isinstance(url, str) else None,
-                    api_key if isinstance(api_key, str) else None,
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if name == "Claude Code" and isinstance(data.get("env"), dict):
+                url = data["env"].get("ANTHROPIC_BASE_URL")
+            elif name == "Continue.dev" and isinstance(data.get("models"), list):
+                url = next(
+                    (
+                        model.get("apiBase")
+                        for model in data["models"]
+                        if isinstance(model, dict)
+                        and model.get("title") == "rapid-mlx"
+                        and model.get("provider") == "openai"
+                    ),
+                    None,
                 )
-            )
+            elif name == "Cline" and data.get("apiProvider") == "openai":
+                url = data.get("openAiBaseUrl")
         except (OSError, UnicodeError, json.JSONDecodeError):
-            configured.append((name, path, None, None))
-    return configured
+            pass
+        integrations.append((name, path, url if isinstance(url, str) else None))
+    return integrations
 
 
-class _NoAgentProbeRedirects(urllib.request.HTTPRedirectHandler):
-    """Keep configured API keys on the exact origin the user selected."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        return None
-
-
-def _agent_server_alive(
-    base_url: str,
+def _server_reachable(
+    url: str,
     *,
-    api_key: str | None = None,
-    open_url: Callable[..., Any] | None = None,
-    timeout: float = 0.5,
+    connect: Callable[..., object] = socket.create_connection,
 ) -> bool:
-    """Probe Rapid-MLX liveness, authenticating from the client config."""
-    try:
-        parsed = urllib.parse.urlsplit(base_url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            return False
-        path = parsed.path.rstrip("/")
-        if path.endswith("/v1"):
-            path = path[:-3]
-        host = parsed.hostname or ""
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        port = f":{parsed.port}" if parsed.port is not None else ""
-        health_url = urllib.parse.urlunsplit(
-            (parsed.scheme, host + port, path + "/healthz", "", "")
-        )
-        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-        request = urllib.request.Request(  # noqa: S310
-            health_url, headers=headers, method="GET"
-        )
-    except ValueError:
-        return False
-    opener = open_url
-    if opener is None:
-        opener = urllib.request.build_opener(_NoAgentProbeRedirects()).open
-    try:
-        with opener(request, timeout=timeout) as response:  # noqa: S310
-            if not 200 <= int(response.status) < 300:
-                return False
-            payload = json.loads(response.read(_AGENT_CONFIG_MAX_BYTES + 1))
-            if not isinstance(payload, dict):
-                return False
-            standard = (
-                payload.get("status") == "healthy"
-                and isinstance(payload.get("ready"), bool)
-                and isinstance(payload.get("model_loaded"), bool)
-            )
-            ddtree = (
-                payload.get("engine") == "ddtree"
-                and payload.get("status") in {"ok", "loading", "error"}
-                and isinstance(payload.get("ready"), bool)
-            )
-            dflash = (
-                payload.get("engine") == "dflash"
-                and payload.get("status") == "ok"
-                and payload.get("mode") == "single-user-serial"
-                and isinstance(payload.get("drafter"), str)
-            )
-            return standard or ddtree or dflash
-    except urllib.error.HTTPError:
-        # An auth challenge proves that *something* answered, but not that it
-        # was Rapid-MLX. Without a health payload the identity is unverifiable.
-        return False
-    except (
-        OSError,
-        TypeError,
-        UnicodeError,
-        http.client.HTTPException,
-        urllib.error.URLError,
-        ValueError,
-    ):
-        return False
-
-
-def _probe_agent_urls(
-    endpoints: list[tuple[str, str | None]],
-    *,
-    open_url: Callable[..., Any] | None = None,
-    deadline: float = 0.75,
-) -> dict[tuple[str, str | None], bool]:
-    """Probe endpoints concurrently without ever waiting past ``deadline``.
-
-    ``urlopen(timeout=...)`` does not cover DNS resolution on every platform.
-    Daemon workers let the short-lived doctor process return its diagnosis even
-    if libc's resolver remains blocked. Late results only mutate this function's
-    private dictionary and are discarded.
-    """
-    unique_endpoints = list(dict.fromkeys(endpoints))
-    results: dict[tuple[str, str | None], bool] = {}
-    lock = threading.Lock()
-
-    def probe(endpoint: tuple[str, str | None]) -> None:
-        url, api_key = endpoint
-        alive = _agent_server_alive(url, api_key=api_key, open_url=open_url)
-        with lock:
-            results[endpoint] = alive
-
-    workers = [
-        threading.Thread(target=probe, args=(endpoint,), daemon=True)
-        for endpoint in unique_endpoints
-    ]
-    expires = time.monotonic() + deadline
-    for worker in workers:
-        worker.start()
-    for worker in workers:
-        worker.join(timeout=max(0.0, expires - time.monotonic()))
-
-    with lock:
-        return {endpoint: results.get(endpoint, False) for endpoint in unique_endpoints}
-
-
-def _redacted_server_url(url: str) -> str:
-    """Render an endpoint without credentials, query values, or fragments."""
+    """Perform a short TCP reachability check; do not interpret engine APIs."""
     try:
         parsed = urllib.parse.urlsplit(url)
-        host = parsed.hostname or ""
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        port = f":{parsed.port}" if parsed.port is not None else ""
-        return urllib.parse.urlunsplit(
-            (parsed.scheme, host + port, parsed.path, "", "")
-        )
-    except ValueError:
-        return "<invalid URL>"
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return False
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        connection = connect((parsed.hostname, port), timeout=0.25)
+        close = getattr(connection, "close", None)
+        if close:
+            close()
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def section_agent_integrations(
     *,
     home: Path | None = None,
-    open_url: Callable[..., Any] | None = None,
+    connect: Callable[..., object] = socket.create_connection,
 ) -> Section:
-    """Show configured IDE/agent clients and verify their target is alive."""
-    s = Section("Agent Integrations")
-    integrations = _configured_agent_urls(home or Path.home())
+    """Report whether installed agent configs point to a reachable server."""
+    section = Section("Agent Integrations")
+    integrations = _agent_integrations(home or Path.home())
     if not integrations:
-        s.add("No Claude Code, Cline, or Continue.dev config found", CheckStatus.OK)
-        return s
+        section.add(
+            "No Claude Code, Cline, or Continue.dev config found", CheckStatus.OK
+        )
+        return section
 
-    endpoints = [(url, api_key) for _, _, url, api_key in integrations if url]
-    alive_by_endpoint = _probe_agent_urls(endpoints, open_url=open_url)
-
-    for name, path, url, api_key in integrations:
+    for name, path, url in integrations:
         if not url:
-            s.add(
-                f"{name} config found, but no Rapid-MLX server is configured",
+            section.add(
+                f"{name} config found, but Rapid-MLX is not configured",
                 CheckStatus.WARN,
                 detail=f"path={path}",
             )
-        elif alive_by_endpoint[(url, api_key)]:
-            s.add(
-                f"{name} config points to a live server",
+        elif _server_reachable(url, connect=connect):
+            section.add(
+                f"{name} server is reachable",
                 CheckStatus.OK,
-                detail=f"path={path} server={_redacted_server_url(url)}",
+                detail=f"path={path}",
             )
         else:
-            s.add(
-                f"{name} config server could not be verified as Rapid-MLX",
+            section.add(
+                f"{name} server is not reachable",
                 CheckStatus.WARN,
-                detail=f"path={path} server={_redacted_server_url(url)}",
+                detail=f"path={path}",
             )
-    return s
+    return section
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1357,7 +1357,13 @@ def _agent_server_alive(
                 and payload.get("status") in {"ok", "loading", "error"}
                 and isinstance(payload.get("ready"), bool)
             )
-            return standard or ddtree
+            dflash = (
+                payload.get("engine") == "dflash"
+                and payload.get("status") == "ok"
+                and payload.get("mode") == "single-user-serial"
+                and isinstance(payload.get("drafter"), str)
+            )
+            return standard or ddtree or dflash
     except urllib.error.HTTPError:
         # An auth challenge proves that *something* answered, but not that it
         # was Rapid-MLX. Without a health payload the identity is unverifiable.

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1246,21 +1246,28 @@ def section_optional_tools(
 # ---------------------------------------------------------------------------
 
 
-def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
+def _configured_agent_urls(
+    home: Path,
+) -> list[tuple[str, Path, str | None, str | None]]:
     """Return configured Rapid-MLX endpoints from supported agent clients.
 
     Missing files are intentionally omitted: agent integrations are optional,
     and installing Rapid-MLX must not make ``doctor`` warn about clients the
     user has never used.
     """
-    candidates: list[tuple[str, Path, Callable[[dict[str, Any]], str | None]]] = [
+    candidates: list[
+        tuple[str, Path, Callable[[dict[str, Any]], tuple[str | None, str | None]]]
+    ] = [
         (
             "Claude Code",
             home / ".claude/settings.json",
             lambda data: (
-                data.get("env", {}).get("ANTHROPIC_BASE_URL")
+                (
+                    data.get("env", {}).get("ANTHROPIC_BASE_URL"),
+                    data.get("env", {}).get("ANTHROPIC_API_KEY"),
+                )
                 if isinstance(data.get("env"), dict)
-                else None
+                else (None, None)
             ),
         ),
         (
@@ -1269,16 +1276,16 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
             lambda data: (
                 next(
                     (
-                        entry.get("apiBase")
+                        (entry.get("apiBase"), entry.get("apiKey"))
                         for entry in data.get("models", [])
                         if isinstance(entry, dict)
                         and entry.get("title") == "rapid-mlx"
                         and entry.get("provider") == "openai"
                     ),
-                    None,
+                    (None, None),
                 )
                 if isinstance(data.get("models"), list)
-                else None
+                else (None, None)
             ),
         ),
     ]
@@ -1299,36 +1306,44 @@ def _configured_agent_urls(home: Path) -> list[tuple[str, Path, str | None]]:
                     "Cline",
                     path,
                     lambda data: (
-                        data.get("openAiBaseUrl")
+                        (data.get("openAiBaseUrl"), data.get("openAiApiKey"))
                         if data.get("apiProvider") == "openai"
-                        else None
+                        else (None, None)
                     ),
                 )
             )
 
-    configured: list[tuple[str, Path, str | None]] = []
+    configured: list[tuple[str, Path, str | None, str | None]] = []
     for name, path, extract in candidates:
         if not path.is_file():
             continue
         try:
             if path.stat().st_size > _AGENT_CONFIG_MAX_BYTES:
-                configured.append((name, path, None))
+                configured.append((name, path, None, None))
                 continue
             data = json.loads(path.read_text(encoding="utf-8"))
-            url = extract(data) if isinstance(data, dict) else None
-            configured.append((name, path, url if isinstance(url, str) else None))
+            url, api_key = extract(data) if isinstance(data, dict) else (None, None)
+            configured.append(
+                (
+                    name,
+                    path,
+                    url if isinstance(url, str) else None,
+                    api_key if isinstance(api_key, str) else None,
+                )
+            )
         except (OSError, UnicodeError, json.JSONDecodeError):
-            configured.append((name, path, None))
+            configured.append((name, path, None, None))
     return configured
 
 
 def _agent_server_alive(
     base_url: str,
     *,
+    api_key: str | None = None,
     open_url: Callable[..., Any] | None = None,
     timeout: float = 0.5,
 ) -> bool:
-    """Probe the unauthenticated Rapid-MLX liveness endpoint."""
+    """Probe Rapid-MLX liveness, authenticating from the client config."""
     root = base_url.rstrip("/")
     if root.endswith("/v1"):
         root = root[:-3]
@@ -1336,7 +1351,10 @@ def _agent_server_alive(
         parsed = urllib.parse.urlsplit(root)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             return False
-        request = urllib.request.Request(root + "/healthz", method="GET")  # noqa: S310
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        request = urllib.request.Request(  # noqa: S310
+            root + "/healthz", headers=headers, method="GET"
+        )
     except ValueError:
         return False
     opener = open_url or urllib.request.urlopen
@@ -1379,11 +1397,11 @@ def _agent_server_alive(
 
 
 def _probe_agent_urls(
-    urls: list[str],
+    endpoints: list[tuple[str, str | None]],
     *,
     open_url: Callable[..., Any] | None = None,
     deadline: float = 0.75,
-) -> dict[str, bool]:
+) -> dict[tuple[str, str | None], bool]:
     """Probe endpoints concurrently without ever waiting past ``deadline``.
 
     ``urlopen(timeout=...)`` does not cover DNS resolution on every platform.
@@ -1391,17 +1409,19 @@ def _probe_agent_urls(
     if libc's resolver remains blocked. Late results only mutate this function's
     private dictionary and are discarded.
     """
-    unique_urls = list(dict.fromkeys(urls))
-    results: dict[str, bool] = {}
+    unique_endpoints = list(dict.fromkeys(endpoints))
+    results: dict[tuple[str, str | None], bool] = {}
     lock = threading.Lock()
 
-    def probe(url: str) -> None:
-        alive = _agent_server_alive(url, open_url=open_url)
+    def probe(endpoint: tuple[str, str | None]) -> None:
+        url, api_key = endpoint
+        alive = _agent_server_alive(url, api_key=api_key, open_url=open_url)
         with lock:
-            results[url] = alive
+            results[endpoint] = alive
 
     workers = [
-        threading.Thread(target=probe, args=(url,), daemon=True) for url in unique_urls
+        threading.Thread(target=probe, args=(endpoint,), daemon=True)
+        for endpoint in unique_endpoints
     ]
     expires = time.monotonic() + deadline
     for worker in workers:
@@ -1410,7 +1430,7 @@ def _probe_agent_urls(
         worker.join(timeout=max(0.0, expires - time.monotonic()))
 
     with lock:
-        return {url: results.get(url, False) for url in unique_urls}
+        return {endpoint: results.get(endpoint, False) for endpoint in unique_endpoints}
 
 
 def _redacted_server_url(url: str) -> str:
@@ -1440,17 +1460,17 @@ def section_agent_integrations(
         s.add("No Claude Code, Cline, or Continue.dev config found", CheckStatus.OK)
         return s
 
-    urls = [url for _, _, url in integrations if url]
-    alive_by_url = _probe_agent_urls(urls, open_url=open_url)
+    endpoints = [(url, api_key) for _, _, url, api_key in integrations if url]
+    alive_by_endpoint = _probe_agent_urls(endpoints, open_url=open_url)
 
-    for name, path, url in integrations:
+    for name, path, url, api_key in integrations:
         if not url:
             s.add(
                 f"{name} config found, but no Rapid-MLX server is configured",
                 CheckStatus.WARN,
                 detail=f"path={path}",
             )
-        elif alive_by_url[url]:
+        elif alive_by_endpoint[(url, api_key)]:
             s.add(
                 f"{name} config points to a live server",
                 CheckStatus.OK,

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1342,11 +1342,26 @@ def _agent_server_alive(
     opener = open_url or urllib.request.urlopen
     try:
         with opener(request, timeout=timeout) as response:  # noqa: S310
-            return 200 <= int(response.status) < 300
-    except urllib.error.HTTPError as error:
-        # Authentication proves that a server answered. Some supported
-        # serving modes intentionally protect even their health endpoint.
-        return error.code in {401, 403}
+            if not 200 <= int(response.status) < 300:
+                return False
+            payload = json.loads(response.read(_AGENT_CONFIG_MAX_BYTES + 1))
+            if not isinstance(payload, dict):
+                return False
+            standard = (
+                payload.get("status") == "healthy"
+                and isinstance(payload.get("ready"), bool)
+                and isinstance(payload.get("model_loaded"), bool)
+            )
+            ddtree = (
+                payload.get("engine") == "ddtree"
+                and payload.get("status") in {"ok", "loading", "error"}
+                and isinstance(payload.get("ready"), bool)
+            )
+            return standard or ddtree
+    except urllib.error.HTTPError:
+        # An auth challenge proves that *something* answered, but not that it
+        # was Rapid-MLX. Without a health payload the identity is unverifiable.
+        return False
     except (
         OSError,
         TypeError,
@@ -1437,7 +1452,7 @@ def section_agent_integrations(
             )
         else:
             s.add(
-                f"{name} config points to a server that is not responding",
+                f"{name} config server could not be verified as Rapid-MLX",
                 CheckStatus.WARN,
                 detail=f"path={path} server={_redacted_server_url(url)}",
             )


### PR DESCRIPTION
## Summary
- teach `rapid-mlx doctor` to discover configured Claude Code, Cline, and Continue.dev clients and perform a short TCP reachability check against their selected endpoint
- keep absent optional clients quiet while warning on malformed/inactive configuration or an unreachable configured server
- expose a release-safe Settings → App → Run setup again action that preserves preferences, conversations, downloaded models, and telemetry consent

## Deliberate scope / review contract
This is a small diagnostic utility, not a server identity, protocol-health, or security subsystem.

- “server alive” intentionally means “the configured host and port accept a TCP connection within 250 ms”
- do not require HTTP health-payload validation, engine-specific schemas, API-key handling, redirect policy, concurrent probe orchestration, or hostile/racing multi-megabyte config defenses
- review for correctness within this contract, ordinary malformed/missing config handling, regressions, and whether the two user-facing features remain narrowly implemented
- recommend scope expansion only for a concrete high-severity regression in normal supported use

## Validation
- `ruff check vllm_mlx/doctor/env_health.py tests/test_doctor_env_health.py`
- `.venv/bin/python -m pytest -q tests/test_doctor_env_health.py` (65 passed)
- `swift test --package-path apps/rapid-mac --filter ReonboardingResetTests` (10 passed)
- `swift build --package-path apps/rapid-mac -c release`
