### PR TITLE
fix(mirror): serve subfolder-per-quant repos from R2 instead of hard-declining

### DIFF
--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -547,6 +547,35 @@ def test_mirror_runs_subfolder_repos_with_allow_patterns(monkeypatch):
     assert seen == [None], "flat repo must pull the whole repo (allow_patterns=None)"
 
 
+def test_mirror_filter_discards_unselected_siblings_before_io(monkeypatch, tmp_path):
+    """The Linux gate exercises the real mirror-side filter, not only CLI wiring."""
+    from types import SimpleNamespace
+
+    import huggingface_hub
+
+    import vllm_mlx._mirror as mirror
+
+    info = SimpleNamespace(
+        sha="deadbeef",
+        siblings=[
+            SimpleNamespace(rfilename="8bit/model.safetensors", size=400, lfs=None),
+            SimpleNamespace(rfilename="LICENSE", size=50, lfs=None),
+        ],
+    )
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", mirror.MIRROR_DEFAULT)
+    monkeypatch.setattr(huggingface_hub, "model_info", lambda *a, **kw: info)
+
+    assert (
+        mirror.download_with_mirror_fallback(
+            REPO, cache_dir=tmp_path, allow_patterns=["4bit/*"]
+        )
+        is False
+    )
+    assert list(tmp_path.iterdir()) == [], (
+        "an empty selection must fall through before creating cache state"
+    )
+
+
 def test_registry_fails_closed_on_every_load_not_just_the_first(monkeypatch):
     """A caught validation error must not leave a usable registry behind.
 

--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -511,32 +511,40 @@ def test_cache_probe_does_not_invent_a_directory(tmp_path):
     assert _descend_to_checkpoint(str(snap), REPO) == str(snap)
 
 
-def test_mirror_declines_subfolder_repos(monkeypatch):
-    """The R2 mirror hydrates whole repos and has no per-folder mode.
+def test_mirror_runs_subfolder_repos_with_allow_patterns(monkeypatch):
+    """The mirror IS consulted for a subfolder repo — narrowed to its quant.
 
-    Letting it run on a subfolder repo would pull all eight quantizations
-    behind a progress bar that says "Pulling LiquidAI/LFM2.5-2.6B-MLX".
-    None of these repos is mirrored today; this guard is what keeps
-    mirroring one later from silently reintroducing the 20 GB pull.
+    A subfolder repo is mirrored one quant at a time (``mirror_to_r2.py
+    --subfolder 4bit``), so ``_try_mirror_prefetch`` hands the matching
+    ``allow_patterns`` down to the mirror instead of hard-declining it. The
+    ``allow_patterns`` is what stops the pull from enumerating all eight
+    quants (the 20 GB fear) — the mirror only fetches ``4bit/*``.
+
+    Regression guard: this used to ``return False`` for every subfolder repo
+    on the assumption none were mirrored, which stranded lfm2.5-2.6b-4bit's
+    R2 copy and routed the desktop through a HF path that could hang at
+    "Starting…".
     """
     import vllm_mlx.cli as cli
 
-    called: list[str] = []
+    seen: list[list[str] | None] = []
 
     def tripwire(*a, **kw):
-        called.append("mirror ran")
+        seen.append(kw.get("allow_patterns"))
         return True
 
     import vllm_mlx._mirror as mirror
 
     monkeypatch.setattr(mirror, "download_with_mirror_fallback", tripwire)
 
-    assert cli._try_mirror_prefetch(REPO) is False
-    assert called == [], "mirror must not be consulted for a subfolder repo"
+    # Subfolder repo → mirror runs, scoped to the declared quant.
+    assert cli._try_mirror_prefetch(REPO) is True
+    assert seen == [["4bit/*"]], "subfolder repo must reach the mirror with its glob"
 
-    # Control: a flat repo still goes through the mirror.
+    # Control: a flat repo still goes through the mirror with no filter.
+    seen.clear()
     assert cli._try_mirror_prefetch("mlx-community/LFM2.5-8B-A1B-MLX-4bit") is True
-    assert called == ["mirror ran"]
+    assert seen == [None], "flat repo must pull the whole repo (allow_patterns=None)"
 
 
 def test_registry_fails_closed_on_every_load_not_just_the_first(monkeypatch):

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4073,3 +4073,79 @@ def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
     assert ok
     assert suppress_seen[".gitattributes"] is True  # metadata → bar muted
     assert suppress_seen["model.safetensors"] is False  # weight → bar kept
