### PR TITLE
fix(mac): show live model download progress in readiness banner

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -480,20 +480,29 @@ struct ContentView: View {
         }
     }
 
-    /// Progress is only read while the server is actually starting.
+    /// Progress is only read while the selected model is being downloaded
+    /// or while the server is actually starting.
     ///
     /// This is an observation-scope decision, not a cosmetic one.
     /// ``DownloadProgress`` republishes every 500 ms, and reading it in
     /// this view's body registers ``ContentView`` — and therefore the
-    /// whole split view — as an observer. Gating on ``.starting`` keeps
-    /// that half-second churn confined to the window where the banner
-    /// genuinely needs it, instead of paying it for the entire session.
+    /// whole split view — as an observer. Gating each source keeps that
+    /// half-second churn confined to the window where the banner genuinely
+    /// needs it. The sidecar job must win: download-only pulls leave the
+    /// server idle, and are the source of truth also shown in DownloadStrip.
     private var progressSnapshot: ModelReadiness.ProgressSnapshot? {
+        if let job = downloads.job(for: alias), case .running = job.status {
+            return Self.progressSnapshot(from: job.progress)
+        }
         guard case .starting = server.state else { return nil }
-        return ModelReadiness.ProgressSnapshot(
-            activity: server.downloadProgress.startupActivity,
-            subtitle: server.downloadProgress.progressSubtitle,
-            fraction: server.downloadProgress.progressFraction
+        return Self.progressSnapshot(from: server.downloadProgress)
+    }
+
+    static func progressSnapshot(from progress: DownloadProgress) -> ModelReadiness.ProgressSnapshot {
+        ModelReadiness.ProgressSnapshot(
+            activity: progress.startupActivity,
+            subtitle: progress.progressSubtitle,
+            fraction: progress.progressFraction
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -714,6 +714,21 @@ struct ModelReadinessTests {
         XCTAssertEqual(state.statusRole, .working)
     }
 
+    @Test
+    @MainActor
+    func testContentBannerSnapshotCarriesDownloadManagerProgress() {
+        let progress = DownloadProgress()
+        progress.ingest(
+            "model-00006-of-00007.safetensors:  86%|████████▌ | 4.30G/5.00G [01:28<00:14, 50.0MB/s]"
+        )
+
+        let snapshot = ContentView.progressSnapshot(from: progress)
+
+        XCTAssertEqual(snapshot.activity, .downloading)
+        XCTAssertEqual(snapshot.fraction, 0.86)
+        XCTAssertTrue(snapshot.subtitle?.contains("86%") == true)
+    }
+
     /// Loading / warming up are NOT downloading. The word "Downloading"
     /// may only appear when bytes are provably moving — the invariant
     /// ``DownloadProgress.startupActivity`` exists to protect.


### PR DESCRIPTION
## Problem

A download-only model pull leaves the server idle. `ContentView` therefore rendered the readiness banner from no progress snapshot (`Starting the download…`) while `DownloadStrip` showed the real progress, such as 86%.

## Why

The contradictory states make an active download look stalled and force users to discover the small footer indicator. The prominent readiness banner should use the same live progress source because it is the surface explaining why chat is unavailable.

## Fix

- Prefer the selected alias's running `DownloadManager` job when building the readiness progress snapshot.
- Preserve the existing server-start progress path for in-band serve downloads.
- Keep observation scoped to active work so the full split view does not refresh throughout an idle session.
- Add a regression test proving parsed 86% sidecar progress reaches the banner snapshot.

## Validation

- `swift test --filter ModelReadinessTests.testContentBannerSnapshotCarriesDownloadManagerProgress`
- `git diff --check`