### PR TITLE
ci(mac): route GUI journeys by changed UI surface

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -221,6 +221,9 @@ jobs:
       - name: GUI golden-flow coverage contract
         run: pytest tests/test_gui_golden_ci_coverage.py -q
 
+      - name: GUI journey routing contract
+        run: pytest tests/test_gui_journey_routing.py -q
+
       - name: Fake sidecar catalog contract
         run: pytest tests/test_fake_sidecar_image_catalog.py -q
 

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -17,11 +17,10 @@
 # no `.accessibilityIdentifier(...)` — see the script's module docstring for the
 # rationale, the escape hatch, and the shapes it deliberately does not detect.
 #
-# Third gate: `gui-golden-flows` actually RUNS that harness. The identifier gate
-# only ensures new controls are reachable; nothing was checking that the
-# journeys still pass or that the committed AX baselines still describe the app.
-# They did not — #1705 shipped a new sidebar button and left all 12 baselines
-# stale. See the job's own comment for why a hosted runner can drive it.
+# Third gate: `gui-golden-flows` actually RUNS the routed part of that harness.
+# The identifier gate only ensures new controls are reachable; known UI surfaces
+# select their journey groups, while shared or unknown UI changes fail closed to
+# the full suite. See the job's own comment for why a hosted runner can drive it.
 name: rapid-mac CI
 
 on:
@@ -45,6 +44,9 @@ jobs:
     outputs:
       desktop: ${{ steps.policy.outputs.desktop }}
       full_gate: ${{ steps.policy.outputs.full_gate }}
+      gui_required: ${{ steps.gui.outputs.gui_required }}
+      gui_groups: ${{ steps.gui.outputs.gui_groups }}
+      gui_flows: ${{ steps.gui.outputs.gui_flows }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -76,6 +78,34 @@ jobs:
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"
             echo "full_gate=$FULL_CI" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python for GUI routing
+        if: steps.policy.outputs.desktop == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install routing dependency
+        if: steps.policy.outputs.desktop == 'true'
+        run: pip install PyYAML
+
+      - name: Route GUI journeys
+        if: steps.policy.outputs.desktop == 'true'
+        id: gui
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "merge_group" ] || [ "$FULL_CI" = true ]; then
+            python scripts/route_gui_journeys.py \
+              --force-all \
+              --github-output "$GITHUB_OUTPUT"
+          else
+            python scripts/route_gui_journeys.py \
+              --paths-file /tmp/changed-paths \
+              --github-output "$GITHUB_OUTPUT"
           fi
 
   # Pure text lint over the diff — no Swift toolchain, no simulator, no app
@@ -281,7 +311,7 @@ jobs:
     needs: changes
     if: >-
       needs.changes.outputs.desktop == 'true' &&
-      needs.changes.outputs.full_gate == 'true'
+      needs.changes.outputs.gui_required == 'true'
     # macos-15 for the same reason as the build job: Package.swift is
     # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
     runs-on: macos-15
@@ -338,6 +368,7 @@ jobs:
       # which closes the one gap AX structurally cannot: prove two gallery
       # records actually draw different pixels rather than the same bitmap.
       - name: 'XCUITest: image-generation pixels'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation')
         id: xcui
         continue-on-error: true
         env:
@@ -372,42 +403,49 @@ jobs:
       # named flow. `test_gui_golden_ci_coverage.py` fails if any other flow is
       # absent from this job, or if this exception silently grows.
       - name: 'Golden flow: fresh-install'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'fresh-install')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow fresh-install
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/fresh-install
 
       - name: 'Golden flow: cached-quickstart'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'cached-quickstart')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow cached-quickstart
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-quickstart
 
       - name: 'Golden flow: cached-curated-tradeup'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'cached-curated-tradeup')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow cached-curated-tradeup
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-curated-tradeup
 
       - name: 'Golden flow: cached-variant-collapse'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'cached-variant-collapse')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow cached-variant-collapse
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-variant-collapse
 
       - name: 'Golden flow: download-progress'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'download-progress')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow download-progress
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/download-progress
 
       - name: 'Golden flow: settings-persistence'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'settings-persistence')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow settings-persistence
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/settings-persistence
 
       - name: 'Golden flow: chat-restore'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'chat-restore')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow chat-restore
         env:
