### PR TITLE
fix(harness): run LangChain checks under bench

### DIFF
--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -212,7 +212,20 @@ def _run_tests() -> None:
 # can import the module without triggering live API calls — restores the
 # PR #660 fix without re-introducing the empty-results harness bug.
 _UNDER_PYTEST = "_pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
-if not _UNDER_PYTEST:
+
+
+def _should_run_tests() -> bool:
+    """Run for script semantics even when the parent loaded pytest.
+
+    The release harness executes this file with ``__name__ == "__main__"``
+    inside the long-lived bench process.  That process may already have
+    imported pytest, which must not make the live integration battery look
+    like pytest collection and silently leave ``results`` empty.
+    """
+    return __name__ == "__main__" or not _UNDER_PYTEST
+
+
+if _should_run_tests():
     _run_tests()
     if __name__ == "__main__":
         exit(0 if all(_is_ok_result(v) for v in results.values()) else 1)

--- a/tests/test_pr_validate_runner.py
+++ b/tests/test_pr_validate_runner.py
@@ -991,6 +991,15 @@ class TestStressPreexistingClassification:
 
 
 class TestLangChainGuidedCapabilityHandling:
+    def test_harness_script_semantics_override_parent_pytest_import(self, monkeypatch):
+        from tests.integrations import test_langchain
+
+        assert not test_langchain._should_run_tests()
+
+        monkeypatch.setattr(test_langchain, "__name__", "__main__")
+
+        assert test_langchain._should_run_tests()
+
     def test_guided_extra_error_is_skip_eligible(self):
         from tests.integrations import test_langchain
 


### PR DESCRIPTION
## Intention
Ensure the release harness actually executes the LangChain live integration battery when invoked by the bench runner.

## Why
The bench process can already have pytest loaded before it executes an integration file with script semantics. Treating that process state as pytest collection silently skipped all live checks and produced an empty-results release failure.

## Scope
- make script semantics take precedence over parent-process pytest imports
- add a focused regression for the execution decision

## Non-goals
- server or model behavior
- agent retry policy
- other harness profiles
- GUI changes
- release publication

## Acceptance
- normal pytest import remains side-effect free
- bench-style `__main__` execution runs even when pytest is loaded
- focused unit tests and formatting/lint pass
- live LangChain + DeepSeek filtered harness passes against the RC model
- required CI passes

## Verification
- 60 focused tests passed
- ruff check and format passed
- live filtered harness: LangChain 15 passed; DeepSeek Harness 13 passed; tier passed