### PR TITLE
test(mac): inventory GUI journeys and timings [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -1,0 +1,247 @@
+version: 1
+
+# Machine-readable inventory for GUI coverage and future source-based routing.
+# `source_paths` are intentionally conservative product-area prefixes, not a
+# promise that every edit below them requires this journey. Routing will be a
+# separate, fail-closed change once this inventory is established.
+journeys:
+  - name: fresh-install
+    group: onboarding-settings
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/, apps/rapid-mac/Sources/Rapid/RapidApp.swift]
+    owns_baseline: true
+  - name: cached-quickstart
+    group: onboarding-settings
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, cached-model, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/, apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: false
+  - name: cached-curated-tradeup
+    group: onboarding-settings
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, cached-model, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/, apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: false
+  - name: cached-variant-collapse
+    group: models
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, cached-model, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: false
+  - name: download-progress
+    group: onboarding-settings
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, slow-download, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/, apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: false
+  - name: settings-persistence
+    group: onboarding-settings
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift]
+    owns_baseline: true
+  - name: settings-mtp
+    group: onboarding-settings
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/, apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: true
+  - name: chat-restore
+    group: chat
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/UI/ChatView.swift]
+    owns_baseline: true
+  - name: message-actions
+    group: chat
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: false
+  - name: restored-tools
+    group: chat
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/Tools/]
+    owns_baseline: false
+  - name: tool-loop-budget
+    group: chat
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/Tools/]
+    owns_baseline: false
+  - name: chat-depth
+    group: chat
+    risk: low
+    driver: ax
+    ci_tier: local
+    fixtures: [fake-sidecar, large-window, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: true
+  - name: math-rendering
+    group: chat
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/UI/Markdown/]
+    owns_baseline: false
+  - name: slow-stream-stop
+    group: chat
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, slow-stream, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: true
+  - name: model-crash-recovery
+    group: app-lifecycle
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, crash-once, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/]
+    owns_baseline: true
+  - name: low-memory-choice
+    group: models
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, low-memory, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/UI/]
+    owns_baseline: false
+  - name: update-state
+    group: onboarding-settings
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, update-state, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift, apps/rapid-mac/Sources/Rapid/Updater/]
+    owns_baseline: true
+  - name: update-busy
+    group: onboarding-settings
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, update-busy, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift, apps/rapid-mac/Sources/Rapid/Updater/]
+    owns_baseline: true
+  - name: campaign-banner
+    group: app-lifecycle
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, campaign, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift, apps/rapid-mac/Sources/Rapid/RapidApp.swift]
+    owns_baseline: true
+  - name: window-close-prompt
+    group: app-lifecycle
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/MainWindowCloseInterceptor.swift, apps/rapid-mac/Sources/Rapid/UI/DockVisibilityPrompt.swift]
+    owns_baseline: false
+  - name: no-dead-controls
+    group: onboarding-settings
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/]
+    owns_baseline: false
+  - name: catalog-integrity
+    group: models
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, mixed-capability-catalog, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: false
+  - name: browse-all-destination
+    group: onboarding-settings
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/UI/]
+    owns_baseline: false
+  - name: chat-document-attachment
+    group: chat
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, document, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: false
+  - name: chat-multimodal-attachments
+    group: chat
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, two-images, document, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    owns_baseline: false
+  - name: image-generation
+    group: images
+    risk: high
+    driver: hybrid
+    ci_tier: pr
+    fixtures: [fake-sidecar, generated-images, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Images/]
+    owns_baseline: true
+  - name: dictation
+    group: audio
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, delayed-transcription, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/]
+    owns_baseline: false
+  - name: audio-readiness
+    group: audio
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, audio-models, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Dictation/]
+    owns_baseline: true
+  - name: resident-load-rejected
+    group: models
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, resident-model, low-memory, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/Audio/]
+    owns_baseline: false
+  - name: launch-integrations
+    group: app-lifecycle
+    risk: medium
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/RapidApp.swift, apps/rapid-mac/Sources/Rapid/UI/]
+    owns_baseline: true

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -97,8 +97,8 @@ PR workflow. `chat-depth` is explicitly local-only because the hosted runner's
 small window virtualizes its oldest transcript rows; all other declared flows
 are PR-gated when the full Desktop gate is selected.
 
