### PR TITLE
fix: recover malformed tool calls through the tool loop

### DIFF
--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -1,0 +1,98 @@
+"""Malformed Hermes calls stay in the tool loop without being executed."""
+
+import json
+
+from tests.test_postprocessor import _make_cfg, _make_output
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "browse",
+            "parameters": {
+                "type": "object",
+                "properties": {"url": {"type": "string"}},
+                "required": ["url"],
+            },
+        },
+    }
+]
+REQUEST = {"tools": TOOLS}
+MALFORMED = (
+    "<tool_call>\n"
+    "<function=browse>\n"
+    "<parameter=url>\n"
+    "https://example.com/guide\n"
+    "</tool_call>"
+)
+MALFORMED_JSON = (
+    '<tool_call>{"name":"browse","arguments":{"url":'
+    '"https://example.com/guide"</tool_call>'
+)
+
+
+def test_parser_surfaces_declared_malformed_call_with_unparseable_arguments():
+    result = HermesToolParser(None).extract_tool_calls(MALFORMED, request=REQUEST)
+
+    assert result.tools_called is True
+    assert result.content is None
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    assert call["name"] == "browse"
+    # The orchestration layer must reject this before dispatch and return its
+    # normal parse-error tool result to the model. Do not silently repair and
+    # execute a request whose structure the model failed to close.
+    try:
+        json.loads(call["arguments"])
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("malformed arguments unexpectedly became executable JSON")
+
+
+def test_parser_does_not_promote_undeclared_malformed_function():
+    result = HermesToolParser(None).extract_tool_calls(
+        MALFORMED.replace("function=browse", "function=delete_everything"),
+        request=REQUEST,
+    )
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content == MALFORMED.replace(
+        "function=browse", "function=delete_everything"
+    )
+
+
+def test_parser_surfaces_declared_malformed_json_call_for_executor_feedback():
+    result = HermesToolParser(None).extract_tool_calls(MALFORMED_JSON, request=REQUEST)
+
+    assert result.tools_called is True
+    assert result.content is None
+    assert result.tool_calls[0]["name"] == "browse"
+    try:
+        json.loads(result.tool_calls[0]["arguments"])
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("malformed JSON unexpectedly became executable")
+
+
+def test_stream_finalize_emits_standard_tool_call_not_raw_xml():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+
+    streamed = processor.process_chunk(_make_output(MALFORMED))
+    finalized = processor.finalize()
+    events = [*streamed, *finalized]
+
+    tool_events = [event for event in events if event.type == "tool_call"]
+    assert len(tool_events) == 1
+    call = tool_events[0].tool_calls[0]
+    assert call["function"]["name"] == "browse"
+    assert MALFORMED not in "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )

--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -96,3 +96,40 @@ def test_stream_finalize_emits_standard_tool_call_not_raw_xml():
     assert MALFORMED not in "".join(
         event.content or "" for event in events if event.type in {"content", "finish"}
     )
+
+
+def test_stream_preserves_trailing_prose_once_when_it_shares_the_close_chunk():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+
+    events = processor.process_chunk(_make_output(MALFORMED + "\nAfterward."))
+    events.extend(processor.finalize())
+
+    assert len([event for event in events if event.type == "tool_call"]) == 1
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert content == "\nAfterward."
+    assert MALFORMED not in content
+
+
+def test_stream_preserves_trailing_prose_once_when_it_arrives_later():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+
+    events = processor.process_chunk(_make_output(MALFORMED))
+    events.extend(processor.process_chunk(_make_output("\nAfterward.")))
+    events.extend(processor.finalize())
+
+    assert len([event for event in events if event.type == "tool_call"]) == 1
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert content == "\nAfterward."
+    assert MALFORMED not in content

--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -1,8 +1,12 @@
 """Malformed Hermes calls stay in the tool loop without being executed."""
 
 import json
+from types import SimpleNamespace
+
+import pytest
 
 from tests.test_postprocessor import _make_cfg, _make_output
+from vllm_mlx.reasoning.deepseek_r1_parser import DeepSeekR1DistillReasoningParser
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
 from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
 
@@ -50,6 +54,17 @@ def test_parser_surfaces_declared_malformed_call_with_unparseable_arguments():
         pass
     else:
         raise AssertionError("malformed arguments unexpectedly became executable JSON")
