### PR TITLE
test(mac): add native chat attachment journey

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -423,15 +423,27 @@ jobs:
         if: contains(fromJSON(matrix.gui_flows), 'image-generation')
         continue-on-error: true
         env:
-          RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidUITests.xcresult
+          RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidImageUITests.xcresult
+          RAPID_XCUI_ONLY_TESTING: RapidUITests/ImageGenerationPixelTests
+        run: ./scripts/run-xcui-tests.sh
+
+      - name: 'XCUITest: chat attachment ownership'
+        id: chat_xcui
+        if: >-
+          contains(fromJSON(matrix.gui_flows), 'chat-multimodal-attachments') ||
+          contains(fromJSON(matrix.gui_flows), 'chat-document-attachment')
+        continue-on-error: true
+        env:
+          RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidChatAttachmentUITests.xcresult
+          RAPID_XCUI_ONLY_TESTING: RapidUITests/ChatAttachmentJourneyTests
         run: ./scripts/run-xcui-tests.sh
 
       - name: Upload XCUITest evidence
-        if: steps.xcui.outcome == 'failure'
+        if: steps.xcui.outcome == 'failure' || steps.chat_xcui.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rapid-xcui-evidence-${{ matrix.group }}
-          path: ${{ runner.temp }}/RapidUITests.xcresult
+          path: ${{ runner.temp }}/Rapid*UITests.xcresult
           if-no-files-found: ignore
 
       # One step per flow so a red check names the journey that broke rather
@@ -733,16 +745,19 @@ jobs:
         if: always()
         env:
           XCUI_OUTCOME: ${{ steps.xcui.outcome }}
+          CHAT_XCUI_OUTCOME: ${{ steps.chat_xcui.outcome }}
           IMAGE_SELECTED: ${{ contains(fromJSON(matrix.gui_flows), 'image-generation') }}
+          CHAT_SELECTED: ${{ contains(fromJSON(matrix.gui_flows), 'chat-multimodal-attachments') || contains(fromJSON(matrix.gui_flows), 'chat-document-attachment') }}
         run: |
-          if [[ "$IMAGE_SELECTED" != true && "$XCUI_OUTCOME" == skipped ]]; then
-            echo "Image-generation journey not selected; native XCUITest not required"
-            exit 0
-          fi
-          if [[ "$XCUI_OUTCOME" != success ]]; then
+          if [[ "$IMAGE_SELECTED" == true && "$XCUI_OUTCOME" != success ]]; then
             echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
             exit 1
           fi
+          if [[ "$CHAT_SELECTED" == true && "$CHAT_XCUI_OUTCOME" != success ]]; then
+            echo "::error::Native Chat attachment XCUITest failed ($CHAT_XCUI_OUTCOME)"
+            exit 1
+          fi
+          echo "All selected native XCUITests passed"
 
   desktop-tests:
     # Stable required-check facade. It is present even on non-desktop PRs,

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -192,7 +192,7 @@ journeys:
   - name: chat-document-attachment
     group: chat
     risk: high
-    driver: ax
+    driver: hybrid
     ci_tier: pr
     fixtures: [fake-sidecar, document, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
@@ -200,7 +200,7 @@ journeys:
   - name: chat-multimodal-attachments
     group: chat
     risk: high
-    driver: ax
+    driver: hybrid
     ci_tier: pr
     fixtures: [fake-sidecar, two-images, document, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3608146521E5B0C044E55806 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB04F3C22EF0AAABD315027F /* main.swift */; };
+		BAAEA208E5B564003CD10FA9 /* RapidUITestHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981AB696C88019DDE1FC4C44 /* RapidUITestHarness.swift */; };
+		CA82A5D835D063658376D1AD /* ChatAttachmentJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3511FF388A5B23AA16F8D1 /* ChatAttachmentJourneyTests.swift */; };
 		D71E30DFF3F95D912DA8B3D5 /* ImageGenerationPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -24,7 +26,9 @@
 /* Begin PBXFileReference section */
 		09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerationPixelTests.swift; sourceTree = "<group>"; };
 		132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RapidUITestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D3511FF388A5B23AA16F8D1 /* ChatAttachmentJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentJourneyTests.swift; sourceTree = "<group>"; };
 		7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RapidUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		981AB696C88019DDE1FC4C44 /* RapidUITestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RapidUITestHarness.swift; sourceTree = "<group>"; };
 		C125516144CFDFB692F0EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB04F3C22EF0AAABD315027F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,7 +64,9 @@
 		F27E5155342C1F7C1AFFB341 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				3D3511FF388A5B23AA16F8D1 /* ChatAttachmentJourneyTests.swift */,
 				09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */,
