### PR TITLE
fix(agents): use cross-version Hermes toolsets

### DIFF
--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -199,7 +199,7 @@ class TestMergeOnWrite:
                   max_tokens: 4096
                 my_custom_setting: true
                 platform_toolsets:
-                  cli: [terminal, file, image, my_custom_tool]
+                  cli: [terminal, file, image, computer_use, my_custom_tool]
             """)
         )
 
@@ -211,7 +211,7 @@ class TestMergeOnWrite:
               context_length: 131072
               max_tokens: 4096
             platform_toolsets:
-              cli: [terminal, file, code_execution, web, browser, skills, image, computer_use]
+              cli: [terminal, file, code_execution, web, browser, skills, image_gen]
         """)
 
         result = _merge_file_config(existing, new_template, "yaml")
@@ -222,10 +222,20 @@ class TestMergeOnWrite:
         assert parsed["model"]["context_length"] == 131072
         # User's custom key is preserved
         assert parsed["my_custom_setting"] is True
-        # platform_toolsets.cli is replaced by template (authoritative)
+        # Stable defaults come first; user-enabled capabilities survive.
         cli = parsed["platform_toolsets"]["cli"]
-        assert "code_execution" in cli  # from template
-        assert "my_custom_tool" not in cli  # template list wins
+        assert cli == [
+            "terminal",
+            "file",
+            "code_execution",
+            "web",
+            "browser",
+            "skills",
+            "image_gen",
+            "computer_use",
+            "my_custom_tool",
+        ]
+        assert "image" not in cli
 
     def test_json_merge_preserves_user_keys(self, tmp_path):
         existing = tmp_path / "config.json"

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -193,9 +193,7 @@ class TestHermesToolsets:
         assert _hermes_supported_toolsets() == {"image_gen", "computer_use"}
 
     @pytest.mark.parametrize("failure", ["nonzero", "timeout", "malformed"])
-    def test_registry_discovery_failures_are_unknown(
-        self, monkeypatch, failure
-    ):
+    def test_registry_discovery_failures_are_unknown(self, monkeypatch, failure):
         monkeypatch.setattr("shutil.which", lambda name: "/opt/bin/hermes")
 
         def fake_run(*args, **kwargs):
@@ -362,8 +360,7 @@ class TestMergeOnWrite:
     ):
         existing = tmp_path / "config.yaml"
         existing.write_text(
-            "platform_toolsets:\n"
-            "  cli: [terminal, image, computer_use, spotify]\n"
+            "platform_toolsets:\n  cli: [terminal, image, computer_use, spotify]\n"
         )
         template = "platform_toolsets:\n  cli: [terminal]\n"
 
@@ -460,10 +457,7 @@ class TestMergeOnWrite:
             config=AgentConfigSpec(
                 type="yaml",
                 path=str(config_path),
-                template=(
-                    "platform_toolsets:\n"
-                    "  cli: [terminal, file, image_gen]\n"
-                ),
+                template=("platform_toolsets:\n  cli: [terminal, file, image_gen]\n"),
             )
         )
         monkeypatch.setattr(

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -398,6 +398,33 @@ class TestMergeOnWrite:
         summary = setup_agent_config(profile, "http://x/v1", "m")
         assert summary.startswith("Cannot")
 
+    def test_setup_reports_failure_on_non_string_hermes_toolset(
+        self, tmp_path, monkeypatch
+    ):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "platform_toolsets:\n  cli: [terminal, {custom: true}]\n"
+        )
+        profile = _hermes_profile(
+            config=AgentConfigSpec(
+                type="yaml",
+                path=str(config_path),
+                template=(
+                    "platform_toolsets:\n"
+                    "  cli: [terminal, file, image_gen]\n"
+                ),
+            )
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.agents.adapter._hermes_supported_toolsets",
+            lambda: {"terminal", "file", "image_gen"},
+        )
+
+        summary = setup_agent_config(profile, "http://x/v1", "m")
+
+        assert summary.startswith("Cannot parse existing config")
+        assert "entries must be strings" in summary
+
     def test_dry_run_does_not_touch_an_existing_config(self, tmp_path):
         """``--dry-run`` must preview, never write.
 

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -2,7 +2,7 @@
 
 Covers:
   1. context_length placeholder is resolved from server-reported context_window
-  2. hermes template includes image + computer_use in platform_toolsets
+  2. hermes template uses valid cross-version platform toolsets by default
   3. merge-on-write preserves existing user config keys
   4. fresh write works when no config file exists
 """
@@ -137,6 +137,25 @@ class TestHermesToolsets:
             "browser",
             "skills",
             "image_gen",
