### PR TITLE
fix: support isolated release candidates

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -121,14 +121,14 @@ jobs:
           SUBJECT=$(git log -1 --pretty=%s)
           echo "subject: $SUBJECT"
 
-          # Strict format: ``chore: bump version to X.Y.Z``, optionally followed
-          # by GitHub's squash-merge suffix `` (#N)``.
-          if ! echo "$SUBJECT" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
+          # One SSOT accepts stable X.Y.Z and prerelease X.Y.Z-rcN subjects.
+          # The push path tolerates GitHub's squash suffix for compatibility;
+          # PF-1 still requires the clean subject before merge.
+          if ! VERSION=$(python3 scripts/release_version.py subject --allow-pr-suffix "$SUBJECT"); then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Not a version bump — skipping (gate + release will not run)"
             exit 0
           fi
-          VERSION=$(echo "$SUBJECT" | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
 
           # pyproject.toml must match the subject — a mismatch is a hard error,
           # not a silent skip.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,7 @@ jobs:
 
           manifest = json.loads(Path("candidate/release-manifest.json").read_text())
           version = os.environ["EXPECTED_VERSION"].removeprefix("v")
+          artifact_version = version.replace("-rc", "rc")
           if manifest.get("schema") != 1 or manifest.get("project") != "rapid-mlx":
               raise SystemExit("invalid release manifest schema/project")
           if manifest.get("version") != version:
@@ -136,9 +137,9 @@ jobs:
           sdists = [name for name in artifacts if name.endswith(".tar.gz")]
           if len(sdists) != 1:
               raise SystemExit("manifest must contain exactly one sdist")
-          if not wheels[0].startswith(f"rapid_mlx-{version}-"):
+          if not wheels[0].startswith(f"rapid_mlx-{artifact_version}-"):
               raise SystemExit("wheel filename does not match the release tag")
-          if sdists[0] != f"rapid_mlx-{version}.tar.gz":
+          if sdists[0] != f"rapid_mlx-{artifact_version}.tar.gz":
               raise SystemExit("sdist filename does not match the release tag")
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
               output.write(f"sdist_sha256={artifacts[sdists[0]]['sha256']}\n")

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -550,8 +550,8 @@ jobs:
             exit 1
           }
           VERSION="${TAG#rapid-mac-v}"
