### PR TITLE
fix(mac): preserve dictation checkpoint across rc1 upgrade

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -69,10 +69,11 @@ final class AudioViewModel {
     /// with a Recommended badge may appear first), and feeding that order
     /// back into default selection silently changes the active checkpoint.
     private var transcriptionSelectionModels: [ModelEntry] {
-        audioModels.filter {
+        let candidates = audioModels.filter {
             $0.audioCapability?.supportsTranscription == true
                 && ModelCatalog.isDesktopAudioAliasVisible($0.alias)
         }
+        return Self.stablyDeduplicatedTranscriptionModels(candidates)
     }
 
     var speechModels: [ModelEntry] {
@@ -332,6 +333,31 @@ final class AudioViewModel {
     /// a visual picker should not show the same checkpoint three times. Group
     /// by HF repo and keep the explicit product alias where one exists.
     static func deduplicatedTranscriptionModels(_ entries: [ModelEntry]) -> [ModelEntry] {
+        let deduplicated = stablyDeduplicatedTranscriptionModels(entries)
+        let position = Dictionary(
+            uniqueKeysWithValues: deduplicated.enumerated().map {
+                let key = $1.hfRepo?.lowercased() ?? "alias:\($1.alias.lowercased())"
+                return (key, $0)
+            }
+        )
+        return deduplicated.sorted { lhs, rhs in
+            let lhsRecommended = transcriptionDetails(
+                alias: lhs.alias, family: lhs.audioFamily
+            ).isRecommended
+            let rhsRecommended = transcriptionDetails(
+                alias: rhs.alias, family: rhs.audioFamily
+            ).isRecommended
+            if lhsRecommended != rhsRecommended { return lhsRecommended }
+            if lhs.cached != rhs.cached { return lhs.cached }
+            let lhsKey = lhs.hfRepo?.lowercased() ?? "alias:\(lhs.alias.lowercased())"
+            let rhsKey = rhs.hfRepo?.lowercased() ?? "alias:\(rhs.alias.lowercased())"
+            return position[lhsKey, default: .max] < position[rhsKey, default: .max]
+        }
+    }
+
+    private static func stablyDeduplicatedTranscriptionModels(
+        _ entries: [ModelEntry]
+    ) -> [ModelEntry] {
         var order: [String] = []
         var representative: [String: ModelEntry] = [:]
 
@@ -347,20 +373,7 @@ final class AudioViewModel {
                 representative[key] = entry
             }
         }
-        let position = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($1, $0) })
-        return order.compactMap { representative[$0] }.sorted { lhs, rhs in
-            let lhsRecommended = transcriptionDetails(
-                alias: lhs.alias, family: lhs.audioFamily
-            ).isRecommended
-            let rhsRecommended = transcriptionDetails(
-                alias: rhs.alias, family: rhs.audioFamily
-            ).isRecommended
-            if lhsRecommended != rhsRecommended { return lhsRecommended }
-            if lhs.cached != rhs.cached { return lhs.cached }
-            let lhsKey = lhs.hfRepo?.lowercased() ?? "alias:\(lhs.alias.lowercased())"
-            let rhsKey = rhs.hfRepo?.lowercased() ?? "alias:\(rhs.alias.lowercased())"
-            return position[lhsKey, default: .max] < position[rhsKey, default: .max]
-        }
+        return order.compactMap { representative[$0] }
     }
 
     private static func transcriptionAliasPriority(_ alias: String) -> Int {

--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -61,11 +61,18 @@ final class AudioViewModel {
     }
 
     var transcriptionModels: [ModelEntry] {
-        let candidates = audioModels.filter {
+        Self.deduplicatedTranscriptionModels(transcriptionSelectionModels)
+    }
+
+    /// Runtime selection keeps the catalog's stable order among cached models.
+    /// ``transcriptionModels`` is presentation-ranked (for example, a model
+    /// with a Recommended badge may appear first), and feeding that order
+    /// back into default selection silently changes the active checkpoint.
+    private var transcriptionSelectionModels: [ModelEntry] {
+        audioModels.filter {
             $0.audioCapability?.supportsTranscription == true
                 && ModelCatalog.isDesktopAudioAliasVisible($0.alias)
         }
-        return Self.deduplicatedTranscriptionModels(candidates)
     }
 
     var speechModels: [ModelEntry] {
@@ -387,10 +394,12 @@ final class AudioViewModel {
         return serving
     }
 
-    private func resolveSelections() {
-        if !transcriptionModels.contains(where: { $0.alias == selectedTranscriptionAlias }) {
+    func resolveSelections() {
+        if !transcriptionSelectionModels.contains(where: {
+            $0.alias == selectedTranscriptionAlias
+        }) {
             selectedTranscriptionAlias = preferredAlias(
-                from: transcriptionModels,
+                from: transcriptionSelectionModels,
                 preferred: ["whisper-small", "whisper-large-v3-turbo", "whisper-large-v3"]
             )
         }

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -126,6 +126,43 @@ struct AudioCatalogTests {
         #expect(viewModel.selectedTranscriptionAlias == "qwen3-asr")
     }
 
+    @Test("runtime selection deduplicates aliases without presentation sorting")
+    @MainActor
+    func transcriptionSelectionPreservesDeduplication() {
+        let viewModel = AudioViewModel(server: ServerManager(testingState: .idle))
+        let qwenRepo = "mlx-community/Qwen3-ASR-1.7B-5bit"
+        viewModel.audioModels = [
+            audioEntry(
+                alias: "qwen3-asr-1.7b",
+                capability: .transcription,
+                family: "qwen3_asr",
+                repo: qwenRepo,
+                cached: true
+            ),
+            audioEntry(
+                alias: "qwen3-asr",
+                capability: .transcription,
+                family: "qwen3_asr",
+                repo: qwenRepo,
+                cached: true
+            ),
+            audioEntry(
+                alias: "whisper-large-v3-turbo",
+                capability: .transcription,
+                family: "whisper",
+                cached: true
+            ),
+        ]
+
+        viewModel.resolveSelections()
+
+        #expect(viewModel.selectedTranscriptionAlias == "qwen3-asr")
+        #expect(viewModel.transcriptionModels.map(\.alias) == [
+            "whisper-large-v3-turbo",
+            "qwen3-asr",
+        ])
+    }
+
     @Test("speech-to-text picker renders explanatory rows instead of a native alias menu")
     func transcriptionPickerUsesRichRows() throws {
         let source = try String(contentsOf: Self.dictationViewURL, encoding: .utf8)

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -98,6 +98,34 @@ struct AudioCatalogTests {
         ])
     }
 
+    @Test("presentation ranking cannot silently change the selected checkpoint")
+    @MainActor
+    func transcriptionRecommendationDoesNotOverrideCachedSelectionOrder() {
+        let viewModel = AudioViewModel(server: ServerManager(testingState: .idle))
+        viewModel.audioModels = [
+            audioEntry(
+                alias: "qwen3-asr",
+                capability: .transcription,
+                family: "qwen3_asr",
+                cached: true
+            ),
+            audioEntry(
+                alias: "whisper-large-v3-turbo",
+                capability: .transcription,
+                family: "whisper",
+                cached: true
+            ),
+        ]
+
+        // The recommendation remains a presentation decision.
+        #expect(viewModel.transcriptionModels.first?.alias == "whisper-large-v3-turbo")
+
+        // Default selection retains the existing cached-first selection contract
+        // instead of treating visual rank as a request to swap checkpoints.
+        viewModel.resolveSelections()
+        #expect(viewModel.selectedTranscriptionAlias == "qwen3-asr")
+    }
+
     @Test("speech-to-text picker renders explanatory rows instead of a native alias menu")
     func transcriptionPickerUsesRichRows() throws {
         let source = try String(contentsOf: Self.dictationViewURL, encoding: .utf8)
@@ -333,13 +361,14 @@ struct AudioCatalogTests {
         alias: String,
         capability: AudioModelCapability,
         family: String,
-        repo: String? = nil
+        repo: String? = nil,
+        cached: Bool = false
     ) -> ModelEntry {
         ModelEntry(
             alias: alias,
             hfRepo: repo ?? "mlx-community/\(alias)",
             sizeOnDisk: nil,
-            cached: false,
+            cached: cached,
             kind: .audio,
             audioCapability: capability,
             audioFamily: family


### PR DESCRIPTION
## What does this PR do?

Separates the speech-to-text picker's presentation ranking from its runtime default-selection input. The Recommended model can still appear first in the picker, but refreshing the catalog no longer treats that visual rank as a request to replace the first cached checkpoint.

Adds deterministic regression tests for the upgrade case where Qwen3 ASR and Whisper Turbo are both cached and no transcription preference has been persisted, including compatibility aliases that refer to the same checkpoint.

## Review contract

- **User-visible goal:** upgrading to rc1 must not silently change the dictation checkpoint merely because the picker visually promotes a recommendation.
- **Allowed scope:** Desktop `AudioViewModel` selection inputs and focused Audio catalog regression coverage.
- **Explicit non-goals:** no engine/server or audio-capture changes; no model metadata/ranking redesign; no public API, language, transcription protocol, persistence, or release changes; no transcript rewriting, model-name/hash inference, or regex heuristics.
- **Constraints:** preserve visible Recommended-first picker order, stable checkpoint deduplication, explicit user selection, cached-model preference, custom aliases, and existing speech synthesis selection behavior.
- **Acceptance criteria:** with Qwen3 ASR then Whisper Turbo in stable catalog order and both cached, the picker still displays Turbo first while default runtime selection remains Qwen3 ASR; compatibility aliases for one repo remain deduplicated; focused tests and a local release build pass.
- **Exact review range:** `b42b0293b3df7889a541c15212151dc3b2094a9b..221dae5ef8e17eac9d16b1adfc023a024e3774d3`.

## Why is this needed?

Fixes #2298.

The rc1 picker redesign introduced a presentation sort and then reused the sorted array when resolving the active checkpoint. On installations without a persisted dictation selection, that could silently change the checkpoint after upgrade. Controlled reproduction with five identical synthetic Mandarin recordings showed:

- the previous release and rc1 produced identical text when run with the same checkpoint, in both automatic-language and explicit-Chinese modes;
- capture remained 16 kHz mono signed 16-bit PCM in both releases;
- the two checkpoints selected before and after the UI change produced aggregate raw character error rates of 5.10% and 18.37% respectively on the same 98 reference characters.

This PR restores the prior runtime-selection contract without transcript rewriting, model-name inference, language heuristics, audio-pipeline changes, or changes to the visible recommendation order.

## AI assistance disclosure

Codex investigated the signed release builds, generated and evaluated the consent-free synthetic fixtures, identified the selection-order regression, and wrote the two-file fix and regression tests. I reviewed the scoped diff and verified it with the focused suite, a production Swift build, controlled inference runs, and proportional regression testing.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- `swift test --filter AudioCatalogTests` — 18 passed
- `swift build -c release` — passed after both implementation commits
- `swift test` — 2,767 tests executed; related Audio catalog, Dictation, and AudioClient suites passed. Two runs exposed different unrelated process-wide concurrency flakes; each failing suite passed immediately in isolation.
- Signed v0.12.18 vs v0.13.0-rc1 sidecar comparison on five deterministic synthetic Mandarin WAVs, automatic and explicit `zh`
- Controlled checkpoint comparison on the same fixtures with raw Unicode-character CER
- `python3.12 -m scripts.pr_validate.pr_validate 2303 -v` — MERGE-SAFE; 18,597 passed, 97 skipped, 22 deselected, 6 xfailed, 1 xpassed

## Checklist

- [x] Focused tests pass locally
- [x] Local release build passes
- [x] Regression tests fail if runtime selection consumes presentation-ranked models or bypasses checkpoint deduplication
- [x] README/docs not applicable; behavior is covered by code comments and automated regression tests
- [x] Self-validated with `python3.12 -m scripts.pr_validate.pr_validate 2303 -v`
- [x] No breaking changes to existing API

