### PR TITLE
fix(mac): smooth streaming Markdown rendering

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -436,6 +436,7 @@ struct ChatView: View {
                         TranscriptScrollPositionProbe(
                             isPinnedToBottom: $isPinnedToBottom,
                             bottomResumeSlack: bottomResumeSlack,
+                            isStreaming: viewModel.isStreaming,
                             scrollToBottomRequest: scrollToBottomRequest
                         )
                     )

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -213,11 +213,12 @@ struct PhotoCapabilityNotice: Equatable {
 /// or attachments.
 struct ChatView: View {
     @Bindable var viewModel: ChatViewModel
-    /// Compiled blocks for the streaming message. Keeps the raw streamed
-    /// string out of the streaming view's inputs — see
-    /// `StreamingMarkdownStore`. (`MessageRow` still receives the raw
-    /// `ChatMessage` for non-markdown concerns like tool chips.)
+    /// Incremental documents for assistant messages created in this view.
+    /// A completed row keeps its document so finishing never swaps renderers.
     @State private var streamingMarkdown = StreamingMarkdownStore()
+    /// Messages that started on the incremental renderer keep using it after
+    /// completion. The set changes once per response, not once per token.
+    @State private var incrementalAssistantIDs: Set<UUID> = []
     @Bindable var server: ServerManager
     @Binding var alias: String
     /// The single readiness value for this window, resolved once by
@@ -298,6 +299,20 @@ struct ChatView: View {
         )
     }
 
+    /// Startup failures and app-added grounding sources can change content
+    /// after `streamingBody` disappears. Observe only the retained live row so
+    /// token updates do not compare every completed message in the transcript.
+    private var retainedSettledAssistantBody: ChatViewModel.StreamingBody? {
+        guard let id = streamingMarkdown.documentMessageID,
+              incrementalAssistantIDs.contains(id),
+              let message = messages.first(where: { $0.id == id }),
+              message.role == .assistant,
+              message.status != .streaming else {
+            return nil
+        }
+        return .init(id: message.id, text: message.content)
+    }
+
     var body: some View {
         // The reader exists for one value: the surface's own width, which
         // the lifecycle band needs in order to pick its height on the
@@ -370,26 +385,66 @@ struct ChatView: View {
         } else {
             ScrollView {
                 transcriptRows
-                    .onChange(of: viewModel.streamingBody) { _, body in
-                        // The one place the raw string is fed into the
-                        // debounced compiler. The row itself is still
-                        // invalidated per SSE batch — `MessageRow` holds the
-                        // raw `ChatMessage` — but the expensive part (markdown
-                        // parse + block rebuild) now runs on the store's
-                        // 100 ms beat instead of once per delta.
+                    .onChange(of: viewModel.streamingBody, initial: true) { previous, body in
+                        // The one place the raw accumulated string enters the
+                        // presentation buffer. The live row does not receive
+                        // this growing value; display frames release deltas to
+                        // its incremental Markdown document instead.
                         if let body {
+                            if let previous, previous.id != body.id {
+                                streamingMarkdown.finish(
+                                    id: previous.id,
+                                    finalText: authoritativeContent(
+                                        for: previous.id,
+                                        fallback: previous.text
+                                    )
+                                )
+                            }
+                            if streamingMarkdown.documentMessageID != body.id {
+                                incrementalAssistantIDs.removeAll()
+                            }
+                            incrementalAssistantIDs.insert(body.id)
                             streamingMarkdown.enqueue(id: body.id, text: body.text)
+                        } else if let previous {
+                            streamingMarkdown.finish(
+                                id: previous.id,
+                                finalText: authoritativeContent(
+                                    for: previous.id,
+                                    fallback: previous.text
+                                )
+                            )
                         } else {
                             streamingMarkdown.finish()
+                        }
+                    }
+                    .onChange(of: retainedSettledAssistantBody) { _, body in
+                        guard let body else { return }
+                        streamingMarkdown.synchronizeCompleted(
+                            id: body.id,
+                            text: body.text
+                        )
+                    }
+                    .onChange(of: messages.map(\.id), initial: true) { _, ids in
+                        let visibleIDs = Set(ids)
+                        incrementalAssistantIDs.formIntersection(visibleIDs)
+                        if let owner = streamingMarkdown.documentMessageID,
+                           !visibleIDs.contains(owner) {
+                            streamingMarkdown.reset()
                         }
                     }
                     .background(
                         TranscriptScrollPositionProbe(
                             isPinnedToBottom: $isPinnedToBottom,
                             bottomResumeSlack: bottomResumeSlack,
-                            isStreaming: viewModel.isStreaming,
                             scrollToBottomRequest: scrollToBottomRequest
                         )
+                    )
+                    .background(
+                        StreamingPresentationDisplayLink(
+                            isActive: streamingMarkdown.isPresentationActive
+                        ) { duration in
+                            streamingMarkdown.advancePresentationFrame(duration: duration)
+                        }
                     )
             }
             // The probe is the single owner of transcript positioning.
@@ -404,6 +459,8 @@ struct ChatView: View {
             // at A's old scroll offset instead of B's latest message.
             .onChange(of: viewModel.activeConversationID) { _, _ in
                 isPinnedToBottom = true
+                incrementalAssistantIDs.removeAll()
+                streamingMarkdown.reset()
             }
             .overlay(alignment: .bottom) { jumpToBottomOverlay }
         }
@@ -455,18 +512,31 @@ struct ChatView: View {
         // and the cost is bounded by conversation length rather than
         // transcript length. Settled rows are not recompiled on streamed
         // deltas — `ForEach` re-instantiates only the row whose identity
-        // changed, and their markdown views read no per-delta state; profiled
-        // at ~0.2 % of the main thread during a stream. `MessageRow` itself
-        // still re-evaluates per delta (it holds the raw `ChatMessage`), but
-        // its expensive part, the markdown compile, is what this keeps cheap.
+        // changed, and their markdown views read no per-delta state. The live
+        // assistant receives a presentation snapshot whose growing prose is
+        // blanked while streaming, so a token update does not rebuild row
+        // chrome. Its Markdown child reads the incremental store directly.
         VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
             ForEach(messages) { message in
                 if message.role != .tool {
+                    let usesIncrementalMarkdown = message.role == .assistant
+                        && (
+                            message.status == .streaming
+                                || (
+                                    incrementalAssistantIDs.contains(message.id)
+                                        && streamingMarkdown.hasDocument(for: message.id)
+                                )
+                        )
                     MessageRow(
-                        message: message,
+                        message: ChatView.transcriptPresentationMessage(message),
                         isStreaming: viewModel.isStreaming,
-                        streamingMarkdown: streamingMarkdown,
                         toolResults: toolResults,
+                        assistantHasContent: message.role == .assistant
+                            ? !message.content.isEmpty
+                            : nil,
+                        streamingMarkdown: usesIncrementalMarkdown
+                            ? streamingMarkdown
+                            : nil,
                         onEdit: { newContent in
                             // Edit and Retry re-enter ``send`` inside the view
                             // model, so they answer to the same readiness gate
@@ -554,6 +624,23 @@ struct ChatView: View {
             if let id = m.toolCallID { out[id] = m }
         }
         return out
+    }
+
+    /// Keep transport deltas out of `MessageRow` while preserving all stable
+    /// metadata and the row's identity. The authoritative content continues
+    /// growing in the view model and is fed to `StreamingMarkdownStore`; the
+    /// completed snapshot enters this row exactly once when status settles.
+    static func transcriptPresentationMessage(_ message: ChatMessage) -> ChatMessage {
+        guard message.role == .assistant, message.status == .streaming else {
+            return message
+        }
+        var presentation = message
+        presentation.content = ""
+        return presentation
+    }
+
+    private func authoritativeContent(for id: UUID, fallback: String) -> String {
+        messages.first(where: { $0.id == id })?.content ?? fallback
     }
 
     /// Whether the lifecycle band owns the current moment.
@@ -1360,10 +1447,15 @@ struct ChatView: View {
 private struct MessageRow: View {
     let message: ChatMessage
     let isStreaming: Bool
-    let streamingMarkdown: StreamingMarkdownStore
     /// Tool-result rows keyed by the ``ToolCall.id`` they answer. Used to
     /// pair each dispatched call with its outcome inside this row.
     var toolResults: [String: ChatMessage] = [:]
+    /// The authoritative body is deliberately not part of `message` while it
+    /// streams. This one-bit projection changes only when content first lands.
+    var assistantHasContent: Bool? = nil
+    /// Present for assistant rows that originated from a live stream. Keeping
+    /// it after completion preserves the same incremental Markdown renderer.
+    var streamingMarkdown: StreamingMarkdownStore? = nil
     var onEdit: (String) -> Bool = { _ in false }
     var onRetry: () -> Bool = { false }
     /// Whether Retry can actually start a turn right now. Mirrors the
@@ -1644,22 +1736,16 @@ private struct MessageRow: View {
                 Text(ChatMessage.toolCallArtifactSuppressedCaptionCopy)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-            } else if !message.content.isEmpty {
-                // #1843: both paths now render through TextKit 2.
-                //
-                // Streaming goes through a debounced compiler that caches per
-                // message, so a flush reparses on a 100 ms beat instead of
-                // rebuilding a SwiftUI subtree from the whole accumulated
-                // string every time. That is the O(length²) term `8f7e0847`
-                // could only bound rather than remove.
-                //
-                // The split is per-message (`message.status`), not the view
-                // model's `isStreaming` — the latter is true for the whole
-                // transcript while the last answer arrives, so keying off it
-                // would swap every earlier message's renderer the moment a new
-                // one starts.
-                if message.status == .streaming {
-                    StreamingTextKitMarkdownView(store: streamingMarkdown)
+            } else if hasAssistantContent {
+                if let streamingMarkdown {
+                    // The same child remains mounted when status changes from
+                    // streaming to complete. Its final mutable tail is
+                    // committed in place; actions and stats appear below it
+                    // without replacing or remeasuring the Markdown renderer.
+                    StreamingTextKitMarkdownView(
+                        store: streamingMarkdown,
+                        messageID: message.id
+                    )
                 } else {
                     TextKitMarkdownView(content: message.content)
                 }
@@ -1705,6 +1791,10 @@ private struct MessageRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var hasAssistantContent: Bool {
+        assistantHasContent ?? !message.content.isEmpty
     }
 
     /// "Calling web_search…" filler for the window between a tool_calls

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -166,22 +166,39 @@ struct MarkdownCompiler: Sendable {
     private static func index(at location: SourceLocation, in source: String) -> String.Index? {
         guard location.line >= 1, location.column >= 1 else { return nil }
 
+        let utf8 = source.utf8
         var line = 1
-        var lineStart = source.startIndex
+        var lineStart = utf8.startIndex
         while line < location.line {
-            guard let newline = source[lineStart...].firstIndex(where: \.isNewline) else {
-                return nil
+            guard lineStart < utf8.endIndex else { return nil }
+            var cursor = lineStart
+            while cursor < utf8.endIndex, utf8[cursor] != 0x0A, utf8[cursor] != 0x0D {
+                cursor = utf8.index(after: cursor)
             }
-            lineStart = source.index(after: newline)
+            guard cursor < utf8.endIndex else { return nil }
+
+            // SourceLocation counts CRLF as one line ending. Consume the pair
+            // explicitly instead of relying on String's grapheme clustering.
+            if utf8[cursor] == 0x0D {
+                cursor = utf8.index(after: cursor)
+                if cursor < utf8.endIndex, utf8[cursor] == 0x0A {
+                    cursor = utf8.index(after: cursor)
+                }
+            } else {
+                cursor = utf8.index(after: cursor)
+            }
+            lineStart = cursor
             line += 1
         }
 
-        let utf8 = source.utf8
-        guard let utf8LineStart = lineStart.samePosition(in: utf8),
-              let utf8Target = utf8.index(
-                utf8LineStart,
+        var lineEnd = lineStart
+        while lineEnd < utf8.endIndex, utf8[lineEnd] != 0x0A, utf8[lineEnd] != 0x0D {
+            lineEnd = utf8.index(after: lineEnd)
+        }
+        guard let utf8Target = utf8.index(
+                lineStart,
                 offsetBy: location.column - 1,
-                limitedBy: utf8.endIndex
+                limitedBy: lineEnd
               ) else {
             return nil
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -64,6 +64,46 @@ struct MarkdownCompiler: Sendable {
             parsing: String(stablePrefix),
             options: [.parseBlockDirectives]
         )
+        if let definitionOffset = Self.firstReferenceDefinitionUTF8Offset(
+            in: stableDocument,
+            source: String(stablePrefix)
+        ),
+           let definitionUTF8 = source.utf8.index(
+            source.utf8.startIndex,
+            offsetBy: definitionOffset,
+            limitedBy: source.utf8.endIndex
+           ),
+           let definitionStart = definitionUTF8.samePosition(in: source) {
+            let safePrefix = source[..<definitionStart]
+            let safeSource = String(safePrefix)
+            let safeDocument = Document(
+                parsing: safeSource,
+                options: [.parseBlockDirectives]
+            )
+            if let blockedLocation = Self.firstPotentialReferenceBlock(
+                in: safeDocument,
+                source: safeSource
+            ),
+               let blockedStart = Self.index(at: blockedLocation, in: source) {
+                let prefixBeforeReference = source[..<blockedStart]
+                guard blockedStart > source.startIndex,
+                      Self.hasBlankLineBoundary(in: prefixBeforeReference) else {
+                    return nil
+                }
+                return TopLevelStreamingSplit(
+                    stablePrefix: String(prefixBeforeReference),
+                    mutableTail: String(source[blockedStart...])
+                )
+            }
+            guard definitionStart > source.startIndex,
+                  Self.hasBlankLineBoundary(in: safePrefix) else {
+                return nil
+            }
+            return TopLevelStreamingSplit(
+                stablePrefix: String(safePrefix),
+                mutableTail: String(source[definitionStart...])
+            )
+        }
         if let blockedLocation = Self.firstPotentialReferenceBlock(
             in: stableDocument,
             source: String(stablePrefix)
@@ -84,6 +124,37 @@ struct MarkdownCompiler: Sendable {
             stablePrefix: String(stablePrefix),
             mutableTail: String(source[tailStart...])
         )
+    }
+
+    /// Keep a definition and everything after it in one compiler document.
+    /// A later independently-compiled segment may reference it, while the
+    /// parser intentionally emits definitions as no visible AST node. Code
+    /// and HTML ranges are excluded so a literal `[name]: value` does not
+    /// disable incremental splitting for the rest of a code-heavy answer.
+    private static func firstReferenceDefinitionUTF8Offset(
+        in document: Document,
+        source: String
+    ) -> Int? {
+        var opaqueRanges: [Range<String.Index>] = []
+        collectReferenceOpaqueRanges(in: document, source: source, into: &opaqueRanges)
+
+        var searchStart = source.startIndex
+        while searchStart < source.endIndex,
+              let match = source.range(
+                of: #"(?m)^[ ]{0,3}\[[^\]\r\n]+\]:"#,
+                options: .regularExpression,
+                range: searchStart..<source.endIndex
+            ) {
+            if !opaqueRanges.contains(where: { $0.overlaps(match) }),
+               let utf8Index = match.lowerBound.samePosition(in: source.utf8) {
+                return source.utf8.distance(
+                    from: source.utf8.startIndex,
+                    to: utf8Index
+                )
+            }
+            searchStart = match.upperBound
+        }
+        return nil
     }
 
     /// Convert swift-markdown's one-based UTF-8 line/column location into a

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -141,7 +141,11 @@ struct MarkdownCompiler: Sendable {
         var searchStart = source.startIndex
         while searchStart < source.endIndex,
               let match = source.range(
-                of: #"(?m)^[ ]{0,3}\[[^\]\r\n]+\]:"#,
+                // Labels may contain escaped closing brackets and one or
+                // more soft line endings. This deliberately follows the
+                // parser's broad label surface; opaque AST ranges still keep
+                // definition-shaped code and HTML out of the result.
+                of: #"(?m)^[ ]{0,3}\[(?:\\.|[^\]])+\]:"#,
                 options: .regularExpression,
                 range: searchStart..<source.endIndex
             ) {

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -159,7 +159,10 @@ struct MarkdownCompiler: Sendable {
         var searchStart = scanRange.lowerBound
         while searchStart < scanRange.upperBound,
               let match = source.range(
-                of: #"(?<!\\)\[[^\]\n]+\](?!\()"#,
+                // CommonMark reference labels may contain a soft line
+                // ending. The scan is already bounded to one parsed block,
+                // so allowing newlines here cannot consume later blocks.
+                of: #"(?<!\\)\[[^\]]+\](?!\()"#,
                 options: .regularExpression,
                 range: searchStart..<scanRange.upperBound
               ) {

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -14,6 +14,14 @@ import Markdown
 /// streaming.
 struct MarkdownCompiler: Sendable {
 
+    /// A conservative streaming split: every top-level node before the last
+    /// one is structurally closed, while the last node remains mutable until a
+    /// following sibling proves its boundary.
+    struct TopLevelStreamingSplit: Equatable, Sendable {
+        let stablePrefix: String
+        let mutableTail: String
+    }
+
     /// Passes run over the compiled blocks, in order.
     ///
     /// Auto-linking by default because a bare URL rendering as dead text is a
@@ -23,6 +31,92 @@ struct MarkdownCompiler: Sendable {
 
     public init(postProcessors: [MarkdownPostProcessor] = [AutoLinkPostProcessor()]) {
         self.postProcessors = postProcessors
+    }
+
+    /// Split a growing Markdown fragment into a stable prefix and mutable tail.
+    ///
+    /// `swift-markdown` owns the block grammar and source ranges. Keeping the
+    /// final top-level node mutable is deliberately conservative: an unfinished
+    /// paragraph may still become emphasis, a link, or inline code; a list or
+    /// fence may still grow. Once another top-level sibling appears, nodes
+    /// before it can no longer be reinterpreted by later input.
+    func topLevelStreamingSplit(_ source: String) -> TopLevelStreamingSplit? {
+        guard !source.isEmpty else { return nil }
+        let document = Document(parsing: source, options: [.parseBlockDirectives])
+        let children = Array(document.children)
+        guard children.count > 1,
+              let tailLocation = children.last?.range?.lowerBound,
+              let tailStart = Self.index(at: tailLocation, in: source),
+              tailStart > source.startIndex else {
+            return nil
+        }
+        let stablePrefix = source[..<tailStart]
+        guard Self.hasBlankLineBoundary(in: stablePrefix),
+              !Self.containsPotentialReferenceLink(in: stablePrefix) else {
+            return nil
+        }
+
+        return TopLevelStreamingSplit(
+            stablePrefix: String(stablePrefix),
+            mutableTail: String(source[tailStart...])
+        )
+    }
+
+    /// Convert swift-markdown's one-based UTF-8 line/column location into a
+    /// native String index without assuming ASCII input or LF-only newlines.
+    private static func index(at location: SourceLocation, in source: String) -> String.Index? {
+        guard location.line >= 1, location.column >= 1 else { return nil }
+
+        var line = 1
+        var lineStart = source.startIndex
+        while line < location.line {
+            guard let newline = source[lineStart...].firstIndex(where: \.isNewline) else {
+                return nil
+            }
+            lineStart = source.index(after: newline)
+            line += 1
+        }
+
+        let utf8 = source.utf8
+        guard let utf8LineStart = lineStart.samePosition(in: utf8),
+              let utf8Target = utf8.index(
+                utf8LineStart,
+                offsetBy: location.column - 1,
+                limitedBy: utf8.endIndex
+              ) else {
+            return nil
+        }
+        return utf8Target.samePosition(in: source)
+    }
+
+    /// A new AST sibling is not by itself proof of a stable boundary. While a
+    /// GFM table row is still being typed, cmark temporarily reports an empty
+    /// table followed by a paragraph, then folds that paragraph into the table
+    /// once the row is complete. A blank line is the conservative CommonMark
+    /// boundary that prevents that cross-node reinterpretation.
+    private static func hasBlankLineBoundary(in prefix: Substring) -> Bool {
+        var newlineCount = 0
+        for character in prefix.reversed() {
+            if character.isNewline {
+                newlineCount += 1
+                if newlineCount >= 2 { return true }
+            } else if character == " " || character == "\t" {
+                continue
+            } else {
+                return false
+            }
+        }
+        return false
+    }
+
+    /// Reference-link definitions are document-global and may appear after the
+    /// paragraph they style. Keep reference-like brackets mutable, while still
+    /// allowing complete inline links such as `[label](URL)` to be committed.
+    private static func containsPotentialReferenceLink(in source: Substring) -> Bool {
+        source.range(
+            of: #"(?<!\\)\[[^\]\n]+\](?!\()"#,
+            options: .regularExpression
+        ) != nil
     }
 
     /// Drop a trailing fence marker that is still being typed.

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -51,9 +51,33 @@ struct MarkdownCompiler: Sendable {
             return nil
         }
         let stablePrefix = source[..<tailStart]
-        guard Self.hasBlankLineBoundary(in: stablePrefix),
-              !Self.containsPotentialReferenceLink(in: stablePrefix) else {
+        guard Self.hasBlankLineBoundary(in: stablePrefix) else {
             return nil
+        }
+
+        // Reparse only the candidate prefix so reference links count as
+        // resolved only when their definition is actually inside the chunk we
+        // are about to freeze. If one unresolved reference remains, commit the
+        // safe blocks before its top-level owner instead of pinning the whole
+        // growing answer behind it.
+        let stableDocument = Document(
+            parsing: String(stablePrefix),
+            options: [.parseBlockDirectives]
+        )
+        if let blockedLocation = Self.firstPotentialReferenceBlock(
+            in: stableDocument,
+            source: String(stablePrefix)
+        ),
+           let blockedStart = Self.index(at: blockedLocation, in: source) {
+            let safePrefix = source[..<blockedStart]
+            guard blockedStart > source.startIndex,
+                  Self.hasBlankLineBoundary(in: safePrefix) else {
+                return nil
+            }
+            return TopLevelStreamingSplit(
+                stablePrefix: String(safePrefix),
+                mutableTail: String(source[blockedStart...])
+            )
         }
 
         return TopLevelStreamingSplit(
@@ -109,14 +133,68 @@ struct MarkdownCompiler: Sendable {
         return false
     }
 
-    /// Reference-link definitions are document-global and may appear after the
-    /// paragraph they style. Keep reference-like brackets mutable, while still
-    /// allowing complete inline links such as `[label](URL)` to be committed.
-    private static func containsPotentialReferenceLink(in source: Substring) -> Bool {
-        source.range(
-            of: #"(?<!\\)\[[^\]\n]+\](?!\()"#,
-            options: .regularExpression
-        ) != nil
+    /// Return the first top-level block that still contains unresolved
+    /// reference-like syntax. swift-markdown turns a resolved reference into a
+    /// `Link`; code and HTML are opaque, so brackets in those nodes cannot hold
+    /// later blocks mutable.
+    private static func firstPotentialReferenceBlock(
+        in document: Document,
+        source: String
+    ) -> SourceLocation? {
+        for child in document.children
+        where containsPotentialReferenceLink(in: child, source: source) {
+            if let location = child.range?.lowerBound { return location }
+        }
+        return nil
+    }
+
+    private static func containsPotentialReferenceLink(
+        in markup: Markup,
+        source: String
+    ) -> Bool {
+        guard let scanRange = sourceRange(of: markup, in: source) else { return false }
+        var opaqueRanges: [Range<String.Index>] = []
+        collectReferenceOpaqueRanges(in: markup, source: source, into: &opaqueRanges)
+
+        var searchStart = scanRange.lowerBound
+        while searchStart < scanRange.upperBound,
+              let match = source.range(
+                of: #"(?<!\\)\[[^\]\n]+\](?!\()"#,
+                options: .regularExpression,
+                range: searchStart..<scanRange.upperBound
+              ) {
+            if !opaqueRanges.contains(where: { $0.overlaps(match) }) { return true }
+            searchStart = match.upperBound
+        }
+        return false
+    }
+
+    private static func collectReferenceOpaqueRanges(
+        in markup: Markup,
+        source: String,
+        into ranges: inout [Range<String.Index>]
+    ) {
+        switch markup {
+        case is CodeBlock, is InlineCode, is Link, is Image, is HTMLBlock, is InlineHTML:
+            if let range = sourceRange(of: markup, in: source) { ranges.append(range) }
+        default:
+            for child in markup.children {
+                collectReferenceOpaqueRanges(in: child, source: source, into: &ranges)
+            }
+        }
+    }
+
+    private static func sourceRange(
+        of markup: Markup,
+        in source: String
+    ) -> Range<String.Index>? {
+        guard let range = markup.range,
+              let lowerBound = index(at: range.lowerBound, in: source),
+              let upperBound = index(at: range.upperBound, in: source),
+              lowerBound <= upperBound else {
+            return nil
+        }
+        return lowerBound..<upperBound
     }
 
     /// Drop a trailing fence marker that is still being typed.

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MessageMarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MessageMarkdownCompiler.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 
-/// ⚠️ UNWIRED — not instantiated anywhere in this app. The production
-/// streaming compiler is ``StreamingMarkdownStore`` (also a 100 ms debounce,
-/// per-message, with a revision token); this class is a prototype port from
-/// native-chat that nothing calls. Keep it for a future PR or delete it —
-/// either way it must not be mistaken for the live stage-two below.
+/// ⚠️ UNWIRED — not instantiated anywhere in this app. The production path is
+/// ``StreamingMarkdownStore`` with a frame-driven presentation buffer and an
+/// incremental document; this class is a prototype port from native-chat that
+/// nothing calls. Keep it for a future PR or delete it — either way it must not
+/// be mistaken for the live stage-two below.
 ///
 /// Debounced markdown compilation for streaming messages.
 ///

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
@@ -79,15 +79,51 @@ struct StreamingMarkdownDocument: Sendable {
     }
 
     var segments: [Segment] {
-        var output = stableBlocks.map {
+        var raw = stableBlocks.map {
             Segment(id: $0.id, result: $0.result, isMutable: false)
         }
         if !mutableResult.items.isEmpty {
-            output.append(Segment(
+            raw.append(Segment(
                 id: mutableID,
                 result: mutableResult,
                 isMutable: true
             ))
+        }
+        var output: [Segment] = []
+        for segment in raw {
+            guard var previous = output.last,
+                  case let .images(previousImages)? = previous.result.items.last,
+                  case let .images(nextImages)? = segment.result.items.first
+            else {
+                output.append(segment)
+                continue
+            }
+
+            var previousItems = previous.result.items
+            previousItems[previousItems.count - 1] = .images(.init(
+                urls: previousImages.urls + nextImages.urls,
+                altTexts: previousImages.altTexts + nextImages.altTexts
+            ))
+            previous = Segment(
+                id: previous.id,
+                result: MarkdownResult(
+                    items: previousItems,
+                    revision: max(previous.result.revision, segment.result.revision)
+                ),
+                isMutable: previous.isMutable || segment.isMutable
+            )
+            output[output.count - 1] = previous
+
+            let remaining = Array(segment.result.items.dropFirst())
+            if !remaining.isEmpty {
+                output.append(Segment(
+                    id: segment.id,
+                    result: MarkdownResult(
+                        items: remaining, revision: segment.result.revision
+                    ),
+                    isMutable: segment.isMutable
+                ))
+            }
         }
         return output
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
@@ -26,8 +26,13 @@ struct StreamingMarkdownDocument: Sendable {
     struct CompilationStats: Equatable, Sendable {
         private(set) var stableFragmentCompilations = 0
         private(set) var mutableTailCompilations = 0
+        private(set) var splitProbes = 0
         private(set) var totalCompiledUTF8Bytes = 0
         private(set) var largestCompiledFragmentUTF8Bytes = 0
+
+        mutating func recordSplitProbe() {
+            splitProbes += 1
+        }
 
         mutating func recordStable(_ source: String) {
             stableFragmentCompilations += 1
@@ -49,6 +54,7 @@ struct StreamingMarkdownDocument: Sendable {
     private let compiler: MarkdownCompiler
     private(set) var mutableID = 0
     private var revision = 0
+    private var splitBoundaryTracker = SplitBoundaryTracker()
 
     private(set) var receivedSource = ""
     private(set) var stableBlocks: [StableBlock] = []
@@ -88,11 +94,15 @@ struct StreamingMarkdownDocument: Sendable {
 
     mutating func append(_ delta: String) {
         guard !delta.isEmpty, !isFinished else { return }
+        let shouldProbeForSplit = splitBoundaryTracker.consume(delta)
         receivedSource += delta
         mutableSource += delta
 
         revision += 1
-        commitStablePrefixIfAvailable()
+        if shouldProbeForSplit {
+            commitStablePrefixIfAvailable()
+            splitBoundaryTracker.reset(to: mutableSource)
+        }
         compileMutableTail(isComplete: false)
     }
 
@@ -117,7 +127,9 @@ struct StreamingMarkdownDocument: Sendable {
     }
 
     private mutating func commitStablePrefixIfAvailable() {
-        while let split = compiler.topLevelStreamingSplit(mutableSource) {
+        while true {
+            compilationStats.recordSplitProbe()
+            guard let split = compiler.topLevelStreamingSplit(mutableSource) else { return }
             let stable = compile(split.stablePrefix, isComplete: true, stable: true)
             if !stable.items.isEmpty {
                 stableBlocks.append(StableBlock(
@@ -128,6 +140,33 @@ struct StreamingMarkdownDocument: Sendable {
                 mutableID += 1
             }
             mutableSource = split.mutableTail
+        }
+    }
+
+    /// A stable split requires a blank line followed by the first character of
+    /// a new block. Track that cheap lexical event so ordinary display frames
+    /// do not parse the tail once for probing and again for rendering.
+    private struct SplitBoundaryTracker: Sendable {
+        private var trailingLineBreaks = 0
+
+        mutating func consume(_ text: String) -> Bool {
+            var establishedBoundary = false
+            for character in text {
+                if character.isNewline {
+                    trailingLineBreaks += 1
+                } else if character == " " || character == "\t" {
+                    continue
+                } else {
+                    if trailingLineBreaks >= 2 { establishedBoundary = true }
+                    trailingLineBreaks = 0
+                }
+            }
+            return establishedBoundary
+        }
+
+        mutating func reset(to source: String) {
+            self = SplitBoundaryTracker()
+            _ = consume(source)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/StreamingMarkdownDocument.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Incremental Markdown state for one streaming assistant response.
+///
+/// Only the final top-level Markdown node remains mutable. Once a following
+/// sibling establishes a boundary, the preceding source is compiled into an
+/// immutable chunk and is never parsed again. This bounds repeated work to the
+/// current paragraph, list, table, or fenced block instead of the full reply.
+struct StreamingMarkdownDocument: Sendable {
+
+    struct StableBlock: Identifiable, Equatable, Sendable {
+        let id: Int
+        let source: String
+        let result: MarkdownResult
+    }
+
+    /// One independently-rendered document chunk. The mutable tail keeps its
+    /// ID when it is committed, so SwiftUI can preserve the TextKit view that
+    /// was already showing it and mount only the newly-created tail.
+    struct Segment: Identifiable, Equatable, Sendable {
+        let id: Int
+        let result: MarkdownResult
+        let isMutable: Bool
+    }
+
+    struct CompilationStats: Equatable, Sendable {
+        private(set) var stableFragmentCompilations = 0
+        private(set) var mutableTailCompilations = 0
+        private(set) var totalCompiledUTF8Bytes = 0
+        private(set) var largestCompiledFragmentUTF8Bytes = 0
+
+        mutating func recordStable(_ source: String) {
+            stableFragmentCompilations += 1
+            record(source)
+        }
+
+        mutating func recordTail(_ source: String) {
+            mutableTailCompilations += 1
+            record(source)
+        }
+
+        private mutating func record(_ source: String) {
+            let count = source.utf8.count
+            totalCompiledUTF8Bytes += count
+            largestCompiledFragmentUTF8Bytes = max(largestCompiledFragmentUTF8Bytes, count)
+        }
+    }
+
+    private let compiler: MarkdownCompiler
+    private(set) var mutableID = 0
+    private var revision = 0
+
+    private(set) var receivedSource = ""
+    private(set) var stableBlocks: [StableBlock] = []
+    private(set) var mutableSource = ""
+    private(set) var mutableResult: MarkdownResult = .empty
+    private(set) var compilationStats = CompilationStats()
+    private(set) var isFinished = false
+
+    init(compiler: MarkdownCompiler = MarkdownCompiler()) {
+        self.compiler = compiler
+    }
+
+    /// The renderable snapshot. Stable chunks retain their identity separately;
+    /// this flattened result exists for parity checks and the future UI bridge.
+    var result: MarkdownResult {
+        MarkdownResult(
+            items: Self.coalescingAdjacentImages(
+                stableBlocks.flatMap(\.result.items) + mutableResult.items
+            ),
+            revision: revision
+        )
+    }
+
+    var segments: [Segment] {
+        var output = stableBlocks.map {
+            Segment(id: $0.id, result: $0.result, isMutable: false)
+        }
+        if !mutableResult.items.isEmpty {
+            output.append(Segment(
+                id: mutableID,
+                result: mutableResult,
+                isMutable: true
+            ))
+        }
+        return output
+    }
+
+    mutating func append(_ delta: String) {
+        guard !delta.isEmpty, !isFinished else { return }
+        receivedSource += delta
+        mutableSource += delta
+
+        revision += 1
+        commitStablePrefixIfAvailable()
+        compileMutableTail(isComplete: false)
+    }
+
+    /// Commit the final tail in place. This never recompiles the stable prefix.
+    mutating func finish() {
+        guard !isFinished else { return }
+        revision += 1
+        if !mutableSource.isEmpty {
+            let final = compile(mutableSource, isComplete: true, stable: true)
+            if !final.items.isEmpty {
+                stableBlocks.append(StableBlock(
+                    id: mutableID,
+                    source: mutableSource,
+                    result: final
+                ))
+                mutableID += 1
+            }
+        }
+        mutableSource = ""
+        mutableResult = .empty
+        isFinished = true
+    }
+
+    private mutating func commitStablePrefixIfAvailable() {
+        while let split = compiler.topLevelStreamingSplit(mutableSource) {
+            let stable = compile(split.stablePrefix, isComplete: true, stable: true)
+            if !stable.items.isEmpty {
+                stableBlocks.append(StableBlock(
+                    id: mutableID,
+                    source: split.stablePrefix,
+                    result: stable
+                ))
+                mutableID += 1
+            }
+            mutableSource = split.mutableTail
+        }
+    }
+
+    private mutating func compileMutableTail(isComplete: Bool) {
+        guard !mutableSource.isEmpty else {
+            mutableResult = .empty
+            return
+        }
+        mutableResult = compile(mutableSource, isComplete: isComplete, stable: false)
+    }
+
+    private mutating func compile(
+        _ source: String, isComplete: Bool, stable: Bool
+    ) -> MarkdownResult {
+        if stable {
+            compilationStats.recordStable(source)
+        } else {
+            compilationStats.recordTail(source)
+        }
+        return compiler.compile(source, revision: revision, isComplete: isComplete)
+    }
+
+    /// `MarkdownCompiler` merges adjacent image-only paragraphs. Stable chunks
+    /// are compiled independently, so preserve that document-level behavior
+    /// when flattening them back into one result.
+    private static func coalescingAdjacentImages(_ items: [MarkdownItem]) -> [MarkdownItem] {
+        var output: [MarkdownItem] = []
+        for item in items {
+            if case let .images(next) = item,
+               case let .images(previous)? = output.last {
+                output[output.count - 1] = .images(.init(
+                    urls: previous.urls + next.urls,
+                    altTexts: previous.altTexts + next.altTexts
+                ))
+            } else {
+                output.append(item)
+            }
+        }
+        return output
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
@@ -106,7 +106,7 @@ final class TextFadeAnimator {
     ///
     /// That is the common case here, not the rare one. `MessageRow` takes the
     /// raw `ChatMessage`, so every SSE delta (~16 ms) re-renders it, while the
-    /// blocks only change on the compiler's 100 ms beat — five out of six
+    /// blocks only change on the compiler's coalesced beat — five out of six
     /// passes wipe without restoring. native-chat avoids it structurally by
     /// handing its row a compiled, `Equatable` view model keyed on the
     /// compile revision, so SwiftUI skips the pass entirely.

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
@@ -74,11 +74,17 @@ final class TextFadeAnimator {
     /// Called when a message finishes or the transcript changes, so a
     /// re-render does not replay the whole reveal.
     public func reset() {
+        stopAndReveal()
+        animationState.reset()
+    }
+
+    /// Stop this block's animator without resetting the message-wide pacing
+    /// state shared by the next mutable segment.
+    func stopAndReveal() {
         displayLink.stop()
         fadingParts.removeAll()
         scheduledLength = 0
         lastGrowthTime = nil
-        animationState.reset()
         clearRenderingAttributes()
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownBlockStack.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownBlockStack.swift
@@ -43,19 +43,23 @@ struct MarkdownBlockStack: View {
 
     public var body: some View {
         let groups = self.groups
-        let lastTextIndex = groups.lastIndex { if case .text = $0 { return true } else { return false } }
+        let lastTextID = groups.last {
+            if case .text = $0.content { return true }
+            return false
+        }?.id
 
         VStack(alignment: .leading, spacing: options.interContentSpacing) {
-            ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
-                switch group {
+            ForEach(groups) { group in
+                switch group.content {
                 case .text(let blocks):
                     MarkdownTextBlockRepresentable(
                         blocks: blocks,
                         options: options,
+                        revision: result.revision,
                         // Only the trailing text group grows during a stream —
                         // earlier ones are already stable, and fading them
                         // would replay text the reader has read.
-                        streaming: isStreaming && index == lastTextIndex,
+                        streaming: isStreaming && group.id == lastTextID,
                         fadeState: fadeState,
                         fadeConfiguration: fadeConfiguration
                     )
@@ -87,21 +91,32 @@ struct MarkdownBlockStack: View {
         }
     }
 
-    private enum Group {
-        case text([MarkdownItem.TextBlock])
-        case code(MarkdownItem.CodeBlock)
-        case table(MarkdownItem.TableBlock)
-        case images(MarkdownItem.ImagesBlock)
-        case math(MarkdownItem.MathBlock)
+    private struct Group: Identifiable {
+        let id: String
+        let content: Content
+
+        enum Content {
+            case text([MarkdownItem.TextBlock])
+            case code(MarkdownItem.CodeBlock)
+            case table(MarkdownItem.TableBlock)
+            case images(MarkdownItem.ImagesBlock)
+            case math(MarkdownItem.MathBlock)
+        }
     }
 
     private var groups: [Group] {
         var groups: [Group] = []
         var pendingText: [MarkdownItem.TextBlock] = []
+        var textIndex = 0
+        var codeIndex = 0
+        var tableIndex = 0
+        var imagesIndex = 0
+        var mathIndex = 0
 
         func flushText() {
             guard !pendingText.isEmpty else { return }
-            groups.append(.text(pendingText))
+            groups.append(Group(id: "text-\(textIndex)", content: .text(pendingText)))
+            textIndex += 1
             pendingText = []
         }
 
@@ -110,13 +125,21 @@ struct MarkdownBlockStack: View {
             case .text(let block):
                 pendingText.append(block)
             case .code(let block):
-                flushText(); groups.append(.code(block))
+                flushText()
+                groups.append(Group(id: "code-\(codeIndex)", content: .code(block)))
+                codeIndex += 1
             case .table(let block):
-                flushText(); groups.append(.table(block))
+                flushText()
+                groups.append(Group(id: "table-\(tableIndex)", content: .table(block)))
+                tableIndex += 1
             case .images(let block):
-                flushText(); groups.append(.images(block))
+                flushText()
+                groups.append(Group(id: "images-\(imagesIndex)", content: .images(block)))
+                imagesIndex += 1
             case .math(let block):
-                flushText(); groups.append(.math(block))
+                flushText()
+                groups.append(Group(id: "math-\(mathIndex)", content: .math(block)))
+                mathIndex += 1
             }
         }
         flushText()
@@ -128,6 +151,7 @@ struct MarkdownBlockStack: View {
 private struct MarkdownTextBlockRepresentable: NSViewRepresentable {
     let blocks: [MarkdownItem.TextBlock]
     let options: MarkdownOptions
+    let revision: Int?
     var streaming: Bool = false
     var fadeState: TextFadeAnimationState?
     var fadeConfiguration: TextFadeConfiguration = TextFadeConfiguration()
@@ -150,6 +174,7 @@ private struct MarkdownTextBlockRepresentable: NSViewRepresentable {
         view.configure(
             blocks: blocks,
             options: options,
+            revision: revision,
             streaming: streaming,
             fadeState: fadeState,
             fadeConfiguration: fadeConfiguration

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -28,6 +28,15 @@ final class MarkdownTextBlockView: NSView {
     /// ``updateTypingDotLayer``.
     private var typingDotLayer: CAShapeLayer?
 
+    /// SwiftUI may update the representable for every transport delta even
+    /// when the coalesced Markdown result is unchanged. Keep the rendered
+    /// identity and measurement cache so those updates stay no-ops.
+    private var hasConfiguredContent = false
+    private var renderedRevision: Int?
+    private var renderedStreaming = false
+    private var measuredWidth: CGFloat?
+    private var measuredHeight: CGFloat?
+
     public override var isFlipped: Bool { true }
 
     public init(options: MarkdownOptions) {
@@ -44,7 +53,10 @@ final class MarkdownTextBlockView: NSView {
     required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
 
     public func configure(blocks: [MarkdownItem.TextBlock], options: MarkdownOptions) {
-        configure(blocks: blocks, options: options, streaming: false, fadeState: nil)
+        configure(
+            blocks: blocks, options: options, revision: nil,
+            streaming: false, fadeState: nil
+        )
     }
 
     /// Configure, optionally animating text that is arriving now.
@@ -55,11 +67,11 @@ final class MarkdownTextBlockView: NSView {
     public func configure(
         blocks: [MarkdownItem.TextBlock],
         options: MarkdownOptions,
+        revision: Int? = nil,
         streaming: Bool,
         fadeState: TextFadeAnimationState?,
         fadeConfiguration: TextFadeConfiguration = TextFadeConfiguration()
     ) {
-        let contentGrew = streaming && blocks != self.blocks
         // The dot answers "is anything happening?" — a question only worth
         // answering while there is nothing to read. Once the first words
         // arrive, the fade-in of each new word says the same thing better,
@@ -68,17 +80,39 @@ final class MarkdownTextBlockView: NSView {
         // and `showsTypingDotWhenStreaming` are separate fields, so a stream
         // can run without one.
         let wantsDot = Self.showsTypingDot(streaming: streaming, blocks: blocks)
+        let optionsChanged = !hasConfiguredContent
+            || !Self.sameRenderingOptions(self.options, options)
+        let contentChanged = !hasConfiguredContent
+            || blocks != self.blocks
+            || revision != renderedRevision
+            || optionsChanged
         let dotChanged = wantsDot != showsTypingDot
+        let streamingChanged = streaming != renderedStreaming
+
+        // The parent row can still receive raw message updates while the
+        // compiled result is unchanged. Do not replace TextKit storage or
+        // invalidate transcript layout for those passes.
+        guard contentChanged || dotChanged || streamingChanged else { return }
+
+        let contentGrew = streaming && contentChanged
         self.blocks = blocks
         self.options = options
+        self.renderedRevision = revision
         self.showsTypingDot = wantsDot
+        self.renderedStreaming = streaming
+        self.hasConfiguredContent = true
 
         renderer.update(options: options)
-        renderer.setBlocks(blocks, showsTypingDot: wantsDot)
+        var storageUpdate: MarkdownTextRenderer.TextStorageUpdate?
+        if contentChanged || dotChanged {
+            storageUpdate = renderer.setBlocks(blocks, showsTypingDot: wantsDot)
+        }
         // A custom-drawn NSView has no automatic text semantics. Mirror the
         // backing text into AX so VoiceOver and GUI automation can read the
         // answer just as they could through MarkdownUI's native Text views.
-        setAccessibilityValue(renderer.accessibleText)
+        if contentChanged || dotChanged {
+            setAccessibilityValue(renderer.accessibleText)
+        }
 
         if streaming, fadeConfiguration.isEnabled, let fadeState {
             let animator: TextFadeAnimator
@@ -99,11 +133,12 @@ final class MarkdownTextBlockView: NSView {
             }
             animator.configuration = fadeConfiguration
             animator.textColor = options.textColor
+            if case .replaced = storageUpdate {
+                animator.storageDidReset()
+            }
             if contentGrew || dotChanged {
                 animator.contentDidGrow()
-            } else {
-                // `setBlocks` above wiped the rendering attributes even though
-                // nothing changed. Without this the fade never comes back.
+            } else if storageUpdate != nil {
                 animator.storageDidReset()
             }
         } else if let animator = fadeAnimator {
@@ -116,7 +151,9 @@ final class MarkdownTextBlockView: NSView {
 
         updateTypingDotAnimation()
         needsDisplay = true
-        invalidateIntrinsicContentSize()
+        if contentChanged || dotChanged, intrinsicHeightChangedAfterUpdate() {
+            invalidateIntrinsicContentSize()
+        }
     }
 
     /// Whether the typing dot should be shown.
@@ -162,7 +199,10 @@ final class MarkdownTextBlockView: NSView {
 
     /// Measure without rendering. Cheap enough to call for every offscreen row.
     public func height(forWidth width: CGFloat) -> CGFloat {
-        renderer.measureHeight(width: width)
+        let height = renderer.measureHeight(width: width)
+        measuredWidth = width
+        measuredHeight = height
+        return height
     }
 
     /// The width the text actually occupies when laid out at `maxWidth`.
@@ -176,13 +216,96 @@ final class MarkdownTextBlockView: NSView {
     public override var intrinsicContentSize: NSSize {
         let width = bounds.width
         guard width > 0 else { return NSSize(width: NSView.noIntrinsicMetric, height: 0) }
-        return NSSize(width: NSView.noIntrinsicMetric, height: renderer.measureHeight(width: width))
+        let height = renderer.measureHeight(width: width)
+        measuredWidth = width
+        measuredHeight = height
+        return NSSize(width: NSView.noIntrinsicMetric, height: height)
+    }
+
+    /// A visual text append does not always change the row's height. Avoid
+    /// asking SwiftUI to reposition the transcript in that case.
+    private func intrinsicHeightChangedAfterUpdate() -> Bool {
+        let width = bounds.width
+        guard width > 0 else {
+            measuredWidth = nil
+            measuredHeight = nil
+            return true
+        }
+
+        let newHeight = renderer.measureHeight(width: width)
+        defer {
+            measuredWidth = width
+            measuredHeight = newHeight
+        }
+        guard let oldWidth = measuredWidth,
+              let oldHeight = measuredHeight,
+              abs(oldWidth - width) <= 0.5 else {
+            return true
+        }
+        return abs(oldHeight - newHeight) > 0.5
+    }
+
+    /// `MarkdownOptions` intentionally has no global `Equatable` conformance.
+    /// Compare the fields this prose view consumes so Dynamic Type and theme
+    /// changes cannot be mistaken for an unchanged transport update.
+    private static func sameRenderingOptions(
+        _ lhs: MarkdownOptions,
+        _ rhs: MarkdownOptions
+    ) -> Bool {
+        lhs.textPointSize == rhs.textPointSize
+            && lhs.lineHeightMultiple == rhs.lineHeightMultiple
+            && lhs.paragraphSpacing == rhs.paragraphSpacing
+            && lhs.kern == rhs.kern
+            && sameColor(lhs.textColor, rhs.textColor)
+            && sameColor(lhs.strongTextColor, rhs.strongTextColor)
+            && sameColor(lhs.linkColor, rhs.linkColor)
+            && lhs.linkUnderlineStyle == rhs.linkUnderlineStyle
+            && sameColor(lhs.linkUnderlineColor, rhs.linkUnderlineColor)
+            && lhs.inlineCodeBackgroundEnabled == rhs.inlineCodeBackgroundEnabled
+            && sameColor(lhs.inlineCodeBackgroundColor, rhs.inlineCodeBackgroundColor)
+            && sameColor(lhs.inlineCodeTextColor, rhs.inlineCodeTextColor)
+            && lhs.listInterItemSpacing == rhs.listInterItemSpacing
+            && lhs.listDepthIndent == rhs.listDepthIndent
+            && lhs.unorderedListBaseLeftMargin == rhs.unorderedListBaseLeftMargin
+            && lhs.orderedListBaseLeftMargin == rhs.orderedListBaseLeftMargin
+            && lhs.unorderedListSpacingFromMarker == rhs.unorderedListSpacingFromMarker
+            && lhs.listSpacingFromIndex == rhs.listSpacingFromIndex
+            && lhs.blockQuoteLeadingInset == rhs.blockQuoteLeadingInset
+            && lhs.blockQuoteIndentation == rhs.blockQuoteIndentation
+            && lhs.blockQuoteBarWidth == rhs.blockQuoteBarWidth
+            && sameColor(lhs.blockQuoteBarColor, rhs.blockQuoteBarColor)
+            && lhs.horizontalRuleHeight == rhs.horizontalRuleHeight
+            && sameInsets(lhs.horizontalRuleInsets, rhs.horizontalRuleInsets)
+            && sameColor(lhs.horizontalRuleColor, rhs.horizontalRuleColor)
+    }
+
+    private static func sameColor(_ lhs: NSColor?, _ rhs: NSColor?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (lhs?, rhs?):
+            return lhs.isEqual(rhs)
+        default:
+            return false
+        }
+    }
+
+    private static func sameInsets(
+        _ lhs: NSDirectionalEdgeInsets,
+        _ rhs: NSDirectionalEdgeInsets
+    ) -> Bool {
+        lhs.top == rhs.top
+            && lhs.leading == rhs.leading
+            && lhs.bottom == rhs.bottom
+            && lhs.trailing == rhs.trailing
     }
 
     public override func setFrameSize(_ newSize: NSSize) {
         let widthChanged = newSize.width != frame.width
         super.setFrameSize(newSize)
         if widthChanged {
+            measuredWidth = nil
+            measuredHeight = nil
             invalidateIntrinsicContentSize()
             needsDisplay = true
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -143,9 +143,11 @@ final class MarkdownTextBlockView: NSView {
             }
         } else if let animator = fadeAnimator {
             // Streaming ended: leave the text fully visible rather than
-            // replaying the reveal on the next render pass.
+            // replaying the reveal on the next render pass. A segment can end
+            // while its message continues in a new mutable segment, so retain
+            // the message-wide pacing state.
             animator.markAllRevealed()
-            animator.reset()
+            animator.stopAndReveal()
             fadeAnimator = nil
         }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -15,11 +15,20 @@ import AppKit
 @MainActor
 final class MarkdownTextRenderer {
 
+    enum TextStorageUpdate {
+        case initial
+        case incremental
+        case replaced
+    }
+
     public let textContentStorage = NSTextContentStorage()
     public let textLayoutManager = NSTextLayoutManager()
     public let textContainer: NSTextContainer
 
     private var options: MarkdownOptions
+    /// The prose portion is kept separately because the optional typing dot
+    /// is removed and re-added on every streaming flush.
+    private var renderedProse: NSAttributedString?
 
     public init(options: MarkdownOptions) {
         self.options = options
@@ -40,8 +49,45 @@ final class MarkdownTextRenderer {
     /// `showsTypingDot` appends the pulsing indicator as an attachment on the
     /// last line. It is part of the text, not an overlay, so it flows and wraps
     /// with the final glyph and needs no frame maintenance.
-    public func setBlocks(_ blocks: [MarkdownItem.TextBlock], showsTypingDot: Bool = false) {
-        let string = NSMutableAttributedString(attributedString: attributedString(for: blocks))
+    @discardableResult
+    public func setBlocks(
+        _ blocks: [MarkdownItem.TextBlock], showsTypingDot: Bool = false
+    ) -> TextStorageUpdate {
+        let newProse = attributedString(for: blocks)
+        let oldProse = renderedProse
+
+        if let oldProse,
+           let storage = textContentStorage.textStorage,
+           oldProse.length > 0,
+           storage.length >= oldProse.length,
+           isAttributedPrefix(oldProse, of: newProse) {
+            // The normal streaming path is an append. Replace only the old
+            // typing decoration and insert the new suffix, preserving TextKit
+            // rendering state for the already-visible prefix.
+            let changedRange = NSRange(
+                location: oldProse.length,
+                length: storage.length - oldProse.length
+            )
+            let replacement = NSMutableAttributedString()
+            if newProse.length > oldProse.length {
+                replacement.append(newProse.attributedSubstring(from: NSRange(
+                    location: oldProse.length,
+                    length: newProse.length - oldProse.length
+                )))
+            }
+            proseLength = newProse.length
+            typingDotLocation = nil
+            if showsTypingDot {
+                replacement.append(typingDotString(trailing: newProse))
+            }
+            textContentStorage.performEditingTransaction {
+                storage.replaceCharacters(in: changedRange, with: replacement)
+            }
+            renderedProse = newProse.copy() as? NSAttributedString
+            return .incremental
+        }
+
+        let string = NSMutableAttributedString(attributedString: newProse)
         proseLength = string.length
         typingDotLocation = nil
         if showsTypingDot {
@@ -50,6 +96,40 @@ final class MarkdownTextRenderer {
         textContentStorage.performEditingTransaction {
             textContentStorage.textStorage?.setAttributedString(string)
         }
+        renderedProse = newProse.copy() as? NSAttributedString
+        return oldProse == nil ? .initial : .replaced
+    }
+
+    /// Markdown can restyle existing characters when a fence, heading, or
+    /// list marker becomes complete. Only an attributed prefix is safe to
+    /// update incrementally; structural changes use the replacement path.
+    private func isAttributedPrefix(
+        _ prefix: NSAttributedString,
+        of value: NSAttributedString
+    ) -> Bool {
+        guard prefix.length <= value.length else { return false }
+        var offset = 0
+        while offset < prefix.length {
+            var prefixRange = NSRange()
+            var valueRange = NSRange()
+            let prefixAttributes = prefix.attributes(at: offset, effectiveRange: &prefixRange)
+            let valueAttributes = value.attributes(at: offset, effectiveRange: &valueRange)
+            let count = min(
+                prefixRange.location + prefixRange.length,
+                valueRange.location + valueRange.length
+            ) - offset
+            guard count > 0,
+                  prefixAttributes as NSDictionary == valueAttributes as NSDictionary,
+                  (prefix.string as NSString).substring(
+                      with: NSRange(location: offset, length: count)
+                  ) == (value.string as NSString).substring(
+                      with: NSRange(location: offset, length: count)
+                  ) else {
+                return false
+            }
+            offset += count
+        }
+        return true
     }
 
     /// Length of the prose, excluding any typing dot.
@@ -261,6 +341,7 @@ final class MarkdownTextRenderer {
 
         proseLength = string.length
         typingDotLocation = nil
+        renderedProse = nil
         textContentStorage.performEditingTransaction {
             textContentStorage.textStorage?.setAttributedString(string)
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingMarkdownStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingMarkdownStore.swift
@@ -56,7 +56,11 @@ final class StreamingMarkdownStore {
 
     var receivedText: String { presentationBuffer.receivedText }
     var pendingGraphemeCount: Int { presentationBuffer.pendingGraphemeCount }
-    var isPresentationActive: Bool { presentationBuffer.hasPendingText }
+    var isPresentationActive: Bool {
+        isFinishing
+            ? presentationBuffer.hasPendingText
+            : presentationBuffer.hasPresentableText
+    }
 
     /// Note new streamed text. It becomes visible on display frames rather
     /// than at the transport's uneven delivery cadence.

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingMarkdownStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingMarkdownStore.swift
@@ -1,14 +1,14 @@
 import Foundation
 import Observation
 
-/// Compiled markdown for the message currently streaming.
+/// Incremental Markdown document for the message currently streaming.
 ///
 /// ## Why this exists
 ///
-/// `ChatView`'s transcript is `ForEach(messages) { MessageRow(message: …) }`,
-/// and a streaming turn mutates `messages[i].content` on every coalesced SSE
-/// batch. SwiftUI therefore rebuilds that row — and everything under it —
-/// once per batch, at the transport's cadence rather than the renderer's.
+/// The transcript still mutates `messages[i].content` on every coalesced SSE
+/// batch, but `ChatView` removes that growing field from `MessageRow`'s
+/// presentation snapshot. This store is the only high-frequency body
+/// dependency for the streamed prose.
 ///
 /// Measured on a 5 760-character answer streamed at ~313 chars/second: the
 /// stream reader's `await MainActor.run` waited **55.5 ms** per hop while the
@@ -17,80 +17,158 @@ import Observation
 /// **181 s** against an 18 s transmission. The same fixture in the prototype
 /// this renderer came from took 19.9 s, and its hops waited 2.1 ms.
 ///
-/// The prototype avoids this by keeping the streaming text out of the row's
-/// inputs: its rows carry an already-compiled `MarkdownResult` that changes on
-/// the compiler's 100 ms beat, not the raw string that changes 20× a second.
-/// This type is that seam for Rapid — the streaming row reads compiled blocks
-/// from here, so an SSE batch no longer invalidates the row.
+/// The live row reads stable compiled chunks and one mutable tail from this
+/// store instead. Uneven transport batches first enter a presentation buffer;
+/// a display link releases complete graphemes to the mutable tail on screen
+/// frames. An SSE batch therefore no longer invalidates the row chrome or
+/// recompiles the settled prefix.
 ///
-/// Only the streaming message needs it. Settled messages compile once and
-/// render through `TextKitMarkdownView` as before.
+/// Messages that originated in this store retain their compiled segments after
+/// completion. Restored history still compiles once through
+/// `TextKitMarkdownView` because it has no live document to preserve.
 @MainActor
 @Observable
 final class StreamingMarkdownStore {
 
-    /// Compiled blocks for the message being streamed.
-    private(set) var result: MarkdownResult = .empty
-    /// Which message `result` belongs to. Nil when nothing is streaming.
+    /// Stable chunks plus the one mutable tail for the active message.
+    private(set) var document = StreamingMarkdownDocument()
+    /// Which message `document` belongs to. Nil when nothing is streaming.
     private(set) var messageID: UUID?
+    /// The owner of `document` remains available after streaming finishes so
+    /// the settled row can keep the same renderer until another response starts.
+    /// Older rows return to the one-shot renderer instead of retaining a second
+    /// compiled copy of every answer for the lifetime of `ChatView`.
+    private(set) var documentMessageID: UUID?
 
-    private let compiler = MarkdownCompiler()
-    private var pendingText: String?
-    private var flushTask: Task<Void, Never>?
-    private var revision = 0
+    private var presentationBuffer = StreamingTextPresentationBuffer()
+    private var isFinishing = false
 
-    /// How long to accumulate before recompiling.
-    ///
-    /// A full compile of a 24 000-character buffer measures 15 ms, so 100 ms
-    /// leaves the main thread mostly free, and block structure appearing
-    /// within one perceptual beat is fast enough that the delay is invisible.
-    private let coalesceInterval: Duration = .milliseconds(100)
+    var segments: [StreamingMarkdownDocument.Segment] { document.segments }
+    var result: MarkdownResult { document.result }
 
-    /// Note new streamed text. Compilation happens on the next flush.
+    func segments(for messageID: UUID) -> [StreamingMarkdownDocument.Segment] {
+        documentMessageID == messageID ? document.segments : []
+    }
+
+    func hasDocument(for messageID: UUID) -> Bool {
+        documentMessageID == messageID
+    }
+
+    var receivedText: String { presentationBuffer.receivedText }
+    var pendingGraphemeCount: Int { presentationBuffer.pendingGraphemeCount }
+    var isPresentationActive: Bool { presentationBuffer.hasPendingText }
+
+    /// Note new streamed text. It becomes visible on display frames rather
+    /// than at the transport's uneven delivery cadence.
     func enqueue(id: UUID, text: String) {
-        if messageID != id {
-            // A new turn: drop the previous message's blocks rather than
-            // letting them show under the new one for a frame.
-            messageID = id
-            result = .empty
-            revision = 0
+        if documentMessageID != id {
+            // A new turn receives a fresh identity space and document. The
+            // completed row has already settled; `ChatView` moves it back to
+            // the one-shot renderer rather than retaining every live document.
+            document = StreamingMarkdownDocument()
+            documentMessageID = id
+            presentationBuffer = StreamingTextPresentationBuffer()
         }
-        pendingText = text
-        scheduleFlush()
+        messageID = id
+        isFinishing = false
+        if presentationBuffer.receive(text) == .reset {
+            document = StreamingMarkdownDocument()
+        }
     }
 
-    /// Compile whatever is queued right now.
+    /// Finalise the current tail without rebuilding the stable prefix.
     ///
-    /// Called when a stream ends so the final tokens are not left waiting on
-    /// a timer — a visible pause between the last token and the last words.
-    func flushNow() {
-        flushTask?.cancel()
-        flushTask = nil
-        flush()
-    }
-
-    /// Forget the current message. The settled row takes over rendering.
-    func finish() {
-        flushNow()
-        messageID = nil
-        result = .empty
-    }
-
-    private func scheduleFlush() {
-        guard flushTask == nil else { return }
-        flushTask = Task { [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(for: self.coalesceInterval)
-            guard !Task.isCancelled else { return }
-            self.flushTask = nil
-            self.flush()
+    /// Keep the final document under the same message ID. `ChatView` mounts one
+    /// `MessageRow` for streaming and completion, so committing the final tail
+    /// updates that row in place instead of constructing a settled renderer.
+    func finish(id: UUID? = nil, finalText: String? = nil) {
+        if let id, documentMessageID != id { return }
+        if let finalText {
+            synchronizeReceivedText(finalText)
         }
+        messageID = nil
+        isFinishing = true
+        finalizeIfDrained()
     }
 
-    private func flush() {
-        guard let text = pendingText else { return }
-        pendingText = nil
-        revision += 1
-        result = compiler.compile(text, revision: revision, isComplete: false)
+    /// Reconcile a completed row with the authoritative message model.
+    /// Completion-time transforms such as startup failures and grounding-source
+    /// appendages do not travel through `streamingBody`, so they arrive here.
+    func synchronizeCompleted(id: UUID, text: String) {
+        guard documentMessageID == id else { return }
+        if !document.isFinished || presentationBuffer.hasPendingText {
+            finish(id: id, finalText: text)
+            return
+        }
+        guard document.receivedSource != text else { return }
+
+        document = Self.finishedDocument(text)
+        presentationBuffer = Self.drainedPresentationBuffer(text)
+        messageID = nil
+        isFinishing = false
+    }
+
+    /// Drop the live document when its message leaves the visible conversation.
+    func reset() {
+        document = StreamingMarkdownDocument()
+        messageID = nil
+        documentMessageID = nil
+        presentationBuffer = StreamingTextPresentationBuffer()
+        isFinishing = false
+    }
+
+    /// Advance presentation by one real or test-controlled display frame.
+    func advancePresentationFrame(duration: TimeInterval) {
+        if let delta = presentationBuffer.presentFrame(
+            duration: duration,
+            isFinishing: isFinishing
+        ) {
+            var next = document
+            next.append(delta)
+            document = next
+        }
+        finalizeIfDrained()
+    }
+
+    private func finalizeIfDrained() {
+        guard isFinishing, !presentationBuffer.hasPendingText else { return }
+        var next = document
+        next.finish()
+        document = next
+        isFinishing = false
+    }
+
+    /// Bring the presentation input up to the final model value. This check is
+    /// intentionally paid only at completion: validating a growing prefix on
+    /// every transport update would restore the quadratic scan this pipeline
+    /// exists to avoid.
+    private func synchronizeReceivedText(_ text: String) {
+        guard presentationBuffer.receivedText != text else { return }
+        if text.hasPrefix(presentationBuffer.receivedText) {
+            if presentationBuffer.receive(text) == .reset {
+                document = StreamingMarkdownDocument()
+            }
+            return
+        }
+
+        presentationBuffer = StreamingTextPresentationBuffer()
+        _ = presentationBuffer.receive(text)
+        document = StreamingMarkdownDocument()
+    }
+
+    private static func finishedDocument(_ text: String) -> StreamingMarkdownDocument {
+        var document = StreamingMarkdownDocument()
+        document.append(text)
+        document.finish()
+        return document
+    }
+
+    private static func drainedPresentationBuffer(
+        _ text: String
+    ) -> StreamingTextPresentationBuffer {
+        var buffer = StreamingTextPresentationBuffer()
+        _ = buffer.receive(text)
+        _ = buffer.drainAll()
+        return buffer
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
@@ -1,0 +1,73 @@
+import AppKit
+import QuartzCore
+import SwiftUI
+
+/// Delivers frame callbacks in sync with the display containing this view.
+struct StreamingPresentationDisplayLink: NSViewRepresentable {
+    let isActive: Bool
+    let onFrame: @MainActor (TimeInterval) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isActive: isActive, onFrame: onFrame)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.attach(to: view)
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        context.coordinator.onFrame = onFrame
+        context.coordinator.setActive(isActive)
+        context.coordinator.attach(to: view)
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        coordinator.invalidate()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var onFrame: @MainActor (TimeInterval) -> Void
+        private(set) var isActive: Bool
+        private var displayLink: CADisplayLink?
+        var isDisplayLinkPaused: Bool { displayLink?.isPaused ?? !isActive }
+
+        init(
+            isActive: Bool,
+            onFrame: @escaping @MainActor (TimeInterval) -> Void
+        ) {
+            self.isActive = isActive
+            self.onFrame = onFrame
+        }
+
+        func attach(to view: NSView) {
+            guard displayLink == nil else { return }
+            let link = view.displayLink(
+                target: self,
+                selector: #selector(displayLinkDidFire(_:))
+            )
+            link.isPaused = !isActive
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        }
+
+        func setActive(_ isActive: Bool) {
+            self.isActive = isActive
+            displayLink?.isPaused = !isActive
+        }
+
+        func invalidate() {
+            displayLink?.invalidate()
+            displayLink = nil
+        }
+
+        @objc private func displayLinkDidFire(_ link: CADisplayLink) {
+            let duration = link.duration > 0
+                ? link.duration
+                : link.targetTimestamp - link.timestamp
+            onFrame(duration)
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextKitMarkdownView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextKitMarkdownView.swift
@@ -13,6 +13,10 @@ struct StreamingTextKitMarkdownView: View {
     @Bindable var store: StreamingMarkdownStore
     let messageID: UUID
 
+    /// One timeline per message. Segment boundaries are an implementation
+    /// detail and must not restart the reveal as stable blocks are committed.
+    @State private var fadeState = TextFadeAnimationState()
+
     @ScaledMetric(relativeTo: .body) private var basePointSize: CGFloat = 15
 
     var body: some View {
@@ -21,13 +25,21 @@ struct StreamingTextKitMarkdownView: View {
             ForEach(store.segments(for: messageID)) { segment in
                 StreamingMarkdownSegmentView(
                     segment: segment,
-                    basePointSize: basePointSize
+                    basePointSize: basePointSize,
+                    fadeState: fadeState,
+                    fadeConfiguration: Self.fadeConfiguration
                 )
                 .equatable()
             }
         }
         .chatLinkSafetyFilter()
     }
+
+    private static let fadeConfiguration: TextFadeConfiguration = {
+        if UserDefaults.standard.bool(forKey: "rapid.chat.fade.disabled") { return .off }
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion { return .off }
+        return TextFadeConfiguration()
+    }()
 }
 
 /// A committed segment stops changing and is skipped by SwiftUI's diffing.
@@ -36,6 +48,8 @@ struct StreamingTextKitMarkdownView: View {
 private struct StreamingMarkdownSegmentView: View, Equatable {
     let segment: StreamingMarkdownDocument.Segment
     let basePointSize: CGFloat
+    let fadeState: TextFadeAnimationState
+    let fadeConfiguration: TextFadeConfiguration
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.segment == rhs.segment && lhs.basePointSize == rhs.basePointSize
@@ -46,8 +60,8 @@ private struct StreamingMarkdownSegmentView: View, Equatable {
             result: segment.result,
             options: TextKitMarkdownView.options(basePointSize: basePointSize),
             isStreaming: segment.isMutable,
-            fadeState: nil,
-            fadeConfiguration: .off
+            fadeState: fadeState,
+            fadeConfiguration: fadeConfiguration
         )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextKitMarkdownView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextKitMarkdownView.swift
@@ -6,44 +6,48 @@ import SwiftUI
 /// Reads compiled blocks from ``StreamingMarkdownStore`` rather than taking
 /// the raw string as a parameter. That indirection is the point: a
 /// `let content: String` on this view changes on every coalesced SSE batch,
-/// so SwiftUI rebuilds the row around it ~20× a second. The store publishes
-/// on the compiler's 100 ms beat instead — see its doc comment for the
-/// measurements that motivated the change.
+/// so SwiftUI rebuilds the row around it ~20× a second. The store instead
+/// publishes stable blocks and a mutable tail at display cadence; see its doc
+/// comment for the measurements that motivated the change.
 struct StreamingTextKitMarkdownView: View {
     @Bindable var store: StreamingMarkdownStore
-
-    /// Shared across every block of one message so the reveal runs on a
-    /// single timeline. Without it each block would restart the animation at
-    /// its own boundary, and a long answer would visibly re-fade at every
-    /// paragraph.
-    @State private var fadeState = TextFadeAnimationState()
+    let messageID: UUID
 
     @ScaledMetric(relativeTo: .body) private var basePointSize: CGFloat = 15
 
     var body: some View {
-        MarkdownBlockStack(
-            result: store.result,
-            options: TextKitMarkdownView.options(basePointSize: basePointSize),
-            isStreaming: true,
-            fadeState: fadeState,
-            fadeConfiguration: Self.fadeConfiguration
-        )
+        let options = TextKitMarkdownView.options(basePointSize: basePointSize)
+        VStack(alignment: .leading, spacing: options.interContentSpacing) {
+            ForEach(store.segments(for: messageID)) { segment in
+                StreamingMarkdownSegmentView(
+                    segment: segment,
+                    basePointSize: basePointSize
+                )
+                .equatable()
+            }
+        }
         .chatLinkSafetyFilter()
     }
+}
 
-    /// Word-by-word reveal, driven by a display link against the layout
-    /// manager's rendering attributes.
-    ///
-    /// This is what makes streamed text read as text arriving rather than as
-    /// a buffer being redrawn: `setRenderingAttributes` changes a glyph's
-    /// alpha without invalidating layout, so a word can fade in without
-    /// moving anything around it.
-    ///
-    /// Off under Reduce Motion, and behind a defaults key for anyone who
-    /// wants the old instant paint.
-    private static let fadeConfiguration: TextFadeConfiguration = {
-        if UserDefaults.standard.bool(forKey: "rapid.chat.fade.disabled") { return .off }
-        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion { return .off }
-        return TextFadeConfiguration()
-    }()
+/// A committed segment stops changing and is skipped by SwiftUI's diffing.
+/// The mutable segment keeps the same ID when committed, preserving its
+/// TextKit views while a new mutable segment is mounted after it.
+private struct StreamingMarkdownSegmentView: View, Equatable {
+    let segment: StreamingMarkdownDocument.Segment
+    let basePointSize: CGFloat
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.segment == rhs.segment && lhs.basePointSize == rhs.basePointSize
+    }
+
+    var body: some View {
+        MarkdownBlockStack(
+            result: segment.result,
+            options: TextKitMarkdownView.options(basePointSize: basePointSize),
+            isStreaming: segment.isMutable,
+            fadeState: nil,
+            fadeConfiguration: .off
+        )
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Separates uneven transport delivery from the text cadence shown on screen.
+///
+/// The buffer receives the full accumulated response, converts it to a suffix,
+/// then releases complete extended grapheme clusters on display frames. Its
+/// release rate only increases while a backlog exists, so a burst drains by
+/// the latency target instead of slowing down as the queue gets shorter.
+struct StreamingTextPresentationBuffer: Equatable {
+    struct Configuration: Equatable {
+        var targetLatency: TimeInterval = 0.12
+        var completionDrainDuration: TimeInterval = 0.15
+    }
+
+    enum ReceiveResult: Equatable {
+        case unchanged
+        case appended
+        case reset
+    }
+
+    private(set) var receivedText = ""
+    private(set) var presentedText = ""
+    private(set) var pendingText = ""
+    private(set) var pendingGraphemeCount = 0
+
+    private var graphemesPerSecond: Double = 0
+    private let configuration: Configuration
+
+    init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    var hasPendingText: Bool { pendingGraphemeCount > 0 }
+
+    /// Accept the transport's full accumulated text without scanning its
+    /// growing prefix. A non-monotonic update is treated as a replacement.
+    @discardableResult
+    mutating func receive(_ text: String) -> ReceiveResult {
+        let previousByteCount = receivedText.utf8.count
+        let nextByteCount = text.utf8.count
+
+        if nextByteCount < previousByteCount
+            || (nextByteCount == previousByteCount && text != receivedText) {
+            receivedText = text
+            presentedText = ""
+            pendingText = text
+            pendingGraphemeCount = text.count
+            graphemesPerSecond = 0
+            updateReleaseRate(targetDuration: configuration.targetLatency)
+            return .reset
+        }
+        guard nextByteCount > previousByteCount else { return .unchanged }
+
+        let utf8 = text.utf8
+        let suffixStart = utf8.index(utf8.startIndex, offsetBy: previousByteCount)
+        guard let suffix = String(utf8[suffixStart...]) else {
+            receivedText = text
+            presentedText = ""
+            pendingText = text
+            pendingGraphemeCount = text.count
+            graphemesPerSecond = 0
+            updateReleaseRate(targetDuration: configuration.targetLatency)
+            return .reset
+        }
+
+        receivedText = text
+        pendingText.append(suffix)
+        pendingGraphemeCount += suffix.count
+        updateReleaseRate(targetDuration: configuration.targetLatency)
+        return .appended
+    }
+
+    /// Return the delta that should become visible on this display frame.
+    mutating func presentFrame(
+        duration: TimeInterval,
+        isFinishing: Bool = false
+    ) -> String? {
+        guard pendingGraphemeCount > 0 else { return nil }
+
+        let targetDuration = isFinishing
+            ? configuration.completionDrainDuration
+            : configuration.targetLatency
+        updateReleaseRate(targetDuration: targetDuration)
+
+        let safeDuration = duration.isFinite && duration > 0 ? duration : 1.0 / 60.0
+        let releaseCount = min(
+            pendingGraphemeCount,
+            max(1, Int(ceil(graphemesPerSecond * safeDuration)))
+        )
+        let end = pendingText.index(
+            pendingText.startIndex,
+            offsetBy: releaseCount
+        )
+        let delta = String(pendingText[..<end])
+        pendingText.removeSubrange(..<end)
+        pendingGraphemeCount -= releaseCount
+        presentedText.append(delta)
+
+        if pendingGraphemeCount == 0 {
+            graphemesPerSecond = 0
+        }
+        return delta
+    }
+
+    /// Correctness fallback used when a new response starts before the prior
+    /// response's short completion drain has elapsed.
+    mutating func drainAll() -> String? {
+        guard !pendingText.isEmpty else { return nil }
+        let delta = pendingText
+        presentedText.append(delta)
+        pendingText = ""
+        pendingGraphemeCount = 0
+        graphemesPerSecond = 0
+        return delta
+    }
+
+    private mutating func updateReleaseRate(targetDuration: TimeInterval) {
+        guard pendingGraphemeCount > 0 else { return }
+        let safeTarget = max(targetDuration, 1.0 / 240.0)
+        graphemesPerSecond = max(
+            graphemesPerSecond,
+            Double(pendingGraphemeCount) / safeTarget
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
@@ -31,6 +31,9 @@ struct StreamingTextPresentationBuffer: Equatable {
     }
 
     var hasPendingText: Bool { pendingGraphemeCount > 0 }
+    /// The final grapheme stays buffered until another grapheme proves its
+    /// boundary, or completion makes the tail authoritative.
+    var hasPresentableText: Bool { pendingGraphemeCount > 1 }
 
     /// Accept the transport's full accumulated text without scanning its
     /// growing prefix. A non-monotonic update is treated as a replacement.
@@ -67,7 +70,10 @@ struct StreamingTextPresentationBuffer: Equatable {
         duration: TimeInterval,
         isFinishing: Bool = false
     ) -> String? {
-        guard pendingGraphemeCount > 0 else { return nil }
+        let releasableCount = isFinishing
+            ? pendingGraphemeCount
+            : max(0, pendingGraphemeCount - 1)
+        guard releasableCount > 0 else { return nil }
 
         let targetDuration = isFinishing
             ? configuration.completionDrainDuration
@@ -76,7 +82,7 @@ struct StreamingTextPresentationBuffer: Equatable {
 
         let safeDuration = duration.isFinite && duration > 0 ? duration : 1.0 / 60.0
         let releaseCount = min(
-            pendingGraphemeCount,
+            releasableCount,
             max(1, Int(ceil(graphemesPerSecond * safeDuration)))
         )
         let end = pendingText.index(

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingTextPresentationBuffer.swift
@@ -39,33 +39,25 @@ struct StreamingTextPresentationBuffer: Equatable {
         let previousByteCount = receivedText.utf8.count
         let nextByteCount = text.utf8.count
 
-        if nextByteCount < previousByteCount
-            || (nextByteCount == previousByteCount && text != receivedText) {
-            receivedText = text
-            presentedText = ""
-            pendingText = text
-            pendingGraphemeCount = text.count
-            graphemesPerSecond = 0
-            updateReleaseRate(targetDuration: configuration.targetLatency)
-            return .reset
-        }
+        guard text != receivedText else { return .unchanged }
+        guard nextByteCount >= previousByteCount,
+              text.utf8.prefix(previousByteCount).elementsEqual(receivedText.utf8)
+        else { return reset(to: text) }
         guard nextByteCount > previousByteCount else { return .unchanged }
 
         let utf8 = text.utf8
         let suffixStart = utf8.index(utf8.startIndex, offsetBy: previousByteCount)
         guard let suffix = String(utf8[suffixStart...]) else {
-            receivedText = text
-            presentedText = ""
-            pendingText = text
-            pendingGraphemeCount = text.count
-            graphemesPerSecond = 0
-            updateReleaseRate(targetDuration: configuration.targetLatency)
-            return .reset
+            return reset(to: text)
         }
 
         receivedText = text
         pendingText.append(suffix)
-        pendingGraphemeCount += suffix.count
+        // A newly appended scalar can extend the final pending grapheme
+        // (combining marks, emoji modifiers and ZWJ sequences). Recount the
+        // short visual backlog after concatenation instead of adding two
+        // counts whose boundary may have merged.
+        pendingGraphemeCount = pendingText.count
         updateReleaseRate(targetDuration: configuration.targetLatency)
         return .appended
     }
@@ -121,5 +113,15 @@ struct StreamingTextPresentationBuffer: Equatable {
             graphemesPerSecond,
             Double(pendingGraphemeCount) / safeTarget
         )
+    }
+
+    private mutating func reset(to text: String) -> ReceiveResult {
+        receivedText = text
+        presentedText = ""
+        pendingText = text
+        pendingGraphemeCount = text.count
+        graphemesPerSecond = 0
+        updateReleaseRate(targetDuration: configuration.targetLatency)
+        return .reset
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/TextKitMarkdownView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/TextKitMarkdownView.swift
@@ -5,8 +5,8 @@ import SwiftUI
 ///
 /// Replaces the MarkdownUI-backed `LaTeXMarkdownView` for settled messages
 /// (#1843). Streaming messages render through
-/// ``StreamingTextKitMarkdownView`` — a debounced compiler feeding the same
-/// block stack — so both paths are TextKit 2 now.
+/// ``StreamingTextKitMarkdownView`` — an incremental, frame-presented document
+/// feeding the same block stack — so both paths are TextKit 2 now.
 ///
 /// ## What carries over unchanged
 ///

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -8,6 +8,10 @@ import SwiftUI
 struct TranscriptScrollPositionProbe: NSViewRepresentable {
     @Binding var isPinnedToBottom: Bool
     let bottomResumeSlack: CGFloat
+    /// Whether an answer is currently being written. A followed transcript
+    /// releases once the new answer grows beyond one viewport, so the reader
+    /// can start at its beginning without fighting continuous auto-scroll.
+    var isStreaming: Bool = false
     /// Bumped by anything outside that wants the transcript moved to the
     /// bottom right now, ``JumpToBottomButton`` being the only caller today.
     ///
@@ -41,6 +45,7 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             isPinnedToBottom: $isPinnedToBottom,
             bottomResumeSlack: bottomResumeSlack
         )
+        context.coordinator.setStreaming(isStreaming)
         context.coordinator.attach(to: probe)
         // After ``attach``: a first render arrives with the token already at
         // its initial value, and attaching is what anchors that one.
@@ -97,6 +102,9 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
                 attachmentChanged = true
             }
             attachmentChanged = observeDocumentViewIfNeeded() || attachmentChanged
+            if isStreaming, documentHeightAtStreamStart == nil {
+                documentHeightAtStreamStart = documentView?.bounds.height
+            }
             // updateNSView runs for every streamed mutation. Document-frame
             // notifications own steady-state following; only a new attachment
             // needs an explicit initial anchor (#1877).
@@ -129,6 +137,7 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             bottomScrollScheduled = false
             pendingBottomTargetIsAnimated = true
             lastDocumentHeight = nil
+            documentHeightAtStreamStart = nil
             cancelScrollTarget()
         }
 
@@ -184,7 +193,50 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
                 from: previousHeight, to: height
             ) else { return }
             guard isPinnedToBottom.wrappedValue else { return }
+            if releaseIfAnswerOutgrewViewport() { return }
             requestScrollToBottom()
+        }
+
+        private var didReleaseForCurrentStream = false
+        private var isStreaming = false
+        private var documentHeightAtStreamStart: CGFloat?
+
+        func setStreaming(_ streaming: Bool) {
+            guard streaming != isStreaming else { return }
+            isStreaming = streaming
+            if streaming {
+                didReleaseForCurrentStream = false
+                documentHeightAtStreamStart = documentView?.bounds.height
+            } else {
+                documentHeightAtStreamStart = nil
+            }
+        }
+
+        private func releaseIfAnswerOutgrewViewport() -> Bool {
+            guard isStreaming, !didReleaseForCurrentStream else { return false }
+            guard let scrollView, let documentView,
+                  let startingHeight = documentHeightAtStreamStart else { return false }
+            let viewportHeight = scrollView.contentView.bounds.height
+            guard Self.answerOutgrewViewport(
+                documentHeight: documentView.bounds.height,
+                documentHeightAtStreamStart: startingHeight,
+                viewportHeight: viewportHeight
+            ) else { return false }
+            didReleaseForCurrentStream = true
+            cancelScrollTarget()
+            if isPinnedToBottom.wrappedValue {
+                isPinnedToBottom.wrappedValue = false
+            }
+            return true
+        }
+
+        nonisolated static func answerOutgrewViewport(
+            documentHeight: CGFloat,
+            documentHeightAtStreamStart: CGFloat,
+            viewportHeight: CGFloat
+        ) -> Bool {
+            viewportHeight > 0
+                && documentHeight - documentHeightAtStreamStart > viewportHeight
         }
 
         /// Frame notifications also cover unchanged-size layout passes. Only

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 import SwiftUI
 
 /// Owns transcript follow-mode at the AppKit layer. User live-scroll gestures
@@ -7,9 +8,6 @@ import SwiftUI
 struct TranscriptScrollPositionProbe: NSViewRepresentable {
     @Binding var isPinnedToBottom: Bool
     let bottomResumeSlack: CGFloat
-    /// Whether an answer is currently being written. Drives the one-shot
-    /// release described on ``Coordinator/releaseIfAnswerOutgrewViewport()``.
-    var isStreaming: Bool = false
     /// Bumped by anything outside that wants the transcript moved to the
     /// bottom right now, ``JumpToBottomButton`` being the only caller today.
     ///
@@ -43,7 +41,6 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             isPinnedToBottom: $isPinnedToBottom,
             bottomResumeSlack: bottomResumeSlack
         )
-        context.coordinator.setStreaming(isStreaming)
         context.coordinator.attach(to: probe)
         // After ``attach``: a first render arrives with the token already at
         // its initial value, and attaching is what anchors that one.
@@ -62,6 +59,13 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         private weak var documentView: NSView?
         private var isLiveScrolling = false
         private var bottomScrollScheduled = false
+        private var pendingBottomTargetIsAnimated = true
+        private var targetScrollOrigin: NSPoint?
+        private var displayLink: CADisplayLink?
+        /// Last document height handled by ``documentFrameDidChange``. AppKit
+        /// can post several frame notifications for one layout pass; equal
+        /// heights do not require another follow-to-bottom operation.
+        private var lastDocumentHeight: CGFloat?
         /// Last token acted on. Starts at `nil` so the initial value — whatever
         /// it happens to be — is recorded rather than treated as a request.
         private var lastScrollRequest: Int?
@@ -83,23 +87,21 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         }
 
         func attach(to probe: NSView) {
+            attachDisplayLink(to: probe)
             guard let enclosingScrollView = probe.enclosingScrollView else { return }
             var attachmentChanged = false
             if enclosingScrollView !== scrollView {
-                detach()
+                detachScrollView()
                 scrollView = enclosingScrollView
                 observeScrollView(enclosingScrollView)
                 attachmentChanged = true
             }
             attachmentChanged = observeDocumentViewIfNeeded() || attachmentChanged
-            if isStreaming, documentHeightAtStreamStart == nil {
-                documentHeightAtStreamStart = documentView?.bounds.height
-            }
             // updateNSView runs for every streamed mutation. Document-frame
             // notifications own steady-state following; only a new attachment
             // needs an explicit initial anchor (#1877).
             if attachmentChanged, isPinnedToBottom.wrappedValue {
-                requestScrollToBottom()
+                requestScrollToBottom(animated: false)
             }
         }
 
@@ -114,11 +116,20 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         }
 
         func detach() {
+            detachScrollView()
+            displayLink?.invalidate()
+            displayLink = nil
+        }
+
+        private func detachScrollView() {
             NotificationCenter.default.removeObserver(self)
             scrollView = nil
             documentView = nil
             isLiveScrolling = false
             bottomScrollScheduled = false
+            pendingBottomTargetIsAnimated = true
+            lastDocumentHeight = nil
+            cancelScrollTarget()
         }
 
         @objc private func liveScrollWillStart(_ notification: Notification) {
@@ -134,7 +145,7 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         }
 
         @objc private func boundsDidChange(_ notification: Notification) {
-            // Our own ``scrollToBottom`` emits this too; it is not user intent.
+            // Our frame-driven movement emits this too; it is not user intent.
             guard !isProgrammaticScroll else { return }
             if !isAtBottom {
                 // Any move away from the bottom releases the pin — whether or
@@ -165,72 +176,26 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         }
 
         @objc private func documentFrameDidChange(_ notification: Notification) {
+            guard let documentView else { return }
+            let height = documentView.bounds.height
+            let previousHeight = lastDocumentHeight
+            lastDocumentHeight = height
+            guard Self.documentHeightChanged(
+                from: previousHeight, to: height
+            ) else { return }
             guard isPinnedToBottom.wrappedValue else { return }
-            if releaseIfAnswerOutgrewViewport() { return }
             requestScrollToBottom()
         }
 
-        /// Whether this stream has already handed control back to the reader.
-        private var didReleaseForCurrentStream = false
-        private var isStreaming = false
-        private var documentHeightAtStreamStart: CGFloat?
-
-        func setStreaming(_ streaming: Bool) {
-            guard streaming != isStreaming else { return }
-            isStreaming = streaming
-            if streaming {
-                didReleaseForCurrentStream = false
-                documentHeightAtStreamStart = documentView?.bounds.height
-            } else {
-                documentHeightAtStreamStart = nil
-            }
-        }
-
-        /// Stop following the moment a streamed answer grows taller than the
-        /// viewport, once per stream.
-        ///
-        /// Following unconditionally is right while the answer still fits: the
-        /// text simply fills space the reader can already see, and nothing
-        /// appears to move. Past that point every batch drags the viewport
-        /// down, so the reader is held at the newest words and cannot read the
-        /// answer from its start without fighting the scroll — which is what
-        /// "keeps slamming into the bottom" describes.
-        ///
-        /// Releasing the pin instead leaves the text where the reader is
-        /// looking and surfaces ``JumpToBottomButton``, so catching up becomes
-        /// something they ask for rather than something done to them. One shot
-        /// per stream: after the reader presses the button they are pinned
-        /// again deliberately, and that choice is theirs to keep.
-        ///
-        /// Returns true when it released, meaning the caller must not scroll.
-        private func releaseIfAnswerOutgrewViewport() -> Bool {
-            guard isStreaming, !didReleaseForCurrentStream else { return false }
-            guard let scrollView, let documentView,
-                  let startingHeight = documentHeightAtStreamStart else { return false }
-            let viewportHeight = scrollView.contentView.bounds.height
-            guard Self.answerOutgrewViewport(
-                documentHeight: documentView.bounds.height,
-                documentHeightAtStreamStart: startingHeight,
-                viewportHeight: viewportHeight
-            ) else { return false }
-            didReleaseForCurrentStream = true
-            // Not `setPinned(false)` — that helper is reserved for the
-            // user-gesture path (`liveScrollWillStart` / `boundsDidChange`).
-            // This is the app deciding to stop following, and routing it
-            // through the same helper would blur who released the pin.
-            if isPinnedToBottom.wrappedValue {
-                isPinnedToBottom.wrappedValue = false
-            }
-            return true
-        }
-
-        nonisolated static func answerOutgrewViewport(
-            documentHeight: CGFloat,
-            documentHeightAtStreamStart: CGFloat,
-            viewportHeight: CGFloat
+        /// Frame notifications also cover unchanged-size layout passes. Only
+        /// a meaningful height change can move the transcript's trailing edge;
+        /// filtering the rest prevents scroll scheduling from becoming part of
+        /// the normal streaming redraw loop.
+        nonisolated static func documentHeightChanged(
+            from previous: CGFloat?, to current: CGFloat, tolerance: CGFloat = 0.5
         ) -> Bool {
-            viewportHeight > 0
-                && documentHeight - documentHeightAtStreamStart > viewportHeight
+            guard let previous else { return true }
+            return abs(previous - current) > tolerance
         }
 
         private func observeScrollView(_ scrollView: NSScrollView) {
@@ -275,6 +240,7 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
                 )
             }
             documentView = nextDocumentView
+            lastDocumentHeight = nextDocumentView.bounds.height
             nextDocumentView.postsFrameChangedNotifications = true
             NotificationCenter.default.addObserver(
                 self,
@@ -300,28 +266,41 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             return distance <= bottomResumeSlack
         }
 
-        /// True while ``scrollToBottom`` is driving the clip view, so the
+        /// True while a display frame is driving the clip view, so the
         /// bounds notification it emits is not mistaken for the user moving.
         private var isProgrammaticScroll = false
-        /// SwiftUI can resize the document several times for one streamed
-        /// token. Collapse those notifications into one end-of-run-loop scroll.
-        private func requestScrollToBottom() {
+        /// SwiftUI can resize the document several times for one presented
+        /// frame. Collapse those notifications into one target update at the
+        /// end of the run loop; the display link owns actual movement.
+        private func requestScrollToBottom(animated: Bool = true) {
+            if !animated { pendingBottomTargetIsAnimated = false }
             guard !bottomScrollScheduled else { return }
             bottomScrollScheduled = true
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.bottomScrollScheduled = false
+                let shouldAnimate = self.pendingBottomTargetIsAnimated
+                self.pendingBottomTargetIsAnimated = true
                 guard self.isPinnedToBottom.wrappedValue, !self.isLiveScrolling else {
                     return
                 }
-                self.scrollToBottom()
+                self.updateBottomTarget(animated: shouldAnimate)
             }
         }
 
-        private func scrollToBottom() {
-            guard let scrollView, let documentView else { return }
-            isProgrammaticScroll = true
-            defer { isProgrammaticScroll = false }
+        private func updateBottomTarget(animated: Bool) {
+            guard let target = constrainedBottomOrigin() else { return }
+            if !animated {
+                applyScroll(to: target)
+                cancelScrollTarget()
+                return
+            }
+            targetScrollOrigin = target
+            displayLink?.isPaused = false
+        }
+
+        private func constrainedBottomOrigin() -> NSPoint? {
+            guard let scrollView, let documentView else { return nil }
             let clipView = scrollView.contentView
             let targetY: CGFloat
             if documentView.isFlipped {
@@ -346,20 +325,98 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
                 origin: NSPoint(x: clipView.bounds.minX, y: targetY),
                 size: clipView.bounds.size
             )
-            let constrained = clipView.constrainBoundsRect(proposed).origin
-            // Scrolling to the current origin still emits AppKit notifications
-            // and schedules SwiftUI layout. At streaming cadence that no-op can
-            // become a self-sustaining AttributeGraph loop (#1877).
-            guard abs(clipView.bounds.minY - constrained.y) > 0.5 else { return }
-            clipView.scroll(to: constrained)
+            return clipView.constrainBoundsRect(proposed).origin
+        }
+
+        /// Advance the current scroll target by one display frame. Internal so
+        /// deterministic tests can drive the same path without a real screen.
+        func advanceScrollFrame(duration: TimeInterval) {
+            guard isPinnedToBottom.wrappedValue, !isLiveScrolling,
+                  let target = targetScrollOrigin,
+                  let scrollView else {
+                cancelScrollTarget()
+                return
+            }
+            let clipView = scrollView.contentView
+            let current = clipView.bounds.origin
+            let nextY = Self.nextScrollOffset(
+                current: current.y,
+                target: target.y,
+                duration: duration
+            )
+            applyScroll(to: NSPoint(x: target.x, y: nextY))
+
+            if abs(nextY - target.y) <= Self.scrollSnapTolerance {
+                applyScroll(to: target)
+                cancelScrollTarget()
+            }
+        }
+
+        nonisolated static func nextScrollOffset(
+            current: CGFloat,
+            target: CGFloat,
+            duration: TimeInterval,
+            responseTime: TimeInterval = 0.045
+        ) -> CGFloat {
+            let distance = target - current
+            guard abs(distance) > scrollSnapTolerance else { return target }
+            let safeDuration = duration.isFinite && duration > 0
+                ? min(duration, 1.0 / 15.0)
+                : 1.0 / 60.0
+            let progress = 1 - exp(-safeDuration / max(responseTime, 0.001))
+            let next = current + distance * CGFloat(progress)
+            return abs(target - next) <= scrollSnapTolerance ? target : next
+        }
+
+        private nonisolated static let scrollSnapTolerance: CGFloat = 0.5
+        private nonisolated static let scrollApplicationTolerance: CGFloat = 0.01
+
+        private func applyScroll(to origin: NSPoint) {
+            guard let scrollView else { return }
+            let clipView = scrollView.contentView
+            guard abs(clipView.bounds.minY - origin.y) > Self.scrollApplicationTolerance
+                    || abs(clipView.bounds.minX - origin.x)
+                        > Self.scrollApplicationTolerance else {
+                return
+            }
+            isProgrammaticScroll = true
+            defer { isProgrammaticScroll = false }
+            clipView.scroll(to: origin)
             scrollView.reflectScrolledClipView(clipView)
+        }
+
+        private func cancelScrollTarget() {
+            targetScrollOrigin = nil
+            displayLink?.isPaused = true
+        }
+
+        private func attachDisplayLink(to probe: NSView) {
+            guard displayLink == nil else { return }
+            let link = probe.displayLink(
+                target: self,
+                selector: #selector(displayLinkDidFire(_:))
+            )
+            link.isPaused = true
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        }
+
+        @objc private func displayLinkDidFire(_ link: CADisplayLink) {
+            let duration = link.duration > 0
+                ? link.duration
+                : link.targetTimestamp - link.timestamp
+            advanceScrollFrame(duration: duration)
         }
 
         private func setPinned(_ pinned: Bool) {
             if pinned != isPinnedToBottom.wrappedValue {
                 isPinnedToBottom.wrappedValue = pinned
             }
-            if pinned { requestScrollToBottom() }
+            if pinned {
+                requestScrollToBottom()
+            } else {
+                cancelScrollTarget()
+            }
         }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
@@ -40,7 +40,7 @@ struct JumpToBottomScrollTests {
         )
     }
 
-    /// Drains the coalescing hop `requestScrollToBottom` schedules.
+    /// Drains the target-update hop `requestScrollToBottom` schedules.
     private func settle() async {
         await Task.yield()
         try? await Task.sleep(nanoseconds: 60_000_000)
@@ -66,11 +66,21 @@ struct JumpToBottomScrollTests {
         coordinator.attach(to: probe)
         coordinator.honourScrollRequest(1)
         await settle()
+        coordinator.advanceScrollFrame(duration: 1.0 / 60.0)
 
         #expect(
             scrollView.contentView.bounds.minY > 0,
             "the transcript did not move — re-pinning alone never scrolled an already-attached view"
         )
+        #expect(
+            scrollView.contentView.bounds.minY < 1_800,
+            "the first frame jumped directly to the target instead of moving smoothly"
+        )
+
+        for _ in 0..<30 {
+            coordinator.advanceScrollFrame(duration: 1.0 / 60.0)
+        }
+        #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
     }
 
     /// The coalescing this sits next to exists because `updateNSView` runs for
@@ -117,6 +127,85 @@ struct JumpToBottomScrollTests {
         await settle()
 
         #expect(scrollView.contentView.bounds.minY == 0)
+    }
+
+    @Test("Unchanged document heights do not schedule follow scrolling")
+    func unchangedDocumentHeightIsIgnored() {
+        #expect(!TranscriptScrollPositionProbe.Coordinator.documentHeightChanged(
+            from: 2_000, to: 2_000
+        ))
+        #expect(!TranscriptScrollPositionProbe.Coordinator.documentHeightChanged(
+            from: 2_000, to: 2_000.4
+        ))
+        #expect(TranscriptScrollPositionProbe.Coordinator.documentHeightChanged(
+            from: 2_000, to: 2_001
+        ))
+        #expect(TranscriptScrollPositionProbe.Coordinator.documentHeightChanged(
+            from: nil, to: 2_000
+        ))
+    }
+
+    @Test("Frame interpolation moves monotonically and converges")
+    func frameInterpolationConverges() {
+        var current: CGFloat = 0
+        var offsets: [CGFloat] = []
+
+        for _ in 0..<30 {
+            current = TranscriptScrollPositionProbe.Coordinator.nextScrollOffset(
+                current: current,
+                target: 100,
+                duration: 1.0 / 60.0
+            )
+            offsets.append(current)
+        }
+
+        #expect(offsets[0] > 0 && offsets[0] < 100)
+        #expect(zip(offsets, offsets.dropFirst()).allSatisfy { $0.0 <= $0.1 })
+        #expect(offsets[0] < offsets[1])
+        #expect(current == 100)
+    }
+
+    @Test("A user scroll cancels an in-flight bottom target")
+    func userScrollCancelsTarget() async {
+        var pinned = false
+        let binding = Binding(get: { pinned }, set: { pinned = $0 })
+        let (scrollView, _, probe) = makeScrollView()
+        let coordinator = makeCoordinator(pinned: binding)
+
+        coordinator.attach(to: probe)
+        coordinator.honourScrollRequest(0)
+        pinned = true
+        coordinator.honourScrollRequest(1)
+        await settle()
+
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView
+        )
+        let originBeforeFrame = scrollView.contentView.bounds.origin
+        coordinator.advanceScrollFrame(duration: 1.0 / 60.0)
+
+        #expect(!pinned)
+        #expect(scrollView.contentView.bounds.origin == originBeforeFrame)
+    }
+
+    @Test("A long streaming answer stays pinned without user input")
+    func longAnswerKeepsFollowing() async {
+        var pinned = true
+        let binding = Binding(get: { pinned }, set: { pinned = $0 })
+        let (scrollView, document, probe) = makeScrollView()
+        let coordinator = makeCoordinator(pinned: binding)
+
+        coordinator.attach(to: probe)
+        await settle()
+        #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
+
+        document.setFrameSize(NSSize(width: 400, height: 4_000))
+        await settle()
+        coordinator.advanceScrollFrame(duration: 1.0 / 60.0)
+
+        #expect(pinned)
+        #expect(scrollView.contentView.bounds.minY > 1_800)
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
@@ -189,13 +189,14 @@ struct JumpToBottomScrollTests {
         #expect(scrollView.contentView.bounds.origin == originBeforeFrame)
     }
 
-    @Test("A long streaming answer stays pinned without user input")
-    func longAnswerKeepsFollowing() async {
+    @Test("A long streaming answer releases after one viewport")
+    func longAnswerReleasesFollowing() async {
         var pinned = true
         let binding = Binding(get: { pinned }, set: { pinned = $0 })
         let (scrollView, document, probe) = makeScrollView()
         let coordinator = makeCoordinator(pinned: binding)
 
+        coordinator.setStreaming(true)
         coordinator.attach(to: probe)
         await settle()
         #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
@@ -204,8 +205,22 @@ struct JumpToBottomScrollTests {
         await settle()
         coordinator.advanceScrollFrame(duration: 1.0 / 60.0)
 
-        #expect(pinned)
-        #expect(scrollView.contentView.bounds.minY > 1_800)
+        #expect(!pinned)
+        #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
+    }
+
+    @Test("Answer growth threshold is one viewport")
+    func answerGrowthThreshold() {
+        #expect(!TranscriptScrollPositionProbe.Coordinator.answerOutgrewViewport(
+            documentHeight: 2_200,
+            documentHeightAtStreamStart: 2_000,
+            viewportHeight: 200
+        ))
+        #expect(TranscriptScrollPositionProbe.Coordinator.answerOutgrewViewport(
+            documentHeight: 2_201,
+            documentHeightAtStreamStart: 2_000,
+            viewportHeight: 200
+        ))
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -149,6 +149,28 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.result.items == MarkdownCompiler().compile(source).items)
     }
 
+    @Test("A definition remains available to references in later blocks")
+    func earlierDefinitionKeepsLaterReferenceParity() {
+        let first = "Intro.\n\n[docs]: /guide\n\nMiddle."
+        let source = first + "\n\nRead [docs]."
+        var document = StreamingMarkdownDocument()
+
+        document.append(first)
+        document.append("\n\nRead [docs].")
+        document.finish()
+
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+    }
+
+    @Test("A definition-shaped code line does not pin the mutable tail")
+    func definitionInsideCodeRemainsOpaque() {
+        var document = StreamingMarkdownDocument()
+        document.append("```text\n[docs]: /literal\n```\n\nNext paragraph")
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.mutableSource == "Next paragraph")
+    }
+
     @Test("A complete inline link does not block stable prefix commitment")
     func inlineLinkCanCommit() {
         var document = StreamingMarkdownDocument()
@@ -198,8 +220,10 @@ struct StreamingMarkdownDocumentTests {
             "\n\n[**the docs**]: https://rapidmlx.ai/docs\n\nAfter the definition"
         )
 
-        #expect(document.stableBlocks.contains { $0.source.contains("[**the docs**]:") })
-        #expect(document.mutableSource == "After the definition")
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.mutableSource.hasPrefix("Read [**the docs**]."))
+        #expect(document.mutableSource.contains("[**the docs**]: https://rapidmlx.ai/docs"))
+        #expect(document.mutableSource.hasSuffix("After the definition"))
         document.finish()
         let source = document.receivedSource
         #expect(document.result.items == MarkdownCompiler().compile(source).items)

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Streaming Markdown document")
+struct StreamingMarkdownDocumentTests {
+
+    @Test("A following top-level block commits the stable prefix")
+    func commitsStablePrefix() {
+        var document = StreamingMarkdownDocument()
+
+        document.append("First paragraph.")
+        let mutableID = document.segments.first?.id
+
+        document.append("\n\nSecond")
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].id == 0)
+        #expect(document.stableBlocks[0].id == mutableID)
+        #expect(document.stableBlocks[0].source.contains("First paragraph."))
+        #expect(document.mutableSource == "Second")
+        #expect(document.segments.map(\.id) == [0, 1])
+        #expect(document.segments.map(\.isMutable) == [false, true])
+
+        let stable = document.stableBlocks[0]
+        let stableCompilations = document.compilationStats.stableFragmentCompilations
+        document.append(" paragraph continues without closing.")
+
+        #expect(document.stableBlocks == [stable])
+        #expect(document.compilationStats.stableFragmentCompilations == stableCompilations)
+        #expect(document.mutableSource == "Second paragraph continues without closing.")
+    }
+
+    @Test("Byte-sized streaming produces the same final document as one-shot compilation")
+    func characterReplayMatchesOneShotCompile() {
+        let source = """
+        # Streaming title
+
+        A paragraph with **bold**, _emphasis_, `code`, and [Rapid](https://rapidmlx.ai).
+
+        - first item
+        - second item
+
+        ```swift
+        let greeting = "hello"
+        print(greeting)
+        ```
+
+        | model | size |
+        |:------|-----:|
+        | small | 1 GB |
+
+        最后一段包含中文和 $x_1$。
+        """
+        var document = StreamingMarkdownDocument()
+
+        for character in source {
+            document.append(String(character))
+        }
+        document.finish()
+
+        let expected = MarkdownCompiler().compile(source)
+        #expect(document.result.items == expected.items)
+        #expect(document.receivedSource == source)
+        #expect(document.mutableSource.isEmpty)
+        #expect(document.isFinished)
+        #expect(Set(document.stableBlocks.map(\.id)).count == document.stableBlocks.count)
+    }
+
+    @Test("SSE-sized chunks preserve final Markdown parity")
+    func chunkReplayMatchesOneShotCompile() {
+        let chunks = [
+            "Intro with an image.\n\n",
+            "![one](https://example.com/one.png)\n\n",
+            "![two](https://example.com/two.png)\n\n",
+            "> quoted ",
+            "text\n\n",
+            "Final paragraph.",
+        ]
+        let source = chunks.joined()
+        var document = StreamingMarkdownDocument()
+
+        for chunk in chunks {
+            document.append(chunk)
+        }
+        document.finish()
+
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+    }
+
+    @Test("A later reference definition can still style an earlier paragraph")
+    func referenceDefinitionsKeepEarlierSourceMutable() {
+        let source = """
+        Read [the docs] before continuing.
+
+        A second paragraph proves a block boundary.
+
+        [the docs]: https://rapidmlx.ai/docs
+        """
+        var document = StreamingMarkdownDocument()
+
+        for character in source {
+            document.append(String(character))
+        }
+        document.finish()
+
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+        #expect(document.stableBlocks.first?.source.contains("[the docs]") == true)
+    }
+
+    @Test("A complete inline link does not block stable prefix commitment")
+    func inlineLinkCanCommit() {
+        var document = StreamingMarkdownDocument()
+
+        document.append("Read [the docs](https://rapidmlx.ai/docs).\n\nNext paragraph")
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].source.contains("[the docs](https://rapidmlx.ai/docs)"))
+        #expect(document.mutableSource == "Next paragraph")
+    }
+
+    @Test("Unfinished inline syntax and fences remain in the mutable tail")
+    func unfinishedSyntaxStaysMutable() {
+        var document = StreamingMarkdownDocument()
+
+        document.append("Committed paragraph.\n\n**unfinished")
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.mutableSource == "**unfinished")
+        let stableID = document.stableBlocks[0].id
+
+        document.append(" bold** and `inline")
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].id == stableID)
+        #expect(document.mutableSource.hasSuffix("`inline"))
+
+        document.append(" code`\n\n```swift")
+        #expect(document.stableBlocks.count == 2)
+        #expect(document.mutableSource == "```swift")
+        #expect(document.mutableResult.items.isEmpty)
+
+        document.append("\nlet value = 1")
+        #expect(document.stableBlocks.count == 2)
+        #expect(document.mutableResult.items.contains {
+            if case .code = $0 { return true }
+            return false
+        })
+    }
+
+    @Test("Unicode CRLF source locations split on a valid String boundary")
+    func unicodeCRLFSplit() {
+        let source = "你好，世界。\r\n\r\nSecond paragraph with café."
+        var document = StreamingMarkdownDocument()
+
+        document.append(source)
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].source.contains("你好，世界。"))
+        #expect(document.mutableSource == "Second paragraph with café.")
+        document.finish()
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+    }
+
+    @Test("Finishing never recompiles an already committed prefix")
+    func finishOnlyCompilesTail() {
+        var document = StreamingMarkdownDocument()
+        document.append("Stable.\n\nMutable tail")
+        let stableBeforeFinish = document.stableBlocks
+        let stableCompilations = document.compilationStats.stableFragmentCompilations
+
+        document.finish()
+
+        #expect(Array(document.stableBlocks.prefix(stableBeforeFinish.count)) == stableBeforeFinish)
+        #expect(
+            document.compilationStats.stableFragmentCompilations
+                == stableCompilations + 1
+        )
+        #expect(document.stableBlocks.last?.source == "Mutable tail")
+    }
+
+    @Test("Committing a paragraph preserves its rendered height")
+    @MainActor
+    func committedParagraphKeepsItsLayout() {
+        let options = MarkdownOptions.assistantTranscript()
+        let width: CGFloat = 500
+        var document = StreamingMarkdownDocument()
+        document.append("First paragraph.")
+        let mutable = document.segments[0]
+        let mutableHeight = renderedTextHeight(
+            for: mutable.result, options: options, width: width
+        )
+
+        document.append("\n\nSecond paragraph.")
+        let committed = document.segments[0]
+        let committedHeight = renderedTextHeight(
+            for: committed.result, options: options, width: width
+        )
+
+        #expect(committed.id == mutable.id)
+        #expect(committed.result.items == mutable.result.items)
+        #expect(committedHeight == mutableHeight)
+    }
+
+    @MainActor
+    private func renderedTextHeight(
+        for result: MarkdownResult,
+        options: MarkdownOptions,
+        width: CGFloat
+    ) -> CGFloat {
+        let blocks = result.items.compactMap { item -> MarkdownItem.TextBlock? in
+            guard case let .text(block) = item else { return nil }
+            return block
+        }
+        let renderer = MarkdownTextRenderer(options: options)
+        renderer.setBlocks(blocks)
+        return renderer.measureHeight(width: width)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -171,6 +171,26 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.mutableSource == "Next paragraph")
     }
 
+    @Test("Escaped and multiline definition labels keep streaming parity")
+    func complexDefinitionLabelsKeepParity() {
+        let sources = [
+            "[foo\\]]: /target\n\nMiddle.\n\nUse [foo\\]].",
+            "[foo\nbar]: /target\n\nMiddle.\n\nUse [foo bar].",
+        ]
+
+        for source in sources {
+            var document = StreamingMarkdownDocument()
+            for character in source {
+                document.append(String(character))
+            }
+            document.finish()
+            #expect(
+                document.result.items == MarkdownCompiler().compile(source).items,
+                "streaming diverged for \(source)"
+            )
+        }
+    }
+
     @Test("A complete inline link does not block stable prefix commitment")
     func inlineLinkCanCommit() {
         var document = StreamingMarkdownDocument()

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -119,6 +119,96 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.mutableSource == "Next paragraph")
     }
 
+    @Test("Code brackets do not block stable prefix commitment")
+    func codeBracketsCanCommit() {
+        let source = """
+        Intro paragraph.
+
+        Use `arr[0]` for the first value.
+
+        ```swift
+        let pivot = values[indexes[0]]
+        ```
+
+        Next paragraph
+        """
+        var document = StreamingMarkdownDocument()
+
+        document.append(source)
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].source.contains("arr[0]"))
+        #expect(document.stableBlocks[0].source.contains("indexes[0]"))
+        #expect(document.mutableSource == "Next paragraph")
+    }
+
+    @Test("An unresolved reference holds only its own suffix mutable")
+    func unresolvedReferenceCommitsSafeLeadingBlocks() {
+        var document = StreamingMarkdownDocument()
+
+        document.append("Safe paragraph.\n\nRead [**the docs**].\n\nFollowing paragraph")
+
+        #expect(document.stableBlocks.count == 1)
+        #expect(document.stableBlocks[0].source.contains("Safe paragraph."))
+        #expect(!document.stableBlocks[0].source.contains("the docs"))
+        #expect(document.mutableSource.hasPrefix("Read [**the docs**]."))
+
+        document.append(
+            "\n\n[**the docs**]: https://rapidmlx.ai/docs\n\nAfter the definition"
+        )
+
+        #expect(document.stableBlocks.contains { $0.source.contains("[**the docs**]:") })
+        #expect(document.mutableSource == "After the definition")
+        document.finish()
+        let source = document.receivedSource
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+    }
+
+    @Test("Ordinary character frames do not probe for a structural split")
+    func proseFramesSkipSplitProbe() {
+        var document = StreamingMarkdownDocument()
+
+        for character in "A paragraph arriving one character at a time." {
+            document.append(String(character))
+        }
+        #expect(document.compilationStats.splitProbes == 0)
+
+        document.append("\n")
+        document.append("\n")
+        document.append("N")
+        let probesAtBoundary = document.compilationStats.splitProbes
+        #expect(probesAtBoundary == 2)
+
+        for character in "ext paragraph keeps growing." {
+            document.append(String(character))
+        }
+        #expect(document.compilationStats.splitProbes == probesAtBoundary)
+    }
+
+    @Test("Code-heavy bracket streams retain incremental work bounds")
+    func codeBracketsRetainIncrementalBounds() {
+        func replay(expression: String) -> StreamingMarkdownDocument {
+            var document = StreamingMarkdownDocument()
+            for index in 0..<40 {
+                document.append(
+                    "## Part \(index)\n\nUse `\(expression)` in this step.\n\n"
+                )
+            }
+            return document
+        }
+
+        let bracketed = replay(expression: "arr[0]")
+        let control = replay(expression: "arr.first")
+
+        #expect(bracketed.stableBlocks.count == control.stableBlocks.count)
+        #expect(bracketed.stableBlocks.count >= 30)
+        #expect(
+            bracketed.compilationStats.largestCompiledFragmentUTF8Bytes
+                <= control.compilationStats.largestCompiledFragmentUTF8Bytes + 16
+        )
+        #expect(bracketed.compilationStats.splitProbes == control.compilationStats.splitProbes)
+    }
+
     @Test("Unfinished inline syntax and fences remain in the mutable tail")
     func unfinishedSyntaxStaysMutable() {
         var document = StreamingMarkdownDocument()

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -88,6 +88,27 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.result.items == MarkdownCompiler().compile(source).items)
     }
 
+    @Test("Rendered segments coalesce images across stable boundaries")
+    func renderedSegmentsCoalesceAdjacentImages() {
+        let source = """
+            ![one](https://example.com/one.png)
+
+            ![two](https://example.com/two.png)
+            """
+        var document = StreamingMarkdownDocument()
+        document.append("![one](https://example.com/one.png)\n\n")
+        document.append("![two](https://example.com/two.png)")
+
+        let renderedItems = document.segments.flatMap(\.result.items)
+        #expect(renderedItems == MarkdownCompiler().compile(source).items)
+        #expect(renderedItems.count == 1)
+        guard case let .images(images)? = renderedItems.first else {
+            Issue.record("adjacent images did not render as one grid")
+            return
+        }
+        #expect(images.urls.count == 2)
+    }
+
     @Test("A later reference definition can still style an earlier paragraph")
     func referenceDefinitionsKeepEarlierSourceMutable() {
         let source = """

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownDocumentTests.swift
@@ -129,6 +129,26 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.stableBlocks.first?.source.contains("[the docs]") == true)
     }
 
+    @Test("A multiline reference label remains mutable until its definition")
+    func multilineReferenceLabelKeepsParity() {
+        let source = """
+            [foo
+            bar]
+
+            Next paragraph
+
+            [foo bar]: /target
+            """
+        var document = StreamingMarkdownDocument()
+
+        for character in source {
+            document.append(String(character))
+        }
+        document.finish()
+
+        #expect(document.result.items == MarkdownCompiler().compile(source).items)
+    }
+
     @Test("A complete inline link does not block stable prefix commitment")
     func inlineLinkCanCommit() {
         var document = StreamingMarkdownDocument()

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownStoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownStoreTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Streaming Markdown store")
+@MainActor
+struct StreamingMarkdownStoreTests {
+
+    @Test("Accumulated updates append only their suffix")
+    func accumulatedTextBecomesDocumentDeltas() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+
+        store.enqueue(id: id, text: "First paragraph.\n\nSec")
+        presentAll(store)
+        let stable = store.document.stableBlocks[0]
+        let stableCompilations = store.document.compilationStats.stableFragmentCompilations
+
+        store.enqueue(id: id, text: "First paragraph.\n\nSecond paragraph grows.")
+        presentAll(store)
+
+        #expect(store.document.receivedSource == "First paragraph.\n\nSecond paragraph grows.")
+        #expect(store.document.stableBlocks == [stable])
+        #expect(
+            store.document.compilationStats.stableFragmentCompilations
+                == stableCompilations
+        )
+        #expect(store.document.mutableSource == "Second paragraph grows.")
+    }
+
+    @Test("Finishing preserves the final segments for row handoff")
+    func finishKeepsFinalSnapshot() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+        let source = "Intro.\n\nFinal **answer**."
+
+        store.enqueue(id: id, text: source)
+        store.finish()
+        presentAll(store)
+
+        #expect(store.messageID == nil)
+        #expect(store.documentMessageID == id)
+        #expect(store.hasDocument(for: id))
+        #expect(store.document.isFinished)
+        #expect(store.document.mutableSource.isEmpty)
+        #expect(store.segments.allSatisfy { !$0.isMutable })
+        #expect(store.segments(for: id) == store.segments)
+        #expect(store.result.items == MarkdownCompiler().compile(source).items)
+    }
+
+    @Test("Finishing reconciles transport backlog with the authoritative body")
+    func finishUsesAuthoritativeBody() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+        let partial = "Answer body"
+        let final = partial + "\n\nSources:\n- [Rapid](https://rapidmlx.ai)"
+
+        store.enqueue(id: id, text: partial)
+        store.finish(id: id, finalText: final)
+        presentAll(store)
+
+        #expect(store.document.receivedSource == final)
+        #expect(store.result.items == MarkdownCompiler().compile(final).items)
+    }
+
+    @Test("A completed document accepts a later authoritative correction")
+    func completedDocumentSynchronizesLaterContent() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+
+        store.enqueue(id: id, text: "Initial")
+        store.finish()
+        presentAll(store)
+        store.synchronizeCompleted(id: id, text: "Startup failure explanation")
+
+        #expect(store.document.receivedSource == "Startup failure explanation")
+        #expect(store.document.isFinished)
+    }
+
+    @Test("A new message releases the prior completed document")
+    func newMessageReleasesCompletedDocument() {
+        let store = StreamingMarkdownStore()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        store.enqueue(id: firstID, text: "Old first.\n\nOld second.")
+        store.finish()
+        presentAll(store)
+        store.enqueue(id: secondID, text: "New answer")
+        presentAll(store)
+
+        #expect(store.messageID == secondID)
+        #expect(store.documentMessageID == secondID)
+        #expect(store.document.receivedSource == "New answer")
+        #expect(store.document.stableBlocks.isEmpty)
+        #expect(store.segments.map(\.id) == [0])
+        #expect(!store.hasDocument(for: firstID))
+        #expect(store.segments(for: firstID).isEmpty)
+    }
+
+    @Test("A detectable non-monotonic update resets safely")
+    func shorterUpdateResetsDocument() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+
+        store.enqueue(id: id, text: "Long first paragraph.\n\nLong second paragraph.")
+        presentAll(store)
+        store.enqueue(id: id, text: "Replacement")
+        presentAll(store)
+
+        #expect(store.document.receivedSource == "Replacement")
+        #expect(store.document.stableBlocks.isEmpty)
+        #expect(store.document.mutableSource == "Replacement")
+    }
+
+    @Test("Transport input stays buffered until a presentation frame")
+    func inputWaitsForDisplayFrame() {
+        let store = StreamingMarkdownStore()
+        let id = UUID()
+
+        store.enqueue(id: id, text: "Buffered text")
+
+        #expect(store.receivedText == "Buffered text")
+        #expect(store.document.receivedSource.isEmpty)
+        #expect(store.pendingGraphemeCount == "Buffered text".count)
+
+        store.advancePresentationFrame(duration: 1.0 / 60.0)
+
+        #expect(!store.document.receivedSource.isEmpty)
+        #expect("Buffered text".hasPrefix(store.document.receivedSource))
+    }
+
+    @Test("Finishing drains over frames before finalizing in place")
+    func finishDrainsBeforeFinalizing() {
+        let store = StreamingMarkdownStore()
+        let id = UUID()
+        let source = String(repeating: "stream ", count: 30)
+
+        store.enqueue(id: id, text: source)
+        store.finish()
+
+        #expect(!store.document.isFinished)
+        #expect(store.isPresentationActive)
+
+        presentAll(store)
+
+        #expect(store.document.isFinished)
+        #expect(store.document.receivedSource == source)
+        #expect(!store.isPresentationActive)
+    }
+
+    @Test("Reset releases the active document and presentation backlog")
+    func resetReleasesDocument() {
+        let id = UUID()
+        let store = StreamingMarkdownStore()
+
+        store.enqueue(id: id, text: "Buffered response")
+        store.reset()
+
+        #expect(store.documentMessageID == nil)
+        #expect(store.messageID == nil)
+        #expect(!store.hasDocument(for: id))
+        #expect(!store.isPresentationActive)
+    }
+
+    private func presentAll(
+        _ store: StreamingMarkdownStore,
+        maxFrames: Int = 30
+    ) {
+        for _ in 0..<maxFrames where store.isPresentationActive {
+            store.advancePresentationFrame(duration: 1.0 / 60.0)
+        }
+        #expect(!store.isPresentationActive)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownStoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingMarkdownStoreTests.swift
@@ -19,13 +19,14 @@ struct StreamingMarkdownStoreTests {
         store.enqueue(id: id, text: "First paragraph.\n\nSecond paragraph grows.")
         presentAll(store)
 
-        #expect(store.document.receivedSource == "First paragraph.\n\nSecond paragraph grows.")
+        #expect(store.receivedText == "First paragraph.\n\nSecond paragraph grows.")
+        #expect(store.document.receivedSource == "First paragraph.\n\nSecond paragraph grows")
         #expect(store.document.stableBlocks == [stable])
         #expect(
             store.document.compilationStats.stableFragmentCompilations
                 == stableCompilations
         )
-        #expect(store.document.mutableSource == "Second paragraph grows.")
+        #expect(store.document.mutableSource == "Second paragraph grows")
     }
 
     @Test("Finishing preserves the final segments for row handoff")
@@ -91,7 +92,8 @@ struct StreamingMarkdownStoreTests {
 
         #expect(store.messageID == secondID)
         #expect(store.documentMessageID == secondID)
-        #expect(store.document.receivedSource == "New answer")
+        #expect(store.receivedText == "New answer")
+        #expect(store.document.receivedSource == "New answe")
         #expect(store.document.stableBlocks.isEmpty)
         #expect(store.segments.map(\.id) == [0])
         #expect(!store.hasDocument(for: firstID))
@@ -108,9 +110,10 @@ struct StreamingMarkdownStoreTests {
         store.enqueue(id: id, text: "Replacement")
         presentAll(store)
 
-        #expect(store.document.receivedSource == "Replacement")
+        #expect(store.receivedText == "Replacement")
+        #expect(store.document.receivedSource == "Replacemen")
         #expect(store.document.stableBlocks.isEmpty)
-        #expect(store.document.mutableSource == "Replacement")
+        #expect(store.document.mutableSource == "Replacemen")
     }
 
     @Test("Transport input stays buffered until a presentation frame")

--- a/apps/rapid-mac/Tests/RapidTests/StreamingRowIsolationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingRowIsolationTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Guards for the streaming transcript boundary. One `MessageRow` now spans
+/// streaming and completion, while its growing prose remains store-owned.
+@Suite("Streaming row isolation")
+@MainActor
+struct StreamingRowIsolationTests {
+
+    private static var sourceURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // RapidTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent("Sources/Rapid/UI/ChatView.swift")
+    }
+
+    @Test("Streaming and completion use one message row")
+    func streamingAndCompletionShareMessageRow() throws {
+        let source = try String(contentsOf: Self.sourceURL, encoding: .utf8)
+        #expect(!source.contains("StreamingMessageRow"))
+        #expect(source.contains("ChatView.transcriptPresentationMessage(message)"))
+        #expect(source.contains("StreamingTextKitMarkdownView("))
+
+        let messageRowStart = try #require(source.range(of: "private struct MessageRow"))
+        let toolChipStart = try #require(source.range(of: "private struct ToolCallChip"))
+        let messageRow = String(source[messageRowStart.lowerBound..<toolChipStart.lowerBound])
+
+        #expect(messageRow.contains("var streamingMarkdown: StreamingMarkdownStore?"))
+        #expect(messageRow.contains("StreamingTextKitMarkdownView("))
+    }
+
+    @Test("The streaming row snapshot excludes only the growing body")
+    func streamingPresentationExcludesGrowingContent() {
+        let id = UUID()
+        let message = ChatMessage(
+            id: id,
+            role: .assistant,
+            content: "A growing answer",
+            reasoning: "Stable reasoning",
+            status: .streaming,
+            contentTruncated: true
+        )
+
+        let presentation = ChatView.transcriptPresentationMessage(message)
+
+        #expect(presentation.id == id)
+        #expect(presentation.content.isEmpty)
+        #expect(presentation.reasoning == message.reasoning)
+        #expect(presentation.status == .streaming)
+        #expect(presentation.contentTruncated)
+
+        var completed = message
+        completed.status = .complete
+        #expect(ChatView.transcriptPresentationMessage(completed) == completed)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
@@ -41,6 +41,31 @@ struct StreamingTextPresentationBufferTests {
         #expect(deltas.allSatisfy { $0.count == 1 })
     }
 
+    @Test("Transport chunks may complete the final pending grapheme")
+    func chunkBoundaryCanExtendPendingGrapheme() {
+        var buffer = StreamingTextPresentationBuffer(
+            configuration: .init(targetLatency: 1, completionDrainDuration: 1)
+        )
+
+        #expect(buffer.receive("e") == .appended)
+        #expect(buffer.receive("e\u{301}") == .appended)
+        #expect(buffer.pendingGraphemeCount == 1)
+        #expect(buffer.presentFrame(duration: frameDuration) == "e\u{301}")
+        #expect(!buffer.hasPendingText)
+    }
+
+    @Test("A growing correction resets instead of appending to stale text")
+    func growingCorrectionResets() {
+        var buffer = StreamingTextPresentationBuffer()
+        buffer.receive("teh")
+        _ = buffer.presentFrame(duration: frameDuration)
+
+        #expect(buffer.receive("the answer") == .reset)
+        #expect(buffer.receivedText == "the answer")
+        #expect(buffer.presentedText.isEmpty)
+        #expect(buffer.pendingText == "the answer")
+    }
+
     @Test("Adaptive rate bounds a large backlog")
     func adaptiveRateBoundsBacklog() {
         var buffer = StreamingTextPresentationBuffer()

--- a/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
@@ -16,6 +16,11 @@ struct StreamingTextPresentationBufferTests {
         while let delta = buffer.presentFrame(duration: frameDuration) {
             deltas.append(delta)
         }
+        while let delta = buffer.presentFrame(
+            duration: frameDuration, isFinishing: true
+        ) {
+            deltas.append(delta)
+        }
 
         #expect(deltas.count > 1)
         #expect(deltas.count <= 8)
@@ -36,6 +41,11 @@ struct StreamingTextPresentationBufferTests {
         while let delta = buffer.presentFrame(duration: frameDuration) {
             deltas.append(delta)
         }
+        while let delta = buffer.presentFrame(
+            duration: frameDuration, isFinishing: true
+        ) {
+            deltas.append(delta)
+        }
 
         #expect(deltas == graphemes)
         #expect(deltas.allSatisfy { $0.count == 1 })
@@ -50,8 +60,30 @@ struct StreamingTextPresentationBufferTests {
         #expect(buffer.receive("e") == .appended)
         #expect(buffer.receive("e\u{301}") == .appended)
         #expect(buffer.pendingGraphemeCount == 1)
-        #expect(buffer.presentFrame(duration: frameDuration) == "e\u{301}")
+        #expect(buffer.presentFrame(duration: frameDuration) == nil)
+        #expect(buffer.presentFrame(
+            duration: frameDuration, isFinishing: true
+        ) == "e\u{301}")
         #expect(!buffer.hasPendingText)
+    }
+
+    @Test("A displayed frame never exposes an extensible grapheme tail")
+    func holdsExtensibleTailAcrossFrames() {
+        var buffer = StreamingTextPresentationBuffer(
+            configuration: .init(targetLatency: 1, completionDrainDuration: 1)
+        )
+
+        buffer.receive("👨")
+        #expect(buffer.presentFrame(duration: frameDuration) == nil)
+        buffer.receive("👨‍👩")
+        #expect(buffer.presentFrame(duration: frameDuration) == nil)
+        buffer.receive("👨‍👩x")
+        #expect(buffer.presentFrame(duration: frameDuration) == "👨‍👩")
+        #expect(buffer.presentFrame(duration: frameDuration) == nil)
+        #expect(buffer.presentFrame(
+            duration: frameDuration, isFinishing: true
+        ) == "x")
+        #expect(buffer.presentedText == "👨‍👩x")
     }
 
     @Test("A growing correction resets instead of appending to stale text")
@@ -74,7 +106,7 @@ struct StreamingTextPresentationBufferTests {
 
         buffer.receive(source)
         while buffer.hasPendingText {
-            _ = buffer.presentFrame(duration: frameDuration)
+            _ = buffer.presentFrame(duration: frameDuration, isFinishing: true)
             frames += 1
         }
 

--- a/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingTextPresentationBufferTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Streaming text presentation buffer")
+struct StreamingTextPresentationBufferTests {
+    private let frameDuration = 1.0 / 60.0
+
+    @Test("A transport burst is spread across display frames")
+    func burstIsPresentedAcrossFrames() {
+        let source = String(repeating: "abcdefghij", count: 12)
+        var buffer = StreamingTextPresentationBuffer()
+        var deltas: [String] = []
+
+        #expect(buffer.receive(source) == .appended)
+        while let delta = buffer.presentFrame(duration: frameDuration) {
+            deltas.append(delta)
+        }
+
+        #expect(deltas.count > 1)
+        #expect(deltas.count <= 8)
+        #expect(deltas.joined() == source)
+        #expect(buffer.presentedText == source)
+    }
+
+    @Test("Presentation never splits extended grapheme clusters")
+    func preservesGraphemeBoundaries() {
+        let graphemes = ["👨‍👩‍👧‍👦", "é", "🇨🇳", "好"]
+        let source = graphemes.joined()
+        var buffer = StreamingTextPresentationBuffer(
+            configuration: .init(targetLatency: 1, completionDrainDuration: 1)
+        )
+        var deltas: [String] = []
+
+        buffer.receive(source)
+        while let delta = buffer.presentFrame(duration: frameDuration) {
+            deltas.append(delta)
+        }
+
+        #expect(deltas == graphemes)
+        #expect(deltas.allSatisfy { $0.count == 1 })
+    }
+
+    @Test("Adaptive rate bounds a large backlog")
+    func adaptiveRateBoundsBacklog() {
+        var buffer = StreamingTextPresentationBuffer()
+        let source = String(repeating: "字", count: 600)
+        var frames = 0
+
+        buffer.receive(source)
+        while buffer.hasPendingText {
+            _ = buffer.presentFrame(duration: frameDuration)
+            frames += 1
+        }
+
+        #expect(frames <= 8)
+        #expect(buffer.presentedText == source)
+    }
+
+    @Test("Completion drains the remaining text within its deadline")
+    func completionDrainIsBounded() {
+        var buffer = StreamingTextPresentationBuffer(
+            configuration: .init(targetLatency: 1, completionDrainDuration: 0.15)
+        )
+        let source = String(repeating: "tail", count: 100)
+        var frames = 0
+
+        buffer.receive(source)
+        while buffer.hasPendingText {
+            _ = buffer.presentFrame(duration: frameDuration, isFinishing: true)
+            frames += 1
+        }
+
+        #expect(frames <= 9)
+        #expect(buffer.presentedText == source)
+    }
+
+    @Test("A non-monotonic update resets received and presented state")
+    func replacementResetsState() {
+        var buffer = StreamingTextPresentationBuffer()
+
+        buffer.receive("Long accumulated response")
+        _ = buffer.presentFrame(duration: frameDuration)
+        #expect(buffer.receive("Replacement") == .reset)
+
+        #expect(buffer.receivedText == "Replacement")
+        #expect(buffer.presentedText.isEmpty)
+        #expect(buffer.pendingText == "Replacement")
+        #expect(buffer.pendingGraphemeCount == "Replacement".count)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
@@ -116,6 +116,31 @@ struct TextFadeBacklogTests {
         // opaque text color after the disabled fade clears its overrides.
         #expect((alpha ?? 1) > 0.99, "new streaming text was hidden by the fade")
     }
+
+    @Test("Committing one segment preserves the message fade timeline")
+    func segmentStopPreservesSharedState() {
+        let state = TextFadeAnimationState()
+        state.smoothedWordsPerSecond = 96
+        state.accentDecayStartTime = 42
+
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .black
+        let renderer = MarkdownTextRenderer(options: options)
+        let animator = TextFadeAnimator(
+            textLayoutManager: renderer.textLayoutManager,
+            textContentStorage: renderer.textContentStorage,
+            animationState: state
+        )
+
+        animator.stopAndReveal()
+
+        #expect(state.smoothedWordsPerSecond == 96)
+        #expect(state.accentDecayStartTime == 42)
+
+        animator.reset()
+        #expect(state.smoothedWordsPerSecond == 0)
+        #expect(state.accentDecayStartTime == nil)
+    }
 }
 
 /// The rate the reveal adapts to must be *units per second*, not *flushes per

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
@@ -89,6 +89,33 @@ struct TextFadeBacklogTests {
         }
         #expect((alpha ?? 1) > 0.99, "text stayed dim after the schedule elapsed")
     }
+
+    @Test("Disabled streaming fade leaves new text visible immediately")
+    func disabledFadeDoesNotHideNewText() {
+        let (renderer, animator) = makeAnimator()
+        animator.configuration = .off
+        renderer.setBlocks([
+            .init(runs: [InlineRun(text: "latest answer")], kind: .paragraph)
+        ])
+        animator.contentDidGrow()
+
+        guard let location = renderer.textContentStorage.location(
+            renderer.textContentStorage.documentRange.location, offsetBy: 0
+        ) else {
+            Issue.record("streaming text has no TextKit location")
+            return
+        }
+        var alpha: CGFloat?
+        renderer.textLayoutManager.enumerateRenderingAttributes(
+            from: location, reverse: false
+        ) { _, attributes, _ in
+            alpha = (attributes[.foregroundColor] as? NSColor)?.alphaComponent
+            return false
+        }
+        // No temporary foreground attribute means TextKit uses the normal
+        // opaque text color after the disabled fade clears its overrides.
+        #expect((alpha ?? 1) > 0.99, "new streaming text was hidden by the fade")
+    }
 }
 
 /// The rate the reveal adapts to must be *units per second*, not *flushes per

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeBacklogTests.swift
@@ -70,7 +70,7 @@ struct TextFadeBacklogTests {
         renderer.setBlocks([
             .init(runs: [InlineRun(text: "一二三四五六七八九十")], kind: .paragraph)
         ])
-        renderer.measureHeight(width: 400)
+        _ = renderer.measureHeight(width: 400)
         animator.contentDidGrow()
 
         let start = CACurrentMediaTime()
@@ -180,12 +180,12 @@ struct TextFadeRateTests {
         // compiler produces against a fast model.
         let first = (1...40).map { "word\($0)" }.joined(separator: " ")
         renderer.setBlocks([.init(runs: [InlineRun(text: first)], kind: .paragraph)])
-        renderer.measureHeight(width: 600)
+        _ = renderer.measureHeight(width: 600)
         animator.contentDidGrow()
 
         let second = first + " " + (41...80).map { "word\($0)" }.joined(separator: " ")
         renderer.setBlocks([.init(runs: [InlineRun(text: second)], kind: .paragraph)])
-        renderer.measureHeight(width: 600)
+        _ = renderer.measureHeight(width: 600)
         animator.contentDidGrow()
 
         let rate = animator.animationState.smoothedWordsPerSecond

--- a/apps/rapid-mac/Tests/RapidTests/TextKitMarkdownParityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextKitMarkdownParityTests.swift
@@ -29,6 +29,50 @@ struct TextKitMarkdownParityTests {
         #expect(view.accessibilityValue() as? String == "Hello from TextKit")
     }
 
+    @Test("Changing render options refreshes existing TextKit content")
+    func optionChangesRefreshExistingContent() {
+        var options = MarkdownOptions.assistantTranscript()
+        options.textPointSize = 12
+        let view = MarkdownTextBlockView(options: options)
+        let blocks = [MarkdownItem.TextBlock(
+            runs: [InlineRun(text: "Text that wraps across several words")],
+            kind: .paragraph
+        )]
+        view.configure(
+            blocks: blocks,
+            options: options,
+            streaming: false,
+            fadeState: nil
+        )
+        let compactHeight = view.height(forWidth: 120)
+
+        options.textPointSize = 24
+        view.configure(
+            blocks: blocks,
+            options: options,
+            streaming: false,
+            fadeState: nil
+        )
+
+        #expect(view.height(forWidth: 120) > compactHeight)
+    }
+
+    @Test("The presentation display link sleeps while no text is pending")
+    func presentationDisplayLinkPausesWhenInactive() {
+        let coordinator = StreamingPresentationDisplayLink.Coordinator(
+            isActive: false,
+            onFrame: { _ in }
+        )
+        coordinator.attach(to: NSView(frame: .zero))
+
+        #expect(coordinator.isDisplayLinkPaused)
+        coordinator.setActive(true)
+        #expect(!coordinator.isDisplayLinkPaused)
+        coordinator.setActive(false)
+        #expect(coordinator.isDisplayLinkPaused)
+        coordinator.invalidate()
+    }
+
     @Test("Custom TextKit prose resolves rendered links for click handling")
     @MainActor
     func customTextKitLinkHitTesting() throws {
@@ -45,18 +89,41 @@ struct TextKitMarkdownParityTests {
         #expect(renderer.link(at: CGPoint(x: rect.midX, y: rect.midY))?.absoluteString == "https://rapidmlx.ai")
     }
 
-    @Test("A long transcript does not release follow mode for a short new answer")
-    func followModeUsesCurrentAnswerGrowth() {
-        #expect(!TranscriptScrollPositionProbe.Coordinator.answerOutgrewViewport(
-            documentHeight: 5_300,
-            documentHeightAtStreamStart: 5_000,
-            viewportHeight: 800
-        ))
-        #expect(TranscriptScrollPositionProbe.Coordinator.answerOutgrewViewport(
-            documentHeight: 5_900,
-            documentHeightAtStreamStart: 5_000,
-            viewportHeight: 800
-        ))
+    @Test("Streaming prose appends through the incremental TextKit path")
+    func streamingAppendIsIncremental() {
+        let renderer = MarkdownTextRenderer(options: .assistantTranscript())
+        let first = [MarkdownItem.TextBlock(
+            runs: [InlineRun(text: "alpha beta")], kind: .paragraph
+        )]
+        let second = [MarkdownItem.TextBlock(
+            runs: [InlineRun(text: "alpha beta gamma")], kind: .paragraph
+        )]
+
+        guard case .initial = renderer.setBlocks(first, showsTypingDot: true) else {
+            Issue.record("the first render should initialise storage")
+            return
+        }
+        guard case .incremental = renderer.setBlocks(second, showsTypingDot: true) else {
+            Issue.record("an appended stream should use the incremental path")
+            return
+        }
+        #expect(renderer.accessibleText == "alpha beta gamma")
+    }
+
+    @Test("Structural markdown changes use the replacement path")
+    func structuralUpdateReplacesStorage() {
+        let renderer = MarkdownTextRenderer(options: .assistantTranscript())
+        renderer.setBlocks([
+            .init(runs: [InlineRun(text: "alpha beta")], kind: .paragraph)
+        ])
+        let update = renderer.setBlocks([
+            .init(runs: [InlineRun(text: "rewritten")], kind: .paragraph)
+        ])
+        guard case .replaced = update else {
+            Issue.record("a rewritten document must not be treated as an append")
+            return
+        }
+        #expect(renderer.accessibleText == "rewritten")
     }
 
     // MARK: - Structural parity with the MarkdownUI path


### PR DESCRIPTION
## What does this PR do?

- Keep completed top-level Markdown blocks stable while recompiling only the mutable tail.
- Decouple transport updates from visual presentation with a frame-paced grapheme buffer.
- Append growing prose through TextKit without replacing the whole rendered block.
- Preserve stable block identity while Markdown structure is still forming.
- Interpolate bottom-follow scrolling instead of applying discrete layout jumps.
- Reconcile authoritative completion content and preserve Dynamic Type, links, reference definitions, and conversation lifecycle behavior.

## Why is this needed?

Long structured replies could visibly flicker, jump, and appear in uneven batches while streaming.

The growing Markdown tail was repeatedly recompiled and replaced as its structure changed. At the same time, transport bursts and discrete scroll corrections caused abrupt text and viewport movement. The effect was most visible with headings, lists, code blocks, inline formatting, and long replies while following the bottom of the transcript.

This change makes streaming presentation continuous while keeping completed Markdown content stable.

## AI assistance disclosure

Codex authored and iteratively reviewed the Swift/AppKit implementation and tests across the 21 files changed under `apps/rapid-mac/Sources/Rapid/UI` and `apps/rapid-mac/Tests/RapidTests`.

I manually reproduced the original streaming behavior and evaluated the updated long-Markdown output and scrolling. The generated changes were additionally verified with focused tests, a release build, boundary review, and removal of unrelated runtime changes from this branch.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- [x] 63 focused streaming, Markdown, TextKit, fade, and scrolling tests passed across 9 suites after rebasing onto current `main`.
- [x] Release app built successfully with `SKIP_SIDECAR=1 BUNDLE_MODEL=0 ./scripts/build.sh`.
- [x] `git diff --check`.
- [x] Manually exercised a long Markdown reply containing headings, short paragraphs, lists, bold text, inline code, and fenced code while scrolling.

## Checklist

- [x] Relevant tests pass locally.
- [x] No Python lint or format changes are applicable to this Swift-only diff.
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 2280`.
- [x] New behavior is covered by focused regression tests.
- [x] README/docs changes are not required.
- [x] No breaking changes to existing APIs.