### PR TITLE
evals: benchmark first-run starter models on M2 Pro

### DIFF
--- a/docs/engineering/performance/2026-08-23-starter-model-bakeoff.md
+++ b/docs/engineering/performance/2026-08-23-starter-model-bakeoff.md
@@ -1,0 +1,139 @@
+# Starter-model first-impression bake-off on M2 Pro
+
+Date: 2026-08-23
+
+## Outcome
+
+No tested model is a drop-in, low-risk replacement for the bundled LFM2.5
+1.2B model. Qwen3 1.7B is the best candidate for a product trial: it passed
+9/12 first-session cases versus 6/12 for LFM2.5 1.2B and improved tool calling
+from 47% to 63%. The cost is a 47% larger weight file, 0.4--0.5 GB more MLX
+memory, and lower decode throughput.
+
+Do not select a starter from aggregate benchmark score alone:
+
+- Qwen3 1.7B still invented a future sports result, accepted a false premise,
+  and created a reminder with a made-up time. These need prompt/policy or model
+  mitigation before it is presented as a trustworthy default.
+- The locally quantized Qwen3.5 2B led tool calling at 70%, but scored only
+  7/12 on the first-session suite and confidently fabricated both the winner
+  and venue of the 2030 World Cup. It is not the recommended starter artifact.
+- LFM2.5 2.6B led tools (80%) and general questions (80%), but it is a pure
+  reasoning model. With `enable_thinking=false`, `--no-thinking`, and the
+  starter-sized output budget, its visible response was usually unfinished
+  analysis: 10/12 first-session cases failed and most ended at the token cap.
+- Bonsai 1.7B 2-bit is the smallest artifact and scored 8/12, but arithmetic
+  and factual correction regressed. Earlier plain-chat testing also observed
+  repetition/termination failures, so this run does not clear it for default
+  use.
+
+Vector recommends an Atlas-owned product experiment with Qwen3 1.7B, gated on
+targeted safety/termination checks and installer-size acceptance. Keep LFM2.5
+1.2B as the shipping fallback until that gate passes.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Machine | Mac mini, Apple M2 Pro, 32 GB unified memory |
+| OS | macOS 26.5.2 (25F84), arm64 |
+| Rapid-MLX commit | `ba5025f1ac4a804e78417157e2e85530c0d3506f` |
+| Runtime tree (`vllm_mlx`) | `8198558067b5788f6a9fc10a95df988d8c5f35af` |
+| Python environment | `~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python` |
+| MLX / mlx-lm / mlx-vlm | 0.32.1 / 0.31.3 / 0.6.15 |
+| transformers | 5.12.1 |
+| Server | simple engine, one request at a time, localhost |
+| Generation settings | temperature 0; thinking disabled; one deterministic run |
+
+## Artifacts
+
+| Model | Artifact and immutable source revision | Weight bytes | Approx. weight size |
+| --- | --- | ---: | ---: |
+| LFM2.5 1.2B 4-bit | `mlx-community/LFM2.5-1.2B-Instruct-4bit` | 658,540,250 | 628 MiB |
+| Qwen3 1.7B 4-bit | `mlx-community/Qwen3-1.7B-4bit@3b1b1768f8f8cf8351c712464f906e86c2b8269e` | 968,080,210 | 923 MiB |
+| Bonsai 1.7B 2-bit | `prism-ml/Ternary-Bonsai-1.7B-mlx-2bit@5f3e306330f636cfc6c6241b4850fae6711c5985` | 484,049,216 | 462 MiB |
+| LFM2.5 2.6B 4-bit | `LiquidAI/LFM2.5-2.6B-MLX@b41f2b65685e95418f1ac809bb022d4f79e1ab27`, `4bit/` | 1,583,152,892 | 1,510 MiB |
+| Qwen3.5 2B local 4-bit | `Qwen/Qwen3.5-2B@15852e8c16360a2fea060d615a32b45270f8a8fc` | 1,722,271,785 | 1,643 MiB |
+
+The Qwen3.5 artifact was produced with:
+
+```bash
+python -m mlx_vlm convert \
+  --hf-path Qwen/Qwen3.5-2B \
+  --revision 15852e8c16360a2fea060d615a32b45270f8a8fc \
+  --mlx-path ~/starter-bakeoff-models/Qwen3.5-2B-MLX-4bit \
+  --quantize --q-bits 4 --q-group-size 64
+```
+
+The converter reported 6.225 effective bits/weight because sensitive and
+non-quantized components remain. The output weight SHA-256 is
+`713fe7e5d3c3965f7106b0d0ee17615f7869c23c8d327996df8c1196fbcf07d5`.
+
+## Results
+
+| Model | First session | Tools | Coding | Math | General | Cold / warm TTFT | Short / long decode | Active / peak MLX RAM |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| LFM2.5 1.2B 4-bit | 6/12 | 47% | 30% | 60% | 60% | 201 / 96 ms | 86.5 / 172.7 tok/s | 0.7 / 0.7 GB |
+| Qwen3 1.7B 4-bit | **9/12** | 63% | 20% | **70%** | 30% | 195 / 54 ms | 54.9 / 135.1 tok/s | 1.1 / 1.2 GB |
+| Bonsai 1.7B 2-bit | 8/12 | 60% | 30% | 40% | 40% | 347 / **51 ms** | 55.5 / **177.3 tok/s** | 0.7 / 0.8 GB |
+| LFM2.5 2.6B 4-bit | 2/12 | **80%** | 30% | 40% | **80%** | 229 / 143 ms | 78.4 / 91.2 tok/s | 1.6 / 1.8 GB |
+| Qwen3.5 2B local 4-bit | 7/12 | 70% | **40%** | 30% | 20% | **170** / 123 ms | 41.8 / 123.2 tok/s | 1.1 / 1.2 GB |
+
+Bold values are column leaders, not a claim of overall model superiority.
+Long-decode requests were capped at 500 tokens, so a model that naturally
+stopped earlier can have a less stable throughput sample.
+
+The 12-case first-session suite covers a friendly Chinese greeting, child-level
+explanation, multi-turn instruction retention, faithful summary, polite
+rewrite, basic arithmetic, false-premise correction, future uncertainty, exact
+JSON, concise termination, current-weather tool choice, and asking for a
+missing reminder time. It is implemented in `evals/starter_experience.py`.
+
+## Reproduction
+
+Start each artifact through its normal Rapid-MLX alias/profile. For the local
+Qwen3.5 artifact, the exact server command was:
+
+```bash
+cd ~/starter-bakeoff-runtime
+PYTHONPATH="$PWD" ~/mac-model-matrix/venvs/mlxlm-on-mlx032/bin/python \
+  -m vllm_mlx.cli serve \
+  ~/starter-bakeoff-models/Qwen3.5-2B-MLX-4bit \
+  --host 127.0.0.1 --port 18080 --no-thinking \
+  --enable-auto-tool-choice --tool-call-parser hermes
+```
+
+Run the existing common suites and the first-session suite:
+
+```bash
+python evals/run_eval.py \
+  --model MODEL --host 127.0.0.1 --port 18080 \
+  --parser PARSER --quantization QUANTIZATION \
+  --hardware "Mac mini M2 Pro 32GB" --output /tmp/MODEL-eval.json
+
+python evals/starter_experience.py \
+  --base-url http://127.0.0.1:18080/v1 \
+  --model default --artifact ARTIFACT --output /tmp/MODEL-starter.json
+```
+
+Raw JSON contains prompts and model responses and remains local. This report
+distills the reproducible environment, commands, scores, and material failure
+patterns rather than committing transcripts.
+
+## Limitations and release gate
+
+- This is one machine, one deterministic pass, and one quantization per model.
+  It does not establish behavior on 8/16 GB machines or statistical variance.
+- The first-session checks are product heuristics, not an academic capability
+  benchmark. A pass still requires human review of tone and factual safety.
+- The coding grader is sensitive to response formatting; many failures were
+  runtime/extraction failures. Do not interpret small coding-score differences
+  as capability rankings without a manual audit.
+- TTFT uses short prompts and does not measure long-context prefill. Memory is
+  MLX active/peak memory, not total process RSS or installer footprint.
+- A starter change must separately verify license, download reliability,
+  supported macOS/RAM floor, GUI progress/error handling, cancellation,
+  uninstall cleanup, and rollback to the known-good artifact.
+- Before shipping Qwen3 1.7B, rerun the three material failures with product
+  system prompts and tool policy: false premise, unknown future event, and
+  reminder missing a time. Atlas owns the final quality/size tradeoff.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Starter-model first-impression bake-off on M2 Pro](2026-08-23-starter-model-bakeoff.md)
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)
 - [Qwen3.5-9B engine comparison on M2 Pro](2026-08-21-qwen3.5-9b-engine-comparison.md)
 - [Rapid-MLX 0.12.18 performance release gate](2026-08-22-release-0.12.18-perf-gate.md)

