### PR TITLE
[codex] ci: scope full gate promotion by product lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
             tests/test_classify_ci_changes.py \
+            tests/test_ci_lane_promotion.py \
             tests/test_check_mlx_upstream_calls.py \
             tests/test_no_out_of_band_routing.py \
             tests/test_microbench_parsers.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,16 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            if [ "$FULL_CI" = true ]; then
-              # Empty input deliberately fails closed to every product lane.
-              python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
-              full_gate=true
-            else
-              # Disable rename folding so both the removed source path and the
-              # new destination participate in classification.
-              git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
-              python scripts/classify_ci_changes.py \
-                --paths-file /tmp/changed-paths \
-                --github-output "$GITHUB_OUTPUT"
-              full_gate=false
-            fi
+            # Classify the actual diff even during full-ci promotion. Promotion
+            # broadens coverage inside the affected lane; it must not turn an
+            # engine-only PR into a full Desktop run (or vice versa).
+            # Disable rename folding so both the removed source path and the
+            # new destination participate in classification.
+            git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
+            python scripts/classify_ci_changes.py \
+              --paths-file /tmp/changed-paths \
+              --github-output "$GITHUB_OUTPUT"
+            full_gate="$FULL_CI"
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
             if [ "$full_gate" = true ]; then
               echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
@@ -436,11 +433,6 @@ jobs:
     steps:
       - name: Check test results
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ] \
-            && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then
-            echo "PR gate passed; apply the full-ci label when this PR is ready to merge"
-            exit 1
-          fi
           if [ "${{ needs.lint.result }}" != success ]; then
             echo "Lint and static repository contracts failed"
             exit 1
@@ -458,6 +450,11 @@ jobs:
           if [ "$expected" != "true" ]; then
             echo "Engine lanes not required for this change"
             exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then
+            echo "Engine PR gate passed; apply the full-ci label when this PR is ready to merge"
+            exit 1
           fi
           if [ "${{ needs.test-matrix.result }}" != "success" ]; then
             echo "Unit tests failed"

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -58,20 +58,24 @@ jobs:
           FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "merge_group" ] || [ "$FULL_CI" = true ]; then
-            # Empty input deliberately fails closed to every product lane.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            # A future merge queue candidate may combine independently scoped
+            # PRs, so validate both product lanes.
             python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
             {
               echo 'full_gate=true'
             } >> "$GITHUB_OUTPUT"
           else
+            # Keep full-ci promotion scoped to the lanes selected by the real
+            # PR diff. An engine-only PR must not allocate a full GUI run, and
+            # a Desktop-only PR must not allocate model runners.
             # Disable rename folding so both the removed source path and the
             # new destination participate in classification.
             git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
             python scripts/classify_ci_changes.py \
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"
-            echo 'full_gate=false' >> "$GITHUB_OUTPUT"
+            echo "full_gate=$FULL_CI" >> "$GITHUB_OUTPUT"
           fi
 
   # Pure text lint over the diff — no Swift toolchain, no simulator, no app
@@ -675,13 +679,13 @@ jobs:
           GOLDEN_FLOWS: ${{ needs.gui-golden-flows.result }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = pull_request ] && [ "$FULL_GATE" != true ]; then
-            echo "PR gate passed; apply the full-ci label when this PR is ready to merge"
-            exit 1
-          fi
           if [ "$DESKTOP_EXPECTED" != true ]; then
             echo "Desktop lane not required for this PR"
             exit 0
+          fi
+          if [ "${{ github.event_name }}" = pull_request ] && [ "$FULL_GATE" != true ]; then
+            echo "Desktop PR gate passed; apply the full-ci label when this PR is ready to merge"
+            exit 1
           fi
           for result in "$IDENTIFIERS" "$IDENTIFIER_TESTS" "$HARNESS_CONTRACTS" "$BUILD"; do
             if [ "$result" != success ]; then

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -279,7 +279,9 @@ jobs:
   # not promises — which is what the preflight step below is for.
   gui-golden-flows:
     needs: changes
