### PR TITLE
test(mac): stabilize image in-flight golden evidence

### DIFF
--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -340,11 +340,11 @@ class _ImageRenders:
         self.step = 0
         self.total = 0
         self.started_at = 0.0
-        self.warmup_ms = 0
+        self.warming_up = False
         self.cancelled = False
         self.count = 0
 
-    def begin(self, total, first_warmup_ms=0):
+    def begin(self, total, hold_first_warmup=False):
         with self._lock:
             # One render at a time, decided atomically under the lock. The real
             # server is a single model in a single process; a second concurrent
@@ -359,8 +359,8 @@ class _ImageRenders:
             self.total = total
             self.started_at = time.time()
             # Cold preparation is a first-render property. Later generations
-            # on the same resident model must not inherit that delay.
-            self.warmup_ms = first_warmup_ms if self.count == 0 else 0
+            # on the same resident model must not inherit that hold.
+            self.warming_up = hold_first_warmup and self.count == 0
             self.cancelled = False
             self.count += 1
             return self.count
@@ -370,9 +370,14 @@ class _ImageRenders:
             self.step += 1
             return self.cancelled
 
+    def finish_warmup(self):
+        with self._lock:
+            self.warming_up = False
+
     def end(self):
         with self._lock:
             self.running = False
+            self.warming_up = False
             self.step = self.total
 
     def cancel(self):
@@ -382,14 +387,13 @@ class _ImageRenders:
     def snapshot(self):
         with self._lock:
             elapsed = int((time.time() - self.started_at) * 1000) if self.started_at else 0
-            warming_up = self.running and elapsed < self.warmup_ms
             return {
                 # Internally the request already owns the render slot, but
                 # externally denoising has not begun during admission/warmup.
                 # This mirrors a real cold image request and gives GUI fixtures
                 # an event-backed preparing phase without weakening the
                 # single-render concurrency gate.
-                "running": self.running and not warming_up,
+                "running": self.running and not self.warming_up,
                 "step": self.step,
                 "total": self.total,
                 "elapsed_ms": elapsed,
@@ -696,8 +700,8 @@ class Handler(BaseHTTPRequestHandler):
         count = raw_count if isinstance(raw_count, int) and raw_count > 0 else 1
         total = max(1, int(_setting("FAKE_IMAGE_STEPS", 8)))
         step_ms = max(0, int(_setting("FAKE_IMAGE_STEP_MS", 300)))
-        first_warmup_ms = max(0, int(_setting("FAKE_IMAGE_FIRST_WARMUP_MS", 0)))
-        index = RENDERS.begin(total, first_warmup_ms)
+        first_warmup_ack = _setting("FAKE_IMAGE_FIRST_WARMUP_ACK")
+        index = RENDERS.begin(total, bool(first_warmup_ack))
         if index is None:
             # A render is already in flight. The real server runs one model in
             # one process and refuses an overlapping generation rather than
@@ -710,7 +714,6 @@ class Handler(BaseHTTPRequestHandler):
                 "code": "image_render_in_progress",
             }})
             return
-        request_warmup_ms = first_warmup_ms if index == 1 else 0
         _event(
             "image_request",
             prompt=prompt,
@@ -723,10 +726,19 @@ class Handler(BaseHTTPRequestHandler):
                                if editing else None),
         )
         # A real engine may spend meaningful time admitting the request and
-        # preparing tensors before its first denoise step. Keep this opt-in so
-        # the GUI journey can inspect that genuine protocol phase on machines
-        # where an accessibility-tree read itself takes several seconds.
-        time.sleep(request_warmup_ms / 1000)
+        # preparing tensors before its first denoise step. The GUI fixture
+        # explicitly acknowledges its captured preparing state instead of
+        # racing an arbitrary delay on a loaded accessibility runner.
+        if index == 1 and first_warmup_ack:
+            deadline = time.monotonic() + 300
+            while not os.path.exists(first_warmup_ack):
+                if time.monotonic() >= deadline:
+                    RENDERS.end()
+                    _event("image_warmup_timeout")
+                    self._json(500, {"error": {"code": "fixture_warmup_timeout"}})
+                    return
+                time.sleep(0.05)
+            RENDERS.finish_warmup()
         cancelled = False
         for _ in range(total):
             time.sleep(step_ms / 1000)

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -340,10 +340,11 @@ class _ImageRenders:
         self.step = 0
         self.total = 0
         self.started_at = 0.0
