### PR TITLE
feat(mac): add `Copy API endpoint` to the tray menu

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
@@ -57,6 +57,23 @@ final class MenuBarController: NSObject {
         AppDelegate.shared.updater?.availableUpdate != nil
     }
 
+    /// The running server's OpenAI-style base URL, or `nil` when the
+    /// backend is not ready to serve.
+    ///
+    /// The API port is NOT pinned (it sweeps 8000–8009 — see
+    /// ``ConnectToolsView``), so the URL must be read from the live
+    /// ``ServerManager`` rather than hardcoded. Only a `.ready` backend
+    /// has a meaningful URL; in any other lifecycle state there is
+    /// nothing worth copying to the clipboard.
+    private static func apiBaseURL() -> String? {
+        guard let server = AppDelegate.shared.server,
+              case .ready = server.state
+        else {
+            return nil
+        }
+        return "http://\(server.host):\(server.activePort)/v1"
+    }
+
     private func configureButton() {
         guard let button = statusItem.button else { return }
         button.image = Self.trayGlyph()
@@ -130,7 +147,8 @@ final class MenuBarController: NSObject {
             state: AppDelegate.shared.server?.state ?? .idle,
             hasUpdate: Self.hasAvailableUpdate(),
             updateVersion: AppDelegate.shared.updater?.availableUpdate?.version ?? "",
-            checking: AppDelegate.shared.updater?.checking ?? false
+            checking: AppDelegate.shared.updater?.checking ?? false,
+            baseURL: Self.apiBaseURL()
         ) {
             switch item {
             case .separator:
@@ -218,6 +236,14 @@ final class MenuBarController: NSObject {
             Task { _ = await AppDelegate.shared.updater?.check() }
             NSApp.activate(ignoringOtherApps: true)
             AppDelegate.openSettingsWindowAt?(.app)
+        case .copyEndpoint:
+            guard let url = Self.apiBaseURL() else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(url, forType: .string)
+            // Transient "Copied ✓" feedback. The menu rebuilds on every
+            // open (``menuNeedsUpdate``), so this label self-heals back
+            // to "Copy API endpoint" next time without a timer.
+            sender.title = "Copied ✓"
         case .about:
             if let server = AppDelegate.shared.server {
                 AboutPanel.show(server: server)

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarStatus.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarStatus.swift
@@ -56,6 +56,7 @@ enum MenuBarStatus {
     enum MenuBarAction: Int, Equatable {
         case open
         case newChat
+        case copyEndpoint
         case update
         case checkForUpdates
         case about
@@ -88,7 +89,8 @@ enum MenuBarStatus {
 
     /// The full, ordered tray menu given the live inputs. This is the
     /// single source of truth for the menu's structure and its dynamic
-    /// branches (the update row only appears when one is available;
+    /// branches (the "Copy API endpoint" row only appears while the
+    /// backend is serving, the update row only when one is available;
     /// "Check for updates…" is disabled mid-check).
     /// ``MenuBarController.rebuildMenu`` renders exactly this list, so a
     /// test against it pins the real menu.
@@ -96,7 +98,8 @@ enum MenuBarStatus {
         state: ServerState,
         hasUpdate: Bool,
         updateVersion: String,
-        checking: Bool
+        checking: Bool,
+        baseURL: String?
     ) -> [MenuBarItem] {
         var items: [MenuBarItem] = [
             .button(.open, title: "Open Rapid-MLX", enabled: true, shortcut: nil),
@@ -108,8 +111,24 @@ enum MenuBarStatus {
             ),
             .separator,
             .status(statusLine(state: state)),
-            .separator,
         ]
+
+        // Serve-type users live in the tray and never open the main
+        // window; their highest-frequency action is copying the API
+        // endpoint into their own agent/script. Only render the row when
+        // the server is actually serving on a known host:port — otherwise
+        // it would be a dead click for a user whose backend isn't up yet.
+        if let baseURL {
+            items.append(
+                .button(
+                    .copyEndpoint,
+                    title: "Copy API endpoint",
+                    enabled: true,
+                    shortcut: nil
+                )
+            )
+        }
+        items.append(.separator)
 
         if hasUpdate {
             // Newer version visible — surface it as the primary

--- a/apps/rapid-mac/Tests/RapidTests/MenuBarStatusTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MenuBarStatusTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Pins the tray menu's ordering and conditional branches.
+///
+/// The rendered ``NSMenu`` is not AX-introspectable (see
+/// ``MenuBarStatus``), so the strongest regression guard for the menu's
+/// dynamic content — the status line, the update row, and now the
+/// "Copy API endpoint" row — is to pin the pure ``menuItems(_:)`` model
+/// directly. These tests assert the presence/enablement/order of rows
+/// the way ``MenuBarController.rebuildMenu`` actually renders them, not
+/// against a mock menu.
+@Suite("Menu-bar status menu model")
+struct MenuBarStatusTests {
+
+    /// The ``MenuBarStatus.MenuBarAction`` carried by the tray's
+    /// copy-endpoint row.
+    private let copyAction = MenuBarStatus.MenuBarAction.copyEndpoint
+
+    /// Locate the copy-endpoint row (if any) in a rendered menu.
+    private func copyRow(in items: [MenuBarStatus.MenuBarItem])
+        -> (title: String, enabled: Bool)?
+    {
+        guard let row = items.first(where: {
+            if case .button(let action, _, _, _) = $0 { return action == .copyEndpoint }
+            return false
+        }) else { return nil }
+        guard case .button(_, let title, let enabled, _) = row else { return nil }
+        return (title, enabled)
+    }
+
+    @Test("The 'Copy API endpoint' row appears, enabled, directly under the status line, when serving")
+    func copyEndpointRowPresentWhenServing() {
+        let items = MenuBarStatus.menuItems(
+            state: .ready(alias: "lfm2.5-1.2b"),
+            hasUpdate: false,
+            updateVersion: "",
+            checking: false,
+            baseURL: "http://127.0.0.1:8000/v1"
+        )
+
+        // Exactly one copy row, correctly labelled and enabled.
+        let count = items.filter {
+            if case .button(let a, _, _, _) = $0 { return a == copyAction }
+            return false
+        }.count
+        #expect(count == 1, "Expected exactly one Copy API endpoint row, got \(count)")
+
+        let row = copyRow(in: items)
+        #expect(row?.title == "Copy API endpoint")
+        #expect(row?.enabled == true, "The copy row must be enabled while the server is serving")
+
+        // It sits immediately below the status line — the highest-value
+        // action floats toward the top for serve-type users.
+        let statusIndex = items.firstIndex {
+            if case .status = $0 { return true }
+            return false
+        }
+        let copyIndex = items.firstIndex {
+            if case .button(let a, _, _, _) = $0 { return a == copyAction }
+            return false
+        }
+        #expect(
+            copyIndex == statusIndex.map { $0 + 1 },
+            "Copy row (at \(copyIndex.map(String.init) ?? "nil")) must sit right under the status line"
+        )
+    }
+
+    @Test("The 'Copy API endpoint' row is absent when the backend is not serving")
+    func copyEndpointRowAbsentWhenNotServing() {
+        // An idle backend — the controller passes baseURL: nil — must not
+        // surface a dead "copy" click.
+        let items = MenuBarStatus.menuItems(
+            state: .idle,
+            hasUpdate: false,
+            updateVersion: "",
+            checking: false,
+            baseURL: nil
+        )
+        #expect(
+            copyRow(in: items) == nil,
+            "No Copy API endpoint row may render while the server is not serving"
+        )
+    }
+
+    @Test("No copy row for a ready state that reports no resolvable URL")
+    func readyWithoutPortHasNoCopyRow() {
+        // A `.ready` state with a nil baseURL (controller couldn't
+        // resolve host/port — e.g. server deallocated) must not render
+        // the row: copying an unknown URL would be a dead click.
+        let items = MenuBarStatus.menuItems(
+            state: .ready(alias: "demo"),
+            hasUpdate: false,
+            updateVersion: "",
+            checking: false,
+            baseURL: nil
+        )
+        #expect(copyRow(in: items) == nil)
+    }
+}


### PR DESCRIPTION
## Why

Telemetry shows **~85% of usage is serve** — users run Rapid-MLX as a local API server and drive it from their own agent/script (openai-python, curl, claude-code). Their daily action: start the service → grab the base URL → paste it elsewhere.

Today that URL lives only in the main window's Connect/Launch page, but serve-type users keep the **tray** open, not the window. This puts the highest-frequency action on the surface those users actually have up.

## What

Adds a **"Copy API endpoint"** row to the tray (menu bar) menu that copies `http://127.0.0.1:<port>/v1` to the clipboard.

- **Read from the live `ServerManager`**, not hardcoded — the API port sweeps 8000–8009 per launch (`ConnectToolsView` contract), so `:8000` would be wrong for many sessions.
- Row renders **only while the backend is `.ready`** on a known host:port — otherwise it'd be a dead click.
- Placed directly under the status line (highest-value action floats up for serve users).
- On click: copies to `NSPasteboard`, then relabels the row **"Copied ✓"** — the menu rebuilds on every open, so the label self-heals without a timer.

## Files

- `apps/rapid-mac/Sources/Rapid/UI/MenuBarStatus.swift` — pure menu model: new `MenuBarAction.copyEndpoint`, `baseURL:` param, conditional row.
- `apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift` — builds URL from live server, dispatches the copy action with "Copied ✓" feedback.
- `apps/rapid-mac/Tests/RapidTests/MenuBarStatusTests.swift` — pins the new row's presence/enablement/order (present when serving, absent when idle/nil).

## Validation

- `swift test --filter MenuBarStatusTests` → 3/3 pass.
- Full Rapid + RapidTests module compiles (whole test module built green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)