### PR TITLE
refactor(mac): extract dictation enable policy [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -275,45 +275,37 @@ final class DictationController {
         // after ``disable()`` has already torn the session down.
         guard isEnabled, enableRequestID == requestID else { return }
         refreshReadiness()
-        guard readinessSnapshot.microphone else {
-            lastError = "Dictation needs Microphone access before it can be enabled."
+        let decision = DictationEnablePolicy.evaluate(.init(
+            microphone: readinessSnapshot.microphone,
+            accessibility: readinessSnapshot.accessibility,
+            modelSelected: readinessSnapshot.modelSelected,
+            modelOnDisk: readinessSnapshot.modelOnDisk,
+            modelAlias: modelAlias
+        ))
+        if case .reject(let message, let disableIntent) = decision {
+            lastError = message
             phase = .off
-            isEnabled = false
-            return
-        }
-        guard readinessSnapshot.modelSelected else {
-            lastError = "Choose a transcription model before enabling dictation."
-            phase = .off
-            isEnabled = false
-            return
-        }
-        guard readinessSnapshot.modelOnDisk else {
-            lastError = "\(modelAlias) isn't downloaded yet. Download it in the Model row, then turn dictation on."
-            phase = .off
-            isEnabled = false
-            return
-        }
-        guard readinessSnapshot.accessibility else {
-            lastError = "Dictation needs Accessibility access before the hotkey can be used."
-            // The switch records the user's intent and is left alone. Writing
-            // it back to off means a permission that lapses once disables
-            // dictation permanently: the grant is fixed later, but the stored
-            // flag stays false and nothing re-arms. The UI shows an amber dot
-            // and an Arm control for this state, and turning it off by hand is
-            // never blocked, so nobody is stranded by keeping it on.
-            phase = .off
+            // Missing local model/recording prerequisites make the persisted
+            // intent invalid. Accessibility is different: the user already
+            // expressed intent, and granting TCC later should allow re-arm.
+            if disableIntent { isEnabled = false }
             return
         }
         hotkey.stop()
         phase = .preparingModel
         let preparingAlias = modelAlias
-        guard await prewarmModel(replacingCurrent: replacingCurrentPrewarm),
-              isEnabled,
-              enableRequestID == requestID,
-              modelAlias == preparingAlias,
-              phase == .preparingModel,
-              server.servingAlias == preparingAlias
-        else {
+        let prewarmSucceeded = await prewarmModel(
+            replacingCurrent: replacingCurrentPrewarm
+        )
+        guard DictationEnablePolicy.mayRegisterHotkey(after: .init(
+            prewarmSucceeded: prewarmSucceeded,
+            isEnabled: isEnabled,
+            requestIsCurrent: enableRequestID == requestID,
+            selectedAlias: modelAlias,
+            preparingAlias: preparingAlias,
+            isPreparing: phase == .preparingModel,
+            servingAlias: server.servingAlias
+        )) else {
             if isEnabled, enableRequestID == requestID, modelAlias == preparingAlias {
                 lastError = "\(preparingAlias) couldn't load. There may not be enough memory to start dictation."
                 phase = .off

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Pure enable/arming decisions for Dictation.
+///
+/// The controller owns async catalog, model and event-tap side effects. This
+/// value owns the policy between them so every prerequisite and stale-request
+/// boundary can be exhaustively tested without constructing AppKit/AV objects.
+struct DictationEnablePolicy {
+    struct Prerequisites: Equatable {
+        var microphone: Bool
+        var accessibility: Bool
+        var modelSelected: Bool
+        var modelOnDisk: Bool
+        var modelAlias: String
+    }
+
+    enum Decision: Equatable {
+        case prepareModel
+        case reject(message: String, disableIntent: Bool)
+    }
+
+    static func evaluate(_ input: Prerequisites) -> Decision {
+        guard input.microphone else {
+            return .reject(
+                message: "Dictation needs Microphone access before it can be enabled.",
+                disableIntent: true
+            )
+        }
+        guard input.modelSelected else {
+            return .reject(
+                message: "Choose a transcription model before enabling dictation.",
+                disableIntent: true
+            )
+        }
+        guard input.modelOnDisk else {
+            return .reject(
+                message: "\(input.modelAlias) isn't downloaded yet. Download it in the Model row, then turn dictation on.",
+                disableIntent: true
+            )
+        }
+        guard input.accessibility else {
+            return .reject(
+                message: "Dictation needs Accessibility access before the hotkey can be used.",
+                disableIntent: false
+            )
+        }
+        return .prepareModel
+    }
+
+    struct PreparedState: Equatable {
+        var prewarmSucceeded: Bool
+        var isEnabled: Bool
+        var requestIsCurrent: Bool
+        var selectedAlias: String
+        var preparingAlias: String
+        var isPreparing: Bool
+        var servingAlias: String?
+    }
+
+    /// The sole policy gate before installing the process-global hotkey.
+    /// Every async identity must still match after model preparation; a stale
+    /// completion is never allowed to arm input for a different user state.
+    static func mayRegisterHotkey(after state: PreparedState) -> Bool {
+        state.prewarmSucceeded
+            && state.isEnabled
+            && state.requestIsCurrent
+            && state.selectedAlias == state.preparingAlias
+            && state.isPreparing
+            && state.servingAlias == state.preparingAlias
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/DictationEnablePolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationEnablePolicyTests.swift
@@ -1,0 +1,94 @@
+import Testing
+
+@testable import Rapid
+
+@Suite("Dictation enable policy")
+struct DictationEnablePolicyTests {
+    @Test(
+        "every missing prerequisite rejects before model preparation",
+        arguments: [
+            (false, true, true, true, true, "Microphone"),
+            (true, true, false, true, true, "Choose a transcription model"),
+            (true, true, true, false, true, "isn't downloaded yet"),
+            (true, false, true, true, false, "Accessibility"),
+        ]
+    )
+    func prerequisiteFailures(
+        microphone: Bool,
+        accessibility: Bool,
+        selected: Bool,
+        onDisk: Bool,
+        disablesIntent: Bool,
+        messageFragment: String
+    ) {
+        let decision = DictationEnablePolicy.evaluate(.init(
+            microphone: microphone,
+            accessibility: accessibility,
+            modelSelected: selected,
+            modelOnDisk: onDisk,
+            modelAlias: "whisper-small"
+        ))
+
+        guard case .reject(let message, let disableIntent) = decision else {
+            Issue.record("missing prerequisite was allowed to prepare the model")
+            return
+        }
+        #expect(message.contains(messageFragment))
+        #expect(disableIntent == disablesIntent)
+    }
+
+    @Test("complete prerequisites advance to model preparation")
+    func completePrerequisitesPrepare() {
+        #expect(DictationEnablePolicy.evaluate(.init(
+            microphone: true,
+            accessibility: true,
+            modelSelected: true,
+            modelOnDisk: true,
+            modelAlias: "whisper-small"
+        )) == .prepareModel)
+    }
+
+    @Test(
+        "hotkey registration requires every post-warmup identity boundary",
+        arguments: [
+            (false, true, true, "whisper-small", "whisper-small", true, "whisper-small"),
+            (true, false, true, "whisper-small", "whisper-small", true, "whisper-small"),
+            (true, true, false, "whisper-small", "whisper-small", true, "whisper-small"),
+            (true, true, true, "qwen-asr", "whisper-small", true, "whisper-small"),
+            (true, true, true, "whisper-small", "whisper-small", false, "whisper-small"),
+            (true, true, true, "whisper-small", "whisper-small", true, "other-model"),
+        ]
+    )
+    func stalePreparedStateCannotArm(
+        prewarm: Bool,
+        enabled: Bool,
+        currentRequest: Bool,
+        selectedAlias: String,
+        preparingAlias: String,
+        preparing: Bool,
+        servingAlias: String
+    ) {
+        #expect(!DictationEnablePolicy.mayRegisterHotkey(after: .init(
+            prewarmSucceeded: prewarm,
+            isEnabled: enabled,
+            requestIsCurrent: currentRequest,
+            selectedAlias: selectedAlias,
+            preparingAlias: preparingAlias,
+            isPreparing: preparing,
+            servingAlias: servingAlias
+        )))
+    }
+
+    @Test("only the current ready model may register the hotkey")
+    func currentPreparedModelMayArm() {
+        #expect(DictationEnablePolicy.mayRegisterHotkey(after: .init(
+            prewarmSucceeded: true,
+            isEnabled: true,
+            requestIsCurrent: true,
+            selectedAlias: "whisper-small",
+            preparingAlias: "whisper-small",
+            isPreparing: true,
+            servingAlias: "whisper-small"
+        )))
+    }
+}


### PR DESCRIPTION
## Summary
- extract Dictation prerequisite decisions from the side-effectful controller into a pure policy value
- centralize the complete post-warmup identity gate that must pass before the process-global hotkey is registered
- add table-driven coverage for every missing prerequisite and every stale async boundary
- preserve the existing #2193 loading/readiness UX and runtime behavior

Part of #2254. This PR is intentionally limited to Audio/Dictation enable and hotkey policy extraction; it does not change UI or add GUI automation.

## Validation
- `swift test --package-path apps/rapid-mac --filter "DictationEnablePolicyTests|DictationTests"` — 34 passed
- `git diff --check`
- Rapid app target compiled as part of the Swift test build

## Review checklist
- macOS only; no public API or server changes
- no permission, persistence, model-loading, or hotkey behavior change intended
- Accessibility remains the one prerequisite that preserves the user enabled intent
- the hotkey remains impossible to register until the current selected model is serving and preparation is current
- no visual change