+        ]
+
+    def test_hermes_yaml_enables_computer_use_for_explicit_v016(self):
+        from vllm_mlx.agents import get_profile, load_profiles
+
+        load_profiles()
+        profile = get_profile("hermes")
+        assert profile is not None, "hermes profile not found"
+
+        rendered = profile.render_config(
+            "http://localhost:8000/v1",
+            "test-model",
+            agent_version="0.16.0",
+            context_length=32768,
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["platform_toolsets"]["cli"][-2:] == [
+            "image_gen",
+            "computer_use",
         ]
 
 

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -116,8 +116,8 @@ class TestContextLengthPlaceholder:
 
 
 class TestHermesToolsets:
-    def test_hermes_yaml_includes_image_and_computer_use(self):
-        """Hermes profile template must include image + computer_use tools."""
+    def test_hermes_yaml_uses_cross_version_toolsets(self):
+        """Hermes setup must only enable toolsets shared by supported versions."""
         from vllm_mlx.agents import get_profile, load_profiles
 
         load_profiles()
@@ -129,10 +129,15 @@ class TestHermesToolsets:
         )
         parsed = yaml.safe_load(rendered)
         toolsets = parsed.get("platform_toolsets", {}).get("cli", [])
-        assert "image" in toolsets, f"'image' missing from cli toolsets: {toolsets}"
-        assert "computer_use" in toolsets, (
-            f"'computer_use' missing from cli toolsets: {toolsets}"
-        )
+        assert toolsets == [
+            "terminal",
+            "file",
+            "code_execution",
+            "web",
+            "browser",
+            "skills",
+            "image_gen",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 import textwrap
 
 import pytest
@@ -26,6 +27,7 @@ except ModuleNotFoundError:  # pragma: no cover — Python 3.10 only
 
 from vllm_mlx.agents.adapter import (
     _deep_merge,
+    _hermes_supported_toolsets,
     _merge_file_config,
     _MergeParseError,
     _valid_context_window,
@@ -172,6 +174,40 @@ class TestHermesToolsets:
             "computer_use",
         ]
 
+    def test_registry_discovery_parses_real_format_and_ansi(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda name: "/opt/bin/hermes")
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(
+                args[0],
+                0,
+                stdout=(
+                    "Built-in toolsets (cli):\n"
+                    "  ✓ enabled  image_gen  Image Generation\n"
+                    "  \x1b[32m✗ disabled\x1b[0m  computer_use  Computer Use\n"
+                ),
+                stderr="",
+            ),
+        )
+
+        assert _hermes_supported_toolsets() == {"image_gen", "computer_use"}
+
+    @pytest.mark.parametrize("failure", ["nonzero", "timeout", "malformed"])
+    def test_registry_discovery_failures_are_unknown(
+        self, monkeypatch, failure
+    ):
+        monkeypatch.setattr("shutil.which", lambda name: "/opt/bin/hermes")
+
+        def fake_run(*args, **kwargs):
+            if failure == "timeout":
+                raise subprocess.TimeoutExpired(args[0], 5)
+            if failure == "nonzero":
+                return subprocess.CompletedProcess(args[0], 2, "", "boom")
+            return subprocess.CompletedProcess(args[0], 0, "unexpected output", "")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        assert _hermes_supported_toolsets() is None
+
 
 # ---------------------------------------------------------------------------
 # 3. merge-on-write
