### PR TITLE
ci(mac): build GUI app once for golden flows

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -197,6 +197,7 @@ jobs:
       - name: GUI golden-flow coverage contract
         run: |
           pytest \
+            tests/test_gui_app_artifact.py \
             tests/test_gui_golden_ci_coverage.py \
             tests/test_gui_flow_routing.py \
             -q

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -269,6 +269,52 @@ jobs:
       - name: verify chat timeout contract
         run: swift scripts/verify-chat-timeout.swift
 
+  # Build the release-shaped, sidecar-free app exactly once for every full
+  # Desktop gate. GUI consumers must use this commit-bound artifact instead of
+  # compiling their own copy. Keeping this as a dedicated producer makes the
+  # next step (parallel journey shards) cheap without trusting a cache as test
+  # evidence: the archive and its manifest are immutable outputs of this run.
+  gui-app-build:
+    needs: changes
+    if: >-
+      needs.changes.outputs.desktop == 'true' &&
+      needs.changes.outputs.full_gate == 'true'
+    runs-on: macos-15
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/rapid-mac
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Build release-shaped GUI app
+        env:
+          SKIP_SIDECAR: "1"
+          RAPID_BUILD_CONFIG: release
+        run: ./scripts/build.sh
+
+      - name: Verify and package GUI app
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/gui-app-artifact
+        run: |
+          set -euo pipefail
+          app="build/Rapid-MLX Desktop.app"
+          codesign --verify --deep --strict "$app"
+          mkdir -p "$ARTIFACT_DIR"
+          ditto -c -k --keepParent "$app" "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip"
+          python ../../scripts/gui_app_artifact.py create \
+            --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
+            --source-sha "$GITHUB_SHA" \
+            --output "$ARTIFACT_DIR/manifest.json"
+
+      - name: Upload commit-bound GUI app
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-gui-app-${{ github.sha }}
+          path: ${{ runner.temp }}/gui-app-artifact
+          if-no-files-found: error
+          retention-days: 1
+
   # Drives the REAL .app through real user journeys and diffs the resulting
   # accessibility tree against committed structural baselines.
   #
@@ -288,7 +334,9 @@ jobs:
   # session so an .app can actually open a window. Both are image properties,
   # not promises — which is what the preflight step below is for.
   gui-golden-flows:
-    needs: changes
+    needs:
+      - changes
+      - gui-app-build
     if: >-
       needs.changes.outputs.desktop == 'true' &&
       needs.changes.outputs.full_gate == 'true'
@@ -331,21 +379,29 @@ jobs:
           echo "Dock pid: $dock_pid"
           "$RUNNER_TEMP/rapid-ax" trust "$dock_pid"
 
-      # SKIP_SIDECAR=1 drops the 5-10 min pip install of the bundled Python
-      # engine. The golden flows never touch it: every flow points RAPID_BIN
-      # at scripts/fake-rapid-mlx.sh, so there is no model download, no GPU
-      # work and no network in the run at all.
-      #
-      # Exercise the same compile-time surface users receive. Debug builds add
-      # Settings → Developer, so comparing a Debug app against release golden
-      # baselines makes every Settings journey fail even when the product is
-      # unchanged. Optimisation does not matter here; matching the shipped UI
-      # contract does.
-      - name: Build Rapid-MLX Desktop.app
+      - name: Download commit-bound GUI app
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: rapid-gui-app-${{ github.sha }}
+          path: ${{ runner.temp }}/gui-app-artifact
+
+      # Do not merely trust the artifact name. Verify both its declared source
+      # commit and its bytes before extraction, then verify the app's code seal.
+      # Missing, stale, corrupt, or substituted artifacts therefore fail the
+      # merge gate before any journey launches.
+      - name: Verify and extract GUI app
         env:
-          SKIP_SIDECAR: "1"
-          RAPID_BUILD_CONFIG: release
-        run: ./scripts/build.sh
+          ARTIFACT_DIR: ${{ runner.temp }}/gui-app-artifact
+        run: |
+          set -euo pipefail
+          python ../../scripts/gui_app_artifact.py verify \
+            --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
+            --manifest "$ARTIFACT_DIR/manifest.json" \
+            --expected-source-sha "$GITHUB_SHA"
+          rm -rf "build/Rapid-MLX Desktop.app"
+          mkdir -p build
+          ditto -x -k "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" build
+          codesign --verify --deep --strict "build/Rapid-MLX Desktop.app"
 
       # #1719 — the first native XCUITest journey complements (and does not
       # replace) the AX flows below. XCTest can capture an individual element,
@@ -687,6 +743,7 @@ jobs:
       - accessibility-identifier-tests
       - gui-harness-contracts
       - build
+      - gui-app-build
       - gui-golden-flows
     if: always()
     runs-on: ubuntu-latest
@@ -699,6 +756,7 @@ jobs:
           IDENTIFIER_TESTS: ${{ needs.accessibility-identifier-tests.result }}
           HARNESS_CONTRACTS: ${{ needs.gui-harness-contracts.result }}
           BUILD: ${{ needs.build.result }}
