### PR TITLE
chore: bump version to 0.13.0-rc1

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,14 +17,60 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.0-rc1] — 2026-08-24
+
+This first 0.13 release candidate broadens model coverage, makes local tools
+and reasoning more dependable, and removes several first-run and everyday Mac
+friction points. As a release candidate, it is published for validation and
+does not replace the stable updater feed.
+
+### Added
+
+- **Ornith 1.5 is available end to end.** The 9B dense and 35B-A3B
+  mixture-of-experts checkpoints are recognized by the engine and exposed in
+  the Mac model picker with the correct runtime routes.
+- **More local generation choices.** Nemotron Labs Diffusion 3B can generate
+  images through its autoregressive path, and Qwen3-Next can stream routed
+  experts from disk on memory-constrained machines.
+- **Agent health is visible and actionable.** The CLI reports integration
+  health and can re-run setup, while the Mac menu bar can copy the active API
+  endpoint for connecting another client.
+
 ### Changed
 
+- **Hybrid and recurrent models start answering sooner.** Verified model
+  profiles now select measured prefill chunk sizes automatically, while vision
+  and text budgets remain independently bounded.
+- **Chat attachments behave like native Mac inputs.** Files and images can be
+  chosen, dragged, or pasted into the composer, removed before sending, and
+  kept isolated from drafts in other conversations.
+- **Release validation is faster without reducing coverage.** Product lanes
+  and GUI journeys are selected from the real diff, GUI groups run in parallel,
+  and every selected journey still has a fail-closed result contract.
 - **The Mac installer now looks and behaves like a finished install page.**
   Opening the DMG presents Rapid-MLX on the left, Applications on the right,
   a clear drag-to-install arrow, concise instructions, and a branded local-AI
   background instead of Finder's blank auto-arranged window. Both the full and
   slim installers share the layout, and release validation now opens the final
   read-only image to verify the saved icon positions and window geometry.
+
+### Fixed
+
+- Gemma 4 chat templates are selected once from validated model profiles at
+  tokenizer or processor load time instead of being guessed on every request;
+  explicit custom templates continue to take precedence.
+- Tool calls malformed by a model can recover through the tool loop instead of
+  leaking protocol text into chat, and Cohere Command 4 reasoning now uses a
+  protocol-aware lifecycle across Chat and Responses streaming paths.
+- Persisted KV caches are isolated by exact model revision, preventing stale
+  state from crossing checkpoint updates; quantized KV cache corruption on MLX
+  0.32.1 is also blocked.
+- The Mac app now surfaces search-provider failure reasons, shows live model
+  readiness progress, keeps the first chat and bundled image generation path
+  usable, and explains when a model's tool capability is unavailable or only
+  verified for a specific checkpoint.
+- First-run model choices, model-variant presentation, speech-to-text setup,
+  and image defaults received a release-focused polish pass.
 
 ## [0.12.18] — 2026-08-20
 

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.18</string>
+	<string>0.13.0-rc1</string>
 	<key>CFBundleVersion</key>
-	<string>162</string>
+	<string>163</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,7 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
+
+<!-- One or two sentences: what is this release about? -->
+
+## Highlights