+
+
+def test_parser_accepts_typed_request_tool_models():
+    request = SimpleNamespace(
+        tools=[SimpleNamespace(function=SimpleNamespace(name="browse"))]
+    )
+
+    result = HermesToolParser(None).extract_tool_calls(MALFORMED, request=request)
+
+    assert result.tools_called is True
+    assert result.tool_calls[0]["name"] == "browse"
 
 
 def test_parser_does_not_promote_undeclared_malformed_function():
@@ -232,3 +247,34 @@ def test_stream_malformed_then_valid_in_one_chunk_suppresses_only_final_prose():
         event.content or "" for event in events if event.type in {"content", "finish"}
     )
     assert content == "\nBetween.\n"
+
+
+@pytest.mark.parametrize("mode", ["standard", "channel", "reasoning"])
+@pytest.mark.parametrize("finished", [False, True])
+def test_stream_preserves_later_prose_across_processing_modes(mode, finished):
+    cfg_args = {
+        "enable_auto_tool_choice": True,
+        "tool_parser_instance": HermesToolParser(None),
+    }
+    channel = None
+    if mode == "channel":
+        channel = "content"
+    elif mode == "reasoning":
+        cfg_args["reasoning_parser"] = DeepSeekR1DistillReasoningParser(None)
+    processor = StreamingPostProcessor(
+        _make_cfg(**cfg_args), tools_requested=True, request=REQUEST
+    )
+    processor.reset()
+
+    events = processor.process_chunk(_make_output(MALFORMED, channel=channel))
+    events.extend(
+        processor.process_chunk(
+            _make_output("\nAfterward.", finished=finished, channel=channel)
+        )
+    )
+    events.extend(processor.finalize())
+
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert content == "\nAfterward."

--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -173,7 +173,12 @@ def test_stream_valid_call_after_malformed_call_restores_prose_suppression():
     events.extend(processor.process_chunk(_make_output("\nSuppressed.")))
     events.extend(processor.finalize())
 
-    assert len([event for event in events if event.type == "tool_call"]) == 2
+    assert (
+        sum(
+            len(event.tool_calls or []) for event in events if event.type == "tool_call"
+        )
+        == 2
+    )
     content = "".join(
         event.content or "" for event in events if event.type in {"content", "finish"}
     )
@@ -199,3 +204,31 @@ def test_stream_valid_call_does_not_preserve_same_chunk_trailing_prose():
         event.content or "" for event in events if event.type in {"content", "finish"}
     )
     assert "Suppressed." not in content
+
+
+def test_stream_malformed_then_valid_in_one_chunk_suppresses_only_final_prose():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+    valid = (
+        '<tool_call>{"name":"browse","arguments":'
+        '{"url":"https://example.com"}}</tool_call>'
+    )
+
+    events = processor.process_chunk(
+        _make_output(MALFORMED + "\nBetween.\n" + valid + "\nSuppressed.")
+    )
+    events.extend(processor.finalize())
+
+    assert (
+        sum(
+            len(event.tool_calls or []) for event in events if event.type == "tool_call"
+        )
+        == 2
+    )
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert content == "\nBetween.\n"

--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -64,6 +64,15 @@ def test_parser_does_not_promote_undeclared_malformed_function():
     )
 
 
+def test_stream_does_not_wedge_on_undeclared_malformed_function():
+    raw = MALFORMED.replace("function=browse", "function=delete_everything")
+    parser = HermesToolParser(None)
+
+    result = parser.extract_tool_calls_streaming("", raw, raw, request=REQUEST)
+
+    assert result == {"content": raw}
+
+
 def test_parser_surfaces_declared_malformed_json_call_for_executor_feedback():
     result = HermesToolParser(None).extract_tool_calls(MALFORMED_JSON, request=REQUEST)
 
@@ -165,6 +174,27 @@ def test_stream_valid_call_after_malformed_call_restores_prose_suppression():
     events.extend(processor.finalize())
 
     assert len([event for event in events if event.type == "tool_call"]) == 2
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert "Suppressed." not in content
+
+
+def test_stream_valid_call_does_not_preserve_same_chunk_trailing_prose():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+    valid_with_prose = (
+        '<tool_call>{"name":"browse","arguments":'
+        '{"url":"https://example.com"}}</tool_call>\nSuppressed.'
+    )
+
+    events = processor.process_chunk(_make_output(valid_with_prose))
+    events.extend(processor.finalize())
+
+    assert len([event for event in events if event.type == "tool_call"]) == 1
     content = "".join(
         event.content or "" for event in events if event.type in {"content", "finish"}
     )