--- a/evals/starter_experience.py
+++ b/evals/starter_experience.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Evaluate the product's first-chat experience against a running server.
+
+This complements ``run_eval.py``'s academic, coding, and 30-case tool suites.
+It deliberately uses short prompts that a non-technical user is likely to try
+in their first session and records the raw responses for human review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web for current information",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_reminder",
+            "description": "Create a reminder at a specified time",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "time": {"type": "string"},
+                },
+                "required": ["text", "time"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Evaluate an arithmetic expression",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
+            },
+        },
+    },
+]
+
+
+def request(
+    base_url: str, model: str, messages: list[dict], *, tools=None, max_tokens=256
+) -> dict:
+    body = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "stream": False,
+        "enable_thinking": False,
+    }
+    if tools:
+        body["tools"] = tools
+    start = time.perf_counter()
+    response = httpx.post(
+        f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=180
+    )
+    response.raise_for_status()
+    payload = response.json()
+    choice = payload["choices"][0]
+    message = choice["message"]
+    return {
+        "content": message.get("content") or "",
+        "tool_calls": message.get("tool_calls") or [],
+        "finish_reason": choice.get("finish_reason"),
+        "usage": payload.get("usage", {}),
+        "elapsed_s": round(time.perf_counter() - start, 3),
+    }
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def excessive_repetition(text: str) -> bool:
+    words = re.findall(r"\w+", normalized(text))
+    if len(words) < 24:
+        return False
+    trigrams = Counter(tuple(words[i : i + 3]) for i in range(len(words) - 2))
+    return bool(trigrams and max(trigrams.values()) >= 4)
+
+
+def run_case(base_url: str, model: str, case: dict) -> dict:
+    result = request(
+        base_url,
+        model,
+        case["messages"],
+        tools=TOOLS if case.get("tools") else None,
+        max_tokens=case.get("max_tokens", 256),
+    )
+    text = normalized(result["content"])
+    checks: dict[str, bool] = {
+        "nonempty": bool(text or result["tool_calls"]),
+        "terminated": result["finish_reason"] != "length",
+        "no_excessive_repetition": not excessive_repetition(result["content"]),
+    }
+
+    kind = case["kind"]
+    if kind == "keywords":
+        checks["required_content"] = all(
+            any(option.lower() in text for option in group)
+            for group in case["keyword_groups"]
+        )
+    elif kind == "contains":
+        checks["required_content"] = case["value"].lower() in text
+    elif kind == "uncertainty":
+        uncertainty = ["无法确定", "不知道", "尚未", "还没有", "不能预测", "未来", "not known"]
+        checks["does_not_invent_future_fact"] = any(token in text for token in uncertainty)
+    elif kind == "json":
+        try:
+            candidate = result["content"].strip()
+            candidate = re.sub(r"^```(?:json)?\s*|\s*```$", "", candidate)
+            parsed = json.loads(candidate)
+            checks["exact_json"] = parsed == case["value"]
+        except (json.JSONDecodeError, TypeError):
+            checks["exact_json"] = False
+    elif kind == "length":
+        checks["within_length"] = len(result["content"].strip()) <= case["max_chars"]
+    elif kind == "tool":
+        calls = result["tool_calls"]
+        checks["correct_tool"] = bool(calls) and calls[0].get("function", {}).get(
+            "name"
+        ) == case["tool"]
+        if checks["correct_tool"]:
+            try:
+                json.loads(calls[0]["function"].get("arguments", ""))
+                checks["valid_tool_arguments"] = True
+            except (json.JSONDecodeError, KeyError, TypeError):
+                checks["valid_tool_arguments"] = False
+    elif kind == "no_tool":
+        checks["did_not_call_tool"] = not result["tool_calls"]
+        checks["asked_for_missing_detail"] = any(
+            token in text for token in case.get("prompt_tokens", [])
+        )
+
+    result["id"] = case["id"]
+    result["description"] = case["description"]
+    result["checks"] = checks
+    result["passed"] = all(checks.values())
+    return result
+
+
+CASES = [
+    {
+        "id": "first01",
+        "description": "Friendly concise first greeting",
+        "kind": "keywords",
+        "messages": [{"role": "user", "content": "你好！你能帮我做什么？请用三句话以内回答。"}],
+        "keyword_groups": [["帮", "可以"], ["问题", "写", "总结", "分析"]],
+        "max_tokens": 120,
+    },
+    {
+        "id": "first02",
+        "description": "Explain a concept to a child in Chinese",
+        "kind": "keywords",
+        "messages": [{"role": "user", "content": "请像给8岁孩子一样，用一个生活中的比喻解释什么是电池。不要超过100字。"}],
+        "keyword_groups": [["电", "能量"], ["像", "好比", "比如"]],
+        "max_tokens": 160,
+    },
+    {
+        "id": "first03",
+        "description": "Multi-turn constraint and reference retention",
+        "kind": "keywords",
+        "messages": [
+            {"role": "user", "content": "给我三条提高睡眠质量的建议，每条不超过12个字。"},
+            {"role": "assistant", "content": "1. 固定作息时间\n2. 睡前远离屏幕\n3. 下午避免咖啡"},
+            {"role": "user", "content": "只把第二条改成更容易做到的建议，其他两条原样保留。"},
+        ],
+        "keyword_groups": [["固定作息时间"], ["下午避免咖啡"], ["2.", "二"]],
+    },
+    {
+        "id": "first04",
+        "description": "Faithful meeting-note summary",
+        "kind": "keywords",
+        "messages": [{"role": "user", "content": "把下面内容总结成三条要点，不要添加原文没有的信息：产品评审改到周二14:00，在305会议室。小林负责带蓝色原型机，阿杰周一18:00前发测试报告。"}],
+        "keyword_groups": [["周二"], ["14:00", "14点"], ["305"], ["蓝色"], ["周一", "18:00", "18点"]],
+    },
+    {
+        "id": "first05",
+        "description": "Polite rewrite preserves intent",
+        "kind": "keywords",
+        "messages": [{"role": "user", "content": "把这句话改得礼貌但明确：‘你怎么还没交？今天下班前必须给我。’"}],
+        "keyword_groups": [["今天", "下班前"], ["请", "麻烦", "能否"]],
+    },
+    {
+        "id": "first06",
+        "description": "Simple arithmetic word problem",
+        "kind": "contains",
+        "messages": [{"role": "user", "content": "我买了3杯每杯12元的咖啡，又买了10元的面包，一共多少钱？只给答案。"}],
+        "value": "46",
+        "max_tokens": 40,
+    },
+    {
+        "id": "first07",
+        "description": "Correct a false premise instead of agreeing",
+        "kind": "keywords",
+        "messages": [{"role": "user", "content": "埃菲尔铁塔为什么建在罗马？"}],
+        "keyword_groups": [["巴黎"], ["不在罗马", "不是在罗马", "并非"]],
+    },
+    {
+        "id": "first08",
+        "description": "Do not invent a future event",
+        "kind": "uncertainty",
+        "messages": [{"role": "user", "content": "2030年世界杯冠军是谁？请直接告诉我。"}],
+    },
+    {
+        "id": "first09",
+        "description": "Exact structured-output instruction",
+        "kind": "json",
+        "messages": [{"role": "user", "content": "只输出合法JSON，不要Markdown：姓名小王，年龄28岁，字段必须是name和age。"}],
+        "value": {"name": "小王", "age": 28},
+        "max_tokens": 80,
+    },
+    {
+        "id": "first10",
+        "description": "Concise answer terminates without looping",
+        "kind": "length",
+        "messages": [{"role": "user", "content": "用不超过80个汉字说明为什么天空通常是蓝色的。不要重复。"}],
+        "max_chars": 80,
+        "max_tokens": 180,
+    },
+    {
+        "id": "first11",
+        "description": "Uses web search for current weather",
+        "kind": "tool",
+        "tools": True,
+        "tool": "web_search",
+        "messages": [{"role": "user", "content": "帮我查一下东京现在的天气。"}],
+    },
+    {
+        "id": "first12",
+        "description": "Does not call a tool for ordinary conversation",
+        "kind": "no_tool",
+        "tools": True,
+        "messages": [{"role": "user", "content": "提醒我给妈妈打电话。"}],
+        "prompt_tokens": ["时间", "什么时候", "几点"],
+    },
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:18080/v1")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--artifact", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    results = []
+    for case in CASES:
+        print(f"{case['id']}: {case['description']} ... ", end="", flush=True)
+        try:
+            result = run_case(args.base_url, args.model, case)
+        except Exception as exc:  # preserve the failure as benchmark evidence
+            result = {
+                "id": case["id"],
+                "description": case["description"],
+                "passed": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        results.append(result)
+        print("PASS" if result["passed"] else "FAIL")
+
+    passed = sum(bool(item["passed"]) for item in results)
+    payload = {
+        "schema_version": 1,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "model": args.model,
+        "artifact": args.artifact,
+        "settings": {"temperature": 0.0, "enable_thinking": False},
+        "passed": passed,
+        "total": len(results),
+        "score": passed / len(results),
+        "results": results,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    print(f"Starter experience: {passed}/{len(results)}; wrote {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a 12-case first-session evaluation for non-technical starter-model UX
- compare LFM2.5 1.2B, Qwen3 1.7B, Bonsai 1.7B, LFM2.5 2.6B, and a local Qwen3.5 2B quantization on the M2 Pro mini
- record immutable artifact revisions, speed/memory data, quality failures, reproduction commands, and release gates

## Result

Qwen3 1.7B is the strongest candidate for a product trial (9/12 first-session cases and 63% tools versus 6/12 and 47% for the current LFM2.5 1.2B), but it is not approved as a default: it still fails false-premise, unknown-future, and missing-reminder-time cases. The report recommends retaining the current fallback until Atlas accepts the size/performance tradeoff and those product-policy gates pass.

## Verification

- full common speed/tool/coding/reasoning/general suite on all five artifacts
- 12 first-session cases on all five artifacts
- `python3 -m py_compile evals/starter_experience.py`
- `ruff check evals/starter_experience.py`
- `git diff --check`

Raw model responses remain local and were not committed.
