### PR TITLE
fix(mac): isolate async chat attachment drafts

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -6,6 +6,11 @@ import Foundation
 /// rules directly testable: every input method feeds the same draft, a send
 /// atomically consumes it, and a later turn cannot inherit stale attachments.
 struct ChatAttachmentDraft: Equatable {
+    struct FileImport: Equatable {
+        let id: UUID
+        let conversationID: UUID
+    }
+
     /// Immutable ownership transfer from the composer to one user turn.
     ///
     /// The arrays are captured before asynchronous chat work starts, so later
@@ -18,11 +23,11 @@ struct ChatAttachmentDraft: Equatable {
     private(set) var images: [ChatImageAttachment] = []
     private(set) var files: [ChatFileAttachment] = []
     private(set) var sourcePaths: [UUID: String] = [:]
-    private(set) var fileImportID: UUID?
+    private(set) var fileImport: FileImport?
     var notice: String?
 
     var hasAttachments: Bool { !images.isEmpty || !files.isEmpty }
-    var isImportingFiles: Bool { fileImportID != nil }
+    var isImportingFiles: Bool { fileImport != nil }
 
     mutating func appendImage(_ image: ChatImageAttachment, sourceURL: URL? = nil) {
         images.append(image)
@@ -37,10 +42,10 @@ struct ChatAttachmentDraft: Equatable {
 
     /// Starts one asynchronous import generation. A second source cannot race
     /// the first because every UI entry point funnels through this method.
-    mutating func beginFileImport() -> UUID? {
-        guard fileImportID == nil else { return nil }
+    mutating func beginFileImport(conversationID: UUID) -> UUID? {
+        guard fileImport == nil else { return nil }
         let id = UUID()
-        fileImportID = id
+        fileImport = FileImport(id: id, conversationID: conversationID)
         return id
     }
 
@@ -55,13 +60,13 @@ struct ChatAttachmentDraft: Equatable {
         _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
         notice: String?
     ) -> Bool {
-        guard fileImportID == id else { return false }
+        guard fileImport?.id == id else { return false }
         files = ChatFileAttachment.fittedForMessage(files + imported.map(\.attachment))
         for item in imported {
             sourcePaths[item.attachment.id] = Self.attachmentKey(for: item.sourceURL)
         }
         self.notice = notice
-        fileImportID = nil
+        fileImport = nil
         return true
     }
 
@@ -70,11 +75,24 @@ struct ChatAttachmentDraft: Equatable {
     /// announcing navigation that had no attachment work in flight.
     @discardableResult
     mutating func cancelFileImport(id expectedID: UUID? = nil, notice: String? = nil) -> Bool {
-        guard let activeID = fileImportID else { return false }
-        guard expectedID == nil || expectedID == activeID else { return false }
-        fileImportID = nil
+        guard let activeImport = fileImport else { return false }
+        guard expectedID == nil || expectedID == activeImport.id else { return false }
+        fileImport = nil
         if let notice { self.notice = notice }
         return true
+    }
+
+    /// Cancels only work owned by a conversation other than the active one.
+    /// This remains correct even when SwiftUI delivers navigation after the new
+    /// conversation has already started its own import.
+    @discardableResult
+    mutating func cancelFileImport(
+        notOwnedBy conversationID: UUID,
+        notice: String? = nil
+    ) -> Bool {
+        guard let activeImport = fileImport else { return false }
+        guard activeImport.conversationID != conversationID else { return false }
+        return cancelFileImport(id: activeImport.id, notice: notice)
     }
 
     mutating func removeImage(id: UUID) {
@@ -96,7 +114,7 @@ struct ChatAttachmentDraft: Equatable {
         files = []
         sourcePaths = [:]
         notice = nil
-        fileImportID = nil
+        fileImport = nil
         return submission
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -133,4 +133,25 @@ struct ChatAttachmentDraftStore: Equatable {
         get { drafts[conversationID] ?? ChatAttachmentDraft() }
         set { drafts[conversationID] = newValue }
     }
+
+    /// Completes only an import whose owning conversation still exists in the
+    /// store. In particular, a late task cannot recreate a deleted draft.
+    @discardableResult
+    mutating func finishFileImport(
+        conversationID: UUID,
+        id: UUID,
+        _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
+        notice: String?
+    ) -> Bool {
+        guard var draft = drafts[conversationID] else { return false }
+        guard draft.finishFileImport(id: id, imported, notice: notice) else { return false }
+        drafts[conversationID] = draft
+        return true
+    }
+
+    /// Releases attachment data for deleted conversations while retaining the
+    /// unsaved active conversation, which is not present in history yet.
+    mutating func retainDrafts(for conversationIDs: Set<UUID>) {
+        drafts = drafts.filter { conversationIDs.contains($0.key) }
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -65,8 +65,15 @@ struct ChatAttachmentDraft: Equatable {
         return true
     }
 
-    mutating func cancelFileImport() {
+    /// Invalidates the active generation and leaves a visible explanation.
+    /// Returns whether an import was actually cancelled so callers can avoid
+    /// announcing navigation that had no attachment work in flight.
+    @discardableResult
+    mutating func cancelFileImport(notice: String? = nil) -> Bool {
+        guard fileImportID != nil else { return false }
         fileImportID = nil
+        if let notice { self.notice = notice }
+        return true
     }
 
     mutating func removeImage(id: UUID) {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -127,6 +127,11 @@ struct ChatAttachmentDraft: Equatable {
 /// conversation therefore neither exposes the old draft nor cancels the new
 /// conversation's work; returning restores the original draft and results.
 struct ChatAttachmentDraftStore: Equatable {
+    struct ImportRequest: Equatable {
+        let conversationID: UUID
+        let generationID: UUID
+    }
+
     private var drafts: [UUID: ChatAttachmentDraft] = [:]
 
     subscript(conversationID: UUID) -> ChatAttachmentDraft {
@@ -134,18 +139,28 @@ struct ChatAttachmentDraftStore: Equatable {
         set { drafts[conversationID] = newValue }
     }
 
+    mutating func beginFileImport(conversationID: UUID) -> ImportRequest? {
+        var draft = self[conversationID]
+        guard let generationID = draft.beginFileImport() else { return nil }
+        drafts[conversationID] = draft
+        return ImportRequest(conversationID: conversationID, generationID: generationID)
+    }
+
     /// Completes only an import whose owning conversation still exists in the
     /// store. In particular, a late task cannot recreate a deleted draft.
     @discardableResult
     mutating func finishFileImport(
-        conversationID: UUID,
-        id: UUID,
+        request: ImportRequest,
         _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
         notice: String?
     ) -> Bool {
-        guard var draft = drafts[conversationID] else { return false }
-        guard draft.finishFileImport(id: id, imported, notice: notice) else { return false }
-        drafts[conversationID] = draft
+        guard var draft = drafts[request.conversationID] else { return false }
+        guard draft.finishFileImport(
+            id: request.generationID,
+            imported,
+            notice: notice
+        ) else { return false }
+        drafts[request.conversationID] = draft
         return true
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -5,15 +5,7 @@ import Foundation
 /// Keeping this outside ``ChatView`` makes the important identity and lifecycle
 /// rules directly testable: every input method feeds the same draft, a send
 /// atomically consumes it, and a later turn cannot inherit stale attachments.
-/// Like the text composer beside it, this draft survives conversation browsing;
-/// an import is accepted if the user returns to its owning conversation before
-/// completion, but can never land in or cancel work owned by another one.
 struct ChatAttachmentDraft: Equatable {
-    struct FileImport: Equatable {
-        let id: UUID
-        let conversationID: UUID
-    }
-
     /// Immutable ownership transfer from the composer to one user turn.
     ///
     /// The arrays are captured before asynchronous chat work starts, so later
@@ -26,11 +18,11 @@ struct ChatAttachmentDraft: Equatable {
     private(set) var images: [ChatImageAttachment] = []
     private(set) var files: [ChatFileAttachment] = []
     private(set) var sourcePaths: [UUID: String] = [:]
-    private(set) var fileImport: FileImport?
+    private(set) var fileImportID: UUID?
     var notice: String?
 
     var hasAttachments: Bool { !images.isEmpty || !files.isEmpty }
-    var isImportingFiles: Bool { fileImport != nil }
+    var isImportingFiles: Bool { fileImportID != nil }
 
     mutating func appendImage(_ image: ChatImageAttachment, sourceURL: URL? = nil) {
         images.append(image)
@@ -45,10 +37,10 @@ struct ChatAttachmentDraft: Equatable {
 
     /// Starts one asynchronous import generation. A second source cannot race
     /// the first because every UI entry point funnels through this method.
-    mutating func beginFileImport(conversationID: UUID) -> UUID? {
-        guard fileImport == nil else { return nil }
+    mutating func beginFileImport() -> UUID? {
+        guard fileImportID == nil else { return nil }
         let id = UUID()
-        fileImport = FileImport(id: id, conversationID: conversationID)
+        fileImportID = id
         return id
     }
 
@@ -63,40 +55,25 @@ struct ChatAttachmentDraft: Equatable {
         _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
         notice: String?
     ) -> Bool {
-        guard fileImport?.id == id else { return false }
+        guard fileImportID == id else { return false }
         files = ChatFileAttachment.fittedForMessage(files + imported.map(\.attachment))
         for item in imported {
             sourcePaths[item.attachment.id] = Self.attachmentKey(for: item.sourceURL)
         }
         self.notice = notice
-        fileImport = nil
+        fileImportID = nil
         return true
     }
 
-    /// Invalidates the active generation and leaves a visible explanation.
-    /// Returns whether an import was actually cancelled so callers can avoid
-    /// announcing navigation that had no attachment work in flight.
+    /// Invalidates only the expected generation, when supplied. This prevents
+    /// late cleanup from an older task from cancelling newer work.
     @discardableResult
     mutating func cancelFileImport(id expectedID: UUID? = nil, notice: String? = nil) -> Bool {
-        guard let activeImport = fileImport else { return false }
-        guard expectedID == nil || expectedID == activeImport.id else { return false }
-        fileImport = nil
+        guard let activeID = fileImportID else { return false }
+        guard expectedID == nil || expectedID == activeID else { return false }
+        fileImportID = nil
         if let notice { self.notice = notice }
         return true
-    }
-
-    /// Cancels only work owned by a conversation other than the active one.
-    /// This remains correct even when SwiftUI delivers navigation after the new
-    /// conversation has already started its own import. An A -> B -> A sequence
-    /// intentionally preserves A's work, matching the persistent composer.
-    @discardableResult
-    mutating func cancelFileImport(
-        notOwnedBy conversationID: UUID,
-        notice: String? = nil
-    ) -> Bool {
-        guard let activeImport = fileImport else { return false }
-        guard activeImport.conversationID != conversationID else { return false }
-        return cancelFileImport(id: activeImport.id, notice: notice)
     }
 
     mutating func removeImage(id: UUID) {
@@ -118,7 +95,7 @@ struct ChatAttachmentDraft: Equatable {
         files = []
         sourcePaths = [:]
         notice = nil
-        fileImport = nil
+        fileImportID = nil
         return submission
     }
 
@@ -141,5 +118,19 @@ struct ChatAttachmentDraft: Equatable {
             fresh.append(url)
         }
         return (fresh, urls.count - fresh.count)
+    }
+}
+
+/// Conversation-keyed composer state.
+///
+/// Async work always writes through the ID it started with. Browsing another
+/// conversation therefore neither exposes the old draft nor cancels the new
+/// conversation's work; returning restores the original draft and results.
+struct ChatAttachmentDraftStore: Equatable {
+    private var drafts: [UUID: ChatAttachmentDraft] = [:]
+
+    subscript(conversationID: UUID) -> ChatAttachmentDraft {
+        get { drafts[conversationID] ?? ChatAttachmentDraft() }
+        set { drafts[conversationID] = newValue }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -6,7 +6,11 @@ import Foundation
 /// rules directly testable: every input method feeds the same draft, a send
 /// atomically consumes it, and a later turn cannot inherit stale attachments.
 struct ChatAttachmentDraft: Equatable {
-    struct Payload: Equatable {
+    /// Immutable ownership transfer from the composer to one user turn.
+    ///
+    /// The arrays are captured before asynchronous chat work starts, so later
+    /// composer mutations cannot alter an in-flight request.
+    struct Submission: Equatable {
         let images: [ChatImageAttachment]
         let files: [ChatFileAttachment]
     }
@@ -14,10 +18,11 @@ struct ChatAttachmentDraft: Equatable {
     private(set) var images: [ChatImageAttachment] = []
     private(set) var files: [ChatFileAttachment] = []
     private(set) var sourcePaths: [UUID: String] = [:]
+    private(set) var fileImportID: UUID?
     var notice: String?
-    var isImportingFiles = false
 
     var hasAttachments: Bool { !images.isEmpty || !files.isEmpty }
+    var isImportingFiles: Bool { fileImportID != nil }
 
     mutating func appendImage(_ image: ChatImageAttachment, sourceURL: URL? = nil) {
         images.append(image)
@@ -30,16 +35,38 @@ struct ChatAttachmentDraft: Equatable {
         for item in imported { appendImage(item.attachment, sourceURL: item.sourceURL) }
     }
 
+    /// Starts one asynchronous import generation. A second source cannot race
+    /// the first because every UI entry point funnels through this method.
+    mutating func beginFileImport() -> UUID? {
+        guard fileImportID == nil else { return nil }
+        let id = UUID()
+        fileImportID = id
+        return id
+    }
+
+    /// Applies results only to the generation that created them.
+    ///
+    /// A conversation transition can cancel an import while file parsing is
+    /// still off-main-thread. Its late completion must not resurrect stale
+    /// attachments in the current composer.
+    @discardableResult
     mutating func finishFileImport(
+        id: UUID,
         _ imported: [(attachment: ChatFileAttachment, sourceURL: URL)],
         notice: String?
-    ) {
+    ) -> Bool {
+        guard fileImportID == id else { return false }
         files = ChatFileAttachment.fittedForMessage(files + imported.map(\.attachment))
         for item in imported {
             sourcePaths[item.attachment.id] = Self.attachmentKey(for: item.sourceURL)
         }
         self.notice = notice
-        isImportingFiles = false
+        fileImportID = nil
+        return true
+    }
+
+    mutating func cancelFileImport() {
+        fileImportID = nil
     }
 
     mutating func removeImage(id: UUID) {
@@ -55,14 +82,14 @@ struct ChatAttachmentDraft: Equatable {
     /// Returns exactly one turn's attachments and clears all transient state.
     /// This is intentionally one mutation so a new import cannot observe an
     /// old source-path map after the visible chips have already disappeared.
-    mutating func consume() -> Payload {
-        let payload = Payload(images: images, files: files)
+    mutating func takeSubmission() -> Submission {
+        let submission = Submission(images: images, files: files)
         images = []
         files = []
         sourcePaths = [:]
         notice = nil
-        isImportingFiles = false
-        return payload
+        fileImportID = nil
+        return submission
     }
 
     func filteringAlreadyAttached(_ urls: [URL]) -> (fresh: [URL], duplicates: Int) {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -69,8 +69,9 @@ struct ChatAttachmentDraft: Equatable {
     /// Returns whether an import was actually cancelled so callers can avoid
     /// announcing navigation that had no attachment work in flight.
     @discardableResult
-    mutating func cancelFileImport(notice: String? = nil) -> Bool {
-        guard fileImportID != nil else { return false }
+    mutating func cancelFileImport(id expectedID: UUID? = nil, notice: String? = nil) -> Bool {
+        guard let activeID = fileImportID else { return false }
+        guard expectedID == nil || expectedID == activeID else { return false }
         fileImportID = nil
         if let notice { self.notice = notice }
         return true

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -5,6 +5,9 @@ import Foundation
 /// Keeping this outside ``ChatView`` makes the important identity and lifecycle
 /// rules directly testable: every input method feeds the same draft, a send
 /// atomically consumes it, and a later turn cannot inherit stale attachments.
+/// Like the text composer beside it, this draft survives conversation browsing;
+/// an import is accepted if the user returns to its owning conversation before
+/// completion, but can never land in or cancel work owned by another one.
 struct ChatAttachmentDraft: Equatable {
     struct FileImport: Equatable {
         let id: UUID
@@ -84,7 +87,8 @@ struct ChatAttachmentDraft: Equatable {
 
     /// Cancels only work owned by a conversation other than the active one.
     /// This remains correct even when SwiftUI delivers navigation after the new
-    /// conversation has already started its own import.
+    /// conversation has already started its own import. An A -> B -> A sequence
+    /// intentionally preserves A's work, matching the persistent composer.
     @discardableResult
     mutating func cancelFileImport(
         notOwnedBy conversationID: UUID,

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1044,7 +1044,7 @@ struct ChatView: View {
             // ownership here closes the window where A's completion could be
             // accepted into B's composer.
             guard viewModel.activeConversationID == importConversationID else {
-                cancelFileImportAfterNavigation()
+                cancelFileImportAfterNavigation(importID: importID)
                 return
             }
             let notice = selection.rejectedCount > 0
@@ -1055,9 +1055,9 @@ struct ChatView: View {
         return true
     }
 
-    private func cancelFileImportAfterNavigation() {
+    private func cancelFileImportAfterNavigation(importID: UUID? = nil) {
         let notice = "File import canceled because you switched conversations."
-        if attachmentDraft.cancelFileImport(notice: notice) {
+        if attachmentDraft.cancelFileImport(id: importID, notice: notice) {
             VoiceOverAnnouncer.announce(notice)
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1044,7 +1044,9 @@ struct ChatView: View {
             // Do not rely only on SwiftUI's onChange delivery: the observable
             // ID can change before SwiftUI schedules that callback. Comparing
             // ownership here closes the window where A's completion could be
-            // accepted into B's composer.
+            // accepted into B's composer. Returning to A before completion is
+            // intentionally accepted: this composer, including its draft text
+            // and ready chips, persists while the user browses conversations.
             guard viewModel.activeConversationID == importConversationID else {
                 cancelFileImportAfterNavigation(importID: importID)
                 return

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -297,7 +297,10 @@ struct ChatView: View {
         // Parsing runs off-main-thread. A completion started in conversation A
         // must not attach itself after the user has navigated to conversation B.
         .onChange(of: viewModel.activeConversationID) { _, _ in
-            attachmentDraft.cancelFileImport()
+            let notice = "File import canceled because you switched conversations."
+            if attachmentDraft.cancelFileImport(notice: notice) {
+                VoiceOverAnnouncer.announce(notice)
+            }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -296,8 +296,8 @@ struct ChatView: View {
         }
         // Parsing runs off-main-thread. A completion started in conversation A
         // must not attach itself after the user has navigated to conversation B.
-        .onChange(of: viewModel.activeConversationID) { _, _ in
-            cancelFileImportAfterNavigation()
+        .onChange(of: viewModel.activeConversationID) { _, newConversationID in
+            cancelFileImportAfterNavigation(activeConversationID: newConversationID)
         }
     }
 
@@ -1032,8 +1032,10 @@ struct ChatView: View {
             attachmentDraft.notice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
             return false
         }
-        guard let importID = attachmentDraft.beginFileImport() else { return false }
         let importConversationID = viewModel.activeConversationID
+        guard let importID = attachmentDraft.beginFileImport(
+            conversationID: importConversationID
+        ) else { return false }
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
@@ -1055,9 +1057,20 @@ struct ChatView: View {
         return true
     }
 
-    private func cancelFileImportAfterNavigation(importID: UUID? = nil) {
+    private func cancelFileImportAfterNavigation(
+        importID: UUID? = nil,
+        activeConversationID: UUID? = nil
+    ) {
         let notice = "File import canceled because you switched conversations."
-        if attachmentDraft.cancelFileImport(id: importID, notice: notice) {
+        let cancelled = if let activeConversationID {
+            attachmentDraft.cancelFileImport(
+                notOwnedBy: activeConversationID,
+                notice: notice
+            )
+        } else {
+            attachmentDraft.cancelFileImport(id: importID, notice: notice)
+        }
+        if cancelled {
             VoiceOverAnnouncer.announce(notice)
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -297,10 +297,7 @@ struct ChatView: View {
         // Parsing runs off-main-thread. A completion started in conversation A
         // must not attach itself after the user has navigated to conversation B.
         .onChange(of: viewModel.activeConversationID) { _, _ in
-            let notice = "File import canceled because you switched conversations."
-            if attachmentDraft.cancelFileImport(notice: notice) {
-                VoiceOverAnnouncer.announce(notice)
-            }
+            cancelFileImportAfterNavigation()
         }
     }
 
@@ -1036,17 +1033,33 @@ struct ChatView: View {
             return false
         }
         guard let importID = attachmentDraft.beginFileImport() else { return false }
+        let importConversationID = viewModel.activeConversationID
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
             }.value
 
+            // Do not rely only on SwiftUI's onChange delivery: the observable
+            // ID can change before SwiftUI schedules that callback. Comparing
+            // ownership here closes the window where A's completion could be
+            // accepted into B's composer.
+            guard viewModel.activeConversationID == importConversationID else {
+                cancelFileImportAfterNavigation()
+                return
+            }
             let notice = selection.rejectedCount > 0
                 ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
                 : outcome.1
             attachmentDraft.finishFileImport(id: importID, outcome.0, notice: notice)
         }
         return true
+    }
+
+    private func cancelFileImportAfterNavigation() {
+        let notice = "File import canceled because you switched conversations."
+        if attachmentDraft.cancelFileImport(notice: notice) {
+            VoiceOverAnnouncer.announce(notice)
+        }
     }
 
     /// Parse candidates without losing which source produced each attachment.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -298,11 +298,8 @@ struct ChatView: View {
             guard request != 0 else { return }
             composeFocusToken &+= 1
         }
-        .onChange(of: viewModel.conversations.map(\.id)) { _, conversationIDs in
-            attachmentDrafts.retainDrafts(
-                for: Set(conversationIDs).union([viewModel.activeConversationID])
-            )
-        }
+        .onChange(of: viewModel.conversations.map(\.id)) { _, _ in pruneAttachmentDrafts() }
+        .onChange(of: viewModel.activeConversationID) { _, _ in pruneAttachmentDrafts() }
     }
 
     // MARK: - Transcript
@@ -1036,8 +1033,9 @@ struct ChatView: View {
             attachmentDraft.notice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
             return false
         }
-        let importConversationID = viewModel.activeConversationID
-        guard let importID = attachmentDraft.beginFileImport() else { return false }
+        guard let importRequest = attachmentDrafts.beginFileImport(
+            conversationID: viewModel.activeConversationID
+        ) else { return false }
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
@@ -1047,13 +1045,18 @@ struct ChatView: View {
                 ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
                 : outcome.1
             attachmentDrafts.finishFileImport(
-                conversationID: importConversationID,
-                id: importID,
+                request: importRequest,
                 outcome.0,
                 notice: notice
             )
         }
         return true
+    }
+
+    private func pruneAttachmentDrafts() {
+        attachmentDrafts.retainDrafts(
+            for: Set(viewModel.conversations.map(\.id)).union([viewModel.activeConversationID])
+        )
     }
 
     /// Parse candidates without losing which source produced each attachment.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -298,6 +298,11 @@ struct ChatView: View {
             guard request != 0 else { return }
             composeFocusToken &+= 1
         }
+        .onChange(of: viewModel.conversations.map(\.id)) { _, conversationIDs in
+            attachmentDrafts.retainDrafts(
+                for: Set(conversationIDs).union([viewModel.activeConversationID])
+            )
+        }
     }
 
     // MARK: - Transcript
@@ -1041,9 +1046,12 @@ struct ChatView: View {
             let notice = selection.rejectedCount > 0
                 ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
                 : outcome.1
-            var originDraft = attachmentDrafts[importConversationID]
-            originDraft.finishFileImport(id: importID, outcome.0, notice: notice)
-            attachmentDrafts[importConversationID] = originDraft
+            attachmentDrafts.finishFileImport(
+                conversationID: importConversationID,
+                id: importID,
+                outcome.0,
+                notice: notice
+            )
         }
         return true
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -294,6 +294,11 @@ struct ChatView: View {
             guard request != 0 else { return }
             composeFocusToken &+= 1
         }
+        // Parsing runs off-main-thread. A completion started in conversation A
+        // must not attach itself after the user has navigated to conversation B.
+        .onChange(of: viewModel.activeConversationID) { _, _ in
+            attachmentDraft.cancelFileImport()
+        }
     }
 
     // MARK: - Transcript
@@ -858,14 +863,14 @@ struct ChatView: View {
         // tooltip carries.
         guard acknowledgeIfNotReady() else { return }
         draft = ""
-        let attachments = attachmentDraft.consume()
+        let submission = attachmentDraft.takeSubmission()
         composeFocusToken &+= 1
         viewModel.send(
             text,
             alias: alias,
             supportsImageInput: supportsImageInput,
-            imageAttachments: attachments.images,
-            fileAttachments: attachments.files
+            imageAttachments: submission.images,
+            fileAttachments: submission.files
         )
     }
 
@@ -1027,7 +1032,7 @@ struct ChatView: View {
             attachmentDraft.notice = "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
             return false
         }
-        attachmentDraft.isImportingFiles = true
+        guard let importID = attachmentDraft.beginFileImport() else { return false }
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
@@ -1036,7 +1041,7 @@ struct ChatView: View {
             let notice = selection.rejectedCount > 0
                 ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
                 : outcome.1
-            attachmentDraft.finishFileImport(outcome.0, notice: notice)
+            attachmentDraft.finishFileImport(id: importID, outcome.0, notice: notice)
         }
         return true
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -220,7 +220,7 @@ struct ChatView: View {
     @Environment(QuickstartCoordinator.self) private var quickstart
 
     @State private var draft: String = ""
-    @State private var attachmentDraft = ChatAttachmentDraft()
+    @State private var attachmentDrafts = ChatAttachmentDraftStore()
     @State private var isAttachmentDropTarget = false
     @State private var composeFocusToken: Int = 0
     /// Incremented every time the user tries to send while gated. Drives
@@ -248,6 +248,10 @@ struct ChatView: View {
     @State private var scrollToBottomRequest = 0
 
     private var messages: [ChatMessage] { viewModel.messages }
+    private var attachmentDraft: ChatAttachmentDraft {
+        get { attachmentDrafts[viewModel.activeConversationID] }
+        nonmutating set { attachmentDrafts[viewModel.activeConversationID] = newValue }
+    }
 
     var body: some View {
         // The reader exists for one value: the surface's own width, which
@@ -293,11 +297,6 @@ struct ChatView: View {
         .onChange(of: composerFocusRequest) { _, request in
             guard request != 0 else { return }
             composeFocusToken &+= 1
-        }
-        // Parsing runs off-main-thread. A completion started in conversation A
-        // must not attach itself after the user has navigated to conversation B.
-        .onChange(of: viewModel.activeConversationID) { _, newConversationID in
-            cancelFileImportAfterNavigation(activeConversationID: newConversationID)
         }
     }
 
@@ -1033,48 +1032,20 @@ struct ChatView: View {
             return false
         }
         let importConversationID = viewModel.activeConversationID
-        guard let importID = attachmentDraft.beginFileImport(
-            conversationID: importConversationID
-        ) else { return false }
+        guard let importID = attachmentDraft.beginFileImport() else { return false }
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadFileAttachments(selection.accepted)
             }.value
 
-            // Do not rely only on SwiftUI's onChange delivery: the observable
-            // ID can change before SwiftUI schedules that callback. Comparing
-            // ownership here closes the window where A's completion could be
-            // accepted into B's composer. Returning to A before completion is
-            // intentionally accepted: this composer, including its draft text
-            // and ready chips, persists while the user browses conversations.
-            guard viewModel.activeConversationID == importConversationID else {
-                cancelFileImportAfterNavigation(importID: importID)
-                return
-            }
             let notice = selection.rejectedCount > 0
                 ? "Attach up to \(ChatFileAttachment.maxAttachmentsPerMessage) PDF, CSV, or TXT files per message."
                 : outcome.1
-            attachmentDraft.finishFileImport(id: importID, outcome.0, notice: notice)
+            var originDraft = attachmentDrafts[importConversationID]
+            originDraft.finishFileImport(id: importID, outcome.0, notice: notice)
+            attachmentDrafts[importConversationID] = originDraft
         }
         return true
-    }
-
-    private func cancelFileImportAfterNavigation(
-        importID: UUID? = nil,
-        activeConversationID: UUID? = nil
-    ) {
-        let notice = "File import canceled because you switched conversations."
-        let cancelled = if let activeConversationID {
-            attachmentDraft.cancelFileImport(
-                notOwnedBy: activeConversationID,
-                notice: notice
-            )
-        } else {
-            attachmentDraft.cancelFileImport(id: importID, notice: notice)
-        }
-        if cancelled {
-            VoiceOverAnnouncer.announce(notice)
-        }
     }
 
     /// Parse candidates without losing which source produced each attachment.

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -182,6 +182,27 @@ struct ChatAttachmentDraftTests {
         #expect(draft.notice == nil)
     }
 
+    @Test("returning to the owning conversation preserves its pending import")
+    func abaNavigationPreservesOwningImport() throws {
+        let conversationA = UUID()
+        var draft = ChatAttachmentDraft()
+        let startedA = draft.beginFileImport(conversationID: conversationA)
+        let importA = try #require(startedA)
+        let file = try makeFile(name: "a.txt", text: "owned by A")
+
+        // SwiftUI may coalesce A -> B -> A into a final callback carrying A.
+        let cancelled = draft.cancelFileImport(notOwnedBy: conversationA)
+        let accepted = draft.finishFileImport(
+            id: importA,
+            [(file, URL(fileURLWithPath: "/tmp/a.txt"))],
+            notice: nil
+        )
+
+        #expect(!cancelled)
+        #expect(accepted)
+        #expect(draft.files == [file])
+    }
+
     @Test("submission is an immutable snapshot of one composer turn")
     func submissionDoesNotFollowLaterDraftMutations() throws {
         let first = try makeImage(name: "first.png")

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -168,25 +168,20 @@ struct ChatAttachmentDraftTests {
         let fileB = try makeFile(name: "b.txt", text: "owned by B")
         var store = ChatAttachmentDraftStore()
 
-        var draftA = store[conversationA]
-        let startedA = draftA.beginFileImport()
+        let startedA = store.beginFileImport(conversationID: conversationA)
         let importA = try #require(startedA)
-        store[conversationA] = draftA
 
-        var draftB = store[conversationB]
-        let startedB = draftB.beginFileImport()
+        let startedB = store.beginFileImport(conversationID: conversationB)
         let importB = try #require(startedB)
-        draftB.finishFileImport(
-            id: importB,
+        store.finishFileImport(
+            request: importB,
             [(fileB, URL(fileURLWithPath: "/tmp/b.txt"))],
             notice: nil
         )
-        store[conversationB] = draftB
 
         // A may finish while B is visible; it writes only through A's key.
         let acceptedA = store.finishFileImport(
-            conversationID: conversationA,
-            id: importA,
+            request: importA,
             [(fileA, URL(fileURLWithPath: "/tmp/a.txt"))],
             notice: nil
         )
@@ -202,15 +197,12 @@ struct ChatAttachmentDraftTests {
         let survivingConversation = UUID()
         let file = try makeFile(name: "late.txt", text: "late")
         var store = ChatAttachmentDraftStore()
-        var deletedDraft = store[deletedConversation]
-        let startedImport = deletedDraft.beginFileImport()
+        let startedImport = store.beginFileImport(conversationID: deletedConversation)
         let importID = try #require(startedImport)
-        store[deletedConversation] = deletedDraft
 
         store.retainDrafts(for: [survivingConversation])
         let accepted = store.finishFileImport(
-            conversationID: deletedConversation,
-            id: importID,
+            request: importID,
             [(file, URL(fileURLWithPath: "/tmp/late.txt"))],
             notice: nil
         )
@@ -247,12 +239,14 @@ struct ChatAttachmentDraftTests {
         let stripped = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(source)
 
-        #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
-        #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
         #expect(stripped.contains(
-            "attachmentDrafts.finishFileImport(conversationID:importConversationID,id:importID,outcome.0,notice:notice)"
+            "letimportRequest=attachmentDrafts.beginFileImport(conversationID:viewModel.activeConversationID)"
         ))
-        #expect(stripped.contains("attachmentDrafts.retainDrafts("))
+        #expect(stripped.contains(
+            "attachmentDrafts.finishFileImport(request:importRequest,outcome.0,notice:notice)"
+        ))
+        #expect(stripped.contains(".onChange(of:viewModel.activeConversationID){_,_inpruneAttachmentDrafts()}"))
+        #expect(stripped.contains(".onChange(of:viewModel.conversations.map(\\.id)){_,_inpruneAttachmentDrafts()}"))
     }
 
     private func makeImage(name: String) throws -> ChatImageAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -98,7 +98,7 @@ struct ChatAttachmentDraftTests {
         let startedStaleID = draft.beginFileImport()
         let staleID = try #require(startedStaleID)
 
-        draft.cancelFileImport()
+        let cancelled = draft.cancelFileImport(notice: "Import canceled after navigation.")
         let accepted = draft.finishFileImport(
             id: staleID,
             [(staleFile, staleURL)],
@@ -107,7 +107,8 @@ struct ChatAttachmentDraftTests {
 
         #expect(!accepted)
         #expect(draft.files.isEmpty)
-        #expect(draft.notice == nil)
+        #expect(cancelled)
+        #expect(draft.notice == "Import canceled after navigation.")
         #expect(!draft.isImportingFiles)
         #expect(draft.filteringAlreadyAttached([staleURL]).fresh == [staleURL])
     }
@@ -119,7 +120,8 @@ struct ChatAttachmentDraftTests {
         var draft = ChatAttachmentDraft()
         let startedOldID = draft.beginFileImport()
         let oldID = try #require(startedOldID)
-        draft.cancelFileImport()
+        let cancelledOld = draft.cancelFileImport()
+        #expect(cancelledOld)
         let startedNewID = draft.beginFileImport()
         let newID = try #require(startedNewID)
 
@@ -169,7 +171,7 @@ struct ChatAttachmentDraftTests {
         #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
         #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
         #expect(stripped.contains(
-            ".onChange(of:viewModel.activeConversationID){_,_inattachmentDraft.cancelFileImport()"
+            ".onChange(of:viewModel.activeConversationID){_,_inletnotice=\"Fileimportcanceledbecauseyouswitchedconversations.\"ifattachmentDraft.cancelFileImport(notice:notice){VoiceOverAnnouncer.announce(notice)"
         ))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -184,16 +184,40 @@ struct ChatAttachmentDraftTests {
         store[conversationB] = draftB
 
         // A may finish while B is visible; it writes only through A's key.
-        draftA = store[conversationA]
-        draftA.finishFileImport(
+        let acceptedA = store.finishFileImport(
+            conversationID: conversationA,
             id: importA,
             [(fileA, URL(fileURLWithPath: "/tmp/a.txt"))],
             notice: nil
         )
-        store[conversationA] = draftA
 
+        #expect(acceptedA)
         #expect(store[conversationA].files == [fileA])
         #expect(store[conversationB].files == [fileB])
+    }
+
+    @Test("deleted conversations release drafts and reject late imports")
+    func deletedConversationCannotBeRecreatedByCompletion() throws {
+        let deletedConversation = UUID()
+        let survivingConversation = UUID()
+        let file = try makeFile(name: "late.txt", text: "late")
+        var store = ChatAttachmentDraftStore()
+        var deletedDraft = store[deletedConversation]
+        let startedImport = deletedDraft.beginFileImport()
+        let importID = try #require(startedImport)
+        store[deletedConversation] = deletedDraft
+
+        store.retainDrafts(for: [survivingConversation])
+        let accepted = store.finishFileImport(
+            conversationID: deletedConversation,
+            id: importID,
+            [(file, URL(fileURLWithPath: "/tmp/late.txt"))],
+            notice: nil
+        )
+
+        #expect(!accepted)
+        #expect(!store[deletedConversation].hasAttachments)
+        #expect(!store[deletedConversation].isImportingFiles)
     }
 
     @Test("submission is an immutable snapshot of one composer turn")
@@ -225,10 +249,10 @@ struct ChatAttachmentDraftTests {
 
         #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
         #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
-        #expect(stripped.contains("varoriginDraft=attachmentDrafts[importConversationID]"))
         #expect(stripped.contains(
-            "originDraft.finishFileImport(id:importID,outcome.0,notice:notice)attachmentDrafts[importConversationID]=originDraft"
+            "attachmentDrafts.finishFileImport(conversationID:importConversationID,id:importID,outcome.0,notice:notice)"
         ))
+        #expect(stripped.contains("attachmentDrafts.retainDrafts("))
     }
 
     private func makeImage(name: String) throws -> ChatImageAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -13,10 +13,10 @@ struct ChatAttachmentDraftTests {
         let fileURL = URL(fileURLWithPath: "/tmp/notes.txt")
         var draft = ChatAttachmentDraft()
         draft.appendImage(image, sourceURL: imageURL)
-        let startedImportID = draft.beginFileImport(conversationID: UUID())
+        let startedImportID = draft.beginFileImport()
         let importID = try #require(startedImportID)
         draft.finishFileImport(id: importID, [(file, fileURL)], notice: "old notice")
-        _ = draft.beginFileImport(conversationID: UUID())
+        _ = draft.beginFileImport()
 
         let payload = draft.takeSubmission()
 
@@ -37,7 +37,7 @@ struct ChatAttachmentDraftTests {
         var draft = ChatAttachmentDraft()
 
         draft.appendImage(firstImage)
-        let startedFirstImportID = draft.beginFileImport(conversationID: UUID())
+        let startedFirstImportID = draft.beginFileImport()
         let firstImportID = try #require(startedFirstImportID)
         draft.finishFileImport(
             id: firstImportID,
@@ -47,7 +47,7 @@ struct ChatAttachmentDraftTests {
         let first = draft.takeSubmission()
 
         draft.appendImage(secondImage)
-        let startedSecondImportID = draft.beginFileImport(conversationID: UUID())
+        let startedSecondImportID = draft.beginFileImport()
         let secondImportID = try #require(startedSecondImportID)
         draft.finishFileImport(
             id: secondImportID,
@@ -95,7 +95,7 @@ struct ChatAttachmentDraftTests {
         let staleFile = try makeFile(name: "old.txt", text: "old conversation")
         let staleURL = URL(fileURLWithPath: "/tmp/old.txt")
         var draft = ChatAttachmentDraft()
-        let startedStaleID = draft.beginFileImport(conversationID: UUID())
+        let startedStaleID = draft.beginFileImport()
         let staleID = try #require(startedStaleID)
 
         let cancelled = draft.cancelFileImport(notice: "Import canceled after navigation.")
@@ -118,11 +118,11 @@ struct ChatAttachmentDraftTests {
         let oldFile = try makeFile(name: "old.txt", text: "old")
         let newFile = try makeFile(name: "new.txt", text: "new")
         var draft = ChatAttachmentDraft()
-        let startedOldID = draft.beginFileImport(conversationID: UUID())
+        let startedOldID = draft.beginFileImport()
         let oldID = try #require(startedOldID)
         let cancelledOld = draft.cancelFileImport()
         #expect(cancelledOld)
-        let startedNewID = draft.beginFileImport(conversationID: UUID())
+        let startedNewID = draft.beginFileImport()
         let newID = try #require(startedNewID)
 
         let acceptedOld = draft.finishFileImport(
@@ -144,10 +144,10 @@ struct ChatAttachmentDraftTests {
     @Test("a stale generation cannot cancel the newer active import")
     func staleGenerationCannotCancelNewImport() throws {
         var draft = ChatAttachmentDraft()
-        let startedOldID = draft.beginFileImport(conversationID: UUID())
+        let startedOldID = draft.beginFileImport()
         let oldID = try #require(startedOldID)
         _ = draft.cancelFileImport(id: oldID)
-        let startedNewID = draft.beginFileImport(conversationID: UUID())
+        let startedNewID = draft.beginFileImport()
         let newID = try #require(startedNewID)
 
         let cancelled = draft.cancelFileImport(
@@ -156,51 +156,44 @@ struct ChatAttachmentDraftTests {
         )
 
         #expect(!cancelled)
-        #expect(draft.fileImport?.id == newID)
+        #expect(draft.fileImportID == newID)
         #expect(draft.notice == nil)
     }
 
-    @Test("delayed navigation callback preserves the new conversation's import")
-    func delayedNavigationPreservesNewConversationImport() throws {
+    @Test("conversation drafts import independently and restore by identity")
+    func conversationDraftsRemainIsolated() throws {
         let conversationA = UUID()
         let conversationB = UUID()
-        var draft = ChatAttachmentDraft()
-        let startedA = draft.beginFileImport(conversationID: conversationA)
+        let fileA = try makeFile(name: "a.txt", text: "owned by A")
+        let fileB = try makeFile(name: "b.txt", text: "owned by B")
+        var store = ChatAttachmentDraftStore()
+
+        var draftA = store[conversationA]
+        let startedA = draftA.beginFileImport()
         let importA = try #require(startedA)
-        _ = draft.cancelFileImport(id: importA)
-        let startedB = draft.beginFileImport(conversationID: conversationB)
+        store[conversationA] = draftA
+
+        var draftB = store[conversationB]
+        let startedB = draftB.beginFileImport()
         let importB = try #require(startedB)
-
-        // Models SwiftUI delivering A -> B after B has already begun work.
-        let cancelled = draft.cancelFileImport(
-            notOwnedBy: conversationB,
-            notice: "Import canceled after navigation."
-        )
-
-        #expect(!cancelled)
-        #expect(draft.fileImport == .init(id: importB, conversationID: conversationB))
-        #expect(draft.notice == nil)
-    }
-
-    @Test("returning to the owning conversation preserves its pending import")
-    func abaNavigationPreservesOwningImport() throws {
-        let conversationA = UUID()
-        var draft = ChatAttachmentDraft()
-        let startedA = draft.beginFileImport(conversationID: conversationA)
-        let importA = try #require(startedA)
-        let file = try makeFile(name: "a.txt", text: "owned by A")
-
-        // SwiftUI may coalesce A -> B -> A into a final callback carrying A.
-        let cancelled = draft.cancelFileImport(notOwnedBy: conversationA)
-        let accepted = draft.finishFileImport(
-            id: importA,
-            [(file, URL(fileURLWithPath: "/tmp/a.txt"))],
+        draftB.finishFileImport(
+            id: importB,
+            [(fileB, URL(fileURLWithPath: "/tmp/b.txt"))],
             notice: nil
         )
+        store[conversationB] = draftB
 
-        #expect(!cancelled)
-        #expect(accepted)
-        #expect(draft.files == [file])
+        // A may finish while B is visible; it writes only through A's key.
+        draftA = store[conversationA]
+        draftA.finishFileImport(
+            id: importA,
+            [(fileA, URL(fileURLWithPath: "/tmp/a.txt"))],
+            notice: nil
+        )
+        store[conversationA] = draftA
+
+        #expect(store[conversationA].files == [fileA])
+        #expect(store[conversationB].files == [fileB])
     }
 
     @Test("submission is an immutable snapshot of one composer turn")
@@ -217,7 +210,7 @@ struct ChatAttachmentDraftTests {
         #expect(draft.images == [second])
     }
 
-    @Test("ChatView carries the import generation through async work and cancels on navigation")
+    @Test("ChatView writes async completion through the originating conversation key")
     func lifecycleIsWiredIntoChatView() throws {
         let source = try String(
             contentsOf: URL(fileURLWithPath: #filePath)
@@ -231,15 +224,10 @@ struct ChatAttachmentDraftTests {
             .stripCommentsAndWhitespace(source)
 
         #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
+        #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
+        #expect(stripped.contains("varoriginDraft=attachmentDrafts[importConversationID]"))
         #expect(stripped.contains(
-            "letimportID=attachmentDraft.beginFileImport(conversationID:importConversationID)"
-        ))
-        #expect(stripped.contains(
-            "guardviewModel.activeConversationID==importConversationIDelse{cancelFileImportAfterNavigation(importID:importID)"
-        ))
-        #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
-        #expect(stripped.contains(
-            ".onChange(of:viewModel.activeConversationID){_,newConversationIDincancelFileImportAfterNavigation(activeConversationID:newConversationID)"
+            "originDraft.finishFileImport(id:importID,outcome.0,notice:notice)attachmentDrafts[importConversationID]=originDraft"
         ))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -169,9 +169,13 @@ struct ChatAttachmentDraftTests {
             .stripCommentsAndWhitespace(source)
 
         #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
+        #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
+        #expect(stripped.contains(
+            "guardviewModel.activeConversationID==importConversationIDelse{cancelFileImportAfterNavigation()"
+        ))
         #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
         #expect(stripped.contains(
-            ".onChange(of:viewModel.activeConversationID){_,_inletnotice=\"Fileimportcanceledbecauseyouswitchedconversations.\"ifattachmentDraft.cancelFileImport(notice:notice){VoiceOverAnnouncer.announce(notice)"
+            ".onChange(of:viewModel.activeConversationID){_,_incancelFileImportAfterNavigation()"
         ))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -13,10 +13,12 @@ struct ChatAttachmentDraftTests {
         let fileURL = URL(fileURLWithPath: "/tmp/notes.txt")
         var draft = ChatAttachmentDraft()
         draft.appendImage(image, sourceURL: imageURL)
-        draft.finishFileImport([(file, fileURL)], notice: "old notice")
-        draft.isImportingFiles = true
+        let startedImportID = draft.beginFileImport()
+        let importID = try #require(startedImportID)
+        draft.finishFileImport(id: importID, [(file, fileURL)], notice: "old notice")
+        _ = draft.beginFileImport()
 
-        let payload = draft.consume()
+        let payload = draft.takeSubmission()
 
         #expect(payload.images == [image])
         #expect(payload.files == [file])
@@ -35,12 +37,24 @@ struct ChatAttachmentDraftTests {
         var draft = ChatAttachmentDraft()
 
         draft.appendImage(firstImage)
-        draft.finishFileImport([(firstFile, URL(fileURLWithPath: "/tmp/first.txt"))], notice: nil)
-        let first = draft.consume()
+        let startedFirstImportID = draft.beginFileImport()
+        let firstImportID = try #require(startedFirstImportID)
+        draft.finishFileImport(
+            id: firstImportID,
+            [(firstFile, URL(fileURLWithPath: "/tmp/first.txt"))],
+            notice: nil
+        )
+        let first = draft.takeSubmission()
 
         draft.appendImage(secondImage)
-        draft.finishFileImport([(secondFile, URL(fileURLWithPath: "/tmp/second.txt"))], notice: nil)
-        let second = draft.consume()
+        let startedSecondImportID = draft.beginFileImport()
+        let secondImportID = try #require(startedSecondImportID)
+        draft.finishFileImport(
+            id: secondImportID,
+            [(secondFile, URL(fileURLWithPath: "/tmp/second.txt"))],
+            notice: nil
+        )
+        let second = draft.takeSubmission()
 
         #expect(first.images.map(\.filename) == ["first.png"])
         #expect(first.files.map(\.filename) == ["first.txt"])
@@ -74,6 +88,89 @@ struct ChatAttachmentDraftTests {
 
         #expect(result.fresh == [fresh])
         #expect(result.duplicates == 2)
+    }
+
+    @Test("a cancelled import cannot resurrect attachments when it completes late")
+    func staleImportCompletionIsIgnored() throws {
+        let staleFile = try makeFile(name: "old.txt", text: "old conversation")
+        let staleURL = URL(fileURLWithPath: "/tmp/old.txt")
+        var draft = ChatAttachmentDraft()
+        let startedStaleID = draft.beginFileImport()
+        let staleID = try #require(startedStaleID)
+
+        draft.cancelFileImport()
+        let accepted = draft.finishFileImport(
+            id: staleID,
+            [(staleFile, staleURL)],
+            notice: "stale notice"
+        )
+
+        #expect(!accepted)
+        #expect(draft.files.isEmpty)
+        #expect(draft.notice == nil)
+        #expect(!draft.isImportingFiles)
+        #expect(draft.filteringAlreadyAttached([staleURL]).fresh == [staleURL])
+    }
+
+    @Test("a late old generation cannot overwrite a newer import")
+    func importGenerationsDoNotCross() throws {
+        let oldFile = try makeFile(name: "old.txt", text: "old")
+        let newFile = try makeFile(name: "new.txt", text: "new")
+        var draft = ChatAttachmentDraft()
+        let startedOldID = draft.beginFileImport()
+        let oldID = try #require(startedOldID)
+        draft.cancelFileImport()
+        let startedNewID = draft.beginFileImport()
+        let newID = try #require(startedNewID)
+
+        let acceptedOld = draft.finishFileImport(
+            id: oldID,
+            [(oldFile, URL(fileURLWithPath: "/tmp/old.txt"))],
+            notice: nil
+        )
+        #expect(!acceptedOld)
+        #expect(draft.isImportingFiles)
+        let acceptedNew = draft.finishFileImport(
+            id: newID,
+            [(newFile, URL(fileURLWithPath: "/tmp/new.txt"))],
+            notice: nil
+        )
+        #expect(acceptedNew)
+        #expect(draft.files == [newFile])
+    }
+
+    @Test("submission is an immutable snapshot of one composer turn")
+    func submissionDoesNotFollowLaterDraftMutations() throws {
+        let first = try makeImage(name: "first.png")
+        let second = try makeImage(name: "second.png")
+        var draft = ChatAttachmentDraft()
+        draft.appendImage(first)
+
+        let submission = draft.takeSubmission()
+        draft.appendImage(second)
+
+        #expect(submission.images == [first])
+        #expect(draft.images == [second])
+    }
+
+    @Test("ChatView carries the import generation through async work and cancels on navigation")
+    func lifecycleIsWiredIntoChatView() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/Rapid/UI/ChatView.swift"),
+            encoding: .utf8
+        )
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(source)
+
+        #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
+        #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
+        #expect(stripped.contains(
+            ".onChange(of:viewModel.activeConversationID){_,_inattachmentDraft.cancelFileImport()"
+        ))
     }
 
     private func makeImage(name: String) throws -> ChatImageAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -141,6 +141,25 @@ struct ChatAttachmentDraftTests {
         #expect(draft.files == [newFile])
     }
 
+    @Test("a stale generation cannot cancel the newer active import")
+    func staleGenerationCannotCancelNewImport() throws {
+        var draft = ChatAttachmentDraft()
+        let startedOldID = draft.beginFileImport()
+        let oldID = try #require(startedOldID)
+        _ = draft.cancelFileImport(id: oldID)
+        let startedNewID = draft.beginFileImport()
+        let newID = try #require(startedNewID)
+
+        let cancelled = draft.cancelFileImport(
+            id: oldID,
+            notice: "Old conversation changed."
+        )
+
+        #expect(!cancelled)
+        #expect(draft.fileImportID == newID)
+        #expect(draft.notice == nil)
+    }
+
     @Test("submission is an immutable snapshot of one composer turn")
     func submissionDoesNotFollowLaterDraftMutations() throws {
         let first = try makeImage(name: "first.png")
@@ -171,7 +190,7 @@ struct ChatAttachmentDraftTests {
         #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
         #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
         #expect(stripped.contains(
-            "guardviewModel.activeConversationID==importConversationIDelse{cancelFileImportAfterNavigation()"
+            "guardviewModel.activeConversationID==importConversationIDelse{cancelFileImportAfterNavigation(importID:importID)"
         ))
         #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
         #expect(stripped.contains(

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -13,10 +13,10 @@ struct ChatAttachmentDraftTests {
         let fileURL = URL(fileURLWithPath: "/tmp/notes.txt")
         var draft = ChatAttachmentDraft()
         draft.appendImage(image, sourceURL: imageURL)
-        let startedImportID = draft.beginFileImport()
+        let startedImportID = draft.beginFileImport(conversationID: UUID())
         let importID = try #require(startedImportID)
         draft.finishFileImport(id: importID, [(file, fileURL)], notice: "old notice")
-        _ = draft.beginFileImport()
+        _ = draft.beginFileImport(conversationID: UUID())
 
         let payload = draft.takeSubmission()
 
@@ -37,7 +37,7 @@ struct ChatAttachmentDraftTests {
         var draft = ChatAttachmentDraft()
 
         draft.appendImage(firstImage)
-        let startedFirstImportID = draft.beginFileImport()
+        let startedFirstImportID = draft.beginFileImport(conversationID: UUID())
         let firstImportID = try #require(startedFirstImportID)
         draft.finishFileImport(
             id: firstImportID,
@@ -47,7 +47,7 @@ struct ChatAttachmentDraftTests {
         let first = draft.takeSubmission()
 
         draft.appendImage(secondImage)
-        let startedSecondImportID = draft.beginFileImport()
+        let startedSecondImportID = draft.beginFileImport(conversationID: UUID())
         let secondImportID = try #require(startedSecondImportID)
         draft.finishFileImport(
             id: secondImportID,
@@ -95,7 +95,7 @@ struct ChatAttachmentDraftTests {
         let staleFile = try makeFile(name: "old.txt", text: "old conversation")
         let staleURL = URL(fileURLWithPath: "/tmp/old.txt")
         var draft = ChatAttachmentDraft()
-        let startedStaleID = draft.beginFileImport()
+        let startedStaleID = draft.beginFileImport(conversationID: UUID())
         let staleID = try #require(startedStaleID)
 
         let cancelled = draft.cancelFileImport(notice: "Import canceled after navigation.")
@@ -118,11 +118,11 @@ struct ChatAttachmentDraftTests {
         let oldFile = try makeFile(name: "old.txt", text: "old")
         let newFile = try makeFile(name: "new.txt", text: "new")
         var draft = ChatAttachmentDraft()
-        let startedOldID = draft.beginFileImport()
+        let startedOldID = draft.beginFileImport(conversationID: UUID())
         let oldID = try #require(startedOldID)
         let cancelledOld = draft.cancelFileImport()
         #expect(cancelledOld)
-        let startedNewID = draft.beginFileImport()
+        let startedNewID = draft.beginFileImport(conversationID: UUID())
         let newID = try #require(startedNewID)
 
         let acceptedOld = draft.finishFileImport(
@@ -144,10 +144,10 @@ struct ChatAttachmentDraftTests {
     @Test("a stale generation cannot cancel the newer active import")
     func staleGenerationCannotCancelNewImport() throws {
         var draft = ChatAttachmentDraft()
-        let startedOldID = draft.beginFileImport()
+        let startedOldID = draft.beginFileImport(conversationID: UUID())
         let oldID = try #require(startedOldID)
         _ = draft.cancelFileImport(id: oldID)
-        let startedNewID = draft.beginFileImport()
+        let startedNewID = draft.beginFileImport(conversationID: UUID())
         let newID = try #require(startedNewID)
 
         let cancelled = draft.cancelFileImport(
@@ -156,7 +156,29 @@ struct ChatAttachmentDraftTests {
         )
 
         #expect(!cancelled)
-        #expect(draft.fileImportID == newID)
+        #expect(draft.fileImport?.id == newID)
+        #expect(draft.notice == nil)
+    }
+
+    @Test("delayed navigation callback preserves the new conversation's import")
+    func delayedNavigationPreservesNewConversationImport() throws {
+        let conversationA = UUID()
+        let conversationB = UUID()
+        var draft = ChatAttachmentDraft()
+        let startedA = draft.beginFileImport(conversationID: conversationA)
+        let importA = try #require(startedA)
+        _ = draft.cancelFileImport(id: importA)
+        let startedB = draft.beginFileImport(conversationID: conversationB)
+        let importB = try #require(startedB)
+
+        // Models SwiftUI delivering A -> B after B has already begun work.
+        let cancelled = draft.cancelFileImport(
+            notOwnedBy: conversationB,
+            notice: "Import canceled after navigation."
+        )
+
+        #expect(!cancelled)
+        #expect(draft.fileImport == .init(id: importB, conversationID: conversationB))
         #expect(draft.notice == nil)
     }
 
@@ -187,14 +209,16 @@ struct ChatAttachmentDraftTests {
         let stripped = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(source)
 
-        #expect(stripped.contains("letimportID=attachmentDraft.beginFileImport()"))
         #expect(stripped.contains("letimportConversationID=viewModel.activeConversationID"))
+        #expect(stripped.contains(
+            "letimportID=attachmentDraft.beginFileImport(conversationID:importConversationID)"
+        ))
         #expect(stripped.contains(
             "guardviewModel.activeConversationID==importConversationIDelse{cancelFileImportAfterNavigation(importID:importID)"
         ))
         #expect(stripped.contains("attachmentDraft.finishFileImport(id:importID"))
         #expect(stripped.contains(
-            ".onChange(of:viewModel.activeConversationID){_,_incancelFileImportAfterNavigation()"
+            ".onChange(of:viewModel.activeConversationID){_,newConversationIDincancelFileImportAfterNavigation(activeConversationID:newConversationID)"
         ))
     }
 


### PR DESCRIPTION
## Summary

- keep attachment drafts keyed by conversation instead of sharing one mutable composer bucket
- route asynchronous file-import completion back to the conversation where it started
- preserve independent image/file chips and in-flight imports while users browse between chats
- transfer composer attachments through an immutable one-turn submission snapshot

This adopts a conversation-owned draft/store boundary while retaining Rapid-MLX's existing Swift domain model and unified picker/paste/drop path. No UI appearance or CI workflow changes.

## Product semantics

Conversation A and B now own independent attachment drafts. An import started in A can finish while B is visible without appearing in B; returning to A restores A's attachments and result. A stale import generation cannot overwrite or cancel a newer generation in the same conversation.

## Validation

- 11 attachment lifecycle tests covering per-conversation isolation, deletion cleanup, stale/new generations, immutable submission, deduplication, removal, and sequential turns
- complete `swift test --no-parallel` (2,763 tests)
- `git diff --check`