@@ -228,7 +264,21 @@ class TestMergeOnWrite:
               cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
         """)
 
-        result = _merge_file_config(existing, new_template, "yaml")
+        result = _merge_file_config(
+            existing,
+            new_template,
+            "yaml",
+            hermes_supported_toolsets={
+                "terminal",
+                "file",
+                "code_execution",
+                "web",
+                "browser",
+                "skills",
+                "image_gen",
+                "computer_use",
+            },
+        )
         parsed = yaml.safe_load(result)
 
         # Template values win
@@ -293,7 +343,7 @@ class TestMergeOnWrite:
     ):
         existing = tmp_path / "config.yaml"
         existing.write_text(
-            "platform_toolsets:\n  cli: [terminal, computer_use, spotify]\n"
+            "platform_toolsets:\n  cli: [terminal, image, computer_use, spotify]\n"
         )
         template = "platform_toolsets:\n  cli: [terminal, image_gen]\n"
 
@@ -302,6 +352,7 @@ class TestMergeOnWrite:
         assert parsed["platform_toolsets"]["cli"] == [
             "terminal",
             "image_gen",
+            "image",
             "computer_use",
             "spotify",
         ]

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -237,6 +237,28 @@ class TestMergeOnWrite:
         ]
         assert "image" not in cli
 
+    def test_yaml_merge_migrates_the_exact_legacy_rapid_toolset_list(self, tmp_path):
+        existing = tmp_path / "config.yaml"
+        existing.write_text(
+            "platform_toolsets:\n"
+            "  cli: [terminal, file, code_execution, web, browser, skills, image, computer_use]\n"
+        )
+        template = (
+            "platform_toolsets:\n"
+            "  cli: [terminal, file, code_execution, web, browser, skills, image_gen]\n"
+        )
+
+        parsed = yaml.safe_load(_merge_file_config(existing, template, "yaml"))
+        assert parsed["platform_toolsets"]["cli"] == [
+            "terminal",
+            "file",
+            "code_execution",
+            "web",
+            "browser",
+            "skills",
+            "image_gen",
+        ]
+
     def test_json_merge_preserves_user_keys(self, tmp_path):
         existing = tmp_path / "config.json"
         existing.write_text(json.dumps({"base_url": "old", "custom": 42}))

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -262,7 +262,22 @@ class TestMergeOnWrite:
             "  cli: [terminal, file, code_execution, web, browser, skills, image_gen]\n"
         )
 
-        parsed = yaml.safe_load(_merge_file_config(existing, template, "yaml"))
+        parsed = yaml.safe_load(
+            _merge_file_config(
+                existing,
+                template,
+                "yaml",
+                hermes_supported_toolsets={
+                    "terminal",
+                    "file",
+                    "code_execution",
+                    "web",
+                    "browser",
+                    "skills",
+                    "image_gen",
+                },
+            )
+        )
         assert parsed["platform_toolsets"]["cli"] == [
             "terminal",
             "file",
@@ -272,6 +287,45 @@ class TestMergeOnWrite:
             "skills",
             "image_gen",
         ]
+
+    def test_yaml_merge_preserves_capabilities_when_detection_is_unavailable(
+        self, tmp_path
+    ):
+        existing = tmp_path / "config.yaml"
+        existing.write_text(
+            "platform_toolsets:\n  cli: [terminal, computer_use, spotify]\n"
+        )
+        template = "platform_toolsets:\n  cli: [terminal, image_gen]\n"
+
+        parsed = yaml.safe_load(_merge_file_config(existing, template, "yaml"))
+
+        assert parsed["platform_toolsets"]["cli"] == [
+            "terminal",
+            "image_gen",
+            "computer_use",
+            "spotify",
+        ]
+
+    def test_yaml_merge_registry_filters_managed_tools_but_keeps_user_delta(
+        self, tmp_path
+    ):
+        existing = tmp_path / "config.yaml"
+        existing.write_text(
+            "platform_toolsets:\n"
+            "  cli: [terminal, image, computer_use, spotify]\n"
+        )
+        template = "platform_toolsets:\n  cli: [terminal]\n"
+
+        parsed = yaml.safe_load(
+            _merge_file_config(
+                existing,
+                template,
+                "yaml",
+                hermes_supported_toolsets={"terminal"},
+            )
+        )
+
+        assert parsed["platform_toolsets"]["cli"] == ["terminal", "spotify"]
 
     def test_json_merge_preserves_user_keys(self, tmp_path):
         existing = tmp_path / "config.json"

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -139,20 +139,34 @@ class TestHermesToolsets:
             "image_gen",
         ]
 
-    def test_hermes_yaml_enables_computer_use_for_explicit_v016(self):
-        from vllm_mlx.agents import get_profile, load_profiles
-
-        load_profiles()
-        profile = get_profile("hermes")
-        assert profile is not None, "hermes profile not found"
-
-        rendered = profile.render_config(
-            "http://localhost:8000/v1",
-            "test-model",
-            agent_version="0.16.0",
-            context_length=32768,
+    def test_setup_uses_the_installed_hermes_toolset_registry(
+        self, tmp_path, monkeypatch
+    ):
+        config_path = tmp_path / "config.yaml"
+        profile = _hermes_profile(
+            config=AgentConfigSpec(
+                type="yaml",
+                path=str(config_path),
+                template=_hermes_profile().config.template,
+            )
         )
-        parsed = yaml.safe_load(rendered)
+        monkeypatch.setattr(
+            "vllm_mlx.agents.adapter._hermes_supported_toolsets",
+            lambda: {
+                "terminal",
+                "file",
+                "code_execution",
+                "web",
+                "browser",
+                "skills",
+                "image_gen",
+                "computer_use",
+            },
+        )
+
+        setup_agent_config(profile, model_id="test-model")
+
+        parsed = yaml.safe_load(config_path.read_text())
         assert parsed["platform_toolsets"]["cli"][-2:] == [
             "image_gen",
             "computer_use",
@@ -211,7 +225,7 @@ class TestMergeOnWrite:
               context_length: 131072
               max_tokens: 4096
             platform_toolsets:
-              cli: [terminal, file, code_execution, web, browser, skills, image_gen]
+              cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
         """)
 
         result = _merge_file_config(existing, new_template, "yaml")

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -37,29 +37,6 @@ def test_hermes_binary_uses_path_instead_of_one_obsolete_install_layout():
     assert profile.testing.binary == "hermes"
 
 
-def test_hermes_profile_uses_cross_version_toolsets():
-    load_profiles()
-    profile = get_profile("hermes")
-    assert profile is not None
-
-    rendered = yaml.safe_load(
-        profile.render_config(
-            "http://127.0.0.1:8153/v1",
-            "qwen3.5-9b-4bit",
-        )
-    )
-
-    assert rendered["platform_toolsets"]["cli"] == [
-        "terminal",
-        "file",
-        "code_execution",
-        "web",
-        "browser",
-        "skills",
-        "image_gen",
-    ]
-
-
 def test_aider_profile_runs_the_real_cli():
     load_profiles()
     profile = get_profile("aider")

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -37,6 +37,41 @@ def test_hermes_binary_uses_path_instead_of_one_obsolete_install_layout():
     assert profile.testing.binary == "hermes"
 
 
