### PR TITLE
ci(mac): route GUI journeys by changed surface [skip-version-bump]

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -45,6 +45,8 @@ jobs:
     outputs:
       desktop: ${{ steps.policy.outputs.desktop }}
       full_gate: ${{ steps.policy.outputs.full_gate }}
+      gui_flows: ${{ steps.policy.outputs.gui_flows }}
+      gui_flow_count: ${{ steps.policy.outputs.gui_flow_count }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -62,6 +64,7 @@ jobs:
             # A future merge queue candidate may combine independently scoped
             # PRs, so validate both product lanes.
             python scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
+            python scripts/select_gui_flows.py --github-output "$GITHUB_OUTPUT"
             {
               echo 'full_gate=true'
             } >> "$GITHUB_OUTPUT"
@@ -73,6 +76,9 @@ jobs:
             # new destination participate in classification.
             git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
             python scripts/classify_ci_changes.py \
+              --paths-file /tmp/changed-paths \
+              --github-output "$GITHUB_OUTPUT"
+            python scripts/select_gui_flows.py \
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"
             echo "full_gate=$FULL_CI" >> "$GITHUB_OUTPUT"
@@ -189,7 +195,11 @@ jobs:
         run: pytest tests/test_gui_preflight_contract.py -q
 
       - name: GUI golden-flow coverage contract
-        run: pytest tests/test_gui_golden_ci_coverage.py -q
+        run: |
+          pytest \
+            tests/test_gui_golden_ci_coverage.py \
+            tests/test_gui_flow_routing.py \
+            -q
 
       - name: Fake sidecar catalog contract
         run: pytest tests/test_fake_sidecar_image_catalog.py -q
@@ -292,6 +302,10 @@ jobs:
     defaults:
       run:
         working-directory: apps/rapid-mac
+    env:
+      # Compact JSON selected from the real PR diff. Every named step remains
+      # visible, but the harness exits before launch for unaffected journeys.
+      GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -339,6 +353,7 @@ jobs:
       # records actually draw different pixels rather than the same bitmap.
       - name: 'XCUITest: image-generation pixels'
         id: xcui
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation')
         continue-on-error: true
         env:
           RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidUITests.xcresult
@@ -555,6 +570,7 @@ jobs:
         if: always()
         env:
           GOLDEN_ROOT: ${{ runner.temp }}/golden
+          EXPECTED_FLOW_COUNT: ${{ needs.changes.outputs.gui_flow_count }}
         run: |
           python3 - <<'PY'
           import json
@@ -562,7 +578,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 29
+          expected = int(os.environ["EXPECTED_FLOW_COUNT"])
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:
@@ -650,7 +666,12 @@ jobs:
         if: always()
         env:
           XCUI_OUTCOME: ${{ steps.xcui.outcome }}
+          IMAGE_SELECTED: ${{ contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation') }}
         run: |
+          if [[ "$IMAGE_SELECTED" != true && "$XCUI_OUTCOME" == skipped ]]; then
+            echo "Image-generation journey not selected; native XCUITest not required"
+            exit 0
+          fi
           if [[ "$XCUI_OUTCOME" != success ]]; then
             echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
             exit 1

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -211,7 +211,7 @@ journeys:
     driver: hybrid
     ci_tier: pr
     fixtures: [fake-sidecar, generated-images, isolated-home]
-    source_paths: [apps/rapid-mac/Sources/Rapid/Images/]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Images/, apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift]
     owns_baseline: true
   - name: dictation
     group: audio
@@ -219,7 +219,7 @@ journeys:
     driver: ax
     ci_tier: pr
     fixtures: [fake-sidecar, delayed-transcription, isolated-home]
-    source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/UI/DictationView.swift]
     owns_baseline: false
   - name: audio-readiness
     group: audio
@@ -227,7 +227,7 @@ journeys:
     driver: ax
     ci_tier: pr
     fixtures: [fake-sidecar, audio-models, isolated-home]
-    source_paths: [apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Dictation/]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/UI/AudioView.swift, apps/rapid-mac/Sources/Rapid/UI/DictationView.swift]
     owns_baseline: true
   - name: resident-load-rejected
     group: models

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -88,6 +88,23 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# CI may route a Desktop diff to a subset of the manifest's journey groups.
+# Keep the selection check before preflight, app launch, output-directory
+# creation, and cleanup registration so an unaffected named workflow step is a
+# true no-op. Empty/malformed routing input fails closed by running the flow.
+if [[ -n "${GUI_FLOWS:-}" && "$FLOW" != all ]]; then
+    if selected="$(jq -r --arg flow "$FLOW" \
+        'if type == "array" then any(.[]; . == $flow) else error("not an array") end' \
+        <<<"$GUI_FLOWS" 2>/dev/null)"; then
+        if [[ "$selected" != true ]]; then
+            printf '[gui-golden] SKIP — %s is outside the selected risk groups\n' "$FLOW"
+            exit 0
+        fi
+    else
+        printf '[gui-golden] WARN: invalid GUI_FLOWS; running %s fail-closed\n' "$FLOW" >&2
+    fi
+fi
+
 log() { printf '[gui-golden] %s\n' "$*"; }
 die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -39,10 +39,21 @@ actual diff. Apply it only when the PR is ready to merge; removing it returns
 subsequent commits to the path-aware PR gate.
 
 - Engine changes expand to the full five-model L1 matrix.