@@ -417,132 +455,154 @@ jobs:
       # launches below can create artificial cold-start pressure on the hosted
       # Mac. Payload correctness is still asserted by the flow itself.
       - name: 'Golden flow: chat-multimodal-attachments'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'chat-multimodal-attachments')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow chat-multimodal-attachments
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-multimodal-attachments
 
       - name: 'Golden flow: message-actions'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'message-actions')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow message-actions
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/message-actions
 
       - name: 'Golden flow: restored-tools'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'restored-tools')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow restored-tools
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/restored-tools
 
       - name: 'Golden flow: tool-loop-budget'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'tool-loop-budget')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow tool-loop-budget
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/tool-loop-budget
 
       - name: 'Golden flow: math-rendering'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'math-rendering')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow math-rendering
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/math-rendering
 
       - name: 'Golden flow: slow-stream-stop'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'slow-stream-stop')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow slow-stream-stop
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/slow-stream-stop
 
       - name: 'Golden flow: model-crash-recovery'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'model-crash-recovery')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow model-crash-recovery
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/model-crash-recovery
 
       - name: 'Golden flow: low-memory-choice'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'low-memory-choice')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow low-memory-choice
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/low-memory-choice
 
       - name: 'Golden flow: image-generation'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow image-generation
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/image-generation
 
       - name: 'Golden flow: audio-readiness'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'audio-readiness')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow audio-readiness
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/audio-readiness
 
       - name: 'Golden flow: dictation'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'dictation')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow dictation
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/dictation
 
       - name: 'Golden flow: settings-mtp'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'settings-mtp')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow settings-mtp
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/settings-mtp
 
       - name: 'Golden flow: window-close-prompt'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'window-close-prompt')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow window-close-prompt
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/window-close-prompt
 
       - name: 'Golden flow: resident-load-rejected'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'resident-load-rejected')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow resident-load-rejected
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/resident-load-rejected
 
       - name: 'Golden flow: no-dead-controls'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'no-dead-controls')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow no-dead-controls
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/no-dead-controls
 
       - name: 'Golden flow: catalog-integrity'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'catalog-integrity')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow catalog-integrity
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/catalog-integrity
 
       - name: 'Golden flow: browse-all-destination'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'browse-all-destination')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow browse-all-destination
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/browse-all-destination
 
       - name: 'Golden flow: chat-document-attachment'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'chat-document-attachment')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow chat-document-attachment
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-document-attachment
 
       - name: 'Golden flow: update-state'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'update-state')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow update-state
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/update-state
 
       - name: 'Golden flow: update-busy'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'update-busy')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow update-busy
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/update-busy
 
       - name: 'Golden flow: campaign-banner'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'campaign-banner')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow campaign-banner
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/campaign-banner
 
       - name: 'Golden flow: launch-integrations'
+        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'launch-integrations')
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow launch-integrations
         env:
@@ -555,6 +615,7 @@ jobs:
         if: always()
         env:
           GOLDEN_ROOT: ${{ runner.temp }}/golden
+          GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}
         run: |
           python3 - <<'PY'
           import json
@@ -562,8 +623,9 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 29
+          expected_flows = set(json.loads(os.environ["GUI_FLOWS"]))
           results = sorted(root.glob("*/result.json"))
+          observed_flows = {path.parent.name for path in results}
           failures = []
           for path in results:
               try:
@@ -575,11 +637,15 @@ jobs:
                   failures.append(
                       f"{path.parent.name}: {payload.get('status', 'missing status')}"
                   )
-          if len(results) != expected:
-              failures.append(f"expected {expected} result files, found {len(results)}")
+          missing = sorted(expected_flows - observed_flows)
+          unexpected = sorted(observed_flows - expected_flows)
+          if missing:
+              failures.append(f"missing result files: {', '.join(missing)}")
+          if unexpected:
+              failures.append(f"unexpected result files: {', '.join(unexpected)}")
           if failures:
               raise SystemExit("Golden flow gate failed:\n- " + "\n- ".join(failures))
