### PR TITLE
test(mac): cover attachment retry and relaunch [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -151,13 +151,17 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         )
 
         harness.relaunch()
-        // Relaunch preserves the selected model but intentionally leaves it
-        // stopped. Start that persisted selection before exercising Retry.
-        harness.startModel()
+        let restoredConversation = harness.element(label: "Persist both attachments")
+        XCTAssertTrue(restoredConversation.waitForExistence(timeout: 20))
+        restoredConversation.click()
         XCTAssertTrue(sentImage.waitForExistence(timeout: 20))
         XCTAssertTrue(sentDocument.waitForExistence(timeout: 20))
         XCTAssertFalse(imageChip.exists)
         XCTAssertFalse(documentChip.exists)
+
+        // Relaunch preserves the selected model but intentionally leaves it
+        // stopped. Start that persisted selection before exercising Retry.
+        harness.startModel()
 
         harness.retryResponse(expectedRequestCount: 3)
         assertCombinedIdentity(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -148,6 +148,9 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         )
 
         harness.relaunch()
+        // Relaunch preserves the selected model but intentionally leaves it
+        // stopped. Start that persisted selection before exercising Retry.
+        harness.startModel()
         XCTAssertTrue(sentImage.waitForExistence(timeout: 20))
         XCTAssertTrue(sentDocument.waitForExistence(timeout: 20))
         XCTAssertFalse(imageChip.exists)

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -124,7 +124,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         )
         let sentImage = harness.element(label: image.lastPathComponent)
         let sentDocument = harness.element(
-            label: "TXT file, \(document.lastPathComponent), TXT"
+            accessibilityTextPrefix: "TXT file, \(document.lastPathComponent.prefix(8))"
         )
         let expectedImageHash = try dataURLHash(image)
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -123,8 +123,8 @@ final class ChatAttachmentJourneyTests: XCTestCase {
             "ChatView.Attachment.Remove.\(document.lastPathComponent)"
         )
         let sentImage = harness.element(label: image.lastPathComponent)
-        let sentDocument = harness.element(
-            accessibilityTextPrefix: "TXT file, \(document.lastPathComponent.prefix(8))"
+        let sentDocument = harness.staticText(
+            valuePrefix: "TXT file, \(document.lastPathComponent.prefix(8))"
         )
         let expectedImageHash = try dataURLHash(image)
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -146,6 +146,9 @@ final class ChatAttachmentJourneyTests: XCTestCase {
             in: harness.chatRequests()[1],
             expectedImageHash: expectedImageHash
         )
+        harness.waitForConversationPersistence(
+            containing: [image.lastPathComponent, document.lastPathComponent]
+        )
 
         harness.relaunch()
         // Relaunch preserves the selected model but intentionally leaves it

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -104,6 +104,82 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         XCTAssertEqual(imageHashes(in: requests[3]), [try pastedImageHash(image)])
     }
 
