### PR TITLE
fix(mac): surface keyed search failure reasons

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -15,6 +15,15 @@ struct FailureDiagnosis: Equatable, Sendable {
         case engineNotRunning
         case webSearchOffline
         case webSearchUnavailable
+        /// A user-supplied Keenable key was rejected. Keep keyed account
+        /// failures distinct from provider availability: the network is up,
+        /// retrying the same request cannot repair the credential, and the
+        /// useful destination is the key field in Settings.
+        case webSearchKeyRejected
+        /// The stored Keenable key has exhausted its monthly credit allowance.
+        case webSearchKeyQuotaExceeded
+        /// The stored Keenable key hit its account/organisation rate cap.
+        case webSearchKeyRateLimited
         /// The free DuckDuckGo backend throttled this machine. Distinct from
         /// ``webSearchUnavailable`` because the remedy is different: nothing in
         /// Settings is misconfigured, so "check its settings" sends the user to
@@ -68,7 +77,8 @@ struct FailureDiagnosis: Equatable, Sendable {
             // ``webSearchUnavailable`` is the honest ancestor — it is the kind
             // this very condition used to land on, so an older build shows the
             // copy it always showed for a throttled search.
-            case .webSearchRateLimited:
+            case .webSearchRateLimited, .webSearchKeyRejected,
+                 .webSearchKeyQuotaExceeded, .webSearchKeyRateLimited:
                 return .webSearchUnavailable
             case .browsePageTooLarge:
                 return .toolFailed
@@ -218,6 +228,8 @@ extension FailureDiagnosis.Kind {
         // copy and deep-link do the recovering.
         case .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
              .webSearchOffline, .webSearchUnavailable, .webSearchRateLimited,
+             .webSearchKeyRejected, .webSearchKeyQuotaExceeded,
+             .webSearchKeyRateLimited,
              .browsePageTooLarge,
              .commandPermissionDenied, .commandFailed,
              .fileNotFound, .filePermissionDenied, .toolFailed,
@@ -259,6 +271,15 @@ enum FailureDiagnoser {
         case .webSearchUnavailable:
             message = "Web search couldn't finish. Check its settings, then try again."
             action = .retry
+        case .webSearchKeyRejected:
+            message = "Keenable rejected this API key. Re-paste it in Settings → Tools, or clear it to use keyless search."
+            action = .openWebSearchSettings
+        case .webSearchKeyQuotaExceeded:
+            message = "This Keenable key has used its monthly credits. Check its plan, or clear the key in Settings → Tools to use keyless search."
+            action = .openWebSearchSettings
+        case .webSearchKeyRateLimited:
+            message = "This Keenable key is rate-limited. Wait a moment, check its plan, or clear the key in Settings → Tools to use keyless search."
+            action = .openWebSearchSettings
         case .webSearchRateLimited:
             // Deliberately NOT "check its settings": everything in Settings is
             // already correct when this fires. DuckDuckGo rate-limits the free
@@ -370,6 +391,19 @@ enum FailureDiagnoser {
         }
 
         if toolName == "web_search" {
+            // Keenable deliberately returns account failures as errors instead
+            // of silently falling back to the shared keyless pool. Preserve
+            // that precise cause at the UI boundary; collapsing all three to
+            // ``webSearchUnavailable`` hid the only useful recovery action.
+            if raw.contains("keenable rejected the api key") {
+                return .webSearchKeyRejected
+            }
+            if raw.contains("keenable key's monthly credit allowance is used up") {
+                return .webSearchKeyQuotaExceeded
+            }
+            if raw.contains("keenable rate limit hit for this api key") {
+                return .webSearchKeyRateLimited
+            }
             // ``WebSearchTool`` stamps ``.webSearchRateLimited`` on the result
             // directly, so this branch only matters for rows restored from an
             // older transcript (no stored kind) — hence the narrow, DDG-anchored

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -8,6 +8,8 @@ import Foundation
 /// + snippet per result, identically shaped whatever backend
 /// answered.
 enum WebSearchTool {
+    typealias KeenableTransport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
     static let definition = ToolDefinition(
         name: "web_search",
         description: "Search the web and get the top results (title + URL + snippet). Use this when the user asks about current events, recent news, or facts that might have changed since the model was trained.",
@@ -368,7 +370,10 @@ enum WebSearchTool {
     static func runKeenable(
         query q: String,
         apiKey: String?,
-        fallbackNote: String?
+        fallbackNote: String?,
+        transport: KeenableTransport = { request in
+            try await cappedData(for: request)
+        }
     ) async -> ToolCallResult {
         let toolName = "web_search"
         let request: URLRequest?
@@ -387,11 +392,12 @@ enum WebSearchTool {
             return ToolCallResult(
                 toolCallID: "",
                 content: "\(toolName) error: could not build Keenable request — re-paste the API key in Settings → Tools → Web search.",
-                isError: true
+                isError: true,
+                failureKind: .webSearchKeyRejected
             )
         }
         do {
-            let (data, response) = try await cappedData(for: request)
+            let (data, response) = try await transport(request)
             guard let http = response as? HTTPURLResponse else {
                 return await duckDuckGoBackstop(query: q, fallbackNote: fallbackNote)
             }

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -415,13 +415,15 @@ enum WebSearchTool {
                 return ToolCallResult(
                     toolCallID: "",
                     content: "\(toolName) error: Keenable rejected the API key (HTTP \(http.statusCode)). Re-paste it in Settings → Tools → Web search.",
-                    isError: true
+                    isError: true,
+                    failureKind: .webSearchKeyRejected
                 )
             case 402 where apiKey != nil:
                 return ToolCallResult(
                     toolCallID: "",
                     content: "\(toolName) error: the Keenable key's monthly credit allowance is used up (HTTP 402). Searches continue on the keyless pool if you clear the key.",
-                    isError: true
+                    isError: true,
+                    failureKind: .webSearchKeyQuotaExceeded
                 )
             case 429 where apiKey != nil:
                 // Codex r1 MAJOR: a keyed 429 is an account problem
@@ -432,7 +434,8 @@ enum WebSearchTool {
                 return ToolCallResult(
                     toolCallID: "",
                     content: "\(toolName) error: Keenable rate limit hit for this API key (HTTP 429). Wait a moment or check the plan's limits.",
-                    isError: true
+                    isError: true,
+                    failureKind: .webSearchKeyRateLimited
                 )
             default:
                 // Keyless 429 (shared pool exhausted), 5xx, or any

--- a/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
@@ -84,6 +84,8 @@ struct FailureDiagnosisView: View {
         case .modelOutOfMemory: return "memorychip"
         case .engineNotRunning, .modelLoadFailed: return "bolt.slash"
         case .webSearchOffline, .webSearchUnavailable: return "wifi.exclamationmark"
+        case .webSearchKeyRejected, .webSearchKeyQuotaExceeded,
+             .webSearchKeyRateLimited: return "key.fill"
         case .webSearchRateLimited: return "hourglass"
         case .browsePageTooLarge: return "doc.text.magnifyingglass"
         case .commandPermissionDenied, .filePermissionDenied: return "hand.raised.fill"

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
@@ -209,6 +209,55 @@ struct KeenableClientTests {
         return try! JSONSerialization.data(withJSONObject: obj)
     }
 
+    private static func response(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: KeenableSearchClient.restEndpoint)!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    @Test(
+        "Keyed HTTP account failures stamp their producer-owned diagnosis",
+        arguments: [
+            (401, FailureDiagnosis.Kind.webSearchKeyRejected),
+            (403, FailureDiagnosis.Kind.webSearchKeyRejected),
+            (402, FailureDiagnosis.Kind.webSearchKeyQuotaExceeded),
+            (429, FailureDiagnosis.Kind.webSearchKeyRateLimited),
+        ]
+    )
+    func keyedAccountFailureKind(statusCode: Int, expected: FailureDiagnosis.Kind) async {
+        let transport: WebSearchTool.KeenableTransport = { request in
+            #expect(request.value(forHTTPHeaderField: "X-API-Key") == "keen_valid")
+            return (Data("{}".utf8), Self.response(statusCode: statusCode))
+        }
+        let result = await WebSearchTool.runKeenable(
+            query: "current news",
+            apiKey: "keen_valid",
+            fallbackNote: nil,
+            transport: transport
+        )
+        #expect(result.isError)
+        #expect(result.failureKind == expected)
+    }
+
+    @Test("A malformed stored key points to key settings without touching transport")
+    func malformedKeyFailureKind() async {
+        let transport: WebSearchTool.KeenableTransport = { _ in
+            Issue.record("Malformed key must fail before transport")
+            throw CancellationError()
+        }
+        let result = await WebSearchTool.runKeenable(
+            query: "current news",
+            apiKey: "keen_valid\r\nX-Evil: 1",
+            fallbackNote: nil,
+            transport: transport
+        )
+        #expect(result.isError)
+        #expect(result.failureKind == .webSearchKeyRejected)
+    }
+
     @Test("Keyless request is a single JSON-RPC tools/call POST with the snippet cap clamped to the server minimum")
     func keylessRequestShape() throws {
         let req = try #require(KeenableSearchClient.buildKeylessRequest(query: "hello world", snippetMaxLength: 100))

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
@@ -211,6 +211,43 @@ struct WebSearchThrottleTests {
         #expect(unavailable.action == .retry)
     }
 
+    @Test("Keenable keyed failures retain their exact cause and settings remedy")
+    func keenableKeyedFailureDiagnosis() {
+        let cases: [(String, FailureDiagnosis.Kind, String)] = [
+            (
+                "web_search error: Keenable rejected the API key (HTTP 401). Re-paste it in Settings → Tools → Web search.",
+                .webSearchKeyRejected,
+                "rejected this API key"
+            ),
+            (
+                "web_search error: the Keenable key's monthly credit allowance is used up (HTTP 402). Searches continue on the keyless pool if you clear the key.",
+                .webSearchKeyQuotaExceeded,
+                "monthly credits"
+            ),
+            (
+                "web_search error: Keenable rate limit hit for this API key (HTTP 429). Wait a moment or check the plan's limits.",
+                .webSearchKeyRateLimited,
+                "rate-limited"
+            ),
+        ]
+
+        for (content, expectedKind, messageFragment) in cases {
+            let kind = FailureDiagnoser.toolFailureKind(
+                toolName: "web_search",
+                content: content,
+                isError: true
+            )
+            #expect(kind == expectedKind)
+            let diagnosis = FailureDiagnoser.diagnosis(for: expectedKind)
+            #expect(diagnosis.message.contains(messageFragment))
+            #expect(diagnosis.action == .openWebSearchSettings)
+            #expect(FailureDiagnosis.inlineToolCardAction(
+                for: diagnosis,
+                canRouteToSettings: true
+            ) == .openWebSearchSettings)
+        }
+    }
+
     // MARK: - Fallback classification (restored transcripts)
 
     @Test("A restored throttle row without a stored kind still classifies")


### PR DESCRIPTION
## Summary

- preserve Keenable keyed 401/403, 402, and 429 as distinct user-visible failure kinds
- show actionable copy and a Web Search Settings deep-link instead of the generic unavailable error
- keep downgrade-safe transcript persistence and legacy text classification

## Verification

- `swift test --filter WebSearchThrottleTests` (24 passed)
- `swift test --filter SettingsDeepLinkRoutingTests`
- `swift test --filter DeclinedToolDiagnosisTests`
- `swift test --filter OnboardingDirectionDTests`
- Swift package compiled successfully during the test runs