-          print(f"All {expected} named GUI golden flows passed")
+          print(f"All {len(expected_flows)} selected GUI golden flows passed")
           PY
 
       # Each harness invocation stops at its FIRST mismatched baseline, so one
@@ -601,6 +667,7 @@ jobs:
         env:
           GOLDEN_ROOT: ${{ runner.temp }}/golden
           SCRATCH: ${{ runner.temp }}/os-baselines
+          GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}
         run: |
           set -uo pipefail
           structural_failure=0
@@ -618,6 +685,8 @@ jobs:
           mkdir -p "$SCRATCH/snapshots"
           cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
           for flow in fresh-install settings-persistence settings-mtp chat-restore slow-stream-stop model-crash-recovery update-state update-busy campaign-banner image-generation audio-readiness launch-integrations; do
+            jq -e --arg flow "$flow" 'index($flow) != null' \
+              <<<"$GUI_FLOWS" >/dev/null || continue
             RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
             RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
               ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true
@@ -647,7 +716,9 @@ jobs:
       # the blocking verdict after AX diagnostics: placing it last keeps an
       # XCUITest-only failure from needlessly regenerating every AX baseline.
       - name: Require native XCUITest
-        if: always()
+        if: >-
+          always() &&
+          contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation')
         env:
           XCUI_OUTCOME: ${{ steps.xcui.outcome }}
         run: |
@@ -673,7 +744,7 @@ jobs:
       - name: Check desktop results
         env:
           DESKTOP_EXPECTED: ${{ needs.changes.outputs.desktop }}
-          FULL_GATE: ${{ needs.changes.outputs.full_gate }}
+          GUI_REQUIRED: ${{ needs.changes.outputs.gui_required }}
           IDENTIFIERS: ${{ needs.accessibility-identifiers.result }}
           IDENTIFIER_TESTS: ${{ needs.accessibility-identifier-tests.result }}
           HARNESS_CONTRACTS: ${{ needs.gui-harness-contracts.result }}
@@ -689,17 +760,13 @@ jobs:
             echo "Desktop lane not required for this PR"
             exit 0
           fi
-          if [ "${{ github.event_name }}" = pull_request ] && [ "$FULL_GATE" != true ]; then
-            echo "Desktop PR gate passed; apply the full-ci label when this PR is ready to merge"
-            exit 1
-          fi
           for result in "$IDENTIFIERS" "$IDENTIFIER_TESTS" "$HARNESS_CONTRACTS" "$BUILD"; do
             if [ "$result" != success ]; then
               echo "A desktop PR gate failed: $result"
               exit 1
             fi
           done
-          if [ "$FULL_GATE" = true ] && [ "$GOLDEN_FLOWS" != success ]; then
+          if [ "$GUI_REQUIRED" = true ] && [ "$GOLDEN_FLOWS" != success ]; then
             echo "GUI golden-flow merge gate failed: $GOLDEN_FLOWS"
             exit 1
           fi

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -26,6 +26,13 @@ routing:
     audio:
       - apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
       - apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+      # Stateful app-to-UI boundaries; leaf policies and clients remain unit-only.
+      - apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+      - apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+      - apps/rapid-mac/Sources/Rapid/Dictation/DictationHUD.swift
+      - apps/rapid-mac/Sources/Rapid/Dictation/DictationHotkey.swift
+      - apps/rapid-mac/Sources/Rapid/Dictation/DictationInjector.swift
+      - apps/rapid-mac/Sources/Rapid/Dictation/DictationRecorder.swift
     models:
       - apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
       - apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -41,9 +48,11 @@ routing:
       - apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
       - apps/rapid-mac/Sources/Rapid/UI/AppearanceConfig.swift
       - apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+      - apps/rapid-mac/Sources/Rapid/Updater/
     images:
       - apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
       - apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+      - apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
     app-lifecycle:
       - apps/rapid-mac/Sources/Rapid/RapidApp.swift
       - apps/rapid-mac/Sources/Rapid/UI/MainWindowCloseInterceptor.swift