-          [[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo "::error::release tag must be rapid-mac-vMAJOR.MINOR.PATCH"
+          [[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?$ ]] || {
+            echo "::error::release tag must be rapid-mac-vMAJOR.MINOR.PATCH[-rcN]"
             exit 1
           }
           DMG="dist/rapid-mlx-desktop.dmg"
@@ -669,6 +669,9 @@ jobs:
           path: sparkle
 
       - name: Publish updater fallback monotonically
+        # RC artifacts are mirrored under immutable versioned keys and exposed
+        # through a GitHub prerelease, but must never replace the stable feed.
+        if: ${{ !contains(github.ref_name, '-rc') }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -231,9 +231,10 @@ jobs:
           if len(sdists) != 1:
               raise SystemExit("manifest must contain exactly one sdist")
           version = os.environ["EXPECTED_VERSION"]
-          if not wheels[0].startswith(f"rapid_mlx-{version}-"):
+          artifact_version = version.replace("-rc", "rc")
+          if not wheels[0].startswith(f"rapid_mlx-{artifact_version}-"):
               raise SystemExit("wheel filename does not match the candidate version")
-          if sdists[0] != f"rapid_mlx-{version}.tar.gz":
+          if sdists[0] != f"rapid_mlx-{artifact_version}.tar.gz":
               raise SystemExit("sdist filename does not match the candidate version")
           print("release manifest verified")
           PY

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -41,6 +41,7 @@ jobs:
       is_bump: ${{ steps.check.outputs.is_bump }}
       version: ${{ steps.check.outputs.version }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - id: check
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -48,8 +48,7 @@ jobs:
           # Match the auto-release.yml regex EXACTLY. If the PR title
           # doesn't match, every job below is skipped — non-bump PRs
           # pay zero CI cost.
-          if echo "$TITLE" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+$'; then
-            VERSION=$(echo "$TITLE" | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+          if VERSION=$(python3 scripts/release_version.py subject "$TITLE"); then
             echo "is_bump=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Detected bump PR for v$VERSION"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -107,14 +107,12 @@ jobs:
           # docs/development/pr_merge_sop.md) — merge bump PRs with an explicit
           # --subject, per releasing.md.
           TITLE_IS_RELEASE=false
-          if echo "$TITLE" | grep -qE '^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
+          if TITLE_VER=$(python3 scripts/release_version.py subject --allow-pr-suffix "$TITLE"); then
             TITLE_IS_RELEASE=true
             # The title's X.Y.Z must equal the new pyproject version — a title
             # claiming 0.10.6 must not greenlight a pyproject change to 0.10.7
             # (that mismatch is exactly the drift class this guard exists to
             # stop).
-            TITLE_VER=$(echo "$TITLE" \
-              | sed -E 's/^chore: bump version to ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
             if [ "$TITLE_VER" = "$HEAD_VER" ]; then
               IS_BUMP=true
               REASON="PR title matches 'chore: bump version to $HEAD_VER'"
@@ -215,8 +213,8 @@ jobs:
           # would sort-normalize under ``sort -V`` (so ``1.00.1`` could read as
           # greater than ``1.0.1``) and would also confuse PyPI's canonical
           # ordering. A malformed version is always a hard error.
-          if ! echo "$HEAD_VER" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
-            echo "❌ New version '$HEAD_VER' is not a well-formed X.Y.Z (no leading zeros)." >&2
+          if ! python3 scripts/release_version.py validate "$HEAD_VER" >/dev/null; then
+            echo "❌ New version '$HEAD_VER' is not X.Y.Z or X.Y.Z-rcN (no leading zeros)." >&2
             exit 1
           fi
 
@@ -237,12 +235,11 @@ jobs:
           # strictly greater. ``sort -V`` is safe now that leading zeros are
           # rejected on HEAD; guard BASE the same way so a malformed base can't
           # skew the comparison.
-          if ! echo "$BASE_VER" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
-            echo "❌ Base version '$BASE_VER' is not a well-formed X.Y.Z — cannot compare." >&2
+          if ! python3 scripts/release_version.py validate "$BASE_VER" >/dev/null; then
+            echo "❌ Base version '$BASE_VER' is not X.Y.Z or X.Y.Z-rcN — cannot compare." >&2
             exit 1
           fi
-          GREATER=$(printf '%s\n%s\n' "$BASE_VER" "$HEAD_VER" | sort -V | tail -1)
-          if [ "$GREATER" != "$HEAD_VER" ]; then
+          if ! python3 scripts/release_version.py greater "$BASE_VER" "$HEAD_VER" >/dev/null; then
             echo "❌ New version '$HEAD_VER' is not greater than base '$BASE_VER'." >&2
             exit 1
           fi

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
@@ -226,12 +226,26 @@ enum ServerLocator {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// Strict dotted-numeric parser matching the sidecar build gate.
-    private static func parsedVersion(_ raw: String?) -> [Int]? {
+    private struct ParsedVersion {
+        let parts: [Int]
+        let rc: Int?
+    }
+
+    /// Strict dotted-numeric/RC parser matching the sidecar build gate.
+    private static func parsedVersion(_ raw: String?) -> ParsedVersion? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty else { return nil }
         if value.hasPrefix("v") || value.hasPrefix("V") {
             value.removeFirst()
+        }
+        var rc: Int?
+        if let range = value.range(of: "-rc", options: .backwards) {
+            let suffix = value[range.upperBound...]
+            guard !suffix.isEmpty,
+                  suffix.allSatisfy({ $0 >= "0" && $0 <= "9" }),
+                  let parsedRC = Int(suffix), parsedRC >= 1 else { return nil }
+            rc = parsedRC
+            value = String(value[..<range.lowerBound])
         }
         let fields = value.split(separator: ".", omittingEmptySubsequences: false)
         guard fields.count >= 2 else { return nil }
@@ -243,14 +257,24 @@ enum ServerLocator {
                   let part = Int(field) else { return nil }
             parts.append(part)
         }
-        return parts
+        return ParsedVersion(parts: parts, rc: rc)
     }
 
-    private static func compareVersion(_ lhs: [Int], _ rhs: [Int]) -> ComparisonResult {
-        let width = max(lhs.count, rhs.count)
+    private static func compareVersion(
+        _ lhs: ParsedVersion, _ rhs: ParsedVersion
+    ) -> ComparisonResult {
+        let width = max(lhs.parts.count, rhs.parts.count)
         for index in 0..<width {
-            let left = index < lhs.count ? lhs[index] : 0
-            let right = index < rhs.count ? rhs[index] : 0
+            let left = index < lhs.parts.count ? lhs.parts[index] : 0
+            let right = index < rhs.parts.count ? rhs.parts[index] : 0
+            if left < right { return .orderedAscending }
+            if left > right { return .orderedDescending }
+        }
+        switch (lhs.rc, rhs.rc) {
+        case (nil, nil): return .orderedSame
+        case (nil, _): return .orderedDescending
+        case (_, nil): return .orderedAscending
+        case let (left?, right?):
             if left < right { return .orderedAscending }
             if left > right { return .orderedDescending }
         }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -57,7 +57,7 @@ struct ReleaseManifestWorkflowTests {
         #expect(branchEnd.upperBound < firstUpload.lowerBound)
         #expect(job.contains(#"[[ "$R2_BUCKET" == "rapid-desktop-dist" ]]"#))
         #expect(job.contains(#"[[ "$CDN_BASE" == "https://dl.rapidmlx.com" ]]"#))
-        #expect(job.contains(#"[[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]]"#))
+        #expect(job.contains(#"[[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?$ ]]"#))
     }
 
     @Test("manifest describes the bundled DMG and is committed last")

--- a/apps/rapid-mac/Tests/RapidTests/ServerLocatorVersionSelectionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerLocatorVersionSelectionTests.swift
@@ -112,6 +112,22 @@ struct ServerLocatorVersionSelectionTests {
             runtimeOverrideVersion: "0.12.4.0",
             bundledVersion: "0.12.4"
         ))
+        #expect(ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.12.18",
+            bundledVersion: "0.13.0-rc1"
+        ))
+        #expect(ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.13.0-rc1",
+            bundledVersion: "0.13.0-rc2"
+        ))
+        #expect(!ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.13.0",
+            bundledVersion: "0.13.0-rc2"
+        ))
+        #expect(ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.13.0-rc0",
+            bundledVersion: "0.13.0-rc1"
+        ))
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
@@ -75,7 +75,7 @@ struct SidecarVersionGateTests {
         )
     }
 