+
+
+# ---------------------------------------------------------------------------
+# 8. Subfolder-per-quant repo — allow_patterns narrows the mirror pull to
+#    one quant's directory (regression: the CLI used to hard-decline the
+#    mirror for every subfolder repo, stranding lfm2.5-2.6b-4bit's R2 copy).
+# ---------------------------------------------------------------------------
+
+
+def test_subfolder_allow_patterns_fetches_only_that_quant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``allow_patterns=["4bit/*"]`` pulls ONLY the 4bit dir from R2.
+
+    The repo ships two quants (``4bit/`` + ``8bit/``) plus a root LICENSE;
+    only ``4bit/`` is mirrored. With the filter, the mirror must request and
+    land exactly the two ``4bit/`` files and NEVER touch ``8bit/`` or
+    ``LICENSE`` — proven by leaving those URLs unmocked, so any request for
+    them raises ``AssertionError`` from the router.
+    """
+    repo_id = "LiquidAI/LFM2.5-2.6B-MLX"
+    revision = "b41f2b65" * 5
+    # Full multi-quant sibling set as HF would report it.
+    files = [
+        ("4bit/config.json", 100),
+        ("4bit/model.safetensors", 200),
+        ("8bit/config.json", 110),
+        ("8bit/model.safetensors", 400),
+        ("LICENSE", 50),
+    ]
+    catalog = _catalog_payload([("lfm2.5-2.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # ONLY the 4bit files are routed (mirrored). 8bit/* and LICENSE are left
+    # unmocked on purpose — requesting them would raise from the router.
+    for fname, size in files:
+        if fname.startswith("4bit/"):
+            url = f"https://models.rapidmlx.com/LiquidAI/LFM2.5-2.6B-MLX/{fname}"
+            router.add(url, _FakeResponse(200, b"x" * size))
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        raise AssertionError(f"HF fallback should not fire for {filename}")
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf),
+    ):
+        ok = _mirror.download_with_mirror_fallback(
+            repo_id, cache_dir=tmp_path, allow_patterns=["4bit/*"]
+        )
+
+    assert ok, "the 4bit quant is fully mirrored — pull must succeed from R2"
+    snap = tmp_path / "models--LiquidAI--LFM2.5-2.6B-MLX" / "snapshots" / revision
+    on_disk = sorted(
+        str(p.relative_to(snap))
+        for p in snap.rglob("*")
+        if p.is_file() and not p.name.endswith(".rapid-mlx-mirror.lock")
+    )
+    assert on_disk == ["4bit/config.json", "4bit/model.safetensors"], (
+        "only the 4bit quant should land — 8bit/ and LICENSE must be filtered out"
+    )
+    # The router recorded every request; assert 8bit/LICENSE were never asked
+    # for (the unmocked-URL guard would already have raised, but pin it).
+    requested = [r["url"] for r in router.requests]
+    assert not any("/8bit/" in u for u in requested)
+    assert not any(u.endswith("/LICENSE") for u in requested)

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1431,6 +1431,7 @@ def download_with_mirror_fallback(
     *,
     revision: str | None = None,
     on_pull_start: Callable[[], None] | None = None,
+    allow_patterns: list[str] | None = None,
 ) -> bool:
     """Download ``repo_id`` to the HF cache via R2-first / HF-fallback.
 
@@ -1460,7 +1461,19 @@ def download_with_mirror_fallback(
     round-trips resolve). The CLI uses it to retire a "Resolving…" spinner so
     it doesn't collide with the download output. It never fires on the
     ``return False`` fall-through path.
+
+    ``allow_patterns`` narrows the enumerated repo to a subset of files,
+    ``fnmatch``-ed against each sibling's in-repo path — the SAME contract as
+    ``snapshot_download(allow_patterns=…)``. A subfolder-per-quant repo
+    (``LiquidAI/LFM2.5-2.6B-MLX`` ships eight quants side by side, of which
+    ``4bit/`` is one) is mirrored a single quant at a time, so the caller
+    passes ``["4bit/*"]`` to fetch ONLY that quant from R2 — without it the
+    enumeration would list all ~20 GB of siblings, 404 the non-mirrored quants
+    on R2, and fall each back to HF. ``None`` (the default) keeps the whole
+    repo, correct for the one-quant-per-repo layout every other mirror uses.
     """
+    from fnmatch import fnmatch
+
     from ._hf_logging import silence_hf_unauthenticated_warning
 
     # Whether we pull via R2 + hf_hub_download below or bail (returning
@@ -1542,6 +1555,16 @@ def download_with_mirror_fallback(
             # malicious, refuse to act on it. Punt to HF's own loader,
             # which has its own checks.
             return False
+        # Narrow to the requested subset (a subfolder-per-quant repo asks for
+        # one quant's directory). Filter HERE, before every downstream
+        # consumer — the plan count, byte total, fetch loop and verify pass all
+        # read ``files`` — so a subfolder pull can never enumerate, fetch, or
+        # measure the quants the caller didn't ask for. Match ``snapshot_
+        # download``'s semantics: a file is kept if it matches ANY pattern.
+        if allow_patterns is not None and not any(
+            fnmatch(rname, pat) for pat in allow_patterns
+        ):
+            continue
         size = getattr(s, "size", None)
         size = size if isinstance(size, int) else None
         lfs = getattr(s, "lfs", None)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1620,23 +1620,28 @@ def _try_mirror_prefetch(
     bugs in the mirror module surface as real stack traces instead of
     silently routing to ``snapshot_download``.
     """
