### PR TITLE
test(mac): cover chat drag, paste, and removal [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -2169,6 +2169,30 @@ final class AutosizingTextView: NSTextView {
         super.paste(sender)
     }
 
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // A plain-text NSTextView can reject an image-only pasteboard before
+        // AppKit dispatches paste(_:). Give the composer first refusal on the
+        // native Command-V event so screenshot/Preview image copies still
+        // reach the attachment importer. Shift-Command-V remains AppKit's
+        // alternate paste behavior.
+        if Self.isStandardPasteKeyEquivalent(event),
+           onPasteAttachments?() == true {
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    static func isStandardPasteKeyEquivalent(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown,
+              event.charactersIgnoringModifiers?.lowercased() == "v" else {
+            return false
+        }
+        let relevant = event.modifierFlags.intersection([
+            .command, .control, .option, .shift,
+        ])
+        return relevant == .command
+    }
+
     /// Height of the laid-out text plus the editor's vertical insets.
     var measuredHeight: CGFloat {
         guard let lm = layoutManager, let tc = textContainer else { return 28 }

--- a/apps/rapid-mac/Tests/RapidTests/ChatFileAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatFileAttachmentTests.swift
@@ -217,6 +217,50 @@ struct ChatFileAttachmentTests {
         #expect(textView.string.isEmpty)
     }
 
+    @Test("Command-V offers image-only clipboard events to the attachment importer")
+    func nativePasteKeyEquivalentUsesAttachmentImporter() throws {
+        let textView = AutosizingTextView()
+        var calls = 0
+        textView.onPasteAttachments = {
+            calls += 1
+            return true
+        }
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "v",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ))
+
+        #expect(textView.performKeyEquivalent(with: event))
+        #expect(calls == 1)
+        #expect(textView.string.isEmpty)
+    }
+
+    @Test("Shift-Command-V retains AppKit alternate paste behavior")
+    func alternatePasteKeyEquivalentIsNotIntercepted() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "V",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ))
+
+        #expect(!AutosizingTextView.isStandardPasteKeyEquivalent(event))
+    }
+
     @Test("Retry preserves the locally extracted source")
     func retryPreservesAttachment() throws {
         let attachment = try ChatFileAttachment(

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -2,7 +2,77 @@ import AppKit
 
 // Xcode requires a target application for an UI-testing bundle. The tests
 // deliberately launch the already-built production bundle by identifier; this
-// inert host exists only as XCTest's runner and never stands in for Rapid.
+// host normally remains inert. A native attachment journey can opt into its
+// small, deterministic file-drag surface so the production app receives a real
+// macOS file-URL drag without depending on Finder's ambient window geometry.
+final class FileDragView: NSView, NSDraggingSource {
+    let fileURL: URL
+    private var startedDragging = false
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+        super.init(frame: .zero)
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(fileURL.lastPathComponent)
+        setAccessibilityIdentifier("RapidUITests.FileDragSource")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.windowBackgroundColor.setFill()
+        dirtyRect.fill()
+        NSWorkspace.shared.icon(forFile: fileURL.path).draw(
+            in: bounds.insetBy(dx: 24, dy: 12),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1
+        )
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        startedDragging = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard !startedDragging else { return }
+        startedDragging = true
+        let item = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
+        item.setDraggingFrame(bounds, contents: NSWorkspace.shared.icon(forFile: fileURL.path))
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation { .copy }
+}
+
 let app = NSApplication.shared
-app.setActivationPolicy(.accessory)
-app.terminate(nil)
+if let path = ProcessInfo.processInfo.environment["RAPID_XCUI_DRAG_FILE"] {
+    app.setActivationPolicy(.regular)
+    let size = NSSize(width: 140, height: 110)
+    let visible = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1_440, height: 900)
+    let panel = NSPanel(
+        contentRect: NSRect(
+            x: visible.minX + 20,
+            y: visible.maxY - size.height - 20,
+            width: size.width,
+            height: size.height
+        ),
+        styleMask: [.titled],
+        backing: .buffered,
+        defer: false
+    )
+    panel.title = "Drag attachment"
+    panel.contentView = FileDragView(fileURL: URL(fileURLWithPath: path))
+    panel.level = .floating
+    panel.makeKeyAndOrderFront(nil)
+    app.activate(ignoringOtherApps: true)
+    app.run()
+} else {
+    app.setActivationPolicy(.accessory)
+    app.terminate(nil)
+}

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CryptoKit
 import XCTest
 
@@ -7,8 +8,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         continueAfterFailure = false
         let harness = try RapidUITestHarness(
             testName: name,
-            fakeSettings: ["FAKE_VISION_CHAT": "1"],
-            port: 65_001
+            fakeSettings: ["FAKE_VISION_CHAT": "1"]
         )
         defer { harness.shutDown() }
         harness.launch()
@@ -59,6 +59,51 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         XCTAssertTrue(imageHashes(in: requests[3]).isEmpty)
     }
 
