### PR TITLE
[codex] ci: reject newly introduced mypy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,11 +231,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy pydantic fastapi
+          # The ratchet compares two commits with one environment. Pin the
+          # type surface so a registry release cannot invent PR-local errors.
+          pip install mypy==2.3.1 pydantic==2.13.4 fastapi==0.141.1
 
-      - name: Run mypy
-        run: mypy vllm_mlx/ --ignore-missing-imports --no-error-summary
-        continue-on-error: true
+      - name: Reject new mypy errors
+        env:
+          MYPY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$MYPY_BASE_SHA"
+          python scripts/check_mypy_new_errors.py --base "$MYPY_BASE_SHA"
 
   test-matrix:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
             tests/test_release_baselines.py \
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
+            tests/test_check_mypy_new_errors.py \
             tests/test_classify_ci_changes.py \
             tests/test_ci_lane_promotion.py \
             tests/test_check_mlx_upstream_calls.py \

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -32,6 +32,22 @@ matching branch-protection migration. `tests` includes lint, type-check job
 health, the MLX dependency-bound guard on pull requests, and all selected engine
 test lanes; `desktop-tests` includes every selected Desktop lane.
 
+### Type-error ratchet
+
+Engine changes may not introduce new mypy errors. The type-check job runs one
+pinned mypy/Pydantic/FastAPI toolchain against both the candidate and its event
+base SHA, removes unstable line and column numbers, and compares the remaining
+error multiset. Existing errors therefore remain visible but do not block an
+unrelated PR merely because they moved within the same file. An extra copy of
+an existing error, a changed error, or an error in a new file blocks `tests`.
+
+The comparison fails closed when the base commit is unavailable or either mypy
+run exits operationally instead of returning a normal type-check verdict. This
+is deliberately a dynamic base comparison rather than a checked-in snapshot:
+fixed errors disappear immediately and cannot be reintroduced after the base
+advances, while dependency releases cannot create candidate-only drift because
+both commits use the same pinned environment.
+
 ## Merge gate
 
 Adding the `full-ci` label upgrades the lanes selected by the pull request's
@@ -131,3 +147,7 @@ one serial consumer without changing which journeys are selected.
 If GUI artifact reuse is suspect, restore the build step inside
 `gui-golden-flows` and remove `gui-app-build` from its dependencies. This costs
 additional macOS build time but preserves the same release-shaped UI coverage.
+If the type-error ratchet produces false positives, temporarily restore the
+advisory direct mypy command with `continue-on-error: true` while retaining its
+logs, then revert or repair `scripts/check_mypy_new_errors.py`. Do not bypass an
+individual candidate by changing its comparison base.

