### PR TITLE
ci: stop engine evidence from allocating GUI runners

### DIFF
--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -18,6 +18,11 @@ product area selects all applicable lanes.
   or macOS runner. Universal guards retain workflow-expression, immutable
   Action-pin, and architecture-SSOT checks.
 
+Engine classification includes the serving packages and their tests, scripts,
+examples, evaluations, benchmark inputs/results, regression harness, and
+engine-only type-check configuration. These paths must not allocate Desktop or
+GUI runners merely because they live outside the primary Python package.
+
 Engine-only contracts are admitted by the same fail-closed classifier as the
 engine test lanes. They include CLI/config fidelity, release and installer
 offline tests, and the parser microbenchmark. Desktop-only and

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -31,12 +31,20 @@ class Lanes:
 
 _ENGINE_ROOTS = {
     "vllm_mlx",
+    "videox_fun_mlx",
     "tests",
     "scripts",
-    "benchmarks",
+    "bench",
+    "community-benchmarks",
+    "evals",
     "examples",
+    "harness",
+    "reports",
 }
 _ENGINE_FILES = {
+    "Makefile",
+    "config/mypy-error-baseline.txt",
+    "config/mypy-requirements.txt",
     "pyproject.toml",
     "uv.lock",
     "pytest.ini",

--- a/tests/test_classify_ci_changes.py
+++ b/tests/test_classify_ci_changes.py
@@ -1,6 +1,17 @@
+from pathlib import Path
+
 import pytest
 
+import scripts.classify_ci_changes as ci_changes
 from scripts.classify_ci_changes import Lanes, classify
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_known_engine_roots_exist_in_the_repository():
+    assert {
+        root for root in ci_changes._ENGINE_ROOTS if not (ROOT / root).is_dir()
+    } == set()
 
 
 def test_docs_only_selects_no_product_lane():
@@ -19,6 +30,48 @@ def test_engine_only_does_not_select_desktop():
     assert classify(["vllm_mlx/server.py"]) == Lanes(
         engine=True, desktop=False, docs_only=False
     )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "bench/bench_spec_decode_mtp.py",
+        "community-benchmarks/schema.json",
+        "config/mypy-error-baseline.txt",
+        "config/mypy-requirements.txt",
+        "evals/coherence_gate.py",
+        "examples/tool_calling.py",
+        "harness/perf_floors.json",
+        "Makefile",
+        "reports/benchmarks/model.json",
+        "scripts/l1_smoke.sh",
+        "tests/test_coherence.py",
+        "videox_fun_mlx/pipeline/scheduler.py",
+        "vllm_mlx/server.py",
+    ],
+)
+def test_known_engine_area_does_not_select_desktop(path):
+    assert classify([path]) == Lanes(engine=True, desktop=False, docs_only=False)
+
+
+def test_evaluation_report_change_does_not_select_desktop():
+    assert classify(
+        [
+            "docs/engineering/performance/starter-model-bakeoff.md",
+            "evals/starter_experience.py",
+        ]
+    ) == Lanes(engine=True, desktop=False, docs_only=False)
+
+
+def test_engine_benchmark_evidence_change_does_not_select_desktop():
+    assert classify(
+        [
+            "bench/bench_spec_decode_mtp.py",
+            "reports/benchmarks/mtp/result.json",
+            "tests/test_mtp_spec_decode.py",
+            "vllm_mlx/spec_decode/mtp/generator.py",
+        ]
+    ) == Lanes(engine=True, desktop=False, docs_only=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Known engine evaluation and benchmark directories were absent from the lane registry, so harmless engine-only evidence changes were treated as unknown cross-product changes and allocated six scarce Desktop GUI runners. Explicitly classifying the existing engine areas removes that queue pressure while retaining fail-closed behavior for genuinely unknown paths. This is a scoped part of #2252.

## Scope

- classify the existing engine package, evaluation, benchmark, harness, report, and engine-only type-check paths as engine-only
- replace the stale nonexistent `benchmarks/` route with the repository actual `bench/` root
- add route contracts for every newly explicit area and for the two observed evaluation/benchmark PR shapes
- document that engine evidence outside the primary package does not require Desktop runners

## Non-goals

- no GUI tests or journey coverage are removed
- no Desktop, workflow, mixed-product, or unknown path is narrowed
- no change to the `full-ci` promotion or merge policy
- no product behavior or public API change

## Acceptance and safety

Unknown/new product areas, workflow changes, Desktop paths, and mixed engine/Desktop diffs still select Desktop validation. Replaying the latest 100 merged PRs changes no route. Of 21 current open PRs, only #2140 and #2248 change, both from engine+Desktop to engine-only; neither file list was truncated. Rollback is a direct revert of the classifier entries.

## Verification

- `ruff check scripts/classify_ci_changes.py tests/test_classify_ci_changes.py`
- `ruff format --check scripts/classify_ci_changes.py tests/test_classify_ci_changes.py`
- focused routing/workflow suite: 63 passed
- full unit selection: 18,391 passed, 97 skipped, 229 deselected, 6 xfailed
- `git diff --check`
- real file-list replay for #2140, #2248, 21 open PRs, and 100 recently merged PRs