### PR TITLE
fix(agents): keep Aider on the served local model

### DIFF
--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -43,6 +43,13 @@ def test_aider_profile_runs_the_real_cli():
     assert profile is not None
     assert profile.testing.binary == "aider"
     assert profile.testing.query_cmd is not None
+    assert profile.render_config(
+        "http://127.0.0.1:8153/v1", "mlx-community/Qwen3.5-9B-4bit"
+    ) == {
+        "OPENAI_API_BASE": "http://127.0.0.1:8153/v1",
+        "OPENAI_API_KEY": "not-needed",
+        "AIDER_MODEL": "openai/mlx-community/Qwen3.5-9B-4bit",
+    }
 
 
 def test_qwen_code_profile_matches_current_provider_schema():

--- a/vllm_mlx/agents/profiles/aider.yaml
+++ b/vllm_mlx/agents/profiles/aider.yaml
@@ -8,6 +8,10 @@ config:
   env_vars:
     OPENAI_API_BASE: "{base_url}"
     OPENAI_API_KEY: "not-needed"
+    # Aider defaults to a hosted Anthropic model when its HOME is clean.
+    # Pin the one-shot harness (and `agents aider --setup`) to the model the
+    # local Rapid-MLX server is actually serving.
+    AIDER_MODEL: "openai/{model_id}"
 
 models:
   recommended:


### PR DESCRIPTION
## Summary
- pin Aider to `openai/{model_id}` through its supported `AIDER_MODEL` environment variable
- prevent isolated harness/setup runs from silently falling back to a hosted Anthropic model
- add a profile rendering regression test

## Release-blocker evidence
`release-check-m3` reproducibly failed Aider E2E because clean-HOME Aider 0.86.2 selected `claude-sonnet-4-5` and attempted the hosted Anthropic API. With this change, the real Aider CLI uses the attached Rapid-MLX Qwen3.5 9B server and the filtered harness passes 3/3.

## Verification
- `pytest -q tests/test_deepseek_harness_profile.py::test_aider_profile_runs_the_real_cli`
- `ruff check tests/test_deepseek_harness_profile.py`
- real `bench --tier harness` filtered to Aider: PASS (3/3)