### PR TITLE
ci(mac): raise raw bundle cap to 550 MB

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -96,7 +96,10 @@ jobs:
       SIGNED: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 != '' && secrets.MACOS_DEVID_CERT_PASSWORD != '' && secrets.AC_API_KEY_P8_BASE64 != '' && secrets.AC_API_KEY_ID != '' && secrets.AC_API_ISSUER_ID != '' }}
       # Absolute .app size ceiling — enforced by the "Bundle size gate"
       # step. The bundled sidecar (Contents/Resources/rapid-mlx) dominates.
-      BUNDLE_SIZE_CAP_MB: "500"
+      # v0.13.0-rc1 measured 501 MB after MLX 0.32.1 added ~10 MB of
+      # uncompressed native code. Keep bounded headroom while the independent
+      # compressed-DMG delta gate below continues to catch shipping growth.
+      BUNDLE_SIZE_CAP_MB: "550"
       # Per-release DMG growth ceiling — enforced by the "Bundle size delta
       # gate" step against the previous rapid-mac release.
       BUNDLE_SIZE_DELTA_CAP_MB: "50"
@@ -274,7 +277,7 @@ jobs:
           set -euo pipefail
           APP="build/Rapid-MLX Desktop.app"
           SIDECAR="$APP/Contents/Resources/rapid-mlx"
-          CAP_MB="${BUNDLE_SIZE_CAP_MB:-500}"
+          CAP_MB="${BUNDLE_SIZE_CAP_MB:-550}"
 
           if [[ ! -d "$APP" ]]; then
             echo "::error::Expected $APP to exist after build step but it does not."

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -100,7 +100,7 @@ struct SidecarBuildScriptTests {
                 "The no-deps sidecar install must never float within a range.")
         // The Images tab is only shippable because mflux's module-level
         // `import torch` is deferred into the three torch-only loading modes —
-        // bundling torch itself would be +363 MB against a 500 MB cap. Both
+        // bundling torch itself would be +363 MB against a 550 MB cap. Both
         // halves of that argument have to fail closed, or a future mflux bump
         // ships an Images tab that dies on every generation: the patch must
         // refuse to guess when weight_loader.py has been reshaped, and the

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -22,6 +22,14 @@ def test_rc_tag_is_accepted_for_immutable_desktop_artifacts():
     assert "(-rc[1-9][0-9]*)?" in workflow
 
 
+def test_desktop_raw_bundle_headroom_does_not_weaken_dmg_growth_gate():
+    workflow = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    assert 'BUNDLE_SIZE_CAP_MB: "550"' in workflow
+    assert 'CAP_MB="${BUNDLE_SIZE_CAP_MB:-550}"' in workflow
+    assert 'BUNDLE_SIZE_DELTA_CAP_MB: "50"' in workflow
+    assert 'DELTA_CAP_MB="${BUNDLE_SIZE_DELTA_CAP_MB:-50}"' in workflow
+
+
 def test_bump_detection_checks_out_version_parser_before_invoking_it():
     workflow = PREFLIGHT_WORKFLOW.read_text(encoding="utf-8")
     detect = workflow[workflow.index("  detect-bump-pr:") : workflow.index("\n  pf1-")]


### PR DESCRIPTION
## Why

The signed 0.13.0-rc1 Desktop build measured 501 MB and was correctly blocked by the legacy 500 MB raw `.app` ceiling before notarization. The increase is bounded and understood: the bundled sidecar grew from 453 MB to 464 MB, with MLX accounting for 10 MB of the 11 MB change, while the compressed sidecar remained 144 MB.

## What changed

- raise the uncompressed `.app` ceiling from 500 MB to 550 MB
- keep the independent compressed DMG growth ceiling unchanged at 50 MB
- add a workflow contract pinning both limits
- update the sidecar test comment to match the enforced ceiling

## Non-goals

No product, dependency, version, signing, notarization, publishing, updater, or tag behavior changes.

## Validation

- `actionlint -ignore SC2046 .github/workflows/rapid-mac-release.yml`
- 19 focused Python release workflow/secret contracts passed
- 7 focused Swift sidecar build contracts passed
- `git diff --check`

## Rollback

Restore the raw bundle ceiling and fallback to 500 MB if the bundled dependency footprint is reduced below it. The separate +50 MB DMG delta gate remains fail-closed throughout.