+    func testRetryAndRelaunchPreserveSentAttachmentIdentity() throws {
+        continueAfterFailure = false
+        let harness = try RapidUITestHarness(
+            testName: name,
+            fakeSettings: ["FAKE_VISION_CHAT": "1"]
+        )
+        defer { harness.shutDown() }
+        harness.launch()
+        harness.startModel()
+
+        let image = harness.rapidMacRoot
+            .appendingPathComponent("Tests/RapidTests/__Snapshots__/cheetah-logo-96.png")
+        let document = harness.rapidMacRoot
+            .appendingPathComponent("Tests/GUIGoldenFlows/Fixtures/chat-document.txt")
+        let imageChip = harness.element("ChatView.Attachment.Remove.\(image.lastPathComponent)")
+        let documentChip = harness.element(
+            "ChatView.Attachment.Remove.\(document.lastPathComponent)"
+        )
+        let sentImage = harness.element(label: image.lastPathComponent)
+        let sentDocument = harness.element(
+            label: "TXT file, \(document.lastPathComponent), TXT"
+        )
+        let expectedImageHash = try dataURLHash(image)
+
+        harness.chooseFile(image, actionIdentifier: "ChatView.Attachments.UploadPhoto")
+        XCTAssertTrue(imageChip.waitForExistence(timeout: 10))
+        harness.chooseFile(document, actionIdentifier: "ChatView.Attachments.UploadFile")
+        XCTAssertTrue(documentChip.waitForExistence(timeout: 10))
+        harness.send("Persist both attachments", expectedRequestCount: 1)
+
+        XCTAssertTrue(sentImage.waitForExistence(timeout: 10))
+        XCTAssertTrue(sentDocument.waitForExistence(timeout: 10))
+        assertCombinedIdentity(
+            in: harness.chatRequests()[0],
+            expectedImageHash: expectedImageHash
+        )
+
+        harness.retryResponse(expectedRequestCount: 2)
+        assertCombinedIdentity(
+            in: harness.chatRequests()[1],
+            expectedImageHash: expectedImageHash
+        )
+
+        harness.relaunch()
+        XCTAssertTrue(sentImage.waitForExistence(timeout: 20))
+        XCTAssertTrue(sentDocument.waitForExistence(timeout: 20))
+        XCTAssertFalse(imageChip.exists)
+        XCTAssertFalse(documentChip.exists)
+
+        harness.retryResponse(expectedRequestCount: 3)
+        assertCombinedIdentity(
+            in: harness.chatRequests()[2],
+            expectedImageHash: expectedImageHash
+        )
+
+        harness.element("Sidebar.NewChat").click()
+        XCTAssertTrue(harness.waitUntil(timeout: 10) { !sentImage.exists && !sentDocument.exists })
+        XCTAssertFalse(imageChip.exists)
+        XCTAssertFalse(documentChip.exists)
+        harness.send("Fresh turn after relaunch", expectedRequestCount: 4)
+        XCTAssertTrue(imageHashes(in: harness.chatRequests()[3]).isEmpty)
+        XCTAssertFalse(text(in: harness.chatRequests()[3]).contains("Revenue: 42"))
+        XCTAssertFalse(text(in: harness.chatRequests()[3]).contains("Region: APAC"))
+    }
+
+    private func assertCombinedIdentity(
+        in request: [String: Any],
+        expectedImageHash: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(imageHashes(in: request), [expectedImageHash], file: file, line: line)
+        XCTAssertTrue(text(in: request).contains("Revenue: 42"), file: file, line: line)
+        XCTAssertTrue(text(in: request).contains("Region: APAC"), file: file, line: line)
+    }
+
     private func imageHashes(in request: [String: Any]) -> [String] {
         guard let payloads = request["user_payloads"] as? [[String: Any]],
               let latest = payloads.last else { return [] }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -153,6 +153,16 @@ final class RapidUITestHarness {
         ).firstMatch
     }
 
