### PR TITLE
feat(mac): make Connect your agents useful before an engine starts

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -201,11 +201,10 @@ enum DevSnapshot {
                         .fill(RapidTheme.hairline)
                         .frame(width: 1)
 
-                    LaunchView(
+                    LaunchPreviewHost(
                         server: server,
-                        alias: "bonsai-1.7b-2bit",
-                        readiness: readiness,
-                        onReadinessAction: { _ in }
+                        downloads: downloads,
+                        readiness: readiness
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(RapidTheme.surfaceCanvas)
@@ -850,14 +849,13 @@ enum DevSnapshot {
         // renders faithfully — unlike the NSViewRepresentable composer).
         render(
             AnyView(
-                ConnectToolsView(
-                    host: "127.0.0.1", port: 8000,
-                    bearer: "rapid-sk-demo1234567890abcdef",
-                    alias: "bonsai-1.7b-2bit", onClose: {}
-                ).cardContent
-                    .frame(width: 460)
-                    .background(RapidTheme.canvas)
-                    .tint(RapidTheme.brand)
+                ConnectToolsCardHost(
+                    server: server,
+                    downloads: downloads
+                )
+                .frame(width: 460)
+                .background(RapidTheme.canvas)
+                .tint(RapidTheme.brand)
             ),
             to: "\(dir)/connect-tools.png"
         )
@@ -1464,5 +1462,47 @@ private struct SettingsControlProofSheet: View {
         .frame(width: 560, alignment: .leading)
         .background(RapidTheme.surfaceCanvas)
         .tint(RapidTheme.brandAmber)
+    }
+}
+
+/// Dev-snapshot host for the Launch page. Owns the model-alias `@State`
+/// so ``ConnectToolsView`` can take a `@Binding` to it (its stopped state
+/// embeds the reusable model picker), then renders the real ``LaunchView``
+/// exactly as ``ContentView`` would.
+private struct LaunchPreviewHost: View {
+    @Bindable var server: ServerManager
+    @Bindable var downloads: DownloadManager
+    var readiness: ModelReadiness? = nil
+    @State private var alias: String = "bonsai-1.7b-2bit"
+
+    var body: some View {
+        LaunchView(
+            server: server,
+            downloads: downloads,
+            alias: $alias,
+            readiness: readiness,
+            onReadinessAction: { _ in }
+        )
+    }
+}
+
+/// Dev-snapshot host for the standalone "Connect your agents" card (the
+/// pure-SwiftUI sheet scene). Renders ``ConnectToolsView.cardContent`` on a
+/// fixed frame, owning the same model-alias state the page now binds.
+private struct ConnectToolsCardHost: View {
+    @Bindable var server: ServerManager
+    @Bindable var downloads: DownloadManager
+    @State private var alias: String = "bonsai-1.7b-2bit"
+
+    var body: some View {
+        ConnectToolsView(
+            host: "127.0.0.1",
+            port: 8000,
+            bearer: "rapid-sk-demo1234567890abcdef",
+            alias: $alias,
+            server: server,
+            downloads: downloads,
+            onClose: {}
+        ).cardContent
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -1489,9 +1489,17 @@ private struct LaunchPreviewHost: View {
 /// Dev-snapshot host for the standalone "Connect your agents" card (the
 /// pure-SwiftUI sheet scene). Renders ``ConnectToolsView.cardContent`` on a
 /// fixed frame, owning the same model-alias state the page now binds.
+///
+/// ``readiness`` defaults to the stopped state (model chosen, not serving)
+/// so ``connect-tools.png`` exercises the picker + readiness banner that
+/// #2297 always renders — the same non-`nil` value the real ``ContentView``
+/// supplies. Without it the scene would fall back to
+/// ``ConnectToolsView``'s `nil` path and never capture the stopped-state UI
+/// this DevSnapshot exists to document.
 private struct ConnectToolsCardHost: View {
     @Bindable var server: ServerManager
     @Bindable var downloads: DownloadManager
+    var readiness: ModelReadiness? = .needsStart(alias: "bonsai-1.7b-2bit")
     @State private var alias: String = "bonsai-1.7b-2bit"
 
     var body: some View {
@@ -1502,7 +1510,8 @@ private struct ConnectToolsCardHost: View {
             alias: $alias,
             server: server,
             downloads: downloads,
-            onClose: {}
+            onClose: {},
+            readiness: readiness
         ).cardContent
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -115,11 +115,34 @@ struct ConnectToolsView: View {
     /// resolved. Anything less and the snippets below would be a
     /// half-filled template.
     private var configReady: Bool {
-        let selectedModelIsServing = readiness?.isReady ?? true
-        return port > 0
-            && !bearer.isEmpty
-            && resolvedModel != nil
-            && selectedModelIsServing
+        Self.configIsReady(
+            hasPort: port > 0,
+            hasBearer: !bearer.isEmpty,
+            modelResolved: resolvedModel != nil,
+            modelServing: readiness?.isReady
+        )
+    }
+
+    /// The single decision behind the page's disabled-Copy gate, factored
+    /// out so the whole truth table is behaviorally testable without a view
+    /// host (the readiness boundary itself is pinned in ``ModelReadiness``).
+    ///
+    /// A snippet is only paste-worthy once the server has a real port, has
+    /// minted a bearer, and a model name is resolved — and, when a readiness
+    /// value is supplied (the live page), that model is actually serving.
+    /// Passing ``modelServing == false`` (the #2297 stopped state) forces the
+    /// config NOT ready even when every static value is present: copying a
+    /// half-filled template is the silent-failure defect the disabled-Copy
+    /// gate exists to prevent. ``nil`` (the dev snapshot harness, which has
+    /// no live server to resolve against) keeps the legacy behavior of
+    /// trusting the static values alone.
+    static func configIsReady(
+        hasPort: Bool,
+        hasBearer: Bool,
+        modelResolved: Bool,
+        modelServing: Bool?
+    ) -> Bool {
+        hasPort && hasBearer && modelResolved && (modelServing ?? true)
     }
 
     /// One concise sentence naming what is missing.

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -293,13 +293,20 @@ struct ConnectToolsView: View {
             // downloaded model before starting, without leaving the page.
             // Composer style renders only the compact chip (no duplicate
             // Start/Stop — the readiness banner below owns the action).
+            //
+            // Deliberately no identifier stamped on the composite. The picker
+            // already names its own controls — the menu popup is
+            // ``ModelPickerBar.ModelMenu`` and the (i) info button is
+            // ``ModelPickerBar.ModelInfo`` — so the golden flow addresses the
+            // picker by ``ModelPickerBar.ModelMenu`` directly. Stamping the
+            // whole bar would propagate one identifier onto both descendants
+            // and make them indistinguishable to AX (and to the harness).
             ModelPickerBar(
                 server: server,
                 downloads: downloads,
                 alias: $alias,
                 composerStyle: true
             )
-            .accessibilityIdentifier("ConnectTools.ModelPicker")
             ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
             Text("When the model is running, the key and model rows below fill in and the Copy buttons wake up.")
                 .font(RapidFont.caption)

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -15,7 +15,23 @@ struct ConnectToolsView: View {
     let host: String
     let port: Int
     let bearer: String
-    let alias: String
+    /// The currently-chosen model. A binding so the inline model picker
+    /// (see ``stoppedSetup``) can change it directly and the shared
+    /// readiness value in ``ContentView`` re-derives from the new choice —
+    /// choosing a different downloaded model then Start both work without
+    /// leaving this page.
+    @Binding var alias: String
+    /// The live server, fed straight to the inline ``ModelPickerBar`` in
+    /// the stopped state so the user can pick any compatible downloaded
+    /// model before starting. Kept as a direct reference (not merely the
+    /// readiness value) because the picker is the app's single
+    /// model-selection source of truth and knows how to read the catalog
+    /// and cache itself — embedding it here beats building a second,
+    /// ad-hoc model list.
+    @Bindable var server: ServerManager
+    /// Side-channel downloader the inline picker's context menu uses
+    /// ("Download in background") and its cache-state glyphs.
+    @Bindable var downloads: DownloadManager
     /// The absolute path to the `rapid-mlx` sidecar binary this app owns
     /// (``ServerLocator`` resolution). The Desktop app deliberately does NOT
     /// install its sidecar onto the user's `PATH` (see ``ServerLocator`` —
@@ -161,14 +177,23 @@ struct ConnectToolsView: View {
             // the composer renders, so the two surfaces cannot disagree,
             // and unlike the old local sentence it carries the action
             // that resolves the problem.
+            //
+            // #2297: the stopped state used to return here — ONLY the
+            // "Start here" banner — and hide the endpoint shape and the
+            // integration rows entirely. That is the exact moment a new
+            // user needs guidance, and they got a mostly-blank page.
+            // The endpoint base URLs are real information even before a
+            // model runs (the loopback address and port are known), and
+            // the setup rows are usable as documentation with Copy gated
+            // on readiness (``configReady`` already disables Copy on
+            // runtime-only values). So the stopped branch now leads with
+            // the pick-and-start flow and STILL renders that static
+            // content below it, marked pending via the existing
+            // ``CopyableRow`` placeholder machinery.
             if let readiness, !readiness.isReady {
-                VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
-                    SectionHeader(
-                        "Start here",
-                        subtitle: "Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands."
-                    )
-                    ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
-                }
+                stoppedSetup(readiness: readiness)
+                endpointSection
+                toolsSection(tools)
             } else if !configReady {
                 // Either no readiness was supplied (dev snapshot), or the
                 // model is up but a value is still missing — a narrow
@@ -217,6 +242,46 @@ struct ConnectToolsView: View {
         .frame(maxWidth: RapidTheme.Layout.pageMaxWidth, alignment: .leading)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(RapidTheme.Space.xl)
+    }
+
+    /// The pick-and-start block shown in the stopped state (#2297).
+    ///
+    /// Answers the four questions a first-time user lands with — what a
+    /// connection enables, why a text model must run, what Start will do,
+    /// and how the resulting details are used — as one short flow:
+    ///
+    ///   1. Name the model to start and let the user swap it for any other
+    ///      compatible downloaded model (inline ``ModelPickerBar`` — the
+    ///      app's single model-selection source of truth, reused rather
+    ///      than reinvented).
+    ///   2. Run the shared readiness banner, whose Start action already
+    ///      routes through ``ContentView`` → ``ReadinessModelStart`` and
+    ///      owns its own starting/progress/failed states.
+    ///   3. Point at the endpoint rows right below ("the details here fill
+    ///      in the moment the model is running").
+    @ViewBuilder
+    private func stoppedSetup(readiness: ModelReadiness) -> some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+            SectionHeader(
+                "Start here",
+                subtitle: "Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands."
+            )
+            // The inline picker lets the user choose a different compatible
+            // downloaded model before starting, without leaving the page.
+            // Composer style renders only the compact chip (no duplicate
+            // Start/Stop — the readiness banner below owns the action).
+            ModelPickerBar(
+                server: server,
+                downloads: downloads,
+                alias: $alias,
+                composerStyle: true
+            )
+            .accessibilityIdentifier("ConnectTools.ModelPicker")
+            ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
+            Text("When the model is running, the key and model rows below fill in and the Copy buttons wake up.")
+                .font(RapidFont.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 
     private var header: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -308,7 +308,11 @@ struct ConnectToolsView: View {
                 composerStyle: true
             )
             ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
-            Text("When the model is running, the key and model rows below fill in and the Copy buttons wake up.")
+            // The base-URL and (already-resolved) Model rows are real values
+            // and stay copyable while stopped; it is the API key row and the
+            // per-tool integration commands that are gated until the model
+            // serves. Say exactly that, not "the Copy buttons" broadly.
+            Text("When the model is running, the API key and integration commands below fill in and their Copy buttons wake up.")
                 .font(RapidFont.caption)
                 .foregroundStyle(.secondary)
         }
@@ -388,6 +392,14 @@ struct ConnectToolsView: View {
             VStack(spacing: 0) {
                 ForEach(Array(displayedTools.enumerated()), id: \.element.id) { index, tool in
                     if index > 0 { rowDivider }
+                    // The per-tool Copy/Launch is gated on ``configReady``,
+                    // which delegates to the pure ``configIsReady`` decision
+                    // that ``ConnectToolsConfigGateTests`` pins — so the unit
+                    // test of the gate is the test of this row's enabled state.
+                    // In the #2297 stopped state the model is not serving, so
+                    // ``isReady`` is false and every integration Copy button is
+                    // disabled; a future change that stops threading this gate
+                    // into the rows is a change to the tested decision itself.
                     ConnectToolRow(tool: tool, isReady: configReady)
                 }
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -677,7 +677,8 @@ struct ContentView: View {
         case .launch:
             LaunchView(
                 server: server,
-                alias: alias,
+                downloads: downloads,
+                alias: $alias,
                 readiness: readiness,
                 onReadinessAction: performReadinessAction
             )

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -1364,7 +1364,13 @@ private struct SidebarRow<Content: View>: View {
 /// `rapid-mlx launch …` command without changing this surface's shape.
 struct LaunchView: View {
     @Bindable var server: ServerManager
-    let alias: String
+    /// The side-channel downloader the inline model picker uses. Optional
+    /// so the dev snapshot harness can render the page without threading a
+    /// download manager; the real ContentView always supplies it.
+    @Bindable var downloads: DownloadManager
+    /// The currently-chosen model, bound so the stopped state's inline
+    /// picker can change it and the shared readiness re-derives.
+    @Binding var alias: String
     /// The window's shared readiness value. Optional so the dev snapshot
     /// harness can render the page standalone; when supplied, the page
     /// describes the model lifecycle in exactly the same words the chat
@@ -1377,7 +1383,9 @@ struct LaunchView: View {
             host: "127.0.0.1",
             port: server.activePort,
             bearer: server.activeBearer ?? "",
-            alias: alias,
+            alias: $alias,
+            server: server,
+            downloads: downloads,
             // The sidecar binary this app owns lives off-PATH (see
             // ``ServerLocator``); pass its absolute path so the launch/agent
             // commands this page generates actually run in a terminal.

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -1364,9 +1364,9 @@ private struct SidebarRow<Content: View>: View {
 /// `rapid-mlx launch …` command without changing this surface's shape.
 struct LaunchView: View {
     @Bindable var server: ServerManager
-    /// The side-channel downloader the inline model picker uses. Optional
-    /// so the dev snapshot harness can render the page without threading a
-    /// download manager; the real ContentView always supplies it.
+    /// The side-channel downloader the inline model picker uses. Always
+    /// supplied by the real ``ContentView``; the dev snapshot harness passes
+    /// its own empty manager so the page renders standalone.
     @Bindable var downloads: DownloadManager
     /// The currently-chosen model, bound so the stopped state's inline
     /// picker can change it and the shared readiness re-derives.

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -13,10 +13,39 @@ AXApplication title="Rapid-MLX"
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
           AXScrollArea
             AXHeading desc="Start here, Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands." enabled=true
+            AXPopUpButton id="ConnectTools.ModelPicker" desc="Model" help="Choose which model to run" value=text enabled=true
+            AXButton id="ConnectTools.ModelPicker" desc="Show model details" help="Show model details" enabled=true
             AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
               AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Start" enabled=true
+            AXStaticText value=text enabled=true
+            AXHeading desc="Endpoint" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="ConnectTools.Copy.OpenAI base URL" desc="Copy OpenAI base URL" help="Copy OpenAI base URL" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="ConnectTools.Copy.Anthropic base URL" desc="Copy Anthropic base URL" help="Copy Anthropic base URL" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="ConnectTools.Copy.API key" desc="Copy API key" help="Start a model to generate a valid key and configuration." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="ConnectTools.Copy.Model" desc="Copy Model" help="Copy Model" enabled=true
+            AXHeading desc="Editors and agents" enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.hermes" desc="Copy Hermes command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -13,8 +13,8 @@ AXApplication title="Rapid-MLX"
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
           AXScrollArea
             AXHeading desc="Start here, Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands." enabled=true
-            AXPopUpButton id="ConnectTools.ModelPicker" desc="Model" help="Choose which model to run" value=text enabled=true
-            AXButton id="ConnectTools.ModelPicker" desc="Show model details" help="Show model details" enabled=true
+            AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+            AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
             AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
               AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -544,6 +544,21 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
+    /// The stopped-state inline model picker (#2297) is addressed by its own
+    /// menu popup identifier inside ``ModelPickerBar``, not by a composite id
+    /// stamped on the whole bar (a composite id would propagate onto both the
+    /// popup and the (i) info button and make them indistinguishable to AX).
+    /// The `launch-integrations` golden journey now asserts this id to reach
+    /// the picker directly.
+    @Test("Stopped-state model picker is reachable by its menu popup identifier")
+    func stoppedStatePickerMenuIdentifier() throws {
+        try assertDeclared(
+            [#""ModelPickerBar.ModelMenu""#],
+            in: "Sources/Rapid/UI/ModelPickerBar.swift",
+            surface: "Stopped-state inline model picker"
+        )
+    }
+
     /// The positive test above would still pass if someone re-added the
     /// container identifier, bringing the propagation bug back with it. Naming
     /// the wrapper is the mistake, so the absence has to be asserted directly.

--- a/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
@@ -1,0 +1,117 @@
+import Testing
+@testable import Rapid
+
+/// Behavioral truth-table for the Connect-tools disabled-Copy gate
+/// (`ConnectToolsView.configIsReady`), factored out of the view so the full
+/// question — "is it safe to let the user copy a snippet right now?" — is a
+/// testable decision rather than an untested view-local expression.
+///
+/// The gate is the one behavior #2297's stopped state must not regress: when
+/// the model is not serving, the page still renders the endpoint shape and
+/// the integration rows as documentation, but every Copy action must stay
+/// disabled until the endpoint/key/model actually exist. Copying a
+/// half-filled template (a placeholder that *looks* like a command) is the
+/// silent-failure defect the gate exists to prevent — see #1470's key
+/// generation and the pre-#2297 behavior that let a user paste a placeholder.
+/// ``ConnectToolsView`` is a ``@MainActor`` SwiftUI view, so its static
+/// ``configIsReady`` is main-actor-isolated — same shape as
+/// ``ModelPickerBarSectionOrderTests``. The test body is pure and touches no
+/// live state; the annotation just matches the isolation of the function
+/// under test.
+@MainActor
+@Suite("Connect tools config gate — stopped-state Copy disabled (#2297)")
+struct ConnectToolsConfigGateTests {
+
+    /// The #2297 stopped state: the page supplies a readiness value and the
+    /// model is NOT serving (`modelServing == false`). Even with every static
+    /// value present (real port, minted bearer, resolved model), the config
+    /// must NOT be copyable — otherwise a user could paste a command that
+    /// points at a placeholder. This is the regression guard for "Copy on a
+    /// placeholder".
+    @Test("Stopped state: picker + endpoint render but Copy stays disabled even when values fill in")
+    func stoppedStateNeverCopyable() {
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: true,
+            hasBearer: true,
+            modelResolved: true,
+            modelServing: false // the model is not running (#2297 stopped estate)
+        ))
+    }
+
+    /// Each individual missing ingredient independently forces NOT ready.
+    /// The gate is ANDed across all four inputs, so removing any one must
+    /// drop the whole config below the copy threshold.
+    @Test("Any single missing ingredient disables Copy")
+    func everySingleMissingIngredientDisables() {
+        // No real port yet.
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: false, hasBearer: true, modelResolved: true, modelServing: true
+        ))
+        // No bearer minted yet ("Created when the server starts").
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: true, hasBearer: false, modelResolved: true, modelServing: true
+        ))
+        // No model name resolved yet (placeholder row).
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: true, hasBearer: true, modelResolved: false, modelServing: true
+        ))
+        // Model resolved but not serving.
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: true, hasBearer: true, modelResolved: true, modelServing: false
+        ))
+    }
+
+    /// Fully complete + serving is exactly the single copy-ready state.
+    @Test("Only a complete, serving config is copyable")
+    func completeServingConfigIsCopyable() {
+        #expect(ConnectToolsView.configIsReady(
+            hasPort: true,
+            hasBearer: true,
+            modelResolved: true,
+            modelServing: true
+        ))
+    }
+
+    /// `nil` modelServing is the dev-snapshot harness path, which has no live
+    /// server to resolve readiness against. It must preserve the pre-#2297
+    /// behavior of trusting the static values alone (never `false` out of
+    /// nowhere), so standalone renders still show live content.
+    @Test("Dev-snapshot path (no readiness) trusts static values")
+    func nilServingPreservesLegacyTrust() {
+        #expect(ConnectToolsView.configIsReady(
+            hasPort: true, hasBearer: true, modelResolved: true, modelServing: nil
+        ))
+        // Even the harness still needs the static ingredients.
+        #expect(!ConnectToolsView.configIsReady(
+            hasPort: false, hasBearer: true, modelResolved: true, modelServing: nil
+        ))
+    }
+
+    /// Exhaustive check across all 16 input combinations: the gate reduces
+    /// exactly to `hasPort && hasBearer && modelResolved && (modelServing ?? true)`.
+    /// Locks the boolean shape so a future change to the formula (e.g. OR-ing
+    /// a clause, making serving optional) cannot silently widen Copy without
+    /// a review noticing which combinations flipped.
+    @Test("Exhaustive truth table matches the ANDed definition")
+    func exhaustiveTruthTable() {
+        let servingStates: [Bool?] = [nil, false, true]
+        for hasPort in [false, true] {
+            for hasBearer in [false, true] {
+                for modelResolved in [false, true] {
+                    for modelServing in servingStates {
+                        let expected =
+                            hasPort && hasBearer && modelResolved && (modelServing ?? true)
+                        #expect(
+                            ConnectToolsView.configIsReady(
+                                hasPort: hasPort,
+                                hasBearer: hasBearer,
+                                modelResolved: modelResolved,
+                                modelServing: modelServing
+                            ) == expected
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
@@ -24,11 +24,22 @@ struct ConnectToolsConfigGateTests {
 
     /// The #2297 stopped state: the page supplies a readiness value and the
     /// model is NOT serving (`modelServing == false`). Even with every static
-    /// value present (real port, minted bearer, resolved model), the config
-    /// must NOT be copyable — otherwise a user could paste a command that
-    /// points at a placeholder. This is the regression guard for "Copy on a
-    /// placeholder".
-    @Test("Stopped state: picker + endpoint render but Copy stays disabled even when values fill in")
+    /// value present (real port, minted bearer, resolved model), the gate
+    /// under test must say NOT ready — otherwise a user could paste an
+    /// integration command or key that points at a placeholder. This is the
+    /// regression guard for "Copy on a placeholder".
+    ///
+    /// Scope (deliberately narrower than "every Copy button stays disabled"):
+    /// this pins the gate that disables the runtime-only Copy controls — the
+    /// API-key row (placeholder disables Copy) and every integration
+    /// command's ``Launch.Integration.Copy.*`` button, which ``toolsSection``
+    /// feeds ``configReady`` (== this boolean) into ``ConnectToolRow.isReady``
+    /// → ``.disabled(!isReady)``. The base-URL and already-resolved Model rows
+    /// are real values and correctly stay copyable while stopped; this test
+    /// does not claim otherwise. The rendering-level "integration rows
+    /// present-but-disabled while stopped" is asserted by the
+    /// ``launch-integrations`` AX golden + native journey.
+    @Test("Stopped state: gate NOT ready, so API-key and integration Copy stay disabled even when values fill in")
     func stoppedStateNeverCopyable() {
         #expect(!ConnectToolsView.configIsReady(
             hasPort: true,

--- a/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ConnectToolsConfigGateTests.swift
@@ -87,8 +87,9 @@ struct ConnectToolsConfigGateTests {
         ))
     }
 
-    /// Exhaustive check across all 16 input combinations: the gate reduces
-    /// exactly to `hasPort && hasBearer && modelResolved && (modelServing ?? true)`.
+    /// Exhaustive check across all 24 input combinations (three booleans ×
+    /// the three-state `modelServing` = 2·2·2·3): the gate reduces exactly to
+    /// `hasPort && hasBearer && modelResolved && (modelServing ?? true)`.
     /// Locks the boolean shape so a future change to the formula (e.g. OR-ing
     /// a clause, making serving optional) cannot silently widen Copy without
     /// a review noticing which combinations flipped.

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4175,13 +4175,23 @@ flow_launch_integrations() {
     press "$OUT/main.json" Sidebar.Launch "$OUT/launch.json"
     wait_tree_text "Connect your agents" "$OUT/launch.json" 40
 
-    # Cold Launch is a beginner path, not a wall of dead commands. It should
-    # offer the same actionable readiness banner as Chat and reveal no setup
-    # snippets until the endpoint/key actually exist.
+    # Cold Launch is a beginner path, not a wall of live (copyable) commands.
+    # The stopped state now stays a useful setup destination (#2297): the
+    # endpoint shape and integration rows are shown as documentation, the
+    # inline model picker lets a user choose a different downloaded model,
+    # and the readiness banner offers Start. What must NOT happen is a
+    # command the user can paste while it is still a placeholder — so every
+    # `Launch.Integration.Copy.*` button must be present but `.enabled == false`
+    # until the endpoint/key actually exist (Copy on a placeholder is the
+    # silent-failure defect the disabled-Copy gate exists to prevent).
     count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration.Copy."))] | unique | length' "$OUT/launch.json")"
-    [[ "$count" == 0 ]] || die "Cold Launch rendered $count dead integration commands"
+    [[ "$count" -gt 0 ]] || die "Cold Launch hid the integration setup rows entirely"
+    enabled_count="$(jq '[.data.ui_elements[]? | select(((.identifier // "") | startswith("Launch.Integration.Copy.")) and .enabled == true)] | length' "$OUT/launch.json")"
+    [[ "$enabled_count" == 0 ]] || die "Cold Launch offered $enabled_count copyable commands before the endpoint/key existed"
     jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' "$OUT/launch.json" >/dev/null \
         || die "Cold Launch offered no primary model-start action"
+    jq -e '.data.ui_elements[]? | select(.identifier == "ConnectTools.ModelPicker")' "$OUT/launch.json" >/dev/null \
+        || die "Cold Launch offered no inline model picker"
     baseline launch-integrations.complete "$OUT/launch.json"
 
     press "$OUT/launch.json" Sidebar.NewChat "$OUT/launch-chat.json" \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4525,25 +4525,29 @@ flow_audio_readiness() {
 
     # A media resident is process-wide state, not the Chat model selection.
     # Launch commands must neither advertise the TTS alias to coding agents
-    # nor remain copyable while their selected chat model is not serving.
+    # nor be copyable while their selected chat model is not serving. Since
+    # #2297 the stopped Launch page renders the integration rows as
+    # documentation with Copy deliberately disabled, so the guard is the
+    # rows being present-but-not-copyable (enabled_count == 0), not their
+    # absence — the launch-integrations journey asserts the same contract.
     press "$OUT/speech-resident.json" Sidebar.Launch "$OUT/launch-from-audio.json" \
         || die "Sidebar.Launch is not pressable from an Audio residency"
-    local launch_copy_count=0 launch_ready=0
+    local launch_ready=0
     for ((i=0; i<40; i++)); do
         see_main "$OUT/launch-from-audio.json"
-        launch_copy_count="$(jq '[.data.ui_elements[]?
-                                  | (.identifier // "")
-                                  | select(startswith("Launch.Integration.Copy."))]
-                                 | unique | length' "$OUT/launch-from-audio.json")"
-        if [[ "$launch_copy_count" == 0 ]] &&
-           jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
-              "$OUT/launch-from-audio.json" >/dev/null; then
+        if jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
+              "$OUT/launch-from-audio.json" >/dev/null \
+           && [[ "$(jq '[.data.ui_elements[]?
+                          | select(((.identifier // "")
+                                    | startswith("Launch.Integration.Copy."))
+                                   and .enabled == true)] | length' \
+                       "$OUT/launch-from-audio.json")" == 0 ]]; then
             launch_ready=1; break
         fi
         sleep 0.25
     done
     [[ "$launch_ready" == 1 ]] \
-        || die "Launch exposed dead commands or no chat-model start action from Audio"
+        || die "Launch exposed copyable commands or no chat-model start action from Audio"
     if jq -e '[.data.ui_elements[]? | .value? | strings]
               | any(contains("fake-qwen3-tts")
                     and (contains("--model")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4528,8 +4528,14 @@ flow_audio_readiness() {
     # nor be copyable while their selected chat model is not serving. Since
     # #2297 the stopped Launch page renders the integration rows as
     # documentation with Copy deliberately disabled, so the guard is the
-    # rows being present-but-not-copyable (enabled_count == 0), not their
-    # absence — the launch-integrations journey asserts the same contract.
+    # rows being present-but-not-copyable: the `Launch.Integration.Copy.*`
+    # rows must EXIST (count > 0) and every one of them must be disabled
+    # (enabled_count == 0), plus the Readiness start action must be present.
+    # Counting the rows (not just checking nothing is enabled) is what
+    # distinguishes "documentation rows rendered with Copy disabled" from a
+    # regression where the whole Launch surface silently vanished. The
+    # launch-integrations journey asserts the same present-but-not-copyable
+    # contract.
     press "$OUT/speech-resident.json" Sidebar.Launch "$OUT/launch-from-audio.json" \
         || die "Sidebar.Launch is not pressable from an Audio residency"
     local launch_ready=0
@@ -4537,6 +4543,10 @@ flow_audio_readiness() {
         see_main "$OUT/launch-from-audio.json"
         if jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
               "$OUT/launch-from-audio.json" >/dev/null \
+           && [[ "$(jq '[.data.ui_elements[]?
+                          | select(((.identifier // "")
+                                    | startswith("Launch.Integration.Copy.")))] | length' \
+                       "$OUT/launch-from-audio.json")" -gt 0 ]] \
            && [[ "$(jq '[.data.ui_elements[]?
                           | select(((.identifier // "")
                                     | startswith("Launch.Integration.Copy."))
@@ -4547,7 +4557,7 @@ flow_audio_readiness() {
         sleep 0.25
     done
     [[ "$launch_ready" == 1 ]] \
-        || die "Launch exposed copyable commands or no chat-model start action from Audio"
+        || die "Launch exposed copyable commands, hid the launch rows, or had no chat-model start action from Audio"
     if jq -e '[.data.ui_elements[]? | .value? | strings]
               | any(contains("fake-qwen3-tts")
                     and (contains("--model")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4190,7 +4190,12 @@ flow_launch_integrations() {
     [[ "$enabled_count" == 0 ]] || die "Cold Launch offered $enabled_count copyable commands before the endpoint/key existed"
     jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' "$OUT/launch.json" >/dev/null \
         || die "Cold Launch offered no primary model-start action"
-    jq -e '.data.ui_elements[]? | select(.identifier == "ConnectTools.ModelPicker")' "$OUT/launch.json" >/dev/null \
+    # The inline picker is addressable by its own menu popup
+    # (``ModelPickerBar.ModelMenu``) — NOT by a composite id stamped on the
+    # whole bar, which `ModelPickerBar` deliberately avoids (it propagates one
+    # id onto both the popup and the (i) info button and makes them
+    # indistinguishable). Assert the popup itself is present.
+    jq -e '.data.ui_elements[]? | select(.identifier == "ModelPickerBar.ModelMenu")' "$OUT/launch.json" >/dev/null \
         || die "Cold Launch offered no inline model picker"
     baseline launch-integrations.complete "$OUT/launch.json"
 


### PR DESCRIPTION
## Why

Closes #2297. In a fresh install with no engine ready, the "Connect your agents" tab rendered a near-blank card: the endpoint section and the integration tools were hidden because `cardContent` branched on readiness and returned *only* the "Start here" banner whenever the model wasn't running. That is exactly the moment a new user needs guidance, so the page they landed on told them nothing about how to connect a client.

This is purely the conditional *withholding* of static content — the endpoint rows and Copy buttons already existed and were the intended output once a model was running. The fix always renders the pick-and-start flow, the endpoint, and the integration copy rows, and lets the existing runtime-gating machinery (`configReady`) mark values as pending until the model is up.

## What changed

- **ConnectToolsView** — new `stoppedSetup(readiness:)` renders the model picker + readiness banner up top; the endpoint section and integration tools are now always rendered, with live/pending states driven by `configReady` gating. Documented the root cause in a `// #2297:` comment rather than relying on a model-name/metadata heuristic.
- **Reuses existing primitives instead of new machinery** — `ModelPickerBar` (the single model-selection source of truth), `ReadinessBanner`, and the existing `ReadinessModelStart` start path. No ad-hoc states invented.
- Threads live `alias` binding + `ServerManager`/`DownloadManager` through `ConnectToolsView` so the picker binding stays the one real binding.
- **`configReady` extracted** into a pure `static configIsReady(hasPort:hasBearer:modelResolved:modelServing:)` decision so the disabled-Copy gate is behaviorally testable as a whole truth table.
- **behavioral tests** (`ConnectToolsConfigGateTests`) — exhaustive truth table over the gate, plus the #2297 regression guard: in the stopped state Copy stays disabled even when the static values have filled in.
- **DevSnapshot** — renders the updated card headlessly for pixel confirmation.
- **gui-golden-flows.sh** — `launch-integrations` journey now asserts the stopped-state structure (picker + banner + integration rows present, Copy disabled).
- **`launch-integrations.complete` AX baseline regenerated** on the active macOS GUI runner (the same runner full-ci uses) and committed, so the golden gate describes the new stopped-state tree.

## Verification

- `swift build -c release` passes.
- Behavioral config-gate truth-table tests pass; readiness state-machine + ReadinessModelStart + related suites pass.
- `RAPID_DEV_SNAPSHOT_DIR` headless render of `connect-tools.png` pixel-confirms the stopped-state card is no longer blank.
- Full-ci `gui-golden-flows` re-run on the regenerated baseline reaches green.

## AX golden baseline

The `launch-integrations.complete` baseline was regenerated on the active macOS GUI runner via the harness `--update-baselines` diagnostic path and committed into this PR (not deferred to merge/release). The regenerated baseline locks in the intended stopped-state behavior: the picker and both content sections render stopped, the API-key row and every integration launch-Copy button are `enabled=false` (nothing paste-worthy exists yet), while the static base-URL and chosen-model-name rows stay copyable.

Co-Authored-By: Claude <noreply@anthropic.com>