### PR TITLE
fix(mac): trim 37 MB of dead weight from the sidecar

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -150,8 +150,20 @@ struct SidecarBuildScriptTests {
                 "Only model-family directories outside Qwen3 TTS may be removed.")
         #expect(!script.contains(#"rm -rf "$STAGE/site-packages/mlx_audio/tts/models""#),
                 "The trim must never remove the complete TTS model directory.")
-        #expect(script.contains(#"MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}""#),
+        #expect(script.contains(#"MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-172}""#),
                 "The signing baseline must match the measured post-audio bundle.")
+        #expect(script.contains(#"LIBPYTHON="$STAGE/python/lib/libpython3.12.dylib""#),
+                "The unused shared libpython must be trimmed; it is ~17 MB of the size cap.")
+        #expect(script.contains("refusing to drop it"),
+                "Dropping libpython must stay guarded: a wheel that links it would otherwise produce a bundle that builds clean and fails to import on a user's Mac.")
+        #expect(script.contains(#"-name "modular_*.py" -delete"#),
+                "transformers' modular_ generator sources are 41% of models/ and no runtime path imports them.")
+        #expect(!script.contains(#"-name "configuration_*.py" -delete"#),
+                "configuration_*.py is what AutoConfig reads; trimming it breaks every model whose directory it covers.")
+        #expect(script.contains(#"-path '*.dist-info/RECORD' -delete"#),
+                "RECORD is pip's uninstall manifest; nothing uninstalls from inside the bundle.")
+        #expect(script.contains(#"-name '*.pyi' -delete"#),
+                "Type stubs are read by type checkers, never by the interpreter.")
     }
 
     private static var scriptURL: URL {

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -93,7 +93,21 @@ COMPILEALL_JOBS="${COMPILEALL_JOBS:-0}"
 # STT and Qwen3-TTS smoke imports passing. The non-Qwen TTS implementations
 # and SciPy subpackages outside the signal closure have already been removed
 # before this count is taken.
-MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}"
+#
+# Re-locked at 172 on 2026-08-24: step 3 now drops the unused shared
+# libpython3.12.dylib (the bundled interpreter is the statically-linked
+# `bin/python3.12`; nothing links the dylib). Same shape as the 2026-07-21
+# Tcl/Tk re-lock — we are REMOVING a Mach-O we used to sign, not adding one,
+# so there is no signing-safety implication.
+#
+# Note this is a re-lock of TWO, not one. The baseline had already drifted
+# before this change: the last green build on main reported "found 173
+# Mach-Os (baseline 174)", and a shipped 0.12.18 bundle counts 173 the same
+# way. A wheel dropped a binary at some point and the tolerance absorbed it
+# silently, which is the tolerance working as designed but also means the
+# stated baseline had stopped describing reality. 173 measured minus this
+# change's one removal is 172.
+MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-172}"
 # Allow modest drift without blocking — wheel updates sometimes shift
 # 1-2 .so files. Bigger drift means a new dependency, needs review.
 # Kept at 5 across the 51 → 77 baseline rebase to give Pillow and
@@ -500,6 +514,62 @@ rm -rf \
     "$STAGE/python/lib/"thread* \
     "$STAGE/python/lib/"itcl* \
     "$STAGE/python/lib/python3.12/lib-dynload/"_tkinter*.so