--- a/scripts/check_mypy_new_errors.py
+++ b/scripts/check_mypy_new_errors.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Reject mypy errors introduced by a candidate relative to its base commit.
+
+The repository has existing type-checking debt. This gate runs the same pinned
+mypy toolchain against the candidate and its base, removes unstable line/column
+numbers, and compares the remaining error multiset. Existing errors may move
+within a file without blocking a PR; an additional or changed error does block.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+_ERROR_RE = re.compile(
+    r"^(?P<path>.+?):(?P<line>\d+)(?::(?P<column>\d+))?: error: "
+    r"(?P<message>.*?)(?:  \[(?P<code>[^]]+)\])?$"
+)
+_ACCEPTED_MYPY_EXITS = {0, 1}
+
+
+@dataclass(frozen=True, order=True)
+class ErrorSignature:
+    path: str
+    code: str
+    message: str
+
+    def render(self, count: int = 1) -> str:
+        suffix = f" (x{count})" if count > 1 else ""
+        return f"{self.path}: [{self.code}] {self.message}{suffix}"
+
+
+def parse_errors(output: str) -> collections.Counter[ErrorSignature]:
+    """Return stable error signatures, intentionally ignoring notes/locations."""
+
+    errors: collections.Counter[ErrorSignature] = collections.Counter()
+    for raw_line in output.splitlines():
+        match = _ERROR_RE.match(raw_line.strip())
+        if match is None:
+            continue
+        errors[
+            ErrorSignature(
+                path=match.group("path").removeprefix("./"),
+                code=match.group("code") or "unclassified",
+                message=match.group("message"),
+            )
+        ] += 1
+    return errors
+
+
+def added_errors(
+    base: collections.Counter[ErrorSignature],
+    candidate: collections.Counter[ErrorSignature],
+) -> collections.Counter[ErrorSignature]:
+    return candidate - base
+
+
+def _run(command: Sequence[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def _mypy_errors(
+    root: Path, command: Sequence[str]
+) -> collections.Counter[ErrorSignature]:
+    result = _run(command, cwd=root)
+    if result.returncode not in _ACCEPTED_MYPY_EXITS:
+        print(result.stdout, file=sys.stderr)
+        raise RuntimeError(f"mypy failed operationally with exit {result.returncode}")
+    errors = parse_errors(result.stdout)
+    if result.returncode == 1 and not errors:
+        print(result.stdout, file=sys.stderr)
+        raise RuntimeError("mypy reported failure but produced no parseable errors")
+    return errors
+
+
+def _resolve_commit(repo: Path, revision: str) -> str:
+    result = _run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=repo)
+    if result.returncode != 0:
+        raise RuntimeError(f"base revision is unavailable: {revision}")
+    return result.stdout.strip()
+
+
+def _comparison(
+    repo: Path,
+    base_revision: str,
+    mypy_command: Sequence[str],
+) -> tuple[collections.Counter[ErrorSignature], collections.Counter[ErrorSignature]]:
+    base_commit = _resolve_commit(repo, base_revision)
+    with tempfile.TemporaryDirectory(prefix="rapid-mypy-base-") as directory:
+        base_root = Path(directory)
+        add = _run(
+            ["git", "worktree", "add", "--detach", str(base_root), base_commit],
+            cwd=repo,
+        )
+        if add.returncode != 0:
+            raise RuntimeError(f"could not create base worktree:\n{add.stdout}")
+        try:
+            base = _mypy_errors(base_root, mypy_command)
+        finally:
+            # Best effort here; TemporaryDirectory still removes the files, and
+            # prune clears metadata if git reports an already-removed worktree.
+            _run(["git", "worktree", "remove", "--force", str(base_root)], cwd=repo)
+            _run(["git", "worktree", "prune"], cwd=repo)
+
+    candidate = _mypy_errors(repo, mypy_command)
+    return base, candidate
+
+
+def _default_mypy_command() -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "mypy",
+        "vllm_mlx/",
+        "--ignore-missing-imports",
+        "--no-error-summary",
+        "--show-error-codes",
+        "--no-pretty",
+    ]
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="Git revision to compare against")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    repo = args.repo.resolve()
+    if shutil.which("git") is None:
+        parser.error("git is required")
+
+    try:
+        base, candidate = _comparison(repo, args.base, _default_mypy_command())
+    except RuntimeError as error:
+        print(f"mypy ratchet could not produce a trustworthy comparison: {error}")
+        return 2
+
+    added = added_errors(base, candidate)
+    resolved = base - candidate
+    print(
+        f"mypy ratchet: base={sum(base.values())}, "
+        f"candidate={sum(candidate.values())}, "
+        f"new={sum(added.values())}, resolved={sum(resolved.values())}"
+    )
+    if not added:
+        return 0
+
+    print("New mypy errors:")
+    for signature, count in sorted(added.items()):
+        print(f"  - {signature.render(count)}")
+    print("Fix the new errors; unrelated historical mypy debt remains non-blocking.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_mypy_new_errors.py
+++ b/tests/test_check_mypy_new_errors.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import collections
+import subprocess
+
+import pytest
+
+from scripts import check_mypy_new_errors
+from scripts.check_mypy_new_errors import ErrorSignature, added_errors, parse_errors
+
+
+def test_parse_errors_ignores_locations_notes_and_summary() -> None:
+    output = """\
+vllm_mlx/a.py:10:5: error: Bad assignment  [assignment]
+vllm_mlx/a.py:99: error: Bad assignment  [assignment]
+vllm_mlx/a.py:10: note: This is context
+Found 2 errors in 1 file (checked 2 source files)
+"""
+
+    assert parse_errors(output) == collections.Counter(
+        {ErrorSignature("vllm_mlx/a.py", "assignment", "Bad assignment"): 2}
+    )
+
+
+def test_parse_errors_retains_unclassified_errors() -> None:
+    assert parse_errors("./vllm_mlx/a.py:7: error: Broken") == collections.Counter(
+        {ErrorSignature("vllm_mlx/a.py", "unclassified", "Broken"): 1}
+    )
+
+
+def test_moved_existing_error_does_not_count_as_new() -> None:
+    before = parse_errors("vllm_mlx/a.py:1: error: Broken  [assignment]")
+    after = parse_errors("vllm_mlx/a.py:200: error: Broken  [assignment]")
+
+    assert not added_errors(before, after)
+
+
+def test_additional_copy_of_existing_error_is_new() -> None:
+    before = parse_errors("vllm_mlx/a.py:1: error: Broken  [assignment]")
+    after = parse_errors(
+        "vllm_mlx/a.py:20: error: Broken  [assignment]\n"
+        "vllm_mlx/a.py:30: error: Broken  [assignment]"
+    )
+
+    assert added_errors(before, after) == collections.Counter(
+        {ErrorSignature("vllm_mlx/a.py", "assignment", "Broken"): 1}
+    )
+
+
+def test_changed_error_message_is_new_and_old_one_is_resolved() -> None:
+    before = parse_errors("vllm_mlx/a.py:1: error: Old  [assignment]")
+    after = parse_errors("vllm_mlx/a.py:1: error: New  [assignment]")
+
+    assert added_errors(before, after) == collections.Counter(
+        {ErrorSignature("vllm_mlx/a.py", "assignment", "New"): 1}
+    )
+
+
+def test_unparseable_mypy_failure_fails_closed(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        check_mypy_new_errors,
+        "_run",
+        lambda command, cwd: subprocess.CompletedProcess(
+            command, returncode=1, stdout="unexpected output format"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="no parseable errors"):
+        check_mypy_new_errors._mypy_errors(tmp_path, ["mypy"])

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -103,3 +103,17 @@ def test_engine_jobs_follow_fail_closed_engine_classification():
     condition = str(bound_guard["if"])
     assert "github.event_name == 'pull_request'" in condition
     assert "needs.changes.outputs.engine == 'true'" in condition
+
+
+def test_type_check_blocks_only_new_mypy_errors():
+    type_check = _job(ENGINE_WORKFLOW, "type-check")
+    steps = type_check["steps"]
+    ratchet = next(
+        step for step in steps if step.get("name") == "Reject new mypy errors"
+    )
+
+    assert "continue-on-error" not in ratchet
+    assert "check_mypy_new_errors.py" in ratchet["run"]
+    assert "MYPY_BASE_SHA" in ratchet["env"]
+    install = next(step for step in steps if step.get("name") == "Install dependencies")
+    assert "mypy==" in install["run"]

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -117,3 +117,7 @@ def test_type_check_blocks_only_new_mypy_errors():
     assert "MYPY_BASE_SHA" in ratchet["env"]
     install = next(step for step in steps if step.get("name") == "Install dependencies")
     assert "mypy==" in install["run"]
+    unit_roster = _step_run(
+        ENGINE_WORKFLOW, "test-matrix", "Run unit tests (no MLX required)"
+    )
+    assert "tests/test_check_mypy_new_errors.py" in unit_roster


### PR DESCRIPTION
## Summary

- replace advisory mypy with a blocking new-error ratchet for engine changes
- run one pinned mypy/Pydantic/FastAPI environment against the candidate and its event base SHA
- compare location-independent error multisets so historical debt can move within a file without blocking unrelated work
- fail closed when the base is unavailable, mypy crashes, or its output cannot be parsed
- document behavior and rollback, and add parser/routing regression contracts

This is the first scoped half of #2252 PR 5. Changed-lines coverage remains a separate follow-up so review and rollback stay narrow.

## Why

The repository currently reports 725 mypy errors under the pinned toolchain, so making the whole existing output blocking would stop all engine PRs. At the same time, `continue-on-error: true` permits every PR to add more debt. Comparing the candidate with its actual base blocks only newly introduced errors and immediately ratchets downward when existing errors are fixed.

## Developer impact

An engine PR can still land with unrelated historical mypy findings. It must fix errors it adds or changes. Moving an unchanged error within the same file does not fail; adding another copy of the same signature does.

## Verification

- 30 focused ratchet, CI routing, and immutable-action tests passed
- Ruff lint and format passed
- workflow expression validation passed
- actionlint passed
- real positive comparison: base=725, candidate=725, new=0
- real negative probe: candidate=726, exactly one new `return-value` error reported and blocking
- diff check passed

## Safety / rollback

The comparison uses the immutable event base SHA and the same pinned environment for both commits. It does not suppress or rewrite mypy output. If false positives appear, rollback restores the prior direct advisory mypy command with `continue-on-error: true`; do not bypass individual PRs by changing their base SHA.

## Ownership

CI/CD policy is Harbor-owned. Atlas should review any request to broaden this PR into merge or release policy. This PR changes neither product behavior nor release qualification.

Refs #2252.