-Each invocation writes a `result.json` containing its outcome, UTC start time,
-execution duration in seconds, and artifact directory. This makes per-journey
+Each journey execution writes a `result.json` containing its outcome, UTC start
+time, execution duration in seconds, and artifact directory. This makes per-journey
 timing and failure evidence machine-readable without parsing Actions logs.
 
 ### Current baseline

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -89,17 +89,17 @@ were all invisible to journey-shaped tests:
 
 ### Full flow roster
 
-The numbered narrative above is selective. The authoritative, complete set of
-flows the harness can run is the dispatch table in `scripts/gui-golden-flows.sh`
-(`case "$FLOW" in …`). As of this checkout that is 26 flows: `fresh-install`,
-`cached-quickstart`, `cached-curated-tradeup`, `download-progress`,
-`settings-persistence`, `settings-mtp`, `chat-restore`, `message-actions`,
-`restored-tools`, `tool-loop-budget`, `chat-depth`, `math-rendering`,
-`slow-stream-stop`, `model-crash-recovery`, `low-memory-choice`, `update-state`,
-`window-close-prompt`, `no-dead-controls`, `catalog-integrity`,
-`browse-all-destination`, `chat-document-attachment`, `image-generation`,
-`dictation`, `audio-readiness`, `resident-load-rejected`, `launch-integrations`.
-`--flow all` runs them in that order.
+The numbered narrative above is selective. The authoritative inventory is
+`Tests/GUIGoldenFlows/journeys.yaml`. It records every journey's group, risk,
+driver, fixtures, source-path mapping, CI tier, and structural-baseline
+ownership. Contract tests fail if it drifts from the shell dispatcher or the
+PR workflow. `chat-depth` is explicitly local-only because the hosted runner's
+small window virtualizes its oldest transcript rows; all other declared flows
+are PR-gated when the full Desktop gate is selected.
+
+Each invocation writes a `result.json` containing its outcome, UTC start time,
+execution duration in seconds, and artifact directory. This makes per-journey
+timing and failure evidence machine-readable without parsing Actions logs.
 
 ### Current baseline
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -197,14 +197,14 @@ cleanup_operator_server() {
 finish() {
     local status=$?
     set +e
+    cleanup_persona
+    cleanup_operator_server
     if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 ]]; then
         mkdir -p "$OUT_ROOT" 2>/dev/null || true
         if [[ -d "$OUT_ROOT" ]]; then
             write_result fail "$status" 2>/dev/null || true
         fi
     fi
-    cleanup_persona
-    cleanup_operator_server
 }
 trap finish EXIT
 trap 'cleanup_persona; cleanup_operator_server; exit 130' INT

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -45,6 +45,8 @@ MAIN_WINDOW_ID=""
 BUNDLE_ID=""
 AX_DRIVER=""
 RESULT_WRITTEN=0
+RUN_STARTED_EPOCH="$(date +%s)"
+RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 PERSONA_ENV=()
 
 usage() {
@@ -184,9 +186,16 @@ finish() {
     local status=$?
     set +e
     if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 && -d "$OUT_ROOT" ]]; then
+        local finished_epoch duration_seconds
+        finished_epoch="$(date +%s)"
+        duration_seconds=$((finished_epoch - RUN_STARTED_EPOCH))
         jq -n --arg status fail --arg flow "$FLOW" --arg app "$APP_SOURCE" \
+            --arg started_at "$RUN_STARTED_AT" --arg artifact_path "$OUT_ROOT" \
+            --argjson duration_seconds "$duration_seconds" \
             --argjson exit_code "$status" \
-            '{status: $status, flow: $flow, app: $app, exit_code: $exit_code}' \
+            '{status: $status, flow: $flow, app: $app, started_at: $started_at,
+              duration_seconds: $duration_seconds, artifact_path: $artifact_path,
+              exit_code: $exit_code}' \
             > "$OUT_ROOT/result.json" 2>/dev/null || true
     fi
     cleanup_persona
