### PR TITLE
fix(ci): include Apple evidence in coverage gate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml
+          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests pyyaml
 
       - name: Run unit tests (no MLX required)
         # NOTE: tests in this list MUST not import mlx / mlx_lm at module
@@ -320,16 +320,17 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml
 
-      - name: Enforce changed-lines coverage
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          python -m diff_cover.diff_cover_tool \
-            coverage.xml \
-            --compare-branch "$PR_BASE_SHA" \
-            --show-uncovered \
-            --fail-under 100
+      - name: Preserve Linux coverage evidence
+        if: matrix.python-version == '3.11'
+        run: mv .coverage coverage-linux
+
+      - name: Upload Linux coverage evidence
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: engine-coverage-linux
+          path: coverage-linux
+          retention-days: 1
 
       - name: Upload coverage
         if: matrix.python-version == '3.11'
@@ -354,7 +355,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[vision]"
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio pytest-cov
 
       - name: Verify Apple Silicon
         run: |
@@ -381,15 +382,62 @@ jobs:
             tests/test_streaming_detokenizer.py \
             tests/test_tool_logits.py \
             tests/test_no_mllm_flag.py \
-            tests/test_audio_music_route.py \
-            tests/test_audio_route_registration_gate.py \
+            tests/test_audio*.py \
             tests/test_forced_alignment_route_hardening.py \
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
             -v --tb=short \
             -m "not slow" \
-            -k "not Integration"
+            -k "not Integration" \
+            --cov=vllm_mlx \
+            --cov-report=
+
+      - name: Preserve Apple Silicon coverage evidence
+        run: mv .coverage coverage-apple
+
+      - name: Upload Apple Silicon coverage evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: engine-coverage-apple
+          path: coverage-apple
+          retention-days: 1
+
+  changed-lines-coverage:
+    needs:
+      - changes
+      - test-matrix
+      - test-apple-silicon
+    if: github.event_name == 'pull_request' && needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Download coverage evidence
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          pattern: engine-coverage-*
+          merge-multiple: true
+
+      - name: Enforce changed-lines coverage
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python -m pip install "coverage==7.15.4" "diff-cover==8.0.3"
+          python -m coverage combine coverage-linux coverage-apple
+          python -m coverage xml
+          python -m diff_cover.diff_cover_tool \
+            coverage.xml \
+            --compare-branch "$PR_BASE_SHA" \
+            --show-uncovered \
+            --fail-under 100
 
   l1-smoke:
     # L1 release-flow gate — a small-model GPU coherence + tool-call format
@@ -470,6 +518,7 @@ jobs:
       - type-check
       - test-matrix
       - test-apple-silicon
+      - changed-lines-coverage
       - l1-smoke
     runs-on: ubuntu-latest
     if: always()
@@ -513,6 +562,11 @@ jobs:
           fi
           if [ "${{ needs.test-apple-silicon.result }}" != "success" ]; then
             echo "Apple Silicon tests failed"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && [ "${{ needs.changed-lines-coverage.result }}" != "success" ]; then
+            echo "Changed-lines coverage failed"
             exit 1
           fi
           if [ "${{ needs.l1-smoke.result }}" != "success" ]; then

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -13,6 +13,7 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 ENGINE_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+COVERAGE_CONFIG = ROOT / ".coveragerc"
 
 
 def _step_run(workflow: Path, job: str, step_name: str) -> str:
@@ -137,6 +138,7 @@ def test_type_check_enforces_shrink_only_error_budget():
 
 
 def test_changed_lines_coverage_combines_linux_and_apple_evidence():
