### PR TITLE
fix(mac): refresh onboarding memory safety live

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -309,8 +309,7 @@ enum ModelSizing {
         var confirmTitle: String {
             switch severity {
             case .unsafe: "Load anyway (risky)"
-            case .tight: "Load anyway"
-            case .safe: "Load model"
+            case .tight, .safe: "Load model"
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -228,7 +228,7 @@ enum ModelSizing {
     /// Copy lives here (not in a view) so ``ModelSizingTests`` can pin
     /// it without a SwiftUI host — same pattern as the tooBig alert.
     struct MemoryWarning: Equatable, Sendable, Identifiable {
-        let id = UUID()
+        let id: UUID
         let alias: String
         let hfPath: String?
         let isAutoRespawn: Bool
@@ -240,6 +240,26 @@ enum ModelSizing {
         /// Total unified memory. Needed because the guard is based on
         /// projected utilisation, not on footprint-versus-free alone.
         var totalGB: Double = 0
+
+        init(
+            id: UUID = UUID(),
+            alias: String,
+            hfPath: String?,
+            isAutoRespawn: Bool,
+            severity: MemorySafety,
+            footprintGB: Double,
+            freeGB: Double,
+            totalGB: Double = 0
+        ) {
+            self.id = id
+            self.alias = alias
+            self.hfPath = hfPath
+            self.isAutoRespawn = isAutoRespawn
+            self.severity = severity
+            self.footprintGB = footprintGB
+            self.freeGB = freeGB
+            self.totalGB = totalGB
+        }
 
         static func == (lhs: Self, rhs: Self) -> Bool {
             lhs.alias == rhs.alias
@@ -255,8 +275,10 @@ enum ModelSizing {
             switch severity {
             case .unsafe:
                 return "\(alias) may crash your Mac right now"
-            case .tight, .safe:
+            case .tight:
                 return "\(alias) is a tight fit right now"
+            case .safe:
+                return "\(alias) is ready to load"
             }
         }
 
@@ -276,14 +298,20 @@ enum ModelSizing {
             switch severity {
             case .unsafe:
                 return facts + " Past about 85%, macOS may freeze or restart. Free about \(freeAction) GB by closing some apps, or pick a smaller model."
-            case .tight, .safe:
+            case .tight:
                 return facts + " It should load but may stall under longer chats. Consider closing some apps or picking a smaller model."
+            case .safe:
+                return facts + " There is now enough memory to load it normally."
             }
         }
 
         /// The confirm button title — worded to match the risk.
         var confirmTitle: String {
-            severity == .unsafe ? "Load anyway (risky)" : "Load anyway"
+            switch severity {
+            case .unsafe: "Load anyway (risky)"
+            case .tight: "Load anyway"
+            case .safe: "Load model"
+            }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -203,6 +203,12 @@ enum ModelSizing {
         case unsafe
     }
 
+    /// Only the danger-line verdict parks a load for explicit confirmation.
+    /// Tight is advisory and must continue through the ordinary guarded path.
+    static func requiresMemoryConfirmation(_ safety: MemorySafety) -> Bool {
+        safety == .unsafe
+    }
+
     /// Project ``footprint`` onto ``usedBytes`` and bucket the result.
     /// Returns ``.safe`` when the numbers are unreadable or the param
     /// count is unknown — never block a load on missing data (the

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -213,8 +213,25 @@ enum ModelSizing {
         totalBytes: UInt64
     ) -> MemorySafety {
         guard totalBytes > 0, footprint.paramsBillions != nil else { return .safe }
+        return memorySafety(
+            footprintGB: footprint.totalGB,
+            usedBytes: usedBytes,
+            totalBytes: totalBytes
+        )
+    }
+
+    /// Re-evaluate a warning using the exact footprint captured when the
+    /// guarded load was first classified. A warning can outlive catalog or
+    /// custom-path resolution, so refreshes must not derive a second estimate
+    /// from its alias.
+    static func memorySafety(
+        footprintGB: Double,
+        usedBytes: UInt64,
+        totalBytes: UInt64
+    ) -> MemorySafety {
+        guard totalBytes > 0 else { return .safe }
         let gib = Double(1 << 30)
-        let footprintBytes = footprint.totalGB * gib
+        let footprintBytes = footprintGB * gib
         let projected = (Double(usedBytes) + footprintBytes) / Double(totalBytes)
         if projected >= 0.85 { return .unsafe }
         if projected >= 0.75 { return .tight }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -216,13 +216,9 @@ final class ServerManager {
         memoryWarningRefreshGeneration += 1
         let generation = memoryWarningRefreshGeneration
         let provider = memorySnapshotProvider
-        let snapshot = await withTaskGroup(
-            of: MemoryProbe.Snapshot?.self,
-            returning: MemoryProbe.Snapshot?.self
-        ) { group in
-            group.addTask(priority: .utility) { provider() }
-            return await group.next() ?? nil
-        }
+        let snapshot = await Task.detached(priority: .utility) {
+            provider()
+        }.value
         guard !Task.isCancelled,
               generation == memoryWarningRefreshGeneration,
               pendingMemoryWarning?.id == warningID,
@@ -1446,34 +1442,54 @@ final class ServerManager {
     /// whether the user actually chose the unsafe override; a stale ordinary
     /// Load action can therefore never become a bypass after pressure rises.
     func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) {
+        Task { [weak self] in
+            await self?.activatePendingMemoryLoad(warning)
+        }
+    }
+
+    private func activatePendingMemoryLoad(
+        _ warning: ModelSizing.MemoryWarning
+    ) async {
+        let provider = memorySnapshotProvider
+        let snapshot = await Task.detached(priority: .utility) {
+            provider()
+        }.value
+        guard pendingMemoryWarning?.id == warning.id else { return }
+        if let snapshot {
+            _ = memoryConfirmations.refreshCurrentWarning(snapshot: snapshot)
+        }
+        guard let latestWarning = pendingMemoryWarning,
+              latestWarning.id == warning.id else { return }
+
+        // Only the explicit unsafe action is a waiver. An ordinary Load that
+        // became unsafe during this activation remains parked on the same
+        // queue entry, preserving its waiter and presenting the new facts.
+        let requestedUnsafeOverride = warning.severity == .unsafe
+        guard requestedUnsafeOverride || latestWarning.severity != .unsafe else {
+            return
+        }
+
         memoryConfirmSeq += 1
         let seq = memoryConfirmSeq
-        // A refreshed `.safe` action is an ordinary load, not a permanent
-        // waiver. Re-run the guard at activation so a sudden pressure spike
-        // between the last three-second sample and the click can present a
-        // fresh warning instead of silently loading under stale safe state.
-        let requestedUnsafeOverride = warning.severity == .unsafe
         guard let currentWarning = memoryConfirmations.resolveCurrent(
             warningID: warning.id,
             decision: .confirmed(sequence: seq)
         ) else { return }
-        let bypassMemoryGuard = requestedUnsafeOverride
-            && currentWarning.severity == .unsafe
         memoryConfirmRunning.insert(seq)
-        Task { [weak self] in
-            guard let self else { return }
-            if self.child != nil {
-                await self.stop()
-            }
-            await self.start(
-                alias: currentWarning.alias,
-                hfPath: currentWarning.hfPath,
-                isAutoRespawn: currentWarning.isAutoRespawn,
-                bypassMemoryGuard: bypassMemoryGuard
-            )
-            self.memoryConfirmRunning.remove(seq)
-            self.memoryConfirmations.completeConfirmedLaunch(warningID: currentWarning.id)
+        if child != nil {
+            await stop()
         }
+        // The activation sample above is the guard for this exact click.
+        // Avoid a second sample after the queue has entered `.launching`,
+        // which could otherwise park a duplicate warning behind its owner.
+        await start(
+            alias: currentWarning.alias,
+            hfPath: currentWarning.hfPath,
+            isAutoRespawn: currentWarning.isAutoRespawn,
+            bypassMemoryGuard: true
+        )
+        memoryConfirmRunning.remove(seq)
+        memoryConfirmations.completeConfirmedLaunch(warningID: currentWarning.id)
     }
 
     /// The user backed out of a memory-risky load. Just drops the

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -14,6 +14,7 @@ struct MemoryLoadConfirmationQueue {
     private struct Pending: Equatable {
         enum Phase: Equatable {
             case awaitingDecision
+            case checkingDecision
             case launching
         }
 
@@ -42,27 +43,14 @@ struct MemoryLoadConfirmationQueue {
     ) -> (old: ModelSizing.MemoryWarning, new: ModelSizing.MemoryWarning)? {
         guard pending.first?.phase == .awaitingDecision,
               let old = pending.first?.warning else { return nil }
-        let refreshed = ModelSizing.MemoryWarning(
-            id: old.id,
-            alias: old.alias,
-            hfPath: old.hfPath,
-            isAutoRespawn: old.isAutoRespawn,
-            severity: ModelSizing.memorySafety(
-                footprintGB: old.footprintGB,
-                usedBytes: snapshot.usedBytes,
-                totalBytes: snapshot.totalBytes
-            ),
-            footprintGB: old.footprintGB,
-            freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
-            totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
-        )
+        let refreshed = refreshedWarning(old, snapshot: snapshot)
         pending[0].warning = refreshed
         return (old, refreshed)
     }
 
     func isPending(_ requestID: UUID) -> Bool {
         pending.contains {
-            $0.requestID == requestID && $0.phase == .awaitingDecision
+            $0.requestID == requestID && $0.phase != .launching
         }
     }
 
@@ -83,6 +71,45 @@ struct MemoryLoadConfirmationQueue {
             pending[0].phase = .launching
         }
         return currentWarning
+    }
+
+    mutating func beginChecking(warningID: UUID) -> Bool {
+        guard pending.first?.warning.id == warningID,
+              pending.first?.phase == .awaitingDecision else { return false }
+        pending[0].phase = .checkingDecision
+        return true
+    }
+
+    mutating func checkingWarning(
+        warningID: UUID,
+        snapshot: MemoryProbe.Snapshot?
+    ) -> ModelSizing.MemoryWarning? {
+        guard pending.first?.warning.id == warningID,
+              pending.first?.phase == .checkingDecision else { return nil }
+        if let snapshot, let old = pending.first?.warning {
+            pending[0].warning = refreshedWarning(old, snapshot: snapshot)
+        }
+        return pending[0].warning
+    }
+
+    mutating func restoreAwaiting(warningID: UUID) {
+        guard pending.first?.warning.id == warningID,
+              pending.first?.phase == .checkingDecision else { return }
+        pending[0].phase = .awaitingDecision
+    }
+
+    mutating func confirmChecking(
+        warningID: UUID,
+        sequence: Int
+    ) -> ModelSizing.MemoryWarning? {
+        guard pending.first?.warning.id == warningID,
+              pending.first?.phase == .checkingDecision else { return nil }
+        let warning = pending[0].warning
+        if let requestID = pending[0].requestID {
+            decisions[requestID] = .confirmed(sequence: sequence)
+        }
+        pending[0].phase = .launching
+        return warning
     }
 
     mutating func resolveCurrent(
@@ -118,6 +145,26 @@ struct MemoryLoadConfirmationQueue {
             return
         }
         pending[index].requestID = nil
+    }
+
+    private func refreshedWarning(
+        _ old: ModelSizing.MemoryWarning,
+        snapshot: MemoryProbe.Snapshot
+    ) -> ModelSizing.MemoryWarning {
+        ModelSizing.MemoryWarning(
+            id: old.id,
+            alias: old.alias,
+            hfPath: old.hfPath,
+            isAutoRespawn: old.isAutoRespawn,
+            severity: ModelSizing.memorySafety(
+                footprintGB: old.footprintGB,
+                usedBytes: snapshot.usedBytes,
+                totalBytes: snapshot.totalBytes
+            ),
+            footprintGB: old.footprintGB,
+            freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
+            totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
+        )
     }
 }
 
@@ -1442,6 +1489,11 @@ final class ServerManager {
     /// whether the user actually chose the unsafe override; a stale ordinary
     /// Load action can therefore never become a bypass after pressure rises.
     func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) {
+        // Claim synchronously before SwiftUI dismisses its alert. The binding
+        // writes `false` on the same run-loop turn and treats an unclaimed
+        // warning as Cancel; `.checkingDecision` makes that dismissal a no-op
+        // while the activation probe runs off the main actor.
+        guard memoryConfirmations.beginChecking(warningID: warning.id) else { return }
         Task { [weak self] in
             await self?.activatePendingMemoryLoad(warning)
         }
@@ -1454,26 +1506,25 @@ final class ServerManager {
         let snapshot = await Task.detached(priority: .utility) {
             provider()
         }.value
-        guard pendingMemoryWarning?.id == warning.id else { return }
-        if let snapshot {
-            _ = memoryConfirmations.refreshCurrentWarning(snapshot: snapshot)
-        }
-        guard let latestWarning = pendingMemoryWarning,
-              latestWarning.id == warning.id else { return }
+        guard let latestWarning = memoryConfirmations.checkingWarning(
+            warningID: warning.id,
+            snapshot: snapshot
+        ) else { return }
 
         // Only the explicit unsafe action is a waiver. An ordinary Load that
         // became unsafe during this activation remains parked on the same
         // queue entry, preserving its waiter and presenting the new facts.
         let requestedUnsafeOverride = warning.severity == .unsafe
         guard requestedUnsafeOverride || latestWarning.severity != .unsafe else {
+            memoryConfirmations.restoreAwaiting(warningID: warning.id)
             return
         }
 
         memoryConfirmSeq += 1
         let seq = memoryConfirmSeq
-        guard let currentWarning = memoryConfirmations.resolveCurrent(
+        guard let currentWarning = memoryConfirmations.confirmChecking(
             warningID: warning.id,
-            decision: .confirmed(sequence: seq)
+            sequence: seq
         ) else { return }
         memoryConfirmRunning.insert(seq)
         if child != nil {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1494,6 +1494,10 @@ final class ServerManager {
         // warning as Cancel; `.checkingDecision` makes that dismissal a no-op
         // while the activation probe runs off the main actor.
         guard memoryConfirmations.beginChecking(warningID: warning.id) else { return }
+        // The activation probe now owns the warning's measured facts. Any
+        // periodic sample that began before this click must not apply after a
+        // newly-unsafe activation restores the warning to awaitingDecision.
+        memoryWarningRefreshGeneration += 1
         Task { [weak self] in
             await self?.activatePendingMemoryLoad(warning)
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1432,7 +1432,7 @@ final class ServerManager {
         // waiver. Re-run the guard at activation so a sudden pressure spike
         // between the last three-second sample and the click can present a
         // fresh warning instead of silently loading under stale safe state.
-        let bypassMemoryGuard = warning.severity != .safe
+        let bypassMemoryGuard = warning.severity == .unsafe
         memoryConfirmRunning.insert(seq)
         guard memoryConfirmations.resolveCurrent(
             warning: warning,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1447,14 +1447,11 @@ final class ServerManager {
         // between the last three-second sample and the click can present a
         // fresh warning instead of silently loading under stale safe state.
         let bypassMemoryGuard = warning.severity == .unsafe
-        memoryConfirmRunning.insert(seq)
         guard memoryConfirmations.resolveCurrent(
             warning: warning,
             decision: .confirmed(sequence: seq)
-        ) else {
-            memoryConfirmRunning.remove(seq)
-            return
-        }
+        ) else { return }
+        memoryConfirmRunning.insert(seq)
         Task { [weak self] in
             guard let self else { return }
             if self.child != nil {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -42,14 +42,13 @@ struct MemoryLoadConfirmationQueue {
     ) -> (old: ModelSizing.MemoryWarning, new: ModelSizing.MemoryWarning)? {
         guard pending.first?.phase == .awaitingDecision,
               let old = pending.first?.warning else { return nil }
-        let footprint = ModelSizing.estimate(alias: old.alias)
         let refreshed = ModelSizing.MemoryWarning(
             id: old.id,
             alias: old.alias,
             hfPath: old.hfPath,
             isAutoRespawn: old.isAutoRespawn,
             severity: ModelSizing.memorySafety(
-                footprint: footprint,
+                footprintGB: old.footprintGB,
                 usedBytes: snapshot.usedBytes,
                 totalBytes: snapshot.totalBytes
             ),
@@ -192,6 +191,12 @@ final class ServerManager {
         MemoryProbe.snapshot()
     }
 
+    /// Orders overlapping timer and foreground refreshes. Sampling happens
+    /// off the main actor, so a slower older probe must not overwrite a newer
+    /// decision after actor re-entry.
+    @ObservationIgnored
+    private var memoryWarningRefreshGeneration = 0
+
     /// Re-sample a parked memory decision while its owning UI is visible.
     /// Returns a material safety-state transition for accessibility; metric
     /// ticks within the same state deliberately return nil.
@@ -199,12 +204,16 @@ final class ServerManager {
         old: ModelSizing.MemorySafety,
         new: ModelSizing.MemorySafety
     )? {
-        guard pendingMemoryWarning != nil else { return nil }
+        guard let warningID = pendingMemoryWarning?.id else { return nil }
+        memoryWarningRefreshGeneration += 1
+        let generation = memoryWarningRefreshGeneration
         let provider = memorySnapshotProvider
         let snapshot = await Task.detached(priority: .utility) {
             provider()
         }.value
-        guard let snapshot,
+        guard generation == memoryWarningRefreshGeneration,
+              pendingMemoryWarning?.id == warningID,
+              let snapshot,
               let transition = memoryConfirmations.refreshCurrentWarning(snapshot: snapshot),
               transition.old.severity != transition.new.severity else { return nil }
         return (transition.old.severity, transition.new.severity)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -17,7 +17,7 @@ struct MemoryLoadConfirmationQueue {
             case launching
         }
 
-        let warning: ModelSizing.MemoryWarning
+        var warning: ModelSizing.MemoryWarning
         var requestID: UUID?
         var phase: Phase = .awaitingDecision
         var launchComplete = false
@@ -33,6 +33,32 @@ struct MemoryLoadConfirmationQueue {
 
     mutating func enqueue(warning: ModelSizing.MemoryWarning, requestID: UUID?) {
         pending.append(Pending(warning: warning, requestID: requestID))
+    }
+
+    /// Replace the measured facts for the visible decision without changing
+    /// its identity, waiter ownership, or queue position.
+    mutating func refreshCurrentWarning(
+        snapshot: MemoryProbe.Snapshot
+    ) -> (old: ModelSizing.MemoryWarning, new: ModelSizing.MemoryWarning)? {
+        guard pending.first?.phase == .awaitingDecision,
+              let old = pending.first?.warning else { return nil }
+        let footprint = ModelSizing.estimate(alias: old.alias)
+        let refreshed = ModelSizing.MemoryWarning(
+            id: old.id,
+            alias: old.alias,
+            hfPath: old.hfPath,
+            isAutoRespawn: old.isAutoRespawn,
+            severity: ModelSizing.memorySafety(
+                footprint: footprint,
+                usedBytes: snapshot.usedBytes,
+                totalBytes: snapshot.totalBytes
+            ),
+            footprintGB: old.footprintGB,
+            freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
+            totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
+        )
+        pending[0].warning = refreshed
+        return (old, refreshed)
     }
 
     func isPending(_ requestID: UUID) -> Bool {
@@ -162,8 +188,26 @@ final class ServerManager {
     /// launch auto-start semantics can be verified without depending on the
     /// runner's current pressure.
     @ObservationIgnored
-    internal var memorySnapshotProvider: () -> MemoryProbe.Snapshot? = {
+    internal var memorySnapshotProvider: @Sendable () -> MemoryProbe.Snapshot? = {
         MemoryProbe.snapshot()
+    }
+
+    /// Re-sample a parked memory decision while its owning UI is visible.
+    /// Returns a material safety-state transition for accessibility; metric
+    /// ticks within the same state deliberately return nil.
+    func refreshPendingMemoryWarning() async -> (
+        old: ModelSizing.MemorySafety,
+        new: ModelSizing.MemorySafety
+    )? {
+        guard pendingMemoryWarning != nil else { return nil }
+        let provider = memorySnapshotProvider
+        let snapshot = await Task.detached(priority: .utility) {
+            provider()
+        }.value
+        guard let snapshot,
+              let transition = memoryConfirmations.refreshCurrentWarning(snapshot: snapshot),
+              transition.old.severity != transition.new.severity else { return nil }
+        return (transition.old.severity, transition.new.severity)
     }
 
     /// Confirmed launches still running, by sequence number. Polled by
@@ -1384,6 +1428,11 @@ final class ServerManager {
     func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) {
         memoryConfirmSeq += 1
         let seq = memoryConfirmSeq
+        // A refreshed `.safe` action is an ordinary load, not a permanent
+        // waiver. Re-run the guard at activation so a sudden pressure spike
+        // between the last three-second sample and the click can present a
+        // fresh warning instead of silently loading under stale safe state.
+        let bypassMemoryGuard = warning.severity != .safe
         memoryConfirmRunning.insert(seq)
         guard memoryConfirmations.resolveCurrent(
             warning: warning,
@@ -1401,7 +1450,7 @@ final class ServerManager {
                 alias: warning.alias,
                 hfPath: warning.hfPath,
                 isAutoRespawn: warning.isAutoRespawn,
-                bypassMemoryGuard: true
+                bypassMemoryGuard: bypassMemoryGuard
             )
             self.memoryConfirmRunning.remove(seq)
             self.memoryConfirmations.completeConfirmedLaunch(warningID: warning.id)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -208,10 +208,15 @@ final class ServerManager {
         memoryWarningRefreshGeneration += 1
         let generation = memoryWarningRefreshGeneration
         let provider = memorySnapshotProvider
-        let snapshot = await Task.detached(priority: .utility) {
-            provider()
-        }.value
-        guard generation == memoryWarningRefreshGeneration,
+        let snapshot = await withTaskGroup(
+            of: MemoryProbe.Snapshot?.self,
+            returning: MemoryProbe.Snapshot?.self
+        ) { group in
+            group.addTask(priority: .utility) { provider() }
+            return await group.next() ?? nil
+        }
+        guard !Task.isCancelled,
+              generation == memoryWarningRefreshGeneration,
               pendingMemoryWarning?.id == warningID,
               let snapshot,
               let transition = memoryConfirmations.refreshCurrentWarning(snapshot: snapshot),

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1559,7 +1559,7 @@ final class ServerManager {
             // Every mature local-model app draws the same line: refuse
             // only what is genuinely dangerous, and surface "tight"
             // passively — the picker's static sizing bands already do.
-            if safety == .unsafe {
+            if ModelSizing.requiresMemoryConfirmation(safety) {
                 // A launch auto-start must never greet the user with a scary
                 // modal they did not ask for. Opening the app is not "I want to
                 // chat now" — they may be heading to Audio/Images, or just

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -67,11 +67,12 @@ struct MemoryLoadConfirmationQueue {
     }
 
     mutating func resolveCurrent(
-        warning: ModelSizing.MemoryWarning,
+        warningID: UUID,
         decision: Decision
-    ) -> Bool {
-        guard pending.first?.warning.id == warning.id,
-              pending.first?.phase == .awaitingDecision else { return false }
+    ) -> ModelSizing.MemoryWarning? {
+        guard pending.first?.warning.id == warningID,
+              pending.first?.phase == .awaitingDecision else { return nil }
+        let currentWarning = pending[0].warning
         if let requestID = pending[0].requestID {
             decisions[requestID] = decision
         }
@@ -81,7 +82,14 @@ struct MemoryLoadConfirmationQueue {
         case .confirmed:
             pending[0].phase = .launching
         }
-        return true
+        return currentWarning
+    }
+
+    mutating func resolveCurrent(
+        warning: ModelSizing.MemoryWarning,
+        decision: Decision
+    ) -> Bool {
+        resolveCurrent(warningID: warning.id, decision: decision) != nil
     }
 
     mutating func completeConfirmedLaunch(warningID: UUID) {
@@ -1433,12 +1441,10 @@ final class ServerManager {
     /// transition (the bug Bug A removed), which incidentally also
     /// covered manual restarts. The default is ``false`` to make the
     /// behavior obvious at every public call site.
-    /// The user acknowledged the memory warning and wants to load
-    /// anyway. Takes the ``warning`` by value (not off ``pendingMemory-
-    /// Warning``) because the alert's dismissal clears that property on
-    /// the same run-loop turn the button fires — reading it here would
-    /// race to nil and silently drop the load. Re-enters ``start`` with
-    /// the guard bypassed.
+    /// Resolve the rendered action by stable warning identity, then launch
+    /// from the queue's latest measured facts. The captured severity records
+    /// whether the user actually chose the unsafe override; a stale ordinary
+    /// Load action can therefore never become a bypass after pressure rises.
     func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) {
         memoryConfirmSeq += 1
         let seq = memoryConfirmSeq
@@ -1446,11 +1452,13 @@ final class ServerManager {
         // waiver. Re-run the guard at activation so a sudden pressure spike
         // between the last three-second sample and the click can present a
         // fresh warning instead of silently loading under stale safe state.
-        let bypassMemoryGuard = warning.severity == .unsafe
-        guard memoryConfirmations.resolveCurrent(
-            warning: warning,
+        let requestedUnsafeOverride = warning.severity == .unsafe
+        guard let currentWarning = memoryConfirmations.resolveCurrent(
+            warningID: warning.id,
             decision: .confirmed(sequence: seq)
         ) else { return }
+        let bypassMemoryGuard = requestedUnsafeOverride
+            && currentWarning.severity == .unsafe
         memoryConfirmRunning.insert(seq)
         Task { [weak self] in
             guard let self else { return }
@@ -1458,13 +1466,13 @@ final class ServerManager {
                 await self.stop()
             }
             await self.start(
-                alias: warning.alias,
-                hfPath: warning.hfPath,
-                isAutoRespawn: warning.isAutoRespawn,
+                alias: currentWarning.alias,
+                hfPath: currentWarning.hfPath,
+                isAutoRespawn: currentWarning.isAutoRespawn,
                 bypassMemoryGuard: bypassMemoryGuard
             )
             self.memoryConfirmRunning.remove(seq)
-            self.memoryConfirmations.completeConfirmedLaunch(warningID: warning.id)
+            self.memoryConfirmations.completeConfirmedLaunch(warningID: currentWarning.id)
         }
     }
 
@@ -1477,7 +1485,7 @@ final class ServerManager {
         // to an EARLIER confirmation and its waiter must not be told it
         // finished.
         _ = memoryConfirmations.resolveCurrent(
-            warning: warning,
+            warningID: warning.id,
             decision: .cancelled
         )
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1466,6 +1466,11 @@ struct QuickstartView: View {
     /// the transfer is the job's own status.
     @State private var cancelRequestedAlias: String?
 
+    /// A foreground-triggered probe is async, so retain its task only for the
+    /// view lifetime. The parked warning remains owned by ServerManager; this
+    /// handle exists solely to propagate SwiftUI teardown cancellation.
+    @State private var foregroundMemoryRefreshTask: Task<Void, Never>?
+
     /// First-run setup should present a decision, not mirror every cached
     /// quantization of that decision.  Sibling variants stay reachable behind
     /// one explicit disclosure; Settings → Models and Browse all remain the
@@ -1555,15 +1560,23 @@ struct QuickstartView: View {
                     }
                 }
             }
-            .task {
-                let activations = NotificationCenter.default.notifications(
-                    named: NSApplication.didBecomeActiveNotification
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification
                 )
-                for await _ in activations {
-                    guard !Task.isCancelled else { return }
-                    guard server.pendingMemoryWarning != nil else { continue }
+            ) { _ in
+                foregroundMemoryRefreshTask?.cancel()
+                guard server.pendingMemoryWarning != nil else {
+                    foregroundMemoryRefreshTask = nil
+                    return
+                }
+                foregroundMemoryRefreshTask = Task { @MainActor in
                     await refreshPendingMemoryWarning()
                 }
+            }
+            .onDisappear {
+                foregroundMemoryRefreshTask?.cancel()
+                foregroundMemoryRefreshTask = nil
             }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1549,10 +1549,10 @@ struct QuickstartView: View {
             // result of that action while this exact decision is visible.
             // The view-bound task cancels when onboarding unmounts; three
             // seconds matches the app's existing system-memory telemetry.
-            .task(id: server.pendingMemoryWarning?.id) {
-                guard server.pendingMemoryWarning != nil else { return }
-                while !Task.isCancelled, server.pendingMemoryWarning != nil {
-                    await refreshPendingMemoryWarning()
+            .task(id: visibleMemoryWarningID) {
+                guard let warningID = visibleMemoryWarningID else { return }
+                while !Task.isCancelled, visibleMemoryWarningID == warningID {
+                    await refreshPendingMemoryWarning(expectedID: warningID)
                     do {
                         try await Task.sleep(for: .seconds(3))
                     } catch {
@@ -1566,13 +1566,20 @@ struct QuickstartView: View {
                 )
             ) { _ in
                 foregroundMemoryRefreshTask?.cancel()
-                guard server.pendingMemoryWarning != nil else {
+                guard let warningID = visibleMemoryWarningID else {
                     foregroundMemoryRefreshTask = nil
                     return
                 }
                 foregroundMemoryRefreshTask = Task { @MainActor in
-                    await refreshPendingMemoryWarning()
+                    await refreshPendingMemoryWarning(expectedID: warningID)
                 }
+            }
+            .onChange(of: visibleMemoryWarningID) { _, _ in
+                // A foreground probe is not view-bound like `.task(id:)`.
+                // Cancel it when the rendered decision disappears or changes
+                // owner so it cannot update or announce a hidden warning.
+                foregroundMemoryRefreshTask?.cancel()
+                foregroundMemoryRefreshTask = nil
             }
             .onDisappear {
                 foregroundMemoryRefreshTask?.cancel()
@@ -3994,9 +4001,23 @@ struct QuickstartView: View {
         }
     }
 
+    /// Identity of the decision this onboarding surface actually renders.
+    /// A queued warning for another alias or another onboarding phase belongs
+    /// to a different surface and must not keep this view's sampler alive.
+    private var visibleMemoryWarningID: UUID? {
+        Self.memoryWarningToPresent(
+            phase: coordinator.phase,
+            pending: server.pendingMemoryWarning,
+            selectionAlias: coordinator.selection.alias
+        )?.id
+    }
+
     @MainActor
-    private func refreshPendingMemoryWarning() async {
-        guard let transition = await server.refreshPendingMemoryWarning(),
+    private func refreshPendingMemoryWarning(expectedID: UUID) async {
+        guard visibleMemoryWarningID == expectedID,
+              let transition = await server.refreshPendingMemoryWarning(),
+              !Task.isCancelled,
+              visibleMemoryWarningID == expectedID,
               NSWorkspace.shared.isVoiceOverEnabled else { return }
         let announcement = transition.new == .safe
             ? "Memory is now safe. Load model is available."

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1555,13 +1555,15 @@ struct QuickstartView: View {
                     }
                 }
             }
-            .onReceive(
-                NotificationCenter.default.publisher(
-                    for: NSApplication.didBecomeActiveNotification
+            .task {
+                let activations = NotificationCenter.default.notifications(
+                    named: NSApplication.didBecomeActiveNotification
                 )
-            ) { _ in
-                guard server.pendingMemoryWarning != nil else { return }
-                Task { await refreshPendingMemoryWarning() }
+                for await _ in activations {
+                    guard !Task.isCancelled else { return }
+                    guard server.pendingMemoryWarning != nil else { continue }
+                    await refreshPendingMemoryWarning()
+                }
             }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import SwiftUI
@@ -1538,6 +1539,29 @@ struct QuickstartView: View {
             // status enum changes — exactly the trigger shape we want.
             .task(id: downloadJobStatusKey) {
                 handleDownloadStatusChange()
+            }
+            // The warning asks the user to free memory, so keep observing the
+            // result of that action while this exact decision is visible.
+            // The view-bound task cancels when onboarding unmounts; three
+            // seconds matches the app's existing system-memory telemetry.
+            .task(id: server.pendingMemoryWarning?.id) {
+                guard server.pendingMemoryWarning != nil else { return }
+                while !Task.isCancelled, server.pendingMemoryWarning != nil {
+                    await refreshPendingMemoryWarning()
+                    do {
+                        try await Task.sleep(for: .seconds(3))
+                    } catch {
+                        return
+                    }
+                }
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification
+                )
+            ) { _ in
+                guard server.pendingMemoryWarning != nil else { return }
+                Task { await refreshPendingMemoryWarning() }
             }
     }
 
@@ -3876,8 +3900,8 @@ struct QuickstartView: View {
     private func memoryWarningCard(_ warning: ModelSizing.MemoryWarning) -> some View {
         let fallback = Self.lowMemoryRecoveryChoice(for: warning)
         OnboardingOutcomeBlock(
-            glyph: "exclamationmark.triangle",
-            tone: .amber,
+            glyph: warning.severity == .safe ? "checkmark" : "exclamationmark.triangle",
+            tone: warning.severity == .safe ? .ready : .amber,
             kicker: "STEP \(QuickstartCoordinator.Step.start.displayNumber) "
                 + "OF \(QuickstartCoordinator.Step.total) · BEFORE LOADING",
             title: warning.title,
@@ -3889,7 +3913,9 @@ struct QuickstartView: View {
                 OnboardingStat(
                     label: "NEEDS",
                     value: Self.wholeGB(warning.footprintGB),
-                    tone: RapidTheme.statusError
+                    tone: warning.severity == .safe
+                        ? RapidTheme.statusReady
+                        : RapidTheme.statusError
                 )
                 OnboardingStat(
                     label: "FREE NOW",
@@ -3905,7 +3931,16 @@ struct QuickstartView: View {
             .padding(.top, 30)
         } actions: {
             OnboardingActionLane {
-                if let fallback {
+                if warning.severity == .safe {
+                    Button(warning.confirmTitle) {
+                        server.confirmPendingMemoryLoad(warning)
+                    }
+                    .buttonStyle(.onboardingPrimary)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("Quickstart.Memory.Load")
+                }
+
+                if let fallback, warning.severity != .safe {
                     Button("Switch to \(fallback.displayName)") {
                         server.cancelPendingMemoryLoad(warning)
                         coordinator.returnToChooser()
@@ -3918,15 +3953,17 @@ struct QuickstartView: View {
                     .accessibilityLabel("Switch to \(fallback.displayName), the lowest-memory option")
                 }
 
-                Button(warning.confirmTitle) {
-                    // Re-enters ``start`` with the guard bypassed. We stay in
-                    // ``.starting``; ``handleServerStateChange`` seeds the
-                    // welcome and dismisses the sheet once the child reaches
-                    // ``.ready``.
-                    server.confirmPendingMemoryLoad(warning)
+                if warning.severity != .safe {
+                    Button(warning.confirmTitle) {
+                        // Re-enters ``start`` with the guard bypassed. We stay in
+                        // ``.starting``; ``handleServerStateChange`` seeds the
+                        // welcome and dismisses the sheet once the child reaches
+                        // ``.ready``.
+                        server.confirmPendingMemoryLoad(warning)
+                    }
+                    .buttonStyle(.onboardingOutline)
+                    .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
                 }
-                .buttonStyle(.onboardingOutline)
-                .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
 
                 Button("Cancel") {
                     // Drop the parked load and leave ``.starting`` for the
@@ -3940,6 +3977,16 @@ struct QuickstartView: View {
                 .accessibilityIdentifier("Quickstart.Memory.Cancel")
             }
         }
+    }
+
+    @MainActor
+    private func refreshPendingMemoryWarning() async {
+        guard let transition = await server.refreshPendingMemoryWarning(),
+              NSWorkspace.shared.isVoiceOverEnabled else { return }
+        let announcement = transition.new == .safe
+            ? "Memory is now safe. Load model is available."
+            : "Memory conditions changed to \(transition.new.rawValue)."
+        VoiceOverAnnouncer.announce(announcement)
     }
 
     /// Return the curated low-memory fallback only when the same snapshot

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -3931,7 +3931,7 @@ struct QuickstartView: View {
             .padding(.top, 30)
         } actions: {
             OnboardingActionLane {
-                if warning.severity == .safe {
+                if warning.severity != .unsafe {
                     Button(warning.confirmTitle) {
                         server.confirmPendingMemoryLoad(warning)
                     }
@@ -3940,7 +3940,7 @@ struct QuickstartView: View {
                     .accessibilityIdentifier("Quickstart.Memory.Load")
                 }
 
-                if let fallback, warning.severity != .safe {
+                if let fallback, warning.severity == .unsafe {
                     Button("Switch to \(fallback.displayName)") {
                         server.cancelPendingMemoryLoad(warning)
                         coordinator.returnToChooser()
@@ -3953,7 +3953,7 @@ struct QuickstartView: View {
                     .accessibilityLabel("Switch to \(fallback.displayName), the lowest-memory option")
                 }
 
-                if warning.severity != .safe {
+                if warning.severity == .unsafe {
                     Button(warning.confirmTitle) {
                         // Re-enters ``start`` with the guard bypassed. We stay in
                         // ``.starting``; ``handleServerStateChange`` seeds the

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -159,6 +159,41 @@ struct LaunchAutoStartMemoryTests {
         #expect(await refresh.value == nil)
         #expect(server.pendingMemoryWarning?.severity == .unsafe)
     }
+
+    @MainActor
+    @Test("confirm survives SwiftUI's same-turn alert dismissal")
+    func confirmedWarningIsNotCancelledByAlertDismissal() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = BlockingActivationSnapshots(
+            .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        let completion = LockedCompletionFlag()
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.next() }
+
+        let load = Task {
+            _ = await server.ensureServing(alias: "qwen3.5-9b-4bit")
+            completion.markComplete()
+        }
+        while server.pendingMemoryWarning == nil {
+            await Task.yield()
+        }
+        let warning = try #require(server.pendingMemoryWarning)
+
+        server.confirmPendingMemoryLoad(warning)
+        await snapshots.waitForActivationSample()
+        // SwiftUI writes false to the alert Binding after its button action.
+        // That same-turn dismissal must not reverse an accepted decision.
+        server.cancelPendingMemoryLoad(warning)
+        try await Task.sleep(for: .milliseconds(350))
+        #expect(!completion.isComplete)
+
+        snapshots.releaseActivationSample()
+        _ = await load.value
+    }
 }
 
 private final class LockedMemorySnapshots: @unchecked Sendable {
@@ -222,4 +257,44 @@ private final class OrderedMemorySnapshots: @unchecked Sendable {
     func releaseDelayedSample() {
         delayedRelease.signal()
     }
+}
+
+private final class BlockingActivationSnapshots: @unchecked Sendable {
+    private let lock = NSLock()
+    private let activationRelease = DispatchSemaphore(value: 0)
+    private let value: MemoryProbe.Snapshot
+    private var callCount = 0
+    private var activationStarted = false
+
+    init(_ value: MemoryProbe.Snapshot) {
+        self.value = value
+    }
+
+    func next() -> MemoryProbe.Snapshot {
+        let call = lock.withLock {
+            defer { callCount += 1 }
+            if callCount == 1 { activationStarted = true }
+            return callCount
+        }
+        if call == 1 { activationRelease.wait() }
+        return value
+    }
+
+    func waitForActivationSample() async {
+        while !lock.withLock({ activationStarted }) {
+            await Task.yield()
+        }
+    }
+
+    func releaseActivationSample() {
+        activationRelease.signal()
+    }
+}
+
+private final class LockedCompletionFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var complete = false
+
+    var isComplete: Bool { lock.withLock { complete } }
+    func markComplete() { lock.withLock { complete = true } }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -32,4 +32,81 @@ struct LaunchAutoStartMemoryTests {
         #expect(server.pendingMemoryWarning?.severity == .unsafe)
         #expect(server.servingAlias == nil)
     }
+
+    @MainActor
+    @Test("parked warning re-samples the injected probe in both directions")
+    func parkedWarningRefreshesFromInjectedProbe() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = LockedMemorySnapshots(
+            .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.current }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        let originalID = try #require(server.pendingMemoryWarning?.id)
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        let becameSafe = await server.refreshPendingMemoryWarning()
+        #expect(becameSafe?.old == .unsafe)
+        #expect(becameSafe?.new == .safe)
+        #expect(server.pendingMemoryWarning?.id == originalID)
+        #expect(server.pendingMemoryWarning?.confirmTitle == "Load model")
+
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        let becameUnsafe = await server.refreshPendingMemoryWarning()
+        #expect(becameUnsafe?.old == .safe)
+        #expect(becameUnsafe?.new == .unsafe)
+        #expect(server.pendingMemoryWarning?.id == originalID)
+    }
+
+    @MainActor
+    @Test("a newly-safe Load action rechecks memory at activation")
+    func safeActionDoesNotBecomeAStaleBypass() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = LockedMemorySnapshots(
+            .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.current }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        let originalID = try #require(server.pendingMemoryWarning?.id)
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        _ = await server.refreshPendingMemoryWarning()
+        let safeWarning = try #require(server.pendingMemoryWarning)
+        #expect(safeWarning.severity == .safe)
+
+        // Pressure returns after the last visible sample but before the user
+        // clicks. The ordinary Load action must not carry a stale waiver.
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        server.confirmPendingMemoryLoad(safeWarning)
+        for _ in 0 ..< 100 where server.pendingMemoryWarning == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let rechecked = try #require(server.pendingMemoryWarning)
+        #expect(rechecked.severity == .unsafe)
+        #expect(rechecked.id != originalID)
+    }
+}
+
+private final class LockedMemorySnapshots: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: MemoryProbe.Snapshot
+
+    init(_ value: MemoryProbe.Snapshot) {
+        self.value = value
+    }
+
+    var current: MemoryProbe.Snapshot {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -94,12 +94,13 @@ struct LaunchAutoStartMemoryTests {
         // clicks. The ordinary Load action must not carry a stale waiver.
         snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
         server.confirmPendingMemoryLoad(safeWarning)
-        for _ in 0 ..< 100 where server.pendingMemoryWarning == nil {
+        for _ in 0 ..< 100 where server.pendingMemoryWarning?.severity != .unsafe {
             try await Task.sleep(for: .milliseconds(10))
         }
         let rechecked = try #require(server.pendingMemoryWarning)
         #expect(rechecked.severity == .unsafe)
-        #expect(rechecked.id != originalID)
+        #expect(rechecked.id == originalID)
+        #expect(server.state == .idle)
     }
 
     @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -131,6 +131,33 @@ struct LaunchAutoStartMemoryTests {
         #expect(olderTransition == nil)
         #expect(server.pendingMemoryWarning?.severity == .safe)
     }
+
+    @MainActor
+    @Test("a cancelled view-bound refresh cannot update the parked warning")
+    func cancelledRefreshDoesNotApplyItsSample() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = OrderedMemorySnapshots(
+            initial: .init(totalBytes: 32 * gib, usedBytes: 30 * gib),
+            delayed: .init(totalBytes: 32 * gib, usedBytes: 2 * gib),
+            newest: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.next() }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        let refresh = Task { await server.refreshPendingMemoryWarning() }
+        await snapshots.waitForDelayedSample()
+        refresh.cancel()
+        snapshots.releaseDelayedSample()
+
+        #expect(await refresh.value == nil)
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+    }
 }
 
 private final class LockedMemorySnapshots: @unchecked Sendable {

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -50,9 +50,15 @@ struct LaunchAutoStartMemoryTests {
         let originalID = try #require(server.pendingMemoryWarning?.id)
         #expect(server.pendingMemoryWarning?.severity == .unsafe)
 
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 16 * gib)
+        let becameTight = await server.refreshPendingMemoryWarning()
+        #expect(becameTight?.old == .unsafe)
+        #expect(becameTight?.new == .tight)
+        #expect(server.pendingMemoryWarning?.confirmTitle == "Load model")
+
         snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
         let becameSafe = await server.refreshPendingMemoryWarning()
-        #expect(becameSafe?.old == .unsafe)
+        #expect(becameSafe?.old == .tight)
         #expect(becameSafe?.new == .safe)
         #expect(server.pendingMemoryWarning?.id == originalID)
         #expect(server.pendingMemoryWarning?.confirmTitle == "Load model")

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -101,6 +101,36 @@ struct LaunchAutoStartMemoryTests {
         #expect(rechecked.severity == .unsafe)
         #expect(rechecked.id != originalID)
     }
+
+    @MainActor
+    @Test("an older overlapping sample cannot overwrite a newer result")
+    func overlappingRefreshesKeepNewestResult() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = OrderedMemorySnapshots(
+            initial: .init(totalBytes: 32 * gib, usedBytes: 30 * gib),
+            delayed: .init(totalBytes: 32 * gib, usedBytes: 16 * gib),
+            newest: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.next() }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        let older = Task { await server.refreshPendingMemoryWarning() }
+        await snapshots.waitForDelayedSample()
+        let newer = Task { await server.refreshPendingMemoryWarning() }
+        let newerTransition = await newer.value
+        snapshots.releaseDelayedSample()
+        let olderTransition = await older.value
+
+        #expect(newerTransition?.new == .safe)
+        #expect(olderTransition == nil)
+        #expect(server.pendingMemoryWarning?.severity == .safe)
+    }
 }
 
 private final class LockedMemorySnapshots: @unchecked Sendable {
@@ -114,5 +144,54 @@ private final class LockedMemorySnapshots: @unchecked Sendable {
     var current: MemoryProbe.Snapshot {
         get { lock.withLock { value } }
         set { lock.withLock { value = newValue } }
+    }
+}
+
+private final class OrderedMemorySnapshots: @unchecked Sendable {
+    private let lock = NSLock()
+    private let delayedRelease = DispatchSemaphore(value: 0)
+    private let initial: MemoryProbe.Snapshot
+    private let delayed: MemoryProbe.Snapshot
+    private let newest: MemoryProbe.Snapshot
+    private var callCount = 0
+    private var delayedSampleStarted = false
+
+    init(
+        initial: MemoryProbe.Snapshot,
+        delayed: MemoryProbe.Snapshot,
+        newest: MemoryProbe.Snapshot
+    ) {
+        self.initial = initial
+        self.delayed = delayed
+        self.newest = newest
+    }
+
+    func next() -> MemoryProbe.Snapshot {
+        let call = lock.withLock {
+            defer { callCount += 1 }
+            if callCount == 1 {
+                delayedSampleStarted = true
+            }
+            return callCount
+        }
+        switch call {
+        case 0:
+            return initial
+        case 1:
+            delayedRelease.wait()
+            return delayed
+        default:
+            return newest
+        }
+    }
+
+    func waitForDelayedSample() async {
+        while !lock.withLock({ delayedSampleStarted }) {
+            await Task.yield()
+        }
+    }
+
+    func releaseDelayedSample() {
+        delayedRelease.signal()
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -134,6 +134,47 @@ struct LaunchAutoStartMemoryTests {
     }
 
     @MainActor
+    @Test("activation invalidates an older periodic memory sample")
+    func activationInvalidatesOlderPeriodicSample() async throws {
+        let gib = UInt64(1_073_741_824)
+        let snapshots = ActivationRaceMemorySnapshots(
+            unsafe: .init(totalBytes: 32 * gib, usedBytes: 30 * gib),
+            safe: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.next() }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        _ = await server.refreshPendingMemoryWarning()
+        let safeWarning = try #require(server.pendingMemoryWarning)
+        #expect(safeWarning.severity == .safe)
+
+        let olderPeriodicRefresh = Task {
+            await server.refreshPendingMemoryWarning()
+        }
+        await snapshots.waitForPeriodicSample()
+
+        server.confirmPendingMemoryLoad(safeWarning)
+        for _ in 0 ..< 100 where server.pendingMemoryWarning?.severity != .unsafe {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        snapshots.releasePeriodicSample()
+        let olderTransition = await olderPeriodicRefresh.value
+
+        #expect(olderTransition == nil)
+        #expect(server.pendingMemoryWarning?.id == safeWarning.id)
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+        #expect(server.state == .idle)
+    }
+
+    @MainActor
     @Test("a cancelled view-bound refresh cannot update the parked warning")
     func cancelledRefreshDoesNotApplyItsSample() async throws {
         let gib = UInt64(1_073_741_824)
@@ -256,6 +297,47 @@ private final class OrderedMemorySnapshots: @unchecked Sendable {
 
     func releaseDelayedSample() {
         delayedRelease.signal()
+    }
+}
+
+private final class ActivationRaceMemorySnapshots: @unchecked Sendable {
+    private let lock = NSLock()
+    private let periodicRelease = DispatchSemaphore(value: 0)
+    private let unsafe: MemoryProbe.Snapshot
+    private let safe: MemoryProbe.Snapshot
+    private var callCount = 0
+    private var periodicSampleStarted = false
+
+    init(unsafe: MemoryProbe.Snapshot, safe: MemoryProbe.Snapshot) {
+        self.unsafe = unsafe
+        self.safe = safe
+    }
+
+    func next() -> MemoryProbe.Snapshot {
+        let call = lock.withLock {
+            defer { callCount += 1 }
+            if callCount == 2 { periodicSampleStarted = true }
+            return callCount
+        }
+        switch call {
+        case 0, 3:
+            return unsafe
+        case 2:
+            periodicRelease.wait()
+            return safe
+        default:
+            return safe
+        }
+    }
+
+    func waitForPeriodicSample() async {
+        while !lock.withLock({ periodicSampleStarted }) {
+            await Task.yield()
+        }
+    }
+
+    func releasePeriodicSample() {
+        periodicRelease.signal()
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -219,4 +219,33 @@ struct MemoryLoadConfirmationQueueTests {
         )
         #expect(refreshed == nil)
     }
+
+    @Test("activation check owns the warning before alert dismissal")
+    func activationCheckCannotBeCancelledByAlertDismissal() throws {
+        let gib = UInt64(1 << 30)
+        let request = UUID()
+        var queue = MemoryLoadConfirmationQueue()
+        let original = warning("qwen3.5-9b-4bit")
+        queue.enqueue(warning: original, requestID: request)
+
+        let beganChecking = queue.beginChecking(warningID: original.id)
+        #expect(beganChecking)
+        #expect(queue.currentWarning == nil)
+        #expect(queue.isPending(request))
+        let dismissed = queue.resolveCurrent(warning: original, decision: .cancelled)
+        #expect(!dismissed)
+        #expect(queue.isPending(request))
+
+        let checkedWarning = queue.checkingWarning(
+            warningID: original.id,
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        let checked = try #require(checkedWarning)
+        #expect(checked.id == original.id)
+        #expect(checked.severity == .unsafe)
+
+        queue.restoreAwaiting(warningID: original.id)
+        #expect(queue.currentWarning == checked)
+        #expect(queue.takeDecision(for: request) == nil)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -173,12 +173,11 @@ struct MemoryLoadConfirmationQueueTests {
         // Refreshing is not a decision: the original waiter remains parked
         // until the user activates the newly-safe Load model action.
         #expect(queue.takeDecision(for: request) == nil)
-        let current = try #require(unsafeAgain?.new)
-        let confirmed = queue.resolveCurrent(
-            warning: current,
+        let current = queue.resolveCurrent(
+            warningID: original.id,
             decision: .confirmed(sequence: 12)
         )
-        #expect(confirmed)
+        #expect(current == unsafeAgain?.new)
         #expect(queue.takeDecision(for: request) == .confirmed(sequence: 12))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -182,6 +182,31 @@ struct MemoryLoadConfirmationQueueTests {
         #expect(queue.takeDecision(for: request) == .confirmed(sequence: 12))
     }
 
+    @Test("live refresh reuses the originally captured footprint")
+    func liveRefreshPreservesOriginalFootprint() throws {
+        let gib = UInt64(1 << 30)
+        var queue = MemoryLoadConfirmationQueue()
+        let original = ModelSizing.MemoryWarning(
+            alias: "custom-local-model",
+            hfPath: "/models/custom-local-model",
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: 24,
+            freeGB: 2,
+            totalGB: 32
+        )
+        queue.enqueue(warning: original, requestID: nil)
+
+        let result = queue.refreshCurrentWarning(
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        let refreshed = try #require(result)
+
+        #expect(refreshed.new.severity == .tight)
+        #expect(refreshed.new.footprintGB == 24)
+        #expect(refreshed.new.hfPath == original.hfPath)
+    }
+
     @Test("refresh is ignored after the visible decision starts launching")
     func liveRefreshCannotRewriteLaunchingDecision() {
         let gib = UInt64(1 << 30)

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -136,4 +136,63 @@ struct MemoryLoadConfirmationQueueTests {
         queue.completeConfirmedLaunch(warningID: warning.id)
         #expect(queue.currentWarning == nil)
     }
+
+    @Test("live memory refresh updates facts without replacing the parked decision")
+    func liveRefreshPreservesDecisionIdentity() throws {
+        let gib = UInt64(1 << 30)
+        var queue = MemoryLoadConfirmationQueue()
+        let request = UUID()
+        let original = ModelSizing.MemoryWarning(
+            alias: "qwen3.5-9b-4bit",
+            hfPath: nil,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: ModelSizing.estimate(alias: "qwen3.5-9b-4bit").totalGB,
+            freeGB: 2,
+            totalGB: 32
+        )
+        queue.enqueue(warning: original, requestID: request)
+
+        let refreshed = queue.refreshCurrentWarning(
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        let transition = try #require(refreshed)
+        #expect(transition.old.severity == .unsafe)
+        #expect(transition.new.severity == .safe)
+        #expect(transition.new.id == original.id)
+        #expect(transition.new.freeGB == 30)
+        #expect(queue.currentWarning == transition.new)
+
+        let unsafeAgain = queue.refreshCurrentWarning(
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        #expect(unsafeAgain?.old.severity == .safe)
+        #expect(unsafeAgain?.new.severity == .unsafe)
+        #expect(unsafeAgain?.new.id == original.id)
+
+        // Refreshing is not a decision: the original waiter remains parked
+        // until the user activates the newly-safe Load model action.
+        #expect(queue.takeDecision(for: request) == nil)
+        let current = try #require(unsafeAgain?.new)
+        let confirmed = queue.resolveCurrent(
+            warning: current,
+            decision: .confirmed(sequence: 12)
+        )
+        #expect(confirmed)
+        #expect(queue.takeDecision(for: request) == .confirmed(sequence: 12))
+    }
+
+    @Test("refresh is ignored after the visible decision starts launching")
+    func liveRefreshCannotRewriteLaunchingDecision() {
+        let gib = UInt64(1 << 30)
+        var queue = MemoryLoadConfirmationQueue()
+        let original = warning("qwen3.5-9b-4bit")
+        queue.enqueue(warning: original, requestID: nil)
+        let confirmed = queue.resolveCurrent(warning: original, decision: .confirmed(sequence: 2))
+        #expect(confirmed)
+        let refreshed = queue.refreshCurrentWarning(
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        )
+        #expect(refreshed == nil)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -188,6 +188,8 @@ struct ModelSizingTests {
         #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 13 * gib, totalBytes: 32 * gib) == .tight)
         // Just over the 85% panic line on the same Mac → blocked.
         #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 16 * gib, totalBytes: 32 * gib) == .unsafe)
+        #expect(!ModelSizing.requiresMemoryConfirmation(.tight))
+        #expect(ModelSizing.requiresMemoryConfirmation(.unsafe))
     }
 
     @Test("memorySafety: fails open on unknown params or unreadable probe")

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -800,4 +800,25 @@ struct QuickstartMemoryWiringSourceGuardTests {
             "ContentView's suppression helper no longer keys on the shared memoryWarningToPresent predicate — the two surfaces can drift on who owns the decision (#1503)."
         )
     }
+
+    @Test("Live memory sampling is bound to the warning onboarding actually renders")
+    func liveMemorySamplingUsesVisibleWarningIdentity() throws {
+        let src = try loadStripped("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(
+            src.contains(".task(id:visibleMemoryWarningID)"),
+            "The periodic sampler is no longer keyed to the rendered onboarding warning; a hidden or foreign decision could keep it alive."
+        )
+        #expect(
+            src.contains("while!Task.isCancelled,visibleMemoryWarningID==warningID"),
+            "The periodic sampler no longer stops when the rendered warning changes owner or leaves the current phase."
+        )
+        #expect(
+            src.contains(".onChange(of:visibleMemoryWarningID)"),
+            "The foreground sampler is no longer cancelled when the rendered warning disappears or changes owner."
+        )
+        #expect(
+            src.contains("visibleMemoryWarningID==expectedID,lettransition=awaitserver.refreshPendingMemoryWarning(),!Task.isCancelled,visibleMemoryWarningID==expectedID"),
+            "A foreground or periodic probe can update or announce after its visible warning has disappeared."
+        )
+    }
 }


### PR DESCRIPTION
## Intention

Make onboarding memory-safety decisions track live host memory while the warning is visible and re-check the exact action at activation, without allowing stale asynchronous samples to overwrite newer safety facts.

Fixes #2295.

## Scope

- Preserve the existing server-owned confirmation queue as the single decision state.
- Re-sample host memory every three seconds only while the onboarding-owned warning is visible, plus once when the app returns to the foreground.
- Reuse the existing unsafe, tight, and safe policy; only unsafe parks a load.
- Re-check an ordinary Load action at activation and keep the same request parked if it has become unsafe.
- Order timer, foreground, and activation probes through the existing refresh generation.
- Announce only material visible safety-state transitions to VoiceOver.
- Add deterministic injected-probe and queue lifecycle coverage.

## Non-goals

- No threshold, recommendation, residency, engine, server API, or unrelated onboarding redesign.
- No automatic model load when memory becomes safe.
- No attachment, audio, or other Desktop journey changes.

## Acceptance

- Unsafe-to-safe and safe-to-unsafe updates preserve pending request identity and waiter ownership.
- Older timer or foreground probes cannot overwrite newer refresh results.
- Once activation owns the decision, a blocked older periodic sample cannot overwrite a newer unsafe activation result after the warning is restored.
- Refresh reuses the footprint captured by the original guarded load, including custom local paths.
- Sampling stops when the rendered warning loses ownership or leaves the view lifecycle.

## Verification on final rebased head

- Final head: `0a5174a23b3cdb33631c3788d49b7c3292c83542`, rebased onto `f984de2a35fd36f993a6ed0c9a2b0c9616d15b27`.
- Range-diff: all 13 commits equivalent; no conflicts or rebase delta; clean worktree and diff-check.
- Deterministic race proof: without the activation generation advance, the new test fails because the blocked older sample changes unsafe back to safe; with the fix, the older transition is ignored and unsafe remains parked.
- 194 tests across nine focused memory-warning, sizing, onboarding, and accessibility suites passed.
- Release-shaped local build passed and produced an ad-hoc signed app.
- Directly affected `cached-quickstart` GUI journey passed.
- Automated review remains capped at round 10; no round 11 requested.
- Exact-head PR validation and full-ci are pending on this final pushed head.

The PR remains Draft until all exact-head required gates pass and the final human audit is clean.