@@ -4776,8 +4785,14 @@ case "$FLOW" in
     *) die "unknown flow: $FLOW" ;;
 esac
 
+FINISHED_EPOCH="$(date +%s)"
+DURATION_SECONDS=$((FINISHED_EPOCH - RUN_STARTED_EPOCH))
 jq -n --arg status pass --arg flow "$FLOW" --arg app "$APP_SOURCE" \
-    '{status: $status, flow: $flow, app: $app}' > "$OUT_ROOT/result.json"
+    --arg started_at "$RUN_STARTED_AT" --arg artifact_path "$OUT_ROOT" \
+    --argjson duration_seconds "$DURATION_SECONDS" \
+    '{status: $status, flow: $flow, app: $app, started_at: $started_at,
+      duration_seconds: $duration_seconds, artifact_path: $artifact_path}' \
+    > "$OUT_ROOT/result.json"
 RESULT_WRITTEN=1
 log "PASS — $FLOW"
 log "artifacts: $OUT_ROOT"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -46,7 +46,7 @@ BUNDLE_ID=""
 AX_DRIVER=""
 RESULT_WRITTEN=0
 RUN_STARTED_EPOCH="$(date +%s)"
-RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RUN_STARTED_AT="$(date -u -r "$RUN_STARTED_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
 PERSONA_ENV=()
 
 usage() {
@@ -91,6 +91,18 @@ done
 log() { printf '[gui-golden] %s\n' "$*"; }
 die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
+write_result() {
+    local status="$1" exit_code="$2" finished_epoch duration_seconds
+    finished_epoch="$(date +%s)"
+    duration_seconds=$((finished_epoch - RUN_STARTED_EPOCH))
+    jq -n --arg status "$status" --arg flow "$FLOW" --arg app "$APP_SOURCE" \
+        --arg started_at "$RUN_STARTED_AT" --arg artifact_path "$OUT_ROOT" \
+        --argjson duration_seconds "$duration_seconds" \
+        --argjson exit_code "$exit_code" \
+        '{status: $status, flow: $flow, app: $app, started_at: $started_at,
+          duration_seconds: $duration_seconds, artifact_path: $artifact_path,
+          exit_code: $exit_code}' > "$OUT_ROOT/result.json"
+}
 flow_requires_screen_recording() {
     case "$FLOW" in
         all) return 0 ;;
@@ -186,17 +198,7 @@ finish() {
     local status=$?
     set +e
     if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 && -d "$OUT_ROOT" ]]; then
-        local finished_epoch duration_seconds
-        finished_epoch="$(date +%s)"
-        duration_seconds=$((finished_epoch - RUN_STARTED_EPOCH))
-        jq -n --arg status fail --arg flow "$FLOW" --arg app "$APP_SOURCE" \
-            --arg started_at "$RUN_STARTED_AT" --arg artifact_path "$OUT_ROOT" \
-            --argjson duration_seconds "$duration_seconds" \
-            --argjson exit_code "$status" \
-            '{status: $status, flow: $flow, app: $app, started_at: $started_at,
-              duration_seconds: $duration_seconds, artifact_path: $artifact_path,
-              exit_code: $exit_code}' \
-            > "$OUT_ROOT/result.json" 2>/dev/null || true
+        write_result fail "$status" 2>/dev/null || true
     fi
     cleanup_persona
     cleanup_operator_server
@@ -4785,14 +4787,7 @@ case "$FLOW" in
     *) die "unknown flow: $FLOW" ;;
 esac
 
-FINISHED_EPOCH="$(date +%s)"
-DURATION_SECONDS=$((FINISHED_EPOCH - RUN_STARTED_EPOCH))
-jq -n --arg status pass --arg flow "$FLOW" --arg app "$APP_SOURCE" \
-    --arg started_at "$RUN_STARTED_AT" --arg artifact_path "$OUT_ROOT" \
-    --argjson duration_seconds "$DURATION_SECONDS" \
-    '{status: $status, flow: $flow, app: $app, started_at: $started_at,
-      duration_seconds: $duration_seconds, artifact_path: $artifact_path}' \
-    > "$OUT_ROOT/result.json"
+write_result pass 0
 RESULT_WRITTEN=1
 log "PASS — $FLOW"
 log "artifacts: $OUT_ROOT"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -207,8 +207,11 @@ finish() {
     fi
 }
 trap finish EXIT