+          GUI_APP_BUILD: ${{ needs.gui-app-build.result }}
           GOLDEN_FLOWS: ${{ needs.gui-golden-flows.result }}
         run: |
           set -euo pipefail
@@ -720,7 +778,13 @@ jobs:
               exit 1
             fi
           done
-          if [ "$FULL_GATE" = true ] && [ "$GOLDEN_FLOWS" != success ]; then
-            echo "GUI golden-flow merge gate failed: $GOLDEN_FLOWS"
-            exit 1
+          if [ "$FULL_GATE" = true ]; then
+            if [ "$GUI_APP_BUILD" != success ]; then
+              echo "GUI app artifact build failed: $GUI_APP_BUILD"
+              exit 1
+            fi
+            if [ "$GOLDEN_FLOWS" != success ]; then
+              echo "GUI golden-flow merge gate failed: $GOLDEN_FLOWS"
+              exit 1
+            fi
           fi

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -72,6 +72,21 @@ rather than repeatedly validating each PR against an obsolete base.
 
 Pushes to `main` retain the full engine coverage as a post-merge signal.
 
+### Desktop GUI artifact provenance
+
+The full Desktop gate builds one release-configured app with
+`SKIP_SIDECAR=1`, packages it, and uploads it under an artifact name containing
+the exact candidate SHA. GUI jobs do not rebuild the app. Before extraction,
+they verify a versioned manifest that binds the SHA, build mode, sidecar mode,
+archive filename, and SHA-256 digest; after extraction they verify the macOS
+code-signing seal. Missing, stale, malformed, or modified artifacts fail
+closed.
+
+This artifact is test-only and retained for one day. It is not signed for
+distribution, notarized, published, or eligible for release promotion. Release
+workflows continue to build their own Developer-ID-signed artifact with the
+bundled sidecar and release credentials.
+
 ## Repository configuration
 
 GitHub currently offers merge queues only to public repositories owned by an
@@ -100,3 +115,6 @@ lanes for every PR; this restores the previous validation coverage without
 renaming required checks. For GUI routing specifically, removing the
 `GUI_FLOWS` job environment or making `scripts/select_gui_flows.py` return the
 full manifest roster restores the previous all-journey behavior.
+If GUI artifact reuse is suspect, restore the build step inside
+`gui-golden-flows` and remove `gui-app-build` from its dependencies. This costs
+additional macOS build time but preserves the same release-shaped UI coverage.