-    @Test("scripts/build.sh's bash regex empirically accepts dotted-digit + rejects SHA / pre-release (#411 layer 2 — empirical)")
+    @Test("scripts/build.sh accepts dotted-digit/RC and rejects malformed versions (#411 layer 2 — empirical)")
     func buildScriptRegexEmpiricalBehaviour() throws {
         // Codex #412 r2 MINOR: source-substring assertions catch
         // accidental deletions but not subtle regex breakage (e.g. a
@@ -99,8 +99,12 @@ struct SidecarVersionGateTests {
             ("0.8.18", true),         // canonical sidecar release
             ("1.2.3", true),          // generic semver
             ("0.8", true),            // two-segment also acceptable to validator
+            ("0.13.0-rc1", true),     // supported release candidate
+            ("0.13.0-rc12", true),    // multi-digit RC sequence
             ("26ac5b4", false),       // the v0.8.6 bug
             ("0.8.19-rc.1", false),   // codex r1 BLOCKING — must reject
+            ("0.8.19-rc0", false),    // RC numbering begins at one
+            ("0.8.19-beta1", false),  // unsupported prerelease family
             ("0.8.18+build.7", false),// build suffix — must reject
             ("v0.8.18", false),       // leading ``v`` not allowed at this layer (bootstrapper strips it ITSELF; we hand off the bare form)
             ("0.8.", false),          // trailing dot
@@ -136,8 +140,8 @@ struct SidecarVersionGateTests {
     func tarballScriptHasDefenseInDepth() throws {
         let body = try Self.load(Self.tarballScriptPath)
         #expect(
-            body.contains("^[0-9]+(\\.[0-9]+)+$"),
-            "scripts/build-sidecar-tarball.sh must SemVer-regex-gate ``$SIDECAR_VERSION`` against the strict dotted-digit form ``^[0-9]+(\\.[0-9]+)+$`` (no pre-release suffix). Codex #412 r1 BLOCKING: a looser suffix regex would accept ``0.8.19-rc.1`` here while the bootstrapper validator rejects it at runtime — re-creating #411."
+            body.contains("^[0-9]+(\\.[0-9]+)+(-rc[1-9][0-9]*)?$"),
+            "scripts/build-sidecar-tarball.sh must accept only dotted-digit versions with an optional strict -rcN suffix. A looser suffix regex would accept ``0.8.19-rc.1`` while the bootstrapper validator rejects it at runtime — re-creating #411."
         )
         #expect(
             body.contains("Bootstrapper validator (BootstrapCoordinator.isValidVersionString) would reject"),

--- a/apps/rapid-mac/scripts/build-sidecar-tarball.sh
+++ b/apps/rapid-mac/scripts/build-sidecar-tarball.sh
@@ -96,7 +96,7 @@ if [[ -f "$SIDECAR_VERSION_FILE" ]]; then
 fi
 # Defense-in-depth (#411): the bootstrapper's manifest validator at
 # Sources/Rapid/Bootstrapper/BootstrapCoordinator.swift's
-# ``isValidVersionString`` enforces a strict dotted-digit grammar on
+# ``isValidVersionString`` enforces a strict dotted-digit or ``-rcN`` grammar on
 # ``sidecar_version`` (the optional leading ``v`` is stripped). v0.8.6
 # shipped ``sidecar_version: "26ac5b4"`` because the upstream VERSION
 # file carried a short SHA — that bricked 100% of slim-DMG installs.
@@ -104,13 +104,13 @@ fi
 # reject. scripts/build.sh has the upstream tag-based derivation; this
 # regex gate is the floor.
 # Grammar MUST match Sources/Rapid/Bootstrapper/BootstrapCoordinator
-# .swift's isValidVersionString: pure dotted-digit, no pre-release or
-# build suffix. Codex #412 r1 BLOCKING: a looser ``[-+][0-9A-Za-z.-]+``
+# .swift's isValidVersionString: pure dotted-digit with an optional ``-rcN``;
+# no arbitrary pre-release or build suffix. A looser ``[-+][0-9A-Za-z.-]+``
 # tail would accept ``0.8.19-rc.1`` here but the bootstrapper would
 # reject the manifest at runtime — re-creating exactly the #411
 # bricking bug for a different upstream value.
-if [[ ! "$SIDECAR_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
-  echo "::error::sidecar VERSION '$SIDECAR_VERSION' is not dotted-digit (expected e.g. '0.8.18'). Bootstrapper validator (BootstrapCoordinator.isValidVersionString) would reject this manifest — refusing to emit. See $SIDECAR_VERSION_FILE; fix scripts/build.sh's submodule derivation upstream (#411)." >&2
+if [[ ! "$SIDECAR_VERSION" =~ ^[0-9]+(\.[0-9]+)+(-rc[1-9][0-9]*)?$ ]]; then
+  echo "::error::sidecar VERSION '$SIDECAR_VERSION' is not dotted-digit or an -rcN candidate (expected e.g. '0.8.18' or '0.13.0-rc1'). Bootstrapper validator (BootstrapCoordinator.isValidVersionString) would reject this manifest — refusing to emit. See $SIDECAR_VERSION_FILE; fix scripts/build.sh's submodule derivation upstream (#411)." >&2
   exit 1
 fi
 

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -343,7 +343,7 @@ else
     # IS the engine, so its VERSION is the engine version. Downstream
     # consumers (AboutPanel, bootstrapper manifest emit at
     # scripts/build-sidecar-tarball.sh, BootstrapCoordinator validator)
-    # all require a strict SemVer-shaped string.
+    # all require a stable or RC SemVer-shaped string.
     #
     # SSOT precedence:
     #   1. the engine's pyproject.toml ``[project] version = "X.Y.Z"`` at
@@ -357,9 +357,10 @@ else
     # installs on v0.8.6 (issue #411). Grammar MUST stay in lockstep with
     # ``Sources/Rapid/Bootstrapper/BootstrapCoordinator.swift``'s
     # ``isValidVersionString`` (strip optional ``v``/``V`` then every
-    # dot-separated segment must be pure decimal digits). No pre-release
-    # or build suffixes (codex #412 r1 BLOCKING).
-    SIDECAR_SEMVER_RE='^[0-9]+(\.[0-9]+)+$'
+    # dot-separated segment must be pure decimal digits). The only supported
+    # prerelease suffix is ``-rcN``; arbitrary prerelease/build suffixes remain
+    # forbidden so malformed values cannot enter the manifest.
+    SIDECAR_SEMVER_RE='^[0-9]+(\.[0-9]+)+(-rc[1-9][0-9]*)?$'
     SIDECAR_VERSION=""
     if [[ -f "$ENGINE_ROOT/pyproject.toml" ]]; then
         # Scope to the [project] table so a version key in another table

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -46,7 +46,7 @@ The full path from "I want to release" to "users on `brew upgrade` see the new v
    Post-tag verification: `python3 scripts/release_smoke.py --version X.Y.Z`
    re-runs the gate against the wheel actually published to PyPI.
 
-2. **Bump `pyproject.toml` in a dedicated bump PR** — change `version = "X.Y.Z"` to `X.Y.(Z+1)` (or minor / major as appropriate). Never push the bump directly to `main`: `version-check.yml` only accepts a `version`-line change in a PR titled `chore: bump version to X.Y.Z` (see "Safety nets" below), and direct pushes to `main` are against repo convention anyway.
+2. **Bump `pyproject.toml` in a dedicated bump PR** — change `version = "X.Y.Z"` to `X.Y.(Z+1)` (or minor / major as appropriate). A release candidate uses `X.Y.Z-rcN`, beginning at `rc1`; RCs publish as GitHub/PyPI prereleases and immutable desktop artifacts, but deliberately do not replace the stable desktop updater feed. Never push the bump directly to `main`: `version-check.yml` only accepts a `version`-line change in a PR titled `chore: bump version to X.Y.Z` or `chore: bump version to X.Y.Z-rcN` (see "Safety nets" below), and direct pushes to `main` are against repo convention anyway.
 
    ```bash
    git checkout -b chore/bump-0.6.16 raullenchai/main

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -46,9 +46,13 @@ file move.
 from __future__ import annotations
 
 import plistlib
-import re
 import sys
 from pathlib import Path
+
+try:
+    from release_version import VERSION_RE
+except ModuleNotFoundError:  # imported by tests as ``scripts.*`` from repo root
+    from scripts.release_version import VERSION_RE
 
 try:  # 3.11+
     import tomllib
@@ -60,7 +64,7 @@ PYPROJECT = ROOT / "pyproject.toml"
 INFO_PLIST = ROOT / "apps" / "rapid-mac" / "Resources" / "Info.plist"
 
 # Both numbers feed release tags and an updater that compares them, so a
-# value neither side can order (``0.12``, ``1.0.0-rc1``, an empty string)
+# value neither side can order (``0.12``, ``1.0.0-beta1``, an empty string)
 # is a defect wherever it appears, not merely a mismatch.
 #
 # Matched with ``fullmatch`` and an explicit ASCII class, not ``^…$`` and
@@ -74,8 +78,7 @@ INFO_PLIST = ROOT / "apps" / "rapid-mac" / "Resources" / "Info.plist"
 # ``1.2.3`` while the plist and the git tag keep ``01.02.3``. Both files
 # would agree and this check would pass, having produced exactly the
 # split version it exists to prevent.
-_NUM = r"(?:0|[1-9][0-9]*)"
-SEMVER = re.compile(rf"{_NUM}\.{_NUM}\.{_NUM}")
+SEMVER = VERSION_RE
 
 
 class VersionSyncError(Exception):
@@ -108,7 +111,7 @@ def engine_version(pyproject: Path = PYPROJECT) -> str:
     if not SEMVER.fullmatch(version):
         raise VersionSyncError(
             f"{_rel(pyproject)} [project] version is {version!r}, "
-            "which is not X.Y.Z — release tags are built from it"
+            "which is not X.Y.Z or X.Y.Z-rcN — release tags are built from it"
         )
     return version
 
@@ -145,7 +148,7 @@ def app_version(info_plist: Path = INFO_PLIST) -> str:
     if not SEMVER.fullmatch(version):
         raise VersionSyncError(
             f"{_rel(info_plist)} CFBundleShortVersionString is {version!r}, "
-            "which is not X.Y.Z — the rapid-mac-v tag is built from it"
+            "which is not X.Y.Z or X.Y.Z-rcN — the rapid-mac-v tag is built from it"
         )
     return version
 

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -39,6 +39,8 @@ set -euo pipefail
 : "${NOTES_FILE:?create_release.sh: NOTES_FILE is required}"
 : "${GITHUB_REPOSITORY:?create_release.sh: GITHUB_REPOSITORY is required}"
 GH_BIN="${GH:-gh}"
+PRERELEASE_FLAG=""
+[[ "$TAG" =~ -rc[1-9][0-9]*$ ]] && PRERELEASE_FLAG="--prerelease"
 [ -f "$NOTES_FILE" ] || { echo "❌ notes file missing: $NOTES_FILE" >&2; exit 1; }
 AUTOMATION_MARKER="<!-- rapid-mlx-auto-release:$TAG:$RELEASE_SHA -->"
 DRAFT_NOTES_FILE=$(mktemp)
@@ -122,6 +124,7 @@ finish_verified_existing_release() {
     "$GH_BIN" release edit "$TAG" \
       --title "$TAG" \
       --notes-file "$NOTES_FILE" \
+      $PRERELEASE_FLAG \
       --draft=false
     local published_sha
     published_sha=$(resolve_tag_commit || true)
@@ -179,6 +182,7 @@ if ! CREATE_ERROR=$(
     --title "$TAG" \
     --notes-file "$DRAFT_NOTES_FILE" \
     --target "$RELEASE_SHA" \
+    $PRERELEASE_FLAG \
     --draft 2>&1
 ); then
   # Close the second race: another run can publish after our re-check but
@@ -206,6 +210,7 @@ fi
 "$GH_BIN" release edit "$TAG" \
   --title "$TAG" \
   --notes-file "$NOTES_FILE" \
+  $PRERELEASE_FLAG \
   --draft=false
 
 # Defense in depth for an out-of-policy force-update after the pre-publish

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -18,6 +18,11 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+try:
+    from release_version import parse_version
+except ModuleNotFoundError:  # imported by tests as ``scripts.*`` from repo root
+    from scripts.release_version import parse_version
+
 
 def sha256(path: Path) -> str:
     """Return the SHA-256 digest of a regular file."""
@@ -52,13 +57,18 @@ def release_files(dist_dir: Path) -> list[Path]:
 def validate_artifact_versions(files: list[Path], version: str) -> None:
     """Require artifact filenames to bind to the declared release version."""
 
+    parse_version(version)
+    # PEP 440 normalizes our human/tag spelling ``X.Y.Z-rcN`` to ``X.Y.ZrcN``
+    # in wheel and sdist filenames. The manifest retains the source spelling,
+    # but binds it to the canonical artifact spelling here.
+    artifact_version = version.replace("-rc", "rc")
     wheel = next(path for path in files if path.suffix == ".whl")
     sdist = next(path for path in files if path.name.endswith(".tar.gz"))
-    if not wheel.name.startswith(f"rapid_mlx-{version}-"):
+    if not wheel.name.startswith(f"rapid_mlx-{artifact_version}-"):
         raise ValueError(
             f"wheel filename {wheel.name!r} does not match release version {version!r}"
         )
-    expected_sdist = f"rapid_mlx-{version}.tar.gz"
+    expected_sdist = f"rapid_mlx-{artifact_version}.tar.gz"
     if sdist.name != expected_sdist:
         raise ValueError(
             f"sdist filename {sdist.name!r} does not match release version {version!r}"

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate and compare Rapid release versions and bump subjects.
+
+The source version is SemVer-shaped and may be either a stable ``X.Y.Z`` or
+an RC ``X.Y.Z-rcN``.  Packaging tools normalize the latter to PEP 440's
+``X.Y.ZrcN`` in artifact filenames, while Git tags and the desktop bundle keep
+the human-facing hyphenated spelling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+VERSION_PATTERN = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-rc(?:[1-9][0-9]*))?"
+VERSION_RE = re.compile(rf"^(?P<version>{VERSION_PATTERN})$")
+SUBJECT_RE = re.compile(rf"^chore: bump version to (?P<version>{VERSION_PATTERN})$")
+SUBJECT_WITH_PR_RE = re.compile(
+    rf"^chore: bump version to (?P<version>{VERSION_PATTERN})(?: \(#[0-9]+\))?$"
+)
+
+
+@dataclass(frozen=True, order=True)
+class ReleaseVersion:
+    major: int
+    minor: int
+    patch: int
+    stability: int
+    rc: int
+
+
+def parse_version(value: str) -> ReleaseVersion:
+    if VERSION_RE.fullmatch(value) is None:
+        raise ValueError(f"invalid release version: {value!r}")
+    core, separator, rc_text = value.partition("-rc")
+    major, minor, patch = (int(part) for part in core.split("."))
+    return ReleaseVersion(
+        major,
+        minor,
+        patch,
+        0 if separator else 1,  # every RC sorts before its stable release
+        int(rc_text) if separator else 0,
+    )
+
+
+def version_from_subject(subject: str, *, allow_pr_suffix: bool = False) -> str:
+    pattern = SUBJECT_WITH_PR_RE if allow_pr_suffix else SUBJECT_RE
+    match = pattern.fullmatch(subject)
+    if match is None:
+        raise ValueError(f"invalid release subject: {subject!r}")
+    return match.group("version")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("version")
+
+    greater = subparsers.add_parser("greater")
+    greater.add_argument("base")
+    greater.add_argument("candidate")
+
+    subject = subparsers.add_parser("subject")
+    subject.add_argument("subject")
+    subject.add_argument("--allow-pr-suffix", action="store_true")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate":
+            parse_version(args.version)
+            print(args.version)
+        elif args.command == "greater":
+            if parse_version(args.candidate) <= parse_version(args.base):
+                raise ValueError(
+                    f"candidate {args.candidate!r} is not greater than {args.base!r}"
+                )
+            print(args.candidate)
+        else:
+            print(
+                version_from_subject(
+                    args.subject, allow_pr_suffix=args.allow_pr_suffix
+                )
+            )
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -15,7 +15,9 @@ import re
 import sys
 from dataclasses import dataclass
 
-VERSION_PATTERN = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-rc(?:[1-9][0-9]*))?"
+VERSION_PATTERN = (
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-rc(?:[1-9][0-9]*))?"
+)
 VERSION_RE = re.compile(rf"^(?P<version>{VERSION_PATTERN})$")
 SUBJECT_RE = re.compile(rf"^chore: bump version to (?P<version>{VERSION_PATTERN})$")
 SUBJECT_WITH_PR_RE = re.compile(
@@ -82,9 +84,7 @@ def main(argv: list[str] | None = None) -> int:
             print(args.candidate)
         else:
             print(
-                version_from_subject(
-                    args.subject, allow_pr_suffix=args.allow_pr_suffix
-                )
+                version_from_subject(args.subject, allow_pr_suffix=args.allow_pr_suffix)
             )
     except ValueError as error:
         print(error, file=sys.stderr)

--- a/scripts/tag_desktop_app.sh
+++ b/scripts/tag_desktop_app.sh
@@ -75,14 +75,9 @@ HAVE_PAT="${HAVE_PAT-true}"
 
 # The tag is built from this string, so a value the tag namespace cannot
 # carry has to fail here rather than produce ``rapid-mac-v0.12.7\n``.
-case "$VERSION" in
-  *[!0-9.]* | *..* | .* | *. | "")
-    echo "❌ VERSION is '$VERSION', which is not X.Y.Z" >&2
-    exit 1
-    ;;
-esac
-if [ "$(printf '%s' "$VERSION" | tr -cd '.' | wc -c | tr -d ' ')" != "2" ]; then
-  echo "❌ VERSION is '$VERSION', which is not X.Y.Z" >&2
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+if ! python3 "$REPO_ROOT/scripts/release_version.py" validate "$VERSION" >/dev/null; then
+  echo "❌ VERSION is '$VERSION', which is not X.Y.Z or X.Y.Z-rcN" >&2
   exit 1
 fi
 

--- a/scripts/validate_release_subject.py
+++ b/scripts/validate_release_subject.py
@@ -31,6 +31,7 @@ try:
 except ModuleNotFoundError:  # imported by tests as ``scripts.*`` from repo root
     from scripts.release_version import SUBJECT_RE
 
+
 def diagnose(subject: str) -> list[str]:
     """Return a list of human-readable problems with the subject.
 

--- a/scripts/validate_release_subject.py
+++ b/scripts/validate_release_subject.py
@@ -4,7 +4,7 @@
 
 The ``auto-release.yml`` workflow watches for a strict subject:
 
-    chore: bump version to X.Y.Z
+    chore: bump version to X.Y.Z[-rcN]
 
 GitHub's default squash-merge appends ``(#NN)`` to the subject unless
 the merger passes ``--subject``. That suffix breaks the regex match and
@@ -26,9 +26,10 @@ import argparse
 import re
 import sys
 
-# Mirror auto-release.yml's regex EXACTLY. If you tweak one, tweak both.
-SUBJECT_RE = re.compile(r"^chore: bump version to \d+\.\d+\.\d+$")
-
+try:
+    from release_version import SUBJECT_RE
+except ModuleNotFoundError:  # imported by tests as ``scripts.*`` from repo root
+    from scripts.release_version import SUBJECT_RE
 
 def diagnose(subject: str) -> list[str]:
     """Return a list of human-readable problems with the subject.
@@ -46,14 +47,14 @@ def diagnose(subject: str) -> list[str]:
         problems.append(
             "subject has a `(#NN)` PR-number suffix — GitHub's default "
             'squash-merge added it. Pass `--subject "chore: bump version '
-            'to X.Y.Z"` to `gh pr merge` to strip it.'
+            'to X.Y.Z[-rcN]"` to `gh pr merge` to strip it.'
         )
     if not subject.startswith("chore: bump version to "):
         problems.append(
             "subject does not start with the literal `chore: bump version to ` prefix"
         )
-    if not re.search(r"\b\d+\.\d+\.\d+\b", subject):
-        problems.append("subject contains no X.Y.Z version number")
+    if not re.search(r"\b\d+\.\d+\.\d+(?:-rc\d+)?\b", subject):
+        problems.append("subject contains no X.Y.Z or X.Y.Z-rcN version number")
     if "\n" in subject:
         problems.append(
             "subject contains a newline — only the first line is the subject"
@@ -85,10 +86,10 @@ def main(argv: list[str] | None = None) -> int:
     for prob in problems:
         print(f"  - {prob}", file=sys.stderr)
     print(
-        "\nFix: rename the PR to exactly `chore: bump version to X.Y.Z` and, "
+        "\nFix: rename the PR to exactly `chore: bump version to X.Y.Z[-rcN]` and, "
         "at merge time, use:\n"
         "  gh pr merge <PR#> --repo raullenchai/Rapid-MLX --squash "
-        '--subject "chore: bump version to X.Y.Z" --delete-branch',
+        '--subject "chore: bump version to X.Y.Z[-rcN]" --delete-branch',
         file=sys.stderr,
     )
     return 1

--- a/tests/release/test_create_release.sh
+++ b/tests/release/test_create_release.sh
@@ -64,6 +64,7 @@ contains "$(cat "$WORKFLOW")" "bash scripts/create_release.sh" \
 #   MOCK_CONCURRENT_RELEASE "yes" -> losing tag claim observes a new Release
 #   MOCK_CREATE_RACE    "yes" -> create loses to a concurrent Release writer
 run_script() {
+  local release_tag="${TEST_TAG:-v1.2.3}"
   export GH="$TMP/mock-gh"
   : > "$TMP/calls"
   cat > "$GH" <<MOCK
@@ -80,10 +81,10 @@ case "\$cmd" in
           if [ "${MOCK_WRONG_TAG_MARKER:-}" = "yes" ]; then
             echo '<!-- rapid-mlx-auto-release:v9.9.9:$SHA_GOOD -->'
           elif [ "${MOCK_MARKER_NOT_FIRST:-}" = "yes" ]; then
-            printf 'manual preface\n<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->\n'
+            printf 'manual preface\n<!-- rapid-mlx-auto-release:$release_tag:$SHA_GOOD -->\n'
           elif [ "${MOCK_RELEASE_MARKED:-}" = "yes" ] || \
              [ "\$(cat "$TMP/release-state" 2>/dev/null)" = "draft-marked" ]; then
-            echo '<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->'
+            echo '<!-- rapid-mlx-auto-release:$release_tag:$SHA_GOOD -->'
           else
             echo 'manually staged draft notes'
           fi
@@ -91,9 +92,9 @@ case "\$cmd" in
         fi
         if [ "${MOCK_RELEASE_DRAFT:-}" = "yes" ] || \
            [[ "\$(cat "$TMP/release-state" 2>/dev/null)" == draft* ]]; then
-          printf 'v1.2.3\ttrue\n'
+          printf '$release_tag\ttrue\n'
         else
-          printf 'v1.2.3\tfalse\n'
+          printf '$release_tag\tfalse\n'
         fi
       else
         exit 1
@@ -113,12 +114,12 @@ case "\$cmd" in
         shift
       done
       if [ -n "\$NOTES_ARG" ] && grep -qF \
-        '<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->' "\$NOTES_ARG"; then
+        '<!-- rapid-mlx-auto-release:$release_tag:$SHA_GOOD -->' "\$NOTES_ARG"; then
         echo draft-marked > "$TMP/release-state"
       else
         echo draft > "$TMP/release-state"
       fi
-      echo "created-v1.2.3" >&2
+      echo "created-$release_tag" >&2
     elif [ "\$sub" = "edit" ]; then
       echo published > "$TMP/release-state"
     else
@@ -148,10 +149,10 @@ case "\$cmd" in
           shift
         fi
       done
-      [ "\$SUBMITTED_REF" = "refs/tags/v1.2.3" ] || exit 3
+      [ "\$SUBMITTED_REF" = "refs/tags/$release_tag" ] || exit 3
       [ "\$SUBMITTED_SHA" = "$SHA_GOOD" ] || exit 3
       echo "\$SUBMITTED_SHA" > "$TMP/ref-state"
-      echo '{"ref":"refs/tags/v1.2.3"}'
+      echo '{"ref":"refs/tags/$release_tag"}'
     elif [[ "\$1" == repos/o/r/git/tags/* ]]; then
       if [ "${MOCK_REF_UNREADABLE:-}" = "yes" ]; then exit 1; fi
       printf 'commit\t%s\n' "${MOCK_TAG_REF:-$SHA_GOOD}"
@@ -188,7 +189,7 @@ MOCK
   export MOCK_RELEASE_VIEW MOCK_CLAIM_FAILS MOCK_TAG_REF MOCK_CREATE_FAILS
   export MOCK_RELEASE_DRAFT MOCK_RELEASE_MARKED MOCK_REF_UNREADABLE MOCK_TAG_TYPE
   export MOCK_CONCURRENT_RELEASE MOCK_CREATE_RACE
-  if GH_TOKEN=test TAG=v1.2.3 RELEASE_SHA="$SHA_GOOD" \
+  if GH_TOKEN=test TAG="$release_tag" RELEASE_SHA="$SHA_GOOD" \
      NOTES_FILE="$TMP/notes.md" GITHUB_REPOSITORY="o/r" \
      bash "$SCRIPT" >"$TMP/out" 2>"$TMP/err"; then
     echo "0"
@@ -204,6 +205,7 @@ run_case() (
   export MOCK_CLAIM_FAILS=no MOCK_TAG_REF="" MOCK_TAG_TYPE=commit
   export MOCK_CREATE_FAILS=no MOCK_CREATE_RACE=no MOCK_REF_UNREADABLE=no
   export MOCK_CONCURRENT_RELEASE=no
+  export TEST_TAG=v1.2.3
   for setting in "$@"; do
     export "$setting"
   done
@@ -229,6 +231,13 @@ contains "$CREATE_CALL" "--draft" "release create starts as a draft"
 contains "$(call_order)" \
   "release edit v1.2.3 --title v1.2.3 --notes-file $TMP/notes.md --draft=false" \
   "verified draft is explicitly published"
+
+RC=$(run_case TEST_TAG=v1.2.3-rc1)
+[ "$RC" = "0" ] && ok "fresh RC release succeeds" || bad "fresh RC release succeeds (rc=$RC)"
+contains "$(grep '^release create' "$TMP/calls" | head -1)" "--prerelease" \
+  "RC Release draft is explicitly marked prerelease"
+contains "$(grep '^release edit' "$TMP/calls" | tail -1)" "--prerelease" \
+  "RC Release remains prerelease when published"
 
 # Negative control: prove the mock fails if production submits the wrong SHA,
 # rather than hard-coding a successful claim independently of request args.

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -145,10 +145,15 @@ contains "$OUT" "refusing to guess" "says why it stopped"
 # ==========================================================================
 echo "== 6. a version the tag namespace cannot carry is rejected =="
 # ==========================================================================
-for BADV in "0.12" "0.12.8-rc1" "v0.12.8" ""; do
+for BADV in "0.12" "0.12.8-rc0" "0.12.8-beta1" "v0.12.8" ""; do
   OUT=$(run free "" "$BADV") && RC=0 || RC=$?
   [ "${RC:-0}" -ne 0 ] && ok "rejects VERSION='$BADV'" || bad "rejects VERSION='$BADV'"
 done
+
+OUT=$(run free "" "0.13.0-rc1") && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "accepts VERSION='0.13.0-rc1'" || bad "accepts VERSION='0.13.0-rc1'"
+contains "$(cat "$TMP/calls")" "ref=refs/tags/rapid-mac-v0.13.0-rc1" \
+  "RC desktop tag keeps the prerelease suffix"
 
 # ==========================================================================
 echo "== 6b. a deep annotated-tag chain still peels to its commit =="

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-release.yml"
+PREFLIGHT_WORKFLOW = ROOT / ".github/workflows/release-preflight.yml"
 
 
 def _step(workflow: str, name: str) -> str:
@@ -15,6 +16,14 @@ def _step(workflow: str, name: str) -> str:
 def test_rc_tag_is_accepted_for_immutable_desktop_artifacts():
     workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
     assert "(-rc[1-9][0-9]*)?" in workflow
+
+
+def test_bump_detection_checks_out_version_parser_before_invoking_it():
+    workflow = PREFLIGHT_WORKFLOW.read_text(encoding="utf-8")
+    detect = workflow[workflow.index("  detect-bump-pr:") : workflow.index("\n  pf1-")]
+    checkout = detect.index("actions/checkout@")
+    invocation = detect.index("scripts/release_version.py")
+    assert checkout < invocation
 
 
 def test_rc_never_replaces_stable_updater_pointer():

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -5,6 +5,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-release.yml"
 PREFLIGHT_WORKFLOW = ROOT / ".github/workflows/release-preflight.yml"
+PUBLISH_WORKFLOWS = [
+    ROOT / ".github/workflows/publish.yml",
+    ROOT / ".github/workflows/release-artifact-matrix.yml",
+]
 
 
 def _step(workflow: str, name: str) -> str:
@@ -40,3 +44,11 @@ def test_rc_github_release_is_still_created_as_prerelease():
     release = _step(workflow, "Create the GitHub Release (last — nothing ships before the pointer)")
     assert '[[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease"' in release
     assert "gh release create" in release
+
+
+def test_privileged_publish_verifiers_use_pep440_rc_filenames():
+    for path in PUBLISH_WORKFLOWS:
+        workflow = path.read_text(encoding="utf-8")
+        assert 'artifact_version = version.replace("-rc", "rc")' in workflow
+        assert 'f"rapid_mlx-{artifact_version}-"' in workflow
+        assert 'f"rapid_mlx-{artifact_version}.tar.gz"' in workflow

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -41,7 +41,9 @@ def test_rc_never_replaces_stable_updater_pointer():
 
 def test_rc_github_release_is_still_created_as_prerelease():
     workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
-    release = _step(workflow, "Create the GitHub Release (last — nothing ships before the pointer)")
+    release = _step(
+        workflow, "Create the GitHub Release (last — nothing ships before the pointer)"
+    )
     assert '[[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease"' in release
     assert "gh release create" in release
 

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -1,0 +1,33 @@
+"""RC publishing must not promote prerelease bits to stable users."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-release.yml"
+
+
+def _step(workflow: str, name: str) -> str:
+    start = workflow.index(f"      - name: {name}")
+    next_step = workflow.find("\n      - name:", start + 1)
+    return workflow[start:] if next_step == -1 else workflow[start:next_step]
+
+
+def test_rc_tag_is_accepted_for_immutable_desktop_artifacts():
+    workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    assert "(-rc[1-9][0-9]*)?" in workflow
+
+
+def test_rc_never_replaces_stable_updater_pointer():
+    workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    publish = _step(workflow, "Publish updater fallback monotonically")
+    assert "if: ${{ !contains(github.ref_name, '-rc') }}" in publish
+    assert 'r2 object put "${R2_BUCKET}/latest.json"' in publish
+    assert 'r2 object put "${R2_BUCKET}/appcast.xml"' in publish
+    assert '"${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg"' in publish
+
+
+def test_rc_github_release_is_still_created_as_prerelease():
+    workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    release = _step(workflow, "Create the GitHub Release (last — nothing ships before the pointer)")
+    assert '[[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease"' in release
+    assert "gh release create" in release

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -47,6 +47,26 @@ def test_create_then_verify_round_trips(manifest_module, tmp_path):
     )
 
 
+def test_release_candidate_uses_pep440_artifact_spelling(manifest_module, tmp_path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "rapid_mlx-0.13.0rc1-py3-none-any.whl").write_bytes(b"wheel")
+    (dist / "rapid_mlx-0.13.0rc1.tar.gz").write_bytes(b"sdist")
+    manifest = manifest_module.create_manifest(
+        dist_dir=dist, source_sha=_SHA, version="0.13.0-rc1"
+    )
+    assert manifest["version"] == "0.13.0-rc1"
+    assert {item["filename"] for item in manifest["artifacts"]} == {
+        "rapid_mlx-0.13.0rc1-py3-none-any.whl",
+        "rapid_mlx-0.13.0rc1.tar.gz",
+    }
+    output = tmp_path / "release-manifest.json"
+    manifest_module.write_manifest(manifest, output)
+    assert (
+        manifest_module.verify_manifest(dist_dir=dist, manifest_path=output) == manifest
+    )
+
+
 def test_verify_rejects_changed_artifact(manifest_module, tmp_path):
     dist, wheel, _ = _dist(tmp_path)
     output = tmp_path / "release-manifest.json"

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Release-version SSOT regression tests."""
+
+from scripts.release_version import parse_version, version_from_subject
+
+
+def test_release_order_supports_rc_progression_and_stable_promotion():
+    versions = [
+        parse_version("0.12.18"),
+        parse_version("0.13.0-rc1"),
+        parse_version("0.13.0-rc2"),
+        parse_version("0.13.0"),
+    ]
+    assert versions == sorted(versions)
+
+
+def test_subject_parser_preserves_hyphenated_rc_spelling():
+    assert (
+        version_from_subject("chore: bump version to 0.13.0-rc1")
+        == "0.13.0-rc1"
+    )
+
+
+def test_auto_release_parser_can_tolerate_squash_suffix():
+    assert (
+        version_from_subject(
+            "chore: bump version to 0.13.0-rc1 (#42)", allow_pr_suffix=True
+        )
+        == "0.13.0-rc1"
+    )

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -15,10 +15,7 @@ def test_release_order_supports_rc_progression_and_stable_promotion():
 
 
 def test_subject_parser_preserves_hyphenated_rc_spelling():
-    assert (
-        version_from_subject("chore: bump version to 0.13.0-rc1")
-        == "0.13.0-rc1"
-    )
+    assert version_from_subject("chore: bump version to 0.13.0-rc1") == "0.13.0-rc1"
 
 
 def test_auto_release_parser_can_tolerate_squash_suffix():

--- a/tests/test_validate_release_subject.py
+++ b/tests/test_validate_release_subject.py
@@ -43,6 +43,16 @@ def test_any_three_part_semver_is_accepted(vrs, version):
     assert vrs.diagnose(f"chore: bump version to {version}") == []
 
 
+@pytest.mark.parametrize("version", ["0.13.0-rc1", "2.0.0-rc12"])
+def test_release_candidate_subject_is_accepted(vrs, version):
+    assert vrs.diagnose(f"chore: bump version to {version}") == []
+
+
+@pytest.mark.parametrize("version", ["0.13.0-rc0", "0.13.0-rc", "0.13.0-beta1"])
+def test_malformed_prerelease_subject_is_rejected(vrs, version):
+    assert vrs.diagnose(f"chore: bump version to {version}") != []
+
+
 # ---------- the suffix trap (PF-1, primary class of bug) -------------
 
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -89,6 +89,14 @@ def test_match_is_accepted(tmp_path):
     assert check(pyproject, plist) == ("0.12.7", "0.12.7")
 
 
+def test_matching_release_candidate_is_accepted(tmp_path):
+    pyproject = write_pyproject(tmp_path / "pyproject.toml", "0.13.0-rc1")
+    plist = write_plist(
+        tmp_path / "Info.plist", CFBundleShortVersionString="0.13.0-rc1"
+    )
+    assert check(pyproject, plist) == ("0.13.0-rc1", "0.13.0-rc1")
+
+
 @pytest.mark.parametrize("missing", ["pyproject", "plist"])
 def test_missing_input_fails_rather_than_passes(tmp_path, missing):
     """A file move must turn the guard RED, not silently disable it."""
@@ -161,7 +169,8 @@ def test_non_dict_plist_root_fails(tmp_path):
     "bad",
     [
         "0.12",
-        "1.0.0-rc1",
+        "1.0.0-rc0",
+        "1.0.0-beta1",
         "v1.2.3",
         "",
         # ``$`` matches BEFORE a trailing newline, so an ``^…$`` check


### PR DESCRIPTION
## Summary
- accept and correctly order `X.Y.Z-rcN` release versions across release gates
- mark engine and desktop RC releases as prereleases
- mirror immutable RC artifacts without replacing the stable desktop updater feed
- add offline regression coverage for RC tags, publishing, and version sync

## Verification
- `python3.12 -m pytest -q tests/test_release_version.py tests/test_validate_release_subject.py tests/test_version_sync.py tests/test_release_candidate_workflows.py` (52 passed)
- `bash tests/release/test_tag_desktop_app.sh` (39 passed)
- `bash tests/release/test_create_release.sh` (44 passed)
- focused ruff + `git diff --check`