### PR TITLE
feat(server): own audio lifecycle on the model worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml
+          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart
 
       - name: Run unit tests (no MLX required)
         # NOTE: tests in this list MUST not import mlx / mlx_lm at module
@@ -310,6 +310,7 @@ jobs:
             tests/test_telemetry_consent.py \
             tests/test_community_bench_upload.py \
             tests/test_music_engine.py \
+            tests/test_audio_model_worker.py \
             tests/test_aliases_contract.py \
             tests/test_chat_template_registry.py \
             tests/test_alias_subfolder.py \

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -593,6 +593,7 @@ async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
 async def test_lifespan_binds_audio_worker_when_lane_is_enabled(monkeypatch):
     import vllm_mlx._signal_observability as signal_observability
     import vllm_mlx.server as server
+    from vllm_mlx.routes import video as video_route
 
     class _Engine:
         _loaded = True
@@ -615,15 +616,32 @@ async def test_lifespan_binds_audio_worker_when_lane_is_enabled(monkeypatch):
 
     engine = _Engine()
     bound: list[object] = []
+    lifecycle_config = SimpleNamespace(
+        ready=False,
+        draining=False,
+        bind_host=None,
+        bind_port=None,
+        bind_listen_fd=None,
+        model_alias=None,
+        model_name=None,
+    )
+
+    async def _shutdown_video_jobs() -> None:
+        pass
+
     monkeypatch.setattr(
         signal_observability, "install_signal_observability", lambda: False
     )
+    monkeypatch.setattr(video_route, "start_video_jobs", lambda: None)
+    monkeypatch.setattr(video_route, "shutdown_video_jobs", _shutdown_video_jobs)
     monkeypatch.setattr(server, "_engine", engine)
     monkeypatch.setattr(server, "_residency_manager", _Residency())
     monkeypatch.setattr(server, "_mcp_manager", None)
+    monkeypatch.setattr(server, "_gc_control", False)
     monkeypatch.setattr(server, "_enable_audio_lane", True)
     monkeypatch.setattr(server, "_model_name", "chat-model")
     monkeypatch.setattr(server, "_model_alias", "chat-model")