--- a/tests/test_hermes_malformed_tool_feedback.py
+++ b/tests/test_hermes_malformed_tool_feedback.py
@@ -78,6 +78,19 @@ def test_parser_surfaces_declared_malformed_json_call_for_executor_feedback():
         raise AssertionError("malformed JSON unexpectedly became executable")
 
 
+def test_parser_does_not_promote_name_nested_inside_malformed_arguments():
+    nested_name = (
+        '<tool_call>{"arguments":{"payload":{"name":"browse"}},'
+        '"other":"truncated"</tool_call>'
+    )
+
+    result = HermesToolParser(None).extract_tool_calls(nested_name, request=REQUEST)
+
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content == nested_name
+
+
 def test_stream_finalize_emits_standard_tool_call_not_raw_xml():
     cfg = _make_cfg(
         enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
@@ -133,3 +146,26 @@ def test_stream_preserves_trailing_prose_once_when_it_arrives_later():
     )
     assert content == "\nAfterward."
     assert MALFORMED not in content
+
+
+def test_stream_valid_call_after_malformed_call_restores_prose_suppression():
+    cfg = _make_cfg(
+        enable_auto_tool_choice=True, tool_parser_instance=HermesToolParser(None)
+    )
+    processor = StreamingPostProcessor(cfg, tools_requested=True, request=REQUEST)
+    processor.reset()
+    valid = (
+        '\n<tool_call>{"name":"browse","arguments":'
+        '{"url":"https://example.com"}}</tool_call>'
+    )
+
+    events = processor.process_chunk(_make_output(MALFORMED))
+    events.extend(processor.process_chunk(_make_output(valid)))
+    events.extend(processor.process_chunk(_make_output("\nSuppressed.")))
+    events.extend(processor.finalize())
+
+    assert len([event for event in events if event.type == "tool_call"]) == 2
+    content = "".join(
+        event.content or "" for event in events if event.type in {"content", "finish"}
+    )
+    assert "Suppressed." not in content

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -5,6 +5,24 @@ import json
 
 import pytest
 