--- a/docs/release-notes/v0.13.0-rc1.md
+++ b/docs/release-notes/v0.13.0-rc1.md
@@ -1,0 +1,67 @@
+Rapid-MLX 0.13.0-rc1 is the first validation build for the 0.13 line. It adds
+new model families, hardens reasoning and tool execution, and makes the Mac app
+more predictable from installation through a real multi-turn chat. This RC is
+published as a prerelease and deliberately does not replace the stable updater
+feed.
+
+## Highlights
+
+- **Ornith 1.5, from engine to model picker.** The 9B dense and 35B-A3B MoE
+  checkpoints have stable aliases, sizes, runtime routing, and Mac catalog
+  entries, with dense versus hybrid/MoE selection verified on real hardware.
+  ([#2197](https://github.com/raullenchai/Rapid-MLX/pull/2197),
+  [#2200](https://github.com/raullenchai/Rapid-MLX/pull/2200))
+- **Broader local generation.** Nemotron Labs Diffusion 3B is served through
+  its autoregressive image path, Qwen3-Next gains routed-expert disk streaming,
+  and the Mac bundle carries a compatible image-generation runtime.
+  ([#2194](https://github.com/raullenchai/Rapid-MLX/pull/2194),
+  [#2192](https://github.com/raullenchai/Rapid-MLX/pull/2192),
+  [#2204](https://github.com/raullenchai/Rapid-MLX/pull/2204))
+- **Faster, safer model defaults.** Measured recurrent prefill profiles are
+  applied only where verified, text and vision prefill budgets are independent,
+  persisted KV data is keyed by exact model revision, and MLX 0.32.1 adoption is
+  backed by cross-model Mac measurements plus a quantized-cache correctness
+  guard. ([#2203](https://github.com/raullenchai/Rapid-MLX/pull/2203),
+  [#2213](https://github.com/raullenchai/Rapid-MLX/pull/2213),
+  [#2215](https://github.com/raullenchai/Rapid-MLX/pull/2215),
+  [#2202](https://github.com/raullenchai/Rapid-MLX/pull/2202),
+  [#2234](https://github.com/raullenchai/Rapid-MLX/pull/2234))
+- **Tools and reasoning fail more cleanly.** Malformed tool calls can recover
+  through the tool loop instead of surfacing protocol debris, native model tool
+  routing preserves conversation context, and Cohere Command 4 reasoning uses a
+  protocol-driven detector across Chat and Responses, streaming and
+  non-streaming. ([#2278](https://github.com/raullenchai/Rapid-MLX/pull/2278),
+  [#2244](https://github.com/raullenchai/Rapid-MLX/pull/2244),
+  [#2284](https://github.com/raullenchai/Rapid-MLX/pull/2284))
+- **Chat templates resolve once, from validated model identity.** Gemma 4 and
+  future profiled checkpoints select their compatible template when the text
+  tokenizer or multimodal processor loads, rather than repeating a
+  request-time guess. Explicit custom templates retain precedence, and aliases,
+  exact repositories, downloaded snapshots, and dynamically loaded models all
+  carry the same resolved contract. ([#2288](https://github.com/raullenchai/Rapid-MLX/pull/2288))
+- **Mac chat feels more native.** Images and documents can be selected, dragged,
+  or pasted into the composer and removed before send; drafts remain scoped to
+  their conversation. Search failures retain their real provider reason, model
+  readiness reports live progress, and tool availability is tied to evidence
+  for the exact checkpoint rather than an entire family.
+  ([#2265](https://github.com/raullenchai/Rapid-MLX/pull/2265),
+  [#2277](https://github.com/raullenchai/Rapid-MLX/pull/2277),
+  [#2250](https://github.com/raullenchai/Rapid-MLX/pull/2250),
+  [#2249](https://github.com/raullenchai/Rapid-MLX/pull/2249),
+  [#2287](https://github.com/raullenchai/Rapid-MLX/pull/2287))
+- **A smoother path from install to first useful run.** The DMG, first-run
+  screens, model recommendations, variant presentation, speech-to-text setup,
+  and image defaults received a release-focused friction pass. The menu bar can
+  copy the active API endpoint, and agent health is visible with a direct setup
+  retry. ([#2214](https://github.com/raullenchai/Rapid-MLX/pull/2214),
+  [#2212](https://github.com/raullenchai/Rapid-MLX/pull/2212),
+  [#2196](https://github.com/raullenchai/Rapid-MLX/pull/2196),
+  [#2229](https://github.com/raullenchai/Rapid-MLX/pull/2229),
+  [#2187](https://github.com/raullenchai/Rapid-MLX/pull/2187),
+  [#2246](https://github.com/raullenchai/Rapid-MLX/pull/2246),
+  [#2230](https://github.com/raullenchai/Rapid-MLX/pull/2230))
+
+The main-versus-0.12.18 performance spot check found model-dependent results,
+not a universal 10–20% gain. This RC therefore makes no blanket throughput
+claim; the reproducible measurements are recorded in the repository and the
+release gates continue to enforce per-model floors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.18"
+version = "0.13.0-rc1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Cut the first 0.13.0 release candidate.

## Why

The changes accumulated after 0.12.18 need an isolated customer-testable build before stable promotion. A dedicated RC bump lets the existing release pipeline produce immutable engine and Desktop prerelease artifacts while deliberately leaving stable updater feeds unchanged.

## Scope

- bump the engine and Desktop version SSOT to `0.13.0-rc1`
- increment the Desktop build number to 163
- archive curated 0.13.0-rc1 notes and reset the unreleased template
- add the required Desktop changelog section

## Non-goals

- no feature or bug-fix changes
- no stable updater promotion; RC publication remains isolated from the stable feed
- no release-gate bypass

## Acceptance

- version SSOT and release subject contracts pass
- clean-room wheel installation imports every shipped surface
- release preflight confirms credentials, distribution build, RC workflow behavior, and Desktop release metadata
- PR validation/full CI are green before the exact squash subject is merged

## Local evidence

- `make release-smoke`
- 33 focused version/RC workflow tests
- 63 release-note generation contracts
- `scripts/check_version_sync.py`
- `git diff --check`

## G10 advisory audit

#404-audited: the reported upstream new_thread_local_stream(default_device()) sites are covered by Rapid-MLX’s probe-and-cache compatibility shim before those modules load, with dedicated import-order and single-stream contracts. The reported module-scope metal.is_available() sites are capability reads, not stream allocation or mutation; no new affected path is introduced by this version-only PR.