### PR TITLE
fix(mac): scope Bonsai tool evidence by checkpoint

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -116,6 +116,7 @@ enum ToolUseCapability {
     /// Individually dogfooded aliases whose evidence must not be widened to
     /// arbitrary size siblings by a family rule.
     static let exactKnownAliases: Set<String> = [
+        "bonsai-1.7b-2bit",
         "ornith-1.5-9b-bf16",
         "ornith-1.5-35b-a3b-bf16",
     ]
@@ -245,6 +246,14 @@ enum ToolUseCapability {
         // variants may tool-call and must not be locked out (see the
         // IMPORTANT note above).
         "deepseek-r1-8b",
+        // 2026-08-24 release-candidate dogfood: bonsai-8b-2bit
+        // answered an explicit Tokyo-weather request from its priors
+        // ("22 C, clear skies") instead of emitting the advertised
+        // weather tool call. Keep this weight family out of the native
+        // tool path until it passes the same behavioral gate as the
+        // separately verified 1.7B checkpoint. Quant siblings share the
+        // same weights, so the size-qualified prefix is intentional.
+        "bonsai-8b",
         // NOTE: the Mistral / Devstral family was here (2026-07-09
         // sweep: PARSER MISCONFIG, not model incapacity — the model
         // emits a textbook ``[TOOL_CALLS]name[ARGS]{json}`` call but
@@ -311,14 +320,12 @@ enum ToolUseCapability {
 
         // MARK: Bonsai (Ternary) family — the first-run starter
 
-        // bonsai — PrismML Ternary Bonsai, a real Qwen3-architecture
-        // checkpoint packed at 1.58-bit (MLX-2bit). Verified 6/6 clean
-        // tool_calls (hermes parser) on the 1.7B in the eval harness
-        // (rapid-mlx PR #1092); it's the first-run starter, so promoting
-        // it to .known lets the empty-state capability chips surface.
-        // 1.5B floor: the starter is 1.7B (below the 3.0 floor the other
-        // rows use), and the smallest shipped ternary is 1.7B.
-        KnownFamily(prefix: "bonsai-", minSizeBillions: 1.5, note: "Ternary Bonsai (Qwen3 arch); 6/6 clean tool_calls on 1.7B, hermes parser; rapid-mlx PR #1092. NOT the first-run starter since 2026-08-05 — it degenerates on plain chat; see QuickstartCoordinator.defaultChoice"),
+        // Bonsai is intentionally not a family-level promotion. The 1.7B
+        // checkpoint has direct 6/6 evidence and lives in
+        // ``exactKnownAliases``; that result must not be inherited by other
+        // independently trained sizes. RC dogfood proved the 8B checkpoint
+        // silently ignores an explicit weather request, so it is pinned in
+        // ``brokenPrefixes`` above.
 
         // MARK: Llama family
 

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -167,6 +167,7 @@ final class BuiltinToolsTests {
         // confidently-hallucinated answer with no chip to warn the user.
         let enabled = makeRegistry().definitions
         #expect(ChatViewModel.wireDefinitions(forAlias: "hermes3-8b-4bit", enabled: enabled).isEmpty)
+        #expect(ChatViewModel.wireDefinitions(forAlias: "bonsai-8b-2bit", enabled: enabled).isEmpty)
         #expect(ChatViewModel.wireDefinitions(forAlias: "qwen3.5-4b-4bit", enabled: enabled).count == 3)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
@@ -182,6 +182,13 @@ struct ToolUseCapabilityTests {
         #expect(ToolUseCapability.confidence(for: "bonsai-1.7b-2bit") == .known)
     }
 
+    @Test("Bonsai tool evidence is checkpoint-specific")
+    func bonsaiEvidenceDoesNotLeakAcrossSizes() {
+        #expect(ToolUseCapability.confidence(for: "bonsai-8b-2bit") == .broken)
+        #expect(ToolUseCapability.confidence(for: "bonsai-8b-4bit") == .broken)
+        #expect(ToolUseCapability.confidence(for: "bonsai-4b-unpacked") == .unknown)
+    }
+
     // MARK: - shouldDisableToolsChip helper
 
     @Test("shouldDisableToolsChip is true for every .broken alias")


### PR DESCRIPTION
## Intention
Prevent Bonsai 8B from being presented or invoked as native-tool capable after release-candidate dogfood showed it can ignore an explicit weather request and answer from model priors.

## Why
The existing family rule generalized a directly measured 1.7B result to independently trained Bonsai checkpoints. Release-candidate dogfood produced contrary evidence on 8B, so checkpoint-scoped evidence is the smallest reliable correction and preserves the existing native-tool architecture.

## Scope
- Keep the directly verified Bonsai 1.7B alias native-tool capable.
- Mark the empirically failing Bonsai 8B weight family as native-tool broken.
- Stop promoting every Bonsai checkpoint from the 1.7B result.
- Pin Desktop capability and wire-filter behavior with focused tests.

## Non-goals
- No prompt or response-text heuristics.
- No new compatibility tool router.
- No engine, parser, server API, model catalog, or unrelated GUI changes.

## Acceptance criteria
- Bonsai 8B surfaces the existing no-tools disclosure and receives no native tool definitions.
- Bonsai 1.7B remains verified.
- Unverified Bonsai sizes remain unknown instead of inheriting another checkpoint's result.
- Verified native-tool models remain unaffected.

## Verification
- `swift test --filter 'ToolUseCapabilityTests|BuiltinToolsTests|ToolUseCapabilityCatalogCoverageTests|ToolUseCapabilitySourceGuardTests'` — 57 passed.
- `swift test` — 2,764 passed across 239 suites.
- Full local release build with bundled 0.12.18 sidecar succeeded.
- GUI dogfood: Bonsai 8B showed the no-tools disclosure and did not receive the weather tool; Gemma 4 12B still emitted a structured weather call and returned the live result.