@@ -54,8 +63,9 @@ routing:
 
 # Machine-readable inventory for GUI coverage and future source-based routing.
 # `source_paths` are intentionally conservative product-area prefixes, not a
-# promise that every edit below them requires this journey. Routing will be a
-# separate, fail-closed change once this inventory is established.
+# promise that every edit below them requires this journey. The routing table
+# above narrows these broad ownership hints to UI and stateful integration
+# boundaries; leaf logic remains covered by Swift tests and the app build.
 journeys:
   - name: fresh-install
     group: onboarding-settings

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -1,5 +1,57 @@
 version: 1
 
+routing:
+  # Infrastructure and shared navigation can affect every journey. Any match
+  # here selects all groups, as does an unknown path under `gui_roots`.
+  shared_paths:
+    - .github/workflows/rapid-mac-ci.yml
+    - scripts/route_gui_journeys.py
+    - tests/test_gui_journey_routing.py
+    - tests/test_gui_golden_ci_coverage.py
+    - apps/rapid-mac/scripts/gui-golden-flows.sh
+    - apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+    - apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/
+    - apps/rapid-mac/Tests/RapidUITests/
+    - apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+    - apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+  gui_roots:
+    - apps/rapid-mac/Sources/Rapid/UI/
+  group_paths:
+    chat:
+      - apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/ConversationSearchView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/ConversationExportPanel.swift
+      - apps/rapid-mac/Sources/Rapid/UI/SelectTextSheet.swift
+      - apps/rapid-mac/Sources/Rapid/UI/Markdown/
+    audio:
+      - apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+    models:
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+      - apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+      - apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
+      - apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+    onboarding-settings:
+      - apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/Onboarding
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+      - apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
+      - apps/rapid-mac/Sources/Rapid/UI/AppearanceConfig.swift
+      - apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+    images:
+      - apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+      - apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+    app-lifecycle:
+      - apps/rapid-mac/Sources/Rapid/RapidApp.swift
+      - apps/rapid-mac/Sources/Rapid/UI/MainWindowCloseInterceptor.swift
+      - apps/rapid-mac/Sources/Rapid/UI/DockVisibilityPrompt
+      - apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+      - apps/rapid-mac/Sources/Rapid/UI/MenuBar
+      - apps/rapid-mac/Sources/Rapid/Window
+
 # Machine-readable inventory for GUI coverage and future source-based routing.
 # `source_paths` are intentionally conservative product-area prefixes, not a
 # promise that every edit below them requires this journey. Routing will be a

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -101,6 +101,17 @@ Each journey execution writes a `result.json` containing its outcome, UTC start
 time, execution duration in seconds, and artifact directory. This makes per-journey
 timing and failure evidence machine-readable without parsing Actions logs.
 
