### PR TITLE
fix(mac): stabilize image generation ETA

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Observation
 
-/// Estimates denoising time from completed step transitions, not a wall clock.
+/// Estimates denoising time from reported step-start transitions, not a wall clock.
 ///
 /// The HUD redraws many times while one diffusion step is running. Recomputing
 /// from that live clock makes "time left" grow on every redraw until the next
@@ -14,8 +14,8 @@ struct ImageDenoiseETA {
     private var secondsPerStep: TimeInterval?
 
     mutating func observe(step: Int, total: Int, elapsed: TimeInterval) {
-        guard step > 0, total > step else {
-            if step >= total, total > 0 { secondsRemaining = nil }
+        guard step > 0, total >= step else {
+            if step > total, total > 0 { secondsRemaining = nil }
             return
         }
         guard elapsed.isFinite, elapsed >= 0 else { return }
@@ -28,7 +28,7 @@ struct ImageDenoiseETA {
                 lastElapsed = elapsed
             }
             if let secondsPerStep {
-                secondsRemaining = secondsPerStep * Double(total - step)
+                secondsRemaining = secondsPerStep * Double(total - step + 1)
             }
             return
         }
@@ -39,7 +39,9 @@ struct ImageDenoiseETA {
             // A small exponential smoothing window reacts to sustained speed
             // changes without making every slightly noisy step jerk the HUD.
             secondsPerStep = secondsPerStep.map { $0 * 0.75 + interval * 0.25 } ?? interval
-            secondsRemaining = secondsPerStep.map { $0 * Double(total - step) }
+            // The engine reports `step = t + 1` when that step starts. The
+            // current step therefore still belongs in the remaining-work count.
+            secondsRemaining = secondsPerStep.map { $0 * Double(total - step + 1) }
         }
         lastStep = step
         lastElapsed = elapsed
@@ -103,10 +105,10 @@ final class ImageGenViewModel {
     enum Phase: Equatable { case preparing, denoising, finalizing }
 
     static func nextPhase(from current: Phase, progress: ImageClient.ImageProgress) -> Phase {
+        if progress.running { return .denoising }
         if progress.total > 0, progress.step >= progress.total {
             return .finalizing
         }
-        if progress.running { return .denoising }
         return .preparing
     }
 
@@ -183,7 +185,7 @@ final class ImageGenViewModel {
     /// When the current run started — drives a live elapsed clock in the HUD
     /// that keeps moving even during the cold model-load phase.
     private(set) var genStartedAt: Date?
-    /// Frozen between completed denoise steps so the countdown cannot grow
+    /// Frozen between reported denoise-step starts so the countdown cannot grow
     /// merely because the HUD redraw clock advanced.
     private(set) var denoiseETASeconds: TimeInterval?
     private var denoiseETA = ImageDenoiseETA()

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -1,6 +1,55 @@
 import Foundation
 import Observation
 
+/// Estimates denoising time from completed step transitions, not a wall clock.
+///
+/// The HUD redraws many times while one diffusion step is running. Recomputing
+/// from that live clock makes "time left" grow on every redraw until the next
+/// step arrives. This sampler changes only when the engine reports new work,
+/// and deliberately waits for two observations before claiming an ETA.
+struct ImageDenoiseETA {
+    private(set) var secondsRemaining: TimeInterval?
+    private var lastStep: Int?
+    private var lastElapsed: TimeInterval?
+    private var secondsPerStep: TimeInterval?
+
+    mutating func observe(step: Int, total: Int, elapsed: TimeInterval) {
+        guard step > 0, total > step else {
+            if step >= total, total > 0 { secondsRemaining = nil }
+            return
+        }
+        guard elapsed.isFinite, elapsed >= 0 else { return }
+
+        guard let previousStep = lastStep,
+              let previousElapsed = lastElapsed,
+              step > previousStep else {
+            if lastStep == nil || step > (lastStep ?? 0) {
+                lastStep = step
+                lastElapsed = elapsed
+            }
+            if let secondsPerStep {
+                secondsRemaining = secondsPerStep * Double(total - step)
+            }
+            return
+        }
+
+        let completedSteps = step - previousStep
+        let interval = (elapsed - previousElapsed) / Double(completedSteps)
+        if interval.isFinite, interval > 0 {
+            // A small exponential smoothing window reacts to sustained speed
+            // changes without making every slightly noisy step jerk the HUD.
+            secondsPerStep = secondsPerStep.map { $0 * 0.75 + interval * 0.25 } ?? interval
+            secondsRemaining = secondsPerStep.map { $0 * Double(total - step) }
+        }
+        lastStep = step
+        lastElapsed = elapsed
+    }
+
+    mutating func reset() {
+        self = Self()
+    }
+}
+
 /// State + orchestration for the Images tab. Mirrors ``ChatViewModel``:
 /// an ``@Observable`` store the view binds to, owning the image client and
 /// the results, and reading ``ServerManager.activePort`` / ``activeBearer``
@@ -134,10 +183,10 @@ final class ImageGenViewModel {
     /// When the current run started — drives a live elapsed clock in the HUD
     /// that keeps moving even during the cold model-load phase.
     private(set) var genStartedAt: Date?
-    /// When denoising actually began (first `running` step). ETA is computed
-    /// from THIS, not ``genStartedAt`` — otherwise minutes of cold model load
-    /// inflate the per-step estimate.
-    private(set) var denoiseStartedAt: Date?
+    /// Frozen between completed denoise steps so the countdown cannot grow
+    /// merely because the HUD redraw clock advanced.
+    private(set) var denoiseETASeconds: TimeInterval?
+    private var denoiseETA = ImageDenoiseETA()
 
     /// Steps the bar should assume before the server reports a live total.
     /// Derived from the selected model family (turbo Z-Image wants ~8, the
@@ -345,8 +394,13 @@ final class ImageGenViewModel {
                     guard let self else { return }
                     self.progress = snap
                     self.phase = Self.nextPhase(from: self.phase, progress: snap)
-                    if snap.running, self.denoiseStartedAt == nil {
-                        self.denoiseStartedAt = Date()
+                    if snap.running {
+                        self.denoiseETA.observe(
+                            step: snap.step,
+                            total: snap.total,
+                            elapsed: Double(snap.elapsedMs) / 1_000
+                        )
+                        self.denoiseETASeconds = self.denoiseETA.secondsRemaining
                     }
                 }
                 try? await Task.sleep(for: .milliseconds(300))
@@ -391,7 +445,8 @@ final class ImageGenViewModel {
         phase = .preparing
         progress = nil
         genStartedAt = Date()
-        denoiseStartedAt = nil
+        denoiseETA.reset()
+        denoiseETASeconds = nil
         errorMessage = nil
         defer {
             isGenerating = false
@@ -399,7 +454,8 @@ final class ImageGenViewModel {
             inFlightAlias = nil
             progress = nil
             genStartedAt = nil
-            denoiseStartedAt = nil
+            denoiseETA.reset()
+            denoiseETASeconds = nil
         }
         do {
             try await body()

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -406,15 +406,10 @@ struct ImagesView: View {
                             .foregroundStyle(RapidTheme.bandInkSecondary)
                             .monospacedDigit()
                         Spacer()
-                        // ETA from the denoise-phase clock, not total elapsed —
-                        // otherwise cold-load time inflates the per-step estimate.
-                        let denoiseElapsed = viewModel.denoiseStartedAt
-                            .map { context.date.timeIntervalSince($0) } ?? elapsed
                         Text(finalizing
                              ? "Decoding and saving…"
                              : (denoising
-                                ? (etaText(step: step, total: total, elapsed: denoiseElapsed)
-                                   ?? "Finalizing next…")
+                                ? etaText(secondsRemaining: viewModel.denoiseETASeconds)
                                 : "First run — only happens once"))
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(RapidTheme.bandInkSecondary)
@@ -445,10 +440,11 @@ struct ImagesView: View {
         }
     }
 
-    private func etaText(step: Int, total: Int, elapsed: TimeInterval) -> String? {
-        guard step > 0, total > step, elapsed > 0 else { return nil }
-        let perStep = elapsed / Double(step)
-        return "~\(Int((perStep * Double(total - step)).rounded()))s left"
+    private func etaText(secondsRemaining: TimeInterval?) -> String {
+        guard let secondsRemaining, secondsRemaining.isFinite, secondsRemaining > 0 else {
+            return "Estimating…"
+        }
+        return "~\(max(1, Int(secondsRemaining.rounded())))s left"
     }
 
     // MARK: - Filmstrip

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -378,6 +378,7 @@ struct ImagesView: View {
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                                 .foregroundStyle(RapidTheme.bandInkSecondary)
                                 .monospacedDigit()
+                                .accessibilityIdentifier("Images.Progress.Step")
                         }
                         Button { viewModel.cancel() } label: {
                             Image(systemName: "xmark")
@@ -413,6 +414,7 @@ struct ImagesView: View {
                                 : "First run — only happens once"))
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(RapidTheme.bandInkSecondary)
+                            .accessibilityIdentifier("Images.Progress.ETA")
                     }
                 }
                 .padding(18)

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -20,7 +20,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXButton id="Images.Cancel" desc="Close" help="Cancel" enabled=true
           AXStaticText value=text enabled=true
-          AXStaticText value=text enabled=true
+          AXStaticText id="Images.Progress.ETA" value=text enabled=true
           AXScrollArea id="Images.Prompt"
             AXTextArea id="rapid.images.compose" desc="Image prompt field" value=text
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXButton id="Images.Cancel" desc="Close" help="Cancel" enabled=true
           AXStaticText value=text enabled=true
-          AXStaticText value=text enabled=true
+          AXStaticText id="Images.Progress.ETA" value=text enabled=true
           AXScrollArea id="Images.Prompt"
             AXTextArea id="rapid.images.compose" desc="Image prompt field" value=text
           AXButton id="Images.Aspect.square" desc="1:1" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -7,6 +7,9 @@ struct ImageGenerationPhaseTests {
     @Test("ETA waits for a completed step transition and stays frozen between steps")
     func etaSamplesCompletedStepsOnly() {
         var eta = ImageDenoiseETA()
+        eta.observe(step: 0, total: 4, elapsed: 12)
+        #expect(eta.secondsRemaining == nil)
+
         eta.observe(step: 1, total: 4, elapsed: 20)
         #expect(eta.secondsRemaining == nil)
 
@@ -18,6 +21,24 @@ struct ImageGenerationPhaseTests {
 
         eta.observe(step: 2, total: 4, elapsed: 39)
         #expect(eta.secondsRemaining == 20)
+    }
+
+    @Test("ETA reacts to a genuinely slower later step but not polling time")
+    func etaAdaptsOnlyAfterSlowStepCompletes() {
+        var eta = ImageDenoiseETA()
+        eta.observe(step: 1, total: 6, elapsed: 1)
+        eta.observe(step: 2, total: 6, elapsed: 2)
+        #expect(eta.secondsRemaining == 4)
+
+        // Five seconds of polling at the same completed-work boundary must
+        // not manufacture five seconds of additional remaining time.
+        eta.observe(step: 2, total: 6, elapsed: 7)
+        #expect(eta.secondsRemaining == 4)
+
+        // The next completed step really took ten seconds. The EMA moves from
+        // 1.0 to 3.25 seconds/step, so the three remaining steps become 9.75s.
+        eta.observe(step: 3, total: 6, elapsed: 12)
+        #expect(eta.secondsRemaining == 9.75)
     }
 
     @Test("ETA handles skipped progress samples and changing totals")

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -4,6 +4,48 @@ import Testing
 @Suite("Image generation phase semantics")
 @MainActor
 struct ImageGenerationPhaseTests {
+    @Test("ETA waits for a completed step transition and stays frozen between steps")
+    func etaSamplesCompletedStepsOnly() {
+        var eta = ImageDenoiseETA()
+        eta.observe(step: 1, total: 4, elapsed: 20)
+        #expect(eta.secondsRemaining == nil)
+
+        eta.observe(step: 1, total: 4, elapsed: 28)
+        #expect(eta.secondsRemaining == nil)
+
+        eta.observe(step: 2, total: 4, elapsed: 30)
+        #expect(eta.secondsRemaining == 20)
+
+        eta.observe(step: 2, total: 4, elapsed: 39)
+        #expect(eta.secondsRemaining == 20)
+    }
+
+    @Test("ETA handles skipped progress samples and changing totals")
+    func etaHandlesStepJumpsAndNewTotals() {
+        var eta = ImageDenoiseETA()
+        eta.observe(step: 1, total: 8, elapsed: 40)
+        eta.observe(step: 3, total: 8, elapsed: 52)
+        #expect(eta.secondsRemaining == 30)
+
+        eta.observe(step: 3, total: 10, elapsed: 60)
+        #expect(eta.secondsRemaining == 42)
+    }
+
+    @Test("ETA clears at completion and reset discards the previous run")
+    func etaCompletesAndResets() {
+        var eta = ImageDenoiseETA()
+        eta.observe(step: 1, total: 4, elapsed: 10)
+        eta.observe(step: 2, total: 4, elapsed: 15)
+        #expect(eta.secondsRemaining == 10)
+
+        eta.observe(step: 4, total: 4, elapsed: 25)
+        #expect(eta.secondsRemaining == nil)
+
+        eta.reset()
+        eta.observe(step: 1, total: 4, elapsed: 55)
+        #expect(eta.secondsRemaining == nil)
+    }
+
     @Test("The final denoise step becomes finalizing until the response lands")
     func completedDenoiseFinalizes() {
         let final = ImageClient.ImageProgress(

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -4,8 +4,8 @@ import Testing
 @Suite("Image generation phase semantics")
 @MainActor
 struct ImageGenerationPhaseTests {
-    @Test("ETA waits for a completed step transition and stays frozen between steps")
-    func etaSamplesCompletedStepsOnly() {
+    @Test("ETA waits for a step-start transition and stays frozen within a step")
+    func etaSamplesStepStartsOnly() {
         var eta = ImageDenoiseETA()
         eta.observe(step: 0, total: 4, elapsed: 12)
         #expect(eta.secondsRemaining == nil)
@@ -17,10 +17,10 @@ struct ImageGenerationPhaseTests {
         #expect(eta.secondsRemaining == nil)
 
         eta.observe(step: 2, total: 4, elapsed: 30)
-        #expect(eta.secondsRemaining == 20)
+        #expect(eta.secondsRemaining == 30)
 
         eta.observe(step: 2, total: 4, elapsed: 39)
-        #expect(eta.secondsRemaining == 20)
+        #expect(eta.secondsRemaining == 30)
     }
 
     @Test("ETA reacts to a genuinely slower later step but not polling time")
@@ -28,17 +28,17 @@ struct ImageGenerationPhaseTests {
         var eta = ImageDenoiseETA()
         eta.observe(step: 1, total: 6, elapsed: 1)
         eta.observe(step: 2, total: 6, elapsed: 2)
-        #expect(eta.secondsRemaining == 4)
+        #expect(eta.secondsRemaining == 5)
 
-        // Five seconds of polling at the same completed-work boundary must
+        // Five seconds of polling within the same reported step must
         // not manufacture five seconds of additional remaining time.
         eta.observe(step: 2, total: 6, elapsed: 7)
-        #expect(eta.secondsRemaining == 4)
+        #expect(eta.secondsRemaining == 5)
 
-        // The next completed step really took ten seconds. The EMA moves from
-        // 1.0 to 3.25 seconds/step, so the three remaining steps become 9.75s.
+        // The next step-start transition really took ten seconds. The EMA moves
+        // from 1.0 to 3.25 seconds/step; current step 3 plus steps 4...6 remain.
         eta.observe(step: 3, total: 6, elapsed: 12)
-        #expect(eta.secondsRemaining == 9.75)
+        #expect(eta.secondsRemaining == 13)
     }
 
     @Test("ETA handles skipped progress samples and changing totals")
@@ -46,21 +46,21 @@ struct ImageGenerationPhaseTests {
         var eta = ImageDenoiseETA()
         eta.observe(step: 1, total: 8, elapsed: 40)
         eta.observe(step: 3, total: 8, elapsed: 52)
-        #expect(eta.secondsRemaining == 30)
+        #expect(eta.secondsRemaining == 36)
 
         eta.observe(step: 3, total: 10, elapsed: 60)
-        #expect(eta.secondsRemaining == 42)
+        #expect(eta.secondsRemaining == 48)
     }
 
-    @Test("ETA clears at completion and reset discards the previous run")
-    func etaCompletesAndResets() {
+    @Test("ETA includes the running final step and reset discards the previous run")
+    func etaIncludesFinalStepAndResets() {
         var eta = ImageDenoiseETA()
         eta.observe(step: 1, total: 4, elapsed: 10)
         eta.observe(step: 2, total: 4, elapsed: 15)
-        #expect(eta.secondsRemaining == 10)
+        #expect(eta.secondsRemaining == 15)
 
         eta.observe(step: 4, total: 4, elapsed: 25)
-        #expect(eta.secondsRemaining == nil)
+        #expect(eta.secondsRemaining == 5)
 
         eta.reset()
         eta.observe(step: 1, total: 4, elapsed: 55)
@@ -80,7 +80,7 @@ struct ImageGenerationPhaseTests {
         )
         #expect(
             ImageGenViewModel.nextPhase(from: .denoising, progress: finalStillRunning)
-                == .finalizing
+                == .denoising
         )
     }
 

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -700,7 +700,13 @@ class Handler(BaseHTTPRequestHandler):
         count = raw_count if isinstance(raw_count, int) and raw_count > 0 else 1
         total = max(1, int(_setting("FAKE_IMAGE_STEPS", 8)))
         step_ms = max(0, int(_setting("FAKE_IMAGE_STEP_MS", 300)))
+        step_ms_sequence = []
+        for raw_delay in _setting("FAKE_IMAGE_STEP_MS_SEQUENCE", "").split(","):
+            raw_delay = raw_delay.strip()
+            if raw_delay:
+                step_ms_sequence.append(max(0, int(raw_delay)))
         first_warmup_ack = _setting("FAKE_IMAGE_FIRST_WARMUP_ACK")
+        step_hold_ack = _setting("FAKE_IMAGE_STEP_HOLD_ACK")
         index = RENDERS.begin(total, bool(first_warmup_ack))
         if index is None:
             # A render is already in flight. The real server runs one model in
@@ -740,11 +746,22 @@ class Handler(BaseHTTPRequestHandler):
                 time.sleep(0.05)
             RENDERS.finish_warmup()
         cancelled = False
-        for _ in range(total):
-            time.sleep(step_ms / 1000)
+        for step_index in range(total):
+            delay_ms = (step_ms_sequence[step_index]
+                        if step_index < len(step_ms_sequence) else step_ms)
+            time.sleep(delay_ms / 1000)
             if RENDERS.advance():
                 cancelled = True
                 break
+            if step_hold_ack and step_index + 1 == 2:
+                deadline = time.monotonic() + 300
+                while not os.path.exists(step_hold_ack):
+                    if time.monotonic() >= deadline:
+                        RENDERS.end()
+                        _event("image_step_hold_timeout", step=2)
+                        self._json(500, {"error": {"code": "fixture_step_hold_timeout"}})
+                        return
+                    time.sleep(0.05)
         # Real image engines still perform VAE decode / PNG encoding after the
         # last denoise step. Keep that tail observable for GUI phase coverage.
         finish_ms = max(0, int(_setting("FAKE_IMAGE_FINISH_MS", 0)))

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -748,9 +748,8 @@ class Handler(BaseHTTPRequestHandler):
             RENDERS.finish_warmup()
         cancelled = False
         for step_index in range(total):
-            delay_ms = (step_ms_sequence[step_index]
-                        if step_index < len(step_ms_sequence) else step_ms)
-            time.sleep(delay_ms / 1000)
+            # Production publishes `step = t + 1` when a denoise step starts.
+            # Advance before sleeping so the fixture has the same wire meaning.
             if RENDERS.advance():
                 cancelled = True
                 break
@@ -763,15 +762,20 @@ class Handler(BaseHTTPRequestHandler):
                         self._json(500, {"error": {"code": "fixture_step_hold_timeout"}})
                         return
                     time.sleep(0.05)
+            delay_ms = (step_ms_sequence[step_index]
+                        if step_index < len(step_ms_sequence) else step_ms)
+            time.sleep(delay_ms / 1000)
         # Real image engines still perform VAE decode / PNG encoding after the
         # last denoise step. Keep that tail observable for GUI phase coverage.
         finish_ms = max(0, int(_setting("FAKE_IMAGE_FINISH_MS", 0)))
+        # Production clears `running` when denoising returns, before PNG
+        # encoding. Publish that same finalizing boundary ahead of the tail.
+        RENDERS.end()
         # Cancellation exits denoising without entering the successful
         # decode/encode tail. Keeping that tail after RENDERS.cancel() would
         # make the fixture report a stopped render as if it were finalizing.
         if not cancelled:
             time.sleep(finish_ms / 1000)
-        RENDERS.end()
         png = _one_pixel_png(((index * 70) % 256, (index * 130) % 256, (index * 190) % 256))
         encoded = base64.b64encode(png).decode("ascii")
         # The digest is of the BYTES that go on the wire, so a fixture (or an

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -45,6 +45,7 @@ import time
 import wave
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
 
 
 if sys.argv[1:] == ["launch", "list", "--json"]:
@@ -765,7 +766,11 @@ class Handler(BaseHTTPRequestHandler):
         # Real image engines still perform VAE decode / PNG encoding after the
         # last denoise step. Keep that tail observable for GUI phase coverage.
         finish_ms = max(0, int(_setting("FAKE_IMAGE_FINISH_MS", 0)))
-        time.sleep(finish_ms / 1000)
+        # Cancellation exits denoising without entering the successful
+        # decode/encode tail. Keeping that tail after RENDERS.cancel() would
+        # make the fixture report a stopped render as if it were finalizing.
+        if not cancelled:
+            time.sleep(finish_ms / 1000)
         RENDERS.end()
         png = _one_pixel_png(((index * 70) % 256, (index * 130) % 256, (index * 190) % 256))
         encoded = base64.b64encode(png).decode("ascii")
@@ -786,18 +791,19 @@ class Handler(BaseHTTPRequestHandler):
         )
 
     def do_POST(self):
-        if self.path == "/v1/models/load":
+        path = urlsplit(self.path).path
+        if path == "/v1/models/load":
             self._models_load()
             return
-        if self.path == "/v1/images/generations":
+        if path == "/v1/images/generations":
             self._images_generate()
             return
-        if self.path == "/v1/images/cancel":
+        if path == "/v1/images/cancel":
             RENDERS.cancel()
             _event("image_cancel")
             self._json(200, {"cancelled": True})
             return
-        if self.path == "/v1/images/edits":
+        if path == "/v1/images/edits":
             self._images_generate(editing=True)
             return
         if self.path == "/v1/audio/speech":

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4075,7 +4075,7 @@ flow_image_generation() {
         || die "exiting edit mode after an import did not restore generation controls"
 
     # 9. ETA evidence across unchanged samples, cancellation, and restart.
-    # The fixture holds one completed step for five seconds. Capture the same
+    # The fixture holds one reported step start. Capture the same
     # structured step twice during that hold: the numeric ETA must remain
     # identical even though the HUD's elapsed clock keeps advancing.
     local cancel_prompt="a cheetah render to cancel after ETA appears"
@@ -4105,7 +4105,7 @@ flow_image_generation() {
     [[ "$eta_step_b" == "$eta_step_a" ]] \
         || die "the deterministic unchanged-step fixture advanced unexpectedly ($eta_step_a -> $eta_step_b)"
     [[ "$eta_value_b" == "$eta_value_a" ]] \
-        || die "ETA changed while completed progress stayed at $eta_step_a ($eta_value_a -> $eta_value_b)"
+        || die "ETA changed while reported progress stayed at $eta_step_a ($eta_value_a -> $eta_value_b)"
     press "$OUT/ig-eta-sample-b.json" Images.Generate "$OUT/ig-eta-cancel-press.json" \
         || die "the primary Stop control is not pressable after numeric ETA appears"
     local cancel_requested=0

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4106,12 +4106,25 @@ flow_image_generation() {
         || die "the deterministic unchanged-step fixture advanced unexpectedly ($eta_step_a -> $eta_step_b)"
     [[ "$eta_value_b" == "$eta_value_a" ]] \
         || die "ETA changed while completed progress stayed at $eta_step_a ($eta_value_a -> $eta_value_b)"
-    : > "$OUT/ig-eta-hold-ack"
-
-    press "$OUT/ig-eta-sample-b.json" Images.Cancel "$OUT/ig-eta-cancel-press.json" \
-        || die "Images.Cancel is not pressable after numeric ETA appears"
+    press "$OUT/ig-eta-sample-b.json" Images.Generate "$OUT/ig-eta-cancel-press.json" \
+        || die "the primary Stop control is not pressable after numeric ETA appears"
+    local cancel_requested=0
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/ig-eta-cancel-requested.json"
+        if jq -e 'any(.data.ui_elements[]?;
+                      .identifier == "Images.Generate" and .enabled == false)
+                  and any(.data.ui_elements[]?;
+                          .identifier == "Images.Cancel" and .enabled == false)' \
+               "$OUT/ig-eta-cancel-requested.json" >/dev/null; then
+            cancel_requested=1; break
+        fi
+        sleep 0.05
+    done
+    [[ "$cancel_requested" == 1 ]] \
+        || die "the primary Stop control did not enter the cancelling state"
     wait_fake_event '.event == "image_cancel"' \
         "the ETA-bearing render did not receive cancellation"
+    : > "$OUT/ig-eta-hold-ack"
     local eta_cleared=0
     for ((i=0; i<120; i++)); do
         see_main "$OUT/ig-eta-cancelled.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3586,10 +3586,16 @@ flow_image_generation() {
     # AX baseline normalization itself takes several seconds on a busy mini;
     # keep the synthetic decode tail long enough to observe after it.
     start_persona image-generation FAKE_IMAGE_STEPS=8 FAKE_IMAGE_STEP_MS=300 \
+        FAKE_IMAGE_STEP_MS_SEQUENCE=5000,300,5000,300,300,300,300,300 \
         FAKE_IMAGE_FIRST_WARMUP_ACK="$OUT_ROOT/image-generation/ig-warmup-ack" \
+        FAKE_IMAGE_STEP_HOLD_ACK="$OUT_ROOT/image-generation/ig-eta-hold-ack" \
         FAKE_IMAGE_FINISH_MS=15000 \
         RAPID_GUI_GOLDEN_MODE=1 \
         RAPID_SIMULATED_IMPORT_PATH="$ROOT/Tests/RapidTests/__Snapshots__/cheetah-logo-96.png"
+
+    # Existing renders pass step 2 immediately. Section 9 removes this file
+    # for one request so its two ETA reads are event-gated, not timing-gated.
+    : > "$OUT/ig-eta-hold-ack"
 
     dismiss_first_run
 
@@ -4067,6 +4073,85 @@ flow_image_generation() {
     done
     [[ "$import_exited" == 1 ]] \
         || die "exiting edit mode after an import did not restore generation controls"
+
+    # 9. ETA evidence across unchanged samples, cancellation, and restart.
+    # The fixture holds one completed step for five seconds. Capture the same
+    # structured step twice during that hold: the numeric ETA must remain
+    # identical even though the HUD's elapsed clock keeps advancing.
+    local cancel_prompt="a cheetah render to cancel after ETA appears"
+    rm -f "$OUT/ig-eta-hold-ack"
+    type_prompt "$cancel_prompt" ig-eta-cancel-draft
+    press "$OUT/ig-eta-cancel-draft.json" Images.Generate "$OUT/ig-eta-cancel-submit.json" \
+        || die "Images.Generate is not pressable for ETA cancellation evidence"
+    wait_fake_event \
+        ".event == \"image_request\" and .prompt == \"$cancel_prompt\"" \
+        "the ETA cancellation request never reached the sidecar"
+
+    local eta_ready=0 eta_step_a eta_value_a eta_step_b eta_value_b
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/ig-eta-sample-a.json"
+        eta_step_a="$(element_field "$OUT/ig-eta-sample-a.json" Images.Progress.Step value)"
+        eta_value_a="$(element_field "$OUT/ig-eta-sample-a.json" Images.Progress.ETA value)"
+        if [[ "$eta_step_a" == "2 / 8" && "$eta_value_a" == *"s left" ]]; then
+            eta_ready=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$eta_ready" == 1 ]] \
+        || die "the held denoise step never exposed a numeric ETA at step 2 / 8"
+    see_main "$OUT/ig-eta-sample-b.json"
+    eta_step_b="$(element_field "$OUT/ig-eta-sample-b.json" Images.Progress.Step value)"
+    eta_value_b="$(element_field "$OUT/ig-eta-sample-b.json" Images.Progress.ETA value)"
+    [[ "$eta_step_b" == "$eta_step_a" ]] \
+        || die "the deterministic unchanged-step fixture advanced unexpectedly ($eta_step_a -> $eta_step_b)"
+    [[ "$eta_value_b" == "$eta_value_a" ]] \
+        || die "ETA changed while completed progress stayed at $eta_step_a ($eta_value_a -> $eta_value_b)"
+    : > "$OUT/ig-eta-hold-ack"
+
+    press "$OUT/ig-eta-sample-b.json" Images.Cancel "$OUT/ig-eta-cancel-press.json" \
+        || die "Images.Cancel is not pressable after numeric ETA appears"
+    wait_fake_event '.event == "image_cancel"' \
+        "the ETA-bearing render did not receive cancellation"
+    local eta_cleared=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/ig-eta-cancelled.json"
+        if jq -e '.success == true and .data.walk.complete == true
+                  and (([.data.ui_elements[]? | .identifier // ""]
+                        | index("Images.Progress.ETA")) == null)
+                  and (([.data.ui_elements[]? | .identifier // ""]
+                        | index("Images.Cancel")) == null)' \
+               "$OUT/ig-eta-cancelled.json" >/dev/null; then
+            eta_cleared=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$eta_cleared" == 1 ]] \
+        || die "numeric ETA remained visible after cancellation completed"
+
+    # A restarted request begins at a new evidence window. The old numeric ETA
+    # must not flash on the new card before two completed samples exist.
+    local restart_prompt="a fresh cheetah render after cancellation"
+    type_prompt "$restart_prompt" ig-eta-restart-draft
+    press "$OUT/ig-eta-restart-draft.json" Images.Generate "$OUT/ig-eta-restart-submit.json" \
+        || die "Images.Generate is not pressable after ETA cancellation"
+    wait_fake_event \
+        ".event == \"image_request\" and .prompt == \"$restart_prompt\"" \
+        "the post-cancellation restart never reached the sidecar"
+    local restart_estimating=0
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/ig-eta-restart-estimating.json"
+        if [[ "$(element_field "$OUT/ig-eta-restart-estimating.json" Images.Progress.ETA value)" == "Estimating…" ]]; then
+            restart_estimating=1; break
+        fi
+        sleep 0.05
+    done
+    [[ "$restart_estimating" == 1 ]] \
+        || die "a restarted render reused stale numeric ETA instead of estimating from fresh progress"
+    press "$OUT/ig-eta-restart-estimating.json" Images.Cancel "$OUT/ig-eta-restart-cancel.json" \
+        || die "the restarted ETA fixture could not be cancelled for cleanup"
+    wait_fake_event \
+        ".event == \"image_response\" and .cancelled == true and .index == 6" \
+        "the restarted ETA fixture did not settle as cancelled"
 
     log "  image-generation OK"
 }

--- a/tests/test_fake_sidecar_image_catalog.py
+++ b/tests/test_fake_sidecar_image_catalog.py
@@ -15,7 +15,10 @@ Stdlib + bash only, so it runs on the Linux CI lane that never sees a Mac.
 
 import json
 import os
+import socket
 import subprocess
+import time
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -241,6 +244,64 @@ def test_flow_and_fixture_agree_on_the_alias(models_output):
         f"gui-golden-flows.sh does not declare FAKE_IMAGE_ALIAS={alias!r}; "
         "the flow would assert against a model the fixture never prints"
     )
+
+
+def test_image_cancel_route_accepts_the_clients_model_query(tmp_path):
+    """The fake must match HTTP paths independently from their query string.
+
+    ``ImageClient.cancel`` identifies the active model with ``?model=...``.
+    Production routing parses that query separately; treating the entire
+    request target as a literal path makes the native cancellation journey get
+    a false 404 even though its wire request is valid.
+    """
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    events = tmp_path / "events.jsonl"
+    env = os.environ.copy()
+    env["FAKE_EVENT_LOG"] = str(events)
+    process = subprocess.Popen(
+        [
+            str(FAKE),
+            "serve",
+            "fake-image-alias",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    break
+            except OSError:
+                if process.poll() is not None or time.monotonic() >= deadline:
+                    raise AssertionError("fake sidecar did not start")
+                time.sleep(0.05)
+
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/images/cancel?model=fake-image-alias",
+            data=b"",
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            assert response.status == 200
+            assert json.load(response) == {"cancelled": True}
+        logged = [json.loads(line) for line in events.read_text().splitlines()]
+        assert [entry["event"] for entry in logged].count("image_cancel") == 1
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
 
 
 def test_info_reports_each_aliass_own_repo(models_output):


### PR DESCRIPTION
## Intention

Make the image-generation HUD report a truthful, stable denoising ETA instead of increasing the displayed time left while the current step is unchanged.

## Scope

- Sample ETA only from completed denoise-step transitions.
- Keep the estimate frozen between unchanged progress samples.
- Show an estimating state until two valid step observations exist.
- Reset ETA state between completion, cancellation, failure, and retry.
- Add deterministic focused Swift regression coverage.

## Non-goals

- No image engine scheduling changes.
- No server progress protocol changes.
- No visual redesign.
- No changes to download progress or other release blockers.

Closes #2299.

## Local evidence

- Reproduced the old formula deterministically: at fixed step 2 / 4, elapsed 10–14 seconds produced approximately 10–14 seconds left.
- Focused ImageGenerationPhaseTests: 6 passed.
- Release-configuration local Rapid-MLX Desktop.app build passed.
- Full deterministic image-generation GUI journey passed against that exact app, covering warm-up, generation, finalization, cancellation, repeated generation, and edit states.

## Risk

Low and localized to Desktop image ETA display state. The existing server progress payload and image generation lifecycle remain unchanged.