+def test_hermes_toolsets_match_the_detected_cli_version():
+    load_profiles()
+    profile = get_profile("hermes")
+    assert profile is not None
+
+    legacy = yaml.safe_load(
+        profile.render_config(
+            "http://127.0.0.1:8153/v1",
+            "qwen3.5-9b-4bit",
+            agent_version="0.9.0",
+        )
+    )
+    current = yaml.safe_load(
+        profile.render_config(
+            "http://127.0.0.1:8153/v1",
+            "qwen3.5-9b-4bit",
+            agent_version="0.16.0",
+        )
+    )
+
+    assert legacy["platform_toolsets"]["cli"] == [
+        "terminal",
+        "file",
+        "code_execution",
+        "web",
+        "browser",
+        "skills",
+        "image_gen",
+    ]
+    assert current["platform_toolsets"]["cli"] == [
+        *legacy["platform_toolsets"]["cli"],
+        "computer_use",
+    ]
+
+
 def test_aider_profile_runs_the_real_cli():
     load_profiles()
     profile = get_profile("aider")

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -37,33 +37,19 @@ def test_hermes_binary_uses_path_instead_of_one_obsolete_install_layout():
     assert profile.testing.binary == "hermes"
 
 
-def test_hermes_toolsets_match_the_detected_cli_version():
+def test_hermes_profile_uses_cross_version_toolsets():
     load_profiles()
     profile = get_profile("hermes")
     assert profile is not None
 