-- Desktop changes expand to the complete GUI golden-flow job.
+- Desktop changes build the release GUI once, then run every journey group
+  mapped to the changed controls and product sources in
+  `Tests/GUIGoldenFlows/journeys.yaml`.
 - Cross-cutting or unknown changes expand both lanes.
 - Documentation-only changes require neither product lane and do not need the
   label.
+
+GUI routing expands a changed source to its complete journey group, so sibling
+flows around the same user workflow remain covered. It fails closed: empty or
+invalid diffs, new unmapped Desktop paths, shared UI components, packaging
+inputs, the harness, its manifest, and the CI workflow select every PR journey.
+Each named workflow step remains visible but an unselected journey exits before
+preflight, app launch, or artifact creation. The final verdict requires exactly
+the number of result records selected by the classifier, so a selected journey
+cannot silently disappear.
 
 The label never changes lane classification. This prevents an engine-only PR
 from allocating the full Desktop gate, or a Desktop-only PR from allocating
@@ -83,4 +94,6 @@ Disable the merge queue first, restore `full-ci` label-based merging, and leave
 the `merge_group` triggers in place. The triggers are harmless while the queue
 is disabled. If path classification is suspect, make its policy select both
 lanes for every PR; this restores the previous validation coverage without
-renaming required checks.
+renaming required checks. For GUI routing specifically, removing the
+`GUI_FLOWS` job environment or making `scripts/select_gui_flows.py` return the
+full manifest roster restores the previous all-journey behavior.

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -50,6 +50,9 @@ GUI routing expands a changed source to its complete journey group, so sibling
 flows around the same user workflow remain covered. It fails closed: empty or
 invalid diffs, new unmapped Desktop paths, shared UI components, packaging
 inputs, the harness, its manifest, and the CI workflow select every PR journey.