-    if: needs.changes.outputs.full_gate == 'true'
+    if: >-
+      needs.changes.outputs.desktop == 'true' &&
+      needs.changes.outputs.full_gate == 'true'
     # macos-15 for the same reason as the build job: Package.swift is
     # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
     runs-on: macos-15

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -24,12 +24,21 @@ test lanes; `desktop-tests` includes every selected Desktop lane.
 
 ## Merge gate
 
-Adding the `full-ci` label upgrades a pull request to the full five-model L1
-matrix and complete GUI golden-flow job. Apply it only when the PR is ready to
-merge; removing it returns subsequent commits to the path-aware PR gate.
-The stable aggregate checks intentionally remain non-successful until this
-label is present, so branch protection cannot accidentally bypass the merge
-gate.
+Adding the `full-ci` label upgrades the lanes selected by the pull request's
+actual diff. Apply it only when the PR is ready to merge; removing it returns
+subsequent commits to the path-aware PR gate.
+
+- Engine changes expand to the full five-model L1 matrix.
+- Desktop changes expand to the complete GUI golden-flow job.
+- Cross-cutting or unknown changes expand both lanes.
+- Documentation-only changes require neither product lane and do not need the
+  label.
+
+The label never changes lane classification. This prevents an engine-only PR
+from allocating the full Desktop gate, or a Desktop-only PR from allocating
+the full model gate. The selected product aggregate intentionally remains
+non-successful until the label is present, so branch protection cannot bypass
+its merge gate.
 
 The workflows also subscribe to GitHub's `merge_group` event. After the
 repository becomes eligible for GitHub merge queues, every queue candidate will

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -21,6 +21,10 @@ def _step_run(workflow: Path, job: str, step_name: str) -> str:
     return str(step["run"])
 
 
+def _job(workflow: Path, job: str) -> dict[str, object]:
+    return yaml.safe_load(workflow.read_text())["jobs"][job]
+
+
 def test_engine_full_ci_still_classifies_the_pr_diff():
     run = _step_run(ENGINE_WORKFLOW, "changes", "Classify validation lanes")
     assert 'git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA"' in run
@@ -48,3 +52,9 @@ def test_non_desktop_change_exits_before_full_ci_requirement():
     no_lane = run.index('if [ "$DESKTOP_EXPECTED" != true ]')
     promotion = run.index('if [ "${{ github.event_name }}" = pull_request ]')
     assert no_lane < promotion
+
+
+def test_gui_golden_job_requires_both_desktop_lane_and_full_promotion():
+    condition = str(_job(DESKTOP_WORKFLOW, "gui-golden-flows")["if"])
+    assert "needs.changes.outputs.desktop == 'true'" in condition
+    assert "needs.changes.outputs.full_gate == 'true'" in condition

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for lane-scoped full-CI promotion.
+
+These tests intentionally inspect the workflows: a future cleanup must not
+restore the expensive behavior where applying ``full-ci`` changed an
+engine-only or Desktop-only PR into an all-product run.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+ENGINE_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+
+
+def _step_run(workflow: Path, job: str, step_name: str) -> str:
+    steps = yaml.safe_load(workflow.read_text())["jobs"][job]["steps"]
+    (step,) = [candidate for candidate in steps if candidate.get("name") == step_name]
+    return str(step["run"])
+
+
+def test_engine_full_ci_still_classifies_the_pr_diff():
+    run = _step_run(ENGINE_WORKFLOW, "changes", "Classify validation lanes")
+    assert 'git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA"' in run
+    assert 'full_gate="$FULL_CI"' in run
+    assert 'if [ "$FULL_CI" = true ]' not in run
+
+
+def test_desktop_full_ci_still_classifies_the_pr_diff():
+    run = _step_run(DESKTOP_WORKFLOW, "changes", "Classify desktop lane")
+    assert 'git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA"' in run
+    assert 'echo "full_gate=$FULL_CI"' in run
+    assert '|| [ "$FULL_CI" = true ]' not in run
+
+
+def test_non_engine_change_exits_before_full_ci_requirement():
+    run = _step_run(ENGINE_WORKFLOW, "tests", "Check test results")
+    common_gate = run.index("needs.lint.result")
+    no_lane = run.index('if [ "$expected" != "true" ]')
+    promotion = run.index("needs.changes.outputs.full_gate")
+    assert common_gate < no_lane < promotion
+
+
+def test_non_desktop_change_exits_before_full_ci_requirement():
+    run = _step_run(DESKTOP_WORKFLOW, "desktop-tests", "Check desktop results")
+    no_lane = run.index('if [ "$DESKTOP_EXPECTED" != true ]')
+    promotion = run.index('if [ "${{ github.event_name }}" = pull_request ]')
+    assert no_lane < promotion


