### PR TITLE
[codex] ci: route engine-only contracts after classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,19 +93,6 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check .
 
-      # Structural check — catches "silent flag drop" bugs where a CLI
-      # arg is defined but never plumbed to its target config (#400).
-      # Pure stdlib + AST — no mlx import required, runs on Linux.
-      - name: CLI ↔ Config fidelity audit
-        run: python scripts/audit_cli_config_fidelity.py
-
-      # The engine and the desktop app ship ONE version number. Two
-      # hand-maintained sources (pyproject.toml and the app's Info.plist)
-      # had nothing between them and drifted to 0.12.5 vs 0.12.6, both
-      # called "the latest release". Stdlib only — no mlx, no macOS.
-      - name: Engine ↔ desktop app version sync
-        run: python scripts/check_version_sync.py
-
       # PF-3 — all GitHub Actions are immutable 40-char commit SHA pins.
       # Dependabot or a reviewed PR is required to advance an action.
       - name: GitHub Actions SHA pinning
@@ -124,6 +111,29 @@ jobs:
       # regenerating the GitHub-facing Mermaid/SVG views.
       - name: Model-management architecture SSOT
         run: python scripts/render_model_management_architecture.py --check
+
+      # The engine and the desktop app ship ONE version number. Keep this
+      # universal because either side of that cross-product contract can change.
+      - name: Engine ↔ desktop app version sync
+        run: python scripts/check_version_sync.py
+
+  engine-contracts:
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.13"
+
+      # Structural check — catches "silent flag drop" bugs where a CLI
+      # arg is defined but never plumbed to its target config (#400).
+      # Pure stdlib + AST — no mlx import required, runs on Linux.
+      - name: CLI ↔ Config fidelity audit
+        run: python scripts/audit_cli_config_fidelity.py
 
       # The release scripts cannot be exercised without cutting a release, so
       # their tag-claim, recovery and refuse-to-move paths are covered offline
@@ -174,7 +184,10 @@ jobs:
     # unless a guarded specifier actually changes. PR-only: it diffs the head
     # against the PR base, which a push-to-main event has no meaningful analogue
     # for (origin/main == the pushed commit).
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.engine == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -204,6 +217,8 @@ jobs:
         run: python scripts/check_mlx_bound_move.py
 
   type-check:
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -424,6 +439,7 @@ jobs:
     needs:
       - changes
       - lint
+      - engine-contracts
       - mlx-bound-guard
       - type-check
       - test-matrix
@@ -434,8 +450,21 @@ jobs:
     steps:
       - name: Check test results
         run: |
+          if [ "${{ needs.changes.result }}" != success ]; then
+            echo "CI change classifier failed"
+            exit 1
+          fi
           if [ "${{ needs.lint.result }}" != success ]; then
-            echo "Lint and static repository contracts failed"
+            echo "Universal repository guards failed"
+            exit 1
+          fi
+          expected="${{ needs.changes.outputs.engine }}"
+          if [ "$expected" != "true" ]; then
+            echo "Engine lanes not required for this change"
+            exit 0
+          fi
+          if [ "${{ needs.engine-contracts.result }}" != success ]; then
+            echo "Engine lint and static contracts failed"
             exit 1
           fi
           if [ "${{ needs.type-check.result }}" != success ]; then
@@ -446,11 +475,6 @@ jobs:
             && [ "${{ needs.mlx-bound-guard.result }}" != success ]; then
             echo "MLX dependency-bound guard failed"
             exit 1
-          fi
-          expected="${{ needs.changes.outputs.engine }}"
-          if [ "$expected" != "true" ]; then
-            echo "Engine lanes not required for this change"
-            exit 0
           fi
           if [ "${{ github.event_name }}" = "pull_request" ] \
             && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -681,6 +681,10 @@ jobs:
           GOLDEN_FLOWS: ${{ needs.gui-golden-flows.result }}
         run: |
           set -euo pipefail
+          if [ "${{ needs.changes.result }}" != success ]; then
+            echo "Desktop change classifier failed"
+            exit 1
+          fi
           if [ "$DESKTOP_EXPECTED" != true ]; then
             echo "Desktop lane not required for this PR"
             exit 0

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -13,8 +13,18 @@ product area selects all applicable lanes.
   one representative L1 model (`qwen3.5-4b-4bit`).
 - Desktop changes run the Swift build/test and the inexpensive GUI harness
   contracts. They do not run engine model smokes.
-- Documentation-only changes run the common lightweight checks and stable
-  aggregate jobs, without allocating a macOS runner.
+- Documentation-only changes run universal repository guards and stable
+  aggregate jobs, without allocating an engine, type-check, MLX-bound, model,
+  or macOS runner. Universal guards retain workflow-expression, immutable
+  Action-pin, and architecture-SSOT checks.
+
+Engine-only contracts are admitted by the same fail-closed classifier as the
+engine test lanes. They include CLI/config fidelity, release and installer
+offline tests, and the parser microbenchmark. Desktop-only and
+documentation-only changes do not pay for those engine-specific dependencies
+and commands. Whole-repository Ruff and engine/Desktop version synchronization
+remain universal because Desktop support code includes Python and either side
+of the shared version contract may change.
 
 The required checks are the stable aggregate jobs `tests` and `desktop-tests`.
 They must not be renamed or hidden behind workflow-level path filters without a

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -41,20 +41,65 @@ def test_desktop_full_ci_still_classifies_the_pr_diff():
 
 def test_non_engine_change_exits_before_full_ci_requirement():
     run = _step_run(ENGINE_WORKFLOW, "tests", "Check test results")