-trap 'cleanup_persona; cleanup_operator_server; exit 130' INT
-trap 'cleanup_persona; cleanup_operator_server; exit 143' TERM
+# Signal handlers only select the conventional exit code. The EXIT handler is
+# the single owner of cleanup and final evidence, avoiding double-cleanup and
+# ensuring cancellation/timeout failures receive the same result schema.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # The preconditions every flow depends on and none of them can observe:
 # permission to read another process's AX tree, and a session that can actually

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -45,8 +45,8 @@ MAIN_WINDOW_ID=""
 BUNDLE_ID=""
 AX_DRIVER=""
 RESULT_WRITTEN=0
+RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 RUN_STARTED_EPOCH="$(date +%s)"
-RUN_STARTED_AT="$(python3 -c 'from datetime import datetime, timezone; import sys; print(datetime.fromtimestamp(int(sys.argv[1]), timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))' "$RUN_STARTED_EPOCH")"
 PERSONA_ENV=()
 
 usage() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -46,7 +46,7 @@ BUNDLE_ID=""
 AX_DRIVER=""
 RESULT_WRITTEN=0
 RUN_STARTED_EPOCH="$(date +%s)"
-RUN_STARTED_AT="$(date -u -r "$RUN_STARTED_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+RUN_STARTED_AT="$(python3 -c 'from datetime import datetime, timezone; import sys; print(datetime.fromtimestamp(int(sys.argv[1]), timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))' "$RUN_STARTED_EPOCH")"
 PERSONA_ENV=()
 
 usage() {
@@ -197,8 +197,11 @@ cleanup_operator_server() {
 finish() {
     local status=$?
     set +e
-    if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 && -d "$OUT_ROOT" ]]; then
-        write_result fail "$status" 2>/dev/null || true
+    if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 ]]; then
+        mkdir -p "$OUT_ROOT" 2>/dev/null || true
+        if [[ -d "$OUT_ROOT" ]]; then
+            write_result fail "$status" 2>/dev/null || true
+        fi
     fi
     cleanup_persona
     cleanup_operator_server

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import subprocess
+from datetime import datetime
 from pathlib import Path
 
 import yaml
@@ -147,6 +151,34 @@ def test_result_evidence_records_timing_and_artifact_location():
     assert '--argjson exit_code "$exit_code"' in writer
     assert 'write_result fail "$status"' in finish
     assert "write_result pass 0" in dispatch_tail