+        self.warmup_ms = 0
         self.cancelled = False
         self.count = 0
 
-    def begin(self, total):
+    def begin(self, total, first_warmup_ms=0):
         with self._lock:
             # One render at a time, decided atomically under the lock. The real
             # server is a single model in a single process; a second concurrent
@@ -357,6 +358,9 @@ class _ImageRenders:
             self.step = 0
             self.total = total
             self.started_at = time.time()
+            # Cold preparation is a first-render property. Later generations
+            # on the same resident model must not inherit that delay.
+            self.warmup_ms = first_warmup_ms if self.count == 0 else 0
             self.cancelled = False
             self.count += 1
             return self.count
@@ -378,8 +382,14 @@ class _ImageRenders:
     def snapshot(self):
         with self._lock:
             elapsed = int((time.time() - self.started_at) * 1000) if self.started_at else 0
+            warming_up = self.running and elapsed < self.warmup_ms
             return {
-                "running": self.running,
+                # Internally the request already owns the render slot, but
+                # externally denoising has not begun during admission/warmup.
+                # This mirrors a real cold image request and gives GUI fixtures
+                # an event-backed preparing phase without weakening the
+                # single-render concurrency gate.
+                "running": self.running and not warming_up,
                 "step": self.step,
                 "total": self.total,
                 "elapsed_ms": elapsed,
@@ -686,7 +696,8 @@ class Handler(BaseHTTPRequestHandler):
         count = raw_count if isinstance(raw_count, int) and raw_count > 0 else 1
         total = max(1, int(_setting("FAKE_IMAGE_STEPS", 8)))
         step_ms = max(0, int(_setting("FAKE_IMAGE_STEP_MS", 300)))
-        index = RENDERS.begin(total)
+        first_warmup_ms = max(0, int(_setting("FAKE_IMAGE_FIRST_WARMUP_MS", 0)))
+        index = RENDERS.begin(total, first_warmup_ms)
         if index is None:
             # A render is already in flight. The real server runs one model in
             # one process and refuses an overlapping generation rather than
@@ -699,6 +710,7 @@ class Handler(BaseHTTPRequestHandler):
                 "code": "image_render_in_progress",
             }})
             return
+        request_warmup_ms = first_warmup_ms if index == 1 else 0
         _event(
             "image_request",
             prompt=prompt,
@@ -710,6 +722,11 @@ class Handler(BaseHTTPRequestHandler):
             image_rgba_sha256=(_png_rgba_sha256(_extract_image_part(raw_body, self.headers.get("content-type")))
                                if editing else None),
         )