+# Drop the unused shared libpython. python-build-standalone ships BOTH a
+# statically-linked `bin/python3.12` and `lib/libpython3.12.dylib` — ~17 MB
+# each, distinct inodes, the same interpreter twice. sidecar-shim.sh only
+# ever execs the former, and nothing in the bundle links the dylib: on a
+# shipped 0.12.18 desktop the sidecar never mapped it across a session that
+# included a full dictation round-trip.
+#
+# The guard below is not ceremony. macOS extension modules conventionally
+# resolve CPython symbols against the executable (`-undefined
+# dynamic_lookup`) rather than linking libpython, but that is a convention,
+# not a rule — a future wheel that links it would turn this `rm` into a
+# bundle that builds clean and then fails to import on a user's Mac. Fail
+# the build instead of shipping that.
+LIBPYTHON="$STAGE/python/lib/libpython3.12.dylib"
+if [ -f "$LIBPYTHON" ]; then
+    # `|| true` is mandatory, not sloppy: xargs exits non-zero whenever ANY
+    # child does, and `grep -q` fails for every non-consumer, so the happy
+    # path always returns non-zero. That swallowing is why the sentinel
+    # below exists — without it a broken `find`/`otool` would also produce an
+    # empty result and read as "nothing links it", and we would delete on the
+    # strength of a scan that never ran.
+    LIBPYTHON_SCANNED="$(find "$STAGE" \( -name '*.so' -o -name '*.dylib' \) | wc -l | tr -d ' ')"
+    if [ "$LIBPYTHON_SCANNED" -lt 2 ]; then
+        echo "::error::libpython consumer scan found $LIBPYTHON_SCANNED Mach-Os under $STAGE; the scan is broken, refusing to trim on its say-so"
+        exit 1
+    fi
+    LIBPYTHON_CONSUMERS="$(
+        find "$STAGE" \( -name '*.so' -o -name '*.dylib' \) ! -path "$LIBPYTHON" -print0 \
+            | xargs -0 -n1 -P4 sh -c \
+                'otool -L "$0" 2>/dev/null | grep -q libpython3\.12 && echo "$0"' \
+            2>/dev/null || true
+    )"
+    if [ -n "$LIBPYTHON_CONSUMERS" ]; then
+        echo "::error::libpython3.12.dylib is linked by bundled extensions; refusing to drop it:"
+        echo "$LIBPYTHON_CONSUMERS"
+        exit 1
+    fi
+    echo "==> dropping unused libpython3.12.dylib ($(du -m "$LIBPYTHON" | cut -f1) MB)"
+    rm -f "$LIBPYTHON"
+fi
+# Packaging detritus that no runtime path reads. Small individually, ~5 MB
+# together, and none of it is a judgement call:
+#   * .pyi — type stubs, consumed by type checkers, never by the interpreter.
+#   * .dist-info/RECORD — the installed-file manifest pip uses to UNINSTALL.
+#     Nothing uninstalls from inside the bundle. METADATA stays, so
+#     importlib.metadata.version() (which the release smoke below calls)
+#     keeps working; RECORD is not part of that path.
+#   * headers and static libs — build inputs for compiling against these
+#     wheels, and nothing in the bundle compiles.
+#   * leftover tests/ packages in wheels other than numpy/scipy/mlx_audio,
+#     which already get swept by name further down.
+echo "==> trimming packaging detritus (stubs, RECORD, headers, stray tests)"
+find "$STAGE" -name '*.pyi' -delete
+find "$STAGE/site-packages" -path '*.dist-info/RECORD' -delete
+find "$STAGE" \( -name '*.h' -o -name '*.hpp' -o -name '*.a' \) -delete
+find "$STAGE/site-packages" -type d -name tests -prune -exec rm -rf {} + 2>/dev/null || true
 find "$STAGE" -type d -name __pycache__ -prune -exec rm -rf {} +
 
 # ----- step 3.5: aggressive trim (post-strip, pre-compileall) ----------
@@ -598,6 +668,28 @@ find "$STAGE/site-packages/transformers/models" \
     \( -name "image_processing_*.py" -o -name "feature_extraction_*.py" \) \
     -not -path "*/transformers/models/whisper/feature_extraction_whisper.py" \
     -print -delete
+
+# `modular_*.py` is the largest single thing left in models/ — 13 MB across
+# 518 files, 41% of the subtree. These are the SOURCE files transformers'
+# own `utils/modular_model_converter.py` reads to GENERATE `modeling_*.py`;
+# nothing imports them at runtime, and no file outside models/ references
+# them. We already delete the generated `modeling_*.py` above, so keeping
+# the generator input is strictly less defensible than what we drop.
+#
+# Deliberately NOT allowlisted the way modeling_/image_processing_ are: a
+# modular file is a build-time artifact for every model equally, including
+# the multimodal ones we preserve implementations for.
+#
+# Not to be confused with a whole-directory trim. Deleting unused
+# `models/<arch>/` directories looks tempting (another ~25 MB) but breaks
+# `AutoConfig`/`AutoTokenizer` for any architecture whose directory goes:
+# mlx-lm serves several transformers model_types from one module — Mistral
+# rides the llama implementation — so "what mlx-lm bundles" is not the set
+# of configs we must still parse. Dropping modular_ needs no such judgement.
+echo "==> trimming transformers modular_ generator sources"
+find "$STAGE/site-packages/transformers/models" -name "modular_*.py" -delete
+find "$STAGE/site-packages/transformers/models" \
+    -path "*__pycache__/modular_*.pyc" -delete
 
 echo "==> trimming numpy dev/test detritus"
 rm -rf \


### PR DESCRIPTION
## Status

**No longer urgent.** The 500 MB cap that blocked `rapid-mac-v0.13.0-rc1` was raised
to 550 in b42b0293, so this is cleanup, not a fix. It removes things nothing reads,
each item measured and verified rather than assumed.

**Sidecar 452.1 MB → 415.2 MB.**

| item | saved | why it is dead |
|---|---:|---|
| `libpython3.12.dylib` | 17.3 MB | the interpreter, shipped twice |
| transformers `modular_*` | 14.3 MB | generator inputs for files we already delete |
| `.pyi` type stubs | 2.7 MB | read by type checkers, never the interpreter |
| `.dist-info/RECORD` | 1.1 MB | pip's uninstall manifest |
| stray `tests/` packages | 0.9 MB | wheel test suites |
| headers + static libs | 0.6 MB | build inputs; nothing here compiles |

## libpython

python-build-standalone ships the interpreter twice — a statically linked
`bin/python3.12` and `lib/libpython3.12.dylib`, ~17 MB each. Evidence, not inference:

- `otool -L` across every Mach-O in a shipped 0.12.18 bundle — the only file naming
  `libpython3.12` is the dylib itself.
- `bin/python3.12` does not link it (CoreFoundation, libSystem, ncurses, panel,
  SystemConfiguration, libedit, libz).
- On a running 0.12.18 desktop, `lsof` sampled every 3 s across a session including a
  full dictation round-trip: never mapped into the sidecar process.

Guarded twice rather than deleted blind. macOS extensions conventionally resolve
CPython symbols against the executable instead of linking libpython, but that is a
convention, not a rule — a future wheel that links it would turn this into a bundle
that builds clean and then fails to import on a user's Mac, so a consumer aborts the
build and names the file. The scan's `|| true` is mandatory (`xargs` exits non-zero
whenever any child does, and `grep -q` fails for every non-consumer), so a sentinel
asserts the scan actually enumerated Mach-Os — otherwise a broken `find`/`otool`
would read as "nothing links it".

Four paths exercised against real staged trees:

| case | expected | result |
|---|---|---|
| no consumer | drop, exit 0 | drops 18 MB, exit 0 |
| a bundled `.so` links libpython | refuse, exit 1 | refuses and names it, exit 1 |
| scan finds < 2 Mach-Os | refuse, exit 1 | refuses, exit 1 |
| re-run on a trimmed stage | no-op, exit 0 | no-op, exit 0 |

## transformers `modular_*`

41% of `models/` — 13 MB across 518 files. These are the sources transformers' own
`utils/modular_model_converter.py` reads to **generate** `modeling_*.py`. Nothing
imports them at runtime, and nothing outside `models/` references them. We already
delete the generated `modeling_*.py`, so keeping the generator input was strictly
less defensible than what we drop. Needs no allowlist — a modular file is a
build-time artifact for every model equally.

## Deliberately not included

- **Deleting unused `models/<arch>/` directories (~25 MB).** Tempting and it does
  work mechanically, but it breaks `AutoConfig`/`AutoTokenizer` for any architecture
  whose directory goes, and "what mlx-lm bundles" does not enumerate the configs we
  must still parse: mlx-lm serves Mistral through its llama implementation, so a
  registry-derived allowlist silently drops `models/mistral/`. I caught this only
  because an import-closure loop added it back. Its own change, if wanted.
- **Hoisting the stdlib to sourceless `.pyc` (~11 MB).** Works, but costs stdlib
  traceback source lines and `inspect.getsource` (verified: `argparse` →
  `OSError: could not get source code`). `build-sidecar.sh` deliberately chose to
  keep stdlib source; this PR does not overturn that.
- **scipy (52 MB).** Not prunable — `scipy.signal` transitively pulls spatial →
  interpolate → optimize → stats → integrate, and `mlx_audio` needs `resample_poly`.
- **`mlx.metallib` (120 MB, a quarter of the app).** No strippable fat: 85% is
  bitcode across 15,150 modules, zero DWARF, no build paths. Would need MLX built
  from source with JIT.

## Mach-O baseline

`MACHO_BASELINE_COUNT` moves 174 → **172**, a re-lock of two rather than one. The
baseline had already drifted before this change: the last green build on main reports
`found 173 Mach-Os (baseline 174)`, and a shipped 0.12.18 bundle counts 173 the same
way. A wheel dropped a binary at some point and the tolerance absorbed it silently —
the tolerance working as designed, but it also means the stated baseline had stopped
describing reality. 173 measured minus this change's one removal is 172, and the
trimmed stage counts exactly 172.

## Verification

The trim blocks were extracted from the script itself and run against a clone of a
shipped sidecar, so this measures the script rather than hand-typed commands:
452.1 → 415.2 MB, Mach-O count exactly 172. The result passes:

- the full import surface (mlx, numpy, transformers, soundfile, PIL, tokenizers,
  sentencepiece, mlx_audio, mlx_vlm, mlx_lm, vllm_mlx, llguidance, ssl, sqlite3, ctypes)
- **this script's own release smoke assertion, verbatim** — STT and Qwen3-TTS loaders,
  `WhisperFeatureExtractor`, `scipy.signal`, `soundfile`, and a real `TTSEngine.to_bytes`
  WAV encode asserting a `RIFF` header
- `AutoConfig` for 11 architectures including `mistral` and `gemma3`
- an MLX GPU matmul, and `rapid-mlx --version` end to end
- stdlib tracebacks still carrying source lines, since the stdlib is untouched

## Separately

Unrelated shipped bug found while measuring scipy, filed apart rather than smuggled
in: `build-sidecar.sh` deliberately removes `scipy/io`, but
`vllm_mlx/routes/audio.py:3108` has an unguarded `import scipy.io.wavfile` on a main
path. Any audio request specifying `sample_rate` or `channels` raises
`ModuleNotFoundError` in shipped 0.12.18. The stdlib `wave` module is already in use
six lines above.