+
+
+def test_early_precondition_failure_writes_typed_result_evidence(tmp_path: Path):
+    output = tmp_path / "not-created-yet"
+    missing_app = tmp_path / "missing.app"
+    result = subprocess.run(
+        ["bash", str(HARNESS), "--flow", "fresh-install"],
+        env={
+            **os.environ,
+            "HOME": str(tmp_path),
+            "RAPID_GUI_GOLDEN_OUT": str(output),
+            "RAPID_GUI_SOURCE_APP": str(missing_app),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    payload = json.loads((output / "result.json").read_text())
+    assert payload["status"] == "fail"
+    assert payload["flow"] == "fresh-install"
+    assert payload["app"] == str(missing_app)
+    assert payload["exit_code"] == result.returncode
+    assert isinstance(payload["duration_seconds"], int)
+    assert payload["duration_seconds"] >= 0
+    assert payload["artifact_path"] == str(output)
+    datetime.strptime(payload["started_at"], "%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else():

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -181,6 +181,18 @@ def test_early_precondition_failure_writes_typed_result_evidence(tmp_path: Path)
     datetime.strptime(payload["started_at"], "%Y-%m-%dT%H:%M:%SZ")
 
 
+def test_help_does_not_require_harness_runtime_dependencies():
+    result = subprocess.run(
+        ["bash", str(HARNESS), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Usage: gui-golden-flows.sh" in result.stdout
+
+
 def test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else():
     assert diagnostic_flows() == workflow_flows() & baseline_flows()
 

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -11,6 +11,7 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
 
 # `chat-depth` requires all five turns to be simultaneously realised in AX.
 # The hosted runner's 1024x681 app window virtualises the oldest messages, so
@@ -44,6 +45,12 @@ def workflow_steps() -> list[dict[str, object]]:
     return yaml.safe_load(WORKFLOW.read_text())["jobs"]["gui-golden-flows"]["steps"]
 
 
+def manifest_journeys() -> list[dict[str, object]]:
+    payload = yaml.safe_load(MANIFEST.read_text())
+    assert payload["version"] == 1
+    return payload["journeys"]
+
+
 def diagnostic_flows() -> set[str]:
     workflow = WORKFLOW.read_text()
     loop = workflow.split("for flow in ", 1)[1].split("; do", 1)[0]
@@ -66,6 +73,71 @@ def test_every_named_flow_is_gated_or_explicitly_excluded():
     gated = workflow_flows()
     assert named - gated == CI_EXCLUSIONS
     assert not gated - named
+
+
+def test_manifest_is_the_complete_unique_flow_inventory():
+    journeys = manifest_journeys()
+    names = [str(journey["name"]) for journey in journeys]
+    assert len(names) == len(set(names))
+    assert set(names) == harness_flows()
+
+
+def test_manifest_fields_are_valid_and_fail_closed():
+    allowed_groups = {
+        "chat",
+        "audio",
+        "models",
+        "onboarding-settings",
+        "images",
+        "app-lifecycle",
+    }
+    allowed_risks = {"low", "medium", "high"}
+    allowed_drivers = {"ax", "xcuitest", "hybrid"}
+    allowed_tiers = {"pr", "local"}
+
+    for journey in manifest_journeys():
+        assert journey["group"] in allowed_groups
+        assert journey["risk"] in allowed_risks
+        assert journey["driver"] in allowed_drivers
+        assert journey["ci_tier"] in allowed_tiers
+        assert journey["fixtures"]
+        assert journey["source_paths"]
+        assert all(
+            str(path).startswith("apps/rapid-mac/") for path in journey["source_paths"]
+        )
+        assert all((ROOT / str(path)).exists() for path in journey["source_paths"])
+        assert isinstance(journey["owns_baseline"], bool)
+
+
+def test_manifest_ci_tiers_match_the_workflow_contract():
+    pr_flows = {
+        str(journey["name"])
+        for journey in manifest_journeys()
+        if journey["ci_tier"] == "pr"
+    }
+    local_flows = {
+        str(journey["name"])
+        for journey in manifest_journeys()
+        if journey["ci_tier"] == "local"
+    }
+    assert pr_flows == workflow_flows()
+    assert local_flows == CI_EXCLUSIONS
+
+
+def test_manifest_baseline_ownership_matches_harness_usage():
+    declared = {
+        str(journey["name"])
+        for journey in manifest_journeys()
+        if journey["owns_baseline"]
+    }
+    assert declared == baseline_flows()
+
+
+def test_result_evidence_records_timing_and_artifact_location():
+    source = HARNESS.read_text()
+    assert source.count("duration_seconds: $duration_seconds") == 2
+    assert source.count("artifact_path: $artifact_path") == 2
+    assert source.count("started_at: $started_at") == 2
 
 
 def test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else():

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -135,9 +135,18 @@ def test_manifest_baseline_ownership_matches_harness_usage():
 
 def test_result_evidence_records_timing_and_artifact_location():
     source = HARNESS.read_text()
-    assert source.count("duration_seconds: $duration_seconds") == 2
-    assert source.count("artifact_path: $artifact_path") == 2
-    assert source.count("started_at: $started_at") == 2
+    writer = source.split("write_result() {", 1)[1].split("\n}", 1)[0]
+    finish = source.split("finish() {", 1)[1].split("\n}", 1)[0]
+    dispatch_tail = source.rsplit('case "$FLOW" in', 1)[1].split(
+        'log "PASS — $FLOW"', 1
+    )[0]
+
+    assert "started_at: $started_at" in writer
+    assert "duration_seconds: $duration_seconds" in writer
+    assert "artifact_path: $artifact_path" in writer
+    assert '--argjson exit_code "$exit_code"' in writer
+    assert 'write_result fail "$status"' in finish
+    assert "write_result pass 0" in dispatch_tail
 
 
 def test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else():

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -98,18 +98,55 @@ def test_manifest_fields_are_valid_and_fail_closed():
     allowed_risks = {"low", "medium", "high"}
     allowed_drivers = {"ax", "xcuitest", "hybrid"}
     allowed_tiers = {"pr", "local"}
+    allowed_fixtures = {
+        "audio-models",
+        "cached-model",
+        "campaign",
+        "crash-once",
+        "delayed-transcription",
+        "document",
+        "fake-sidecar",
+        "generated-images",
+        "isolated-home",
+        "large-window",
+        "low-memory",
+        "mixed-capability-catalog",
+        "resident-model",
+        "slow-download",
+        "slow-stream",
+        "two-images",
+        "update-busy",
+        "update-state",
+    }
+    expected_keys = {
+        "name",
+        "group",
+        "risk",
+        "driver",
+        "ci_tier",
+        "fixtures",
+        "source_paths",
+        "owns_baseline",
+    }
 
     for journey in manifest_journeys():
+        assert set(journey) == expected_keys
+        assert isinstance(journey["name"], str) and journey["name"]
         assert journey["group"] in allowed_groups
         assert journey["risk"] in allowed_risks
         assert journey["driver"] in allowed_drivers
         assert journey["ci_tier"] in allowed_tiers
-        assert journey["fixtures"]
-        assert journey["source_paths"]
+        assert isinstance(journey["fixtures"], list) and journey["fixtures"]
         assert all(
-            str(path).startswith("apps/rapid-mac/") for path in journey["source_paths"]
+            isinstance(fixture, str) and fixture in allowed_fixtures
+            for fixture in journey["fixtures"]
         )
-        assert all((ROOT / str(path)).exists() for path in journey["source_paths"])
+        assert isinstance(journey["source_paths"], list) and journey["source_paths"]
+        assert all(
+            isinstance(path, str) and path.startswith("apps/rapid-mac/")
+            for path in journey["source_paths"]
+        )
+        assert all((ROOT / path).exists() for path in journey["source_paths"])
         assert isinstance(journey["owns_baseline"], bool)
 
 

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -230,6 +230,13 @@ def test_help_does_not_require_harness_runtime_dependencies():
     assert "Usage: gui-golden-flows.sh" in result.stdout
 
 
+def test_interrupt_and_termination_flow_through_exit_evidence_handler():
+    source = HARNESS.read_text()
+    assert "trap finish EXIT" in source
+    assert "trap 'exit 130' INT" in source
+    assert "trap 'exit 143' TERM" in source
+
+
 def test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else():
     assert diagnostic_flows() == workflow_flows() & baseline_flows()
 


### PR DESCRIPTION
## Summary

Establish a machine-readable GUI journey inventory before adding source-based routing. The manifest records every journey group, risk, driver, CI tier, fixture set, real source-path mapping, and baseline ownership. Golden-flow result evidence now includes UTC start time, duration, and artifact location for both pass and failure paths.

Refs #2254

## Why

The flow roster and metadata were spread across Bash, workflow YAML, documentation, and tests. Routing or timing work built on that state would silently drift. This PR creates the fail-closed source of truth and telemetry contract without changing which journeys run.

## Test plan

- [x] Run GUI coverage, preflight, behavior, walk-completeness, and CI-classifier contract tests.
- [x] Run Ruff lint/format for the changed Python test.
- [x] Run `bash -n` on the golden-flow harness.
- [x] Run `git diff --check`.

## Scope

Manifest, result telemetry, contracts, and documentation only. No source-based routing, job fan-out, artifact reuse, or product behavior changes.