### PR DESCRIPTION
## ELI5

The final `full-ci` promotion now makes the affected product lane deeper instead of making every pull request test every product. Engine changes still receive the full model gate, Desktop changes still receive the full GUI gate, and cross-cutting changes still receive both.

## What changed

- Preserve the actual PR diff classification when `full-ci` is applied.
- Let non-engine changes pass the engine aggregate after common repository guards succeed.
- Let non-Desktop changes pass the Desktop aggregate without requiring GUI promotion.
- Keep merge-group candidates fail-closed to both lanes for future merge-queue eligibility.
- Add workflow contract tests that prevent all-product promotion from returning.
- Update the operational merge-gate and rollback documentation.

## Why

Previously, applying `full-ci` called the classifier with an empty path set. Empty input correctly fails closed, but in this context it converted every PR into both an engine and Desktop change. As a result:

- engine-only PRs allocated the full GUI golden suite;
- Desktop-only PRs allocated Python, Apple Silicon, and five real-model lanes;
- docs-only PRs could not land without both product gates.

The repository is currently ineligible for GitHub Merge Queue because it is public under a personal account, so this PR retains the label-based final product gate. It removes only coverage unrelated to the classified change.

## Developer impact

Expected immediate effect:

- docs-only: common guards only; no `full-ci`, model, or GUI allocation;
- engine-only: full five-model promotion, no full GUI;
- Desktop-only: full GUI promotion, no engine/model matrix;
- cross-cutting/unknown: both full gates, unchanged.

This reduces required-green time and scarce macOS runner use without making a healthy risk-relevant gate advisory.

## Linked issue

Partial progress on #2252.

## Visual proof

N/A — CI routing and operational documentation only.

## Testing

- [x] `python3 -m pytest tests/test_ci_lane_promotion.py tests/test_classify_ci_changes.py tests/test_check_gha_pinning.py tests/test_gui_golden_ci_coverage.py -q` — 43 passed
- [x] `python3 scripts/check_workflow_expressions.py`
- [x] `python3 scripts/check_gha_pinning.py`
- [x] Both modified workflows parse as YAML
- [x] `ruff check tests/test_ci_lane_promotion.py`
- [x] `ruff format --check tests/test_ci_lane_promotion.py`
- [x] `git diff --check`

## Rollout and rollback

Rollout requires no branch-protection rename: required checks remain `tests` and `desktop-tests`. Observe one docs-only, engine-only, Desktop-only, and cross-cutting PR before marking the umbrella item complete.

Rollback is a single revert of this PR. That restores conservative all-product `full-ci` promotion. No release, secret, or production-data behavior changes.

## Review notes

Please specifically verify:

- common lint/type/workflow guards still block non-engine PRs before the engine aggregate exits;
- unknown and workflow paths still classify both lanes;
- `merge_group` still forces both full lanes;
- label application does not expand lane classification;
- branch protection check names are unchanged.
