### PR TITLE
fix(desktop): keep conversation model resident during dictation

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -119,10 +119,9 @@ final class AudioViewModel {
         isLoadingVoices = true
         errorMessage = nil
         defer { isLoadingVoices = false }
-        guard await server.ensureServing(
+        guard await ensureVoiceLane(
             alias: entry.alias,
-            hfPath: entry.hfRepo,
-            residencyEligible: false
+            hfPath: entry.hfRepo
         ) else {
             errorMessage = "The speech model couldn't start. Audio support may be unavailable in this app build."
             return false
@@ -161,10 +160,9 @@ final class AudioViewModel {
         errorMessage = nil
         synthesizedAudio = nil
         defer { isSynthesizing = false }
-        guard await server.ensureServing(
+        guard await ensureVoiceLane(
             alias: entry.alias,
-            hfPath: entry.hfRepo,
-            residencyEligible: false
+            hfPath: entry.hfRepo
         ) else {
             errorMessage = "The speech model is no longer running. Load its voices and try again."
             return
@@ -193,10 +191,9 @@ final class AudioViewModel {
         errorMessage = nil
         defer { previewingVoice = nil }
 
-        guard await server.ensureServing(
+        guard await ensureVoiceLane(
                   alias: entry.alias,
-                  hfPath: entry.hfRepo,
-                  residencyEligible: false
+                  hfPath: entry.hfRepo
               ),
               !Task.isCancelled else {
             if !Task.isCancelled {
@@ -402,9 +399,16 @@ final class AudioViewModel {
         }
     }
 
-    func wouldReplaceServingModel(alias: String) -> String? {
-        guard let serving = server.servingAlias, serving != alias else { return nil }
-        return serving
+    /// Ensure a server is reachable for a voice (STT/TTS) request, reusing the
+    /// app's primary LLM/VLM process so speech co-loads alongside the chat
+    /// model instead of replacing it.
+    ///
+    /// See ``ServerManager.ensureVoiceLane`` for the co-load-or-fallback
+    /// contract. Returns false only when no server can be brought up at all
+    /// (e.g. the voice model's weights couldn't start), mirroring the old swap
+    /// contract so call sites can keep their error messaging.
+    func ensureVoiceLane(alias: String, hfPath: String?) async -> Bool {
+        await server.ensureVoiceLane(alias: alias, hfPath: hfPath)
     }
 
     func resolveSelections() {

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -417,10 +417,12 @@ final class DictationController {
 
     /// Brings the transcription model up.
     ///
-    /// Audio models must pass `residencyEligible: false`: the residency path
-    /// loads in-process, which the audio sidecar does not support, so the
-    /// server has to swap the whole process instead. Getting this wrong fails
-    /// at request time with nothing to distinguish it from a missing model.
+    /// Voice co-loading: when the app is already serving a chat LLM/VLM, the
+    /// voice lane mounts in that same process (``--enable-audio``), so dictation
+    /// reuses the primary server instead of swapping it away — LLM/VLM + speech
+    /// run side by side. Only when no primary model is up do we serve the
+    /// transcription model as its own audio process. See
+    /// ``ServerManager.ensureVoiceLane``.
     @discardableResult
     private func ensureModelServing(alias requestedAlias: String? = nil) async -> Bool {
         let alias = requestedAlias ?? modelAlias
@@ -432,11 +434,7 @@ final class DictationController {
         guard let facts = await catalogFacts(for: alias), facts.cached else {
             return false
         }
-        return await server.ensureServing(
-            alias: alias,
-            hfPath: facts.repo,
-            residencyEligible: false
-        )
+        return await server.ensureVoiceLane(alias: alias, hfPath: facts.repo)
     }
 
     private func catalogFacts(for alias: String) async -> CatalogFacts? {

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -458,21 +458,23 @@ final class DictationController {
     }
 
     /// Loads the model ahead of the first hotkey press. Without this the first
-    /// dictation of a session pays for a process swap while the user is
-    /// already talking. Never a download: ``ensureModelServing`` refuses
+    /// dictation of a session pays for loading the STT engine while the user
+    /// is already talking. Never a download: ``ensureModelServing`` refuses
     /// models that aren't on disk.
     ///
-    /// Three costs move off the hotkey path here, in order:
+    /// The costs move off the hotkey path here, in order:
     /// 1. The alias→repo catalog lookup. On a cache miss ``catalogFacts``
     ///    spawns `rapid-mlx` CLI subprocesses — one to three SECONDS of cold
     ///    interpreter — and the old early-return below skipped it exactly when
     ///    the sidecar was already serving this model, so the most common warm
     ///    session still paid it inside the first transcription.
-    /// 2. The process swap, when another model is being served.
+    /// 2. The STT engine co-load: when a primary chat model is up, dictation
+    ///    reuses its server (voice co-loading) and the engine lazy-loads on the
+    ///    first request; when nothing is up, a fresh audio server must start.
     /// 3. The STT weights: the engine loads them lazily on the first
     ///    transcription of each process lifetime (measured ~1.2 s for
     ///    parakeet), so ``warmUpEngine()`` sends a beat of silence to make
-    ///    the sidecar pay that now instead of inside the user's first real
+    ///    the server pay that now instead of inside the user's first real
     ///    dictation.
     /// - Parameter replacingCurrent: pass `true` when the model CHANGED —
     ///   an in-flight prewarm is then warming the wrong model and must be
@@ -544,7 +546,11 @@ final class DictationController {
     /// serialises transcriptions, so a probe would queue in front of it.
     private func warmUpEngine() async -> Bool {
         guard phase == .idle || phase == .preparingModel else { return false }
-        guard server.servingAlias == modelAlias else { return false }
+        // A live conversation server owns the lazy audio lane; otherwise the
+        // audio-only fallback must itself be serving this transcription model.
+        guard server.servingAlias == modelAlias || server.voiceCoLoadsOnPrimary else {
+            return false
+        }
         if let testingWarmup { return await testingWarmup() }
         do {
             _ = try await client.transcribe(
@@ -755,8 +761,9 @@ final class DictationController {
 
         let started = Date()
         // Phase timing: "how long was that" is unanswerable from one opaque
-        // number when the cost can hide in catalog resolution, a model swap,
-        // or inference. The split is surfaced in the Dictation tab.
+        // number when the cost can hide in catalog resolution, a cold
+        // co-load of the STT engine, or inference. The split is surfaced in
+        // the Dictation tab.
         let ensureStarted = Date()
         guard await ensureModelServing(alias: alias) else {
             guard transcribeRequestID == requestID, modelAlias == alias else { return }
@@ -766,7 +773,7 @@ final class DictationController {
             } else if facts?.cached != true {
                 lastError = "\(alias) isn't downloaded. Open Rapid → Audio to download it."
             } else {
-                lastError = "\(alias) couldn't start. There may not be enough memory to swap models."
+                lastError = "\(alias) couldn't start. There may not be enough memory to load it alongside the conversation model."
             }
             // The user is mid-flow in another app with only the HUD visible.
             // Leaving "Transcribing…" up while silently failing reads as a

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -124,6 +124,7 @@ final class DictationController {
     private let testingPrewarm: (@MainActor () async -> Bool)?
     private let testingWarmup: (@MainActor () async -> Bool)?
     private let testingHotkeyStart: (@MainActor () -> Bool)?
+    private let testingRecorderStart: (@MainActor () throws -> Void)?
     private let testingRecorderCancel: (@MainActor () -> Void)?
     private let testingTranscribeCancel: (@MainActor () -> Void)?
 
@@ -170,6 +171,7 @@ final class DictationController {
         testingPrewarm: (@MainActor () async -> Bool)? = nil,
         testingWarmup: (@MainActor () async -> Bool)? = nil,
         testingHotkeyStart: (@MainActor () -> Bool)? = nil,
+        testingRecorderStart: (@MainActor () throws -> Void)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
         testingTranscribeCancel: (@MainActor () -> Void)? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
@@ -185,6 +187,7 @@ final class DictationController {
         self.testingPrewarm = testingPrewarm
         self.testingWarmup = testingWarmup
         self.testingHotkeyStart = testingHotkeyStart
+        self.testingRecorderStart = testingRecorderStart
         self.testingRecorderCancel = testingRecorderCancel
         self.testingTranscribeCancel = testingTranscribeCancel
 
@@ -304,7 +307,7 @@ final class DictationController {
             selectedAlias: modelAlias,
             preparingAlias: preparingAlias,
             isPreparing: phase == .preparingModel,
-            servingAlias: server.servingAlias
+            voiceLaneReady: server.isVoiceLaneReady(for: preparingAlias)
         )) else {
             if isEnabled, enableRequestID == requestID, modelAlias == preparingAlias {
                 lastError = "\(preparingAlias) couldn't load. There may not be enough memory to start dictation."
@@ -521,7 +524,7 @@ final class DictationController {
         // disable() or a model change to land. Re-check before each step
         // that mutates the sidecar or touches the wire.
         guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
-        if server.servingAlias != alias {
+        if !server.isVoiceLaneReady(for: alias) {
             guard await ensureModelServing(alias: alias) else { return false }
             guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         }
@@ -529,7 +532,7 @@ final class DictationController {
         guard !Task.isCancelled,
               isEnabled,
               modelAlias == alias,
-              server.servingAlias == alias else { return false }
+              server.isVoiceLaneReady(for: alias) else { return false }
         if warmed {
             lastWarmupWarning = nil
         } else {
@@ -548,7 +551,7 @@ final class DictationController {
         guard phase == .idle || phase == .preparingModel else { return false }
         // A live conversation server owns the lazy audio lane; otherwise the
         // audio-only fallback must itself be serving this transcription model.
-        guard server.servingAlias == modelAlias || server.voiceCoLoadsOnPrimary else {
+        guard server.isVoiceLaneReady(for: modelAlias) else {
             return false
         }
         if let testingWarmup { return await testingWarmup() }
@@ -648,7 +651,7 @@ final class DictationController {
             return
         }
         let requestedAlias = modelAlias
-        guard server.servingAlias == requestedAlias else {
+        guard server.isVoiceLaneReady(for: requestedAlias) else {
             hotkey.stop()
             phase = .preparingModel
             beginRecordingTask = nil
@@ -677,7 +680,11 @@ final class DictationController {
             return
         }
         do {
-            try recorder.startCapture()
+            if let testingRecorderStart {
+                try testingRecorderStart()
+            } else {
+                try recorder.startCapture()
+            }
         } catch {
             lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             refreshReadiness()

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationEnablePolicy.swift
@@ -54,10 +54,12 @@ struct DictationEnablePolicy {
         var selectedAlias: String
         var preparingAlias: String
         var isPreparing: Bool
-        var servingAlias: String?
+        var voiceLaneReady: Bool
     }
 
     /// The sole policy gate before installing the process-global hotkey.
+    /// Readiness is capability-based because a conversation process can own a
+    /// separate, lazily loaded voice lane without changing its serving alias.
     /// Every async identity must still match after model preparation; a stale
     /// completion is never allowed to arm input for a different user state.
     static func mayRegisterHotkey(after state: PreparedState) -> Bool {
@@ -66,6 +68,6 @@ struct DictationEnablePolicy {
             && state.requestIsCurrent
             && state.selectedAlias == state.preparingAlias
             && state.isPreparing
-            && state.servingAlias == state.preparingAlias
+            && state.voiceLaneReady
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -204,6 +204,15 @@ final class ServerManager {
         servingAlias != nil && activeBearer != nil
     }
 
+    /// Whether the selected voice model can receive requests without another
+    /// process transition. An audio-only server is ready when it already owns
+    /// that alias; a conversation server is ready through its mounted lazy
+    /// audio lane. Callers use this capability boundary instead of requiring
+    /// the process-owning alias to equal an auxiliary voice alias.
+    func isVoiceLaneReady(for alias: String) -> Bool {
+        servingAlias == alias || voiceCoLoadsOnPrimary
+    }
+
     /// Bring up a server for a voice (STT/TTS) request, reusing the primary
     /// chat LLM/VLM process when one is already up so voice and text/vision
     /// run side-by-side instead of voice replacing the chat model.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -190,6 +190,44 @@ final class ServerManager {
         return nil
     }
 
+    /// True when the app is already serving a model (a chat LLM/VLM) on the
+    /// current server. When true, speech (STT/TTS) requests should target that
+    /// same server's ``/v1/audio/*`` lane so the chosen voice engine lazy-loads
+    /// alongside the chat model — voice and text/vision run in the SAME
+    /// process (see ``serveArguments``'s unconditional ``--enable-audio``).
+    ///
+    /// Auth is required to target the lane (the bearer secret is minted per
+    /// spawn), so both the ready state AND a live bearer are demanded here;
+    /// this keeps ``AudioViewModel`` from needlessly tearing down the chat
+    /// model just to run a transcription.
+    var voiceCoLoadsOnPrimary: Bool {
+        servingAlias != nil && activeBearer != nil
+    }
+
+    /// Bring up a server for a voice (STT/TTS) request, reusing the primary
+    /// chat LLM/VLM process when one is already up so voice and text/vision
+    /// run side-by-side instead of voice replacing the chat model.
+    ///
+    /// Every spawn carries ``--enable-audio`` (see ``serveArguments``), so the
+    /// current server always has a mountable ``/v1/audio/*`` lane and the
+    /// chosen STT/TTS engine is lazy — it only loads on the first request. That
+    /// means when ``voiceCoLoadsOnPrimary`` is true we can just point audio
+    /// traffic at ``activePort`` and never tear the chat model down. Otherwise
+    /// we fall back to serving the requested voice model as its own process
+    /// (the pre-existing audio-sidecar behaviour), which a caller exercises
+    /// when no primary model is running at all.
+    @discardableResult
+    func ensureVoiceLane(alias: String, hfPath: String?) async -> Bool {
+        if voiceCoLoadsOnPrimary {
+            return true
+        }
+        return await ensureServing(
+            alias: alias,
+            hfPath: hfPath,
+            residencyEligible: false
+        )
+    }
+
     func isModelResident(_ alias: String) -> Bool {
         guard case .ready = state else { return false }
         return residency.contains(alias) || servingAlias == alias
@@ -707,9 +745,11 @@ final class ServerManager {
     internal init(
         testingState: ServerState,
         binaryPath: URL? = nil,
-        residency: ModelResidencySnapshot = .empty
+        residency: ModelResidencySnapshot = .empty,
+        activeBearer: String? = nil
     ) {
         self.state = testingState
+        self.activeBearer = activeBearer
         self.binaryPath = binaryPath
         self.residency = residency
         self.binaryResolution = binaryPath.map {
@@ -3095,6 +3135,16 @@ final class ServerManager {
             alias,
             "--host", host,
             "--port", String(port),
+            // Voice co-loading: mount the ``/v1/audio/*`` lane on EVERY spawned
+            // server so speech (STT/TTS) can run side-by-side with the primary
+            // LLM/VLM in the same process. ``--enable-audio`` tells a text-mode
+            // boot to attach the audio router; the STT/TTS engines stay lazy —
+            // they only load on the first ``/v1/audio/*`` request, so a pure
+            // LLM/VLM user pays no memory for a voice engine they never use. It
+            // is unconditional (not a user opt-in) because the mount is
+            // near-free and the engine is on-demand; ``voiceCoLoadsOnPrimary``
+            // drives the client side of reusing this same server for voice.
+            "--enable-audio",
             // Issue #306: pin an explicit loopback-only CORS allowlist
             // so a future rapid-mlx bundle bump that wires the CORS
             // middleware can't silently re-enable wildcard

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -5,9 +5,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 /// Audio workflows backed by the local OpenAI-compatible routes. The page
-/// deliberately starts no model on appearance: with today's single-model
-/// runtime, a model is swapped only when the user transcribes, loads voices,
-/// or synthesizes speech.
+/// deliberately starts no model on appearance. A voice engine loads only when
+/// the user transcribes, loads voices, or synthesizes speech; when an existing
+/// server exposes the shared audio lane, that engine co-loads in its process.
 struct AudioView: View {
     @Bindable var viewModel: AudioViewModel
     @Bindable var server: ServerManager

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -44,6 +44,19 @@ struct AudioView: View {
     /// Audio uses the same lifecycle SSOT and CTA semantics as Chat and
     /// Images: choose → Download & start / Start → ready.
     private var readiness: ModelReadiness {
+        // Voice co-loading: once the app is serving ANY model on the primary
+        // server, speech is available in the same process — the chosen STT/TTS
+        // engine lazy-loads on the mounted ``/v1/audio/*`` lane whenever an
+        // audio request arrives (the desktop passes ``--enable-audio`` on every
+        // spawn). So with a primary model up AND the voice weights on disk,
+        // the selected audio model is effectively ready without ever replacing
+        // the chat LLM/VLM. When the voice weights aren't cached yet, fall
+        // through so the download/start CTA still appears.
+        if server.voiceCoLoadsOnPrimary,
+           viewModel.audioModels.first(where: { $0.alias == selectedAlias })?.cached == true,
+           !selectedAlias.isEmpty {
+            return .ready(alias: selectedAlias)
+        }
         // Audio-only `serve` processes intentionally report healthy before
         // loading their lazy STT/TTS engine. For an uncached model that
         // process-level signal is not readiness: the first audio request would
@@ -238,7 +251,6 @@ struct AudioView: View {
                 }
 
                 speechSetupCard
-                swapNotice(alias: viewModel.selectedSpeechAlias)
                 operationNotice
 
                 HStack(spacing: RapidTheme.Space.md) {
@@ -615,26 +627,16 @@ struct AudioView: View {
         // model. Keep the completed cache, but do not start the stale choice.
         guard selectedAlias == alias else { return }
         let entry = viewModel.audioModels.first { $0.alias == alias }
-        _ = await server.ensureServing(
+        // Voice co-loading: when the app is already serving a chat LLM/VLM,
+        // reuse that process (the engine lazy-loads on the /v1/audio/* lane)
+        // instead of tearing it down to run the voice model alone. Only when
+        // nothing is running does this spin the voice model up as its own
+        // server — see AudioViewModel.ensureVoiceLane for the branch.
+        _ = await viewModel.ensureVoiceLane(
             alias: alias,
-            hfPath: entry?.hfRepo,
-            estimatedMemoryGB: ModelSizing.residentEstimateGB(
-                alias: alias,
-                sizeText: entry?.sizeOnDisk
-            ),
-            residencyEligible: false
+            hfPath: entry?.hfRepo
         )
         await viewModel.refreshCatalog()
-    }
-
-    @ViewBuilder
-    private func swapNotice(alias: String) -> some View {
-        if let running = viewModel.wouldReplaceServingModel(alias: alias) {
-            InlineNotice(
-                message: "Starting \(alias) will stop \(running). This version runs one model at a time.",
-                tone: .info
-            )
-        }
     }
 
     @ViewBuilder

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -319,7 +319,11 @@ struct AudioCatalogTests {
         let cacheProof = try #require(source.range(
             of: "guard viewModel.audioModels.first(where: { $0.alias == alias })?.cached == true"
         ))
-        let serve = try #require(source.range(of: "_ = await server.ensureServing(", options: .backwards))
+        // Voice co-loading routes activation through ``ensureVoiceLane`` (reuse
+        // the primary server / fall back to a voice-only one) instead of a raw
+        // ``server.ensureServing`` — the ordering guarantee download-then-serve
+        // is what this pins, not the specific spawning call.
+        let serve = try #require(source.range(of: "_ = await viewModel.ensureVoiceLane(", options: .backwards))
 
         #expect(pull.lowerBound < wait.lowerBound)
         #expect(wait.lowerBound < cacheProof.lowerBound)

--- a/apps/rapid-mac/Tests/RapidTests/DictationEnablePolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationEnablePolicyTests.swift
@@ -51,12 +51,12 @@ struct DictationEnablePolicyTests {
     @Test(
         "hotkey registration requires every post-warmup identity boundary",
         arguments: [
-            (false, true, true, "whisper-small", "whisper-small", true, "whisper-small"),
-            (true, false, true, "whisper-small", "whisper-small", true, "whisper-small"),
-            (true, true, false, "whisper-small", "whisper-small", true, "whisper-small"),
-            (true, true, true, "qwen-asr", "whisper-small", true, "whisper-small"),
-            (true, true, true, "whisper-small", "whisper-small", false, "whisper-small"),
-            (true, true, true, "whisper-small", "whisper-small", true, "other-model"),
+            (false, true, true, "whisper-small", "whisper-small", true, true),
+            (true, false, true, "whisper-small", "whisper-small", true, true),
+            (true, true, false, "whisper-small", "whisper-small", true, true),
+            (true, true, true, "qwen-asr", "whisper-small", true, true),
+            (true, true, true, "whisper-small", "whisper-small", false, true),
+            (true, true, true, "whisper-small", "whisper-small", true, false),
         ]
     )
     func stalePreparedStateCannotArm(
@@ -66,7 +66,7 @@ struct DictationEnablePolicyTests {
         selectedAlias: String,
         preparingAlias: String,
         preparing: Bool,
-        servingAlias: String
+        voiceLaneReady: Bool
     ) {
         #expect(!DictationEnablePolicy.mayRegisterHotkey(after: .init(
             prewarmSucceeded: prewarm,
@@ -75,12 +75,12 @@ struct DictationEnablePolicyTests {
             selectedAlias: selectedAlias,
             preparingAlias: preparingAlias,
             isPreparing: preparing,
-            servingAlias: servingAlias
+            voiceLaneReady: voiceLaneReady
         )))
     }
 
-    @Test("only the current ready model may register the hotkey")
-    func currentPreparedModelMayArm() {
+    @Test("the current prepared voice lane may register the hotkey")
+    func currentPreparedVoiceLaneMayArm() {
         #expect(DictationEnablePolicy.mayRegisterHotkey(after: .init(
             prewarmSucceeded: true,
             isEnabled: true,
@@ -88,7 +88,7 @@ struct DictationEnablePolicyTests {
             selectedAlias: "whisper-small",
             preparingAlias: "whisper-small",
             isPreparing: true,
-            servingAlias: "whisper-small"
+            voiceLaneReady: true
         )))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -410,6 +410,50 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("co-loaded dictation arms and records while the conversation alias stays primary")
+    func coLoadedConversationLaneArmsAndRecords() async {
+        var hotkeyStartCount = 0
+        var recorderStartCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let server = ServerManager(
+            testingState: .ready(alias: "qwen3-0.6b-4bit"),
+            binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx"),
+            activeBearer: "test-bearer"
+        )
+        let controller = DictationController(
+            server: server,
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: { true },
+            testingHotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            },
+            testingRecorderStart: { recorderStartCount += 1 },
+            audioCatalogLoader: { _ in [entry] }
+        )
+
+        await controller.enable()
+
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+        #expect(server.servingAlias == "qwen3-0.6b-4bit")
+
+        controller.toggleFromUI()
+        while recorderStartCount == 0 { await Task.yield() }
+
+        #expect(controller.phase == .starting)
+        #expect(recorderStartCount == 1)
+        #expect(server.servingAlias == "qwen3-0.6b-4bit")
+    }
+
+    @MainActor
     @Test("disabling during model warmup cannot register a stale hotkey")
     func disableDuringWarmupDoesNotArmHotkey() async {
         var continuation: CheckedContinuation<Bool, Never>?

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -231,10 +231,12 @@ final class MCPConnectorsTests {
         #expect(corsIdx < idx)
     }
 
-    @Test("serveArguments is unchanged when no MCP config path is supplied")
+    @Test("serveArguments omits --mcp-config when no path is supplied")
     func serveArgumentsOmitsMCPConfigByDefault() {
-        // A user who never turns connectors on must get the exact pre-#1716
-        // argv — no new flag, no behaviour change.
+        // A user who never turns connectors on must NOT get --mcp-config in
+        // argv — no connector behaviour change. (The voice co-loading flag
+        // ``--enable-audio`` is unrelated and intentionally present always.
+        // ``--cors-origins`` still terminates the flag list.)
         let argv = ServerManager.serveArguments(
             alias: "qwen3.5-4b-4bit",
             host: "127.0.0.1",
@@ -246,6 +248,7 @@ final class MCPConnectorsTests {
             "qwen3.5-4b-4bit",
             "--host", "127.0.0.1",
             "--port", "8000",
+            "--enable-audio",
             "--cors-origins", "http://127.0.0.1", "http://localhost",
         ])
     }

--- a/apps/rapid-mac/Tests/RapidTests/SpawnArgumentsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SpawnArgumentsTests.swift
@@ -178,7 +178,7 @@ struct SpawnArgumentsTests {
 
     // MARK: - argv shape
 
-    @Test("serve argv has exactly serve + alias + --host + --port + --cors-origins loopback allowlist")
+    @Test("serve argv has exactly serve + alias + --host + --port + --enable-audio + --cors-origins loopback allowlist")
     func argvIsExactlyExpectedShape() {
         let argv = ServerManager.serveArguments(
             alias: "qwen3.5-4b-4bit",
@@ -190,13 +190,36 @@ struct SpawnArgumentsTests {
         // further argv element that could be misparsed as an
         // additional origin. Keeping ``--cors-origins`` last in the
         // builder satisfies that constraint without a brittle escape.
+        // ``--enable-audio`` precedes it (still before ``--cors-origins``
+        // so the CORS values stay the tail of the flag's ``nargs="+"``).
         #expect(argv == [
             "serve",
             "qwen3.5-4b-4bit",
             "--host", "127.0.0.1",
             "--port", "8000",
+            "--enable-audio",
             "--cors-origins", "http://127.0.0.1", "http://localhost",
         ])
+    }
+
+    @Test("serve argv mounts the voice lane via --enable-audio")
+    func argvMountsVoiceLane() {
+        // Voice co-loading relies on EVERY spawned server mounting
+        // ``/v1/audio/*``. Pin that the flag is present AND sits before
+        // ``--cors-origins`` so it never gets absorbed into that flag's
+        // greedy ``nargs="+"`` collection.
+        let argv = ServerManager.serveArguments(
+            alias: "qwen3.5-4b-4bit",
+            host: "127.0.0.1",
+            port: 8000
+        )
+        #expect(argv.contains("--enable-audio"))
+        if let audioIndex = argv.firstIndex(of: "--enable-audio"),
+           let corsIndex = argv.firstIndex(of: "--cors-origins") {
+            #expect(audioIndex < corsIndex, "--enable-audio must precede --cors-origins")
+        } else {
+            Issue.record("serve argv must carry both --enable-audio and --cors-origins")
+        }
     }
 
     @Test("serve argv NEVER carries --api-key (bearer must travel via env)")

--- a/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Voice co-loading: speech (STT/TTS) should run side-by-side with the
+/// primary chat LLM/VLM instead of replacing it. The desktop mounts an
+/// ``/v1/audio/*`` lane on every server (unconditional ``--enable-audio``) and
+/// lazy-loads the chosen voice engine on demand, so when a model is already
+/// serving we can reuse that process for audio. These tests pin the two
+/// decisions that make "voice + LLM/VLM coexist" true:
+///
+/// * ``ServerManager.voiceCoLoadsOnPrimary`` — is there a live primary server
+///   (ready + authed) whose ``/v1/audio/*`` lane audio can target?
+/// * ``ServerManager.ensureVoiceLane`` — reuse that primary process when
+///   possible, otherwise (nothing running) fall back to serving the voice
+///   model as its own audio-only process.
+@Suite("Voice co-loader (voice + LLM/VLM together)")
+@MainActor
+struct VoiceCoLoadTests {
+
+    // MARK: - voiceCoLoadsOnPrimary
+
+    @Test("no server -> voice does not co-load")
+    func notCoLoadedWhenIdle() {
+        let server = ServerManager(testingState: .idle)
+        #expect(server.voiceCoLoadsOnPrimary == false, "idle server cannot host the voice lane")
+    }
+
+    @Test("ready model without a bearer -> not co-loaded (needs auth to target the lane)")
+    func notCoLoadedWithoutBearer() {
+        let server = ServerManager(testingState: .ready(alias: "qwen3.6-27b-4bit"))
+        #expect(server.activeBearer == nil)
+        #expect(server.voiceCoLoadsOnPrimary == false, "targeting the lane requires the minted bearer")
+    }
+
+    @Test("ready model with a bearer -> voice co-loads on the primary server")
+    func coLoadedWhenReadyAndAuthed() {
+        let server = ServerManager(
+            testingState: .ready(alias: "qwen3.6-27b-4bit"),
+            activeBearer: "test-bearer"
+        )
+        #expect(server.servingAlias == "qwen3.6-27b-4bit")
+        #expect(server.voiceCoLoadsOnPrimary == true)
+    }
+
+    @Test("mid-start is not co-loaded (no live serving alias yet)")
+    func notCoLoadedWhileStarting() {
+        let server = ServerManager(
+            testingState: .starting(alias: "qwen3.6-27b-4bit"),
+            activeBearer: "test-bearer"
+        )
+        #expect(server.voiceCoLoadsOnPrimary == false)
+    }
+
+    // MARK: - ensureVoiceLane
+
+    @Test("co-loaded primary is reused without spawning a replacement")
+    func ensureVoiceLaneReusesPrimary() async {
+        let server = ServerManager(
+            testingState: .ready(alias: "qwen3.6-27b-4bit"),
+            activeBearer: "test-bearer"
+        )
+        // Must succeed immediately (reuse) even though no voice model binary
+        // could ever be spawned in this test harness — proving we are NOT
+        // swapping the process.
+        let result = await server.ensureVoiceLane(alias: "whisper-tiny", hfPath: nil)
+        #expect(result == true)
+        // The primary chat model is untouched by the voice request.
+        #expect(server.servingAlias == "qwen3.6-27b-4bit")
+    }
+
+    @Test("with nothing running, voice falls back to its own server")
+    func ensureVoiceLaneFallsBackWhenNothingRunning() async {
+        // No binary → the fallback start short-circuits to .missing and fails
+        // closed, which is the truthful "not available" answer. The point of
+        // this test is that a voice request does NOT tear down a primary model
+        // (there is none) — it just reports it cannot start.
+        let server = ServerManager(testingState: .idle)
+        let result = await server.ensureVoiceLane(alias: "whisper-tiny", hfPath: nil)
+        #expect(result == false)
+    }
+
+}

--- a/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
@@ -80,4 +80,25 @@ struct VoiceCoLoadTests {
         #expect(result == false)
     }
 
+    @Test("crashed / stopped server is never co-loaded (no live serving alias)")
+    func notCoLoadedWhenCrashedOrStopped() {
+        let crashed = ServerManager(
+            testingState: .crashed(alias: "qwen3.6-27b-4bit", message: "boom"),
+            activeBearer: "test-bearer"
+        )
+        #expect(crashed.voiceCoLoadsOnPrimary == false)
+        let stopped = ServerManager(testingState: .stopped, activeBearer: "test-bearer")
+        #expect(stopped.voiceCoLoadsOnPrimary == false)
+    }
+
+    @Test("voice co-load requires BOTH a live model AND a bearer")
+    @MainActor
+    func coLoadRequiresBothReadyAndAuthed() {
+        // Bearer but no model.
+        let bearerOnly = ServerManager(testingState: .idle, activeBearer: "b")
+        #expect(bearerOnly.voiceCoLoadsOnPrimary == false)
+        // Model but no bearer.
+        let readyNoAuth = ServerManager(testingState: .ready(alias: "qwen3.6-27b-4bit"))
+        #expect(readyNoAuth.voiceCoLoadsOnPrimary == false)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
@@ -41,6 +41,7 @@ struct VoiceCoLoadTests {
         )
         #expect(server.servingAlias == "qwen3.6-27b-4bit")
         #expect(server.voiceCoLoadsOnPrimary == true)
+        #expect(server.isVoiceLaneReady(for: "whisper-small") == true)
     }
 
     @Test("mid-start is not co-loaded (no live serving alias yet)")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4769,10 +4769,22 @@ flow_dictation() {
     # enabling speech input must reuse the mounted audio lane, never replace
     # the conversation process with a transcription-only server.
     start_model
+    send_prompt "Conversation state before dictation" "dictation-before"
+    local i conversation_id=""
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/chat-before-dictation.json"
+        conversation_id="$(jq -r '.data.ui_elements[] | (.identifier // "")
+            | select(test("^Sidebar\\.Conversation\\.[0-9A-Fa-f-]{36}$"))' \
+            "$OUT/chat-before-dictation.json" | head -1)"
+        [[ -n "$conversation_id" ]] && break
+        sleep 0.1
+    done
+    [[ -n "$conversation_id" ]] \
+        || die "Dictation precondition produced no conversation row"
     press "$OUT/chat.json" Sidebar.Audio "$OUT/dictation-open.json" \
         || die "Sidebar.Audio is not pressable"
 
-    local i controls_ready=0
+    local controls_ready=0
     for ((i=0; i<80; i++)); do
         see_main "$OUT/dictation.json"
         if jq -e '[.data.ui_elements[]?
@@ -4886,9 +4898,11 @@ flow_dictation() {
         "$OUT/fake-events.jsonl" >/dev/null \
         || die "Dictation did not preserve the active conversation alias"
 
-    press "$OUT/dictation-ready.json" Sidebar.Chat "$OUT/chat-after-dictation.json" \
-        || die "Chat is not reachable after Dictation warmup"
+    press "$OUT/dictation-ready.json" "$conversation_id" "$OUT/chat-after-dictation.json" \
+        || die "The existing conversation is not reachable after Dictation warmup"
     wait_send_idle "$OUT/chat-after-dictation-ready.json"
+    assert_tree_text "$OUT/chat-after-dictation-ready.json" \
+        "Conversation state before dictation"
     send_prompt "Conversation survives dictation" "dictation-chat"
 
     log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, and preserved chat produced effects"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4763,6 +4763,12 @@ flow_dictation() {
         FAKE_AUDIO_TRANSCRIPTION_DELAY_MS=1800
     dismiss_first_run
     see_main "$OUT/chat.json"
+
+    # Dictation is an input method for the active conversation. Start that
+    # conversation first so this journey detects the release-blocking failure:
+    # enabling speech input must reuse the mounted audio lane, never replace
+    # the conversation process with a transcription-only server.
+    start_model
     press "$OUT/chat.json" Sidebar.Audio "$OUT/dictation-open.json" \
         || die "Sidebar.Audio is not pressable"
 
@@ -4826,10 +4832,9 @@ flow_dictation() {
     press "$OUT/speech-ready.json" Audio.Mode.Dictation "$OUT/dictation-return.json" \
         || die "Dictation mode is not pressable after visiting Speech"
     wait_identifier Dictation.Enable "$OUT/dictation-restored.json"
-    if jq -e -s 'any(.[]; .event == "server_started")' "$OUT/fake-events.jsonl" \
-        >/dev/null 2>&1; then
-        die "Opening and configuring Dictation started a model before dictation"
-    fi
+    [[ "$(jq -rs 'map(select(.event == "server_started")) | length' \
+            "$OUT/fake-events.jsonl")" == 1 ]] \
+        || die "Opening and configuring Dictation started another server"
 
     # Enabling is a readiness operation, not merely a preference flip. Hold
     # the fake STT probe open long enough to observe the contract in AX: the
@@ -4871,7 +4876,22 @@ flow_dictation() {
     [[ "$ready_seen" == 1 ]] \
         || die "Dictation did not become Ready after model warmup"
 
-    log "  setup controls, privacy toggle, vocabulary, mode round-trip, and Loading -> Ready produced effects"
+    # The warmup request must have stayed on the conversation server. A
+    # transcription-only start here is the exact silent-eviction regression.
+    [[ "$(jq -rs 'map(select(.event == "server_started")) | length' \
+            "$OUT/fake-events.jsonl")" == 1 ]] \
+        || die "Dictation replaced the active conversation server"
+    jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias")
+              and (any(.[]; .event == "server_started" and .alias == "fake-whisper-small") | not)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "Dictation did not preserve the active conversation alias"
+
+    press "$OUT/dictation-ready.json" Sidebar.Chat "$OUT/chat-after-dictation.json" \
+        || die "Chat is not reachable after Dictation warmup"
+    wait_send_idle "$OUT/chat-after-dictation-ready.json"
+    send_prompt "Conversation survives dictation" "dictation-chat"
+
+    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, and preserved chat produced effects"
     log "  dictation OK"
     cleanup_persona
 }


### PR DESCRIPTION
## Intention

Fix the release-blocking ordinary dictation workflow: starting, using, cancelling, or failing speech input must not evict or restart the active conversation model or lose its state.

This is stacked on #2282, which supplies the server-owned audio worker and lifecycle contract.

## Scope

- Mount the lazy audio lane on every Desktop-launched server.
- Reuse a ready authenticated conversation server for speech input/output requests.
- Fall back to an audio-only server only when no primary model is running.
- Route Dictation and Audio through the role-specific voice-lane contract.
- Report voice readiness from the shared lane without changing the primary conversation alias.
- Add deterministic lifecycle tests and strengthen the Dictation GUI journey to prove warmup does not start a replacement server and chat remains usable afterward.

## Explicit non-goals

- Combined capacity accounting or a new memory-ceiling policy.
- Audio idle-TTL/unload policy.
- Insufficient-memory conflict-choice UI.
- An exhaustive four-role capacity/GUI matrix.
- Public API shape changes or broad model-manager redesign.
- Merge or release.

Deferred work is tracked in #2305 and #2306.

## Constraints

- No model-name/hash residency inference.
- No regex-only protocol patch or private engine-topology traversal.
- The active LLM/VLM process and conversation state remain untouched across speech lifecycle outcomes.
- Existing audio-only serving remains the no-primary fallback.

## Acceptance criteria

- A ready conversation server is reused for ASR instead of being stopped or restarted.
- Cancellation and failure isolation remain owned by the server audio lifecycle and cannot tear down the conversation engine.
- Server residency identifies the primary conversation model and auxiliary STT lane independently.
- Deterministic Desktop lifecycle tests pass.
- A local bundled-sidecar chat → real transcription → chat sequence succeeds with the same primary model resident throughout.

## Verification

- Baseline reproduction: the previous Desktop contract explicitly routed audio through global stop/start and launched no audio lane.
- Focused Desktop suites: 119 passed across voice co-load, Dictation, spawn arguments, audio catalog, and adjacent connector coverage.
- Final CI-shaped Desktop suite: 2773 tests in 240 suites passed with serial execution.
- Server audio/lifecycle regression: 150 passed; one unchanged capability-probe baseline failure. This branch has no Python diff relative to #2282.
- Full local release app build succeeded; bundled sidecar assembled and the app passed strict deep signature verification.
- Local Apple Silicon E2E using the built bundle: conversation chat returned HTTP 200, Whisper Small transcribed the WAV fixture, chat returned HTTP 200 afterward, residency kept the same primary model and reported STT as a separate resident lane, and graceful shutdown unloaded STT before stopping the primary engine.
- The strengthened GUI journey is committed for CI; local execution was precondition-blocked because the Mac screen was locked.

Relates to #2300. This PR covers the no-eviction dictation path; the deferred capacity, idle-unload, conflict-choice, and exhaustive role-matrix acceptance remains tracked in #2305 and #2306.