+    assert "relative_files = true" in COVERAGE_CONFIG.read_text()
     test_matrix = _job(ENGINE_WORKFLOW, "test-matrix")
     linux_upload = next(
         step
@@ -148,9 +150,7 @@ def test_changed_lines_coverage_combines_linux_and_apple_evidence():
 
     apple = _job(ENGINE_WORKFLOW, "test-apple-silicon")
     apple_run = next(
-        step
-        for step in apple["steps"]
-        if step.get("name") == "Run MLX-dependent tests"
+        step for step in apple["steps"] if step.get("name") == "Run MLX-dependent tests"
     )
     assert "--cov=vllm_mlx" in apple_run["run"]
     assert "tests/test_audio*.py" in apple_run["run"]
@@ -177,4 +177,6 @@ def test_changed_lines_coverage_combines_linux_and_apple_evidence():
 
     aggregate = _step_run(ENGINE_WORKFLOW, "tests", "Check test results")
     coverage_gate = aggregate.index("needs.changed-lines-coverage.result")
-    assert aggregate.rfind('github.event_name }}" = "pull_request"', 0, coverage_gate) >= 0
+    assert (
+        aggregate.rfind('github.event_name }}" = "pull_request"', 0, coverage_gate) >= 0
+    )

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -136,34 +136,45 @@ def test_type_check_enforces_shrink_only_error_budget():
     assert "tests/test_check_mypy_error_budget.py" in unit_roster
 
 
-def test_python_311_enforces_changed_lines_coverage_without_repository_baseline():
+def test_changed_lines_coverage_combines_linux_and_apple_evidence():
     test_matrix = _job(ENGINE_WORKFLOW, "test-matrix")
-    checkout = next(
+    linux_upload = next(
         step
         for step in test_matrix["steps"]
-        if str(step.get("uses", "")).startswith("actions/checkout@")
+        if step.get("name") == "Upload Linux coverage evidence"
     )
-    assert checkout["with"]["fetch-depth"] == 0
+    assert linux_upload["if"] == "matrix.python-version == '3.11'"
+    assert linux_upload["with"]["retention-days"] == 1
 
-    install = next(
+    apple = _job(ENGINE_WORKFLOW, "test-apple-silicon")
+    apple_run = next(
         step
-        for step in test_matrix["steps"]
-        if step.get("name") == "Install dependencies"
+        for step in apple["steps"]
+        if step.get("name") == "Run MLX-dependent tests"
     )
-    assert '"diff-cover==8.0.3"' in install["run"]
+    assert "--cov=vllm_mlx" in apple_run["run"]
+    assert "tests/test_audio*.py" in apple_run["run"]
 
+    coverage = _job(ENGINE_WORKFLOW, "changed-lines-coverage")
+    assert set(coverage["needs"]) == {
+        "changes",
+        "test-matrix",
+        "test-apple-silicon",
+    }
     gate = next(
         step
-        for step in test_matrix["steps"]
+        for step in coverage["steps"]
         if step.get("name") == "Enforce changed-lines coverage"
-    )
-    assert gate["if"] == (
-        "github.event_name == 'pull_request' && matrix.python-version == '3.11'"
     )
     assert gate["env"] == {"PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}"}
     assert "continue-on-error" not in gate
+    assert "coverage combine coverage-linux coverage-apple" in gate["run"]
     assert "coverage.xml" in gate["run"]
     assert '--compare-branch "$PR_BASE_SHA"' in gate["run"]
     assert "--show-uncovered" in gate["run"]
     assert "--fail-under 100" in gate["run"]
     assert "--cov-fail-under" not in gate["run"]
+
+    aggregate = _step_run(ENGINE_WORKFLOW, "tests", "Check test results")
+    coverage_gate = aggregate.index("needs.changed-lines-coverage.result")
+    assert aggregate.rfind('github.event_name }}" = "pull_request"', 0, coverage_gate) >= 0


### PR DESCRIPTION
## Why

The changed-lines coverage ratchet currently reads only Linux coverage. MLX-native server behavior is required to run on the Apple Silicon lane, so fully tested engine changes can be reported as 0% covered and cannot merge.

## Intention

Keep the 100% changed-lines threshold while allowing the gate to consume trustworthy evidence from both required engine test lanes.

## Scope

- Preserve the Python 3.11 Linux coverage data as a one-day commit-bound artifact.
- Collect coverage from the existing Apple Silicon suite, including the audio test family.
- Combine both artifacts in a dedicated coverage verdict job before applying the unchanged 100% diff threshold.
- Require that verdict from the stable `tests` aggregate for pull requests.

## Non-goals

- No product, engine, server, or Desktop behavior changes.
- No threshold reduction, exclusions, baseline expansion, or cross-commit coverage cache.
- No changes to path classification or full-ci promotion policy.

## Acceptance criteria

- Linux-testable changes remain subject to the existing evidence.
- MLX-only changed lines can be satisfied only by passing Apple Silicon tests that execute them.
- Missing artifacts or a failed required lane fail closed.
- Pushes retain their existing behavior; the PR-only diff comparison does not make the main aggregate fail when skipped.

## Verification

- 45 workflow/classifier/SHA-pinning contracts pass.
- Ruff and diff checks pass.
- Local two-file coverage combine and XML generation succeeds.