+Broad mixed-responsibility directories such as `Sources/Rapid/UI/` never grant
+narrow ownership to a new file; that requires an explicit file or cohesive
+domain-directory mapping in the manifest.
 Each named workflow step remains visible but an unselected journey exits before
 preflight, app launch, or artifact creation. The final verdict requires exactly
 the number of result records selected by the classifier, so a selected journey

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -47,6 +47,7 @@ _DESKTOP_PREFIX = "apps/rapid-mac/"
 _DESKTOP_SUPPORT_PREFIXES = ("tests/fixtures/ax_baseline/",)
 _DESKTOP_SUPPORT = {
     "scripts/check_rapid_mac_ax_identifiers.py",
+    "scripts/select_gui_flows.py",
     "tests/test_rapid_mac_ax_identifiers.py",
     "tests/test_rapid_mac_xcui_target.py",
     "tests/test_ax_baseline.py",
@@ -54,6 +55,7 @@ _DESKTOP_SUPPORT = {
     "tests/test_gui_control_behavior_contract.py",
     "tests/test_gui_preflight_contract.py",
     "tests/test_gui_golden_ci_coverage.py",
+    "tests/test_gui_flow_routing.py",
     "tests/test_gui_walk_completeness.py",
     "tests/test_fake_sidecar_image_catalog.py",
 }

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Select Desktop GUI journeys affected by changed repository paths.
+
+The journey manifest is the source of truth. A path selects every PR journey
+whose declared source prefix contains it, then expands to the complete journey
+group so related controls are exercised together. Paths which can affect the
+harness, packaging, shared app surface, or cannot be mapped fail closed to the
+entire PR journey set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
+DESKTOP_ROOT = "apps/rapid-mac/"
+SOURCE_ROOT = f"{DESKTOP_ROOT}Sources/Rapid/"
+
+# These inputs influence every journey or the routing policy itself. Keep this
+# list intentionally broad: an unnecessary full run is cheaper than a false
+# green caused by an unsafe narrow match.
+FULL_SUITE_PREFIXES = (
+    ".github/workflows/rapid-mac-ci.yml",
+    "apps/rapid-mac/Package",
+    "apps/rapid-mac/Resources/",
+    "apps/rapid-mac/Sources/Rapid/UI/Components/",
+    "apps/rapid-mac/Tests/GUIGoldenFlows/",
+    "apps/rapid-mac/scripts/build",
+    "apps/rapid-mac/scripts/fake-rapid-mlx.sh",
+    "apps/rapid-mac/scripts/gui-golden-flows.sh",
+    "apps/rapid-mac/scripts/rapid-ax.swift",
+    "scripts/select_gui_flows.py",
+    "tests/test_gui_flow_routing.py",
+    "tests/test_gui_golden_ci_coverage.py",
+)
+
+
+def _manifest() -> list[dict[str, object]]:
+    """Read the routing fields without adding a network dependency to CI.
+
+    The full manifest schema is validated with PyYAML in gui-harness-contracts.
+    The classifier job intentionally remains stdlib-only, so this strict reader
+    accepts exactly the simple scalar/inline-list shape used by the routing
+    fields and fails the job if that representation changes.
+    """
+
+    source = MANIFEST.read_text()
+    if not re.search(r"(?m)^version: 1\s*$", source):
+        raise ValueError("unsupported GUI journey manifest version")
+
+    journeys: list[dict[str, object]] = []
+    for block in re.split(r"(?m)^  - name: ", source)[1:]:
+        lines = block.splitlines()
+        values: dict[str, object] = {"name": lines[0].strip()}
+        for line in lines[1:]:
+            match = re.match(r"^    (group|ci_tier): ([a-z-]+)\s*$", line)
+            if match:
+                values[match.group(1)] = match.group(2)
+                continue
+            match = re.match(r"^    source_paths: \[(.*)\]\s*$", line)
+            if match:
+                values["source_paths"] = [
+                    item.strip() for item in match.group(1).split(",") if item.strip()
+                ]
+        required = {"name", "group", "ci_tier", "source_paths"}
+        if set(values) != required or not values["source_paths"]:
+            raise ValueError(f"malformed GUI journey routing fields: {values['name']}")
+        journeys.append(values)
+    if not journeys:
+        raise ValueError("GUI journey manifest contains no journeys")
+    return journeys
+
+
+def _pr_journeys() -> list[dict[str, object]]:
+    return [journey for journey in _manifest() if journey["ci_tier"] == "pr"]
+
+
+def all_flows() -> list[str]:
+    return [str(journey["name"]) for journey in _pr_journeys()]
+
+
+def _matches(path: str, declared: str) -> bool:
+    return path == declared.rstrip("/") or path.startswith(declared)
+
+
+def select(paths: Iterable[str]) -> list[str]:
+    normalized = sorted(
+        {path.strip().removeprefix("./") for path in paths if path.strip()}
+    )
+    journeys = _pr_journeys()
+    if not normalized:
+        return all_flows()
+
+    selected_groups: set[str] = set()
+    for path in normalized:
+        if path.startswith(FULL_SUITE_PREFIXES):
+            return all_flows()
+
+        # Non-Desktop files do not narrow the Desktop lane. They can coexist
+        # with Desktop files in a cross-cutting PR and are handled by their own
+        # CI lane.
+        if not path.startswith(DESKTOP_ROOT):
+            continue
+
+        matches = [
+            journey
+            for journey in journeys
+            if any(_matches(path, str(prefix)) for prefix in journey["source_paths"])
+        ]
+        if not matches:
+            # New Desktop production/support paths are unsafe until classified.
+            return all_flows()
+        selected_groups.update(str(journey["group"]) for journey in matches)
+
+    if not selected_groups:
+        # The caller expected a Desktop lane but supplied no classifiable
+        # Desktop path. Treat an invalid diff as a full-suite request.
+        return all_flows()
+
+    return [
+        str(journey["name"])
+        for journey in journeys
+        if str(journey["group"]) in selected_groups
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", help="Changed repository-relative paths")
+    parser.add_argument("--paths-file", type=argparse.FileType("r"))
+    parser.add_argument("--github-output", type=argparse.FileType("a"))
+    args = parser.parse_args()
+
+    paths = list(args.paths)
+    if args.paths_file:
+        paths.extend(args.paths_file.read().splitlines())
+    flows = select(paths)
+    payload = json.dumps(flows, separators=(",", ":"))
+
+    if args.github_output:
+        print(f"gui_flows={payload}", file=args.github_output)
+        print(f"gui_flow_count={len(flows)}", file=args.github_output)
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -93,7 +93,8 @@ def _matches(path: str, declared: str) -> bool:
     # to inherit their journey ownership.
     if declared in UNSAFE_BROAD_PREFIXES:
         return False
-    return path == declared.rstrip("/") or path.startswith(declared)
+    normalized = declared.rstrip("/")
+    return path == normalized or (declared.endswith("/") and path.startswith(declared))
 
 
 def select(paths: Iterable[str]) -> list[str]:

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -20,6 +20,7 @@ ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
 DESKTOP_ROOT = "apps/rapid-mac/"
 SOURCE_ROOT = f"{DESKTOP_ROOT}Sources/Rapid/"
+UNSAFE_BROAD_PREFIXES = {f"{SOURCE_ROOT}UI/"}
 
 # These inputs influence every journey or the routing policy itself. Keep this
 # list intentionally broad: an unnecessary full run is cheaper than a false
@@ -85,6 +86,13 @@ def all_flows() -> list[str]:
 
 
 def _matches(path: str, declared: str) -> bool:
+    # UI is a mixed-responsibility directory. A new file under it cannot
+    # inherit ownership from the broad inventory prefix: only an explicit file
+    # or a narrower declared subdirectory may route narrowly. Cohesive domain
+    # folders such as Chat/, Audio/, and Images/ intentionally allow new files
+    # to inherit their journey ownership.
+    if declared in UNSAFE_BROAD_PREFIXES:
+        return False
     return path == declared.rstrip("/") or path.startswith(declared)
 
 

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -25,6 +25,7 @@ def test_engine_only_does_not_select_desktop():
     "path",
     [
         "scripts/check_rapid_mac_ax_identifiers.py",
+        "scripts/select_gui_flows.py",
         "tests/test_rapid_mac_ax_identifiers.py",
         "tests/test_rapid_mac_xcui_target.py",
         "tests/test_ax_baseline.py",
@@ -32,6 +33,7 @@ def test_engine_only_does_not_select_desktop():
         "tests/test_gui_control_behavior_contract.py",
         "tests/test_gui_preflight_contract.py",
         "tests/test_gui_golden_ci_coverage.py",
+        "tests/test_gui_flow_routing.py",
         "tests/test_gui_walk_completeness.py",
         "tests/test_fake_sidecar_image_catalog.py",
         "tests/fixtures/ax_baseline/macos.txt",

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -68,6 +68,17 @@ def test_new_file_cannot_inherit_ownership_from_mixed_ui_directory():
     )
 
 
+def test_unmapped_top_level_presentation_file_fails_closed():
+    assert select(["apps/rapid-mac/Sources/Rapid/AboutPanel.swift"]) == all_flows()
+
+
+def test_file_prefix_collision_does_not_inherit_explicit_file_ownership():
+    assert (
+        select(["apps/rapid-mac/Sources/Rapid/UI/ChatView.swift.preview"])
+        == all_flows()
+    )
+
+
 @pytest.mark.parametrize(
     "shared_control",
     ["ReadinessBanner.swift", "ModelPickerBar.swift", "InstructionTextEditor.swift"],

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts.select_gui_flows import all_flows, select
@@ -65,6 +66,14 @@ def test_new_file_cannot_inherit_ownership_from_mixed_ui_directory():
         select(["apps/rapid-mac/Sources/Rapid/UI/NewImagesToolbar.swift"])
         == all_flows()
     )
+
+
+@pytest.mark.parametrize(
+    "shared_control",
+    ["ReadinessBanner.swift", "ModelPickerBar.swift", "InstructionTextEditor.swift"],
+)
+def test_shared_controls_without_explicit_ownership_run_every_flow(shared_control):
+    assert select([f"apps/rapid-mac/Sources/Rapid/UI/{shared_control}"]) == all_flows()
 
 
 def test_empty_or_invalid_diff_fails_closed():

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -60,6 +60,13 @@ def test_unknown_desktop_path_fails_closed():
     assert select(["apps/rapid-mac/Sources/NewSurface.swift"]) == all_flows()
 
 
+def test_new_file_cannot_inherit_ownership_from_mixed_ui_directory():
+    assert (
+        select(["apps/rapid-mac/Sources/Rapid/UI/NewImagesToolbar.swift"])
+        == all_flows()
+    )
+
+
 def test_empty_or_invalid_diff_fails_closed():
     assert select([]) == all_flows()
     assert select(["docs/readme.md"]) == all_flows()

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed contracts for source-aware Desktop GUI journey routing."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.select_gui_flows import all_flows, select
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
+WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
+
+
+def _groups() -> dict[str, set[str]]:
+    journeys = yaml.safe_load(MANIFEST.read_text())["journeys"]
+    result: dict[str, set[str]] = {}
+    for journey in journeys:
+        if journey["ci_tier"] == "pr":
+            result.setdefault(journey["group"], set()).add(journey["name"])
+    return result
+
+
+def test_chat_component_selects_the_complete_chat_group():
+    selected = set(select(["apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift"]))
+    assert _groups()["chat"] <= selected
+    assert "image-generation" not in selected
+
+
+def test_image_component_selects_only_the_image_group():
+    assert set(select(["apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift"])) == {
+        "image-generation"
+    }
+
+
+def test_user_facing_image_and_audio_controls_select_their_journeys():
+    assert "image-generation" in select(
+        ["apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift"]
+    )
+    assert _groups()["audio"] <= set(
+        select(["apps/rapid-mac/Sources/Rapid/UI/DictationView.swift"])
+    )
+
+
+def test_shared_ui_expands_to_every_declared_consumer_group():
+    selected = set(
+        select(["apps/rapid-mac/Sources/Rapid/UI/Components/EmptyState.swift"])
+    )
+    assert selected == set(all_flows())
+
+
+def test_unknown_desktop_path_fails_closed():
+    assert select(["apps/rapid-mac/Sources/NewSurface.swift"]) == all_flows()
+
+
+def test_empty_or_invalid_diff_fails_closed():
+    assert select([]) == all_flows()
+    assert select(["docs/readme.md"]) == all_flows()
+
+
+def test_harness_manifest_and_workflow_changes_fail_closed():
+    for path in (
+        "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml",
+        "apps/rapid-mac/scripts/gui-golden-flows.sh",
+        ".github/workflows/rapid-mac-ci.yml",
+        "scripts/select_gui_flows.py",
+    ):
+        assert select([path]) == all_flows()
+
+
+def test_cli_emits_compact_json_and_github_outputs(tmp_path: Path):
+    output = tmp_path / "github-output"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/select_gui_flows.py"),
+            "--github-output",
+            str(output),
+            "apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+    lines = output.read_text().splitlines()
+    assert json.loads(lines[0].removeprefix("gui_flows=")) == ["image-generation"]
+    assert lines[1] == "gui_flow_count=1"
+
+
+def test_unselected_harness_step_is_a_true_noop(tmp_path: Path):
+    output = tmp_path / "must-not-exist"
+    result = subprocess.run(
+        ["bash", str(HARNESS), "--flow", "fresh-install"],
+        env={
+            **os.environ,
+            "GUI_FLOWS": '["image-generation"]',
+            "RAPID_GUI_GOLDEN_OUT": str(output),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "SKIP" in result.stdout
+    assert not output.exists()
+
+
+def test_workflow_passes_real_diff_to_router_and_consumes_its_outputs():
+    workflow = WORKFLOW.read_text()
+    assert "python scripts/select_gui_flows.py" in workflow
+    assert "--paths-file /tmp/changed-paths" in workflow
+    assert "gui_flows: ${{ steps.policy.outputs.gui_flows }}" in workflow
+    assert "GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}" in workflow

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -268,7 +268,9 @@ def test_all_named_flows_run_before_one_blocking_verdict():
     assert len(verdicts) == 1
     verdict = verdicts[0]
     assert verdict.get("if") == "always()"
-    assert f"expected = {len(workflow_flows())}" in str(verdict.get("run", ""))
+    assert 'expected = int(os.environ["EXPECTED_FLOW_COUNT"])' in str(
+        verdict.get("run", "")
+    )
 
 
 def test_golden_job_builds_the_release_ui_surface():

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -25,10 +25,13 @@ def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
     upload_index, upload = named_steps["Upload XCUITest evidence"]
     verdict_index, verdict = named_steps["Require native XCUITest"]
     assert xcui["id"] == "xcui"
+    assert "image-generation" in xcui["if"]
     assert xcui["continue-on-error"] is True
     assert upload["if"] == "steps.xcui.outcome == 'failure'"
     assert verdict["if"] == "always()"
     assert "steps.xcui.outcome" in verdict["env"]["XCUI_OUTCOME"]
+    assert "image-generation" in verdict["env"]["IMAGE_SELECTED"]
+    assert "IMAGE_SELECTED" in verdict["run"]
     assert xcui_index < upload_index < verdict_index
 
 


### PR DESCRIPTION
## Summary

- select GUI journey groups from the real PR diff using the checked-in journey manifest
- fail closed to all PR journeys for shared, unknown, packaging, harness, manifest, and workflow changes
- keep one release app build and skip unaffected named flow steps before GUI preflight/app launch
- route the image-generation XCUITest with its owning journey
- retain a count-based final verdict so selected flows cannot silently disappear

## Why

The Desktop merge gate currently runs all 29 PR GUI journeys serially for every Desktop change. The journey inventory landed in #2258 gives CI enough provenance to run the flows affected by a changed product surface while retaining full coverage for ambiguous changes. This is deliberately the first routing slice; build-artifact reuse and parallel journey shards remain separate follow-up work.

## Safety / rollback

Unknown or malformed inputs return the full manifest roster. Removing the GUI_FLOWS job environment restores the prior all-flow behavior without changing required-check names.

## Verification

- 149 focused routing, GUI contract, AX baseline, XCUITest, and lane-classification tests
- 2,756 Swift tests (pre-rebase; no Swift product source changed)
- Ruff lint/format
- actionlint
- workflow expression and immutable Action pin checks
- shell syntax and diff checks