+        # A real engine may spend meaningful time admitting the request and
+        # preparing tensors before its first denoise step. Keep this opt-in so
+        # the GUI journey can inspect that genuine protocol phase on machines
+        # where an accessibility-tree read itself takes several seconds.
+        time.sleep(request_warmup_ms / 1000)
         cancelled = False
         for _ in range(total):
             time.sleep(step_ms / 1000)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3586,7 +3586,7 @@ flow_image_generation() {
     # AX baseline normalization itself takes several seconds on a busy mini;
     # keep the synthetic decode tail long enough to observe after it.
     start_persona image-generation FAKE_IMAGE_STEPS=8 FAKE_IMAGE_STEP_MS=300 \
-        FAKE_IMAGE_FIRST_WARMUP_MS=10000 \
+        FAKE_IMAGE_FIRST_WARMUP_ACK="$OUT_ROOT/image-generation/ig-warmup-ack" \
         FAKE_IMAGE_FINISH_MS=15000 \
         RAPID_GUI_GOLDEN_MODE=1 \
         RAPID_SIMULATED_IMPORT_PATH="$ROOT/Tests/RapidTests/__Snapshots__/cheetah-logo-96.png"
@@ -3715,6 +3715,7 @@ flow_image_generation() {
     done
     [[ "$inflight" == 1 ]] \
         || die "no settled in-flight progress card with Cancel and busy indicator"
+    : > "$OUT/ig-warmup-ack"
     baseline image-generation.inflight "$OUT/ig-inflight.json"
 
     # Sampling completion is followed by VAE decode / encoding. That tail must

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3586,6 +3586,7 @@ flow_image_generation() {
     # AX baseline normalization itself takes several seconds on a busy mini;
     # keep the synthetic decode tail long enough to observe after it.
     start_persona image-generation FAKE_IMAGE_STEPS=8 FAKE_IMAGE_STEP_MS=300 \
+        FAKE_IMAGE_FIRST_WARMUP_MS=10000 \
         FAKE_IMAGE_FINISH_MS=15000 \
         RAPID_GUI_GOLDEN_MODE=1 \
         RAPID_SIMULATED_IMPORT_PATH="$ROOT/Tests/RapidTests/__Snapshots__/cheetah-logo-96.png"
@@ -3689,6 +3690,13 @@ flow_image_generation() {
     type_prompt "$prompt1" ig-draft
     press "$OUT/ig-draft.json" Images.Generate "$OUT/ig-generate.json" \
         || die "Images.Generate is not pressable with a prompt and a ready model"
+
+    # Synchronize on the wire accepting the request before asking AX for the
+    # preparing card. The fake keeps this real protocol phase open long enough
+    # for one potentially expensive tree read; no retry count guesses whether
+    # the button action has reached the server yet.
+    wait_fake_event '.event == "image_request" and .operation == "generation"' \
+        "the image request never reached the sidecar"
 
     # The in-flight card. Asserted BEFORE the result so a render that returns
     # instantly (or a card that never appears) is a failure rather than a frame

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -206,14 +206,21 @@ def test_image_inflight_baseline_uses_an_event_backed_warmup_phase():
     )
     fake = FAKE_SIDECAR.read_text()
 
-    assert "FAKE_IMAGE_FIRST_WARMUP_MS=10000" in flow
+    assert (
+        'FAKE_IMAGE_FIRST_WARMUP_ACK="$OUT_ROOT/image-generation/ig-warmup-ack"' in flow
+    )
     wire_gate = 'wait_fake_event \'.event == "image_request"'
     assert wire_gate in flow
     assert flow.index(wire_gate) < flow.index('see_main "$OUT/ig-inflight.json"')
-    assert '_setting("FAKE_IMAGE_FIRST_WARMUP_MS", 0)' in fake
-    assert '"running": self.running and not warming_up' in fake
-    warmup_state = "self.warmup_ms = first_warmup_ms if self.count == 0 else 0"
-    assert fake.index(warmup_state) < fake.index("time.sleep(request_warmup_ms / 1000)")
+    assert '_setting("FAKE_IMAGE_FIRST_WARMUP_ACK")' in fake
+    assert '"running": self.running and not self.warming_up' in fake
+    assert "while not os.path.exists(first_warmup_ack)" in fake
+    assert '[[ "$inflight" == 1 ]]' in flow
+    acknowledgement = ': > "$OUT/ig-warmup-ack"'
+    assert flow.index('[[ "$inflight" == 1 ]]') < flow.index(acknowledgement)
+    assert flow.index(acknowledgement) < flow.index(
+        "baseline image-generation.inflight"
+    )
 
 
 def test_audio_baseline_waits_for_residency_poll_to_settle():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -201,21 +201,19 @@ def test_start_model_waits_for_an_interactive_readiness_action():
 
 
 def test_image_inflight_baseline_uses_an_event_backed_warmup_phase():
-    flow = HARNESS.read_text().split("flow_image_generation() {", 1)[1].split(
-        "\n}", 1
-    )[0]
+    flow = (
+        HARNESS.read_text().split("flow_image_generation() {", 1)[1].split("\n}", 1)[0]
+    )
     fake = FAKE_SIDECAR.read_text()
 
     assert "FAKE_IMAGE_FIRST_WARMUP_MS=10000" in flow
-    wire_gate = "wait_fake_event '.event == \"image_request\""
+    wire_gate = 'wait_fake_event \'.event == "image_request"'
     assert wire_gate in flow
     assert flow.index(wire_gate) < flow.index('see_main "$OUT/ig-inflight.json"')
     assert '_setting("FAKE_IMAGE_FIRST_WARMUP_MS", 0)' in fake
     assert '"running": self.running and not warming_up' in fake
     warmup_state = "self.warmup_ms = first_warmup_ms if self.count == 0 else 0"
-    assert fake.index(warmup_state) < fake.index(
-        "time.sleep(request_warmup_ms / 1000)"
-    )
+    assert fake.index(warmup_state) < fake.index("time.sleep(request_warmup_ms / 1000)")
 
 
 def test_audio_baseline_waits_for_residency_poll_to_settle():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -200,6 +200,24 @@ def test_start_model_waits_for_an_interactive_readiness_action():
     assert ".leftMouseDown" in click and ".leftMouseUp" in click
 
 
+def test_image_inflight_baseline_uses_an_event_backed_warmup_phase():
+    flow = HARNESS.read_text().split("flow_image_generation() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    fake = FAKE_SIDECAR.read_text()
+
+    assert "FAKE_IMAGE_FIRST_WARMUP_MS=10000" in flow
+    wire_gate = "wait_fake_event '.event == \"image_request\""
+    assert wire_gate in flow
+    assert flow.index(wire_gate) < flow.index('see_main "$OUT/ig-inflight.json"')
+    assert '_setting("FAKE_IMAGE_FIRST_WARMUP_MS", 0)' in fake
+    assert '"running": self.running and not warming_up' in fake
+    warmup_state = "self.warmup_ms = first_warmup_ms if self.count == 0 else 0"
+    assert fake.index(warmup_state) < fake.index(
+        "time.sleep(request_warmup_ms / 1000)"
+    )
+
+
 def test_audio_baseline_waits_for_residency_poll_to_settle():
     flow = (
         HARNESS.read_text().split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]


### PR DESCRIPTION
## Why

The Images release gate could deterministically miss the real first-render progress card because it polled for a brief preparing frame without first proving that the request had reached the sidecar. Expensive accessibility dumps could observe only later protocol phases and report a false product failure.

## What changed

- model an opt-in, first-render-only cold preparation phase in the image fixture while retaining exclusive render admission
- wait for the exact generation request event before capturing the preparing progress card
- keep later generations and edits at their existing timing
- add a contract test for the event-before-AX ordering and first-render scope

## Scope

GUI golden-flow harness and fake fixture only. No product UI, inference behavior, release metadata, baseline, routing, required-check, or assertion weakening changes.

## Validation

- `python3.12 -m pytest -q tests/test_gui_preflight_contract.py tests/test_fake_sidecar_image_catalog.py` — 19 passed
- `bash -n apps/rapid-mac/scripts/fake-rapid-mlx.sh apps/rapid-mac/scripts/gui-golden-flows.sh`
- `git diff --check`
- complete local `image-generation` golden journey passed once, including in-flight/finalizing/generate/edit/import and wire evidence
- a second run passed the target in-flight gate; its later timeout exposed and led to narrowing the fixture delay to first render only
- a third run was correctly stopped by the locked-screen preflight before app launch