### PR TITLE
refactor(mac): extract chat attachment draft state [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Product state for attachments waiting in the Chat composer.
+///
+/// Keeping this outside ``ChatView`` makes the important identity and lifecycle
+/// rules directly testable: every input method feeds the same draft, a send
+/// atomically consumes it, and a later turn cannot inherit stale attachments.
+struct ChatAttachmentDraft: Equatable {
+    struct Payload: Equatable {
+        let images: [ChatImageAttachment]
+        let files: [ChatFileAttachment]
+    }
+
+    private(set) var images: [ChatImageAttachment] = []
+    private(set) var files: [ChatFileAttachment] = []
+    private(set) var sourcePaths: [UUID: String] = [:]
+    var notice: String?
+    var isImportingFiles = false
+
+    var hasAttachments: Bool { !images.isEmpty || !files.isEmpty }
+
+    mutating func appendImage(_ image: ChatImageAttachment, sourceURL: URL? = nil) {
+        images.append(image)
+        if let sourceURL { sourcePaths[image.id] = Self.attachmentKey(for: sourceURL) }
+    }
+
+    mutating func appendImages(
+        _ imported: [(attachment: ChatImageAttachment, sourceURL: URL)]
+    ) {
+        for item in imported { appendImage(item.attachment, sourceURL: item.sourceURL) }
+    }
+
+    mutating func finishFileImport(
+        _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
+        notice: String?
+    ) {
+        files = ChatFileAttachment.fittedForMessage(files + imported.map(\.attachment))
+        for item in imported {
+            sourcePaths[item.attachment.id] = Self.attachmentKey(for: item.sourceURL)
+        }
+        self.notice = notice
+        isImportingFiles = false
+    }
+
+    mutating func removeImage(id: UUID) {
+        images.removeAll { $0.id == id }
+        sourcePaths[id] = nil
+    }
+
+    mutating func removeFile(id: UUID) {
+        files.removeAll { $0.id == id }
+        sourcePaths[id] = nil
+    }
+
+    /// Returns exactly one turn's attachments and clears all transient state.
+    /// This is intentionally one mutation so a new import cannot observe an
+    /// old source-path map after the visible chips have already disappeared.
+    mutating func consume() -> Payload {
+        let payload = Payload(images: images, files: files)
+        images = []
+        files = []
+        sourcePaths = [:]
+        notice = nil
+        isImportingFiles = false
+        return payload
+    }
+
+    func filteringAlreadyAttached(_ urls: [URL]) -> (fresh: [URL], duplicates: Int) {
+        Self.withoutAlreadyAttached(urls, attached: Set(sourcePaths.values))
+    }
+
+    /// Identity for "the same file". Symlinks and `..` are resolved; equal
+    /// bytes at distinct real paths deliberately remain separate attachments.
+    static func attachmentKey(for url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    static func withoutAlreadyAttached(
+        _ urls: [URL], attached: Set<String>
+    ) -> (fresh: [URL], duplicates: Int) {
+        var seen = attached
+        var fresh: [URL] = []
+        for url in urls where seen.insert(attachmentKey(for: url)).inserted {
+            fresh.append(url)
+        }
+        return (fresh, urls.count - fresh.count)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -220,19 +220,8 @@ struct ChatView: View {
     @Environment(QuickstartCoordinator.self) private var quickstart
 
     @State private var draft: String = ""
-    @State private var imageAttachments: [ChatImageAttachment] = []
-    @State private var fileAttachments: [ChatFileAttachment] = []
-    /// Source path per attachment, image or document, so the same file cannot
-    /// be added twice.
-    ///
-    /// Kept beside the attachments rather than on the attachment types: both
-    /// are `Codable` and persist with the conversation, and an absolute path
-    /// written into chat history carries the user's account name and stops
-    /// being true the moment the file moves.
-    @State private var attachedSourcePaths: [UUID: String] = [:]
-    @State private var attachmentNotice: String?
+    @State private var attachmentDraft = ChatAttachmentDraft()
     @State private var isAttachmentDropTarget = false
-    @State private var isImportingFiles = false
     @State private var composeFocusToken: Int = 0
     /// Incremented every time the user tries to send while gated. Drives
     /// the banner's brief emphasis so a blocked Return is never silent.
@@ -608,7 +597,7 @@ struct ChatView: View {
                 InlineNotice(message: error, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
-            } else if let attachmentNotice {
+            } else if let attachmentNotice = attachmentDraft.notice {
                 InlineNotice(message: attachmentNotice, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
@@ -623,7 +612,7 @@ struct ChatView: View {
             // tall and read as a card that happened to contain a text
             // area; this reads as a text field with controls in it.
             VStack(spacing: RapidTheme.Space.sm - 2) {
-                if !imageAttachments.isEmpty || !fileAttachments.isEmpty {
+                if attachmentDraft.hasAttachments {
                     attachmentStrip
                 }
                 // The field stays live in every state — a user may draft
@@ -685,7 +674,7 @@ struct ChatView: View {
                     .background(Circle().fill(Color.primary.opacity(0.06)))
             }
             .buttonStyle(.plain)
-            .disabled(viewModel.isStreaming || isImportingFiles)
+            .disabled(viewModel.isStreaming || attachmentDraft.isImportingFiles)
             .help("Add photos or files")
             .accessibilityLabel("Add attachments")
             .accessibilityIdentifier("ChatView.AddAttachments")
@@ -836,14 +825,13 @@ struct ChatView: View {
     /// replaces the old behaviour where pressing Send on a cold model
     /// silently kicked off a multi-gigabyte download behind a spinner.
     private var sendEnabled: Bool {
-        hasDraft && readiness.sendAllowed && !isImportingFiles
-            && (imageAttachments.isEmpty || supportsImageInput)
+        hasDraft && readiness.sendAllowed && !attachmentDraft.isImportingFiles
+            && (attachmentDraft.images.isEmpty || supportsImageInput)
     }
 
     private var hasDraft: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || !imageAttachments.isEmpty
-            || !fileAttachments.isEmpty
+            || attachmentDraft.hasAttachments
     }
 
     // MARK: - Actions
@@ -851,11 +839,10 @@ struct ChatView: View {
     private func send() {
         let text = draft
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                || !imageAttachments.isEmpty
-                || !fileAttachments.isEmpty else { return }
+                || attachmentDraft.hasAttachments else { return }
         guard !viewModel.isStreaming else { return }
-        guard !isImportingFiles else { return }
-        guard imageAttachments.isEmpty || supportsImageInput else {
+        guard !attachmentDraft.isImportingFiles else { return }
+        guard attachmentDraft.images.isEmpty || supportsImageInput else {
             rejectImageInputForCurrentModel()
             return
         }
@@ -871,26 +858,21 @@ struct ChatView: View {
         // tooltip carries.
         guard acknowledgeIfNotReady() else { return }
         draft = ""
-        let images = imageAttachments
-        let files = fileAttachments
-        imageAttachments = []
-        fileAttachments = []
-        attachedSourcePaths = [:]
-        attachmentNotice = nil
+        let attachments = attachmentDraft.consume()
         composeFocusToken &+= 1
         viewModel.send(
             text,
             alias: alias,
             supportsImageInput: supportsImageInput,
-            imageAttachments: images,
-            fileAttachments: files
+            imageAttachments: attachments.images,
+            fileAttachments: attachments.files
         )
     }
 
     private var attachmentStrip: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: RapidTheme.Space.sm) {
-                ForEach(imageAttachments) { attachment in
+                ForEach(attachmentDraft.images) { attachment in
                     ZStack(alignment: .topTrailing) {
                         if let image = NSImage(data: attachment.data) {
                             Image(nsImage: image)
@@ -900,8 +882,7 @@ struct ChatView: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                         }
                         Button {
-                            imageAttachments.removeAll { $0.id == attachment.id }
-                            attachedSourcePaths[attachment.id] = nil
+                            attachmentDraft.removeImage(id: attachment.id)
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .symbolRenderingMode(.palette)
@@ -915,7 +896,7 @@ struct ChatView: View {
                         )
                     }
                 }
-                ForEach(fileAttachments) { attachment in
+                ForEach(attachmentDraft.files) { attachment in
                     HStack(spacing: RapidTheme.Space.sm) {
                         Image(systemName: attachment.kind.systemImage)
                             .font(.system(size: 20))
@@ -931,8 +912,7 @@ struct ChatView: View {
                                 .lineLimit(1)
                         }
                         Button {
-                            fileAttachments.removeAll { $0.id == attachment.id }
-                            attachedSourcePaths[attachment.id] = nil
+                            attachmentDraft.removeFile(id: attachment.id)
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
@@ -978,18 +958,16 @@ struct ChatView: View {
 
     @discardableResult
     private func addAttachmentURLs(_ urls: [URL]) -> Bool {
-        guard !isImportingFiles else { return false }
+        guard !attachmentDraft.isImportingFiles else { return false }
         // Filter before splitting, so images and documents get the same
         // answer to "is this already here". Re-attaching is not merely
         // redundant for a document: the per-message character budget is split
         // evenly across attachments (``fittedForMessage``), so the same PDF
         // added four times sends a quarter of it four times over instead of
         // the whole thing once, and says so only with a "partial" chip.
-        let (urls, duplicates) = Self.withoutAlreadyAttached(
-            urls, attached: Set(attachedSourcePaths.values)
-        )
+        let (urls, duplicates) = attachmentDraft.filteringAlreadyAttached(urls)
         guard !urls.isEmpty else {
-            attachmentNotice = duplicates == 1
+            attachmentDraft.notice = duplicates == 1
                 ? "That file is already attached."
                 : "Those files are already attached."
             return false
@@ -1021,55 +999,44 @@ struct ChatView: View {
             accepted = addFileURLs(fileURLs) || accepted
         }
         if unsupported {
-            attachmentNotice = "Choose PDF, CSV, TXT, PNG, JPEG, or GIF files."
+            attachmentDraft.notice = "Choose PDF, CSV, TXT, PNG, JPEG, or GIF files."
         }
         return accepted
     }
 
     private func addImageURLs(_ urls: [URL]) {
-        var accepted: [ChatImageAttachment] = []
+        var accepted: [(attachment: ChatImageAttachment, sourceURL: URL)] = []
         var rejection: String?
         for url in urls {
             do {
-                let attachment = try ChatImageAttachment(contentsOf: url)
-                attachedSourcePaths[attachment.id] = Self.attachmentKey(for: url)
-                accepted.append(attachment)
+                accepted.append((try ChatImageAttachment(contentsOf: url), url))
             }
             catch { rejection = error.localizedDescription }
         }
-        imageAttachments.append(contentsOf: accepted)
-        attachmentNotice = rejection
+        attachmentDraft.appendImages(accepted)
+        attachmentDraft.notice = rejection
     }
 
     @discardableResult
     private func addFileURLs(_ urls: [URL]) -> Bool {
         let selection = ChatFileAttachment.importCandidates(
             urls,
-            existingCount: fileAttachments.count
+            existingCount: attachmentDraft.files.count
         )
         guard !selection.accepted.isEmpty else {
-            attachmentNotice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
+            attachmentDraft.notice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
             return false
         }
-        isImportingFiles = true
+        attachmentDraft.isImportingFiles = true
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
             }.value
 
-            let combined = fileAttachments + outcome.0.map(\.attachment)
-            fileAttachments = ChatFileAttachment.fittedForMessage(combined)
-            for imported in outcome.0 {
-                attachedSourcePaths[imported.attachment.id] = Self.attachmentKey(
-                    for: imported.sourceURL
-                )
-            }
-            if selection.rejectedCount > 0 {
-                attachmentNotice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
-            } else {
-                attachmentNotice = outcome.1
-            }
-            isImportingFiles = false
+            let notice = selection.rejectedCount > 0
+                ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
+                : outcome.1
+            attachmentDraft.finishFileImport(outcome.0, notice: notice)
         }
         return true
     }
@@ -1126,42 +1093,18 @@ struct ChatView: View {
                 return true
             }
             do {
-                imageAttachments.append(try ChatImageAttachment(
+                attachmentDraft.appendImage(try ChatImageAttachment(
                     filename: "Pasted image.png", mimeType: "image/png", data: png
                 ))
-                attachmentNotice = nil
-            } catch { attachmentNotice = error.localizedDescription }
+                attachmentDraft.notice = nil
+            } catch { attachmentDraft.notice = error.localizedDescription }
         }
         return true
     }
 
-    /// Identity for "the same file". Symlinks and `..` segments are resolved
-    /// so two spellings of one path do not read as two files; the same bytes
-    /// living at two real paths deliberately still count as two, because
-    /// deciding otherwise would mean reading every candidate before we know
-    /// whether we want it.
-    nonisolated static func attachmentKey(for url: URL) -> String {
-        url.standardizedFileURL.resolvingSymlinksInPath().path
-    }
-
-    /// Split incoming URLs into ones not yet attached and a count of the rest.
-    /// Also collapses repeats WITHIN one batch — selecting the same file twice
-    /// in the open panel is the same mistake as pasting it twice.
-    nonisolated static func withoutAlreadyAttached(
-        _ urls: [URL], attached: Set<String>
-    ) -> (fresh: [URL], duplicates: Int) {
-        var seen = attached
-        var fresh: [URL] = []
-        for url in urls {
-            let key = attachmentKey(for: url)
-            if seen.insert(key).inserted { fresh.append(url) }
-        }
-        return (fresh, urls.count - fresh.count)
-    }
-
     private func rejectImageInputForCurrentModel() {
-        attachmentNotice = "\(alias) doesn't support image input. Choose a vision model to add photos."
-        VoiceOverAnnouncer.announce(attachmentNotice ?? "This model doesn't support images.")
+        attachmentDraft.notice = "\(alias) doesn't support image input. Choose a vision model to add photos."
+        VoiceOverAnnouncer.announce(attachmentDraft.notice ?? "This model doesn't support images.")
     }
 
     /// The shared lifecycle gate for every path that would start a turn:

--- a/apps/rapid-mac/Tests/RapidTests/AttachmentDedupTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AttachmentDedupTests.swift
@@ -24,7 +24,7 @@ struct AttachmentDedupTests {
 
     /// A filter nothing calls is not a filter.
     ///
-    /// The cases below all exercise ``ChatView/withoutAlreadyAttached`` in
+    /// The cases below all exercise ``ChatAttachmentDraft/withoutAlreadyAttached`` in
     /// isolation, so deleting its one call site leaves every one of them
     /// green — verified by doing exactly that. This session has now produced
     /// three bugs of that shape (a window floor declared but never applied, a
@@ -47,7 +47,7 @@ struct AttachmentDedupTests {
         // Reduced to a Bool first: `#expect` prints the expression it is
         // handed, and the stripped source is the whole of ChatView.
         let wired = stripped.contains(
-            "Self.withoutAlreadyAttached(urls,attached:Set(attachedSourcePaths.values))"
+            "attachmentDraft.filteringAlreadyAttached(urls)"
         )
         #expect(
             wired,
@@ -65,8 +65,8 @@ struct AttachmentDedupTests {
 
     @Test("A file already attached is rejected, and counted")
     func rejectsAlreadyAttached() {
-        let attached: Set<String> = [ChatView.attachmentKey(for: url("/tmp/report.pdf"))]
-        let (fresh, duplicates) = ChatView.withoutAlreadyAttached(
+        let attached: Set<String> = [ChatAttachmentDraft.attachmentKey(for: url("/tmp/report.pdf"))]
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/report.pdf")], attached: attached
         )
         #expect(fresh.isEmpty)
@@ -77,7 +77,7 @@ struct AttachmentDedupTests {
     /// pasting it twice, and arrives as a single batch.
     @Test("Repeats inside one batch collapse")
     func collapsesRepeatsWithinABatch() {
-        let (fresh, duplicates) = ChatView.withoutAlreadyAttached(
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/a.pdf"), url("/tmp/a.pdf"), url("/tmp/b.csv")],
             attached: []
         )
@@ -89,8 +89,8 @@ struct AttachmentDedupTests {
     /// `a.pdf` reached from different working directories both attach.
     @Test("Path spelling does not create a second file")
     func normalisesPathSpelling() {
-        let attached: Set<String> = [ChatView.attachmentKey(for: url("/tmp/docs/a.pdf"))]
-        let (fresh, _) = ChatView.withoutAlreadyAttached(
+        let attached: Set<String> = [ChatAttachmentDraft.attachmentKey(for: url("/tmp/docs/a.pdf"))]
+        let (fresh, _) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/docs/../docs/a.pdf")], attached: attached
         )
         #expect(fresh.isEmpty, "a non-normalised path attached the same file again")
@@ -102,8 +102,8 @@ struct AttachmentDedupTests {
     /// discovered later.
     @Test("Distinct paths remain distinct")
     func distinctPathsAreKept() {
-        let attached: Set<String> = [ChatView.attachmentKey(for: url("/tmp/a.pdf"))]
-        let (fresh, duplicates) = ChatView.withoutAlreadyAttached(
+        let attached: Set<String> = [ChatAttachmentDraft.attachmentKey(for: url("/tmp/a.pdf"))]
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/copy/a.pdf")], attached: attached
         )
         #expect(fresh.count == 1)
@@ -115,10 +115,10 @@ struct AttachmentDedupTests {
     @Test("The filter does not care whether the file is an image or a document")
     func imagesAndDocumentsShareTheFilter() {
         let attached: Set<String> = [
-            ChatView.attachmentKey(for: url("/tmp/shot.png")),
-            ChatView.attachmentKey(for: url("/tmp/report.pdf")),
+            ChatAttachmentDraft.attachmentKey(for: url("/tmp/shot.png")),
+            ChatAttachmentDraft.attachmentKey(for: url("/tmp/report.pdf")),
         ]
-        let (fresh, duplicates) = ChatView.withoutAlreadyAttached(
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/shot.png"), url("/tmp/report.pdf"), url("/tmp/new.csv")],
             attached: attached
         )
@@ -128,7 +128,7 @@ struct AttachmentDedupTests {
 
     @Test("Nothing attached yet lets everything through")
     func emptyAttachedSetAcceptsAll() {
-        let (fresh, duplicates) = ChatView.withoutAlreadyAttached(
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
             [url("/tmp/a.pdf"), url("/tmp/b.pdf")], attached: []
         )
         #expect(fresh.count == 2)

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import Rapid
+
+@Suite("Chat attachment draft state")
+struct ChatAttachmentDraftTests {
+    @Test("consume atomically clears attachments, identity, notice, and import state")
+    func consumeClearsEveryTransientField() throws {
+        let image = try makeImage(name: "first.png")
+        let file = try makeFile(name: "notes.txt", text: "first turn")
+        let imageURL = URL(fileURLWithPath: "/tmp/first.png")
+        let fileURL = URL(fileURLWithPath: "/tmp/notes.txt")
+        var draft = ChatAttachmentDraft()
+        draft.appendImage(image, sourceURL: imageURL)
+        draft.finishFileImport([(file, fileURL)], notice: "old notice")
+        draft.isImportingFiles = true
+
+        let payload = draft.consume()
+
+        #expect(payload.images == [image])
+        #expect(payload.files == [file])
+        #expect(!draft.hasAttachments)
+        #expect(draft.sourcePaths.isEmpty)
+        #expect(draft.notice == nil)
+        #expect(!draft.isImportingFiles)
+    }
+
+    @Test("a second turn cannot inherit the first turn's image or file")
+    func sequentialTurnsRemainIsolated() throws {
+        let firstImage = try makeImage(name: "first.png")
+        let secondImage = try makeImage(name: "second.png")
+        let firstFile = try makeFile(name: "first.txt", text: "alpha")
+        let secondFile = try makeFile(name: "second.txt", text: "beta")
+        var draft = ChatAttachmentDraft()
+
+        draft.appendImage(firstImage)
+        draft.finishFileImport([(firstFile, URL(fileURLWithPath: "/tmp/first.txt"))], notice: nil)
+        let first = draft.consume()
+
+        draft.appendImage(secondImage)
+        draft.finishFileImport([(secondFile, URL(fileURLWithPath: "/tmp/second.txt"))], notice: nil)
+        let second = draft.consume()
+
+        #expect(first.images.map(\.filename) == ["first.png"])
+        #expect(first.files.map(\.filename) == ["first.txt"])
+        #expect(second.images.map(\.filename) == ["second.png"])
+        #expect(second.files.map(\.filename) == ["second.txt"])
+    }
+
+    @Test("removing an attachment also releases its source identity")
+    func removalReleasesIdentity() throws {
+        let url = URL(fileURLWithPath: "/tmp/reusable.png")
+        let image = try makeImage(name: "reusable.png")
+        var draft = ChatAttachmentDraft()
+        draft.appendImage(image, sourceURL: url)
+        #expect(draft.filteringAlreadyAttached([url]).duplicates == 1)
+
+        draft.removeImage(id: image.id)
+
+        #expect(draft.filteringAlreadyAttached([url]).fresh == [url])
+    }
+
+    @Test("all input methods share one path-normalized duplicate filter")
+    func duplicateFilterCoversExistingAndBatchDuplicates() {
+        let existing = URL(fileURLWithPath: "/tmp/docs/photo.png")
+        let sameSpelling = URL(fileURLWithPath: "/tmp/docs/../docs/photo.png")
+        let fresh = URL(fileURLWithPath: "/tmp/new.txt")
+        var draft = ChatAttachmentDraft()
+        let image = try? makeImage(name: "photo.png")
+        if let image { draft.appendImage(image, sourceURL: existing) }
+
+        let result = draft.filteringAlreadyAttached([sameSpelling, fresh, fresh])
+
+        #expect(result.fresh == [fresh])
+        #expect(result.duplicates == 2)
+    }
+
+    private func makeImage(name: String) throws -> ChatImageAttachment {
+        try ChatImageAttachment(
+            filename: name,
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4E, 0x47])
+        )
+    }
+
+    private func makeFile(name: String, text: String) throws -> ChatFileAttachment {
+        try ChatFileAttachment(
+            filename: name,
+            kind: .txt,
+            extractedText: text,
+            sourceByteCount: text.utf8.count
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- move pending Chat image/document state out of `ChatView` into a directly testable `ChatAttachmentDraft` value
- make send atomically consume attachments, source identity, notices, and import state
- keep open-panel, drag/drop, paste, removal, and duplicate filtering on the same state boundary
- add deterministic coverage for sequential A → B turns so old images/files cannot leak into a later request

Part of #2254. This PR is intentionally limited to the first Chat attachment state extraction; it does not add XCUITest or change attachment UX.

## Validation
- `swift test --package-path apps/rapid-mac --filter "ChatAttachmentDraftTests|AttachmentDedupTests|ChatImageAttachmentTests|ChatFileAttachmentTests"` — 35 passed
- `git diff --check`
- Rapid app target compiled as part of the Swift test build

## Review checklist
- macOS only; no public API or backend changes
- no network, model, persistence format, or security-boundary changes
- existing open-panel, paste, and drag/drop entry points remain wired to the shared importer
- no visual change