+# This file is the Linux parser-matrix entry point. Import the focused
+# malformed-call regressions so changed-line coverage exercises the full
+# parser/postprocessor feedback path on every supported Python version.
+from tests.test_hermes_malformed_tool_feedback import (  # noqa: F401
+    test_parser_accepts_typed_request_tool_models,
+    test_parser_does_not_promote_name_nested_inside_malformed_arguments,
+    test_parser_does_not_promote_undeclared_malformed_function,
+    test_parser_surfaces_declared_malformed_call_with_unparseable_arguments,
+    test_parser_surfaces_declared_malformed_json_call_for_executor_feedback,
+    test_stream_does_not_wedge_on_undeclared_malformed_function,
+    test_stream_finalize_emits_standard_tool_call_not_raw_xml,
+    test_stream_malformed_then_valid_in_one_chunk_suppresses_only_final_prose,
+    test_stream_preserves_later_prose_across_processing_modes,
+    test_stream_preserves_trailing_prose_once_when_it_arrives_later,
+    test_stream_preserves_trailing_prose_once_when_it_shares_the_close_chunk,
+    test_stream_valid_call_after_malformed_call_restores_prose_suppression,
+    test_stream_valid_call_does_not_preserve_same_chunk_trailing_prose,
+)
 from vllm_mlx.api.tool_calling import parse_tool_calls
 from vllm_mlx.tool_parsers import (
     AutoToolParser,

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -425,6 +425,11 @@ class StreamingPostProcessor:
         # onboarding sweep finding #5.
         self.accumulated_reasoning = ""
         self.tool_calls_detected = False
+        # A malformed Hermes call is deliberately promoted into a rejected
+        # tool invocation so the model can retry. Preserve ordinary prose
+        # following that synthetic call without changing the long-standing
+        # suppression behavior for valid/channel-routed calls.
+        self._preserve_post_tool_content = False
         # R11-A invariant tracker (PR 0.8.13 hotfix). Counts ``tool_call``
         # StreamEvents the postprocessor has actually emitted to the wire
         # this turn (i.e. the route layer will serialize a ``delta.tool_calls``
@@ -2406,6 +2411,7 @@ class StreamingPostProcessor:
         self.tool_accumulated_text = ""
         self.accumulated_reasoning = ""
         self.tool_calls_detected = False
+        self._preserve_post_tool_content = False
         # R11-A invariant tracker — see ``__init__`` for the contract. The
         # reset MUST clear this so a re-used processor doesn't carry the
         # prior turn's emitted-count into a new stream and lie to
@@ -2869,6 +2875,8 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                if result.get("preserve_post_tool_content"):
+                    self._preserve_post_tool_content = True
                 # When the streaming parser carries BOTH a content
                 # delta AND a tool-call delta in one return (one
                 # delta carried ``preface + tool_close`` — codex r4
@@ -2957,6 +2965,19 @@ class StreamingPostProcessor:
             content = result.get("content", "")
 
         if self.tool_calls_detected:
+            if self._preserve_post_tool_content and content:
+                content = sanitize_output(content)
+                if content:
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason=self._compute_finish_reason(output),
+                                content=content,
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return [StreamEvent(type="content", content=content)]
             if output.finished:
                 # R11-A: route the finish through ``_compute_finish_reason``
                 # so the wire-truth gate (``_tool_calls_emitted_to_wire``)
@@ -3267,6 +3288,8 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                if result.get("preserve_post_tool_content"):
+                    self._preserve_post_tool_content = True
                 # Combined content+tool delta — emit content half
                 # regardless of how the parallel-cap rules out the
                 # tool half (codex r6 MAJOR: enabling
@@ -3352,6 +3375,19 @@ class StreamingPostProcessor:
             content = result.get("content", "")
 
         if self.tool_calls_detected:
+            if self._preserve_post_tool_content and content:
+                content = sanitize_output(content)
+                if content:
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason=self._compute_finish_reason(output),
+                                content=content,
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return [StreamEvent(type="content", content=content)]
             if output.finished:
                 # R11-A: route the finish through ``_compute_finish_reason``
                 # so the wire-truth gate (``_tool_calls_emitted_to_wire``)
@@ -3468,6 +3504,8 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
+                if result.get("preserve_post_tool_content"):
+                    self._preserve_post_tool_content = True
                 # Combined content+tool delta — emit content half
                 # regardless of how the parallel-cap rules out the
                 # tool half (codex r6 MAJOR). Match the plain-content
@@ -3563,6 +3601,19 @@ class StreamingPostProcessor:
             content = strip_special_tokens(result.get("content", ""))
 
         if self.tool_calls_detected:
+            if self._preserve_post_tool_content and content:
+                content = sanitize_output(content)
+                if content:
+                    if output.finished:
+                        return [
+                            StreamEvent(
+                                type="finish",
+                                finish_reason=self._compute_finish_reason(output),
+                                content=content,
+                                tool_calls_detected=True,
+                            )
+                        ]
+                    return [StreamEvent(type="content", content=content)]
             if output.finished:
                 # R11-A: route the finish through ``_compute_finish_reason``
                 # so the wire-truth gate (``_tool_calls_emitted_to_wire``)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2875,8 +2875,9 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
-                if result.get("preserve_post_tool_content"):
-                    self._preserve_post_tool_content = True
+                self._preserve_post_tool_content = bool(
+                    result.get("preserve_post_tool_content")
+                )
                 # When the streaming parser carries BOTH a content
                 # delta AND a tool-call delta in one return (one
                 # delta carried ``preface + tool_close`` — codex r4
@@ -3288,8 +3289,9 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
-                if result.get("preserve_post_tool_content"):
-                    self._preserve_post_tool_content = True
+                self._preserve_post_tool_content = bool(
+                    result.get("preserve_post_tool_content")
+                )
                 # Combined content+tool delta — emit content half
                 # regardless of how the parallel-cap rules out the
                 # tool half (codex r6 MAJOR: enabling
@@ -3504,8 +3506,9 @@ class StreamingPostProcessor:
                     ]
                 return []
             if result.get("tool_calls"):