+### PR routing
+
+The same manifest owns fail-closed PR routing. Non-rendering Swift logic relies
+on unit tests plus the app build and allocates no GUI runner. Known SwiftUI
+surfaces select the smallest matching journey group; mixed-domain diffs take
+the union. Shared navigation, GUI infrastructure, an unknown path below a GUI
+root, `full-ci`, and merge-queue candidates select every group. The classifier
+prints the reason, selected groups, and exact flow list as machine-readable
+outputs so the workflow's final verdict can reject both missing and unexpected
+results.
+
 ### Current baseline
 
 **2026-08-09** — the whole suite (`gui-golden-flows.sh`, no `--flow`) passes on

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -47,6 +47,7 @@ _DESKTOP_PREFIX = "apps/rapid-mac/"
 _DESKTOP_SUPPORT_PREFIXES = ("tests/fixtures/ax_baseline/",)
 _DESKTOP_SUPPORT = {
     "scripts/check_rapid_mac_ax_identifiers.py",
+    "scripts/route_gui_journeys.py",
     "tests/test_rapid_mac_ax_identifiers.py",
     "tests/test_rapid_mac_xcui_target.py",
     "tests/test_ax_baseline.py",
@@ -56,6 +57,7 @@ _DESKTOP_SUPPORT = {
     "tests/test_gui_golden_ci_coverage.py",
     "tests/test_gui_walk_completeness.py",
     "tests/test_fake_sidecar_image_catalog.py",
+    "tests/test_gui_journey_routing.py",
 }
 _DOC_ROOTS = {"docs"}
 _DOC_FILES = {

--- a/scripts/route_gui_journeys.py
+++ b/scripts/route_gui_journeys.py
@@ -21,6 +21,12 @@ DEFAULT_MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
 
 
 def _matches(path: str, prefix: str) -> bool:
+    # Manifest entries ending in a filename extension are exact file rules.
+    # Stem/directory rules intentionally cover a family (for example the
+    # Onboarding*.swift surfaces); a file rule must never absorb an unknown
+    # sibling such as ChatView.swift.generated and bypass fail-closed routing.
+    if Path(prefix).suffix:
+        return path == prefix
     return path == prefix or path.startswith(prefix)
 
 

--- a/scripts/route_gui_journeys.py
+++ b/scripts/route_gui_journeys.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Route changed paths to the smallest safe GUI journey set.
+
+Non-rendering Desktop logic intentionally selects no GUI group: Swift unit
+tests and the app build own that layer. Unknown GUI paths, shared navigation,
+test infrastructure, and explicit full promotion fail closed to every group.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
+
+
+def _matches(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(prefix)
+
+
+def route(
+    paths: Iterable[str], manifest: Mapping[str, Any], *, force_all: bool = False
+) -> dict[str, object]:
+    journeys = manifest["journeys"]
+    routing = manifest["routing"]
+    all_groups = sorted({journey["group"] for journey in journeys})
+    normalized = sorted(
+        {path.strip().removeprefix("./") for path in paths if path.strip()}
+    )
+
+    selected: set[str] = set()
+    all_reason: str | None = "explicit-full" if force_all else None
+    if not normalized and not force_all:
+        all_reason = "empty-diff"
+
+    for path in normalized:
+        if any(_matches(path, prefix) for prefix in routing["shared_paths"]):
+            all_reason = f"shared:{path}"
+            break
+
+        matched = {
+            group
+            for group, prefixes in routing["group_paths"].items()
+            if any(_matches(path, prefix) for prefix in prefixes)
+        }
+        if matched:
+            selected.update(matched)
+        elif any(_matches(path, root) for root in routing["gui_roots"]):
+            all_reason = f"unclassified-gui:{path}"
+            break
+
+    if all_reason:
+        selected = set(all_groups)
+
+    flows = sorted(
+        journey["name"]
+        for journey in journeys
+        if journey["ci_tier"] == "pr" and journey["group"] in selected
+    )
+    return {
+        "gui_required": bool(selected),
+        "gui_groups": sorted(selected),
+        "gui_flows": flows,
+        "gui_all": selected == set(all_groups),
+        "gui_reason": all_reason or ("matched" if selected else "logic-only"),
+    }
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument("--paths-file", type=argparse.FileType("r"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--force-all", action="store_true")
+    parser.add_argument("--github-output", type=argparse.FileType("a"))
+    args = parser.parse_args()
+
+    paths = list(args.paths)
+    if args.paths_file:
+        paths.extend(args.paths_file.read().splitlines())
+    result = route(paths, load_manifest(args.manifest), force_all=args.force_all)
+
+    if args.github_output:
+        for key, value in result.items():
+            encoded = json.dumps(value, separators=(",", ":"))
+            print(f"{key}={encoded}", file=args.github_output)
+    else:
+        print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -49,18 +49,53 @@ def test_non_engine_change_exits_before_full_ci_requirement():
     assert classifier_gate < common_gate < no_lane < engine_gate < promotion
 
 
-def test_non_desktop_change_exits_before_full_ci_requirement():
+def test_non_desktop_change_exits_before_desktop_results():
     run = _step_run(DESKTOP_WORKFLOW, "desktop-tests", "Check desktop results")
     classifier_gate = run.index("needs.changes.result")
     no_lane = run.index('if [ "$DESKTOP_EXPECTED" != true ]')
-    promotion = run.index('if [ "${{ github.event_name }}" = pull_request ]')
-    assert classifier_gate < no_lane < promotion
+    build_gate = run.index('for result in "$IDENTIFIERS"')
+    gui_gate = run.index('if [ "$GUI_REQUIRED" = true ]')
+    assert classifier_gate < no_lane < build_gate < gui_gate
 
 
-def test_gui_golden_job_requires_both_desktop_lane_and_full_promotion():
+def test_gui_golden_job_requires_desktop_lane_and_routed_gui_work():
     condition = str(_job(DESKTOP_WORKFLOW, "gui-golden-flows")["if"])
     assert "needs.changes.outputs.desktop == 'true'" in condition
-    assert "needs.changes.outputs.full_gate == 'true'" in condition
+    assert "needs.changes.outputs.gui_required == 'true'" in condition
+    assert "needs.changes.outputs.full_gate" not in condition
+
+
+def test_full_ci_is_an_all_gui_override_not_a_merge_prerequisite():
+    route_run = _step_run(DESKTOP_WORKFLOW, "changes", "Route GUI journeys")
+    assert '[ "$FULL_CI" = true ]' in route_run
+    assert "--force-all" in route_run
+
+    aggregate = _step_run(DESKTOP_WORKFLOW, "desktop-tests", "Check desktop results")
+    assert "apply the full-ci label" not in aggregate
+    assert 'if [ "$GUI_REQUIRED" = true ]' in aggregate
+
+
+def test_gui_router_dependencies_are_desktop_scoped():
+    changes = _job(DESKTOP_WORKFLOW, "changes")
+    scoped_steps = {
+        step["name"]: step
+        for step in changes["steps"]
+        if step.get("name")
+        in {
+            "Set up Python for GUI routing",
+            "Install routing dependency",
+            "Route GUI journeys",
+        }
+    }
+    assert set(scoped_steps) == {
+        "Set up Python for GUI routing",
+        "Install routing dependency",
+        "Route GUI journeys",
+    }
+    assert all(
+        step.get("if") == "steps.policy.outputs.desktop == 'true'"
+        for step in scoped_steps.values()
+    )
 
 
 def test_engine_only_contracts_are_not_universal_pr_guards():

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -98,6 +98,13 @@ def test_gui_router_dependencies_are_desktop_scoped():
     )
 
 
+def test_gui_router_contract_runs_in_desktop_ci():
+    run = _step_run(
+        DESKTOP_WORKFLOW, "gui-harness-contracts", "GUI journey routing contract"
+    )
+    assert "pytest tests/test_gui_journey_routing.py -q" in run
+
+
 def test_engine_only_contracts_are_not_universal_pr_guards():
     universal_steps = {
         step.get("name") for step in _job(ENGINE_WORKFLOW, "lint")["steps"]

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -25,6 +25,7 @@ def test_engine_only_does_not_select_desktop():
     "path",
     [
         "scripts/check_rapid_mac_ax_identifiers.py",
+        "scripts/route_gui_journeys.py",
         "tests/test_rapid_mac_ax_identifiers.py",
         "tests/test_rapid_mac_xcui_target.py",
         "tests/test_ax_baseline.py",
@@ -34,6 +35,7 @@ def test_engine_only_does_not_select_desktop():
         "tests/test_gui_golden_ci_coverage.py",
         "tests/test_gui_walk_completeness.py",
         "tests/test_fake_sidecar_image_catalog.py",
+        "tests/test_gui_journey_routing.py",
         "tests/fixtures/ax_baseline/macos.txt",
     ],
 )

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -261,6 +261,11 @@ def test_all_named_flows_run_before_one_blocking_verdict():
     ]
     assert len(flow_steps) == len(workflow_flows())
     assert all(step.get("continue-on-error") is True for step in flow_steps)
+    for step in flow_steps:
+        flow = str(step["name"]).removeprefix("Golden flow: ")
+        assert step.get("if") == (
+            f"contains(fromJSON(needs.changes.outputs.gui_flows), '{flow}')"
+        )
 
     verdicts = [
         step for step in steps if step.get("name") == "Require every named golden flow"
@@ -268,7 +273,10 @@ def test_all_named_flows_run_before_one_blocking_verdict():
     assert len(verdicts) == 1
     verdict = verdicts[0]
     assert verdict.get("if") == "always()"
-    assert f"expected = {len(workflow_flows())}" in str(verdict.get("run", ""))
+    run = str(verdict.get("run", ""))
+    assert 'json.loads(os.environ["GUI_FLOWS"])' in run
+    assert "expected_flows - observed_flows" in run
+    assert "observed_flows - expected_flows" in run
 
 
 def test_golden_job_builds_the_release_ui_surface():

--- a/tests/test_gui_journey_routing.py
+++ b/tests/test_gui_journey_routing.py
@@ -26,7 +26,12 @@ def groups(*paths: str, force_all: bool = False) -> set[str]:
         ("apps/rapid-mac/Sources/Rapid/UI/Markdown/MathView.swift", {"chat"}),
         ("apps/rapid-mac/Sources/Rapid/UI/AudioView.swift", {"audio"}),
         ("apps/rapid-mac/Sources/Rapid/UI/DictationView.swift", {"audio"}),
+        (
+            "apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift",
+            {"audio"},
+        ),
         ("apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift", {"images"}),
+        ("apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift", {"images"}),
         (
             "apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift",
             {"models"},
@@ -38,6 +43,10 @@ def groups(*paths: str, force_all: bool = False) -> set[str]:
         (
             "apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift",
             {"app-lifecycle"},
+        ),
+        (
+            "apps/rapid-mac/Sources/Rapid/Updater/UpdateChecker.swift",
+            {"onboarding-settings"},
         ),
     ],
 )
@@ -51,6 +60,7 @@ def test_domain_ui_routes_to_one_group(path: str, expected: set[str]):
         "apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift",
         "apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift",
         "apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift",
+        "apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift",
         "apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift",
         "apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift",
         "README.md",

--- a/tests/test_gui_journey_routing.py
+++ b/tests/test_gui_journey_routing.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.route_gui_journeys import ROOT, load_manifest, route
+
+MANIFEST = load_manifest()
+ALL_GROUPS = {
+    "app-lifecycle",
+    "audio",
+    "chat",
+    "images",
+    "models",
+    "onboarding-settings",
+}
+
+
+def groups(*paths: str, force_all: bool = False) -> set[str]:
+    return set(route(paths, MANIFEST, force_all=force_all)["gui_groups"])
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("apps/rapid-mac/Sources/Rapid/UI/ChatView.swift", {"chat"}),
+        ("apps/rapid-mac/Sources/Rapid/UI/Markdown/MathView.swift", {"chat"}),
+        ("apps/rapid-mac/Sources/Rapid/UI/AudioView.swift", {"audio"}),
+        ("apps/rapid-mac/Sources/Rapid/UI/DictationView.swift", {"audio"}),
+        ("apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift", {"images"}),
+        (
+            "apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift",
+            {"models"},
+        ),
+        (
+            "apps/rapid-mac/Sources/Rapid/UI/OnboardingDirectionD.swift",
+            {"onboarding-settings"},
+        ),
+        (
+            "apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift",
+            {"app-lifecycle"},
+        ),
+    ],
+)
+def test_domain_ui_routes_to_one_group(path: str, expected: set[str]):
+    assert groups(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift",
+        "apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift",
+        "apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift",
+        "apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift",
+        "apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift",
+        "README.md",
+    ],
+)
+def test_logic_and_non_gui_paths_do_not_allocate_gui(path: str):
+    result = route([path], MANIFEST)
+    assert result["gui_required"] is False
+    assert result["gui_flows"] == []
+    assert result["gui_reason"] == "logic-only"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "apps/rapid-mac/Sources/Rapid/UI/BrandNewSurface.swift",
+        "apps/rapid-mac/Sources/Rapid/UI/ContentView.swift",
+        "apps/rapid-mac/scripts/gui-golden-flows.sh",
+        "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml",
+        "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat.txt",
+        ".github/workflows/rapid-mac-ci.yml",
+        "scripts/route_gui_journeys.py",
+    ],
+)
+def test_unknown_or_shared_gui_paths_fail_closed(path: str):
+    result = route([path], MANIFEST)
+    assert set(result["gui_groups"]) == ALL_GROUPS
+    assert result["gui_all"] is True
+    assert len(result["gui_flows"]) == 29
+
+
+def test_mixed_domain_paths_union_groups():
+    assert groups(
+        "apps/rapid-mac/Sources/Rapid/UI/ChatView.swift",
+        "apps/rapid-mac/Sources/Rapid/UI/AudioView.swift",
+    ) == {"chat", "audio"}
+
+
+def test_full_promotion_and_empty_diff_fail_closed():
+    assert groups(force_all=True) == ALL_GROUPS
+    assert groups() == ALL_GROUPS
+
+
+def test_selected_flows_are_pr_tier_members_of_selected_groups():
+    result = route(["apps/rapid-mac/Sources/Rapid/UI/ChatView.swift"], MANIFEST)
+    expected = sorted(
+        journey["name"]
+        for journey in MANIFEST["journeys"]
+        if journey["group"] == "chat" and journey["ci_tier"] == "pr"
+    )
+    assert result["gui_flows"] == expected
+    assert "chat-depth" not in result["gui_flows"]
+
+
+def test_routing_schema_covers_every_group_and_real_repository_paths():
+    routing = MANIFEST["routing"]
+    assert set(routing) == {"shared_paths", "gui_roots", "group_paths"}
+    assert set(routing["group_paths"]) == ALL_GROUPS
+
+    repository_files = [str(path.relative_to(ROOT)) for path in ROOT.rglob("*")]
+    prefixes = [
+        *routing["shared_paths"],
+        *routing["gui_roots"],
+        *(
+            prefix
+            for group_prefixes in routing["group_paths"].values()
+            for prefix in group_prefixes
+        ),
+    ]
+    assert all(isinstance(prefix, str) and prefix for prefix in prefixes)
+    assert all(
+        any(path == prefix or path.startswith(prefix) for path in repository_files)
+        for prefix in prefixes
+    )
+
+
+def test_group_prefixes_are_not_ambiguously_owned():
+    owners: dict[str, str] = {}
+    for group, prefixes in MANIFEST["routing"]["group_paths"].items():
+        for prefix in prefixes:
+            assert prefix not in owners, f"{prefix} is owned by two GUI groups"
+            owners[prefix] = group

