### PR TITLE
ci(mac): run GUI journey groups in parallel

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -47,6 +47,7 @@ jobs:
       full_gate: ${{ steps.policy.outputs.full_gate }}
       gui_flows: ${{ steps.policy.outputs.gui_flows }}
       gui_flow_count: ${{ steps.policy.outputs.gui_flow_count }}
+      gui_shards: ${{ steps.policy.outputs.gui_shards }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -344,17 +345,26 @@ jobs:
     # macos-15 for the same reason as the build job: Package.swift is
     # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
     runs-on: macos-15
-    # Build is ~the same cost as the build job; the flows are seconds each
-    # (6-11 s on an M3 Ultra). 30 leaves room for a cold package resolve
-    # without letting a wedged app sit on the 6-hour default.
+    strategy:
+      # A failure in one product journey must not cancel independent evidence
+      # from the other selected groups. The stable desktop-tests facade still
+      # blocks unless every matrix child succeeds.
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.gui_shards) }}
+    # The shared app is already built. Individual flows are usually seconds
+    # each (6-11 s on an M3 Ultra), while hosted-runner launch variance can be
+    # much higher. 30 minutes catches a wedged shard far before the six-hour
+    # default without weakening the existing journey time budget.
     timeout-minutes: 30
     defaults:
       run:
         working-directory: apps/rapid-mac
     env:
-      # Compact JSON selected from the real PR diff. Every named step remains
-      # visible, but the harness exits before launch for unaffected journeys.
-      GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}
+      # Each matrix child receives only one manifest group. Every named step
+      # remains visible, but the harness exits before launch for journeys owned
+      # by another shard. Separate hosted VMs isolate HOME, defaults, ports,
+      # app processes, and result directories by construction.
+      GUI_FLOWS: ${{ matrix.gui_flows }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -410,7 +420,7 @@ jobs:
       # records actually draw different pixels rather than the same bitmap.
       - name: 'XCUITest: image-generation pixels'
         id: xcui
-        if: contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation')
+        if: contains(fromJSON(matrix.gui_flows), 'image-generation')
         continue-on-error: true
         env:
           RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidUITests.xcresult
@@ -420,7 +430,7 @@ jobs:
         if: steps.xcui.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: rapid-xcui-evidence
+          name: rapid-xcui-evidence-${{ matrix.group }}
           path: ${{ runner.temp }}/RapidUITests.xcresult
           if-no-files-found: ignore
 
@@ -627,7 +637,7 @@ jobs:
         if: always()
         env:
           GOLDEN_ROOT: ${{ runner.temp }}/golden
-          EXPECTED_FLOW_COUNT: ${{ needs.changes.outputs.gui_flow_count }}
+          EXPECTED_FLOW_COUNT: ${{ matrix.flow_count }}
         run: |
           python3 - <<'PY'
           import json
@@ -707,7 +717,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: gui-golden-flow-evidence
+          name: gui-golden-flow-evidence-${{ matrix.group }}
           # Both halves: the failing flow's own dumps, and the full
           # runner-vs-committed regeneration from the diagnostic step above.
           path: |
@@ -723,7 +733,7 @@ jobs:
         if: always()
         env:
           XCUI_OUTCOME: ${{ steps.xcui.outcome }}
-          IMAGE_SELECTED: ${{ contains(fromJSON(needs.changes.outputs.gui_flows), 'image-generation') }}
+          IMAGE_SELECTED: ${{ contains(fromJSON(matrix.gui_flows), 'image-generation') }}
         run: |
           if [[ "$IMAGE_SELECTED" != true && "$XCUI_OUTCOME" == skipped ]]; then
             echo "Image-generation journey not selected; native XCUITest not required"

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -76,11 +76,20 @@ Pushes to `main` retain the full engine coverage as a post-merge signal.
 
 The full Desktop gate builds one release-configured app with
 `SKIP_SIDECAR=1`, packages it, and uploads it under an artifact name containing
-the exact candidate SHA. GUI jobs do not rebuild the app. Before extraction,
-they verify a versioned manifest that binds the SHA, build mode, sidecar mode,
-archive filename, and SHA-256 digest; after extraction they verify the macOS
-code-signing seal. Missing, stale, malformed, or modified artifacts fail
-closed.
+the exact candidate SHA. Selected manifest journey groups run as independent
+matrix shards and reuse that artifact; GUI jobs do not rebuild the app. Before
+extraction, they verify a versioned manifest that binds the SHA, build mode,
+sidecar mode, archive filename, and SHA-256 digest; after extraction they
+verify the macOS code-signing seal. Missing, stale, malformed, or modified
+artifacts fail closed.
+
+The classifier emits the matrix from the same journey SSOT used for routing.
+Each selected flow appears in exactly one group shard. Matrix fail-fast is
+disabled so one failure cannot cancel evidence from sibling groups, while the
+stable `desktop-tests` facade remains red unless every selected shard passes.
+Hosted-runner isolation gives every shard a separate HOME, defaults database,
+ports, app processes, and result directory. Failure artifact names include the
+group so concurrent uploads cannot overwrite one another.
 
 This artifact is test-only and retained for one day. It is not signed for
 distribution, notarized, published, or eligible for release promotion. Release
@@ -115,6 +124,10 @@ lanes for every PR; this restores the previous validation coverage without
 renaming required checks. For GUI routing specifically, removing the
 `GUI_FLOWS` job environment or making `scripts/select_gui_flows.py` return the
 full manifest roster restores the previous all-journey behavior.
+If GUI matrix execution is suspect, remove the matrix strategy, restore
+`GUI_FLOWS` and `EXPECTED_FLOW_COUNT` to the classifier's whole-selection
+outputs, and remove group suffixes from evidence artifact names. This restores
+one serial consumer without changing which journeys are selected.
 If GUI artifact reuse is suspect, restore the build step inside
 `gui-golden-flows` and remove `gui-app-build` from its dependencies. This costs
 additional macOS build time but preserves the same release-shaped UI coverage.

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -85,6 +85,33 @@ def all_flows() -> list[str]:
     return [str(journey["name"]) for journey in _pr_journeys()]
 
 
+def shard_matrix(flows: Iterable[str]) -> dict[str, list[dict[str, object]]]:
+    """Partition selected flows by their manifest group for a CI matrix."""
+
+    selected = set(flows)
+    journeys = _pr_journeys()
+    known = {str(journey["name"]) for journey in journeys}
+    if not selected or not selected <= known:
+        raise ValueError("GUI shard input must contain known PR journeys")
+
+    groups: dict[str, list[str]] = {}
+    for journey in journeys:
+        name = str(journey["name"])
+        if name in selected:
+            groups.setdefault(str(journey["group"]), []).append(name)
+
+    return {
+        "include": [
+            {
+                "group": group,
+                "gui_flows": json.dumps(group_flows, separators=(",", ":")),
+                "flow_count": len(group_flows),
+            }
+            for group, group_flows in sorted(groups.items())
+        ]
+    }
+
+
 def _matches(path: str, declared: str) -> bool:
     # UI is a mixed-responsibility directory. A new file under it cannot
     # inherit ownership from the broad inventory prefix: only an explicit file
@@ -150,10 +177,12 @@ def main() -> int:
         paths.extend(args.paths_file.read().splitlines())
     flows = select(paths)
     payload = json.dumps(flows, separators=(",", ":"))
+    shards = json.dumps(shard_matrix(flows), separators=(",", ":"))
 
     if args.github_output:
         print(f"gui_flows={payload}", file=args.github_output)
         print(f"gui_flow_count={len(flows)}", file=args.github_output)
+        print(f"gui_shards={shards}", file=args.github_output)
     else:
         print(payload)
     return 0

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from scripts.select_gui_flows import all_flows, select
+from scripts.select_gui_flows import all_flows, select, shard_matrix
 
 ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
@@ -120,6 +120,47 @@ def test_cli_emits_compact_json_and_github_outputs(tmp_path: Path):
     lines = output.read_text().splitlines()
     assert json.loads(lines[0].removeprefix("gui_flows=")) == ["image-generation"]
     assert lines[1] == "gui_flow_count=1"
+    assert json.loads(lines[2].removeprefix("gui_shards=")) == {
+        "include": [
+            {
+                "group": "images",
+                "gui_flows": '["image-generation"]',
+                "flow_count": 1,
+            }
+        ]
+    }
+
+
+def test_shards_partition_every_selected_flow_once_by_manifest_group():
+    selected = all_flows()
+    matrix = shard_matrix(selected)
+    shards = matrix["include"]
+    assert [shard["group"] for shard in shards] == sorted(_groups())
+
+    flattened = [
+        flow
+        for shard in shards
+        for flow in json.loads(str(shard["gui_flows"]))
+    ]
+    assert set(flattened) == set(selected)
+    assert len(flattened) == len(set(flattened))
+    assert all(
+        group_flows == sorted(group_flows, key=selected.index)
+        for group_flows in (
+            json.loads(str(shard["gui_flows"])) for shard in shards
+        )
+    )
+    assert all(
+        shard["flow_count"] == len(json.loads(str(shard["gui_flows"])))
+        for shard in shards
+    )
+
+
+def test_shard_matrix_rejects_empty_or_unknown_flow_sets():
+    with pytest.raises(ValueError, match="known PR journeys"):
+        shard_matrix([])
+    with pytest.raises(ValueError, match="known PR journeys"):
+        shard_matrix(["not-a-flow"])
 
 
 def test_unselected_harness_step_is_a_true_noop(tmp_path: Path):
@@ -145,4 +186,8 @@ def test_workflow_passes_real_diff_to_router_and_consumes_its_outputs():
     assert "python scripts/select_gui_flows.py" in workflow
     assert "--paths-file /tmp/changed-paths" in workflow
     assert "gui_flows: ${{ steps.policy.outputs.gui_flows }}" in workflow
-    assert "GUI_FLOWS: ${{ needs.changes.outputs.gui_flows }}" in workflow
+    assert "gui_shards: ${{ steps.policy.outputs.gui_shards }}" in workflow
+    assert "matrix: ${{ fromJSON(needs.changes.outputs.gui_shards) }}" in workflow
+    assert "GUI_FLOWS: ${{ matrix.gui_flows }}" in workflow
+    assert "EXPECTED_FLOW_COUNT: ${{ matrix.flow_count }}" in workflow
+    assert "fail-fast: false" in workflow

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -138,17 +138,13 @@ def test_shards_partition_every_selected_flow_once_by_manifest_group():
     assert [shard["group"] for shard in shards] == sorted(_groups())
 
     flattened = [
-        flow
-        for shard in shards
-        for flow in json.loads(str(shard["gui_flows"]))
+        flow for shard in shards for flow in json.loads(str(shard["gui_flows"]))
     ]
     assert set(flattened) == set(selected)
     assert len(flattened) == len(set(flattened))
     assert all(
         group_flows == sorted(group_flows, key=selected.index)
-        for group_flows in (
-            json.loads(str(shard["gui_flows"])) for shard in shards
-        )
+        for group_flows in (json.loads(str(shard["gui_flows"])) for shard in shards)
     )
     assert all(
         shard["flow_count"] == len(json.loads(str(shard["gui_flows"])))


### PR DESCRIPTION
## Summary

- derive a dynamic GUI matrix from the existing journey manifest and source-aware flow selection
- run each selected journey group on an isolated macOS runner while reusing the single verified app artifact from #2264
- keep fail-fast disabled so sibling evidence completes, while `desktop-tests` remains the stable all-shards aggregate gate
- make failure evidence names group-specific and preserve the image-only XCUITest contract
- document execution isolation and a one-job rollback

This PR does not change source-to-flow ownership, journey coverage, release behavior, or merge policy. It only changes the execution topology for the already-selected flows.

Continues #2252.

## Baseline and expected result

Two consecutive full-ci runs after #2264 measured the shared producer at 3:17 / 3:00 and the serial GUI consumer at 19:44 / 19:26. The full 29-flow selection now becomes six shards: app-lifecycle 4, audio 2, chat 8, images 1, models 4, onboarding-settings 10. Expected critical path is producer plus the slowest group instead of producer plus all 29 flows.

## Verification

- 59 focused routing/workflow/artifact/XCUITest/preflight tests passed
- full-suite selector smoke produced six shards containing all 29 flows exactly once
- Ruff passed
- actionlint passed
- git diff check passed

## Safety / rollback

Unknown/shared/workflow changes still fail closed to all 29 flows. Each shard validates its own exact result count, and the aggregate requires every selected matrix child. Rollback restores one serial consumer by removing the matrix strategy and pointing `GUI_FLOWS`/expected count back to whole-selection outputs.