+    monkeypatch.setattr(server, "get_config", lambda: lifecycle_config)
     monkeypatch.setattr(
         server,
         "_bind_audio_worker_for_engine",

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -834,6 +834,76 @@ async def test_primary_reload_commits_audio_worker_handoff(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_primary_reload_restores_old_config_after_publication_failure(
+    monkeypatch,
+):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import (
+        ResidentModelManager,
+        ResidentPerformanceConfig,
+    )
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    registry = ModelRegistry()
+    primary = ModelEntry(
+        engine=old_worker,
+        model_name="chat-old",
+        model_path="repo/chat-old",
+    )
+    registry.add(primary, is_default=True)
+    loaded: list[_ReplacementWorker] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        worker = _ReplacementWorker(f"{name}-reload-{len(loaded) + 1}")
+        loaded.append(worker)
+        return ModelEntry(
+            engine=worker,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    def publish(entry: ModelEntry) -> None:
+        server._set_resident_primary(entry)
+        if entry.engine is loaded[0]:
+            raise RuntimeError("primary publication failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=server._handoff_resident_primary_audio_worker,
+        on_primary_changed=publish,
+    )
+    manager.register_primary(primary, estimated_bytes=1)
+    bind_audio_worker(old_worker)
+    try:
+        with pytest.raises(RuntimeError, match="primary publication failed"):
+            await manager.load(
+                "chat-old",
+                performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+                reload_if_changed=True,
+            )
+
+        rejected, restored = loaded
+        assert old_worker.stopped is True
+        assert rejected.stopped is True
+        assert restored.stopped is False
+        assert registry.default_name == "chat-old"
+        assert registry.get_entry("chat-old").engine is restored
+        assert server._engine is restored
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+        assert rejected.async_calls == 0
+        assert restored.async_calls == 1
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
 async def test_primary_replacement_rolls_back_after_old_worker_stop_failure(
     monkeypatch,
 ):

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -46,8 +46,9 @@ class _RecordingWorker:
 class _ReplacementWorker:
     is_mllm = False
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, *, fail_stop: bool = False) -> None:
         self.name = name
+        self.fail_stop = fail_stop
         self.stopped = False
         self.worker_active = False
         self.stopped_during_audio = False
@@ -73,6 +74,8 @@ class _ReplacementWorker:
 
     async def stop(self) -> None:
         self.stopped_during_audio = self.worker_active
+        if self.fail_stop:
+            raise RuntimeError("old stop failed")
         self.stopped = True
 
 
@@ -158,6 +161,27 @@ def test_bind_rejects_engine_without_complete_worker_contract():
 
     with pytest.raises(TypeError, match="model-worker contract"):
         dispatcher.bind(object())
+
+
+def test_audio_worker_handoff_gates_requests_and_supports_rollback():
+    from vllm_mlx.runtime.audio_worker import AudioWorkerBusyError
+
+    dispatcher = AudioWorkerDispatcher()
+    old_worker = _RecordingWorker()
+    new_worker = _RecordingWorker()
+    dispatcher.bind(old_worker)
+
+    handoff = dispatcher.begin_handoff()
+    with pytest.raises(AudioWorkerBusyError, match="handoff is in progress"):
+        dispatcher.execute_sync("stt", "whisper", "infer", lambda: None)
+    handoff.rollback()
+    assert dispatcher.execute_sync("stt", "whisper", "infer", lambda: "old") == ("old")
+    assert len(old_worker.sync_calls) == 1
+
+    handoff = dispatcher.begin_handoff()
+    handoff.commit(new_worker)
+    assert dispatcher.execute_sync("stt", "whisper", "infer", lambda: "new") == ("new")
+    assert len(new_worker.sync_calls) == 1
 
 
 def test_server_selects_isolated_fallback_for_non_batched_engine():
@@ -734,6 +758,111 @@ async def test_primary_replacement_rejects_active_audio_without_stopping_old_wor
     finally:
         release.set()
         assert await task == "done"
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_rejects_active_audio_without_stopping_worker(
+    monkeypatch,
+):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.resident_models import (
+        ResidentModelBusyError,
+        ResidentPerformanceConfig,
+    )
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    started = threading.Event()
+    release = threading.Event()
+
+    def active_audio() -> str:
+        started.set()
+        assert release.wait(timeout=5)
+        return "done"
+
+    bind_audio_worker(old_worker)
+    task = asyncio.create_task(run_audio_mlx("stt", "whisper", "infer", active_audio))
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        with pytest.raises(ResidentModelBusyError, match="active audio work"):
+            await manager.load(
+                "chat-old",
+                performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+                reload_if_changed=True,
+            )
+
+        assert registry.default_name == "chat-old"
+        assert server._engine is old_worker
+        assert old_worker.stopped is False
+        assert loaded == {}
+    finally:
+        release.set()
+        assert await task == "done"
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_commits_audio_worker_handoff(monkeypatch):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.resident_models import ResidentPerformanceConfig
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    bind_audio_worker(old_worker)
+    try:
+        replacement = await manager.load(
+            "chat-old",
+            performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+            reload_if_changed=True,
+        )
+
+        assert old_worker.stopped is True
+        assert registry.default_name == "chat-old"
+        assert server._engine is replacement.entry.engine
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+        assert old_worker.async_calls == 0
+        assert loaded["chat-old"].async_calls == 1
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_replacement_rolls_back_after_old_worker_stop_failure(
+    monkeypatch,
+):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+
+    old_worker = _ReplacementWorker("chat-old", fail_stop=True)
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    bind_audio_worker(old_worker)
+    try:
+        with pytest.raises(RuntimeError, match="old stop failed"):
+            await manager.load(
+                "chat-new",
+                estimated_bytes=1,
+                replace_group="assistant",
+            )
+
+        assert registry.default_name == "chat-old"
+        assert [entry.model_name for entry in registry.list_entries()] == ["chat-old"]
+        assert server._engine is old_worker
+        assert old_worker.stopped is False
+        assert loaded["chat-new"].stopped is True
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+        assert old_worker.async_calls == 1
+        assert loaded["chat-new"].async_calls == 0
+    finally:
         bind_audio_worker(None)
 
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -267,3 +267,37 @@ async def test_server_shutdown_continues_after_audio_unload_failure(
     assert audio_route._music_engine is None
     assert "Failed to unload stt audio lane" in caplog.text
     assert "damaged test backend" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_stt_eviction_uses_async_model_worker(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    class _CachedAligner:
+        model_name = "aligner"
+
+        def __init__(self) -> None:
+            self.unloaded = False
+
+        def unload(self) -> None:
+            self.unloaded = True
+
+    class _AsyncOnlyWorker:
+        async def execute_on_model_worker(self, func, *args, **kwargs):
+            await asyncio.sleep(0)
+            return func(*args, **kwargs)
+
+        def execute_on_model_worker_sync(self, func, *args, **kwargs):
+            raise AssertionError("async STT eviction used the blocking boundary")
+
+    aligner = _CachedAligner()
+    monkeypatch.setattr(audio_route, "_aligner_engine", aligner)
+    bind_audio_worker(_AsyncOnlyWorker())
+    try:
+        await audio_route._evict_other_lane("asr")
+    finally:
+        bind_audio_worker(None)
+
+    assert aligner.unloaded
+    assert audio_route._aligner_engine is None

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -53,6 +53,7 @@ class _ReplacementWorker:
         self.worker_active = False
         self.stopped_during_audio = False
         self.async_calls = 0
+        self.stop_calls = 0
 
     def get_stats(self):
         return {"num_running": 0, "num_waiting": 0}
@@ -73,6 +74,7 @@ class _ReplacementWorker:
         return func(*args, **kwargs)
 
     async def stop(self) -> None:
+        self.stop_calls += 1
         self.stopped_during_audio = self.worker_active
         if self.fail_stop:
             raise RuntimeError("old stop failed")
@@ -182,6 +184,58 @@ def test_audio_worker_handoff_gates_requests_and_supports_rollback():
     handoff.commit(new_worker)
     assert dispatcher.execute_sync("stt", "whisper", "infer", lambda: "new") == ("new")
     assert len(new_worker.sync_calls) == 1
+
+
+def test_audio_worker_handoff_defensive_contracts():
+    from vllm_mlx.runtime.audio_worker import AudioWorkerBusyError
+
+    dispatcher = AudioWorkerDispatcher()
+    assert dispatcher.execute_sync("stt", "whisper", "infer", lambda: "fallback") == (
+        "fallback"
+    )
+    assert dispatcher._fallback is not None
+
+    handoff = dispatcher.begin_handoff()
+    with pytest.raises(AudioWorkerBusyError, match="handoff is in progress"):
+        dispatcher.bind(_RecordingWorker())
+    with pytest.raises(AudioWorkerBusyError, match="handoff is in progress"):
+        dispatcher.begin_handoff()
+    with pytest.raises(RuntimeError, match="lease is not active"):
+        dispatcher._finish_handoff(object(), None)
+
+    handoff.commit(_RecordingWorker())
+    assert dispatcher._fallback is None
+    handoff.rollback()
+    with pytest.raises(RuntimeError, match="already complete"):
+        handoff.commit(None)
+
+
+@pytest.mark.asyncio
+async def test_bind_rejects_worker_change_during_active_audio():
+    from vllm_mlx.runtime.audio_worker import AudioWorkerBusyError
+
+    dispatcher = AudioWorkerDispatcher()
+    old_worker = _ReplacementWorker("chat-old")
+    started = threading.Event()
+    release = threading.Event()
+
+    def active_audio() -> str:
+        started.set()
+        assert release.wait(timeout=5)
+        return "done"
+
+    dispatcher.bind(old_worker)
+    task = asyncio.create_task(
+        dispatcher.execute("stt", "whisper", "infer", active_audio)
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        with pytest.raises(AudioWorkerBusyError, match="audio work is active"):
+            dispatcher.bind(_ReplacementWorker("chat-new"))
+    finally:
+        release.set()
+        assert await task == "done"
+        dispatcher.bind(None)
 
 
 def test_server_selects_isolated_fallback_for_non_batched_engine():
@@ -899,6 +953,166 @@ async def test_primary_reload_restores_old_config_after_publication_failure(
         )
         assert rejected.async_calls == 0
         assert restored.async_calls == 1
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_rolls_back_handoff_when_old_stop_fails(monkeypatch):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.resident_models import ResidentPerformanceConfig
+
+    old_worker = _ReplacementWorker("chat-old", fail_stop=True)
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    bind_audio_worker(old_worker)
+    try:
+        with pytest.raises(RuntimeError, match="old stop failed"):
+            await manager.load(
+                "chat-old",
+                performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+                reload_if_changed=True,
+            )
+
+        assert old_worker.stop_calls == 1
+        assert old_worker.stopped is False
+        assert loaded == {}
+        assert registry.default_name == "chat-old"
+        assert registry.get_entry("chat-old").engine is old_worker
+        assert server._engine is old_worker
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_restores_old_config_when_new_load_fails(monkeypatch):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import (
+        ResidentModelManager,
+        ResidentPerformanceConfig,
+    )
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    registry = ModelRegistry()
+    primary = ModelEntry(
+        engine=old_worker,
+        model_name="chat-old",
+        model_path="repo/chat-old",
+    )
+    registry.add(primary, is_default=True)
+    restored_workers: list[_ReplacementWorker] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        if performance is not None:
+            raise RuntimeError("new config failed")
+        restored = _ReplacementWorker("chat-old-restored")
+        restored_workers.append(restored)
+        return ModelEntry(
+            engine=restored,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=server._handoff_resident_primary_audio_worker,
+        on_primary_changed=server._set_resident_primary,
+    )
+    manager.register_primary(primary, estimated_bytes=1)
+    bind_audio_worker(old_worker)
+    try:
+        with pytest.raises(RuntimeError, match="new config failed"):
+            await manager.load(
+                "chat-old",
+                performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+                reload_if_changed=True,
+            )
+
+        restored = restored_workers[0]
+        assert old_worker.stopped is True
+        assert registry.get_entry("chat-old").engine is restored
+        assert server._engine is restored
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+        assert restored.async_calls == 1
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_releases_handoff_when_cleanup_and_restore_fail(
+    monkeypatch, caplog
+):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import (
+        ResidentModelManager,
+        ResidentPerformanceConfig,
+    )
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    registry = ModelRegistry()
+    primary = ModelEntry(
+        engine=old_worker,
+        model_name="chat-old",
+        model_path="repo/chat-old",
+    )
+    registry.add(primary, is_default=True)
+    rejected_workers: list[_ReplacementWorker] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        if rejected_workers:
+            raise RuntimeError("restore failed")
+        rejected = _ReplacementWorker("chat-old-rejected", fail_stop=True)
+        rejected_workers.append(rejected)
+        return ModelEntry(
+            engine=rejected,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    def reject_publication(entry: ModelEntry) -> None:
+        server._set_resident_primary(entry)
+        raise RuntimeError("primary publication failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=server._handoff_resident_primary_audio_worker,
+        on_primary_changed=reject_publication,
+    )
+    manager.register_primary(primary, estimated_bytes=1)
+    bind_audio_worker(old_worker)
+    try:
+        with pytest.raises(RuntimeError, match="primary publication failed"):
+            await manager.load(
+                "chat-old",
+                performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
+                reload_if_changed=True,
+            )
+
+        rejected = rejected_workers[0]
+        assert rejected.stop_calls == 1
+        assert rejected.stopped is False
+        assert registry.list_entries() == []
+        assert "Failed to stop rejected resident model" in caplog.text
+        assert "Failed to restore resident model" in caplog.text
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "fallback") == (
+            "fallback"
+        )
     finally:
         bind_audio_worker(None)
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1,0 +1,193 @@
+"""Contracts for server-owned auxiliary audio execution."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+
+import pytest
+
+from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.runtime.audio_worker import AudioWorkerDispatcher
+
+
+class _RecordingWorker:
+    def __init__(self) -> None:
+        self.async_calls: list[tuple[object, tuple, dict]] = []
+        self.sync_calls: list[tuple[object, tuple, dict]] = []
+
+    async def execute_on_model_worker(self, func, *args, **kwargs):
+        self.async_calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    def execute_on_model_worker_sync(self, func, *args, **kwargs):
+        self.sync_calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_audio_only_dispatch_runs_inline_without_primary_worker():
+    dispatcher = AudioWorkerDispatcher()
+    caller_thread = threading.get_ident()
+
+    assert (
+        await dispatcher.execute("stt", "whisper", "infer", threading.get_ident)
+        == caller_thread
+    )
+    assert (
+        dispatcher.execute_sync("tts", "kokoro", "infer", threading.get_ident)
+        == caller_thread
+    )
+
+
+@pytest.mark.asyncio
+async def test_bound_dispatch_uses_public_worker_contract():
+    dispatcher = AudioWorkerDispatcher()
+    worker = _RecordingWorker()
+    dispatcher.bind(worker)
+
+    assert (
+        await dispatcher.execute("stt", "whisper", "infer", lambda value: value + 1, 4)
+        == 5
+    )
+    assert (
+        dispatcher.execute_sync(
+            "tts", "kokoro", "infer", lambda *, value: value + 1, value=6
+        )
+        == 7
+    )
+    assert len(worker.async_calls) == 1
+    assert len(worker.sync_calls) == 1
+
+
+def test_bind_rejects_engine_without_complete_worker_contract():
+    dispatcher = AudioWorkerDispatcher()
+
+    with pytest.raises(TypeError, match="model-worker contract"):
+        dispatcher.bind(object())
+
+
+@pytest.mark.asyncio
+async def test_unbind_restores_audio_only_inline_path():
+    dispatcher = AudioWorkerDispatcher()
+    dispatcher.bind(_RecordingWorker())
+    dispatcher.bind(None)
+
+    assert (
+        await dispatcher.execute("stt", "whisper", "infer", lambda: "inline")
+        == "inline"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_async_dispatch_uses_owning_executor_thread():
+    owner = object.__new__(BatchedEngine)
+    caller_thread = threading.get_ident()
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="test-model-worker"
+    )
+    owner._model_load_executor = executor
+    try:
+        worker_thread = await owner.execute_on_model_worker(threading.get_ident)
+    finally:
+        executor.shutdown(wait=True)
+
+    assert worker_thread != caller_thread
+
+
+def test_batched_engine_sync_dispatch_uses_owning_executor_thread():
+    owner = object.__new__(BatchedEngine)
+    caller_thread = threading.get_ident()
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="test-model-worker"
+    )
+    owner._model_load_executor = executor
+    try:
+        worker_thread = owner.execute_on_model_worker_sync(threading.get_ident)
+    finally:
+        executor.shutdown(wait=True)
+
+    assert worker_thread != caller_thread
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_rejects_async_dispatch_when_stopped():
+    owner = object.__new__(BatchedEngine)
+    owner._model_load_executor = None
+
+    with pytest.raises(RuntimeError, match="model worker is not running"):
+        await owner.execute_on_model_worker(lambda: None)
+
+
+def test_batched_engine_rejects_sync_dispatch_when_stopped():
+    owner = object.__new__(BatchedEngine)
+    owner._model_load_executor = None
+
+    with pytest.raises(RuntimeError, match="model worker is not running"):
+        owner.execute_on_model_worker_sync(lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_lane_snapshot_reports_resident_model_after_successful_load():
+    dispatcher = AudioWorkerDispatcher()
+
+    await dispatcher.execute("stt", "whisper-small", "load", lambda: None)
+
+    assert dispatcher.snapshot() == [
+        {
+            "lane": "stt",
+            "model": "whisper-small",
+            "state": "resident",
+            "active_requests": 0,
+            "loaded_at": dispatcher.snapshot()[0]["loaded_at"],
+            "idle_seconds": pytest.approx(0.0, abs=0.1),
+            "last_error": None,
+        }
+    ]
+
+
+def test_lane_snapshot_records_failure_without_leaking_message():
+    dispatcher = AudioWorkerDispatcher()
+
+    with pytest.raises(ValueError, match="secret detail"):
+        dispatcher.execute_sync(
+            "tts",
+            "kokoro",
+            "load",
+            lambda: (_ for _ in ()).throw(ValueError("secret detail")),
+        )
+
+    lane = dispatcher.snapshot()[0]
+    assert lane["state"] == "failed"
+    assert lane["active_requests"] == 0
+    assert lane["last_error"] == "ValueError"
+    assert "secret detail" not in repr(lane)
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_unloads_cached_audio_engines(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    class _Cached:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+            self.unloaded = False
+
+        def unload(self) -> None:
+            self.unloaded = True
+
+    stt = _Cached("whisper")
+    aligner = _Cached("aligner")
+    tts = _Cached("kokoro")
+    monkeypatch.setattr(audio_route, "_stt_engine", stt)
+    monkeypatch.setattr(audio_route, "_aligner_engine", aligner)
+    monkeypatch.setattr(audio_route, "_tts_engine", tts)
+    monkeypatch.setattr(audio_route, "_music_engine", object())
+
+    await audio_route.shutdown_audio_lanes()
+
+    assert stt.unloaded and aligner.unloaded and tts.unloaded
+    assert audio_route._stt_engine is None
+    assert audio_route._aligner_engine is None
+    assert audio_route._tts_engine is None
+    assert audio_route._music_engine is None

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures
 import threading
 
@@ -26,18 +27,19 @@ class _RecordingWorker:
 
 
 @pytest.mark.asyncio
-async def test_audio_only_dispatch_runs_inline_without_primary_worker():
+async def test_audio_only_dispatch_uses_dedicated_worker_without_primary():
     dispatcher = AudioWorkerDispatcher()
     caller_thread = threading.get_ident()
 
     assert (
         await dispatcher.execute("stt", "whisper", "infer", threading.get_ident)
-        == caller_thread
+        != caller_thread
     )
     assert (
         dispatcher.execute_sync("tts", "kokoro", "infer", threading.get_ident)
-        == caller_thread
+        != caller_thread
     )
+    dispatcher.bind(None)
 
 
 @pytest.mark.asyncio
@@ -67,16 +69,24 @@ def test_bind_rejects_engine_without_complete_worker_contract():
         dispatcher.bind(object())
 
 
+def test_server_selects_isolated_fallback_for_non_batched_engine():
+    from vllm_mlx import server
+
+    assert server._bind_audio_worker_for_engine(object()) is False
+
+
 @pytest.mark.asyncio
-async def test_unbind_restores_audio_only_inline_path():
+async def test_unbind_restores_dedicated_audio_only_worker():
     dispatcher = AudioWorkerDispatcher()
     dispatcher.bind(_RecordingWorker())
     dispatcher.bind(None)
 
+    caller_thread = threading.get_ident()
     assert (
-        await dispatcher.execute("stt", "whisper", "infer", lambda: "inline")
-        == "inline"
+        await dispatcher.execute("stt", "whisper", "infer", threading.get_ident)
+        != caller_thread
     )
+    dispatcher.bind(None)
 
 
 @pytest.mark.asyncio
@@ -144,6 +154,7 @@ async def test_lane_snapshot_reports_resident_model_after_successful_load():
             "last_error": None,
         }
     ]
+    dispatcher.bind(None)
 
 
 def test_lane_snapshot_records_failure_without_leaking_message():
@@ -162,6 +173,35 @@ def test_lane_snapshot_records_failure_without_leaking_message():
     assert lane["active_requests"] == 0
     assert lane["last_error"] == "ValueError"
     assert "secret detail" not in repr(lane)
+    dispatcher.bind(None)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_drains_worker_before_releasing_lane_lease():
+    dispatcher = AudioWorkerDispatcher()
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_transcription() -> str:
+        started.set()
+        assert release.wait(timeout=5)
+        return "done"
+
+    task = asyncio.create_task(
+        dispatcher.execute("stt", "whisper", "infer", blocking_transcription)
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    task.cancel()
+    await asyncio.sleep(0.05)
+
+    assert not task.done()
+    assert dispatcher.snapshot()[0]["active_requests"] == 1
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert dispatcher.snapshot()[0]["active_requests"] == 0
+    dispatcher.bind(None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -231,3 +231,39 @@ async def test_server_shutdown_unloads_cached_audio_engines(monkeypatch):
     assert audio_route._aligner_engine is None
     assert audio_route._tts_engine is None
     assert audio_route._music_engine is None
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_continues_after_audio_unload_failure(
+    monkeypatch, caplog
+):
+    from vllm_mlx.routes import audio as audio_route
+
+    class _Cached:
+        def __init__(self, model_name: str, *, fails: bool = False) -> None:
+            self.model_name = model_name
+            self.fails = fails
+            self.unloaded = False
+
+        def unload(self) -> None:
+            self.unloaded = True
+            if self.fails:
+                raise RuntimeError("damaged test backend")
+
+    stt = _Cached("whisper", fails=True)
+    aligner = _Cached("aligner")
+    tts = _Cached("kokoro")
+    monkeypatch.setattr(audio_route, "_stt_engine", stt)
+    monkeypatch.setattr(audio_route, "_aligner_engine", aligner)
+    monkeypatch.setattr(audio_route, "_tts_engine", tts)
+    monkeypatch.setattr(audio_route, "_music_engine", object())
+
+    await audio_route.shutdown_audio_lanes()
+
+    assert stt.unloaded and aligner.unloaded and tts.unloaded
+    assert audio_route._stt_engine is None
+    assert audio_route._aligner_engine is None
+    assert audio_route._tts_engine is None
+    assert audio_route._music_engine is None
+    assert "Failed to unload stt audio lane" in caplog.text
+    assert "damaged test backend" in caplog.text

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -4,12 +4,29 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import importlib.util
+import sys
 import threading
+import types
+from types import SimpleNamespace
 
 import pytest
 
 from vllm_mlx.engine.batched import BatchedEngine
 from vllm_mlx.runtime.audio_worker import AudioWorkerDispatcher
+
+
+@pytest.fixture(autouse=True)
+def _stub_mlx_thread_init_on_non_mlx_hosts(monkeypatch):
+    """Keep the worker contract testable in the Linux unit-test lane."""
+    if importlib.util.find_spec("mlx") is not None:
+        return
+
+    engine_core = types.ModuleType("vllm_mlx.engine_core")
+    engine_core._init_mlx_step_thread = lambda: None
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine_core", engine_core)
+    if importlib.util.find_spec("uvicorn") is None:
+        monkeypatch.setitem(sys.modules, "uvicorn", types.ModuleType("uvicorn"))
 
 
 class _RecordingWorker:
@@ -205,6 +222,37 @@ async def test_cancellation_drains_worker_before_releasing_lane_lease():
 
 
 @pytest.mark.asyncio
+async def test_repeated_cancellation_drains_a_failing_worker():
+    dispatcher = AudioWorkerDispatcher()
+    started = threading.Event()
+    release = threading.Event()
+
+    def failing_transcription() -> None:
+        started.set()
+        assert release.wait(timeout=5)
+        raise RuntimeError("worker failed after cancellation")
+
+    task = asyncio.create_task(
+        dispatcher.execute("stt", "whisper", "infer", failing_transcription)
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    task.cancel()
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0.05)
+
+    assert not task.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    lane = dispatcher.snapshot()[0]
+    assert lane["active_requests"] == 0
+    assert lane["state"] == "failed"
+    assert lane["last_error"] == "RuntimeError"
+    dispatcher.bind(None)
+
+
+@pytest.mark.asyncio
 async def test_server_shutdown_unloads_cached_audio_engines(monkeypatch):
     from vllm_mlx.routes import audio as audio_route
 
@@ -270,6 +318,20 @@ async def test_server_shutdown_continues_after_audio_unload_failure(
 
 
 @pytest.mark.asyncio
+async def test_server_shutdown_ignores_cached_objects_without_unload(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    monkeypatch.setattr(audio_route, "_stt_engine", object())
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+    monkeypatch.setattr(audio_route, "_tts_engine", None)
+    monkeypatch.setattr(audio_route, "_music_engine", None)
+
+    await audio_route.shutdown_audio_lanes()
+
+    assert audio_route._stt_engine is None
+
+
+@pytest.mark.asyncio
 async def test_async_stt_eviction_uses_async_model_worker(monkeypatch):
     from vllm_mlx.routes import audio as audio_route
     from vllm_mlx.runtime.audio_worker import bind_audio_worker
@@ -301,3 +363,276 @@ async def test_async_stt_eviction_uses_async_model_worker(monkeypatch):
 
     assert aligner.unloaded
     assert audio_route._aligner_engine is None
+
+
+@pytest.mark.asyncio
+async def test_empty_stt_lanes_do_not_dispatch_eviction(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+
+    await audio_route._evict_other_lane("asr")
+    audio_route._evict_other_lane_sync("aligner")
+
+
+@pytest.mark.asyncio
+async def test_stt_load_and_inference_use_audio_worker(monkeypatch):
+    from vllm_mlx.audio import stt as stt_module
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    operations: list[str] = []
+
+    class _Upload:
+        filename = "speech.wav"
+        size = 4
+
+        def __init__(self) -> None:
+            self._read = False
+
+        async def read(self, _size: int = -1) -> bytes:
+            if self._read:
+                return b""
+            self._read = True
+            return b"RIFF"
+
+    class _OldAligner:
+        model_name = "old-aligner"
+
+        def unload(self) -> None:
+            operations.append("unload-aligner")
+
+    class _STT:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load-stt")
+
+        def transcribe(self, path: str, **kwargs):
+            operations.append("infer-stt")
+            assert path.endswith(".wav")
+            assert kwargs["context"] == "prompt"
+            return SimpleNamespace(text="hello", language="en", duration=1.0)
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr(stt_module, "STTEngine", _STT)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    monkeypatch.setattr(audio_route, "_aligner_engine", _OldAligner())
+    bind_audio_worker(worker)
+    try:
+        response = await audio_route._run_stt_request(
+            _Upload(),
+            "whisper-small",
+            "en",
+            "json",
+            "transcribe",
+            context=" prompt ",
+        )
+    finally:
+        bind_audio_worker(None)
+
+    assert response == {"text": "hello", "language": "en", "duration": 1.0}
+    assert operations == ["unload-aligner", "load-stt", "infer-stt"]
+    assert len(worker.async_calls) == 3
+
+
+def test_alignment_load_and_inference_use_audio_worker(monkeypatch):
+    from vllm_mlx.audio import stt as stt_module
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    operations: list[str] = []
+
+    class _Aligner:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load-aligner")
+
+        def align(self, path: str, text: str, **kwargs):
+            operations.append("infer-aligner")
+            assert (path, text, kwargs) == (
+                "speech.wav",
+                "known text",
+                {"language": "en"},
+            )
+            return "aligned"
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr(stt_module, "STTEngine", _Aligner)
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    bind_audio_worker(worker)
+    try:
+        result = audio_route._align_blocking(
+            "aligner-model", "speech.wav", "known text", "en"
+        )
+    finally:
+        bind_audio_worker(None)
+
+    assert result == "aligned"
+    assert operations == ["load-aligner", "infer-aligner"]
+    assert len(worker.sync_calls) == 2
+
+
+def test_sync_stt_eviction_uses_sync_model_worker(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    class _CachedSTT:
+        model_name = "whisper"
+
+        def __init__(self) -> None:
+            self.unloaded = False
+
+        def unload(self) -> None:
+            self.unloaded = True
+
+    stt = _CachedSTT()
+    monkeypatch.setattr(audio_route, "_stt_engine", stt)
+
+    audio_route._evict_other_lane_sync("aligner")
+
+    assert stt.unloaded
+    assert audio_route._stt_engine is None
+
+
+def test_tts_replacement_and_reference_inference_use_audio_worker(monkeypatch):
+    from vllm_mlx.audio import output_format
+    from vllm_mlx.audio import tts as tts_module
+    from vllm_mlx.routes import audio as audio_route
+
+    operations: list[str] = []
+
+    class _OldTTS:
+        model_name = "old-tts"
+
+        def unload(self) -> None:
+            operations.append("unload")
+
+    class _NewTTS:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load")
+
+        def generate(self, text: str, **kwargs):
+            operations.append("infer")
+            assert text == "hello"
+            if "ref_text" in kwargs:
+                assert kwargs["ref_text"] == "reference"
+            return SimpleNamespace(audio=b"pcm", sample_rate=24_000)
+
+        def to_bytes(self, audio, format: str) -> bytes:
+            assert format == "wav"
+            return b"encoded"
+
+    monkeypatch.setattr(tts_module, "TTSEngine", _NewTTS)
+    monkeypatch.setattr(audio_route, "_tts_engine", _OldTTS())
+    monkeypatch.setattr(
+        output_format,
+        "convert_audio_output",
+        lambda audio, source_rate, **kwargs: (b"encoded", 24_000, 1),
+    )
+
+    payload, rate, channels = audio_route._generate_speech_blocking(
+        model_name="new-tts",
+        input_text="hello",
+        response_format="wav",
+        gen_kwargs={},
+        ref_bytes=b"reference-audio",
+        ref_text="reference",
+        sample_rate=None,
+        channels=None,
+    )
+
+    assert (payload, rate, channels) == (b"encoded", 24_000, 1)
+    assert operations == ["unload", "load", "infer"]
+
+    payload, rate, channels = audio_route._generate_speech_blocking(
+        model_name="new-tts",
+        input_text="hello",
+        response_format="wav",
+        gen_kwargs={},
+        ref_bytes=None,
+        ref_text=None,
+        sample_rate=None,
+        channels=None,
+    )
+
+    assert (payload, rate, channels) == (b"encoded", 24_000, 1)
+    assert operations == ["unload", "load", "infer", "infer"]
+
+
+@pytest.mark.asyncio
+async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
+    from vllm_mlx.routes import residency
+    from vllm_mlx.runtime.audio_worker import audio_worker
+
+    class _Manager:
+        def snapshot(self):
+            return {"models": [{"id": "chat-model"}]}
+
+    monkeypatch.setattr(residency, "_manager", lambda: _Manager())
+    monkeypatch.setattr(
+        audio_worker,
+        "snapshot",
+        lambda: [{"lane": "stt", "model": "whisper-small"}],
+    )
+
+    assert await residency.model_residency() == {
+        "models": [{"id": "chat-model"}],
+        "audio_lanes": [{"lane": "stt", "model": "whisper-small"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_lifespan_binds_audio_worker_when_lane_is_enabled(monkeypatch):
+    import vllm_mlx._signal_observability as signal_observability
+    import vllm_mlx.server as server
+
+    class _Engine:
+        _loaded = True
+
+        def generate_warmup(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
+
+    class _Residency:
+        async def start(self) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            pass
+
+        def contains(self, model_name: str) -> bool:
+            return True
+
+    engine = _Engine()
+    bound: list[object] = []
+    monkeypatch.setattr(
+        signal_observability, "install_signal_observability", lambda: False
+    )
+    monkeypatch.setattr(server, "_engine", engine)
+    monkeypatch.setattr(server, "_residency_manager", _Residency())
+    monkeypatch.setattr(server, "_mcp_manager", None)
+    monkeypatch.setattr(server, "_enable_audio_lane", True)
+    monkeypatch.setattr(server, "_model_name", "chat-model")
+    monkeypatch.setattr(server, "_model_alias", "chat-model")
+    monkeypatch.setattr(
+        server,
+        "_bind_audio_worker_for_engine",
+        lambda candidate: bound.append(candidate) or True,
+    )
+
+    lifespan = server.lifespan(server.app)
+    await lifespan.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await lifespan.__anext__()
+
+    assert bound == [engine]

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -43,6 +43,80 @@ class _RecordingWorker:
         return func(*args, **kwargs)
 
 
+class _ReplacementWorker:
+    is_mllm = False
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.stopped = False
+        self.worker_active = False
+        self.stopped_during_audio = False
+        self.async_calls = 0
+
+    def get_stats(self):
+        return {"num_running": 0, "num_waiting": 0}
+
+    async def execute_on_model_worker(self, func, *args, **kwargs):
+        if self.stopped:
+            raise RuntimeError("model worker is not running")
+        self.async_calls += 1
+        self.worker_active = True
+        try:
+            return await asyncio.to_thread(func, *args, **kwargs)
+        finally:
+            self.worker_active = False
+
+    def execute_on_model_worker_sync(self, func, *args, **kwargs):
+        if self.stopped:
+            raise RuntimeError("model worker is not running")
+        return func(*args, **kwargs)
+
+    async def stop(self) -> None:
+        self.stopped_during_audio = self.worker_active
+        self.stopped = True
+
+
+def _replacement_manager(server, old_worker):
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import ResidentModelManager
+
+    registry = ModelRegistry()
+    primary = ModelEntry(
+        engine=old_worker,
+        model_name="chat-old",
+        model_path="repo/chat-old",
+    )
+    registry.add(primary, is_default=True)
+    loaded: dict[str, _ReplacementWorker] = {}
+
+    async def loader(name: str, path: str | None, performance=None):
+        worker = _ReplacementWorker(name)
+        loaded[name] = worker
+        return ModelEntry(
+            engine=worker,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=server._handoff_resident_primary_audio_worker,
+        on_primary_changed=server._set_resident_primary,
+    )
+    manager.register_primary(primary, estimated_bytes=1)
+    return manager, registry, loaded
+
+
+def _configure_server_primary(monkeypatch, server, worker) -> None:
+    monkeypatch.setattr(server, "_engine", worker)
+    monkeypatch.setattr(server, "_model_name", "chat-old")
+    monkeypatch.setattr(server, "_model_alias", "chat-old")
+    monkeypatch.setattr(server, "_model_path", "repo/chat-old")
+    monkeypatch.setattr(server, "get_config", lambda: SimpleNamespace())
+
+
 @pytest.mark.asyncio
 async def test_audio_only_dispatch_uses_dedicated_worker_without_primary():
     dispatcher = AudioWorkerDispatcher()
@@ -587,6 +661,80 @@ async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
         "models": [{"id": "chat-model"}],
         "audio_lanes": [{"lane": "stt", "model": "whisper-small"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    bind_audio_worker(old_worker)
+    try:
+        assert (
+            await run_audio_mlx("stt", "whisper", "infer", lambda: "before") == "before"
+        )
+
+        replacement = await manager.load(
+            "chat-new",
+            estimated_bytes=1,
+            replace_group="assistant",
+        )
+
+        assert old_worker.stopped is True
+        assert old_worker.stopped_during_audio is False
+        assert registry.default_name == "chat-new"
+        assert server._engine is replacement.entry.engine
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
+            "after"
+        )
+        assert old_worker.async_calls == 1
+        assert loaded["chat-new"].async_calls == 1
+    finally:
+        bind_audio_worker(None)
+
+
+@pytest.mark.asyncio
+async def test_primary_replacement_rejects_active_audio_without_stopping_old_worker(
+    monkeypatch,
+):
+    import vllm_mlx.server as server
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.resident_models import ResidentModelBusyError
+
+    old_worker = _ReplacementWorker("chat-old")
+    _configure_server_primary(monkeypatch, server, old_worker)
+    manager, registry, loaded = _replacement_manager(server, old_worker)
+    started = threading.Event()
+    release = threading.Event()
+
+    def active_audio() -> str:
+        started.set()
+        assert release.wait(timeout=5)
+        return "done"
+
+    bind_audio_worker(old_worker)
+    task = asyncio.create_task(run_audio_mlx("stt", "whisper", "infer", active_audio))
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        with pytest.raises(ResidentModelBusyError, match="active audio work"):
+            await manager.load(
+                "chat-new",
+                estimated_bytes=1,
+                replace_group="assistant",
+            )
+
+        assert registry.default_name == "chat-old"
+        assert server._engine is old_worker
+        assert old_worker.stopped is False
+        assert old_worker.stopped_during_audio is False
+        assert loaded["chat-new"].stopped is True
+    finally:
+        release.set()
+        assert await task == "done"
+        bind_audio_worker(None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_music_route.py
+++ b/tests/test_audio_music_route.py
@@ -401,6 +401,32 @@ class TestMusicEmptyOutputDetection:
 
 
 class TestMusicConcurrencyShape:
+    def test_generation_does_not_occupy_primary_model_worker(self, _stub_music_engine):
+        """Subprocess waiting stays on the route's blocking executor."""
+        import asyncio
+
+        from vllm_mlx.api.models import AudioMusicRequest
+        from vllm_mlx.routes import audio as audio_route
+        from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+        class _RejectingModelWorker:
+            async def execute_on_model_worker(self, func, *args, **kwargs):
+                raise AssertionError("music occupied the primary model worker")
+
+            def execute_on_model_worker_sync(self, func, *args, **kwargs):
+                raise AssertionError("music occupied the primary model worker")
+
+        bind_audio_worker(_RejectingModelWorker())
+        try:
+            response = asyncio.run(
+                audio_route.create_music(AudioMusicRequest(input="a march", seconds=5))
+            )
+        finally:
+            bind_audio_worker(None)
+
+        assert response.body[:4] == b"RIFF", response.body[:16]
+        assert _FakeMusicEngine.last_call is not None
+
     def test_generation_does_not_block_the_event_loop(self, _stub_music_engine):
         """The blocking render must run off the event loop.
 

--- a/tests/test_forced_alignment_route_hardening.py
+++ b/tests/test_forced_alignment_route_hardening.py
@@ -1018,8 +1018,8 @@ class TestSttLaneMutualExclusion:
 
         src = inspect.getsource(audio_route._run_stt_request)
         lock_at = src.index("async with _get_stt_lane_lock()")
-        load_at = src.index(".load()")
-        transcribe_at = src.index(".transcribe(")
+        load_at = src.index("stt_engine.load")
+        transcribe_at = src.index("_stt_engine.transcribe")
         assert lock_at < load_at < transcribe_at, (
             "the lock must be acquired before the weight load"
         )

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -441,6 +441,7 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         assert status.status_code == 200
         assert status.json()["memory_limit_bytes"] == 12 * GIB
         assert {item["id"] for item in status.json()["models"]} == {"chat", "image"}
+        assert isinstance(status.json()["audio_lanes"], list)
 
         pinned = client.put("/v1/models/image/pin", json={"pinned": True})
         assert pinned.status_code == 200

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1501,6 +1501,31 @@ class BatchedEngine(BaseEngine):
         await self._engine.engine.start(executor=self._model_load_executor)
         self._engine_started = True
 
+    async def execute_on_model_worker(self, func, *args, **kwargs):
+        """Execute auxiliary MLX work on this model's owning worker.
+
+        This is the public worker boundary used by server-side auxiliary
+        lanes.  Callers must not inspect ``_engine`` or its executor topology.
+        The same executor loads the model and performs every forward pass, so
+        arrays created here share the worker's thread-local MLX stream.
+        """
+
+        import asyncio
+
+        executor = self._model_load_executor
+        if executor is None:
+            raise RuntimeError("model worker is not running")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(executor, lambda: func(*args, **kwargs))
+
+    def execute_on_model_worker_sync(self, func, *args, **kwargs):
+        """Blocking counterpart for handlers already running off-loop."""
+
+        executor = self._model_load_executor
+        if executor is None:
+            raise RuntimeError("model worker is not running")
+        return executor.submit(func, *args, **kwargs).result()
+
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         if self._mllm_scheduler:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1527,32 +1527,39 @@ async def shutdown_audio_lanes() -> None:
 
     from ..runtime.audio_worker import run_audio_mlx_sync
 
+    def unload_cached(lane: str, cached: object | None) -> None:
+        if cached is None:
+            return
+        unload = getattr(cached, "unload", None)
+        if not callable(unload):
+            return
+        try:
+            run_audio_mlx_sync(
+                lane,
+                getattr(cached, "model_name", "unknown"),
+                "unload",
+                unload,
+            )
+        except Exception:
+            # Shutdown is best effort: one damaged auxiliary backend must not
+            # strand the remaining lanes or prevent the primary engine from
+            # stopping. Preserve the original exception and traceback in the
+            # server log while continuing terminal cleanup.
+            logger.exception("Failed to unload %s audio lane during shutdown", lane)
+
     async with _get_stt_lane_lock():
-        for lane, cached in (("stt", _stt_engine), ("alignment", _aligner_engine)):
-            if cached is None:
-                continue
-            unload = getattr(cached, "unload", None)
-            if callable(unload):
-                run_audio_mlx_sync(
-                    lane,
-                    getattr(cached, "model_name", "unknown"),
-                    "unload",
-                    unload,
-                )
-        _stt_engine = None
-        _aligner_engine = None
+        try:
+            unload_cached("stt", _stt_engine)
+            unload_cached("alignment", _aligner_engine)
+        finally:
+            _stt_engine = None
+            _aligner_engine = None
 
     async with _get_tts_lane_lock():
-        if _tts_engine is not None:
-            unload = getattr(_tts_engine, "unload", None)
-            if callable(unload):
-                run_audio_mlx_sync(
-                    "tts",
-                    getattr(_tts_engine, "model_name", "unknown"),
-                    "unload",
-                    unload,
-                )
-        _tts_engine = None
+        try:
+            unload_cached("tts", _tts_engine)
+        finally:
+            _tts_engine = None
 
     async with _get_music_lock():
         # MusicEngine owns a subprocess per generation rather than persistent

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -3134,13 +3134,7 @@ def _generate_music_blocking(
     ):
         _music_engine = MusicEngine(dit=dit, decoder=decoder)
 
-    from ..runtime.audio_worker import run_audio_mlx_sync
-
-    run_audio_mlx_sync(
-        "music",
-        f"{dit}:{decoder}",
-        "infer",
-        _music_engine.generate,
+    _music_engine.generate(
         request.input,
         out_path,
         seconds=request.seconds,

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1309,7 +1309,7 @@ async def _run_stt_request(
         async with _get_stt_lane_lock():
             if _stt_engine is None or _stt_engine.model_name != model_name:
                 # Symmetric with the alignment path: one STT model resident.
-                _evict_other_lane("asr")
+                await _evict_other_lane("asr")
                 _stt_engine = None
                 stt_engine = STTEngine(model_name)
                 from ..runtime.audio_worker import run_audio_mlx
@@ -1603,7 +1603,22 @@ def _is_client_alignment_error(exc: Exception) -> bool:
 _aligner_engine = None
 
 
-def _evict_other_lane(keep: str) -> None:
+def _other_stt_lane(keep: str) -> tuple[str, object | None]:
+    if keep == "aligner":
+        return "stt", _stt_engine
+    return "alignment", _aligner_engine
+
+
+def _clear_other_stt_lane(keep: str) -> None:
+    global _stt_engine, _aligner_engine
+
+    if keep == "aligner":
+        _stt_engine = None
+    else:
+        _aligner_engine = None
+
+
+async def _evict_other_lane(keep: str) -> None:
     """Release the STT lane's *other* cached engine before loading one.
 
     ``keep`` is ``"asr"`` or ``"aligner"``. Only ever called with the lane
@@ -1614,32 +1629,45 @@ def _evict_other_lane(keep: str) -> None:
     footprint — alternating requests would leave both models resident. MLX
     frees on refcount, so clearing the global is the release.
     """
-    global _stt_engine, _aligner_engine
+    lane, cached = _other_stt_lane(keep)
+    if cached is None:
+        return
+    logger.info(
+        "Releasing %s model %s to load the other STT lane "
+        "(one STT model resident at a time)",
+        lane,
+        getattr(cached, "model_name", "?"),
+    )
+    unload = getattr(cached, "unload", None)
+    if callable(unload):
+        from ..runtime.audio_worker import run_audio_mlx
 
-    from ..runtime.audio_worker import run_audio_mlx_sync
+        await run_audio_mlx(
+            lane, getattr(cached, "model_name", "unknown"), "unload", unload
+        )
+    _clear_other_stt_lane(keep)
 
-    if keep == "aligner" and _stt_engine is not None:
-        logger.info(
-            "Releasing ASR model %s to load the forced aligner "
-            "(one STT model resident at a time)",
-            getattr(_stt_engine, "model_name", "?"),
+
+def _evict_other_lane_sync(keep: str) -> None:
+    """Blocking counterpart for alignment's existing worker-thread pipeline."""
+
+    lane, cached = _other_stt_lane(keep)
+    if cached is None:
+        return
+    logger.info(
+        "Releasing %s model %s to load the other STT lane "
+        "(one STT model resident at a time)",
+        lane,
+        getattr(cached, "model_name", "?"),
+    )
+    unload = getattr(cached, "unload", None)
+    if callable(unload):
+        from ..runtime.audio_worker import run_audio_mlx_sync
+
+        run_audio_mlx_sync(
+            lane, getattr(cached, "model_name", "unknown"), "unload", unload
         )
-        old_model = getattr(_stt_engine, "model_name", "unknown")
-        unload = getattr(_stt_engine, "unload", None)
-        if callable(unload):
-            run_audio_mlx_sync("stt", old_model, "unload", unload)
-        _stt_engine = None
-    elif keep == "asr" and _aligner_engine is not None:
-        logger.info(
-            "Releasing forced aligner %s to load the ASR model "
-            "(one STT model resident at a time)",
-            getattr(_aligner_engine, "model_name", "?"),
-        )
-        old_model = getattr(_aligner_engine, "model_name", "unknown")
-        unload = getattr(_aligner_engine, "unload", None)
-        if callable(unload):
-            run_audio_mlx_sync("alignment", old_model, "unload", unload)
-        _aligner_engine = None
+    _clear_other_stt_lane(keep)
 
 
 def _align_blocking(
@@ -1676,7 +1704,7 @@ def _align_blocking(
         # unified memory for a server that can only use one at a time. The
         # caller holds the lane lock, so no ASR request is mid-flight and
         # this cannot pull weights out from under one.
-        _evict_other_lane("aligner")
+        _evict_other_lane_sync("aligner")
         # Also drop any PREVIOUS aligner (a different aligner alias) before
         # loading the replacement, so two multi-GB aligner models never sit
         # resident together during ``load()``. Inert under the current

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import wave
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
@@ -155,7 +156,7 @@ _AUDIO_READ_CHUNK_SIZE = 1024 * 1024  # 1 MB chunks
 # Audio engines (lazy loaded, module-level to persist across requests)
 _stt_engine = None
 _tts_engine = None
-_music_engine = None
+_music_engine: Any = None
 
 # OpenAI-style STT model alias → MLX repo. Promoted to module scope so
 # the route can validate the model BEFORE streaming the upload (F-165):

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1303,20 +1303,18 @@ async def _run_stt_request(
 
         from ..audio.stt import STTEngine
 
-        # Same lock the alignment lane takes. ASR still runs INLINE on the
-        # event loop, so this does not change how it executes — it makes
-        # explicit the serialisation it already had implicitly, and closes
-        # the window that offloading alignment would otherwise open: an ASR
-        # request on the loop concurrent with an alignment render in the
-        # executor means two multi-GB models resident and two callers
-        # driving the accelerator. See _stt_lane_lock.
+        # Same lock the alignment lane takes. The lock serialises lifecycle
+        # changes while ``run_audio_mlx`` sends load/inference to the server's
+        # model-owning worker; no route-level executor topology is involved.
         async with _get_stt_lane_lock():
             if _stt_engine is None or _stt_engine.model_name != model_name:
                 # Symmetric with the alignment path: one STT model resident.
                 _evict_other_lane("asr")
                 _stt_engine = None
                 stt_engine = STTEngine(model_name)
-                stt_engine.load()
+                from ..runtime.audio_worker import run_audio_mlx
+
+                await run_audio_mlx("stt", model_name, "load", stt_engine.load)
                 _stt_engine = stt_engine
 
             # Forward ``timestamp_granularities`` only when requested.
@@ -1330,7 +1328,16 @@ async def _run_stt_request(
             # with STTEngine-shaped stubs and third-party engines.
             if context and context.strip():
                 transcribe_kwargs["context"] = context.strip()
-            result = _stt_engine.transcribe(tmp_path, **transcribe_kwargs)
+            from ..runtime.audio_worker import run_audio_mlx
+
+            result = await run_audio_mlx(
+                "stt",
+                model_name,
+                "infer",
+                _stt_engine.transcribe,
+                tmp_path,
+                **transcribe_kwargs,
+            )
 
         # R6-H2: branch on the validated ``response_format`` so callers
         # that requested ``srt`` / ``vtt`` / ``verbose_json`` actually
@@ -1424,10 +1431,9 @@ async def _run_stt_request(
 # ---------------------------------------------------------------------------
 # Forced-alignment lane for ``/v1/audio/transcriptions`` + ``text``.
 #
-# Kept separate from ``_run_stt_request`` because the two lanes have
-# different concurrency models: ASR still runs its engine call inline on
-# the event loop, while alignment offloads to a worker thread (see the
-# lock and engine-cache comments below).
+# Kept separate from ``_run_stt_request`` because ASR and forced alignment
+# have separate model caches and request contracts. Their MLX operations share
+# the same server-owned worker and the lock below protects replacement.
 # ---------------------------------------------------------------------------
 
 
@@ -1437,17 +1443,9 @@ async def _run_stt_request(
 #: The two lanes share no Python state (``_stt_engine`` and
 #: ``_aligner_engine`` are separate caches on purpose), but they share the
 #: accelerator: each loads its own multi-GB model into unified memory and
-#: runs MLX work against it. Before this change every audio lane executed
-#: inline on the event loop, so they were mutually exclusive by accident.
-#: Offloading alignment to a worker thread removes that accident — an ASR
-#: request could then run on the loop while an alignment render is live in
-#: the executor, with two models resident and two callers driving the GPU.
-#: The lock restores the invariant deliberately instead of relying on the
-#: event loop to provide it.
-#:
-#: Note this does not change how ASR EXECUTES: it still runs inline, so
-#: taking the lock around it only makes explicit the serialisation it
-#: already had. TTS, alignment, and music run in workers.
+#: runs MLX work against it. The lock keeps replacement and inference a single
+#: lifecycle lease; actual MLX calls are dispatched to the server-owned model
+#: worker so thread-local streams remain valid.
 #:
 #: An ``asyncio.Lock`` acquired ON THE EVENT LOOP, deliberately not a
 #: ``threading.Lock`` held inside the worker. ``asyncio.to_thread`` uses
@@ -1517,6 +1515,51 @@ def _get_music_lock() -> _CrossLoopAsyncLock:
     return _music_lock
 
 
+async def shutdown_audio_lanes() -> None:
+    """Unload cached audio models on their owning MLX worker.
+
+    The ASGI lifespan calls this before stopping the primary engine. Acquiring
+    the same lane locks as request handlers provides a terminal barrier: no
+    cached model is released while an audio request still owns it.
+    """
+
+    global _stt_engine, _aligner_engine, _tts_engine, _music_engine
+
+    from ..runtime.audio_worker import run_audio_mlx_sync
+
+    async with _get_stt_lane_lock():
+        for lane, cached in (("stt", _stt_engine), ("alignment", _aligner_engine)):
+            if cached is None:
+                continue
+            unload = getattr(cached, "unload", None)
+            if callable(unload):
+                run_audio_mlx_sync(
+                    lane,
+                    getattr(cached, "model_name", "unknown"),
+                    "unload",
+                    unload,
+                )
+        _stt_engine = None
+        _aligner_engine = None
+
+    async with _get_tts_lane_lock():
+        if _tts_engine is not None:
+            unload = getattr(_tts_engine, "unload", None)
+            if callable(unload):
+                run_audio_mlx_sync(
+                    "tts",
+                    getattr(_tts_engine, "model_name", "unknown"),
+                    "unload",
+                    unload,
+                )
+        _tts_engine = None
+
+    async with _get_music_lock():
+        # MusicEngine owns a subprocess per generation rather than persistent
+        # MLX weights; the request barrier is sufficient before dropping it.
+        _music_engine = None
+
+
 #: Signatures of the two ``ValueError``s :meth:`STTEngine.align` raises
 #: for caller mistakes (see its body): a model that isn't a forced
 #: aligner, and empty/blank known text. Matched on message because the
@@ -1543,11 +1586,9 @@ def _is_client_alignment_error(exc: Exception) -> bool:
 #: Cached forced-aligner engine — DELIBERATELY separate from
 #: ``_stt_engine``.
 #:
-#: Sharing one global across both lanes is unsafe now that alignment runs
-#: on a worker thread while ASR still runs on the event loop: an ASR
-#: request can replace the engine in between the alignment path's cache
-#: check and its ``align()`` call, and no lock held on only one side can
-#: prevent that. A dedicated cache removes the shared mutable state
+#: Sharing one global across both lanes is unsafe: an ASR request could
+#: replace the engine in between the alignment path's cache check and its
+#: ``align()`` call. A dedicated cache removes the shared mutable state
 #: instead of trying to synchronise two lanes with different concurrency
 #: models. It also stops the two lanes evicting each other's weights on
 #: every alternating request, since an aligner and an ASR model are never
@@ -1568,12 +1609,18 @@ def _evict_other_lane(keep: str) -> None:
     """
     global _stt_engine, _aligner_engine
 
+    from ..runtime.audio_worker import run_audio_mlx_sync
+
     if keep == "aligner" and _stt_engine is not None:
         logger.info(
             "Releasing ASR model %s to load the forced aligner "
             "(one STT model resident at a time)",
             getattr(_stt_engine, "model_name", "?"),
         )
+        old_model = getattr(_stt_engine, "model_name", "unknown")
+        unload = getattr(_stt_engine, "unload", None)
+        if callable(unload):
+            run_audio_mlx_sync("stt", old_model, "unload", unload)
         _stt_engine = None
     elif keep == "asr" and _aligner_engine is not None:
         logger.info(
@@ -1581,6 +1628,10 @@ def _evict_other_lane(keep: str) -> None:
             "(one STT model resident at a time)",
             getattr(_aligner_engine, "model_name", "?"),
         )
+        old_model = getattr(_aligner_engine, "model_name", "unknown")
+        unload = getattr(_aligner_engine, "unload", None)
+        if callable(unload):
+            run_audio_mlx_sync("alignment", old_model, "unload", unload)
         _aligner_engine = None
 
 
@@ -1639,9 +1690,21 @@ def _align_blocking(
         # is a different hierarchy entirely, so the name would trip that
         # gate with a false positive.
         aligner = STTEngine(model_name)
-        aligner.load()
+        from ..runtime.audio_worker import run_audio_mlx_sync
+
+        run_audio_mlx_sync("alignment", model_name, "load", aligner.load)
         _aligner_engine = aligner
-    return _aligner_engine.align(audio_path, text, **align_kwargs)
+    from ..runtime.audio_worker import run_audio_mlx_sync
+
+    return run_audio_mlx_sync(
+        "alignment",
+        model_name,
+        "infer",
+        _aligner_engine.align,
+        audio_path,
+        text,
+        **align_kwargs,
+    )
 
 
 async def _run_alignment_request(
@@ -2513,10 +2576,17 @@ def _generate_speech_blocking(
     global _tts_engine
 
     from ..audio.tts import TTSEngine
+    from ..runtime.audio_worker import run_audio_mlx_sync
 
     if _tts_engine is None or _tts_engine.model_name != model_name:
+        if _tts_engine is not None:
+            old_model = getattr(_tts_engine, "model_name", "unknown")
+            unload = getattr(_tts_engine, "unload", None)
+            if callable(unload):
+                run_audio_mlx_sync("tts", old_model, "unload", unload)
+            _tts_engine = None
         tts_candidate = TTSEngine(model_name)
-        tts_candidate.load()
+        run_audio_mlx_sync("tts", model_name, "load", tts_candidate.load)
         _tts_engine = tts_candidate
 
     kwargs = dict(gen_kwargs)
@@ -2529,9 +2599,13 @@ def _generate_speech_blocking(
             kwargs["ref_audio"] = ref_path.path
             if ref_text is not None:
                 kwargs["ref_text"] = ref_text
-            audio = _tts_engine.generate(input_text, **kwargs)
+            audio = run_audio_mlx_sync(
+                "tts", model_name, "infer", _tts_engine.generate, input_text, **kwargs
+            )
     else:
-        audio = _tts_engine.generate(input_text, **kwargs)
+        audio = run_audio_mlx_sync(
+            "tts", model_name, "infer", _tts_engine.generate, input_text, **kwargs
+        )
     from ..audio.output_format import convert_audio_output
 
     converted, output_rate, output_channels = convert_audio_output(
@@ -3060,7 +3134,13 @@ def _generate_music_blocking(
     ):
         _music_engine = MusicEngine(dit=dit, decoder=decoder)
 
-    _music_engine.generate(
+    from ..runtime.audio_worker import run_audio_mlx_sync
+
+    run_audio_mlx_sync(
+        "music",
+        f"{dit}:{decoder}",
+        "infer",
+        _music_engine.generate,
         request.input,
         out_path,
         seconds=request.seconds,

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -75,7 +75,11 @@ def _record_payload(record) -> dict:
 async def model_residency():
     """Return resident models and actual process usage against the ceiling."""
 
-    return _manager().snapshot()
+    from ..runtime.audio_worker import audio_worker
+
+    snapshot = _manager().snapshot()
+    snapshot["audio_lanes"] = audio_worker.snapshot()
+    return snapshot
 
 
 @router.post("/v1/models/load")

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -29,6 +29,37 @@ class AudioWorkerBusyError(RuntimeError):
     """The owning model worker cannot change while audio work is active."""
 
 
+class AudioWorkerHandoff:
+    """Exclusive lease for changing the model worker without split ownership."""
+
+    def __init__(
+        self,
+        dispatcher: AudioWorkerDispatcher,
+        token: object,
+        original_worker: ModelWorker | None,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._token = token
+        self._original_worker = original_worker
+        self._finished = False
+
+    def commit(self, worker: ModelWorker | None) -> None:
+        """Publish ``worker`` and release the handoff lease."""
+
+        if self._finished:
+            raise RuntimeError("audio worker handoff is already complete")
+        self._dispatcher._finish_handoff(self._token, worker)
+        self._finished = True
+
+    def rollback(self) -> None:
+        """Keep the original worker and release the handoff lease."""
+
+        if self._finished:
+            return
+        self._dispatcher._finish_handoff(self._token, self._original_worker)
+        self._finished = True
+
+
 @dataclass
 class AudioLaneState:
     model: str | None = None
@@ -47,15 +78,22 @@ class AudioWorkerDispatcher:
         self._fallback: concurrent.futures.ThreadPoolExecutor | None = None
         self._lock = threading.Lock()
         self._lanes: dict[str, AudioLaneState] = {}
+        self._handoff_token: object | None = None
 
-    def bind(self, worker: ModelWorker | None) -> None:
+    @staticmethod
+    def _validate_worker(worker: ModelWorker | None) -> None:
         if worker is not None and (
             not callable(getattr(worker, "execute_on_model_worker", None))
             or not callable(getattr(worker, "execute_on_model_worker_sync", None))
         ):
             raise TypeError("engine does not expose the model-worker contract")
+
+    def bind(self, worker: ModelWorker | None) -> None:
+        self._validate_worker(worker)
         fallback = None
         with self._lock:
+            if self._handoff_token is not None:
+                raise AudioWorkerBusyError("model worker handoff is in progress")
             if worker is not self._worker and any(
                 state.active_requests > 0 for state in self._lanes.values()
             ):
@@ -63,6 +101,33 @@ class AudioWorkerDispatcher:
                     "cannot replace the model worker while audio work is active"
                 )
             self._worker = worker
+            fallback = self._fallback
+            self._fallback = None
+        if fallback is not None:
+            fallback.shutdown(wait=True)
+
+    def begin_handoff(self) -> AudioWorkerHandoff:
+        """Reserve worker ownership while the primary lifecycle changes."""
+
+        with self._lock:
+            if self._handoff_token is not None:
+                raise AudioWorkerBusyError("model worker handoff is in progress")
+            if any(state.active_requests > 0 for state in self._lanes.values()):
+                raise AudioWorkerBusyError(
+                    "cannot replace the model worker while audio work is active"
+                )
+            token = object()
+            self._handoff_token = token
+            return AudioWorkerHandoff(self, token, self._worker)
+
+    def _finish_handoff(self, token: object, worker: ModelWorker | None) -> None:
+        self._validate_worker(worker)
+        fallback = None
+        with self._lock:
+            if token is not self._handoff_token:
+                raise RuntimeError("audio worker handoff lease is not active")
+            self._worker = worker
+            self._handoff_token = None
             fallback = self._fallback
             self._fallback = None
         if fallback is not None:
@@ -89,6 +154,8 @@ class AudioWorkerDispatcher:
     def _begin(self, lane: str, model: str, operation: str) -> None:
         now = time.monotonic()
         with self._lock:
+            if self._handoff_token is not None:
+                raise AudioWorkerBusyError("model worker handoff is in progress")
             state = self._lanes.setdefault(lane, AudioLaneState())
             state.model = model
             state.active_requests += 1

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import threading
 import time
 from collections.abc import Callable
@@ -38,6 +40,7 @@ class AudioWorkerDispatcher:
 
     def __init__(self) -> None:
         self._worker: ModelWorker | None = None
+        self._fallback: concurrent.futures.ThreadPoolExecutor | None = None
         self._lock = threading.Lock()
         self._lanes: dict[str, AudioLaneState] = {}
 
@@ -47,12 +50,31 @@ class AudioWorkerDispatcher:
             or not callable(getattr(worker, "execute_on_model_worker_sync", None))
         ):
             raise TypeError("engine does not expose the model-worker contract")
+        fallback = None
         with self._lock:
             self._worker = worker
+            fallback = self._fallback
+            self._fallback = None
+        if fallback is not None:
+            fallback.shutdown(wait=True)
 
     def _bound_worker(self) -> ModelWorker | None:
         with self._lock:
             return self._worker
+
+    def _fallback_worker(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return the dedicated worker used by audio-only/non-batched servers."""
+
+        with self._lock:
+            if self._fallback is None:
+                from ..engine_core import _init_mlx_step_thread
+
+                self._fallback = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="mlx-audio",
+                    initializer=_init_mlx_step_thread,
+                )
+            return self._fallback
 
     def _begin(self, lane: str, model: str, operation: str) -> None:
         now = time.monotonic()
@@ -116,18 +138,45 @@ class AudioWorkerDispatcher:
         *args: Any,
         **kwargs: Any,
     ) -> _T:
-        self._begin(lane, model, operation)
-        error: BaseException | None = None
+        async def invoke() -> _T:
+            self._begin(lane, model, operation)
+            error: BaseException | None = None
+            try:
+                worker = self._bound_worker()
+                if worker is not None:
+                    return await worker.execute_on_model_worker(func, *args, **kwargs)
+                loop = asyncio.get_running_loop()
+                executor = self._fallback_worker()
+                return await loop.run_in_executor(
+                    executor, lambda: func(*args, **kwargs)
+                )
+            except BaseException as exc:
+                error = exc
+                raise
+            finally:
+                self._finish(lane, model, operation, error)
+
+        task = asyncio.create_task(invoke())
         try:
-            worker = self._bound_worker()
-            if worker is None:
-                return func(*args, **kwargs)
-            return await worker.execute_on_model_worker(func, *args, **kwargs)
-        except BaseException as exc:
-            error = exc
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # The callable may still be reading a request tempfile or touching
+            # cached weights. Do not let the route release its lane lock and
+            # cleanup resources until the worker reaches a terminal state.
+            while not task.done():
+                try:
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    continue
+                except BaseException:
+                    break
+            # Retrieve a terminal exception to avoid an unobserved-task
+            # warning; cancellation remains the caller-visible outcome.
+            try:
+                task.result()
+            except BaseException:
+                pass
             raise
-        finally:
-            self._finish(lane, model, operation, error)
 
     def execute_sync(
         self,
@@ -142,9 +191,9 @@ class AudioWorkerDispatcher:
         error: BaseException | None = None
         try:
             worker = self._bound_worker()
-            if worker is None:
-                return func(*args, **kwargs)
-            return worker.execute_on_model_worker_sync(func, *args, **kwargs)
+            if worker is not None:
+                return worker.execute_on_model_worker_sync(func, *args, **kwargs)
+            return self._fallback_worker().submit(func, *args, **kwargs).result()
         except BaseException as exc:
             error = exc
             raise

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -1,0 +1,181 @@
+"""Server-owned MLX worker dispatch and lifecycle state for audio lanes."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeVar
+
+_T = TypeVar("_T")
+
+
+class ModelWorker(Protocol):
+    """Minimal execution surface exported by an inference engine."""
+
+    async def execute_on_model_worker(
+        self, func: Callable[..., _T], *args: Any, **kwargs: Any
+    ) -> _T: ...
+
+    def execute_on_model_worker_sync(
+        self, func: Callable[..., _T], *args: Any, **kwargs: Any
+    ) -> _T: ...
+
+
+@dataclass
+class AudioLaneState:
+    model: str | None = None
+    state: str = "registered"
+    active_requests: int = 0
+    loaded_at: float | None = None
+    last_used_at: float | None = None
+    last_error: str | None = None
+
+
+class AudioWorkerDispatcher:
+    """Route audio MLX work through the server's model-owning worker."""
+
+    def __init__(self) -> None:
+        self._worker: ModelWorker | None = None
+        self._lock = threading.Lock()
+        self._lanes: dict[str, AudioLaneState] = {}
+
+    def bind(self, worker: ModelWorker | None) -> None:
+        if worker is not None and (
+            not callable(getattr(worker, "execute_on_model_worker", None))
+            or not callable(getattr(worker, "execute_on_model_worker_sync", None))
+        ):
+            raise TypeError("engine does not expose the model-worker contract")
+        with self._lock:
+            self._worker = worker
+
+    def _bound_worker(self) -> ModelWorker | None:
+        with self._lock:
+            return self._worker
+
+    def _begin(self, lane: str, model: str, operation: str) -> None:
+        now = time.monotonic()
+        with self._lock:
+            state = self._lanes.setdefault(lane, AudioLaneState())
+            state.model = model
+            state.active_requests += 1
+            state.state = "loading" if operation == "load" else "busy"
+            state.last_used_at = now
+            state.last_error = None
+
+    def _finish(
+        self, lane: str, model: str, operation: str, error: BaseException | None
+    ) -> None:
+        now = time.monotonic()
+        with self._lock:
+            state = self._lanes.setdefault(lane, AudioLaneState())
+            state.model = model
+            state.active_requests = max(0, state.active_requests - 1)
+            state.last_used_at = now
+            if error is None:
+                state.state = "registered" if operation == "unload" else "resident"
+                state.last_error = None
+                if operation == "load":
+                    state.loaded_at = now
+                elif operation == "unload":
+                    state.model = None
+                    state.loaded_at = None
+            else:
+                state.state = "failed"
+                state.last_error = type(error).__name__
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """Return stable, secret-free lane state for the residency API."""
+
+        now = time.monotonic()
+        with self._lock:
+            return [
+                {
+                    "lane": lane,
+                    "model": state.model,
+                    "state": state.state,
+                    "active_requests": state.active_requests,
+                    "loaded_at": state.loaded_at,
+                    "idle_seconds": (
+                        max(0.0, now - state.last_used_at)
+                        if state.last_used_at is not None and state.active_requests == 0
+                        else 0.0
+                    ),
+                    "last_error": state.last_error,
+                }
+                for lane, state in sorted(self._lanes.items())
+            ]
+
+    async def execute(
+        self,
+        lane: str,
+        model: str,
+        operation: str,
+        func: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        self._begin(lane, model, operation)
+        error: BaseException | None = None
+        try:
+            worker = self._bound_worker()
+            if worker is None:
+                return func(*args, **kwargs)
+            return await worker.execute_on_model_worker(func, *args, **kwargs)
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            self._finish(lane, model, operation, error)
+
+    def execute_sync(
+        self,
+        lane: str,
+        model: str,
+        operation: str,
+        func: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        self._begin(lane, model, operation)
+        error: BaseException | None = None
+        try:
+            worker = self._bound_worker()
+            if worker is None:
+                return func(*args, **kwargs)
+            return worker.execute_on_model_worker_sync(func, *args, **kwargs)
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            self._finish(lane, model, operation, error)
+
+
+audio_worker = AudioWorkerDispatcher()
+
+
+def bind_audio_worker(worker: ModelWorker | None) -> None:
+    audio_worker.bind(worker)
+
+
+async def run_audio_mlx(
+    lane: str,
+    model: str,
+    operation: str,
+    func: Callable[..., _T],
+    *args: Any,
+    **kwargs: Any,
+) -> _T:
+    return await audio_worker.execute(lane, model, operation, func, *args, **kwargs)
+
+
+def run_audio_mlx_sync(
+    lane: str,
+    model: str,
+    operation: str,
+    func: Callable[..., _T],
+    *args: Any,
+    **kwargs: Any,
+) -> _T:
+    return audio_worker.execute_sync(lane, model, operation, func, *args, **kwargs)

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -25,6 +25,10 @@ class ModelWorker(Protocol):
     ) -> _T: ...
 
 
+class AudioWorkerBusyError(RuntimeError):
+    """The owning model worker cannot change while audio work is active."""
+
+
 @dataclass
 class AudioLaneState:
     model: str | None = None
@@ -52,6 +56,12 @@ class AudioWorkerDispatcher:
             raise TypeError("engine does not expose the model-worker contract")
         fallback = None
         with self._lock:
+            if worker is not self._worker and any(
+                state.active_requests > 0 for state in self._lanes.values()
+            ):
+                raise AudioWorkerBusyError(
+                    "cannot replace the model worker while audio work is active"
+                )
             self._worker = worker
             fallback = self._fallback
             self._fallback = None

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -612,31 +612,7 @@ class ResidentModelManager:
             # replacement can fit under the same budget. Best-effort restore
             # the last known-good config; never let a rejected Settings change
             # silently take every route for the primary model down.
-            restored_entry = None
-            try:
-                restored_entry = await self.loader(
-                    model_name, model_path, record.performance
-                )
-                restored = ResidencyRecord(
-                    entry=restored_entry,
-                    estimated_bytes=estimate,
-                    loaded_at=self._clock(),
-                    last_used_at=self._clock(),
-                    pinned=pinned,
-                    primary=primary,
-                    performance=record.performance,
-                )
-                self.registry.add(restored_entry, is_default=primary)
-                self._index_record(restored)
-                if primary and self._on_primary_changed is not None:
-                    self._on_primary_changed(restored_entry)
-            except BaseException:
-                logger.exception(
-                    "Failed to restore resident model %r after reload failure",
-                    model_name,
-                )
-            if handoff is not None:
-                handoff.commit(restored_entry)
+            await self._restore_reload_locked(record, handoff)
             raise reload_error
         after = self._read_memory()
         now = self._clock()
@@ -650,14 +626,71 @@ class ResidentModelManager:
             primary=primary,
             performance=performance,
         )
-        self.registry.add(entry, is_default=primary)
-        self._index_record(replacement)
-        self.loads_total += 1
-        if primary and self._on_primary_changed is not None:
-            self._on_primary_changed(entry)
+        try:
+            self.registry.add(entry, is_default=primary)
+            self._index_record(replacement)
+            self.loads_total += 1
+            if primary and self._on_primary_changed is not None:
+                self._on_primary_changed(entry)
+        except BaseException as publish_error:
+            # The replacement is not committed until every serving-layer
+            # publisher accepts it. Remove and stop it while the audio lease
+            # still gates requests, then restore the last known-good config.
+            self.registry.remove(model_name)
+            self._drop_record(model_name)
+            try:
+                stop = getattr(entry.engine, "stop", None)
+                if callable(stop):
+                    result = stop()
+                    if asyncio.iscoroutine(result):
+                        await result
+            except BaseException:
+                logger.exception(
+                    "Failed to stop rejected resident model %r",
+                    model_name,
+                )
+            _release_allocator_cache()
+            await self._restore_reload_locked(record, handoff)
+            raise publish_error
         if handoff is not None:
             handoff.commit(entry)
         return replacement
+
+    async def _restore_reload_locked(
+        self,
+        record: ResidencyRecord,
+        handoff: PrimaryHandoffLease | None,
+    ) -> None:
+        """Restore the prior reload config and always finalize its handoff."""
+
+        restored_entry = None
+        try:
+            restored_entry = await self.loader(
+                record.model_id,
+                record.entry.model_path,
+                record.performance,
+            )
+            restored = ResidencyRecord(
+                entry=restored_entry,
+                estimated_bytes=record.estimated_bytes,
+                loaded_at=self._clock(),
+                last_used_at=self._clock(),
+                pinned=record.pinned,
+                primary=record.primary,
+                performance=record.performance,
+            )
+            self.registry.add(restored_entry, is_default=record.primary)
+            self._index_record(restored)
+            if record.primary and self._on_primary_changed is not None:
+                self._on_primary_changed(restored_entry)
+        except BaseException:
+            logger.exception(
+                "Failed to restore resident model %r after reload failure",
+                record.model_id,
+            )
+        finally:
+            if handoff is not None:
+                handoff.commit(restored_entry)
 
     async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -10,6 +10,7 @@ import time
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Protocol
 
 from .model_registry import ModelEntry, ModelRegistry
 from .process_memory import get_phys_footprint
@@ -159,7 +160,17 @@ class ResidencyRecord:
 
 Loader = Callable[..., Awaitable[ModelEntry]]
 PrimaryChanged = Callable[[ModelEntry], None]
-PrimaryHandoff = Callable[[ModelEntry], None]
+
+
+class PrimaryHandoffLease(Protocol):
+    """Serving-layer transaction coupled to a primary residency change."""
+
+    def commit(self, entry: ModelEntry | None) -> None: ...
+
+    def rollback(self) -> None: ...
+
+
+PrimaryHandoff = Callable[[ModelEntry], PrimaryHandoffLease]
 
 
 def _modality(entry: ModelEntry) -> str:
@@ -569,6 +580,11 @@ class ResidentModelManager:
         estimate = record.estimated_bytes
         pinned = record.pinned
         primary = record.primary
+        handoff = (
+            self._on_primary_handoff(record.entry)
+            if primary and self._on_primary_handoff is not None
+            else None
+        )
 
         self.registry.remove(model_name)
         self._drop_record(model_name)
@@ -583,6 +599,8 @@ class ResidentModelManager:
             # disappear from routing and residency accounting.
             self.registry.add(record.entry, is_default=primary)
             self._index_record(record)
+            if handoff is not None:
+                handoff.rollback()
             raise
         _release_allocator_cache()
 
@@ -594,6 +612,7 @@ class ResidentModelManager:
             # replacement can fit under the same budget. Best-effort restore
             # the last known-good config; never let a rejected Settings change
             # silently take every route for the primary model down.
+            restored_entry = None
             try:
                 restored_entry = await self.loader(
                     model_name, model_path, record.performance
@@ -616,6 +635,8 @@ class ResidentModelManager:
                     "Failed to restore resident model %r after reload failure",
                     model_name,
                 )
+            if handoff is not None:
+                handoff.commit(restored_entry)
             raise reload_error
         after = self._read_memory()
         now = self._clock()
@@ -634,6 +655,8 @@ class ResidentModelManager:
         self.loads_total += 1
         if primary and self._on_primary_changed is not None:
             self._on_primary_changed(entry)
+        if handoff is not None:
+            handoff.commit(entry)
         return replacement
 
     async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
@@ -666,24 +689,55 @@ class ResidentModelManager:
                 )
 
         old_primary = next((record for record in candidates if record.primary), None)
+        handoff = None
         if old_primary is not None:
-            # The hook owns the serving-layer handoff and may reject it
-            # while auxiliary work still leases the old primary worker. Run
-            # it before mutating residency/registry truth so a rejected
-            # handoff leaves the old primary intact and the caller can roll
-            # back the newly loaded target safely.
+            # Reserve serving-layer ownership before changing any primary
+            # truth. The lease rejects active auxiliary work and prevents a
+            # new request from entering until commit or rollback.
             if self._on_primary_handoff is not None:
-                self._on_primary_handoff(target.entry)
-            old_primary.primary = False
-            old_primary.pinned = False
-            target.primary = True
-            target.pinned = True
-            self.registry.set_default(target.model_id)
-            if self._on_primary_changed is not None:
-                self._on_primary_changed(target.entry)
+                handoff = self._on_primary_handoff(old_primary.entry)
+            old_pinned = old_primary.pinned
+            target_primary = target.primary
+            target_pinned = target.pinned
 
-        for record in candidates:
-            await self._evict_locked(record, reason=f"replace_{group}")
+        # Stop the old primary last. Until it returns successfully, rollback
+        # can restore a live worker and coherent routing if any eviction fails.
+        ordered_candidates = [
+            record for record in candidates if record is not old_primary
+        ]
+        if old_primary is not None:
+            ordered_candidates.append(old_primary)
+
+        try:
+            if old_primary is not None:
+                old_primary.primary = False
+                old_primary.pinned = False
+                target.primary = True
+                target.pinned = True
+                self.registry.set_default(target.model_id)
+                if self._on_primary_changed is not None:
+                    self._on_primary_changed(target.entry)
+            for record in ordered_candidates:
+                await self._evict_locked(record, reason=f"replace_{group}")
+        except BaseException:
+            if old_primary is not None:
+                try:
+                    old_primary.state = "resident"
+                    old_primary.primary = True
+                    old_primary.pinned = old_pinned
+                    target.primary = target_primary
+                    target.pinned = target_pinned
+                    self.registry.add(old_primary.entry, is_default=True)
+                    self._index_record(old_primary)
+                    if self._on_primary_changed is not None:
+                        self._on_primary_changed(old_primary.entry)
+                finally:
+                    if handoff is not None:
+                        handoff.rollback()
+            raise
+        else:
+            if handoff is not None:
+                handoff.commit(target.entry)
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -159,6 +159,7 @@ class ResidencyRecord:
 
 Loader = Callable[..., Awaitable[ModelEntry]]
 PrimaryChanged = Callable[[ModelEntry], None]
+PrimaryHandoff = Callable[[ModelEntry], None]
 
 
 def _modality(entry: ModelEntry) -> str:
@@ -315,6 +316,7 @@ class ResidentModelManager:
         idle_ttl_seconds: float = 0,
         clock: Callable[[], float] = time.monotonic,
         memory_reader: Callable[[], int] = get_phys_footprint,
+        on_primary_handoff: PrimaryHandoff | None = None,
         on_primary_changed: PrimaryChanged | None = None,
     ) -> None:
         self.registry = registry
@@ -323,6 +325,7 @@ class ResidentModelManager:
         self.idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
         self._clock = clock
         self._memory_reader = memory_reader
+        self._on_primary_handoff = on_primary_handoff
         self._on_primary_changed = on_primary_changed
         self._records: dict[str, ResidencyRecord] = {}
         self._index: dict[str, str] = {}
@@ -664,6 +667,13 @@ class ResidentModelManager:
 
         old_primary = next((record for record in candidates if record.primary), None)
         if old_primary is not None:
+            # The hook owns the serving-layer handoff and may reject it
+            # while auxiliary work still leases the old primary worker. Run
+            # it before mutating residency/registry truth so a rejected
+            # handoff leaves the old primary intact and the caller can roll
+            # back the newly loaded target safely.
+            if self._on_primary_handoff is not None:
+                self._on_primary_handoff(target.entry)
             old_primary.primary = False
             old_primary.pinned = False
             target.primary = True

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -126,7 +126,11 @@ from .engine import (
     BatchedEngine,
 )
 from .runtime.model_registry import ModelEntry, ModelRegistry
-from .runtime.resident_models import ResidentModelManager, estimate_model_bytes
+from .runtime.resident_models import (
+    ResidentModelBusyError,
+    ResidentModelManager,
+    estimate_model_bytes,
+)
 from .service.helpers import (  # noqa: F401 — re-export for backward compat
     _FALLBACK_TEMPERATURE,
     _FALLBACK_TOP_P,
@@ -2328,10 +2332,28 @@ def configure_model_residency(
         _load_dynamic_resident_model,
         memory_limit_bytes=_resident_memory_limit_bytes,
         idle_ttl_seconds=_resident_idle_ttl_seconds,
+        on_primary_handoff=_handoff_resident_primary_audio_worker,
         on_primary_changed=_set_resident_primary,
     )
     get_config().residency_manager = _residency_manager
     return _residency_manager
+
+
+def _handoff_resident_primary_audio_worker(entry: ModelEntry) -> None:
+    """Atomically transfer audio ownership before primary replacement."""
+
+    # Transfer auxiliary MLX ownership before publishing the new primary.
+    # ``bind`` is the audio lifecycle's atomic handoff gate: it refuses to
+    # detach an old worker with active work, allowing residency to roll back
+    # the replacement without changing primary or registry truth.
+    from .runtime.audio_worker import AudioWorkerBusyError
+
+    try:
+        _bind_audio_worker_for_engine(entry.engine)
+    except AudioWorkerBusyError as exc:
+        raise ResidentModelBusyError(
+            "primary model is serving active audio work"
+        ) from exc
 
 
 def _set_resident_primary(entry: ModelEntry) -> None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -227,6 +227,23 @@ _default_repetition_penalty: float | None = None  # Set via --default-repetition
 _default_presence_penalty: float | None = None  # Set via --default-presence-penalty
 _default_frequency_penalty: float | None = None  # Set via --default-frequency-penalty
 
+
+def _bind_audio_worker_for_engine(engine: object | None) -> bool:
+    """Bind a compatible primary engine or select the isolated fallback."""
+
+    from .runtime.audio_worker import bind_audio_worker
+
+    compatible = engine is not None and all(
+        callable(getattr(engine, method, None))
+        for method in (
+            "execute_on_model_worker",
+            "execute_on_model_worker_sync",
+        )
+    )
+    bind_audio_worker(engine if compatible else None)
+    return compatible
+
+
 # Sampling overlays populated from the model's AliasProfile +
 # generation_config.json once the path is known (load_model). Both stay
 # as None pre-load; the resolve helpers tolerate missing dicts.
@@ -694,14 +711,13 @@ async def lifespan(app: FastAPI):
         )
     if _engine is not None:
         from .routes.audio import audio_routes_should_register
-        from .runtime.audio_worker import bind_audio_worker
 
         if audio_routes_should_register(
             model_name=_model_name,
             model_alias=_model_alias,
             enable_audio_lane=_enable_audio_lane,
         ):
-            bind_audio_worker(_engine)
+            _bind_audio_worker_for_engine(_engine)
         _primary_entry = next(
             (
                 entry

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -40,6 +40,7 @@ import gc
 import logging
 import os
 from dataclasses import dataclass
+from typing import cast
 
 import uvicorn
 from fastapi import FastAPI
@@ -231,7 +232,7 @@ _default_frequency_penalty: float | None = None  # Set via --default-frequency-p
 def _bind_audio_worker_for_engine(engine: object | None) -> bool:
     """Bind a compatible primary engine or select the isolated fallback."""
 
-    from .runtime.audio_worker import bind_audio_worker
+    from .runtime.audio_worker import ModelWorker, bind_audio_worker
 
     compatible = engine is not None and all(
         callable(getattr(engine, method, None))
@@ -240,7 +241,7 @@ def _bind_audio_worker_for_engine(engine: object | None) -> bool:
             "execute_on_model_worker_sync",
         )
     )
-    bind_audio_worker(engine if compatible else None)
+    bind_audio_worker(cast(ModelWorker, engine) if compatible else None)
     return compatible
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -40,11 +40,14 @@ import gc
 import logging
 import os
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+if TYPE_CHECKING:
+    from .runtime.audio_worker import AudioWorkerHandoff, ModelWorker
 
 # Single source of truth for the OpenAI-shaped 400 / 422 / 500 envelopes
 # (F-161 / F-162 / F-163 / F-094-class). Defined in ``middleware`` so
@@ -236,7 +239,15 @@ _default_frequency_penalty: float | None = None  # Set via --default-frequency-p
 def _bind_audio_worker_for_engine(engine: object | None) -> bool:
     """Bind a compatible primary engine or select the isolated fallback."""
 
-    from .runtime.audio_worker import ModelWorker, bind_audio_worker
+    from .runtime.audio_worker import bind_audio_worker
+
+    worker = _audio_worker_for_engine(engine)
+    bind_audio_worker(worker)
+    return worker is not None
+
+
+def _audio_worker_for_engine(engine: object | None) -> "ModelWorker | None":
+    """Return an engine only when it implements the audio worker contract."""
 
     compatible = engine is not None and all(
         callable(getattr(engine, method, None))
@@ -245,8 +256,7 @@ def _bind_audio_worker_for_engine(engine: object | None) -> bool:
             "execute_on_model_worker_sync",
         )
     )
-    bind_audio_worker(cast(ModelWorker, engine) if compatible else None)
-    return compatible
+    return cast("ModelWorker", engine) if compatible else None
 
 
 # Sampling overlays populated from the model's AliasProfile +
@@ -2339,17 +2349,33 @@ def configure_model_residency(
     return _residency_manager
 
 
-def _handoff_resident_primary_audio_worker(entry: ModelEntry) -> None:
-    """Atomically transfer audio ownership before primary replacement."""
+class _ResidentPrimaryAudioHandoff:
+    """Adapt the audio dispatcher's lease to residency model entries."""
 
-    # Transfer auxiliary MLX ownership before publishing the new primary.
-    # ``bind`` is the audio lifecycle's atomic handoff gate: it refuses to
-    # detach an old worker with active work, allowing residency to roll back
-    # the replacement without changing primary or registry truth.
-    from .runtime.audio_worker import AudioWorkerBusyError
+    def __init__(self, handoff: "AudioWorkerHandoff") -> None:
+        self._handoff = handoff
+
+    def commit(self, entry: ModelEntry | None) -> None:
+        engine = entry.engine if entry is not None else None
+        self._handoff.commit(_audio_worker_for_engine(engine))
+
+    def rollback(self) -> None:
+        self._handoff.rollback()
+
+
+def _handoff_resident_primary_audio_worker(
+    entry: ModelEntry,
+) -> _ResidentPrimaryAudioHandoff:
+    """Reserve audio ownership for a transactional primary replacement."""
+
+    # The entry identifies the primary whose residency transaction owns the
+    # lease. The dispatcher is the worker-ownership SSOT and preserves that
+    # worker until commit or rollback.
+    del entry
+    from .runtime.audio_worker import AudioWorkerBusyError, audio_worker
 
     try:
-        _bind_audio_worker_for_engine(entry.engine)
+        return _ResidentPrimaryAudioHandoff(audio_worker.begin_handoff())
     except AudioWorkerBusyError as exc:
         raise ResidentModelBusyError(
             "primary model is serving active audio work"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -693,6 +693,15 @@ async def lifespan(app: FastAPI):
             gpu_memory_utilization=_resident_gpu_memory_utilization,
         )
     if _engine is not None:
+        from .routes.audio import audio_routes_should_register
+        from .runtime.audio_worker import bind_audio_worker
+
+        if audio_routes_should_register(
+            model_name=_model_name,
+            model_alias=_model_alias,
+            enable_audio_lane=_enable_audio_lane,
+        ):
+            bind_audio_worker(_engine)
         _primary_entry = next(
             (
                 entry
@@ -873,8 +882,14 @@ async def lifespan(app: FastAPI):
         if _mcp_manager is not None:
             await _mcp_manager.stop()
             logger.info("MCP manager stopped")
+        from .routes.audio import shutdown_audio_lanes
+
+        await shutdown_audio_lanes()
         if _residency_manager is not None:
             await _residency_manager.shutdown()
+        from .runtime.audio_worker import bind_audio_worker
+
+        bind_audio_worker(None)
         if _engine is not None:
             await _engine.stop()
             logger.info("Engine stopped")


### PR DESCRIPTION
## Why

Audio routes currently own cached MLX models inside request handlers, while the server owns the thread and stream on which MLX execution is safe. That split makes same-process text and speech serving depend on private engine topology and leaves lifecycle state invisible. The server should own auxiliary audio execution and expose its residency without requiring a Desktop model swap.

## Intention

Make same-process speech coexistence a server capability: when a text/VLM server exposes the audio API, STT/TTS load and inference execute safely on the server-owned MLX worker instead of relying on a desktop process swap or route knowledge of engine internals.

## Scope

- Add a public `BatchedEngine` model-worker execution contract for auxiliary MLX work.
- Bind the audio runtime to that worker during server lifespan startup and clear it before engine teardown.
- Route STT, TTS, and forced-alignment MLX operations through the server-owned worker.
- Keep music subprocess waiting on its existing independent blocking executor so it cannot starve text inference.
- Track per-lane model, state, active request count, load time, idle time, and sanitized failure type in `/v1/models/residency`.
- Unload cached STT/TTS/alignment engines behind their request locks during replacement and shutdown.
- Provide a dedicated single-thread fallback worker for audio-only or non-compatible engines.

## Explicit non-goals

- No Desktop, Swift, or GUI behavior changes.
- No automatic enabling of audio routes on text-only servers; `--enable-audio` remains explicit.
- No public OpenAI-compatible request/response changes.
- No refactor of image/video lifecycle or general scheduler policy.
- No new memory-ceiling policy in this PR.

## Constraints

- MLX streams are thread-local; weight load, inference, and unload for a cached audio model must stay on the model-owning worker.
- Routes must not traverse private engine wrapper topology or access private executors.
- Audio-only and non-compatible engine serving must remain usable through an isolated fallback worker.
- Shutdown must wait for lane locks and release cached audio models before stopping the primary worker.
- Long-running music subprocess waits must not occupy the primary model worker.

## Acceptance criteria

- A text server started with `--enable-audio` can serve chat, STT, TTS, then chat again in one process without a stream ownership error or unloading the primary model.
- Residency status exposes truthful audio lane state and active requests.
- Existing audio-only route behavior and API envelopes remain unchanged.
- Relevant unit, route, residency, and full Python regressions pass apart from documented pre-existing baseline failures.

## Verification

- 166 passed, 3 skipped after review-round-one fixes across worker, telemetry lifespan, STT/TTS/alignment/music, registration, and residency suites.
- 77 passed in the focused post-round-two worker/music/registration/residency regression set; Ruff, formatting, and diff checks pass.
- 727 passed, 5 skipped in the audio suite; one pre-existing capability-probe failure reproduced independently in the current environment.
- Full Python suite excluding that baseline file: 18,501 passed, 217 skipped, 45 deselected, 6 xfailed, 1 xpassed; one test-double compatibility failure found and fixed, then its focused regression passed.
- Apple Silicon E2E on macOS 26.5.2:
  - Qwen3 0.6B chat: HTTP 200.
  - Whisper Small transcription: HTTP 200, `Hello, RapidMLX.`.
  - Qwen3-TTS 1.7B 4-bit speech: HTTP 200, valid 24 kHz mono PCM WAV.
  - Chat remained HTTP 200 after both lanes.
  - Residency kept the primary text model resident and reported STT/TTS as resident with zero active requests.
  - Graceful server shutdown completed and released the test process.
