### PR TITLE
fix(release): isolate Hermes harness config home

### DIFF
--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -94,8 +94,15 @@ def _detect_context_window() -> int:
 
 
 def ensure_hermes_config():
-    """Update ~/.hermes/config.yaml to point to the current server/model."""
-    config_dir = os.path.expanduser("~/.hermes")
+    """Update Hermes' active config to point to the current server/model.
+
+    Release gates redirect ``HERMES_HOME`` to an ephemeral directory so they
+    neither consume nor mutate an operator's real provider configuration.
+    Honour that same home override here; hard-coding ``~/.hermes`` makes the
+    harness silently hit a personal remote provider even though setup wrote a
+    correct isolated fixture.
+    """
+    config_dir = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
     os.makedirs(config_dir, exist_ok=True)
     config_path = os.path.join(config_dir, "config.yaml")
     ctx = _detect_context_window()

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for env-only authentication of local HTTP clients."""
 
+import importlib.util
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -61,3 +62,24 @@ def test_hermes_cli_receives_process_scoped_auth_without_persisting_it():
         "def _hermes_subprocess_env", 1
     )[0]
     assert "api_key" not in config_block
+    assert 'os.environ.get("HERMES_HOME")' in config_block
+    assert 'or os.path.expanduser("~/.hermes")' in config_block
+
+
+def test_hermes_harness_writes_config_to_overridden_home(monkeypatch, tmp_path):
+    """The release gate fixture must never fall back to operator state."""
+    source = REPO_ROOT / "vllm_mlx" / "_integration_tests" / "test_hermes.py"
+    spec = importlib.util.spec_from_file_location("hermes_home_contract", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    isolated_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(isolated_home))
+    monkeypatch.setattr(module, "_detect_context_window", lambda: 65_536)
+
+    module.ensure_hermes_config()
+
+    config = (isolated_home / "config.yaml").read_text()
+    assert f'base_url: "{module.BASE_URL}"' in config
+    assert "context_length: 65536" in config


### PR DESCRIPTION
## Summary
- honor `HERMES_HOME` when the Hermes integration harness writes `config.yaml`
- prevent release dogfood from reading or mutating an operator's real Hermes provider config
- add a live module-level regression proving the override receives the local base URL and context

## Release-blocker evidence
`make release-check-m3` API-level Hermes tests passed 10/10, while CLI E2E inherited the operator config and hit the remote Anthropic API (credit-balance 400). With this fix and an isolated `HERMES_HOME`, the real Qwen3.5 9B Hermes run passed 34/34 (including two 20/20 specific-suite executions), 0 failed, 0 skipped.

## Verification
- `python3.12 -m pytest tests/test_http_auth.py tests/test_hermes_harness_contract.py -q` (7 passed)
- `python3.12 -m ruff check tests/integrations/test_hermes.py tests/test_http_auth.py`
- real `rapid-mlx agents hermes --test` against Qwen3.5 9B: 34/34 passed