### PR TITLE
fix(mac): recover rejected web-search keys

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -122,6 +122,7 @@ final class BuiltinToolRegistry: ToolRegistry {
               key != nil,
               first.failureKind == .webSearchKeyRejected,
               !Task.isCancelled,
+              webSearch.apiKey(for: provider) == key,
               webSearch.setAPIKey(nil, for: provider),
               !Task.isCancelled
         else {

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -121,14 +121,27 @@ final class BuiltinToolRegistry: ToolRegistry {
         guard provider == .keenable,
               key != nil,
               first.failureKind == .webSearchKeyRejected,
-              !Task.isCancelled,
-              webSearch.apiKey(for: provider) == key,
-              webSearch.setAPIKey(nil, for: provider),
               !Task.isCancelled
         else {
             return first
         }
 
+        switch webSearch.apiKey(for: provider) {
+        case key:
+            // This request still owns the rejected value. Establish keyless
+            // mode persistently before replaying so it cannot be resent.
+            guard webSearch.setAPIKey(nil, for: provider) else { return first }
+        case nil:
+            // An overlapping rejection (or the user) already established
+            // keyless mode. This call can share that recovery transition.
+            break
+        default:
+            // Settings saved a replacement while this request was suspended.
+            // The stale response has no authority to clear or test that key.
+            return first
+        }
+
+        guard !Task.isCancelled else { return first }
         let recovered = await webSearchRunner(call.function.arguments, provider, nil)
         return ToolCallResult(
             toolCallID: recovered.toolCallID,

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -16,6 +16,16 @@ import Foundation
 /// disk must not ship without one.
 @MainActor
 final class BuiltinToolRegistry: ToolRegistry {
+    typealias WebSearchRunner = (
+        _ arguments: String,
+        _ provider: WebSearchProvider,
+        _ apiKey: String?
+    ) async -> ToolCallResult
+
+    /// Model-visible audit note for the one credential-recovery transition.
+    /// It deliberately names the mode change without echoing any credential.
+    static let rejectedKeyRecoveryNote = "Note: Rapid removed a rejected saved Keenable key and retried this search using Keenable's keyless mode. Future searches will stay keyless until a new key is saved."
+
     /// Per-invocation approval gate for ``browse``. Held on the shared registry
     /// so the SwiftUI approval dialog + the Settings auto-approve switch bind to
     /// the same object the tool runner consults.
@@ -24,13 +34,24 @@ final class BuiltinToolRegistry: ToolRegistry {
     /// the registry so the chat loop doesn't need to thread a separate
     /// environment value through every tool call.
     let webSearch: WebSearchConfig
+    /// Injected at the service boundary so the state transition can be tested
+    /// without a live provider. Production always uses ``WebSearchTool/run``.
+    private let webSearchRunner: WebSearchRunner
 
     init(
         browseApproval: BrowseApprovalStore = BrowseApprovalStore(),
-        webSearch: WebSearchConfig = WebSearchConfig()
+        webSearch: WebSearchConfig = WebSearchConfig(),
+        webSearchRunner: @escaping WebSearchRunner = { arguments, provider, apiKey in
+            await WebSearchTool.run(
+                arguments: arguments,
+                provider: provider,
+                apiKey: apiKey
+            )
+        }
     ) {
         self.browseApproval = browseApproval
         self.webSearch = webSearch
+        self.webSearchRunner = webSearchRunner
     }
 
     var definitions: [ToolDefinition] {
@@ -45,13 +66,7 @@ final class BuiltinToolRegistry: ToolRegistry {
         let result: ToolCallResult
         switch call.function.name {
         case "web_search":
-            let provider = webSearch.provider
-            let key = webSearch.apiKey(for: provider)
-            result = await WebSearchTool.run(
-                arguments: call.function.arguments,
-                provider: provider,
-                apiKey: key
-            )
+            result = await runWebSearchWithCredentialRecovery(call)
         case "browse":
             result = await BrowseTool.run(
                 arguments: call.function.arguments,
@@ -83,6 +98,42 @@ final class BuiltinToolRegistry: ToolRegistry {
             content: result.content,
             isError: result.isError || failureKind != nil,
             failureKind: failureKind
+        )
+    }
+
+    /// Execute one web-search call, with one narrowly-scoped configuration
+    /// recovery: a rejected optional Keenable credential can transition to the
+    /// provider's supported keyless mode and replay the SAME call once.
+    ///
+    /// This is not a generic retry loop. Producer-owned failure metadata is the
+    /// gate, so network failures, quota/rate limits, malformed queries, and
+    /// prose that happens to mention a key never enter this path. The rejected
+    /// key is removed before replay, which makes resending it impossible and
+    /// persists the selected recovery for later searches. If Keychain cannot
+    /// establish that post-condition, the original failure remains visible.
+    private func runWebSearchWithCredentialRecovery(
+        _ call: ToolCall
+    ) async -> ToolCallResult {
+        let provider = webSearch.provider
+        let key = webSearch.apiKey(for: provider)
+        let first = await webSearchRunner(call.function.arguments, provider, key)
+
+        guard provider == .keenable,
+              key != nil,
+              first.failureKind == .webSearchKeyRejected,
+              !Task.isCancelled,
+              webSearch.setAPIKey(nil, for: provider),
+              !Task.isCancelled
+        else {
+            return first
+        }
+
+        let recovered = await webSearchRunner(call.function.arguments, provider, nil)
+        return ToolCallResult(
+            toolCallID: recovered.toolCallID,
+            content: recovered.content + "\n\n" + Self.rejectedKeyRecoveryNote,
+            isError: recovered.isError,
+            failureKind: recovered.failureKind
         )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -141,7 +141,11 @@ final class BuiltinToolRegistry: ToolRegistry {
             return first
         }
 
-        guard !Task.isCancelled else { return first }
+        // Once the persistent transition begins, finish its one bounded replay
+        // even if cancellation races with the synchronous Keychain mutation.
+        // Otherwise the call could return the old credential failure after
+        // having already removed the key. The real transport still observes
+        // task cancellation and can terminate the replay promptly.
         let recovered = await webSearchRunner(call.function.arguments, provider, nil)
         return ToolCallResult(
             toolCallID: recovered.toolCallID,

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -25,7 +25,7 @@ final class BuiltinToolRegistry: ToolRegistry {
     /// Model-visible audit note for the one credential-recovery transition.
     /// It deliberately names the mode change without echoing any credential.
     static func rejectedKeyRecoveryNote(for provider: WebSearchProvider) -> String {
-        "Note: Rapid removed a rejected saved \(provider.displayName) key and retried this search using \(provider.displayName)'s keyless mode. Future searches will stay keyless until a new key is saved."
+        "Note: Rapid removed a rejected saved \(provider.displayName) key and retried this search using \(provider.displayName)'s keyless mode."
     }
 
     /// Per-invocation approval gate for ``browse``. Held on the shared registry
@@ -143,11 +143,11 @@ final class BuiltinToolRegistry: ToolRegistry {
             return first
         }
 
-        // Once the persistent transition begins, finish its one bounded replay
+        // Once the persistent transition begins, invoke its one bounded replay
         // even if cancellation races with the synchronous Keychain mutation.
         // Otherwise the call could return the old credential failure after
         // having already removed the key. The real transport still observes
-        // task cancellation and can terminate the replay promptly.
+        // task cancellation and can terminate the replay attempt promptly.
         let recovered = await webSearchRunner(call.function.arguments, provider, nil)
         return ToolCallResult(
             toolCallID: recovered.toolCallID,

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -24,7 +24,9 @@ final class BuiltinToolRegistry: ToolRegistry {
 
     /// Model-visible audit note for the one credential-recovery transition.
     /// It deliberately names the mode change without echoing any credential.
-    static let rejectedKeyRecoveryNote = "Note: Rapid removed a rejected saved Keenable key and retried this search using Keenable's keyless mode. Future searches will stay keyless until a new key is saved."
+    static func rejectedKeyRecoveryNote(for provider: WebSearchProvider) -> String {
+        "Note: Rapid removed a rejected saved \(provider.displayName) key and retried this search using \(provider.displayName)'s keyless mode. Future searches will stay keyless until a new key is saved."
+    }
 
     /// Per-invocation approval gate for ``browse``. Held on the shared registry
     /// so the SwiftUI approval dialog + the Settings auto-approve switch bind to
@@ -118,7 +120,7 @@ final class BuiltinToolRegistry: ToolRegistry {
         let key = webSearch.apiKey(for: provider)
         let first = await webSearchRunner(call.function.arguments, provider, key)
 
-        guard provider == .keenable,
+        guard provider.recoversRejectedKeyKeylessly,
               key != nil,
               first.failureKind == .webSearchKeyRejected,
               !Task.isCancelled
@@ -149,7 +151,7 @@ final class BuiltinToolRegistry: ToolRegistry {
         let recovered = await webSearchRunner(call.function.arguments, provider, nil)
         return ToolCallResult(
             toolCallID: recovered.toolCallID,
-            content: recovered.content + "\n\n" + Self.rejectedKeyRecoveryNote,
+            content: recovered.content + "\n\n" + Self.rejectedKeyRecoveryNote(for: provider),
             isError: recovered.isError,
             failureKind: recovered.failureKind
         )

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -39,6 +39,16 @@ final class BuiltinToolRegistry: ToolRegistry {
     /// Injected at the service boundary so the state transition can be tested
     /// without a live provider. Production always uses ``WebSearchTool/run``.
     private let webSearchRunner: WebSearchRunner
+    private struct RejectedKeyRecoveryTransition {
+        let rejectedRevision: UInt64
+        let keylessRevision: UInt64
+    }
+    /// Records only transitions performed by this registry so an overlapping
+    /// stale response can distinguish automatic recovery from a user's manual
+    /// clear. Revisions also make same-value credential replacement observable.
+    private var rejectedKeyRecoveryTransitions: [
+        WebSearchProvider: RejectedKeyRecoveryTransition
+    ] = [:]
 
     init(
         browseApproval: BrowseApprovalStore = BrowseApprovalStore(),
@@ -117,7 +127,8 @@ final class BuiltinToolRegistry: ToolRegistry {
         _ call: ToolCall
     ) async -> ToolCallResult {
         let provider = webSearch.provider
-        let key = webSearch.apiKey(for: provider)
+        let credential = webSearch.credentialSnapshot(for: provider)
+        let key = credential.key
         let first = await webSearchRunner(call.function.arguments, provider, key)
 
         guard provider.recoversRejectedKeyKeylessly,
@@ -128,18 +139,28 @@ final class BuiltinToolRegistry: ToolRegistry {
             return first
         }
 
-        switch webSearch.apiKey(for: provider) {
-        case key:
+        let current = webSearch.credentialSnapshot(for: provider)
+        if current == credential {
             // This request still owns the rejected value. Establish keyless
             // mode persistently before replaying so it cannot be resent.
             guard webSearch.setAPIKey(nil, for: provider) else { return first }
-        case nil:
-            // An overlapping rejection (or the user) already established
-            // keyless mode. This call can share that recovery transition.
-            break
-        default:
-            // Settings saved a replacement while this request was suspended.
-            // The stale response has no authority to clear or test that key.
+            let keyless = webSearch.credentialSnapshot(for: provider)
+            guard keyless.key == nil else { return first }
+            rejectedKeyRecoveryTransitions[provider] = RejectedKeyRecoveryTransition(
+                rejectedRevision: credential.revision,
+                keylessRevision: keyless.revision
+            )
+        } else if current.key == nil,
+                  let transition = rejectedKeyRecoveryTransitions[provider],
+                  transition.rejectedRevision == credential.revision,
+                  transition.keylessRevision == current.revision
+        {
+            // An overlapping rejection already established keyless mode. This
+            // call can share that exact registry-owned transition.
+        } else {
+            // Settings saved, re-saved, or cleared a credential while this
+            // request was suspended. The stale response has no authority to
+            // clear, test, or narrate that user-owned mutation.
             return first
         }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -171,6 +171,11 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
 @MainActor
 @Observable
 final class WebSearchConfig {
+    struct CredentialSnapshot: Equatable, Sendable {
+        let key: String?
+        let revision: UInt64
+    }
+
     /// Backed by ``UserDefaults`` under a single stable key so a
     /// reset-defaults action (or a corrupted prefs file) doesn't
     /// need to sweep multiple keys. The default is ``.keenable``
@@ -203,6 +208,10 @@ final class WebSearchConfig {
     /// looked" from "looked, no secret stored" — the latter must
     /// short-circuit ``apiKey(for:)`` without another keychain hit.
     private var probedAccounts: Set<String> = []
+    /// Process-local mutation generation per Keychain account. Value equality
+    /// cannot detect an ABA replacement (K → another value → K), so callers
+    /// that act on an async response capture this revision with the key.
+    private var keyRevisions: [String: UInt64] = [:]
 
     /// Injection points for tests. Default arguments use the real
     /// system Keychain + the host's standard UserDefaults; the
@@ -245,6 +254,19 @@ final class WebSearchConfig {
             keyCache[account] = value
         }
         return value?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+    }
+
+    /// Atomically capture the cached credential value and its mutation
+    /// generation on the main actor. External Keychain edits are intentionally
+    /// outside this process-owned cache contract, just like ``apiKey(for:)``.
+    func credentialSnapshot(for provider: WebSearchProvider) -> CredentialSnapshot {
+        guard let account = provider.keychainAccount else {
+            return CredentialSnapshot(key: nil, revision: 0)
+        }
+        return CredentialSnapshot(
+            key: apiKey(for: provider),
+            revision: keyRevisions[account, default: 0]
+        )
     }
 
     /// Write or clear the key for ``provider``. Passing an empty
@@ -293,6 +315,7 @@ final class WebSearchConfig {
             if keychain.delete(account: account) {
                 keyCache.removeValue(forKey: account)
                 probedAccounts.insert(account)
+                keyRevisions[account, default: 0] &+= 1
                 return true
             }
             return false
@@ -315,6 +338,7 @@ final class WebSearchConfig {
             if keychain.write(account: account, secret: trimmed) {
                 keyCache[account] = trimmed
                 probedAccounts.insert(account)
+                keyRevisions[account, default: 0] &+= 1
                 // Auto-promote happens AFTER a successful keychain
                 // write so the provider state can never get ahead of
                 // the stored key. Gate on ``provider.requiresKey``

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -29,6 +29,10 @@ struct WebSearchProviderDescriptor: Sendable {
     /// optional and lifts the shared keyless rate limit. Drives the
     /// Settings key field + Keychain prefetch.
     let acceptsKey: Bool
+    /// A rejected optional key can be removed and the same request can run in
+    /// this provider's supported keyless mode. This is deliberately narrower
+    /// than generic retry or fallback eligibility.
+    let recoversRejectedKeyKeylessly: Bool
     /// Keychain account label for this provider's API key. Distinct
     /// per-provider so one provider's key never leaks into another's
     /// call.
@@ -84,6 +88,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 keyDashboardURL: URL(string: "https://keenable.ai/console"),
                 requiresKey: false,
                 acceptsKey: true,
+                recoversRejectedKeyKeylessly: true,
                 keychainAccount: "rapid.web-search.keenable"
             )
         case .parallel:
@@ -94,6 +99,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 keyDashboardURL: URL(string: "https://platform.parallel.ai/"),
                 requiresKey: true,
                 acceptsKey: true,
+                recoversRejectedKeyKeylessly: false,
                 keychainAccount: "rapid.web-search.parallel"
             )
         case .tavily:
@@ -104,6 +110,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 keyDashboardURL: URL(string: "https://app.tavily.com/home"),
                 requiresKey: true,
                 acceptsKey: true,
+                recoversRejectedKeyKeylessly: false,
                 keychainAccount: "rapid.web-search.tavily"
             )
         case .brave:
@@ -122,6 +129,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 keyDashboardURL: URL(string: "https://api-dashboard.search.brave.com/app/keys"),
                 requiresKey: true,
                 acceptsKey: true,
+                recoversRejectedKeyKeylessly: false,
                 keychainAccount: "rapid.web-search.brave"
             )
         case .duckduckgo:
@@ -138,6 +146,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 keyDashboardURL: nil,
                 requiresKey: false,
                 acceptsKey: false,
+                recoversRejectedKeyKeylessly: false,
                 keychainAccount: nil
             )
         }
@@ -151,6 +160,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
     var keyDashboardURL: URL? { descriptor.keyDashboardURL }
     var requiresKey: Bool { descriptor.requiresKey }
     var acceptsKey: Bool { descriptor.acceptsKey }
+    var recoversRejectedKeyKeylessly: Bool { descriptor.recoversRejectedKeyKeylessly }
     var keychainAccount: String? { descriptor.keychainAccount }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
@@ -39,6 +39,18 @@ struct WebSearchProviderDescriptorTests {
         #expect(!WebSearchProvider.duckduckgo.acceptsKey)
     }
 
+    @Test("Only the optional-key backend advertises rejected-key keyless recovery")
+    func rejectedKeyRecoveryCapability() {
+        #expect(WebSearchProvider.keenable.recoversRejectedKeyKeylessly)
+        for provider in WebSearchProvider.allCases where provider.recoversRejectedKeyKeylessly {
+            #expect(provider.acceptsKey)
+            #expect(!provider.requiresKey)
+        }
+        for provider in WebSearchProvider.allCases where provider != .keenable {
+            #expect(!provider.recoversRejectedKeyKeylessly)
+        }
+    }
+
     @Test("Every key-accepting provider links a key dashboard")
     func dashboardsPresent() {
         for provider in WebSearchProvider.allCases where provider.acceptsKey {

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -155,6 +155,44 @@ final class WebSearchRejectedKeyRecoveryTests {
         #expect(config.apiKey(for: .keenable) == "keen_new_valid")
     }
 
+    @Test("A same-value replacement is a new credential revision and is preserved")
+    func sameValueReplacementWinsOverStaleRejection() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_aba", for: .keenable))
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+            attempts += 1
+            #expect(config.setAPIKey("keen_intermediate", for: .keenable))
+            #expect(config.setAPIKey("keen_aba", for: .keenable))
+            return Self.rejectedResult()
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .keenable) == "keen_aba")
+    }
+
+    @Test("A manual clear during the request is not narrated as automatic recovery")
+    func manualClearDoesNotShareAutomaticRecovery() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_user_clears", for: .keenable))
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+            attempts += 1
+            #expect(config.setAPIKey(nil, for: .keenable))
+            return Self.rejectedResult()
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .keenable) == nil)
+        #expect(!result.content.contains("Rapid removed"))
+    }
+
     @Test("Overlapping rejections both share the transition to keyless mode")
     func overlappingRejectionsBothRecover() async {
         let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -155,6 +155,31 @@ final class WebSearchRejectedKeyRecoveryTests {
         #expect(config.apiKey(for: .keenable) == "keen_new_valid")
     }
 
+    @Test("Overlapping rejections both share the transition to keyless mode")
+    func overlappingRejectionsBothRecover() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_shared_stale", for: .keenable))
+        let keyedBarrier = TestBarrier(participants: 2)
+        var observedKeys: [String?] = []
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            observedKeys.append(key)
+            if key != nil {
+                await keyedBarrier.arriveAndWait()
+                return Self.rejectedResult()
+            }
+            return ToolCallResult(toolCallID: "", content: "keyless result")
+        }
+
+        async let first = registry.run(makeCall(id: "overlap_1"))
+        async let second = registry.run(makeCall(id: "overlap_2"))
+        let results = await [first, second]
+
+        #expect(results.allSatisfy { !$0.isError })
+        #expect(observedKeys.compactMap { $0 }.count == 2)
+        #expect(observedKeys.filter { $0 == nil }.count == 2)
+        #expect(config.apiKey(for: .keenable) == nil)
+    }
+
     @Test("Cancellation after rejection does not clear the key or start recovery")
     func cancellationStopsRecovery() async {
         let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
@@ -222,6 +247,26 @@ final class WebSearchRejectedKeyRecoveryTests {
             #expect(attempts == 1)
             #expect(config.apiKey(for: .keenable) == "keen_still_valid")
         }
+    }
+}
+
+private actor TestBarrier {
+    private var remaining: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(participants: Int) {
+        remaining = participants
+    }
+
+    func arriveAndWait() async {
+        remaining -= 1
+        if remaining == 0 {
+            let waiting = waiters
+            waiters.removeAll()
+            for waiter in waiting { waiter.resume() }
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -199,8 +199,8 @@ final class WebSearchRejectedKeyRecoveryTests {
         #expect(config.apiKey(for: .keenable) == "keen_keep_on_cancel")
     }
 
-    @Test("Cancellation racing with key removal completes the bounded replay")
-    func cancellationDuringPersistentTransitionCompletesReplay() async {
+    @Test("Cancellation racing with key removal makes one bounded replay attempt")
+    func cancellationDuringPersistentTransitionAttemptsReplay() async {
         let keychain = CancellationOnDeleteKeychain()
         let config = WebSearchConfig(defaults: freshDefaults(), keychain: keychain)
         #expect(config.setAPIKey("keen_rejected_during_delete", for: .keenable))
@@ -209,16 +209,43 @@ final class WebSearchRejectedKeyRecoveryTests {
         let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
             observedKeys.append(key)
             if key != nil { return Self.rejectedResult() }
-            return ToolCallResult(toolCallID: "", content: "keyless result")
+            #expect(Task.isCancelled)
+            return ToolCallResult(
+                toolCallID: "",
+                content: "keyless replay cancelled",
+                isError: true,
+                failureKind: .toolFailed
+            )
         }
 
         let result = await Task { await registry.run(makeCall()) }.value
 
-        #expect(!result.isError)
+        #expect(result.isError)
+        #expect(result.failureKind == .toolFailed)
+        #expect(result.failureKind != .webSearchKeyRejected)
         #expect(observedKeys.count == 2)
         #expect(observedKeys[0] == "keen_rejected_during_delete")
         #expect(observedKeys[1] == nil)
         #expect(config.apiKey(for: .keenable) == nil)
+    }
+
+    @Test("A replacement saved during replay makes no false future-state claim")
+    func replacementDuringReplayKeepsAuditNoteTruthful() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_rejected_before_replay", for: .keenable))
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            if key != nil { return Self.rejectedResult() }
+            await Task.yield()
+            #expect(config.setAPIKey("keen_replacement_during_replay", for: .keenable))
+            return ToolCallResult(toolCallID: "", content: "keyless result")
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(!result.isError)
+        #expect(result.content.contains("retried this search"))
+        #expect(!result.content.contains("Future searches"))
+        #expect(config.apiKey(for: .keenable) == "keen_replacement_during_replay")
     }
 
     @Test("A failed Keychain delete keeps the original failure and does not replay")

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -199,6 +199,28 @@ final class WebSearchRejectedKeyRecoveryTests {
         #expect(config.apiKey(for: .keenable) == "keen_keep_on_cancel")
     }
 
+    @Test("Cancellation racing with key removal completes the bounded replay")
+    func cancellationDuringPersistentTransitionCompletesReplay() async {
+        let keychain = CancellationOnDeleteKeychain()
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: keychain)
+        #expect(config.setAPIKey("keen_rejected_during_delete", for: .keenable))
+
+        var observedKeys: [String?] = []
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            observedKeys.append(key)
+            if key != nil { return Self.rejectedResult() }
+            return ToolCallResult(toolCallID: "", content: "keyless result")
+        }
+
+        let result = await Task { await registry.run(makeCall()) }.value
+
+        #expect(!result.isError)
+        #expect(observedKeys.count == 2)
+        #expect(observedKeys[0] == "keen_rejected_during_delete")
+        #expect(observedKeys[1] == nil)
+        #expect(config.apiKey(for: .keenable) == nil)
+    }
+
     @Test("A failed Keychain delete keeps the original failure and does not replay")
     func persistenceFailureDoesNotPretendToRecover() async {
         let keychain = DeleteFailingKeychain()
@@ -284,6 +306,26 @@ private final class DeleteFailingKeychain: KeychainStoring, @unchecked Sendable 
     }
 
     func delete(account: String) -> Bool { false }
+}
+
+private final class CancellationOnDeleteKeychain: KeychainStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: String] = [:]
+
+    func read(account: String) -> String? {
+        lock.withLock { storage[account] }
+    }
+
+    func write(account: String, secret: String) -> Bool {
+        lock.withLock { storage[account] = secret }
+        return true
+    }
+
+    func delete(account: String) -> Bool {
+        _ = lock.withLock { storage.removeValue(forKey: account) }
+        withUnsafeCurrentTask { $0?.cancel() }
+        return true
+    }
 }
 
 private final class FirstChatSearchProtocol: URLProtocol, @unchecked Sendable {

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -270,6 +270,24 @@ final class WebSearchRejectedKeyRecoveryTests {
             #expect(config.apiKey(for: .keenable) == "keen_still_valid")
         }
     }
+
+    @Test("A provider without the recovery capability never clears or replays")
+    func ineligibleProviderDoesNotRecover() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        config.provider = .parallel
+        #expect(config.setAPIKey("parallel_rejected", for: .parallel))
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+            attempts += 1
+            return Self.rejectedResult()
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .parallel) == "parallel_rejected")
+    }
 }
 
 private actor TestBarrier {

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -1,0 +1,281 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Rejected web-search key recovery")
+final class WebSearchRejectedKeyRecoveryTests {
+    private var suiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: suiteNames) }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-search-recovery-")
+        suiteNames.append(name)
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    private func makeCall(id: String = "search_1") -> ToolCall {
+        ToolCall(
+            id: id,
+            name: "web_search",
+            arguments: #"{"query":"what is the news today?"}"#
+        )
+    }
+
+    private static func rejectedResult() -> ToolCallResult {
+        ToolCallResult(
+            toolCallID: "",
+            content: "provider rejected the credential",
+            isError: true,
+            failureKind: .webSearchKeyRejected
+        )
+    }
+
+    @Test("First search removes a rejected optional key and replays once keyless")
+    func firstSearchRecoversKeyless() async {
+        let keychain = InMemoryKeychain()
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: keychain)
+        #expect(config.setAPIKey("keen_rejected_secret", for: .keenable))
+
+        var observedKeys: [String?] = []
+        let registry = BuiltinToolRegistry(webSearch: config) { arguments, provider, key in
+            observedKeys.append(key)
+            #expect(arguments == #"{"query":"what is the news today?"}"#)
+            #expect(provider == .keenable)
+            if key != nil { return Self.rejectedResult() }
+            return ToolCallResult(
+                toolCallID: "",
+                content: "Web search via Keenable: keyless result",
+                isError: false
+            )
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(!result.isError)
+        #expect(result.toolCallID == "search_1")
+        #expect(observedKeys.count == 2)
+        #expect(observedKeys[0] == "keen_rejected_secret")
+        #expect(observedKeys[1] == nil)
+        #expect(config.apiKey(for: .keenable) == nil)
+        #expect(result.content.contains("keyless mode"))
+        #expect(!result.content.contains("keen_rejected_secret"))
+    }
+
+    @Test("A first-chat web search completes with recovered evidence, not a failed tool row")
+    func firstChatSearchRecoversInPlace() async throws {
+        FirstChatSearchProtocol.reset()
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_first_chat_stale", for: .keenable))
+
+        var observedKeys: [String?] = []
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            observedKeys.append(key)
+            if key != nil { return Self.rejectedResult() }
+            return ToolCallResult(
+                toolCallID: "",
+                content: "Web search via Keenable (keyless): current headline"
+            )
+        }
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://first-chat-search")!,
+                session: FirstChatSearchProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("What is the news today?", alias: "test-model")
+        for _ in 0..<300 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        #expect(model.messages.last?.content == "Here is today's answer from current search evidence.")
+        #expect(model.messages.last?.status == .complete)
+        #expect(model.messages.filter { $0.role == .tool }.count == 1)
+        let toolRow = try #require(model.messages.first { $0.role == .tool })
+        #expect(toolRow.status == .complete)
+        #expect(toolRow.failureKind == nil)
+        #expect(toolRow.content.contains("keyless"))
+        #expect(!toolRow.content.contains("keen_first_chat_stale"))
+        #expect(observedKeys.count == 2)
+        #expect(observedKeys[0] == "keen_first_chat_stale")
+        #expect(observedKeys[1] == nil)
+        #expect(FirstChatSearchProtocol.requestBodies.count == 2)
+    }
+
+    @Test("Later searches stay keyless and never resend the rejected credential")
+    func repeatedSearchDoesNotReuseRejectedKey() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_stale", for: .keenable))
+
+        var observedKeys: [String?] = []
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            observedKeys.append(key)
+            if key != nil { return Self.rejectedResult() }
+            return ToolCallResult(toolCallID: "", content: "keyless result")
+        }
+
+        let first = await registry.run(makeCall(id: "first"))
+        let second = await registry.run(makeCall(id: "second"))
+
+        #expect(!first.isError)
+        #expect(!second.isError)
+        #expect(observedKeys.count == 3)
+        #expect(observedKeys[0] == "keen_stale")
+        #expect(observedKeys[1] == nil)
+        #expect(observedKeys[2] == nil)
+    }
+
+    @Test("Cancellation after rejection does not clear the key or start recovery")
+    func cancellationStopsRecovery() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_keep_on_cancel", for: .keenable))
+
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+            attempts += 1
+            withUnsafeCurrentTask { $0?.cancel() }
+            return Self.rejectedResult()
+        }
+
+        let result = await Task { await registry.run(makeCall()) }.value
+
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .keenable) == "keen_keep_on_cancel")
+    }
+
+    @Test("A failed Keychain delete keeps the original failure and does not replay")
+    func persistenceFailureDoesNotPretendToRecover() async {
+        let keychain = DeleteFailingKeychain()
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: keychain)
+        #expect(config.setAPIKey("keen_cannot_delete", for: .keenable))
+
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+            attempts += 1
+            return Self.rejectedResult()
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(result.isError)
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .keenable) == "keen_cannot_delete")
+    }
+
+    @Test("Quota, rate-limit, network, and query failures never enter credential recovery")
+    func unrelatedFailuresAreNotRetried() async {
+        for kind in [
+            FailureDiagnosis.Kind.webSearchKeyQuotaExceeded,
+            .webSearchKeyRateLimited,
+            .webSearchOffline,
+            .webSearchUnavailable,
+            .toolFailed,
+        ] {
+            let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+            #expect(config.setAPIKey("keen_still_valid", for: .keenable))
+            var attempts = 0
+            let registry = BuiltinToolRegistry(webSearch: config) { _, _, _ in
+                attempts += 1
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "typed failure",
+                    isError: true,
+                    failureKind: kind
+                )
+            }
+
+            let result = await registry.run(makeCall())
+
+            #expect(result.failureKind == kind)
+            #expect(attempts == 1)
+            #expect(config.apiKey(for: .keenable) == "keen_still_valid")
+        }
+    }
+}
+
+private final class DeleteFailingKeychain: KeychainStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: String] = [:]
+
+    func read(account: String) -> String? {
+        lock.withLock { storage[account] }
+    }
+
+    func write(account: String, secret: String) -> Bool {
+        lock.withLock { storage[account] = secret }
+        return true
+    }
+
+    func delete(account: String) -> Bool { false }
+}
+
+private final class FirstChatSearchProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestBodies: [Data] = []
+
+    static func reset() {
+        requestBodies = []
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FirstChatSearchProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestBodies.append(readBody(from: request))
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        let stream: String
+        if Self.requestBodies.count == 1 {
+            stream = #"""
+            data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"search_1","type":"function","function":{"name":"web_search","arguments":"{\"query\":\"what is the news today?\"}"}}]},"finish_reason":"tool_calls"}]}
+
+            data: [DONE]
+
+            """#
+        } else {
+            stream = """
+            data: {"choices":[{"delta":{"content":"Here is today's answer from current search evidence."},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+        }
+        client?.urlProtocol(self, didLoad: Data(stream.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private func readBody(from request: URLRequest) -> Data {
+        guard let input = request.httpBodyStream else { return request.httpBody ?? Data() }
+        input.open()
+        defer { input.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while input.hasBytesAvailable {
+            let count = input.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchRejectedKeyRecoveryTests.swift
@@ -131,6 +131,30 @@ final class WebSearchRejectedKeyRecoveryTests {
         #expect(observedKeys[2] == nil)
     }
 
+    @Test("A replacement key saved while the request is in flight is preserved")
+    func concurrentReplacementWinsOverStaleRejection() async {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        #expect(config.setAPIKey("keen_old_rejected", for: .keenable))
+
+        var attempts = 0
+        let registry = BuiltinToolRegistry(webSearch: config) { _, _, key in
+            attempts += 1
+            #expect(key == "keen_old_rejected")
+            // Simulate Settings saving a replacement while the first network
+            // request is suspended. Its eventual rejection belongs only to
+            // the credential captured when that request began.
+            #expect(config.setAPIKey("keen_new_valid", for: .keenable))
+            await Task.yield()
+            return Self.rejectedResult()
+        }
+
+        let result = await registry.run(makeCall())
+
+        #expect(result.failureKind == .webSearchKeyRejected)
+        #expect(attempts == 1)
+        #expect(config.apiKey(for: .keenable) == "keen_new_valid")
+    }
+
     @Test("Cancellation after rejection does not clear the key or start recovery")
     func cancellationStopsRecovery() async {
         let config = WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())


### PR DESCRIPTION
## What does this PR do?

When the selected web-search provider rejects a saved optional key, Desktop now removes that rejected credential and replays the original tool call exactly once using the provider's supported keyless mode. The recovered result remains in the original chat turn, and later searches stay keyless until the user saves a new key.

## Why is this needed?

The first current-information request currently fails when Desktop has a stale saved web-search key, even though the selected provider supports keyless search. This blocks an otherwise recoverable first-chat flow.

Closes #2296.

## Intention and scope contract

- User-visible goal: complete the original first search without requiring the user to retype it, never resend the rejected key, and preserve keyless mode for later requests.
- Allowed scope: typed rejected-key recovery at the Desktop tool-registry/configuration boundary and focused Desktop regression coverage.
- Non-goals: generic retry behavior, provider redesign, chat-loop redesign, UI redesign, model/protocol heuristics, merge, or release.
- Constraints: only a producer-stamped rejected-key failure from keyed Keenable can recover; cancellation and failed credential deletion stop recovery; quota, rate-limit, network, availability, malformed-query, and unrelated failures do not replay.
- Acceptance criteria: first-chat recovery succeeds in place; the original arguments replay once keyless; the saved rejected key is removed only after a successful persistent mutation; later searches remain keyless; no credential appears in output; cancellation and unrelated failures remain bounded.
- Review range: `b42b0293..HEAD`.
- Scoped maintainability follow-up range: `9833f074..6794de77`. This delta only moves rejected-key recovery eligibility into the provider descriptor metadata contract, makes the recovery note provider-derived, and adds positive/negative capability tests. It does not alter the user-visible recovery flow or introduce generic retry behavior.
- Scoped review-finding fix range: `6794de77..0fe5f879`. This delta clarifies cancellation-during-delete as one bounded replay attempt whose transport may terminate on cancellation, removes a future-state claim from the audit note, and tests replacement-key persistence during replay.
- Scoped ownership fix range: `0fe5f879..d78ab732`. This delta adds process-local credential mutation revisions and registry-owned transition revisions so ABA replacement and manual clear cannot be mistaken for the rejected credential that an old response may remove.

## AI assistance disclosure

Codex assisted with diagnosis, implementation, tests, and review preparation in `BuiltinToolRegistry.swift` and `WebSearchRejectedKeyRecoveryTests.swift`. I reviewed the complete diff against the issue contract, checked that the retry gate uses typed failure metadata rather than response prose, and verified the behavior with focused tests and a local release build.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. No generated or vendored artifacts are included.

## Test plan

- [x] `swift test --filter WebSearchProviderDescriptorTests` — 9 tests passed, including positive/negative recovery-capability contracts.
- [x] `swift test --filter WebSearchRejectedKeyRecoveryTests` — 13 tests passed, including ineligible-provider, cancellation-at-delete, replacement-during-replay, ABA, and manual-clear contracts.
- [x] `swift test --filter WebSearch` — 84 tests passed.
- [x] `swift test --filter BuiltinToolsTests` — 17 tests passed.
- [x] `swift test --filter HFCacheByteMonitorTests` — isolated follow-up of the unrelated full-suite failure passed 39 tests.
- [x] `SKIP_SIDECAR=1 bash scripts/build.sh` — release app assembled and signed.
- [x] `codesign --verify --deep --strict --verbose=2 build/Rapid-MLX\ Desktop.app` — passed.
- [x] `git diff --check` and staged secret-pattern audit — passed.
- [x] `PR_VALIDATE_NO_CODEX=1 python3.12 -m scripts.pr_validate 2304 -v` — `MERGE-SAFE`; 18,597 full-unit tests passed. The extra Codex step was skipped because scoped review already reached LGTM in PR-wide round 6/10.
- [x] Earlier `full-ci` on `9833f074` — Swift build/test, release-shaped GUI app, accessibility gates, all 6 golden-flow shards, and the `desktop-tests` facade passed.
- [x] Final local Release build and strict codesign verification rerun for `d78ab732` — passed.
- [x] Previous `full-ci` run `32782523175` on `d78ab732` — all 13 jobs passed, including Swift build/test, release-shaped GUI app, accessibility gates, all 6 golden-flow shards, and the `desktop-tests` facade.
- [x] Merge-head reconciliation for `a36ea9f1` — `range-diff` reports all 7 PR commits unchanged, the PR patch-id is identical before and after the merge, and the merged base change touches only unrelated audio files.
- [x] Fresh `full-ci` run `32788616716` on `a36ea9f1` — all 13 jobs passed; this current-head result supersedes the old-head landing evidence.

Two full `swift test` runs executed all 2,772 tests. The new recovery suite passed in both runs. The runs ended non-green because unrelated short-timeout asynchronous tests failed non-deterministically under full parallel load (4 issues, then 8 issues across different suites). An isolated rerun of the initially failing suite passed 39/39; a separate clean-base run passed all 2,766 baseline tests. Independent PR CI remains the final full-suite evidence.

## Checklist

- [x] Focused and proportional Desktop tests pass locally.
- [x] Local Desktop release build passes.
- [x] New behavior has regression coverage and the test exercises the real first-chat tool loop.
- [x] Documentation is not applicable; the user-facing contract is captured in tests and the recovery note.
- [x] No breaking public API change.

Scoped Codex review reached LGTM on `d78ab732` in repository review round 6. The merge-head range-diff is patch-equivalent, so it introduces no non-equivalent delta requiring another review round. Fresh full-ci passed on `a36ea9f1`. The repository owner subsequently merged the PR; no release was performed as part of this work.