+    func element(accessibilityTextPrefix prefix: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: "label BEGINSWITH %@ OR value BEGINSWITH %@",
+                prefix,
+                prefix
+            )
+        ).firstMatch
+    }
+
     func messageAction(_ action: String) -> XCUIElement {
         app.descendants(matching: .any).matching(
             NSPredicate(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -97,6 +97,23 @@ final class RapidUITestHarness {
         dismissFirstRunIfNeeded()
     }
 
+    func relaunch() {
+        app.terminate()
+        terminateFakeSidecars()
+        app.launch()
+        XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
+        dismissFirstRunIfNeeded()
+
+        // The selected model is persisted with the conversation persona, so
+        // a real relaunch must restore both the transcript and an actionable
+        // composer without the test clicking Load a second time.
+        let send = element("ChatView.SendOrStopButton")
+        XCTAssertTrue(send.waitForExistence(timeout: 20))
+        XCTAssertTrue(waitUntil(timeout: 60) {
+            send.label == "Send message" && send.isEnabled
+        })
+    }
+
     func shutDown() {
         app.terminate()
         releasePortReservation()
@@ -128,6 +145,21 @@ final class RapidUITestHarness {
 
     func element(_ identifier: String) -> XCUIElement {
         app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    func element(label: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(
+            NSPredicate(format: "label == %@", label)
+        ).firstMatch
+    }
+
+    func messageAction(_ action: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: "identifier MATCHES %@",
+                "^ChatView\\.Message\\.\(action)\\.[0-9A-Fa-f-]{36}$"
+            )
+        ).firstMatch
     }
 
     func conversationRows() -> XCUIElementQuery {
@@ -233,6 +265,17 @@ final class RapidUITestHarness {
         let send = element("ChatView.SendOrStopButton")
         XCTAssertTrue(waitUntil(timeout: 10) { send.isEnabled })
         send.click()
+        XCTAssertTrue(waitUntil(timeout: 30) { self.chatRequests().count == expectedRequestCount })
+        XCTAssertTrue(waitUntil(timeout: 30) {
+            self.element("ChatView.SendOrStopButton").label == "Send message"
+        })
+    }
+
+    func retryResponse(expectedRequestCount: Int) {
+        let retry = messageAction("Retry")
+        XCTAssertTrue(retry.waitForExistence(timeout: 10))
+        XCTAssertTrue(waitUntil(timeout: 60) { retry.isEnabled })
+        retry.click()
         XCTAssertTrue(waitUntil(timeout: 30) { self.chatRequests().count == expectedRequestCount })
         XCTAssertTrue(waitUntil(timeout: 30) {
             self.element("ChatView.SendOrStopButton").label == "Send message"

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -146,9 +146,6 @@ final class RapidUITestHarness {
             }
             return self.serverStartCount() > priorServerStartCount
         })
-        let composer = element("rapid.chat.compose")
-        XCTAssertTrue(composer.waitForExistence(timeout: 20))
-        XCTAssertTrue(waitUntil(timeout: 60) { composer.isEnabled })
     }
 
     func waitForConversationPersistence(containing markers: [String]) {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -103,15 +103,6 @@ final class RapidUITestHarness {
         app.launch()
         XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
         dismissFirstRunIfNeeded()
-
-        // The selected model is persisted with the conversation persona, so
-        // a real relaunch must restore both the transcript and an actionable
-        // composer without the test clicking Load a second time.
-        let send = element("ChatView.SendOrStopButton")
-        XCTAssertTrue(send.waitForExistence(timeout: 20))
-        XCTAssertTrue(waitUntil(timeout: 60) {
-            send.label == "Send message" && send.isEnabled
-        })
     }
 
     func shutDown() {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -9,6 +9,7 @@ final class RapidUITestHarness {
     let rapidMacRoot: URL
 
     private let testHome: URL
+    private let conversationStore: URL
     private let sidecarAlias: String
     private let sidecarPIDFile: URL
     private var portReservation: Int32?
@@ -57,6 +58,9 @@ final class RapidUITestHarness {
         testHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-xcui-\(testName)-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
+        conversationStore = testHome
+            .appendingPathComponent("Library/Application Support/com.rapidmlx.rapid")
+            .appendingPathComponent("conversations.json")
 
         rapidMacRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent() // Tests
@@ -100,6 +104,15 @@ final class RapidUITestHarness {
     func relaunch() {
         app.terminate()
         terminateFakeSidecars()
+        releasePortReservation()
+        do {
+            let reservedPort = try Self.reserveLoopbackPort()
+            portReservation = reservedPort.descriptor
+            app.launchEnvironment["RAPID_DESKTOP_PORT"] = String(reservedPort.port)
+        } catch {
+            XCTFail("Could not reserve a fresh loopback port for relaunch: \(error)")
+            return
+        }
         app.launch()
         XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
         dismissFirstRunIfNeeded()
@@ -132,6 +145,21 @@ final class RapidUITestHarness {
                 confirmedMemoryWarning = true
             }
             return self.serverStartCount() > priorServerStartCount
+        })
+        let send = element("ChatView.SendOrStopButton")
+        XCTAssertTrue(send.waitForExistence(timeout: 20))
+        XCTAssertTrue(waitUntil(timeout: 60) {
+            send.label == "Send message" && send.isEnabled
+        })
+    }
+
+    func waitForConversationPersistence(containing markers: [String]) {
+        XCTAssertTrue(waitUntil(timeout: 20) {
+            guard let persisted = try? String(
+                contentsOf: self.conversationStore,
+                encoding: .utf8
+            ) else { return false }
+            return markers.allSatisfy(persisted.contains)
         })
     }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -153,13 +153,13 @@ final class RapidUITestHarness {
         ).firstMatch
     }
 
-    func element(accessibilityTextPrefix prefix: String) -> XCUIElement {
-        app.descendants(matching: .any).matching(
-            NSPredicate(
-                format: "label BEGINSWITH %@ OR value BEGINSWITH %@",
-                prefix,
-                prefix
-            )
+    func staticText(valuePrefix prefix: String) -> XCUIElement {
+        // SwiftUI exposes a combined, line-limited accessibility label as the
+        // AX value of a StaticText on hosted macOS. Constraining the query to
+        // that element type also avoids an expensive value predicate across
+        // the entire application hierarchy.
+        app.staticTexts.matching(
+            NSPredicate(format: "value BEGINSWITH %@", prefix)
         ).firstMatch
     }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -146,11 +146,9 @@ final class RapidUITestHarness {
             }
             return self.serverStartCount() > priorServerStartCount
         })
-        let send = element("ChatView.SendOrStopButton")
-        XCTAssertTrue(send.waitForExistence(timeout: 20))
-        XCTAssertTrue(waitUntil(timeout: 60) {
-            send.label == "Send message" && send.isEnabled
-        })
+        let composer = element("rapid.chat.compose")
+        XCTAssertTrue(composer.waitForExistence(timeout: 20))
+        XCTAssertTrue(waitUntil(timeout: 60) { composer.isEnabled })
     }
 
     func waitForConversationPersistence(containing markers: [String]) {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -117,6 +117,7 @@ final class RapidUITestHarness {
         let readiness = element("Readiness.Action")
         XCTAssertTrue(readiness.waitForExistence(timeout: 20))
         XCTAssertTrue(waitUntil(timeout: 20) { readiness.isEnabled })
+        let priorServerStartCount = serverStartCount()
         // Hold the OS-selected port until the app is ready to spawn its fake
         // sidecar, reducing the bind race to the click-to-process-launch edge.
         releasePortReservation()
@@ -130,7 +131,7 @@ final class RapidUITestHarness {
                 memoryConfirmation.click()
                 confirmedMemoryWarning = true
             }
-            return self.events().contains { $0["event"] as? String == "server_started" }
+            return self.serverStartCount() > priorServerStartCount
         })
     }
 
@@ -310,6 +311,10 @@ final class RapidUITestHarness {
             guard let data = line.data(using: .utf8) else { return nil }
             return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         }
+    }
+
+    private func serverStartCount() -> Int {
+        events().count { $0["event"] as? String == "server_started" }
     }
 
     private func terminateFakeSidecars() {

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -95,6 +95,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'element("MemoryWarning.Confirm")' in harness
     assert "let priorServerStartCount = serverStartCount()" in harness
     assert "self.serverStartCount() > priorServerStartCount" in harness
+    assert "func waitForConversationPersistence(containing markers: [String])" in harness
+    assert 'app.launchEnvironment["RAPID_DESKTOP_PORT"] = String(reservedPort.port)' in harness
     assert 'app.dialogs["open-panel"].buttons["OKButton"]' in harness
     assert (
         'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -127,6 +127,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "testDragPasteAndRemovalPreserveWireIdentity" in chat_source
     assert "testRetryAndRelaunchPreserveSentAttachmentIdentity" in chat_source
     assert "assertCombinedIdentity" in chat_source
+    assert 'element(label: "Persist both attachments")' in chat_source
     assert 'element("Sidebar.NewChat").click()' in chat_source
     assert 'element("ChatView.Attachment.Remove.Pasted image.png")' in chat_source
     assert "port: 65_001" not in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -112,6 +112,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "pasteboard.changeCount == ownedPasteboardChangeCount" in harness
     assert "originalPasteboardItems == nil || !stillOwnsPasteboard" in harness
     assert "func relaunch()" in harness
+    assert "func element(accessibilityTextPrefix prefix: String)" in harness
+    assert 'format: "label BEGINSWITH %@ OR value BEGINSWITH %@"' in harness
     assert "terminateFakeSidecars()" in harness
     assert 'messageAction("Retry")' in harness
     assert "testDragPasteAndRemovalPreserveWireIdentity" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -93,6 +93,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'config["FAKE_PID_FILE"] = sidecarPIDFile.path' in harness
     assert "String(contentsOf: sidecarPIDFile" in harness
     assert 'element("MemoryWarning.Confirm")' in harness
+    assert "let priorServerStartCount = serverStartCount()" in harness
+    assert "self.serverStartCount() > priorServerStartCount" in harness
     assert 'app.dialogs["open-panel"].buttons["OKButton"]' in harness
     assert (
         'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -95,8 +95,13 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'element("MemoryWarning.Confirm")' in harness
     assert "let priorServerStartCount = serverStartCount()" in harness
     assert "self.serverStartCount() > priorServerStartCount" in harness
-    assert "func waitForConversationPersistence(containing markers: [String])" in harness
-    assert 'app.launchEnvironment["RAPID_DESKTOP_PORT"] = String(reservedPort.port)' in harness
+    assert (
+        "func waitForConversationPersistence(containing markers: [String])" in harness
+    )
+    assert (
+        'app.launchEnvironment["RAPID_DESKTOP_PORT"] = String(reservedPort.port)'
+        in harness
+    )
     assert 'app.dialogs["open-panel"].buttons["OKButton"]' in harness
     assert (
         'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -111,7 +111,13 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "restorePasteboardIfOwned" in harness
     assert "pasteboard.changeCount == ownedPasteboardChangeCount" in harness
     assert "originalPasteboardItems == nil || !stillOwnsPasteboard" in harness
+    assert "func relaunch()" in harness
+    assert "terminateFakeSidecars()" in harness
+    assert 'messageAction("Retry")' in harness
     assert "testDragPasteAndRemovalPreserveWireIdentity" in chat_source
+    assert "testRetryAndRelaunchPreserveSentAttachmentIdentity" in chat_source
+    assert "assertCombinedIdentity" in chat_source
+    assert 'element("Sidebar.NewChat").click()' in chat_source
     assert 'element("ChatView.Attachment.Remove.Pasted image.png")' in chat_source
     assert "port: 65_001" not in chat_source
     assert "port: 65_002" not in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -112,8 +112,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "pasteboard.changeCount == ownedPasteboardChangeCount" in harness
     assert "originalPasteboardItems == nil || !stillOwnsPasteboard" in harness
     assert "func relaunch()" in harness
-    assert "func element(accessibilityTextPrefix prefix: String)" in harness
-    assert 'format: "label BEGINSWITH %@ OR value BEGINSWITH %@"' in harness
+    assert "func staticText(valuePrefix prefix: String)" in harness
+    assert "app.staticTexts.matching(" in harness
+    assert 'NSPredicate(format: "value BEGINSWITH %@", prefix)' in harness
     assert "terminateFakeSidecars()" in harness
     assert 'messageAction("Retry")' in harness
     assert "testDragPasteAndRemovalPreserveWireIdentity" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -112,6 +112,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "pasteboard.changeCount == ownedPasteboardChangeCount" in harness
     assert "originalPasteboardItems == nil || !stillOwnsPasteboard" in harness
     assert "func relaunch()" in harness
+    relaunch_index = chat_source.index("harness.relaunch()")
+    restart_index = chat_source.index("harness.startModel()", relaunch_index)
+    assert relaunch_index < restart_index
     assert "func staticText(valuePrefix prefix: String)" in harness
     assert "app.staticTexts.matching(" in harness
     assert 'NSPredicate(format: "value BEGINSWITH %@", prefix)' in harness


### PR DESCRIPTION
## Intention

Prove that sent Chat attachments remain the same user-owned evidence across response Retry and an actual app relaunch, while a fresh conversation starts with an empty composer.

## Why

Picker, drag, and paste coverage stops at the first successful send. A regression in branch replay or conversation persistence could still display stale attachment state, omit the persisted source, or silently send different image/document content after Retry or relaunch.

Refs #2254.

## Scope

- Add a production-shaped native journey that sends one image and one text document together.
- Assert the same image hash and extracted document markers on initial send, Retry, and post-relaunch Retry.
- Assert the sent attachment UI restores after relaunch while composer removal chips stay absent.
- Start a fresh conversation and prove neither the composer nor its sidecar request inherits the old attachments.
- Add reusable test-only relaunch and message-action helpers plus focused structural contracts.

## Non-goals

- No product behavior, public API, backend, parser, tool protocol, or CI routing changes.
- No mixed attachment ordering, text-only model rejection, geometry, or pixel-baseline coverage.

## Constraints and acceptance

- Use the release-shaped app, real accessibility controls, persisted persona storage, and the existing fake sidecar.
- Relaunch must terminate only sidecars recorded for the isolated test persona.
- Retry must use the stable per-message accessibility identifier; no coordinate clicks or fixed sleeps.
- The existing attachment journeys and AX Chat flows remain unchanged.

## Validation

- 41 focused GUI/XCUITest contracts pass.
- Fresh-DerivedData XCUITest `build-for-testing` succeeds.
- Release-shaped app build succeeds.
- Local native execution was attempted, but the local XCTest runner hung before establishing its test connection; no test method or assertion ran. Hosted native Chat CI is therefore the execution gate.
- Hosted native/full desktop CI and scoped Codex review are required before merge.