-    from vllm_mlx.model_aliases import resolve_subfolder
+    from vllm_mlx.model_aliases import subfolder_allow_patterns
 
-    # The mirror mirrors whole repos; it has no notion of "just this
-    # folder". For a repo that ships one checkpoint per quantization that
-    # would hydrate every quant, so decline and let the HF path run with
-    # ``allow_patterns``. None of these repos is mirrored today — this is
-    # here so that mirroring one later can't silently turn a 1.6 GB pull
-    # into a 20 GB one.
-    if resolve_subfolder(model_name):
-        return False
+    # A subfolder-per-quant repo ships several quants side by side, so the
+    # mirror holds ONE quant's directory (uploaded via
+    # ``mirror_to_r2.py --subfolder <quant>``) and we hand the same
+    # ``allow_patterns`` down so the R2 pull fetches only that directory —
+    # never the whole ~20 GB quant matrix. ``None`` for the ordinary
+    # one-quant-per-repo layout leaves the mirror serving the full repo.
+    # (This used to hard-decline the mirror for every subfolder repo on the
+    # assumption that none were mirrored; ``lfm2.5-2.6b-4bit`` is, and the
+    # decline stranded its R2 copy while the HF path could hang the desktop
+    # at "Starting…".)
+    allow_patterns = subfolder_allow_patterns(model_name)
     try:
         from vllm_mlx._mirror import download_with_mirror_fallback
     except ImportError:
         # Mirror module not available (minimal-deps install or
         # deliberately removed). Use the legacy HF path.
         return False
-    return download_with_mirror_fallback(model_name, on_pull_start=on_pull_start)
+    return download_with_mirror_fallback(
+        model_name, on_pull_start=on_pull_start, allow_patterns=allow_patterns
+    )
 
 
 def _ensure_model_downloaded(


### PR DESCRIPTION
## Why

A user hit **`lfm2.5-2.6b-4bit` stuck at "Starting the download…"** in the desktop app. Root cause: the model **is** mirrored to R2 (correctly, under `4bit/`), but the engine **hard-declined the mirror for every subfolder-per-quant repo** and routed to HuggingFace, where the pull can hang on a slow/blackholed route. A full-catalog audit (221 mirrored models) found this is the **only** affected model — the sole subfolder-quant alias; the other 220 mirrors serve correctly.

## What

`_try_mirror_prefetch` used to `return False` for any repo with a `subfolder`, on the (now-false) assumption in its comment that *"None of these repos is mirrored today."* We mirrored `lfm2.5-2.6b-4bit` (4bit/ only, via `mirror_to_r2.py --subfolder 4bit`), so its R2 copy sat unused.

The reason for declining — fear that a subfolder pull would enumerate all eight quants (~20 GB) — is exactly what `allow_patterns` solves:

- **`download_with_mirror_fallback`** gains an `allow_patterns` param, `fnmatch`'d against each sibling's in-repo path (same contract as `snapshot_download(allow_patterns=…)`). Filtering happens at the **single point** where `files` is built, so the plan count, byte total, fetch loop and verify pass all read the narrowed set — a subfolder pull can never enumerate, fetch, or measure quants the caller didn't ask for.
- **`_try_mirror_prefetch`** passes `subfolder_allow_patterns(model_name)` down: `["4bit/*"]` for the one subfolder alias, `None` for every flat repo.

The catalog `download_url_base` stays `/<owner>/<repo>/` and R2 keys keep their full `4bit/…` path, so each file resolves to `…/LFM2.5-2.6B-MLX/4bit/config.json` — verified **206** on the live mirror.

## Impact

- The mirror we built now actually serves the model → CDN speed + the `[n/N]` progress protocol the desktop app parses (fixes the hang).
- Generalizes: any future subfolder-quant mirror works automatically.

## Tests

- Rewrote `test_mirror_declines_subfolder_repos` → **`test_mirror_runs_subfolder_repos_with_allow_patterns`** — asserts the mirror is now consulted with `["4bit/*"]` for a subfolder repo and `None` for a flat one.
- Added **`test_subfolder_allow_patterns_fetches_only_that_quant`** — a two-quant repo with only 4bit mirrored lands exactly the two 4bit files and never requests `8bit/` or `LICENSE`.
- `test_alias_subfolder.py` + `test_mirror_pull.py`: **143 pass**; `test_mirror_subfolder_selection.py` + `test_no_out_of_band_routing.py`: 40 pass. `ruff format` + `ruff check` clean.
- Live-confirmed on Studio (0.12.17): the alias resolves `subfolder=4bit` / `allow_patterns=['4bit/*']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)