### PR TITLE
ci: enforce changed-lines coverage ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # diff-cover compares the PR head with the immutable base SHA. A
+          # shallow checkout can make that commit unavailable.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -255,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests pyyaml
+          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml
 
       - name: Run unit tests (no MLX required)
         # NOTE: tests in this list MUST not import mlx / mlx_lm at module
@@ -305,6 +309,17 @@ jobs:
             --cov=vllm_mlx \
             --cov-report=term-missing \
             --cov-report=xml
+
+      - name: Enforce changed-lines coverage
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python -m diff_cover.diff_cover_tool \
+            coverage.xml \
+            --compare-branch "$PR_BASE_SHA" \
+            --show-uncovered \
+            --fail-under 100
 
       - name: Upload coverage
         if: matrix.python-version == '3.11'

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -53,6 +53,23 @@ moving line numbers and messages while preventing debt from spreading or
 growing. As dirty files are repaired and removed from the baseline, they can
 never become dirty again without failing CI.
 
+### Changed-lines coverage
+
+Engine pull requests enforce 100% coverage for executable lines newly added or
+modified under `vllm_mlx/`. The Python 3.11 Linux unit-test leg already produces
+`coverage.xml`; `diff-cover` compares that report with the pull request's
+immutable base SHA and blocks the stable `tests` aggregate when a measurable
+changed line was not exercised. Comments, blank lines, deletions, tests, docs,
+and unchanged production lines do not enter the score.
+
+This is a new-debt ratchet, not a whole-repository percentage target. Existing
+uncovered code remains grandfathered until a pull request changes its executable
+lines, so ordinary feature and bug-fix work is not required to repair unrelated
+historical coverage debt. A production change that cannot run on the Linux lane
+must expose its behavior through a Linux-testable boundary or extend the coverage
+gate to consume trustworthy evidence from the relevant required lane; lowering
+the threshold is not the normal escape hatch.
+
 ## Merge gate
 
 Adding the `full-ci` label upgrades the lanes selected by the pull request's
@@ -155,3 +172,8 @@ additional macOS build time but preserves the same release-shaped UI coverage.
 If the mypy budget gate is operationally broken, restore the prior advisory
 direct mypy command with `continue-on-error: true` while repairing the script.
 Do not increase counts or add files to the baseline merely to make a PR green.
+If changed-lines coverage is operationally broken, remove only the
+`Enforce changed-lines coverage` step while repairing its checkout or tooling;
+keep the existing advisory measurement and coverage XML upload as diagnostic
+evidence. Do not lower `--fail-under` or exclude changed production lines merely
+to make a pull request green.

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -134,3 +134,38 @@ def test_type_check_enforces_shrink_only_error_budget():
         ENGINE_WORKFLOW, "test-matrix", "Run unit tests (no MLX required)"
     )
     assert "tests/test_check_mypy_error_budget.py" in unit_roster
+
+
+def test_python_311_enforces_changed_lines_coverage_without_repository_baseline():
+    test_matrix = _job(ENGINE_WORKFLOW, "test-matrix")
+    checkout = next(
+        step
+        for step in test_matrix["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert checkout["with"]["fetch-depth"] == 0
+
+    install = next(
+        step
+        for step in test_matrix["steps"]
+        if step.get("name") == "Install dependencies"
+    )
+    assert '"diff-cover==8.0.3"' in install["run"]
+
+    gate = next(
+        step
+        for step in test_matrix["steps"]
+        if step.get("name") == "Enforce changed-lines coverage"
+    )
+    assert gate["if"] == (
+        "github.event_name == 'pull_request' && matrix.python-version == '3.11'"
+    )
+    assert gate["env"] == {
+        "PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}"
+    }
+    assert "continue-on-error" not in gate
+    assert "coverage.xml" in gate["run"]
+    assert '--compare-branch "$PR_BASE_SHA"' in gate["run"]
+    assert "--show-uncovered" in gate["run"]
+    assert "--fail-under 100" in gate["run"]
+    assert "--cov-fail-under" not in gate["run"]

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -160,9 +160,7 @@ def test_python_311_enforces_changed_lines_coverage_without_repository_baseline(
     assert gate["if"] == (
         "github.event_name == 'pull_request' && matrix.python-version == '3.11'"
     )
-    assert gate["env"] == {
-        "PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}"
-    }
+    assert gate["env"] == {"PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}"}
     assert "continue-on-error" not in gate
     assert "coverage.xml" in gate["run"]
     assert '--compare-branch "$PR_BASE_SHA"' in gate["run"]


### PR DESCRIPTION
## Intention

Prevent new uncovered executable Python lines from entering `vllm_mlx/` while grandfathering all unchanged historical coverage debt.

## Why

Whole-repository coverage thresholds make ordinary pull requests pay for unrelated historical debt. Diff-scoped coverage freezes that debt while ensuring every newly changed executable line carries test evidence, and it reuses coverage already produced by the required Linux suite instead of adding another instrumented test run.

## Scope

- reuse the existing Python 3.11 Linux unit-test `coverage.xml`
- run pinned `diff-cover` against the PR's immutable base SHA
- require 100% coverage only for measurable added/modified production lines
- add a workflow contract test and operational/rollback documentation

## Non-goals

- no whole-repository coverage percentage or historical cleanup
- no Swift/GUI coverage policy
- no Apple/MLX coverage aggregation in this PR
- no test-suite redesign, CI lane-routing changes, branch-protection changes, or unrelated CI work

## Constraints

- preserve stable required check names
- fail closed on missing base history, invalid coverage evidence, or uncovered changed lines
- comments, blank lines, deletions, tests, docs, and unchanged production lines remain outside the score
- keep the existing advisory measurement intact

## Acceptance

- a PR with an uncovered executable changed line under `vllm_mlx/` fails the required `tests` aggregate
- a PR with all measurable changed lines exercised passes
- historical uncovered lines outside the diff do not affect the result
- the gate runs once on Python 3.11 and prints exact uncovered line numbers
- workflow structure is protected by a focused automated contract test
- rollback is documented without weakening the threshold as a bypass

## Exact diff

`0330db4c..22032f1b`

## Verification

- `python3 -m pytest tests/test_ci_lane_promotion.py tests/test_check_gha_pinning.py tests/test_pr_validate_diff_coverage.py -q` — 79 passed
- `python3 scripts/check_gha_pinning.py` — 14 workflows clean
- `ruff format --check tests/test_ci_lane_promotion.py`
- `git diff --check`

Tracks part of #2252.