--- a/tests/test_gui_journey_routing.py
+++ b/tests/test_gui_journey_routing.py
@@ -77,6 +77,7 @@ def test_logic_and_non_gui_paths_do_not_allocate_gui(path: str):
     "path",
     [
         "apps/rapid-mac/Sources/Rapid/UI/BrandNewSurface.swift",
+        "apps/rapid-mac/Sources/Rapid/UI/ChatView.swift.generated",
         "apps/rapid-mac/Sources/Rapid/UI/ContentView.swift",
         "apps/rapid-mac/scripts/gui-golden-flows.sh",
         "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml",

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -27,7 +27,10 @@ def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
     assert xcui["id"] == "xcui"
     assert xcui["continue-on-error"] is True
     assert upload["if"] == "steps.xcui.outcome == 'failure'"
-    assert verdict["if"] == "always()"
+    condition = str(verdict["if"])
+    assert "always()" in condition
+    assert "needs.changes.outputs.gui_flows" in condition
+    assert "image-generation" in condition
     assert "steps.xcui.outcome" in verdict["env"]["XCUI_OUTCOME"]
     assert xcui_index < upload_index < verdict_index
 


### PR DESCRIPTION
## Summary

- route Desktop PR diffs to the smallest safe GUI journey group set
- skip expensive GUI execution for logic-only Desktop changes while retaining build/unit contracts
- fail closed to every PR-tier journey for shared, unknown UI, `full-ci`, and merge-queue changes
- make the golden-flow verdict validate the exact routed result set

Closes part of #2254.

## Validation

- `python3.12 scripts/check_workflow_expressions.py`
- `python3.12 scripts/check_gha_pinning.py`
- 91 routing/workflow/GUI contract tests
- Ruff check + format

Because this PR changes the GUI workflow and routing manifest, the router intentionally selects all PR-tier GUI groups for its own CI.