+    classifier_gate = run.index("needs.changes.result")
     common_gate = run.index("needs.lint.result")
     no_lane = run.index('if [ "$expected" != "true" ]')
+    engine_gate = run.index("needs.engine-contracts.result")
     promotion = run.index("needs.changes.outputs.full_gate")
-    assert common_gate < no_lane < promotion
+    assert classifier_gate < common_gate < no_lane < engine_gate < promotion
 
 
 def test_non_desktop_change_exits_before_full_ci_requirement():
     run = _step_run(DESKTOP_WORKFLOW, "desktop-tests", "Check desktop results")
+    classifier_gate = run.index("needs.changes.result")
     no_lane = run.index('if [ "$DESKTOP_EXPECTED" != true ]')
     promotion = run.index('if [ "${{ github.event_name }}" = pull_request ]')
-    assert no_lane < promotion
+    assert classifier_gate < no_lane < promotion
 
 
 def test_gui_golden_job_requires_both_desktop_lane_and_full_promotion():
     condition = str(_job(DESKTOP_WORKFLOW, "gui-golden-flows")["if"])
     assert "needs.changes.outputs.desktop == 'true'" in condition
     assert "needs.changes.outputs.full_gate == 'true'" in condition
+
+
+def test_engine_only_contracts_are_not_universal_pr_guards():
+    universal_steps = {
+        step.get("name") for step in _job(ENGINE_WORKFLOW, "lint")["steps"]
+    }
+    engine_steps = {
+        step.get("name") for step in _job(ENGINE_WORKFLOW, "engine-contracts")["steps"]
+    }
+    assert {
+        "GitHub Actions SHA pinning",
+        "Workflow expression sanity",
+        "Model-management architecture SSOT",
+        "Run ruff lint",
+        "Run ruff format check",
+        "Engine ↔ desktop app version sync",
+    } <= universal_steps
+    assert {
+        "CLI ↔ Config fidelity audit",
+        "Release-script offline tests",
+        "Installer offline tests",
+        "Parser microbench",
+    } <= engine_steps
+    assert not universal_steps & {
+        "CLI ↔ Config fidelity audit",
+        "Release-script offline tests",
+        "Installer offline tests",
+        "Parser microbench",
+    }
+
+
+def test_engine_jobs_follow_fail_closed_engine_classification():
+    for job_name in ("engine-contracts", "type-check"):
+        job = _job(ENGINE_WORKFLOW, job_name)
+        assert job["needs"] == "changes"
+        assert str(job["if"]) == "needs.changes.outputs.engine == 'true'"
+
+    bound_guard = _job(ENGINE_WORKFLOW, "mlx-bound-guard")
+    assert bound_guard["needs"] == "changes"
+    condition = str(bound_guard["if"])
+    assert "github.event_name == 'pull_request'" in condition
+    assert "needs.changes.outputs.engine == 'true'" in condition


### PR DESCRIPTION
## ELI5

Documentation and Desktop-only pull requests no longer install or run engine-only parser, installer, release, mypy, and MLX dependency contracts. Universal repository safety checks still run everywhere, and unknown/workflow changes still fail closed into every lane.

## What changed

- Keep universal Ruff, Action pinning, workflow-expression, architecture-SSOT, and engine/Desktop version-sync checks in the always-present `lint` job.
- Move CLI/config fidelity, release-script tests, installer tests, and parser microbench into an `engine-contracts` job selected by `engine=true`.
- Select mypy and the MLX-bound guard only for engine changes.
- Require both engine and Desktop aggregate jobs to fail when their classifier job fails.
- Extend routing contract tests and operational documentation.

## Why

The previous universal job installed parser dependencies and ran engine/release/installer contracts for docs-only and Desktop-only changes. Type-check and MLX-bound jobs also started even when no engine code could be affected.

The split removes irrelevant work without weakening relevant coverage:

- Python-backed Desktop support still receives universal whole-repository Ruff.
- Shared engine/Desktop version consistency remains universal.
- Workflow and unknown paths classify as engine + Desktop and run everything.
- Engine aggregates still require engine contracts, mypy, MLX-bound, unit, Apple Silicon, and model gates.
- A failed classifier can no longer produce empty outputs and accidentally pass an aggregate as an unselected lane.

## Linked issue

Progress on #2252.

## Visual proof

N/A — CI routing only.

## Testing

- [x] 69 focused routing/classifier/workflow/version tests passed
- [x] full-repository `ruff check .`
- [x] full-repository `ruff format --check .`
- [x] workflow expression validation
- [x] immutable GitHub Action pin validation
- [x] model-management architecture SSOT validation
- [x] engine/Desktop version synchronization
- [x] actionlint and YAML parsing
- [x] `git diff --check`

## Expected impact

- docs-only: universal repository guards only; no engine contracts, mypy, MLX-bound, model, or macOS lanes.
- Desktop-only: universal guards plus selected Desktop lanes; no engine contracts, mypy, MLX-bound, or model lanes.
- engine-only: unchanged relevant coverage, with engine contracts running in parallel with other engine jobs.
- cross-cutting/unknown: unchanged full coverage.

GitHub job durations on this PR will provide the post-change timing evidence. This PR itself changes workflows, so it intentionally selects both full product lanes.

## Rollout and rollback

Required check names remain `tests` and `desktop-tests`; no branch-protection migration is required. Rollback is a single revert, which returns all contracts to the universal job. No release, secret, or production-data behavior changes.

## Review notes

Please verify:

- every moved contract is required by the engine aggregate;
- Ruff and version sync remain universal for Desktop Python/version changes;
- classifier failure blocks both aggregates;
- docs/Desktop-only paths skip engine jobs;
- unknown/workflow paths continue to select all lanes.
