### PR TITLE
test(mac): remove full-suite timing flakes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -36,6 +36,9 @@ struct ChatStreamClient {
     /// ``Self.loopbackURL(port:)`` so a PortAllocator fallback off
     /// the default port still reaches the live child.
     var baseURL: URL
+    /// Injectable monotonic time source keeps integration tests independent
+    /// of host scheduling while production continues to use ContinuousClock.
+    let now: @Sendable () -> ContinuousClock.Instant
 
     /// Per-request INACTIVITY deadline — the max time we wait for the
     /// *next* byte from the server, reset every time data arrives (this
@@ -366,10 +369,12 @@ struct ChatStreamClient {
 
     init(
         baseURL: URL = ChatStreamClient.defaultBaseURL,
-        session: URLSession? = nil
+        session: URLSession? = nil,
+        now: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now }
     ) {
         self.baseURL = baseURL
         self.injectedSession = session
+        self.now = now
     }
 
     /// Open a streaming chat completion. ``onEvent`` is called on the
@@ -602,7 +607,7 @@ struct ChatStreamClient {
                         // shrinking the decode window and inflating the rate:
                         // the same direction of error, from the same cause,
                         // that this event was added to remove.
-                        let at = ContinuousClock.now
+                        let at = now()
                         await MainActor.run { onEvent(.firstToken(at)) }
                     }
                     if let r = delta.reasoning_content, !r.isEmpty {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -2641,7 +2641,7 @@ Your previous draft refused the question by claiming you lack real-time access o
         // may have been inserted seconds ago by the tool-call
         // loop (between rounds), and the user reads "elapsed
         // time" as "time the model spent on THIS round."
-        let streamStart = ContinuousClock.now
+        let streamStart = client.now()
         // #478: VoiceOver live-region feedback. Streaming replies are
         // otherwise silent to a screen-reader user — no start / progress
         // / completion signal. ``AssistantStreamAnnouncer`` is the pure,
@@ -2921,7 +2921,7 @@ Your previous draft refused the question by claiming you lack real-time access o
         // crashed mid-stream "produced" 1.7 s and 41 chars but
         // that's noise, not throughput).
         if current.status == .complete && !current.content.isEmpty {
-            let elapsed = streamStart.duration(to: .now).seconds
+            let elapsed = streamStart.duration(to: client.now()).seconds
             current.stats = MessageStats(
                 elapsedSeconds: elapsed,
                 charCount: current.content.count,

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -183,6 +183,7 @@ final class DownloadManager {
 
     private var binaryPath: URL?
     private let resolvesBinaryAtStart: Bool
+    private let binaryLocator: () -> URL?
     private var shutdownSignalledAt: Date?
 
     private var processes: [String: Process] = [:]
@@ -213,9 +214,10 @@ final class DownloadManager {
 
     // MARK: - Construction
 
-    init(binaryPath: URL?) {
+    init(binaryPath: URL?, binaryLocator: @escaping () -> URL? = ServerLocator.find) {
         self.binaryPath = binaryPath
         self.resolvesBinaryAtStart = true
+        self.binaryLocator = binaryLocator
     }
 
     /// Internal test seam. Lets ``RapidTests`` drive the state
@@ -225,6 +227,7 @@ final class DownloadManager {
     internal init() {
         self.binaryPath = nil
         self.resolvesBinaryAtStart = false
+        self.binaryLocator = { nil }
     }
 
     // MARK: - Public API
@@ -313,7 +316,8 @@ final class DownloadManager {
         if isDownloading(trimmed) { return false }
         let binaryResolution = Self.resolveBinaryForStart(
             cached: binaryPath,
-            shouldRelocate: resolvesBinaryAtStart
+            shouldRelocate: resolvesBinaryAtStart,
+            locate: binaryLocator
         )
         guard case .resolved(let binary, let changed) = binaryResolution else {
             // Record a synthetic failed job so the picker UI can

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -184,6 +184,7 @@ final class DownloadManager {
     private var binaryPath: URL?
     private let resolvesBinaryAtStart: Bool
     private let binaryLocator: () -> URL?
+    private let settlementSleep: @MainActor () async throws -> Void
     private var shutdownSignalledAt: Date?
 
     private var processes: [String: Process] = [:]
@@ -218,16 +219,24 @@ final class DownloadManager {
         self.binaryPath = binaryPath
         self.resolvesBinaryAtStart = true
         self.binaryLocator = binaryLocator
+        self.settlementSleep = {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
     }
 
     /// Internal test seam. Lets ``RapidTests`` drive the state
     /// machine without spawning a real subprocess: callers seed a
     /// job, ingest synthetic tqdm lines via ``_testingIngest``, and
     /// finalize via ``_testingFinish``.
-    internal init() {
+    internal init(
+        settlementSleep: @escaping @MainActor () async throws -> Void = {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+    ) {
         self.binaryPath = nil
         self.resolvesBinaryAtStart = false
         self.binaryLocator = { nil }
+        self.settlementSleep = settlementSleep
     }
 
     // MARK: - Public API
@@ -273,7 +282,7 @@ final class DownloadManager {
         guard !trimmed.isEmpty else { return }
         while isDownloading(trimmed) {
             do {
-                try await Task.sleep(nanoseconds: 250_000_000)
+                try await settlementSleep()
             } catch {
                 // Task cancellation — bail instead of busy-looping on a
                 // sleep that throws immediately every iteration.

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -25,46 +25,6 @@ struct DownloadManagerTests {
         return predicate()
     }
 
-    /// Synchronous env mutation helper.
-    ///
-    /// ``setenv`` mutates a **process-global** singleton. The full
-    /// ``swift test`` run schedules many ``@MainActor`` tests onto
-    /// the same actor; whenever the host test ``await``s during the
-    /// mutation window, the main actor is free to pick up an unrelated
-    /// ``@MainActor`` test that reads ``RAPID_BIN`` via
-    /// ``DownloadManager.resolveBinaryForStart`` — and it sees our
-    /// override instead of its own real binary. That spawned the
-    /// pre-fix flake where ``startDownloadUsesRefreshedBinaryPath`` and
-    /// ``cancelDuringRealPull`` corrupted each other's process spawns
-    /// only in the full suite (979 tests / 2 fail) but passed when run
-    /// in isolation or in the paired
-    /// ``DownloadManagerTests|DownloadManagerIntegrationTests`` filter.
-    ///
-    /// Keeping the helper synchronous + non-throwing pins the env
-    /// mutation to a single main-actor scheduling slot — no ``await``
-    /// inside means no opportunity for an unrelated test to slip in.
-    /// The body must be sync; if a test needs to ``await`` after the
-    /// env-sensitive call, it should do so *outside* this helper, since
-    /// once a sync ``Process.run()`` returns macOS has already captured
-    /// the spawned child's environment block and the parent process
-    /// env can be safely restored.
-    private func withEnvironmentValueSync<T>(
-        _ key: String,
-        _ value: String,
-        run body: () -> T
-    ) -> T {
-        let previous = getenv(key).map { String(cString: $0) }
-        setenv(key, value, 1)
-        defer {
-            if let previous {
-                setenv(key, previous, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-        return body()
-    }
-
     private func writeFakeRapidMLX(
         at binary: URL,
         marker: URL
@@ -134,23 +94,12 @@ struct DownloadManagerTests {
         let marker = root.appendingPathComponent("invocation.txt")
         try writeFakeRapidMLX(at: fresh, marker: marker)
 
-        // Keep ``RAPID_BIN`` overridden only across the synchronous
-        // ``startDownload`` window. ``Process.run()`` captures the
-        // child's environment at spawn time (see ``DownloadManager``
-        // line 196: ``process.environment = augmentedEnv(for: binary)``)
-        // so the fake script's invocation is locked in by the time
-        // ``startDownload`` returns. Releasing the env before the
-        // ``await waitUntil`` below stops the override from leaking
-        // into any concurrently scheduled ``@MainActor`` test that
-        // happens to read ``RAPID_BIN`` via the same
-        // ``resolveBinaryForStart`` code path. Pre-fix this leak
-        // overwrote the fake-script's marker with another test's
-        // ``pull qwen3-0.6b-8bit`` payload — see helper comment for
-        // the full diagnosis.
-        let mgr = DownloadManager(binaryPath: stale)
-        let started = withEnvironmentValueSync("RAPID_BIN", fresh.path) {
-            mgr.startDownload(alias: "fake-alias")
-        }
+        // Inject the resolver instead of mutating process-global RAPID_BIN.
+        // Parallel suites may resolve or override that environment variable
+        // concurrently, which made this deterministic unit test depend on
+        // unrelated full-suite scheduling.
+        let mgr = DownloadManager(binaryPath: stale, binaryLocator: { fresh })
+        let started = mgr.startDownload(alias: "fake-alias")
         #expect(started)
 
         let done = await waitUntil(deadline: Date().addingTimeInterval(5)) {

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerDownloadStaggerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerDownloadStaggerTests.swift
@@ -32,17 +32,21 @@ struct ServerManagerDownloadStaggerTests {
 
     @Test("awaitDownloadSettlement returns immediately when no job exists")
     func settlementNoOpsWithoutJob() async {
-        let downloads = DownloadManager()
+        let probe = SettlementSleepProbe()
+        let downloads = DownloadManager(settlementSleep: probe.sleep)
         await downloads.awaitDownloadSettlement(alias: alias)
+        #expect(probe.callCount == 0, "a settled alias must not enter the polling sleep")
         #expect(!downloads.isDownloading(alias))
     }
 
     @Test("awaitDownloadSettlement returns immediately when job already finished")
     func settlementNoOpsAfterTerminalStatus() async {
-        let downloads = DownloadManager()
+        let probe = SettlementSleepProbe()
+        let downloads = DownloadManager(settlementSleep: probe.sleep)
         _ = downloads._testingSeedJob(alias: alias)
         downloads._testingFinish(alias: alias, status: 0, reason: .exit)
         await downloads.awaitDownloadSettlement(alias: alias)
+        #expect(probe.callCount == 0, "a terminal job must not enter the polling sleep")
         #expect(!downloads.isDownloading(alias))
     }
 
@@ -112,20 +116,44 @@ struct ServerManagerDownloadStaggerTests {
         // becomes a tight MainActor busy-poll that freezes the UI
         // until the pull settles. The fix returns out of the loop on
         // cancellation so the start ``Task`` can unwind cleanly.
-        let downloads = DownloadManager()
+        let probe = SettlementSleepProbe()
+        let downloads = DownloadManager(settlementSleep: probe.sleep)
         _ = downloads._testingSeedJob(alias: alias)
         #expect(downloads.isDownloading(alias))
 
         let waiter = Task { @MainActor in
             await downloads.awaitDownloadSettlement(alias: alias)
         }
-        // Give the waiter at least one polling cycle before cancelling.
-        try? await Task.sleep(nanoseconds: 350_000_000)
+        // Synchronize on the exact polling boundary instead of guessing when
+        // a loaded runner has scheduled 350 ms of wall time.
+        await probe.waitUntilEntered()
         waiter.cancel()
         await waiter.value
         // The deterministic signal is that the wait returned while the job
         // is STILL running: it exited via cancellation, not settlement. A
         // sub-second wall-clock bound only measures parallel runner load.
+        #expect(probe.callCount == 1, "cancellation must not re-enter the polling loop")
         #expect(downloads.isDownloading(alias))
+    }
+}
+
+@MainActor
+private final class SettlementSleepProbe {
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var callCount = 0
+
+    func waitUntilEntered() async {
+        if callCount > 0 { return }
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func sleep() async throws {
+        callCount += 1
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        try await Task.sleep(for: .seconds(60))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerDownloadStaggerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerDownloadStaggerTests.swift
@@ -33,11 +33,8 @@ struct ServerManagerDownloadStaggerTests {
     @Test("awaitDownloadSettlement returns immediately when no job exists")
     func settlementNoOpsWithoutJob() async {
         let downloads = DownloadManager()
-        let t0 = Date()
         await downloads.awaitDownloadSettlement(alias: alias)
-        let elapsed = Date().timeIntervalSince(t0)
-        // Must not even hit the 250 ms polling cadence.
-        #expect(elapsed < 0.25)
+        #expect(!downloads.isDownloading(alias))
     }
 
     @Test("awaitDownloadSettlement returns immediately when job already finished")
@@ -45,10 +42,8 @@ struct ServerManagerDownloadStaggerTests {
         let downloads = DownloadManager()
         _ = downloads._testingSeedJob(alias: alias)
         downloads._testingFinish(alias: alias, status: 0, reason: .exit)
-        let t0 = Date()
         await downloads.awaitDownloadSettlement(alias: alias)
-        let elapsed = Date().timeIntervalSince(t0)
-        #expect(elapsed < 0.25)
+        #expect(!downloads.isDownloading(alias))
     }
 
     @Test("awaitDownloadSettlement suspends while running, returns after .completed")
@@ -126,15 +121,11 @@ struct ServerManagerDownloadStaggerTests {
         }
         // Give the waiter at least one polling cycle before cancelling.
         try? await Task.sleep(nanoseconds: 350_000_000)
-        let t0 = Date()
         waiter.cancel()
         await waiter.value
-        let elapsed = Date().timeIntervalSince(t0)
-        // The real signal is that ``isDownloading`` is STILL true
-        // after the wait returns — we exited via cancellation rather
-        // than via settlement. ``elapsed`` should be small (~zero)
-        // because ``Task.sleep`` throws immediately on cancel.
-        #expect(elapsed < 0.5)
+        // The deterministic signal is that the wait returned while the job
+        // is STILL running: it exited via cancellation, not settlement. A
+        // sub-second wall-clock bound only measures parallel runner load.
         #expect(downloads.isDownloading(alias))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ThroughputCaptionIntegrationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ThroughputCaptionIntegrationTests.swift
@@ -22,11 +22,18 @@ struct ThroughputCaptionIntegrationTests {
     /// 8 tokens, and the caption divided by the whole turn.
     @Test("The persisted stats separate prefill from decode on a real stream")
     func streamRecordsTimeToFirstToken() async throws {
-        PrefillHeavyProtocol.reset(prefillDelay: 0.45, contentDeltas: 12, completionTokens: 12)
+        let clock = TestStreamClock()
+        PrefillHeavyProtocol.reset(
+            prefillDelay: 0.45,
+            contentDeltas: 12,
+            completionTokens: 12,
+            clock: clock
+        )
         let model = ChatViewModel(
             client: ChatStreamClient(
                 baseURL: URL(string: "fake://prefill")!,
-                session: PrefillHeavyProtocol.session()
+                session: PrefillHeavyProtocol.session(),
+                now: clock.now
             ),
             persistsConversations: false
         )
@@ -48,7 +55,8 @@ struct ThroughputCaptionIntegrationTests {
 
         // 2. It measured the prefill, not something incidental. The fake
         //    holds the response for 0.45 s before the first delta.
-        #expect(ttft >= 0.4, "TTFT \(ttft)s is below the 0.45s the transport withheld the first token for")
+        #expect(abs(ttft - 0.45) < 0.000_001,
+                "TTFT must use the fixture's deterministic prefill interval")
         #expect(ttft < stats.elapsedSeconds, "TTFT must fall inside the turn it describes")
 
         // 3. The reported rate uses the decode window. The whole-turn
@@ -67,11 +75,18 @@ struct ThroughputCaptionIntegrationTests {
     /// It must not resurrect the whole-turn denominator either.
     @Test("A server that reports no usage still separates prefill from decode")
     func estimateAlsoExcludesPrefill() async throws {
-        PrefillHeavyProtocol.reset(prefillDelay: 0.45, contentDeltas: 12, completionTokens: nil)
+        let clock = TestStreamClock()
+        PrefillHeavyProtocol.reset(
+            prefillDelay: 0.45,
+            contentDeltas: 12,
+            completionTokens: nil,
+            clock: clock
+        )
         let model = ChatViewModel(
             client: ChatStreamClient(
                 baseURL: URL(string: "fake://prefill")!,
-                session: PrefillHeavyProtocol.session()
+                session: PrefillHeavyProtocol.session(),
+                now: clock.now
             ),
             persistsConversations: false
         )
@@ -84,7 +99,7 @@ struct ThroughputCaptionIntegrationTests {
         let stats = try #require(model.messages.last?.stats)
         #expect(stats.completionTokens == nil, "fixture must not report usage for this case")
         let ttft = try #require(stats.timeToFirstTokenSeconds)
-        #expect(ttft >= 0.4)
+        #expect(abs(ttft - 0.45) < 0.000_001)
 
         let estimate = try #require(stats.estimatedTokensPerSecond)
         let wholeTurnEstimate = (Double(stats.charCount) / 4.0) / stats.elapsedSeconds
@@ -256,6 +271,36 @@ private final class InstantBox {
     var value: ContinuousClock.Instant?
 }
 
+/// A lock-protected monotonic clock shared by the fake transport and client.
+/// Advancing virtual time at SSE boundaries tests the timestamp plumbing,
+/// without asking an overloaded test runner to wake within a narrow window.
+private final class TestStreamClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = ContinuousClock.now
+    private var reads = 0
+    private let firstTokenSampled = DispatchSemaphore(value: 0)
+
+    func now() -> ContinuousClock.Instant {
+        lock.withLock {
+            reads += 1
+            // Read one is ChatViewModel's stream start; read two is the SSE
+            // parser sampling its first generated delta.
+            if reads == 2 { firstTokenSampled.signal() }
+            return instant
+        }
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.withLock {
+            instant = instant.advanced(by: .seconds(seconds))
+        }
+    }
+
+    func waitUntilFirstTokenIsSampled() -> Bool {
+        firstTokenSampled.wait(timeout: .now() + 5) == .success
+    }
+}
+
 /// Occupies the main actor for real, rather than yielding it: waits for the
 /// transport to signal that the stream has begun, then holds the actor for a
 /// fixed window.
@@ -376,17 +421,20 @@ private final class PrefillHeavyProtocol: URLProtocol, @unchecked Sendable {
     /// timed window knowing the stream is genuinely underway rather than
     /// merely enqueued.
     nonisolated(unsafe) static var loadingStarted = DispatchSemaphore(value: 0)
+    nonisolated(unsafe) static var clock: TestStreamClock?
 
     static func reset(
         prefillDelay: TimeInterval,
         decodeWindow: TimeInterval = 0.25,
         contentDeltas: Int,
-        completionTokens: Int?
+        completionTokens: Int?,
+        clock: TestStreamClock? = nil
     ) {
         Self.prefillDelay = prefillDelay
         Self.decodeWindow = decodeWindow
         Self.contentDeltas = contentDeltas
         Self.completionTokens = completionTokens
+        Self.clock = clock
         Self.loadingStarted = DispatchSemaphore(value: 0)
     }
 
@@ -411,7 +459,11 @@ private final class PrefillHeavyProtocol: URLProtocol, @unchecked Sendable {
 
         // The prefill. Nothing reaches the view model during this window, so
         // a correctly-wired TTFT lands at or after it.
-        Thread.sleep(forTimeInterval: Self.prefillDelay)
+        if let clock = Self.clock {
+            clock.advance(by: Self.prefillDelay)
+        } else {
+            Thread.sleep(forTimeInterval: Self.prefillDelay)
+        }
 
         // First token, then a deliberate decode window. Emitting every
         // delta back-to-back would leave a decode window of microseconds,
@@ -420,7 +472,17 @@ private final class PrefillHeavyProtocol: URLProtocol, @unchecked Sendable {
         // runner and pass on a slow one, for reasons having nothing to do
         // with the code under test. The window is staged, not hoped for.
         emit("data: {\"choices\":[{\"delta\":{\"content\":\"word \"}}]}\n\n")
-        Thread.sleep(forTimeInterval: Self.decodeWindow)
+        if let clock = Self.clock {
+            guard clock.waitUntilFirstTokenIsSampled() else {
+                client?.urlProtocol(self, didFailWithError: URLError(.timedOut))
+                return
+            }
+        }
+        if let clock = Self.clock {
+            clock.advance(by: Self.decodeWindow)
+        } else {
+            Thread.sleep(forTimeInterval: Self.decodeWindow)
+        }
 
         for _ in 1..<Self.contentDeltas {
             emit("data: {\"choices\":[{\"delta\":{\"content\":\"word \"}}]}\n\n")


### PR DESCRIPTION
## Summary
- inject the download binary resolver instead of mutating process-global `RAPID_BIN` in the unit test
- replace sub-second settlement assertions with deterministic state assertions
- drive throughput integration timing with an injected monotonic test clock

## Verification
- `swift test --filter 'DownloadManagerTests|ServerManagerDownloadStaggerTests|ThroughputCaptionIntegrationTests'` (46 passed)\n- `swift test` (2,741 passed)\n\nCloses #2237