### PR TITLE
fix: hide malformed XML tool-call wire from chat

### DIFF
--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1417,6 +1417,136 @@ def test_codex_r13_visible_scrub_skips_broken_deepseek_begin_then_scrubs_payload
     assert "suffix" in out
 
 
+def test_visible_scrub_removes_truncated_xml_parameter_tool_wire():
+    """A real Qwen retry closed only the outer wrapper and leaked the rest.
+
+    The route must fail closed: remove the malformed action envelope rather
+    than showing it or guessing missing closing tags and executing it.
+    """
+
+    wire = (
+        "Let me retry.\n"
+        "<tool_call> <function=browse> <parameter=url> "
+        "https://example.com/page </tool_call>\n"
+        "Please try again."
+    )
+    assert _contains_structural_tool_wire_leak(wire)
+
+    out = _scrub_visible_tool_wire_leaks(wire)
+
+    assert "<tool_call>" not in out
+    assert "<function=browse>" not in out
+    assert "<parameter=url>" not in out
+    assert "https://example.com/page" not in out
+    assert "Let me retry." in out
+    assert "Please try again." in out
+
+
+def test_visible_scrub_preserves_xml_marker_prose_without_parameter_payload():
+    prose = "The <function=browse> marker names a function in this example."
+
+    assert not _contains_structural_tool_wire_leak(prose)
+    assert _scrub_visible_tool_wire_leaks(prose) == prose
+
+
+def test_auto_choice_route_scrubs_truncated_xml_parameter_tool_wire():
+    wire = (
+        "Let me retry.\n"
+        "<tool_call> <function=add_numbers> <parameter=a> 1 </tool_call>\n"
+        "Please retry the request."
+    )
+    engine = _RecordingEngine(text=wire, raw_text=wire)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add one and two"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "auto",
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    message = resp.json()["choices"][0]["message"]
+    assert not message.get("tool_calls")
+    content = message.get("content") or ""
+    assert "<tool_call>" not in content
+    assert "<function=add_numbers>" not in content
+    assert "<parameter=a>" not in content
+    assert "Let me retry." in content
+    assert "Please retry the request." in content
+
+
+def test_auto_choice_stream_scrubs_truncated_xml_parameter_tool_wire():
+    deltas = [
+        "Let me retry.\n",
+        "<tool_call> <function=add_numbers> ",
+        "<parameter=a> 1 </tool_call>\n",
+        "Please retry the request.",
+    ]
+
+    class _MalformedXMLStreamEngine(_RecordingEngine):
+        async def stream_chat(self, messages, **kwargs):
+            accumulated = ""
+            for index, delta in enumerate(deltas):
+                accumulated += delta
+                finished = index == len(deltas) - 1
+                yield GenerationOutput(
+                    text=accumulated,
+                    raw_text=accumulated,
+                    new_text=delta,
+                    prompt_tokens=4,
+                    completion_tokens=index + 1,
+                    finished=finished,
+                    finish_reason="stop" if finished else None,
+                    channel=None,
+                )
+
+    engine = _MalformedXMLStreamEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add one and two"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "auto",
+            "stream": True,
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    wire = resp.text
+    assert "<tool_call>" not in wire
+    assert "<function=add_numbers>" not in wire
+    assert "<parameter=a>" not in wire
+    assert "Let me retry." in wire
+    assert "Please retry the request." in wire
+
+
 def test_1676_forced_deepseek_section_is_removed_from_visible_channels():
     fullwidth = (
         "narration\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -1449,6 +1449,32 @@ def test_visible_scrub_preserves_xml_marker_prose_without_parameter_payload():
     assert _scrub_visible_tool_wire_leaks(prose) == prose
 
 
+def test_visible_scrub_checks_later_envelopes_after_harmless_marker_prose():
+    wire = (
+        "Example: <tool_call>example</tool_call>. "
+        "Then: <tool_call><function=browse><parameter=url>"
+        "https://example.com/private</tool_call>"
+    )
+
+    assert _contains_structural_tool_wire_leak(wire)
+    out = _scrub_visible_tool_wire_leaks(wire)
+    assert "<tool_call>example</tool_call>" in out
+    assert "https://example.com/private" not in out
+    assert "<function=browse>" not in out
+
+
+def test_visible_scrub_removes_xml_parameter_wire_truncated_at_eof():
+    wire = (
+        "Let me retry. "
+        "<tool_call><function=browse><parameter=url>https://example.com/private"
+    )
+
+    assert _contains_structural_tool_wire_leak(wire)
+    out = _scrub_visible_tool_wire_leaks(wire)
+    assert out == "Let me retry."
+    assert "https://example.com/private" not in out
+
+
 def test_auto_choice_route_scrubs_truncated_xml_parameter_tool_wire():
     wire = (
         "Let me retry.\n"
@@ -1545,6 +1571,96 @@ def test_auto_choice_stream_scrubs_truncated_xml_parameter_tool_wire():
     assert "<parameter=a>" not in wire
     assert "Let me retry." in wire
     assert "Please retry the request." in wire
+
+
+def test_auto_choice_route_scrubs_later_xml_envelope_truncated_at_eof():
+    wire = (
+        "Example: <tool_call>example</tool_call>. Let me retry. "
+        "<tool_call><function=add_numbers><parameter=a>1"
+    )
+    engine = _RecordingEngine(text=wire, raw_text=wire)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add one and two"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "auto",
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    content = resp.json()["choices"][0]["message"].get("content") or ""
+    assert "<tool_call>example</tool_call>" in content
+    assert "<function=add_numbers>" not in content
+    assert "<parameter=a>" not in content
+
+
+def test_auto_choice_stream_scrubs_later_xml_envelope_truncated_at_eof():
+    deltas = [
+        "Example: <tool_call>example</tool_call>. ",
+        "Let me retry. ",
+        "<tool_call><function=add_numbers>",
+        "<parameter=a>1",
+    ]
+
+    class _EOFXMLStreamEngine(_RecordingEngine):
+        async def stream_chat(self, messages, **kwargs):
+            accumulated = ""
+            for index, delta in enumerate(deltas):
+                accumulated += delta
+                finished = index == len(deltas) - 1
+                yield GenerationOutput(
+                    text=accumulated,
+                    raw_text=accumulated,
+                    new_text=delta,
+                    prompt_tokens=4,
+                    completion_tokens=index + 1,
+                    finished=finished,
+                    finish_reason="stop" if finished else None,
+                    channel=None,
+                )
+
+    engine = _EOFXMLStreamEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add one and two"}],
+            "tools": _SOLO_TOOL,
+            "tool_choice": "auto",
+            "stream": True,
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "<tool_call>example</tool_call>" in resp.text
+    assert "<function=add_numbers>" not in resp.text
+    assert "<parameter=a>" not in resp.text
 
 
 def test_1676_forced_deepseek_section_is_removed_from_visible_channels():

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2510,6 +2510,15 @@ _TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(r"[\"'](?:name|arguments)[\"']\s*:")
 _TOOL_WIRE_XML_PAYLOAD_HINT_RE = re.compile(
     r"<function=[^>\s]+>.*?<parameter=[^>\s]+>", re.DOTALL
 )
+# Same payload shape when generation ends before the outer wrapper closes.
+# The tempered body deliberately refuses to cross a real ``</tool_call>``;
+# closed spans remain owned by the balanced/cross-family passes below.
+_TOOL_WIRE_UNCLOSED_XML_TO_EOF_RE = re.compile(
+    r"<tool_call>\s*<function=[^>\s]+>"
+    r"(?:(?!</tool_call>).)*?<parameter=[^>\s]+>"
+    r"(?:(?!</tool_call>).)*\Z",
+    re.DOTALL,
+)
 
 
 def _balanced_json_end(text: str, start: int, *, max_scan: int = 8192) -> int | None:
@@ -2590,11 +2599,14 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
     if not text:
         return False
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
-        match = balanced_re.search(text)
-        if match and _span_has_tool_payload(match.group(0)):
+        if any(_span_has_tool_payload(m.group(0)) for m in balanced_re.finditer(text)):
             return True
-    cross_match = _CROSS_FAMILY_SPAN_RE.search(text)
-    if cross_match and _span_has_tool_payload(cross_match.group(0)):
+    if any(
+        _span_has_tool_payload(m.group(0))
+        for m in _CROSS_FAMILY_SPAN_RE.finditer(text)
+    ):
+        return True
+    if _TOOL_WIRE_UNCLOSED_XML_TO_EOF_RE.search(text):
         return True
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         match = marker_re.search(text)
@@ -2627,6 +2639,10 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
     if not text:
         return text or ""
     result = text
+    # A true EOF truncation has no closer for the balanced passes to anchor
+    # on. Remove the action envelope from its unambiguous structured opener
+    # through EOF; preceding prose remains intact.
+    result = _TOOL_WIRE_UNCLOSED_XML_TO_EOF_RE.sub("", result)
     # DeepSeek V3.1 orphan fragment:
     # ``<｜tool▁call▁begin｜>NAME<｜tool▁sep｜>{...}`` without a closer.
     # Remove the whole fragment so the opener/name prefix cannot leak

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2499,6 +2499,17 @@ def _contains_tool_wire_literal(text: str | None) -> bool:
 
 
 _TOOL_WIRE_PAYLOAD_HINT_RE = re.compile(r"[\"'](?:name|arguments)[\"']\s*:")
+# A model can close the outer ``<tool_call>`` wrapper after truncating the
+# inner Nemotron/Qwen XML (for example, omitting both ``</parameter>`` and
+# ``</function>``).  There is no JSON object for the detector below to use,
+# but a function opener followed by a named parameter is still unambiguous
+# tool-wire structure.  Treat it as payload-bearing residue so it is
+# quarantined instead of rendered verbatim to API/Desktop users.  We do NOT
+# repair or execute the malformed call: guessing structure at this boundary
+# would turn corrupted model output into an action.
+_TOOL_WIRE_XML_PAYLOAD_HINT_RE = re.compile(
+    r"<function=[^>\s]+>.*?<parameter=[^>\s]+>", re.DOTALL
+)
 
 
 def _balanced_json_end(text: str, start: int, *, max_scan: int = 8192) -> int | None:
@@ -2550,7 +2561,9 @@ def _payload_object_after_marker(
     return pos, object_end
 
 
-def _span_has_tool_payload_object(span: str) -> bool:
+def _span_has_tool_payload(span: str) -> bool:
+    if _TOOL_WIRE_XML_PAYLOAD_HINT_RE.search(span):
+        return True
     object_start = span.find("{")
     while object_start != -1:
         object_end = _balanced_json_end(span, object_start)
@@ -2578,10 +2591,10 @@ def _contains_structural_tool_wire_leak(text: str | None) -> bool:
         return False
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         match = balanced_re.search(text)
-        if match and _span_has_tool_payload_object(match.group(0)):
+        if match and _span_has_tool_payload(match.group(0)):
             return True
     cross_match = _CROSS_FAMILY_SPAN_RE.search(text)
-    if cross_match and _span_has_tool_payload_object(cross_match.group(0)):
+    if cross_match and _span_has_tool_payload(cross_match.group(0)):
         return True
     for marker_re in _TOOL_WIRE_STANDALONE_MARKERS:
         match = marker_re.search(text)
@@ -2646,11 +2659,11 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
         search_pos = begin
     for balanced_re in _TOOL_WIRE_BALANCED_SPAN_RES:
         result = balanced_re.sub(
-            lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
+            lambda m: "" if _span_has_tool_payload(m.group(0)) else m.group(0),
             result,
         )
     result = _CROSS_FAMILY_SPAN_RE.sub(
-        lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
+        lambda m: "" if _span_has_tool_payload(m.group(0)) else m.group(0),
         result,
     )
     for _ in range(4):
@@ -2752,7 +2765,7 @@ def _scrub_tool_wire_literals(text: str | None) -> str:
     # between the opener and the unrelated closer survives as
     # ``content`` (codex r3 BLOCKING #1).
     result = _CROSS_FAMILY_SPAN_RE.sub(
-        lambda m: "" if _span_has_tool_payload_object(m.group(0)) else m.group(0),
+        lambda m: "" if _span_has_tool_payload(m.group(0)) else m.group(0),
         result,
     )
     # Phase 2: strip standalone marker tokens (orphan opener OR
@@ -5909,6 +5922,17 @@ async def _create_chat_completion_impl(
         cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
     if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
         reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
+    # Auto tool choice can also end on a malformed structured envelope.  There
+    # is no structured call to authorize or execute in that case, but exposing
+    # the raw XML teaches the UI user nothing and can poison the next turn.
+    # Keep the forced-choice compatibility rule above intact: this narrower
+    # fallback fires only when tools were offered, parsing produced NO call,
+    # and the visible channel contains payload-bearing wire structure.
+    if request.tools and not tool_calls:
+        if _contains_structural_tool_wire_leak(cleaned_text):
+            cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
+        if reasoning_text and _contains_structural_tool_wire_leak(reasoning_text):
+            reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
     if _is_forced_choice and tool_calls:
         # #1676/#1677: a recovered valid DeepSeek call may be followed by a
         # malformed duplicate.  Never expose that native section through the
@@ -7018,6 +7042,37 @@ async def stream_chat_completion(
                 if _forced_terminal_content_consumed
                 else finish_content + finalize_content
             )
+            # Streaming parity for the non-stream auto-mode fallback above.
+            # A truncated XML action is held by the parser until EOF, so this
+            # terminal merge is the last safe point before it becomes visible
+            # SSE content.  Never repair/execute it; preserve surrounding prose
+            # and remove only the payload-bearing wire span.
+            if (
+                request.tools
+                and not fallback_tool_calls
+                and processor._tool_calls_emitted_to_wire == 0
+                and _contains_structural_tool_wire_leak(
+                    content_buffer or terminal_content
+                )
+            ):
+                recovered_content = _scrub_visible_tool_wire_leaks(
+                    content_buffer or terminal_content
+                )
+                # The parser may already have streamed safe prose before the
+                # malformed opener.  Emit only the recovered suffix so this
+                # terminal repair does not replay that prefix.
+                streamed_normalized = re.sub(r"\s+", " ", streamed_content).strip()
+                if streamed_normalized and recovered_content.startswith(
+                    streamed_normalized
+                ):
+                    recovered_content = recovered_content[
+                        len(streamed_normalized) :
+                    ].lstrip()
+                    terminal_content = (
+                        f" {recovered_content}" if recovered_content else ""
+                    )
+                else:
+                    terminal_content = recovered_content
 
             # Issue #569 streaming rescue: if NOTHING was streamed as
             # ``content`` across the whole turn AND no ``tool_calls``


### PR DESCRIPTION
## Why
A model can emit a truncated XML action envelope after a tool failure. Showing that internal wire format confuses Desktop users, can poison the next conversation turn, and exposes parameter payloads that should have remained implementation detail. Failing closed at the existing response scrub boundary is safer than guessing missing tags and executing an ambiguous action.

## Intention
Prevent truncated XML tool-call envelopes from leaking into API and Desktop chat content during automatic tool use.

## Scope
- Recognize payload-bearing XML tool wire when the outer wrapper closes but inner parameter/function tags are truncated, or generation ends before the outer close.
- Inspect all envelopes when harmless marker prose precedes malformed action wire.
- Scrub the malformed action envelope in non-streaming and SSE auto-tool responses.
- Preserve safe prose before and after malformed envelopes without replaying already-streamed prefixes.

## Non-goals
- Do not repair or execute malformed tool calls.
- Do not change valid Hermes/XML parsing, tool permissions, Browse behavior, or model routing.
- Do not alter literal marker prose that lacks a parameter payload.

## Acceptance criteria
- No malformed action envelope or parameter payload leaks to visible content for closed-outer or true EOF-truncated shapes.
- A harmless earlier marker envelope cannot mask a later malformed one.
- No structured tool call is synthesized from truncated output.
- Surrounding user-readable prose survives in both non-streaming and SSE responses.
- Existing auto-tool, forced-tool, reasoning, and valid XML parser behavior remains green.

## Verification
- `python3.12 -m pytest -q tests/test_tool_choice_enforcement.py tests/test_447_stream_tool_choice_auto.py tests/test_r12_reasoning_sanitizer_required.py tests/test_vibethinker_function_xml.py` — 220 passed, 2 skipped
- `python3.12 -m ruff check vllm_mlx/routes/chat.py tests/test_tool_choice_enforcement.py`
- `git diff --check`

Dogfood evidence: a Qwen3.5 9B automatic Browse retry emitted a truncated XML action envelope as visible assistant text after a tool failure. The fix fails closed and keeps the conversation readable.