+				981AB696C88019DDE1FC4C44 /* RapidUITestHarness.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -146,7 +152,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA82A5D835D063658376D1AD /* ChatAttachmentJourneyTests.swift in Sources */,
 				D71E30DFF3F95D912DA8B3D5 /* ImageGenerationPixelTests.swift in Sources */,
+				BAAEA208E5B564003CD10FA9 /* RapidUITestHarness.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -1,0 +1,79 @@
+import CryptoKit
+import XCTest
+
+@MainActor
+final class ChatAttachmentJourneyTests: XCTestCase {
+    func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {
+        continueAfterFailure = false
+        let harness = try RapidUITestHarness(
+            testName: name,
+            fakeSettings: ["FAKE_VISION_CHAT": "1"],
+            port: 65_001
+        )
+        defer { harness.shutDown() }
+        harness.launch()
+        harness.startModel()
+
+        let first = harness.rapidMacRoot
+            .appendingPathComponent("Tests/RapidTests/__Snapshots__/cheetah-logo-28.png")
+        let second = harness.rapidMacRoot
+            .appendingPathComponent("Tests/RapidTests/__Snapshots__/cheetah-logo-96.png")
+        let document = harness.rapidMacRoot
+            .appendingPathComponent("Tests/GUIGoldenFlows/Fixtures/chat-document.txt")
+
+        harness.chooseFile(first, actionIdentifier: "ChatView.Attachments.UploadPhoto")
+        let firstChip = harness.element("ChatView.Attachment.Remove.\(first.lastPathComponent)")
+        XCTAssertTrue(firstChip.waitForExistence(timeout: 10))
+        harness.send("Create conversation A", expectedRequestCount: 1)
+        let conversationA = harness.conversationRows().firstMatch
+        XCTAssertTrue(conversationA.waitForExistence(timeout: 10))
+        let conversationAIdentifier = conversationA.identifier
+
+        // Leave an unsent attachment in A, then prove B does not inherit it.
+        harness.chooseFile(first, actionIdentifier: "ChatView.Attachments.UploadPhoto")
+        XCTAssertTrue(firstChip.waitForExistence(timeout: 10))
+        harness.element("Sidebar.NewChat").click()
+        XCTAssertTrue(harness.waitUntil(timeout: 10) { !firstChip.exists })
+
+        harness.chooseFile(second, actionIdentifier: "ChatView.Attachments.UploadPhoto")
+        let secondChip = harness.element("ChatView.Attachment.Remove.\(second.lastPathComponent)")
+        XCTAssertTrue(secondChip.waitForExistence(timeout: 10))
+        harness.send("Create conversation B", expectedRequestCount: 2)
+
+        harness.element(conversationAIdentifier).click()
+        XCTAssertTrue(firstChip.waitForExistence(timeout: 10))
+        XCTAssertFalse(secondChip.exists)
+        harness.send("Send A's pending image", expectedRequestCount: 3)
+
+        harness.chooseFile(document, actionIdentifier: "ChatView.Attachments.UploadFile")
+        let documentChip = harness.element("ChatView.Attachment.Remove.\(document.lastPathComponent)")
+        XCTAssertTrue(documentChip.waitForExistence(timeout: 10))
+        harness.send("Send A's document", expectedRequestCount: 4)
+
+        let requests = harness.chatRequests()
+        XCTAssertEqual(imageHashes(in: requests[0]), [try dataURLHash(first)])
+        XCTAssertEqual(imageHashes(in: requests[1]), [try dataURLHash(second)])
+        XCTAssertEqual(imageHashes(in: requests[2]), [try dataURLHash(first)])
+        XCTAssertTrue(text(in: requests[3]).contains("Revenue: 42"))
+        XCTAssertTrue(text(in: requests[3]).contains("Region: APAC"))
+        XCTAssertTrue(imageHashes(in: requests[3]).isEmpty)
+    }
+
+    private func imageHashes(in request: [String: Any]) -> [String] {
+        guard let payloads = request["user_payloads"] as? [[String: Any]],
+              let latest = payloads.last else { return [] }
+        return latest["image_url_sha256"] as? [String] ?? []
+    }
+
+    private func text(in request: [String: Any]) -> String {
+        guard let payloads = request["user_payloads"] as? [[String: Any]],
+              let latest = payloads.last else { return "" }
+        return latest["text"] as? String ?? ""
+    }
+
+    private func dataURLHash(_ url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        let encoded = "data:image/png;base64," + data.base64EncodedString()
+        return SHA256.hash(data: Data(encoded.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -1,0 +1,194 @@
+import AppKit
+import Darwin
+import XCTest
+
+@MainActor
+final class RapidUITestHarness {
+    let app: XCUIApplication
+    let eventLog: URL
+    let rapidMacRoot: URL
+
+    private let testHome: URL
+    private let sidecarAlias: String
+    private let sidecarPIDFile: URL
+
+    init(testName: String, fakeSettings: [String: String], port: Int) throws {
+        testHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-xcui-\(testName)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
+
+        rapidMacRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // RapidUITests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // rapid-mac
+        let fakeSidecar = rapidMacRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh").path
+        let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
+        eventLog = testHome.appendingPathComponent("fake-events.jsonl")
+        sidecarPIDFile = testHome.appendingPathComponent("fake-sidecar.pid")
+        sidecarAlias = fakeSettings["FAKE_VISION_CHAT"] == "1"
+            ? "qwen3-vl-2b-4bit"
+            : "fake-alias"
+
+        var config = fakeSettings
+        config["FAKE_EVENT_LOG"] = eventLog.path
+        config["FAKE_PID_FILE"] = sidecarPIDFile.path
+        let configData = try JSONSerialization.data(withJSONObject: config)
+        try configData.write(to: testHome.appendingPathComponent(".rapid-golden-fake.json"))
+
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path))
+        app = XCUIApplication(url: appURL)
+        app.launchEnvironment = [
+            "HOME": testHome.path,
+            "CFFIXED_USER_HOME": testHome.path,
+            "RAPID_BIN": fakeSidecar,
+            "FAKE_EVENT_LOG": eventLog.path,
+            "RAPID_DESKTOP_PORT": String(port),
+            "RAPID_DESKTOP_NO_PORT_SWEEP": "1",
+        ].merging(fakeSettings) { _, fixture in fixture }
+    }
+
+    func launch() {
+        app.launch()
+        XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
+        dismissFirstRunIfNeeded()
+    }
+
+    func shutDown() {
+        app.terminate()
+        terminateFakeSidecars()
+        try? FileManager.default.removeItem(at: testHome)
+    }
+
+    func startModel() {
+        let readiness = element("Readiness.Action")
+        XCTAssertTrue(readiness.waitForExistence(timeout: 20))
+        XCTAssertTrue(waitUntil(timeout: 20) { readiness.isEnabled })
+        readiness.click()
+        let memoryConfirmation = element("MemoryWarning.Confirm")
+        var confirmedMemoryWarning = false
+        XCTAssertTrue(waitUntil(timeout: 60) {
+            if !confirmedMemoryWarning,
+               memoryConfirmation.exists,
+               memoryConfirmation.isEnabled {
+                memoryConfirmation.click()
+                confirmedMemoryWarning = true
+            }
+            return self.events().contains { $0["event"] as? String == "server_started" }
+        })
+    }
+
+    func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    func conversationRows() -> XCUIElementQuery {
+        app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: "identifier MATCHES %@",
+                #"^Sidebar\.Conversation\.[0-9A-Fa-f-]{36}$"#
+            )
+        )
+    }
+
+    func chooseFile(_ url: URL, actionIdentifier: String) {
+        let add = element("ChatView.AddAttachments")
+        XCTAssertTrue(add.waitForExistence(timeout: 10))
+        add.click()
+        let action = element(actionIdentifier)
+        XCTAssertTrue(action.waitForExistence(timeout: 10))
+        XCTAssertTrue(action.isEnabled)
+        action.click()
+
+        // NSOpenPanel has no stable product-owned identifiers. “Go to Folder”
+        // is the native keyboard path and avoids coordinate clicks entirely.
+        app.typeKey("g", modifierFlags: [.command, .shift])
+        app.typeText(url.path)
+        app.typeKey(.return, modifierFlags: [])
+        let open = app.dialogs["open-panel"].buttons["OKButton"]
+        XCTAssertTrue(waitUntil(timeout: 10) { open.isHittable })
+        open.click()
+    }
+
+    func send(_ text: String, expectedRequestCount: Int) {
+        let composer = element("rapid.chat.compose")
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        composer.click()
+        composer.typeText(text)
+        let send = element("ChatView.SendOrStopButton")
+        XCTAssertTrue(waitUntil(timeout: 10) { send.isEnabled })
+        send.click()
+        XCTAssertTrue(waitUntil(timeout: 30) { self.chatRequests().count == expectedRequestCount })
+        XCTAssertTrue(waitUntil(timeout: 30) {
+            self.element("ChatView.SendOrStopButton").label == "Send message"
+        })
+    }
+
+    func chatRequests() -> [[String: Any]] {
+        events().filter { $0["event"] as? String == "chat_request" }
+    }
+
+    @discardableResult
+    func waitUntil(timeout: TimeInterval, condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return condition()
+    }
+
+    private func dismissFirstRunIfNeeded() {
+        let decline = element("TelemetryConsent.DontShare")
+        if decline.waitForExistence(timeout: 5) { decline.click() }
+        let skip = element("Quickstart.Skip")
+        if skip.waitForExistence(timeout: 10) { skip.click() }
+    }
+
+    private func events() -> [[String: Any]] {
+        guard let text = try? String(contentsOf: eventLog, encoding: .utf8) else { return [] }
+        return text.split(separator: "\n").compactMap { line in
+            guard let data = line.data(using: .utf8) else { return nil }
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+    }
+
+    private func terminateFakeSidecars() {
+        var pids: Set<Int32> = Set(events().compactMap { event in
+            guard event["event"] as? String == "server_started",
+                  event["alias"] as? String == sidecarAlias,
+                  let pid = event["pid"] as? NSNumber else { return nil }
+            return pid.int32Value
+        })
+        if let text = try? String(contentsOf: sidecarPIDFile, encoding: .utf8),
+           let pid = Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            pids.insert(pid)
+        }
+        for pid in pids where processCommand(pid: pid).contains("serve \(sidecarAlias)") {
+            Darwin.kill(pid, SIGTERM)
+            for _ in 0..<20 where Darwin.kill(pid, 0) == 0 {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            if Darwin.kill(pid, 0) == 0,
+               processCommand(pid: pid).contains("serve \(sidecarAlias)") {
+                Darwin.kill(pid, SIGKILL)
+            }
+        }
+    }
+
+    private func processCommand(pid: Int32) -> String {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", String(pid), "-o", "command="]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        guard (try? process.run()) != nil else { return "" }
+        process.waitUntilExit()
+        return String(
+            data: output.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+    }
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -285,9 +285,11 @@ walk both halves of the capability boundary:
    before a text-only request is encoded.
 
 The standard file picker itself remains outside the structural AX baseline, as
-with the Images-tab save panel. The flow drives it only to supply the fixture;
-the product assertions begin at the composer thumbnail and end at the recorded
-wire request.
+with the Images-tab save panel. A native XCUITest drives both **Upload photo**
+and **Upload file** through `NSOpenPanel`, then switches conversations and
+matches the visible chips to the fake sidecar's image hashes and document text.
+The AX journeys retain paste coverage and independent transcript/persistence
+evidence; neither layer substitutes for the other.
 
 Real-weight dogfood on 2026-08-09 used the locally built
 `rapid_mlx-0.12.7` wheel with its `[vision]` extra and

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -1199,6 +1199,13 @@ def main():
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
 
+    # XCUITest cleanup must not depend on reaching the later readiness event:
+    # record ownership as soon as this process commits to the long-lived serve
+    # path, so a startup hang can still be reaped without touching real models.
+    if pid_path := _setting("FAKE_PID_FILE"):
+        with open(pid_path, "w", encoding="utf-8") as stream:
+            stream.write(f"{os.getpid()}\n")
+
     if _setting("FAKE_REJECT_IMAGE_SIDECAR") == "1" and args.alias == FAKE_IMAGE_ALIAS:
         _event("server_start_rejected", alias=args.alias, pid=os.getpid())
         print(FAKE_REJECTION_DETAIL, file=sys.stderr, flush=True)

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
 APP="$ROOT/build/Rapid-MLX Desktop.app"
 RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
+ONLY_TESTING="${RAPID_XCUI_ONLY_TESTING:-}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
 xcodebuild -version >/dev/null 2>&1 || {
@@ -21,9 +22,15 @@ xcodebuild -version >/dev/null 2>&1 || {
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 "$LSREGISTER" -f "$APP"
 
+test_selection=()
+if [[ -n "$ONLY_TESTING" ]]; then
+    test_selection+=("-only-testing:$ONLY_TESTING")
+fi
+
 xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \
     -destination 'platform=macOS' \
     -resultBundlePath "$RESULT_BUNDLE" \
+    "${test_selection[@]}" \
     CODE_SIGNING_ALLOWED=NO

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -19,20 +19,31 @@ def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
     assert project.is_file()
     assert "com.apple.product-type.bundle.ui-testing" in project.read_text()
     assert source.is_file()
+    assert (MAC / "Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift").is_file()
     assert "./scripts/run-xcui-tests.sh" in workflow
-    assert "RapidUITests.xcresult" in workflow
+    assert "RapidImageUITests.xcresult" in workflow
+    assert "RapidChatAttachmentUITests.xcresult" in workflow
     xcui_index, xcui = named_steps["XCUITest: image-generation pixels"]
     upload_index, upload = named_steps["Upload XCUITest evidence"]
     verdict_index, verdict = named_steps["Require native XCUITest"]
     assert xcui["id"] == "xcui"
     assert "image-generation" in xcui["if"]
     assert xcui["continue-on-error"] is True
-    assert upload["if"] == "steps.xcui.outcome == 'failure'"
+    chat_xcui_index, chat_xcui = named_steps["XCUITest: chat attachment ownership"]
+    assert chat_xcui["id"] == "chat_xcui"
+    assert "chat-multimodal-attachments" in chat_xcui["if"]
+    assert "chat-document-attachment" in chat_xcui["if"]
+    assert chat_xcui["continue-on-error"] is True
+    assert upload["if"] == (
+        "steps.xcui.outcome == 'failure' || steps.chat_xcui.outcome == 'failure'"
+    )
     assert verdict["if"] == "always()"
     assert "steps.xcui.outcome" in verdict["env"]["XCUI_OUTCOME"]
+    assert "steps.chat_xcui.outcome" in verdict["env"]["CHAT_XCUI_OUTCOME"]
     assert "image-generation" in verdict["env"]["IMAGE_SELECTED"]
     assert "IMAGE_SELECTED" in verdict["run"]
-    assert xcui_index < upload_index < verdict_index
+    assert "CHAT_SELECTED" in verdict["run"]
+    assert xcui_index < chat_xcui_index < upload_index < verdict_index
 
 
 def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
@@ -64,6 +75,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     source = (
         MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
     ).read_text()
+    harness = (MAC / "Tests/RapidUITests/Tests/RapidUITestHarness.swift").read_text()
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
@@ -75,6 +87,10 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "fake-rapid-mlx.sh" in source
     assert 'appendingPathComponent(".rapid-golden-fake.json")' in source
     assert '"FAKE_EVENT_LOG": eventLog.path' in source
+    assert 'config["FAKE_PID_FILE"] = sidecarPIDFile.path' in harness
+    assert "String(contentsOf: sidecarPIDFile" in harness
+    assert 'element("MemoryWarning.Confirm")' in harness
+    assert 'app.dialogs["open-panel"].buttons["OKButton"]' in harness
     assert '"RAPID_DESKTOP_PORT": "65000"' in source
     assert '"RAPID_DESKTOP_NO_PORT_SWEEP": "1"' in source
     assert (


### PR DESCRIPTION
## Summary

- add a reusable native XCUITest harness for isolated HOME, fake-sidecar lifecycle, accessibility waits, native file picking, and wire-event inspection
- drive Upload Photo and Upload File through NSOpenPanel in a real release-shaped app
- prove unsent attachments remain owned by conversation A while B sends a different image, then match every visible attachment to the fake sidecar payload
- run the native journey only in the selected chat GUI shard and retain independent AX attachment journeys

## Why

Unit coverage proves the attachment state machine, but it cannot prove the SwiftUI controls, NSOpenPanel, conversation navigation, request encoder, and sidecar boundary remain wired together. This journey targets the escaped regressions where a new image or file reused earlier attachment content.

## Scope

This builds on the conversation-owned attachment state landed in #2265. It does not change product UI, GUI routing, build-artifact reuse, or shard topology.

## Validation

- release-shaped app built locally with `SKIP_SIDECAR=1 ./scripts/build.sh`
- existing `chat-multimodal-attachments` GUI golden flow passed locally
- XCUITest target `build-for-testing` passed
- 35 GUI routing/XCUITest contracts passed
- complete `swift test --no-parallel`: 2,763 passed

Local native execution is blocked before test launch because Developer Mode is disabled on this Mac; the Xcode worker remains at `waiting for workers to materialize`. The selected hosted chat shard has the required Automation environment and is the authoritative execution gate.