-                if result.get("preserve_post_tool_content"):
-                    self._preserve_post_tool_content = True
+                self._preserve_post_tool_content = bool(
+                    result.get("preserve_post_tool_content")
+                )
                 # Combined content+tool delta — emit content half
                 # regardless of how the parallel-cap rules out the
                 # tool half (codex r6 MAJOR). Match the plain-content

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -26,6 +26,13 @@ def generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    """Read a request/tool field from either wire dicts or typed models."""
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
 def _parse_function_body(
     body: str, valid_names: set[str] | None = None
 ) -> dict[str, Any] | None:
@@ -145,6 +152,16 @@ class HermesToolParser(ToolParser):
     NEMOTRON_PATTERN = re.compile(
         r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>", re.DOTALL
     )
+    # Recovery boundary for a canonical wrapper whose inner XML was cut off.
+    # This deliberately captures ONLY a closed <tool_call> wrapper with an
+    # explicit function header. It does not repair the body into executable
+    # JSON: callers must receive a normal tool call whose arguments fail their
+    # schema/JSON boundary, then return that parse error to the model for a
+    # correction round.
+    MALFORMED_NEMOTRON_PATTERN = re.compile(
+        r"<tool_call>\s*<function=([^>]+)>(.*?)</tool_call>", re.DOTALL
+    )
+    MALFORMED_JSON_NAME_PATTERN = re.compile(r'"name"\s*:\s*"([A-Za-z0-9_.:-]+)"')
     PARAM_PATTERN = re.compile(r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", re.DOTALL)
     REASONING_PATTERN = re.compile(
         r"<tool_call_reasoning>(.*?)</tool_call_reasoning>", re.DOTALL
@@ -306,6 +323,43 @@ class HermesToolParser(ToolParser):
                 if args is None:
                     return None
                 return (m.end(), name, json.dumps(args, ensure_ascii=False))
+            # A closed outer wrapper is enough to identify the protocol
+            # boundary, but never enough to authorize execution when the
+            # inner function/parameter XML is incomplete. Surface the call
+            # only when the request actually advertised that exact name and
+            # preserve the malformed body as deliberately non-JSON arguments.
+            # The executor then follows its ordinary fail-closed path and the
+            # tool error is fed back to the model for self-correction.
+            request_tools = _field(request, "tools", []) or []
+            declared_names = {
+                _field(_field(tool, "function"), "name") for tool in request_tools
+            }
+            malformed = cls.MALFORMED_NEMOTRON_PATTERN.match(text, pos)
+            if malformed is not None and "</function>" not in malformed.group(0):
+                name = malformed.group(1).strip()
+                if name and name in declared_names:
+                    raw_body = malformed.group(2).strip()
+                    arguments = f"<malformed_function_body>{raw_body}"
+                    return (malformed.end(), name, arguments)
+            # Same contract for the canonical JSON-body envelope: an outer
+            # close plus an advertised name and an arguments key establishes
+            # intent, but invalid JSON must remain invalid for the executor.
+            wrapper_end = text.find("</tool_call>", pos)
+            if wrapper_end >= 0:
+                end = wrapper_end + len("</tool_call>")
+                body = text[pos + len("<tool_call>") : wrapper_end].strip()
+                name_match = cls.MALFORMED_JSON_NAME_PATTERN.search(body)
+                if (
+                    body.startswith("{")
+                    and '"arguments"' in body
+                    and name_match is not None
+                    and name_match.group(1) in declared_names
+                ):
+                    return (
+                        end,
+                        name_match.group(1),
+                        f"<malformed_json_arguments>{body}",
+                    )
             return None
         if shape == "function_eq":
             # Shape #3: <function=NAME>...</function>

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -650,11 +650,19 @@ class HermesToolParser(ToolParser):
         return full_text[len(self._safe_content_prefix(full_text)) :]
 
     @classmethod
-    def _has_incomplete_structured_block(cls, text: str) -> bool:
+    def _has_incomplete_structured_block(
+        cls, text: str, request: dict[str, Any] | None = None
+    ) -> bool:
         """Heuristic: is the text currently inside an unclosed structured
         block of any of the three wire shapes? Used by the streaming
         branch to decide whether to suppress emit while a block is
         being assembled."""
+        # Remove every block the request-aware scanner can already account
+        # for. This matters for a closed outer wrapper whose inner function
+        # XML is malformed: its missing ``</function>`` must not keep the
+        # streaming parser wedged after the call has been safely promoted.
+        _, text = cls._scan_tool_call_shapes(text, request)
+
         # Shape #1 + #2 (<tool_call> wrapper)
         if text.count("<tool_call>") > text.count("</tool_call>"):
             return True
@@ -674,7 +682,9 @@ class HermesToolParser(ToolParser):
         return False
 
     @classmethod
-    def _completed_structured_tool_calls(cls, text: str) -> int:
+    def _completed_structured_tool_calls(
+        cls, text: str, request: dict[str, Any] | None = None
+    ) -> int:
         """Count completed structured tool calls in ``text``.
 
         Returns the count of *fully-closed* structured blocks across
@@ -691,8 +701,27 @@ class HermesToolParser(ToolParser):
         tag counting would briefly count a Nemotron inner close as a
         standalone bare-function close.
         """
-        matches, _ = cls._scan_tool_call_shapes(text)
+        matches, _ = cls._scan_tool_call_shapes(text, request)
         return len(matches)
+
+    @staticmethod
+    def _new_residual_content(
+        previous_length: int,
+        current_text: str,
+        spans: list[tuple[int, int, str, str]],
+    ) -> str:
+        """Return newly arrived bytes outside newly completed call spans."""
+        cursor = previous_length
+        residual: list[str] = []
+        for start, end, _name, _arguments in spans:
+            if end <= previous_length:
+                continue
+            if start > cursor:
+                residual.append(current_text[cursor:start])
+            cursor = max(cursor, end)
+        if cursor < len(current_text):
+            residual.append(current_text[cursor:])
+        return "".join(residual)
 
     def extract_tool_calls_streaming(
         self,
@@ -728,7 +757,7 @@ class HermesToolParser(ToolParser):
         )
 
         if has_any_opener:
-            if self._has_incomplete_structured_block(current_text):
+            if self._has_incomplete_structured_block(current_text, request):
                 # Inside an incomplete structured block — suppress output.
                 return None
 
@@ -742,8 +771,10 @@ class HermesToolParser(ToolParser):
             # up bare shapes nested inside (e.g. mid-stream Nemotron
             # XML reaches ``</function>\n`` before its outer
             # ``</tool_call>``).
-            prev_completed = self._completed_structured_tool_calls(previous_text)
-            cur_completed = self._completed_structured_tool_calls(current_text)
+            previous_matches, _ = self._scan_tool_call_shapes(previous_text, request)
+            current_matches, _ = self._scan_tool_call_shapes(current_text, request)
+            prev_completed = len(previous_matches)
+            cur_completed = len(current_matches)
             if cur_completed > prev_completed:
                 # Re-run the source-of-truth scan on current_text to
                 # get the WIRE-ORDERED list of completed tool calls in
@@ -753,9 +784,22 @@ class HermesToolParser(ToolParser):
                 if result.tools_called and len(result.tool_calls) > prev_completed:
                     new_calls = result.tool_calls[prev_completed:]
                     if new_calls:
-                        return self._format_streaming_tool_calls(
+                        formatted = self._format_streaming_tool_calls(
                             new_calls, start_index=prev_completed
                         )
+                        residual = self._new_residual_content(
+                            len(previous_text), current_text, current_matches
+                        )
+                        if residual:
+                            formatted["content"] = residual
+                        if any(
+                            call["arguments"].startswith(
+                                ("<malformed_function_body>", "<malformed_json_arguments>")
+                            )
+                            for call in new_calls
+                        ):
+                            formatted["preserve_post_tool_content"] = True
+                        return formatted
 
             # All current tool calls already emitted; emit post-call
             # content with prefix-hold applied so any partial sentinel

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -164,6 +164,7 @@ class HermesToolParser(ToolParser):
     MALFORMED_JSON_INTENT_PATTERN = re.compile(
         r'^\{\s*"name"\s*:\s*"([A-Za-z0-9_.:-]+)"\s*,\s*"arguments"\s*:'
     )
+    CLOSED_TOOL_WRAPPER_PATTERN = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL)
     PARAM_PATTERN = re.compile(r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", re.DOTALL)
     REASONING_PATTERN = re.compile(
         r"<tool_call_reasoning>(.*?)</tool_call_reasoning>", re.DOTALL
@@ -659,6 +660,12 @@ class HermesToolParser(ToolParser):
         # XML is malformed: its missing ``</function>`` must not keep the
         # streaming parser wedged after the call has been safely promoted.
         _, text = cls._scan_tool_call_shapes(text, request)
+        # A closed outer wrapper cannot still be an in-flight block. Unknown
+        # malformed function names intentionally remain ordinary content, so
+        # the request-aware scanner does not consume them; remove only their
+        # closed protocol boundary here to avoid wedging streaming forever on
+        # the unmatched inner ``<function=...>`` marker.
+        text = cls.CLOSED_TOOL_WRAPPER_PATTERN.sub("", text)
 
         # Shape #1 + #2 (<tool_call> wrapper)
         if text.count("<tool_call>") > text.count("</tool_call>"):
@@ -784,12 +791,7 @@ class HermesToolParser(ToolParser):
                         formatted = self._format_streaming_tool_calls(
                             new_calls, start_index=prev_completed
                         )
-                        residual = self._new_residual_content(
-                            len(previous_text), current_text, current_matches
-                        )
-                        if residual:
-                            formatted["content"] = residual
-                        if any(
+                        recovered_malformed = any(
                             call["arguments"].startswith(
                                 (
                                     "<malformed_function_body>",
@@ -797,7 +799,13 @@ class HermesToolParser(ToolParser):
                                 )
                             )
                             for call in new_calls
-                        ):
+                        )
+                        if recovered_malformed:
+                            residual = self._new_residual_content(
+                                len(previous_text), current_text, current_matches
+                            )
+                            if residual:
+                                formatted["content"] = residual
                             formatted["preserve_post_tool_content"] = True
                         return formatted
 

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -161,7 +161,9 @@ class HermesToolParser(ToolParser):
     MALFORMED_NEMOTRON_PATTERN = re.compile(
         r"<tool_call>\s*<function=([^>]+)>(.*?)</tool_call>", re.DOTALL
     )
-    MALFORMED_JSON_NAME_PATTERN = re.compile(r'"name"\s*:\s*"([A-Za-z0-9_.:-]+)"')
+    MALFORMED_JSON_INTENT_PATTERN = re.compile(
+        r'^\{\s*"name"\s*:\s*"([A-Za-z0-9_.:-]+)"\s*,\s*"arguments"\s*:'
+    )
     PARAM_PATTERN = re.compile(r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", re.DOTALL)
     REASONING_PATTERN = re.compile(
         r"<tool_call_reasoning>(.*?)</tool_call_reasoning>", re.DOTALL
@@ -348,16 +350,11 @@ class HermesToolParser(ToolParser):
             if wrapper_end >= 0:
                 end = wrapper_end + len("</tool_call>")
                 body = text[pos + len("<tool_call>") : wrapper_end].strip()
-                name_match = cls.MALFORMED_JSON_NAME_PATTERN.search(body)
-                if (
-                    body.startswith("{")
-                    and '"arguments"' in body
-                    and name_match is not None
-                    and name_match.group(1) in declared_names
-                ):
+                intent_match = cls.MALFORMED_JSON_INTENT_PATTERN.match(body)
+                if intent_match is not None and intent_match.group(1) in declared_names:
                     return (
                         end,
-                        name_match.group(1),
+                        intent_match.group(1),
                         f"<malformed_json_arguments>{body}",
                     )
             return None
@@ -794,7 +791,10 @@ class HermesToolParser(ToolParser):
                             formatted["content"] = residual
                         if any(
                             call["arguments"].startswith(
-                                ("<malformed_function_body>", "<malformed_json_arguments>")
+                                (
+                                    "<malformed_function_body>",
+                                    "<malformed_json_arguments>",
+                                )
                             )
                             for call in new_calls
                         ):

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -686,9 +686,7 @@ class HermesToolParser(ToolParser):
         return False
 
     @classmethod
-    def _completed_structured_tool_calls(
-        cls, text: str, request: dict[str, Any] | None = None
-    ) -> int:
+    def _completed_structured_tool_calls(cls, text: str) -> int:
         """Count completed structured tool calls in ``text``.
 
         Returns the count of *fully-closed* structured blocks across
@@ -705,7 +703,7 @@ class HermesToolParser(ToolParser):
         tag counting would briefly count a Nemotron inner close as a
         standalone bare-function close.
         """
-        matches, _ = cls._scan_tool_call_shapes(text, request)
+        matches, _ = cls._scan_tool_call_shapes(text)
         return len(matches)
 
     @staticmethod

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -709,22 +709,24 @@ class HermesToolParser(ToolParser):
         return len(matches)
 
     @staticmethod
-    def _new_residual_content(
-        previous_length: int,
+    def _residual_after_malformed_calls(
         current_text: str,
         spans: list[tuple[int, int, str, str]],
+        calls: list[dict[str, Any]],
     ) -> str:
-        """Return newly arrived bytes outside newly completed call spans."""
-        cursor = previous_length
+        """Return prose after malformed calls, stopping at the next call."""
         residual: list[str] = []
-        for start, end, _name, _arguments in spans:
-            if end <= previous_length:
+        for index, ((_start, end, _name, _arguments), call) in enumerate(
+            zip(spans, calls, strict=True)
+        ):
+            if not call["arguments"].startswith(
+                ("<malformed_function_body>", "<malformed_json_arguments>")
+            ):
                 continue
-            if start > cursor:
-                residual.append(current_text[cursor:start])
-            cursor = max(cursor, end)
-        if cursor < len(current_text):
-            residual.append(current_text[cursor:])
+            next_start = (
+                spans[index + 1][0] if index + 1 < len(spans) else len(current_text)
+            )
+            residual.append(current_text[end:next_start])
         return "".join(residual)
 
     def extract_tool_calls_streaming(
@@ -791,21 +793,20 @@ class HermesToolParser(ToolParser):
                         formatted = self._format_streaming_tool_calls(
                             new_calls, start_index=prev_completed
                         )
-                        recovered_malformed = any(
-                            call["arguments"].startswith(
-                                (
-                                    "<malformed_function_body>",
-                                    "<malformed_json_arguments>",
-                                )
-                            )
-                            for call in new_calls
+                        malformed_prefixes = (
+                            "<malformed_function_body>",
+                            "<malformed_json_arguments>",
                         )
-                        if recovered_malformed:
-                            residual = self._new_residual_content(
-                                len(previous_text), current_text, current_matches
-                            )
-                            if residual:
-                                formatted["content"] = residual
+                        final_call_is_malformed = new_calls[-1]["arguments"].startswith(
+                            malformed_prefixes
+                        )
+                        new_matches = current_matches[prev_completed:]
+                        residual = self._residual_after_malformed_calls(
+                            current_text, new_matches, new_calls
+                        )
+                        if residual:
+                            formatted["content"] = residual
+                        if final_call_is_malformed:
                             formatted["preserve_post_tool_content"] = True
                         return formatted
 


### PR DESCRIPTION
## Intention

Keep malformed Hermes/Qwen tool attempts inside the standard tool feedback loop so clients can reject them safely and let the model self-correct, instead of exposing raw protocol markup as assistant prose.

## Why

A model can close the outer tool envelope while truncating the inner XML or JSON arguments. Treating that output as assistant prose leaks protocol markup to users and prevents the normal executor-error/model-retry cycle. The recovery must remain fail-closed: only an advertised tool name is promoted, and its malformed arguments stay deliberately non-executable.

## Scope

- recover closed `<tool_call>` envelopes whose inner XML or JSON arguments are truncated
- promote only names explicitly advertised by the request
- preserve arguments as deliberately invalid JSON so the executor rejects them before dispatch
- preserve ordinary assistant prose following a recovered malformed call
- cover parser, streaming-finalize, typed-request, undeclared-tool, XML, JSON, and split-chunk cases

## Non-goals

- no output scrubbing or UI-only hiding
- no lenient repair followed by tool execution
- no new SSE/API extension
- no changes to well-formed tool calls or other parser families

## Verification

- `pytest -q`: 18,522 passed, 217 skipped, 45 deselected, 6 xfailed, 1 xpassed
- focused parser/postprocessor suite after review fix: 304 passed
- `ruff check .`
- `swift test`: 2,763 tests; two unrelated timing-sensitive suites failed under concurrent Studio GUI activity, then their 27 affected tests passed in isolation
- full local Desktop app with bundled sidecar built successfully
- Qwen3.5 9B live server: malformed assistant tool arguments + structured tool error produced a corrected, valid `browse` tool call on the next model turn

## Risk controls

Recovery requires a closed outer tool envelope and an exact advertised function name. The malformed body never becomes executable JSON; unknown functions remain ordinary content. Existing post-tool prose suppression remains unchanged for valid and channel-routed tool calls.