+    func testDragPasteAndRemovalPreserveWireIdentity() throws {
+        continueAfterFailure = false
+        let harness = try RapidUITestHarness(
+            testName: name,
+            fakeSettings: ["FAKE_VISION_CHAT": "1"]
+        )
+        defer { harness.shutDown() }
+        harness.launch()
+        harness.startModel()
+
+        let image = harness.rapidMacRoot
+            .appendingPathComponent("Tests/RapidTests/__Snapshots__/cheetah-logo-96.png")
+        let document = harness.rapidMacRoot
+            .appendingPathComponent("Tests/GUIGoldenFlows/Fixtures/chat-document.txt")
+
+        harness.dragFile(image)
+        let imageChip = harness.element("ChatView.Attachment.Remove.\(image.lastPathComponent)")
+        XCTAssertTrue(imageChip.waitForExistence(timeout: 15))
+        harness.send("Dragged photo", expectedRequestCount: 1)
+
+        harness.dragFile(document)
+        let documentChip = harness.element("ChatView.Attachment.Remove.\(document.lastPathComponent)")
+        XCTAssertTrue(documentChip.waitForExistence(timeout: 15))
+        harness.send("Dragged document", expectedRequestCount: 2)
+
+        try harness.pasteImage(image)
+        let pastedChip = harness.element("ChatView.Attachment.Remove.Pasted image.png")
+        XCTAssertTrue(pastedChip.waitForExistence(timeout: 15))
+        pastedChip.click()
+        XCTAssertTrue(harness.waitUntil(timeout: 10) { !pastedChip.exists })
+        harness.send("Removed before send", expectedRequestCount: 3)
+
+        try harness.pasteImage(image)
+        XCTAssertTrue(pastedChip.waitForExistence(timeout: 15))
+        harness.send("Pasted photo", expectedRequestCount: 4)
+
+        let requests = harness.chatRequests()
+        XCTAssertEqual(imageHashes(in: requests[0]), [try dataURLHash(image)])
+        XCTAssertTrue(text(in: requests[1]).contains("Revenue: 42"))
+        XCTAssertTrue(text(in: requests[1]).contains("Region: APAC"))
+        XCTAssertTrue(imageHashes(in: requests[1]).isEmpty)
+        XCTAssertTrue(imageHashes(in: requests[2]).isEmpty)
+        XCTAssertEqual(imageHashes(in: requests[3]), [try pastedImageHash(image)])
+    }
+
     private func imageHashes(in request: [String: Any]) -> [String] {
         guard let payloads = request["user_payloads"] as? [[String: Any]],
               let latest = payloads.last else { return [] }
@@ -74,6 +119,19 @@ final class ChatAttachmentJourneyTests: XCTestCase {
     private func dataURLHash(_ url: URL) throws -> String {
         let data = try Data(contentsOf: url)
         let encoded = "data:image/png;base64," + data.base64EncodedString()
+        return SHA256.hash(data: Data(encoded.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func pastedImageHash(_ url: URL) throws -> String {
+        let source = try Data(contentsOf: url)
+        guard let image = NSImage(data: source),
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            XCTFail("Could not reproduce the app's pasted-image encoding")
+            return ""
+        }
+        let encoded = "data:image/png;base64," + png.base64EncodedString()
         return SHA256.hash(data: Data(encoded.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -11,8 +11,49 @@ final class RapidUITestHarness {
     private let testHome: URL
     private let sidecarAlias: String
     private let sidecarPIDFile: URL
+    private var portReservation: Int32?
+    private var originalPasteboardItems: [[NSPasteboard.PasteboardType: Data]]?
+    private var ownedPasteboardChangeCount: Int?
 
-    init(testName: String, fakeSettings: [String: String], port: Int) throws {
+    private static func reserveLoopbackPort() throws -> (descriptor: Int32, port: Int) {
+        let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw POSIXError(.ENOTSOCK) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else {
+            Darwin.close(descriptor)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EADDRINUSE)
+        }
+
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let resolved = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.getsockname(descriptor, $0, &length)
+            }
+        }
+        guard resolved == 0 else {
+            Darwin.close(descriptor)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL)
+        }
+        return (descriptor, Int(UInt16(bigEndian: address.sin_port)))
+    }
+
+    init(testName: String, fakeSettings: [String: String]) throws {
+        let reservedPort = try Self.reserveLoopbackPort()
+        var reservationTransferred = false
+        defer {
+            if !reservationTransferred { Darwin.close(reservedPort.descriptor) }
+        }
+        portReservation = reservedPort.descriptor
         testHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-xcui-\(testName)-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
@@ -44,9 +85,10 @@ final class RapidUITestHarness {
             "CFFIXED_USER_HOME": testHome.path,
             "RAPID_BIN": fakeSidecar,
             "FAKE_EVENT_LOG": eventLog.path,
-            "RAPID_DESKTOP_PORT": String(port),
+            "RAPID_DESKTOP_PORT": String(reservedPort.port),
             "RAPID_DESKTOP_NO_PORT_SWEEP": "1",
         ].merging(fakeSettings) { _, fixture in fixture }
+        reservationTransferred = true
     }
 
     func launch() {
@@ -57,7 +99,9 @@ final class RapidUITestHarness {
 
     func shutDown() {
         app.terminate()
+        releasePortReservation()
         terminateFakeSidecars()
+        restorePasteboardIfOwned()
         try? FileManager.default.removeItem(at: testHome)
     }
 
@@ -65,6 +109,9 @@ final class RapidUITestHarness {
         let readiness = element("Readiness.Action")
         XCTAssertTrue(readiness.waitForExistence(timeout: 20))
         XCTAssertTrue(waitUntil(timeout: 20) { readiness.isEnabled })
+        // Hold the OS-selected port until the app is ready to spawn its fake
+        // sidecar, reducing the bind race to the click-to-process-launch edge.
+        releasePortReservation()
         readiness.click()
         let memoryConfirmation = element("MemoryWarning.Confirm")
         var confirmedMemoryWarning = false
@@ -109,6 +156,61 @@ final class RapidUITestHarness {
         let open = app.dialogs["open-panel"].buttons["OKButton"]
         XCTAssertTrue(waitUntil(timeout: 10) { open.isHittable })
         open.click()
+    }
+
+    func dragFile(_ url: URL) {
+        let dragSource = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")
+        dragSource.launchEnvironment = ["RAPID_XCUI_DRAG_FILE": url.path]
+        dragSource.launch()
+        defer { dragSource.terminate() }
+        let source = dragSource.descendants(matching: .any)
+            .matching(identifier: "RapidUITests.FileDragSource").firstMatch
+        XCTAssertTrue(source.waitForExistence(timeout: 15))
+        let composer = element("rapid.chat.compose")
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        source.click(forDuration: 1, thenDragTo: composer)
+    }
+
+    func pasteImage(_ url: URL) throws {
+        let data = try Data(contentsOf: url)
+        let pasteboard = NSPasteboard.general
+        let stillOwnsPasteboard = ownedPasteboardChangeCount != nil
+            && pasteboard.changeCount == ownedPasteboardChangeCount
+        if originalPasteboardItems == nil || !stillOwnsPasteboard {
+            originalPasteboardItems = pasteboard.pasteboardItems?.map { item in
+                Dictionary(uniqueKeysWithValues: item.types.compactMap { type in
+                    item.data(forType: type).map { (type, $0) }
+                })
+            } ?? []
+        }
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.setData(data, forType: .png))
+        ownedPasteboardChangeCount = pasteboard.changeCount
+        let composer = element("rapid.chat.compose")
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        composer.click()
+        app.typeKey("v", modifierFlags: .command)
+    }
+
+    private func restorePasteboardIfOwned() {
+        let pasteboard = NSPasteboard.general
+        guard let originalPasteboardItems,
+              pasteboard.changeCount == ownedPasteboardChangeCount else { return }
+        let items = originalPasteboardItems.map { representations in
+            let item = NSPasteboardItem()
+            for (type, data) in representations {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        pasteboard.clearContents()
+        if !items.isEmpty { pasteboard.writeObjects(items) }
+    }
+
+    private func releasePortReservation() {
+        guard let portReservation else { return }
+        Darwin.close(portReservation)
+        self.portReservation = nil
     }
 
     func send(_ text: String, expectedRequestCount: Int) {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -197,10 +197,11 @@ final class RapidUITestHarness {
         // NSImage(pasteboard:) portable across hosted macOS image versions.
         XCTAssertTrue(pasteboard.writeObjects([image]))
         ownedPasteboardChangeCount = pasteboard.changeCount
+        XCTAssertNotNil(NSImage(pasteboard: pasteboard))
         let composer = element("rapid.chat.compose")
         XCTAssertTrue(composer.waitForExistence(timeout: 10))
         composer.click()
-        app.typeKey("v", modifierFlags: .command)
+        composer.typeKey("v", modifierFlags: .command)
     }
 
     private func restorePasteboardIfOwned() {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -177,6 +177,10 @@ final class RapidUITestHarness {
 
     func pasteImage(_ url: URL) throws {
         let data = try Data(contentsOf: url)
+        guard let image = NSImage(data: data) else {
+            XCTFail("Could not decode image for native pasteboard journey")
+            return
+        }
         let pasteboard = NSPasteboard.general
         let stillOwnsPasteboard = ownedPasteboardChangeCount != nil
             && pasteboard.changeCount == ownedPasteboardChangeCount
@@ -188,7 +192,10 @@ final class RapidUITestHarness {
             } ?? []
         }
         pasteboard.clearContents()
-        XCTAssertTrue(pasteboard.setData(data, forType: .png))
+        // Use AppKit's image pasteboard writer instead of publishing only a
+        // bare PNG representation. This matches a native image copy and makes
+        // NSImage(pasteboard:) portable across hosted macOS image versions.
+        XCTAssertTrue(pasteboard.writeObjects([image]))
         ownedPasteboardChangeCount = pasteboard.changeCount
         let composer = element("rapid.chat.compose")
         XCTAssertTrue(composer.waitForExistence(timeout: 10))

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -166,9 +166,13 @@ final class RapidUITestHarness {
         let source = dragSource.descendants(matching: .any)
             .matching(identifier: "RapidUITests.FileDragSource").firstMatch
         XCTAssertTrue(source.waitForExistence(timeout: 15))
-        let composer = element("rapid.chat.compose")
-        XCTAssertTrue(composer.waitForExistence(timeout: 10))
-        source.click(forDuration: 1, thenDragTo: composer)
+        // Dropping directly on NSTextView makes AppKit insert the file path as
+        // text before SwiftUI's enclosing URL drop destination can handle it.
+        // The attachment button is inside that same drop destination and does
+        // not consume file URLs, so the native event reaches the product path.
+        let dropTarget = element("ChatView.AddAttachments")
+        XCTAssertTrue(dropTarget.waitForExistence(timeout: 10))
+        source.click(forDuration: 1, thenDragTo: dropTarget)
     }
 
     func pasteImage(_ url: URL) throws {

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -76,6 +76,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
         MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
     ).read_text()
     harness = (MAC / "Tests/RapidUITests/Tests/RapidUITestHarness.swift").read_text()
+    chat_source = (
+        MAC / "Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift"
+    ).read_text()
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
@@ -91,6 +94,23 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "String(contentsOf: sidecarPIDFile" in harness
     assert 'element("MemoryWarning.Confirm")' in harness
     assert 'app.dialogs["open-panel"].buttons["OKButton"]' in harness
+    assert (
+        'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness
+    )
+    assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
+    assert "click(forDuration: 1, thenDragTo: composer)" in harness
+    assert "pasteboard.setData(data, forType: .png)" in harness
+    assert "reserveLoopbackPort" in harness
+    assert "reservationTransferred" in harness
+    assert "Darwin.close(reservedPort.descriptor)" in harness
+    assert "releasePortReservation()" in harness
+    assert "restorePasteboardIfOwned" in harness
+    assert "pasteboard.changeCount == ownedPasteboardChangeCount" in harness
+    assert "originalPasteboardItems == nil || !stillOwnsPasteboard" in harness
+    assert "testDragPasteAndRemovalPreserveWireIdentity" in chat_source
+    assert 'element("ChatView.Attachment.Remove.Pasted image.png")' in chat_source
+    assert "port: 65_001" not in chat_source
+    assert "port: 65_002" not in chat_source
     assert '"RAPID_DESKTOP_PORT": "65000"' in source
     assert '"RAPID_DESKTOP_NO_PORT_SWEEP": "1"' in source
     assert (

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -100,7 +100,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert 'let dropTarget = element("ChatView.AddAttachments")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
-    assert "pasteboard.setData(data, forType: .png)" in harness
+    assert "NSImage(data: data)" in harness
+    assert "pasteboard.writeObjects([image])" in harness
     assert "reserveLoopbackPort" in harness
     assert "reservationTransferred" in harness
     assert "Darwin.close(reservedPort.descriptor)" in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -102,6 +102,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "NSImage(data: data)" in harness
     assert "pasteboard.writeObjects([image])" in harness
+    assert "XCTAssertNotNil(NSImage(pasteboard: pasteboard))" in harness
+    assert 'composer.typeKey("v", modifierFlags: .command)' in harness
     assert "reserveLoopbackPort" in harness
     assert "reservationTransferred" in harness
     assert "Darwin.close(reservedPort.descriptor)" in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -98,7 +98,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
         'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness
     )
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
-    assert "click(forDuration: 1, thenDragTo: composer)" in harness
+    assert 'let dropTarget = element("ChatView.AddAttachments")' in harness
+    assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "pasteboard.setData(data, forType: .png)" in harness
     assert "reserveLoopbackPort" in harness
     assert "reservationTransferred" in harness


### PR DESCRIPTION
## Intention

Exercise Chat attachment input and ownership through the production-shaped macOS app, and close the image-only Command-V responder gap exposed by that native journey.

## Scope

- Add deterministic file-drag and image-paste support to the RapidUITests host/harness.
- Cover file picker, native file drag, native image paste, pre-send removal, conversation switching, and exact wire payload identity.
- Route standard Command-V through the Chat attachment importer when AppKit would otherwise reject an image-only pasteboard before dispatching paste(_:).
- Enforce the native Chat XCUITest outcome in the existing desktop gate.
- Pin the host, harness, workflow, and key-equivalent contracts with focused tests.

## Non-goals

- No attachment redesign, public API, backend, parser, tool protocol, or non-Chat journey changes.
- No alternate Shift-Command-V behavior changes.
- No coordinate clicks or ambient Finder window dependencies.

## Constraints and acceptance

- Run against the production-shaped app with semantic identifiers and unique fake-server ports.
- Use a real macOS file-URL drag and AppKit image pasteboard.
- Preserve exact image/document identity on the wire and per-conversation draft ownership.
- Both native Chat attachment tests and all selected AX Chat flows must pass; the desktop gate must fail when native XCUITest fails.

## Validation

- 41 focused GUI/XCUITest contract tests pass locally.
- 16 focused Chat file/paste tests pass locally, including Command-V interception and Shift-Command-V preservation.
- XCUITest build-for-testing succeeds from fresh DerivedData.
- Full Swift suite and hosted GUI/XCUITest CI are required before merge.

## Why

Native drag and clipboard input must exercise the same attachment importer as picker input because otherwise the composer can appear ready while silently dropping image-only Command-V events or sending a different payload.