-    default = yaml.safe_load(
+    rendered = yaml.safe_load(
         profile.render_config(
             "http://127.0.0.1:8153/v1",
             "qwen3.5-9b-4bit",
-        )
-    )
-    legacy = yaml.safe_load(
-        profile.render_config(
-            "http://127.0.0.1:8153/v1",
-            "qwen3.5-9b-4bit",
-            agent_version="0.9.0",
-        )
-    )
-    current = yaml.safe_load(
-        profile.render_config(
-            "http://127.0.0.1:8153/v1",
-            "qwen3.5-9b-4bit",
-            agent_version="0.16.0",
         )
     )
 
-    assert default["platform_toolsets"]["cli"] == [
+    assert rendered["platform_toolsets"]["cli"] == [
         "terminal",
         "file",
         "code_execution",
@@ -71,11 +57,6 @@ def test_hermes_toolsets_match_the_detected_cli_version():
         "browser",
         "skills",
         "image_gen",
-    ]
-    assert legacy["platform_toolsets"]["cli"] == default["platform_toolsets"]["cli"]
-    assert current["platform_toolsets"]["cli"] == [
-        *legacy["platform_toolsets"]["cli"],
-        "computer_use",
     ]
 
 

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -42,6 +42,12 @@ def test_hermes_toolsets_match_the_detected_cli_version():
     profile = get_profile("hermes")
     assert profile is not None
 
+    default = yaml.safe_load(
+        profile.render_config(
+            "http://127.0.0.1:8153/v1",
+            "qwen3.5-9b-4bit",
+        )
+    )
     legacy = yaml.safe_load(
         profile.render_config(
             "http://127.0.0.1:8153/v1",
@@ -57,7 +63,7 @@ def test_hermes_toolsets_match_the_detected_cli_version():
         )
     )
 
-    assert legacy["platform_toolsets"]["cli"] == [
+    assert default["platform_toolsets"]["cli"] == [
         "terminal",
         "file",
         "code_execution",
@@ -66,6 +72,7 @@ def test_hermes_toolsets_match_the_detected_cli_version():
         "skills",
         "image_gen",
     ]
+    assert legacy["platform_toolsets"]["cli"] == default["platform_toolsets"]["cli"]
     assert current["platform_toolsets"]["cli"] == [
         *legacy["platform_toolsets"]["cli"],
         "computer_use",

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -33,15 +33,9 @@ def _merge_toolset_list(
     result = list(configured)
     for item in existing:
         if not isinstance(item, str):
-            raise _MergeParseError(
-                "platform_toolsets.cli entries must be strings"
-            )
+            raise _MergeParseError("platform_toolsets.cli entries must be strings")
         normalized = item
-        if (
-            item == "image"
-            and supported is not None
-            and "image_gen" in supported
-        ):
+        if item == "image" and supported is not None and "image_gen" in supported:
             normalized = "image_gen"
         if (
             supported is not None
@@ -80,9 +74,7 @@ def _hermes_supported_toolsets() -> set[str] | None:
     return names or None
 
 
-def _render_hermes_runtime_toolsets(
-    rendered: str, supported: set[str] | None
-) -> str:
+def _render_hermes_runtime_toolsets(rendered: str, supported: set[str] | None) -> str:
     """Resolve optional Hermes capabilities from its runtime registry."""
     if supported is None:
         return rendered
@@ -137,9 +129,7 @@ def _deep_merge(
             # Hermes toolsets are capabilities, not an authoritative preset.
             # Keep user-enabled capabilities while normalizing renamed
             # upstream identifiers. Other lists retain replace semantics.
-            merged[key] = _merge_toolset_list(
-                merged[key], val, _supported_toolsets
-            )
+            merged[key] = _merge_toolset_list(merged[key], val, _supported_toolsets)
         else:
             # Lists and scalars: template value wins unconditionally.
             merged[key] = val
@@ -247,9 +237,7 @@ def setup_agent_config(
     hermes_supported_toolsets = None
     if profile.name == "hermes" and isinstance(rendered, str):
         hermes_supported_toolsets = _hermes_supported_toolsets()
-        rendered = _render_hermes_runtime_toolsets(
-            rendered, hermes_supported_toolsets
-        )
+        rendered = _render_hermes_runtime_toolsets(rendered, hermes_supported_toolsets)
 
     if cfg.type == "env":
         lines = []
@@ -445,9 +433,7 @@ def _merge_yaml(
         raise _MergeParseError(f"rendered template is not valid YAML: {exc}") from exc
     if not isinstance(template, dict):
         raise _MergeParseError("rendered template is not a YAML mapping")
-    merged = _deep_merge(
-        existing, template, _supported_toolsets=supported_toolsets
-    )
+    merged = _deep_merge(existing, template, _supported_toolsets=supported_toolsets)
     return yaml.dump(merged, default_flow_style=False, sort_keys=False)
 
 

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -25,12 +25,18 @@ class _MergeParseError(Exception):
 _TOOLSET_ALIASES = {"image": "image_gen"}
 
 
-def _merge_toolset_list(existing: list, configured: list) -> list:
+def _merge_toolset_list(
+    existing: list, configured: list, supported: set[str] | None = None
+) -> list:
     """Merge stable profile defaults with user-enabled Hermes toolsets."""
     result = list(configured)
     for item in existing:
         normalized = _TOOLSET_ALIASES.get(item, item)
-        if normalized == "computer_use" and normalized not in configured:
+        if (
+            supported is not None
+            and normalized in {"image_gen", "computer_use"}
+            and normalized not in supported
+        ):
             continue
         if normalized not in result:
             result.append(normalized)
@@ -62,9 +68,10 @@ def _hermes_supported_toolsets() -> set[str] | None:
     return names or None
 
 
-def _render_hermes_runtime_toolsets(rendered: str) -> str:
+def _render_hermes_runtime_toolsets(
+    rendered: str, supported: set[str] | None
+) -> str:
     """Resolve optional Hermes capabilities from its runtime registry."""
-    supported = _hermes_supported_toolsets()
     if supported is None:
         return rendered
     import yaml
@@ -86,7 +93,13 @@ def _render_hermes_runtime_toolsets(rendered: str) -> str:
     return yaml.safe_dump(config, sort_keys=False)
 
 
-def _deep_merge(base: dict, override: dict, *, _path: tuple[str, ...] = ()) -> dict:
+def _deep_merge(
+    base: dict,
+    override: dict,
+    *,
+    _path: tuple[str, ...] = (),
+    _supported_toolsets: set[str] | None = None,
+) -> dict:
     """Recursively merge *override* into *base*.
 
     - Dict values are merged recursively (existing keys in *base* that
@@ -98,7 +111,12 @@ def _deep_merge(base: dict, override: dict, *, _path: tuple[str, ...] = ()) -> d
     merged = dict(base)
     for key, val in override.items():
         if key in merged and isinstance(merged[key], dict) and isinstance(val, dict):
-            merged[key] = _deep_merge(merged[key], val, _path=(*_path, key))
+            merged[key] = _deep_merge(
+                merged[key],
+                val,
+                _path=(*_path, key),
+                _supported_toolsets=_supported_toolsets,
+            )
         elif (
             (*_path, key) == ("platform_toolsets", "cli")
             and isinstance(merged.get(key), list)
@@ -107,7 +125,9 @@ def _deep_merge(base: dict, override: dict, *, _path: tuple[str, ...] = ()) -> d
             # Hermes toolsets are capabilities, not an authoritative preset.
             # Keep user-enabled capabilities while normalizing renamed
             # upstream identifiers. Other lists retain replace semantics.
-            merged[key] = _merge_toolset_list(merged[key], val)
+            merged[key] = _merge_toolset_list(
+                merged[key], val, _supported_toolsets
+            )
         else:
             # Lists and scalars: template value wins unconditionally.
             merged[key] = val
@@ -212,8 +232,12 @@ def setup_agent_config(
     )
     cfg = profile.get_config_for_version(agent_version)
 
+    hermes_supported_toolsets = None
     if profile.name == "hermes" and isinstance(rendered, str):
-        rendered = _render_hermes_runtime_toolsets(rendered)
+        hermes_supported_toolsets = _hermes_supported_toolsets()
+        rendered = _render_hermes_runtime_toolsets(
+            rendered, hermes_supported_toolsets
+        )
 
     if cfg.type == "env":
         lines = []
@@ -254,7 +278,12 @@ def setup_agent_config(
                     )
 
         try:
-            merged_text = _merge_file_config(config_path, rendered, cfg.type)
+            merged_text = _merge_file_config(
+                config_path,
+                rendered,
+                cfg.type,
+                hermes_supported_toolsets=hermes_supported_toolsets,
+            )
         except OSError as exc:
             return (
                 f"Cannot read existing config at {config_path} ({exc}). "
@@ -296,7 +325,13 @@ def setup_agent_config(
     return "No config to write (template not specified)"
 
 
-def _merge_file_config(existing_path: Path, rendered: str, config_type: str) -> str:
+def _merge_file_config(
+    existing_path: Path,
+    rendered: str,
+    config_type: str,
+    *,
+    hermes_supported_toolsets: set[str] | None = None,
+) -> str:
     """Merge *rendered* template into an existing config file.
 
     Returns *rendered* unchanged when the file does not exist (fresh
@@ -315,7 +350,11 @@ def _merge_file_config(existing_path: Path, rendered: str, config_type: str) -> 
     existing_text = existing_path.read_text(encoding="utf-8")
 
     if config_type == "yaml":
-        return _merge_yaml(existing_text, rendered)
+        return _merge_yaml(
+            existing_text,
+            rendered,
+            supported_toolsets=hermes_supported_toolsets,
+        )
     if config_type == "toml":
         return _merge_toml(existing_text, rendered)
     return _merge_json(existing_text, rendered)
@@ -364,7 +403,12 @@ def _merge_toml(existing_text: str, rendered: str) -> str:
     return tomli_w.dumps(merged)
 
 
-def _merge_yaml(existing_text: str, rendered: str) -> str:
+def _merge_yaml(
+    existing_text: str,
+    rendered: str,
+    *,
+    supported_toolsets: set[str] | None = None,
+) -> str:
     """Parse both YAML strings, deep-merge, and re-serialize.
 
     Raises ``_MergeParseError`` when the existing content is malformed
@@ -389,7 +433,9 @@ def _merge_yaml(existing_text: str, rendered: str) -> str:
         raise _MergeParseError(f"rendered template is not valid YAML: {exc}") from exc
     if not isinstance(template, dict):
         raise _MergeParseError("rendered template is not a YAML mapping")
-    merged = _deep_merge(existing, template)
+    merged = _deep_merge(
+        existing, template, _supported_toolsets=supported_toolsets
+    )
     return yaml.dump(merged, default_flow_style=False, sort_keys=False)
 
 

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -19,7 +19,20 @@ class _MergeParseError(Exception):
     """Raised when an existing config file cannot be parsed for merging."""
 
 
-def _deep_merge(base: dict, override: dict) -> dict:
+_TOOLSET_ALIASES = {"image": "image_gen"}
+
+
+def _merge_toolset_list(existing: list, configured: list) -> list:
+    """Merge stable profile defaults with user-enabled Hermes toolsets."""
+    result = list(configured)
+    for item in existing:
+        normalized = _TOOLSET_ALIASES.get(item, item)
+        if normalized not in result:
+            result.append(normalized)
+    return result
+
+
+def _deep_merge(base: dict, override: dict, *, _path: tuple[str, ...] = ()) -> dict:
     """Recursively merge *override* into *base*.
 
     - Dict values are merged recursively (existing keys in *base* that
@@ -31,12 +44,18 @@ def _deep_merge(base: dict, override: dict) -> dict:
     merged = dict(base)
     for key, val in override.items():
         if key in merged and isinstance(merged[key], dict) and isinstance(val, dict):
-            merged[key] = _deep_merge(merged[key], val)
+            merged[key] = _deep_merge(merged[key], val, _path=(*_path, key))
+        elif (
+            (*_path, key) == ("platform_toolsets", "cli")
+            and isinstance(merged.get(key), list)
+            and isinstance(val, list)
+        ):
+            # Hermes toolsets are capabilities, not an authoritative preset.
+            # Keep user-enabled capabilities while normalizing renamed
+            # upstream identifiers. Other lists retain replace semantics.
+            merged[key] = _merge_toolset_list(merged[key], val)
         else:
             # Lists and scalars: template value wins unconditionally.
-            # This ensures template-defined toolsets are authoritative
-            # (user customizations at the dict-key level are preserved,
-            # but list contents come from the template).
             merged[key] = val
     return merged
 

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -20,10 +20,27 @@ class _MergeParseError(Exception):
 
 
 _TOOLSET_ALIASES = {"image": "image_gen"}
+_LEGACY_RAPID_HERMES_TOOLSETS = [
+    "terminal",
+    "file",
+    "code_execution",
+    "web",
+    "browser",
+    "skills",
+    "image",
+    "computer_use",
+]
 
 
 def _merge_toolset_list(existing: list, configured: list) -> list:
     """Merge stable profile defaults with user-enabled Hermes toolsets."""
+    # This exact list was written by older Rapid-MLX releases. Treat it as a
+    # registry-owned baseline, not a user override: `image` was renamed and
+    # `computer_use` is unsupported by older Hermes. Any deviation from this
+    # signature is a user delta and is preserved below.
+    if existing == _LEGACY_RAPID_HERMES_TOOLSETS:
+        return list(configured)
+
     result = list(configured)
     for item in existing:
         normalized = _TOOLSET_ALIASES.get(item, item)

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -31,6 +31,10 @@ def _merge_toolset_list(
     """Merge stable profile defaults with user-enabled Hermes toolsets."""
     result = list(configured)
     for item in existing:
+        if not isinstance(item, str):
+            raise _MergeParseError(
+                "platform_toolsets.cli entries must be strings"
+            )
         normalized = _TOOLSET_ALIASES.get(item, item)
         if (
             supported is not None

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import shutil
+import subprocess
 from pathlib import Path
 
 from .base import AgentProfile
@@ -20,33 +23,67 @@ class _MergeParseError(Exception):
 
 
 _TOOLSET_ALIASES = {"image": "image_gen"}
-_LEGACY_RAPID_HERMES_TOOLSETS = [
-    "terminal",
-    "file",
-    "code_execution",
-    "web",
-    "browser",
-    "skills",
-    "image",
-    "computer_use",
-]
 
 
 def _merge_toolset_list(existing: list, configured: list) -> list:
     """Merge stable profile defaults with user-enabled Hermes toolsets."""
-    # This exact list was written by older Rapid-MLX releases. Treat it as a
-    # registry-owned baseline, not a user override: `image` was renamed and
-    # `computer_use` is unsupported by older Hermes. Any deviation from this
-    # signature is a user delta and is preserved below.
-    if existing == _LEGACY_RAPID_HERMES_TOOLSETS:
-        return list(configured)
-
     result = list(configured)
     for item in existing:
         normalized = _TOOLSET_ALIASES.get(item, item)
+        if normalized == "computer_use" and normalized not in configured:
+            continue
         if normalized not in result:
             result.append(normalized)
     return result
+
+
+def _hermes_supported_toolsets() -> set[str] | None:
+    """Read the installed Hermes CLI's official built-in toolset registry."""
+    binary = shutil.which("hermes")
+    if binary is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [binary, "tools", "list", "--platform", "cli"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    names = set()
+    for line in proc.stdout.splitlines():
+        match = re.match(r"^\s*[✓✗]\s+\w+\s+([a-z][a-z0-9_-]*)\b", line)
+        if match:
+            names.add(match.group(1))
+    return names or None
+
+
+def _render_hermes_runtime_toolsets(rendered: str) -> str:
+    """Resolve optional Hermes capabilities from its runtime registry."""
+    supported = _hermes_supported_toolsets()
+    if supported is None:
+        return rendered
+    import yaml
+
+    config = yaml.safe_load(rendered)
+    if not isinstance(config, dict):
+        return rendered
+    platform = config.get("platform_toolsets")
+    if not isinstance(platform, dict) or not isinstance(platform.get("cli"), list):
+        return rendered
+    configured = [
+        _TOOLSET_ALIASES.get(item, item)
+        for item in platform["cli"]
+        if _TOOLSET_ALIASES.get(item, item) in supported
+    ]
+    if "computer_use" in supported and "computer_use" not in configured:
+        configured.append("computer_use")
+    platform["cli"] = configured
+    return yaml.safe_dump(config, sort_keys=False)
 
 
 def _deep_merge(base: dict, override: dict, *, _path: tuple[str, ...] = ()) -> dict:
@@ -174,6 +211,9 @@ def setup_agent_config(
         base_url, model_id, agent_version, context_length=context_length
     )
     cfg = profile.get_config_for_version(agent_version)
+
+    if profile.name == "hermes" and isinstance(rendered, str):
+        rendered = _render_hermes_runtime_toolsets(rendered)
 
     if cfg.type == "env":
         lines = []

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -23,6 +23,7 @@ class _MergeParseError(Exception):
 
 
 _TOOLSET_ALIASES = {"image": "image_gen"}
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _merge_toolset_list(
@@ -35,10 +36,16 @@ def _merge_toolset_list(
             raise _MergeParseError(
                 "platform_toolsets.cli entries must be strings"
             )
-        normalized = _TOOLSET_ALIASES.get(item, item)
+        normalized = item
+        if (
+            item == "image"
+            and supported is not None
+            and "image_gen" in supported
+        ):
+            normalized = "image_gen"
         if (
             supported is not None
-            and normalized in {"image_gen", "computer_use"}
+            and normalized in {"image", "image_gen", "computer_use"}
             and normalized not in supported
         ):
             continue
@@ -65,7 +72,8 @@ def _hermes_supported_toolsets() -> set[str] | None:
     if proc.returncode != 0:
         return None
     names = set()
-    for line in proc.stdout.splitlines():
+    output = _ANSI_ESCAPE_RE.sub("", proc.stdout)
+    for line in output.splitlines():
         match = re.match(r"^\s*[✓✗]\s+\w+\s+([a-z][a-z0-9_-]*)\b", line)
         if match:
             names.add(match.group(1))

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -53,6 +53,20 @@ known_issues:
 # Hermes has dual-model routing (smart_model_routing.py)
 # When using with Rapid-MLX multi-model, set the cheap model as secondary
 versions:
+  - range: ">=0.16"
+    notes: "v0.16+ adds the optional computer_use toolset"
+    config:
+      type: yaml
+      path: "~/.hermes/config.yaml"
+      template: |
+        model:
+          provider: "custom"
+          default: "{model_id}"
+          base_url: "{base_url}"
+          context_length: {context_length}
+          max_tokens: 4096
+        platform_toolsets:
+          cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
   - range: ">=0.9"
     notes: "v0.9+ added MCP support and new tool formats"
   - range: ">=0.8,<0.9"

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -53,20 +53,6 @@ known_issues:
 # Hermes has dual-model routing (smart_model_routing.py)
 # When using with Rapid-MLX multi-model, set the cheap model as secondary
 versions:
-  - range: ">=0.16"
-    notes: "Hermes v0.16+ exposes the computer_use toolset"
-    config:
-      type: yaml
-      path: "~/.hermes/config.yaml"
-      template: |
-        model:
-          provider: "custom"
-          default: "{model_id}"
-          base_url: "{base_url}"
-          context_length: {context_length}
-          max_tokens: 4096
-        platform_toolsets:
-          cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
   - range: ">=0.9"
     notes: "v0.9+ added MCP support and new tool formats"
   - range: ">=0.8,<0.9"

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -53,20 +53,6 @@ known_issues:
 # Hermes has dual-model routing (smart_model_routing.py)
 # When using with Rapid-MLX multi-model, set the cheap model as secondary
 versions:
-  - range: ">=0.16"
-    notes: "v0.16+ adds the optional computer_use toolset"
-    config:
-      type: yaml
-      path: "~/.hermes/config.yaml"
-      template: |
-        model:
-          provider: "custom"
-          default: "{model_id}"
-          base_url: "{base_url}"
-          context_length: {context_length}
-          max_tokens: 4096
-        platform_toolsets:
-          cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
   - range: ">=0.9"
     notes: "v0.9+ added MCP support and new tool formats"
   - range: ">=0.8,<0.9"

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -16,7 +16,7 @@ config:
       context_length: {context_length}
       max_tokens: 4096
     platform_toolsets:
-      cli: [terminal, file, code_execution, web, browser, skills, image, computer_use]
+      cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
 
 models:
   recommended:
@@ -53,6 +53,20 @@ known_issues:
 # Hermes has dual-model routing (smart_model_routing.py)
 # When using with Rapid-MLX multi-model, set the cheap model as secondary
 versions:
+  - range: ">=0.9,<0.16"
+    notes: "Hermes before v0.16 does not expose the computer_use toolset"
+    config:
+      type: yaml
+      path: "~/.hermes/config.yaml"
+      template: |
+        model:
+          provider: "custom"
+          default: "{model_id}"
+          base_url: "{base_url}"
+          context_length: {context_length}
+          max_tokens: 4096
+        platform_toolsets:
+          cli: [terminal, file, code_execution, web, browser, skills, image_gen]
   - range: ">=0.9"
     notes: "v0.9+ added MCP support and new tool formats"
   - range: ">=0.8,<0.9"

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -16,7 +16,7 @@ config:
       context_length: {context_length}
       max_tokens: 4096
     platform_toolsets:
-      cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
+      cli: [terminal, file, code_execution, web, browser, skills, image_gen]
 
 models:
   recommended:
@@ -53,8 +53,8 @@ known_issues:
 # Hermes has dual-model routing (smart_model_routing.py)
 # When using with Rapid-MLX multi-model, set the cheap model as secondary
 versions:
-  - range: ">=0.9,<0.16"
-    notes: "Hermes before v0.16 does not expose the computer_use toolset"
+  - range: ">=0.16"
+    notes: "Hermes v0.16+ exposes the computer_use toolset"
     config:
       type: yaml
       path: "~/.hermes/config.yaml"
@@ -66,7 +66,7 @@ versions:
           context_length: {context_length}
           max_tokens: 4096
         platform_toolsets:
-          cli: [terminal, file, code_execution, web, browser, skills, image_gen]
+          cli: [terminal, file, code_execution, web, browser, skills, image_gen, computer_use]
   - range: ">=0.9"
     notes: "v0.9+ added MCP support and new tool formats"
   - range: ">=0.8,<0.9"


### PR DESCRIPTION
## Intention
Make `rapid-mlx agents hermes --setup` configure only toolsets supported by the installed Hermes CLI without deleting valid user capability choices.

## Why
Different supported Hermes installations expose different built-in toolsets. A static profile therefore produces invalid setup output on some supported versions, while destructive fallback behavior could erase deliberate user configuration. Runtime capability discovery keeps generated configuration valid and makes discovery failure safe.

## Scope
- correct the retired `image` toolset identifier
- resolve optional built-in toolsets through Hermes' official runtime registry
- carry one capability snapshot through render and YAML merge
- preserve unknown user-owned toolsets
- fail non-destructively when registry discovery is unavailable
- add focused discovery, merge, malformed-config, and compatibility regressions

## Non-goals
- inference engine or server behavior
- general provider/model registry redesign
- GUI changes
- release publication

## Acceptance
- real Hermes 0.9 excludes unsupported `computer_use` and accepts `image_gen`
- real Hermes 0.16 includes both `image_gen` and `computer_use`
- detection failure does not delete existing capabilities
- known unsupported built-ins cannot return during merge
- malformed existing toolset structures return an actionable setup error
- focused tests, formatting, lint, and required CI pass

## Release-blocker evidence
Studio has real Hermes 0.9.0 and 0.16.0 installations. The previous profile emitted warnings for unsupported toolsets under 0.9.0 and failed the release E2E gate.

## Verification
- focused pytest modules
- ruff check and format
- real toolset discovery under Hermes 0.9.0 and 0.16.0 environments
- managed release gauntlet after merge