--- a/scripts/gui_app_artifact.py
+++ b/scripts/gui_app_artifact.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Create and verify provenance for the Desktop app consumed by GUI CI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+BUILD_CONFIG = "release"
+SIDECAR_MODE = "skipped"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create(archive: Path, source_sha: str, output: Path) -> None:
+    if not archive.is_file():
+        raise SystemExit(f"archive does not exist: {archive}")
+    if not source_sha.strip():
+        raise SystemExit("source SHA must not be empty")
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "source_sha": source_sha,
+        "archive": archive.name,
+        "archive_sha256": sha256(archive),
+        "build_config": BUILD_CONFIG,
+        "sidecar": SIDECAR_MODE,
+    }
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def verify(archive: Path, manifest: Path, expected_source_sha: str) -> None:
+    try:
+        payload = json.loads(manifest.read_text())
+    except (OSError, ValueError) as error:
+        raise SystemExit(f"invalid GUI app manifest: {error}") from error
+    expected = {
+        "schema_version": SCHEMA_VERSION,
+        "source_sha": expected_source_sha,
+        "archive": archive.name,
+        "archive_sha256": sha256(archive),
+        "build_config": BUILD_CONFIG,
+        "sidecar": SIDECAR_MODE,
+    }
+    if payload != expected:
+        differences = [
+            f"{key}: expected {value!r}, found {payload.get(key)!r}"
+            for key, value in expected.items()
+            if payload.get(key) != value
+        ]
+        unexpected = sorted(set(payload) - set(expected))
+        if unexpected:
+            differences.append(f"unexpected fields: {', '.join(unexpected)}")
+        raise SystemExit(
+            "GUI app provenance verification failed:\n- " + "\n- ".join(differences)
+        )
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    create_parser = commands.add_parser("create")
+    create_parser.add_argument("--archive", type=Path, required=True)
+    create_parser.add_argument("--source-sha", required=True)
+    create_parser.add_argument("--output", type=Path, required=True)
+    verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("--archive", type=Path, required=True)
+    verify_parser.add_argument("--manifest", type=Path, required=True)
+    verify_parser.add_argument("--expected-source-sha", required=True)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    if args.command == "create":
+        create(args.archive, args.source_sha, args.output)
+    else:
+        verify(args.archive, args.manifest, args.expected_source_sha)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gui_app_artifact.py
+++ b/tests/test_gui_app_artifact.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the commit-bound GUI app artifact."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts/gui_app_artifact.py"
+WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("gui_app_artifact", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_manifest_round_trip_binds_archive_and_commit(tmp_path: Path):
+    module = load_module()
+    archive = tmp_path / "Rapid-MLX-Desktop.zip"
+    archive.write_bytes(b"signed app bytes")
+    manifest = tmp_path / "manifest.json"
+
+    module.create(archive, "abc123", manifest)
+    module.verify(archive, manifest, "abc123")
+
+    payload = json.loads(manifest.read_text())
+    assert payload["schema_version"] == 1
+    assert payload["build_config"] == "release"
+    assert payload["sidecar"] == "skipped"
+
+
+@pytest.mark.parametrize("mutation", ["archive", "commit", "manifest"])
+def test_verification_fails_closed_on_substitution(tmp_path: Path, mutation: str):
+    module = load_module()
+    archive = tmp_path / "Rapid-MLX-Desktop.zip"
+    archive.write_bytes(b"original")
+    manifest = tmp_path / "manifest.json"
+    module.create(archive, "abc123", manifest)
+
+    expected_sha = "abc123"
+    if mutation == "archive":
+        archive.write_bytes(b"substituted")
+    elif mutation == "commit":
+        expected_sha = "different"
+    else:
+        payload = json.loads(manifest.read_text())
+        payload["sidecar"] = "bundled"
+        manifest.write_text(json.dumps(payload))
+
+    with pytest.raises(SystemExit, match="provenance verification failed"):
+        module.verify(archive, manifest, expected_sha)
+
+
+def test_workflow_builds_once_and_consumes_verified_artifact():
+    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    producer = jobs["gui-app-build"]
+    consumer = jobs["gui-golden-flows"]
+    producer_source = json.dumps(producer)
+    consumer_source = json.dumps(consumer)
+    verify_step = next(
+        step
+        for step in consumer["steps"]
+        if step.get("name") == "Verify and extract GUI app"
+    )
+
+    assert "./scripts/build.sh" in producer_source
+    assert "rapid-gui-app-${{ github.sha }}" in producer_source
+    assert "gui-app-build" in consumer["needs"]
+    assert "download-artifact" in consumer_source
+    assert '--expected-source-sha "$GITHUB_SHA"' in verify_step["run"]
+    assert "./scripts/build.sh" not in consumer_source
+    assert "codesign --verify --deep --strict" in consumer_source

--- a/tests/test_gui_app_artifact.py
+++ b/tests/test_gui_app_artifact.py
@@ -79,3 +79,9 @@ def test_workflow_builds_once_and_consumes_verified_artifact():
     assert '--expected-source-sha "$GITHUB_SHA"' in verify_step["run"]
     assert "./scripts/build.sh" not in consumer_source
     assert "codesign --verify --deep --strict" in consumer_source
+
+
+def test_required_gui_contract_job_runs_artifact_tests():
+    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    contract_source = json.dumps(jobs["gui-harness-contracts"])
+    assert "tests/test_gui_app_artifact.py" in contract_source

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -275,10 +275,13 @@ def test_all_named_flows_run_before_one_blocking_verdict():
 
 def test_golden_job_builds_the_release_ui_surface():
     """Release baselines cannot be compared against Debug-only controls."""
+    workflow = yaml.safe_load(WORKFLOW.read_text())
     build_steps = [
         step
-        for step in workflow_steps()
-        if step.get("name") == "Build Rapid-MLX Desktop.app"
+        for step in workflow["jobs"]["gui-app-build"]["steps"]
+        if step.get("name") == "Build release-shaped GUI app"
     ]
     assert len(build_steps) == 1
     assert build_steps[0].get("env", {}).get("RAPID_BUILD_CONFIG") == "release"
+    assert build_steps[0].get("env", {}).get("SKIP_SIDECAR") == "1"
+    assert "gui-app-build" in workflow["jobs"]["gui-golden-flows"]["needs"]


### PR DESCRIPTION
## Summary

- build one release-shaped, sidecar-free Desktop app in a dedicated full-gate producer
- bind the uploaded archive to the exact candidate SHA and SHA-256 manifest, then verify provenance and codesign before GUI use
- keep release signing/notarization isolated and document rollback
- add fail-closed artifact and workflow contract tests

This is intentionally the artifact-reuse foundation only. It does not shard journeys or reduce coverage; a follow-up will fan journey groups out over this single verified build.

Closes part of #2252.

## Verification

- `python3 -m pytest tests/test_gui_app_artifact.py tests/test_gui_golden_ci_coverage.py tests/test_gui_flow_routing.py tests/test_ci_lane_promotion.py tests/test_rapid_mac_xcui_target.py tests/test_gui_preflight_contract.py -q` (56 passed)
- `python3 -m ruff check scripts/gui_app_artifact.py tests/test_gui_app_artifact.py tests/test_gui_golden_ci_coverage.py`
- `actionlint .github/workflows/rapid-mac-ci.yml`
- manifest CLI create/verify smoke
- `git diff --check`

## Safety / rollback

The artifact is ad-hoc signed, sidecar-free, retained one day, and is not consumed by any release workflow. To roll back, restore the in-job build step and remove the producer dependency.