### PR TITLE
test(mac): synchronize declined-tool approval observation

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
@@ -57,6 +57,7 @@ final class BrowseApprovalStore {
 
     private(set) var pendingRequest: PendingApproval?
     private var pendingContinuation: CheckedContinuation<Decision, Never>?
+    private var pendingRequestWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -88,6 +89,9 @@ final class BrowseApprovalStore {
                     fullURL: url,
                     host: host
                 )
+                let waiters = Array(self.pendingRequestWaiters.values)
+                self.pendingRequestWaiters.removeAll()
+                waiters.forEach { $0.resume(returning: true) }
             }
         } onCancel: { [weak self] in
             Task { @MainActor [weak self] in
@@ -101,6 +105,35 @@ final class BrowseApprovalStore {
                 }
             }
         }
+    }
+
+    /// Suspend until an approval prompt has been published.
+    ///
+    /// This is a lifecycle observation seam for deterministic callers such as
+    /// tests: it observes the same ``pendingRequest`` state the UI renders,
+    /// without guessing when publication happened from sleeps or deadlines.
+    /// Returns `false` when the observer itself is cancelled first.
+    func waitUntilPendingRequest(onWaiting: (() -> Void)? = nil) async -> Bool {
+        if pendingRequest != nil { return true }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                    return
+                }
+                pendingRequestWaiters[waiterID] = continuation
+                onWaiting?()
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.cancelPendingRequestWaiter(waiterID)
+            }
+        }
+    }
+
+    private func cancelPendingRequestWaiter(_ waiterID: UUID) {
+        pendingRequestWaiters.removeValue(forKey: waiterID)?.resume(returning: false)
     }
 
     /// Called by the SwiftUI dialog with the user's choice; resumes the tool.

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
@@ -57,7 +57,7 @@ final class BrowseApprovalStore {
 
     private(set) var pendingRequest: PendingApproval?
     private var pendingContinuation: CheckedContinuation<Decision, Never>?
-    private var pendingRequestWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var pendingRequestWaiters: [UUID: PendingRequestWaiter] = [:]
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -91,7 +91,7 @@ final class BrowseApprovalStore {
                 )
                 let waiters = Array(self.pendingRequestWaiters.values)
                 self.pendingRequestWaiters.removeAll()
-                waiters.forEach { $0.resume(returning: true) }
+                waiters.forEach { $0.resolve(true) }
             }
         } onCancel: { [weak self] in
             Task { @MainActor [weak self] in
@@ -116,16 +116,21 @@ final class BrowseApprovalStore {
     func waitUntilPendingRequest(onWaiting: (() -> Void)? = nil) async -> Bool {
         if pendingRequest != nil { return true }
         let waiterID = UUID()
+        let waiter = PendingRequestWaiter()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                if Task.isCancelled {
-                    continuation.resume(returning: false)
-                    return
+                pendingRequestWaiters[waiterID] = waiter
+                if waiter.attach(continuation) {
+                    onWaiting?()
+                } else {
+                    pendingRequestWaiters.removeValue(forKey: waiterID)
                 }
-                pendingRequestWaiters[waiterID] = continuation
-                onWaiting?()
             }
-        } onCancel: { [weak self] in
+        } onCancel: { [weak self, waiter] in
+            // Settle immediately on the cancelling thread. The actor hop below
+            // is only dictionary cleanup, so a later publication cannot beat a
+            // cancellation that has already won the once-only waiter state.
+            waiter.resolve(false)
             Task { @MainActor [weak self] in
                 self?.cancelPendingRequestWaiter(waiterID)
             }
@@ -133,7 +138,7 @@ final class BrowseApprovalStore {
     }
 
     private func cancelPendingRequestWaiter(_ waiterID: UUID) {
-        pendingRequestWaiters.removeValue(forKey: waiterID)?.resume(returning: false)
+        pendingRequestWaiters.removeValue(forKey: waiterID)
     }
 
     /// Called by the SwiftUI dialog with the user's choice; resumes the tool.
@@ -200,5 +205,40 @@ final class BrowseApprovalStore {
             }
         }
         return out
+    }
+}
+
+/// Once-only bridge between an approval publication and observer cancellation.
+/// Either side may arrive before the continuation is attached, and either may
+/// run off the main actor; the lock preserves the first outcome in both cases.
+private final class PendingRequestWaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var result: Bool?
+
+    /// Returns whether the continuation remains suspended after attachment.
+    func attach(_ continuation: CheckedContinuation<Bool, Never>) -> Bool {
+        lock.lock()
+        if let result {
+            lock.unlock()
+            continuation.resume(returning: result)
+            return false
+        }
+        self.continuation = continuation
+        lock.unlock()
+        return true
+    }
+
+    func resolve(_ result: Bool) {
+        lock.lock()
+        guard self.result == nil else {
+            lock.unlock()
+            return
+        }
+        self.result = result
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: result)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -55,7 +55,7 @@ final class DeclinedToolDiagnosisTests {
 
         // The gate suspends on the user; answer it the way the sheet's
         // "Don't allow" button does.
-        try await waitForPendingApproval(approval)
+        #expect(await approval.waitUntilPendingRequest())
         approval.answer(.deny)
         let result = await pending
 
@@ -80,7 +80,7 @@ final class DeclinedToolDiagnosisTests {
         async let pending = registry.run(
             ToolCall(id: "call_1", name: "browse", arguments: #"{"url":"https://example.com"}"#)
         )
-        try await waitForPendingApproval(approval)
+        #expect(await approval.waitUntilPendingRequest())
         approval.answer(.deny)
         let result = await pending
 
@@ -104,7 +104,7 @@ final class DeclinedToolDiagnosisTests {
                 cache: cache
             )
         }
-        try await waitForPendingApproval(approval)
+        #expect(await approval.waitUntilPendingRequest())
         task.cancel()
         let result = await task.value
 
@@ -118,7 +118,7 @@ final class DeclinedToolDiagnosisTests {
         // is wrong. The user never saw this URL, so the answer cannot be theirs.
         let approval = BrowseApprovalStore(defaults: freshDefaults())
         async let first = approval.requestApproval(url: "https://example.com", host: "example.com")
-        try await waitForPendingApproval(approval)
+        #expect(await approval.waitUntilPendingRequest())
 
         let second = await approval.requestApproval(url: "https://other.example", host: "other.example")
         #expect(second == .unavailable)
@@ -144,7 +144,7 @@ final class DeclinedToolDiagnosisTests {
             url: "https://example.com/article",
             host: "example.com"
         )
-        try await waitForPendingApproval(approval)
+        #expect(await approval.waitUntilPendingRequest())
         approval.alwaysAllow()
 
         #expect(await pending == .allowOnce)
@@ -159,6 +159,55 @@ final class DeclinedToolDiagnosisTests {
         )
         #expect(next == .allowOnce)
         #expect(restored.pendingRequest == nil)
+    }
+
+    @Test("Cancelling a pending-request observer settles without a prompt")
+    func cancelledPendingRequestObserverSettles() async {
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        var observer: Task<Bool, Never>!
+
+        await withCheckedContinuation { registered in
+            observer = Task {
+                await approval.waitUntilPendingRequest {
+                    registered.resume()
+                }
+            }
+        }
+
+        observer.cancel()
+        #expect(await observer.value == false)
+        #expect(approval.pendingRequest == nil)
+    }
+
+    @Test("Publishing one prompt wakes every registered observer")
+    func pendingRequestPublicationWakesEveryObserver() async {
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        var firstObserver: Task<Bool, Never>!
+        var secondObserver: Task<Bool, Never>!
+
+        await withCheckedContinuation { registered in
+            firstObserver = Task {
+                await approval.waitUntilPendingRequest {
+                    registered.resume()
+                }
+            }
+        }
+        await withCheckedContinuation { registered in
+            secondObserver = Task {
+                await approval.waitUntilPendingRequest {
+                    registered.resume()
+                }
+            }
+        }
+
+        async let pending = approval.requestApproval(
+            url: "https://example.com/article",
+            host: "example.com"
+        )
+        #expect(await firstObserver.value)
+        #expect(await secondObserver.value)
+        approval.answer(.deny)
+        #expect(await pending == .deny)
     }
 
     // MARK: - Declining a cross-origin redirect
@@ -509,22 +558,6 @@ final class DeclinedToolDiagnosisTests {
         return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    /// Suspend until the approval gate has published its prompt, so the test
-    /// answers a request that actually exists. Bounded by wall-clock rather
-    /// than by an iteration count — a loaded machine must not fail correct
-    /// code — and it still fails rather than hanging if the prompt never comes.
-    private func waitForPendingApproval(
-        _ approval: BrowseApprovalStore,
-        timeout: Duration = .seconds(10)
-    ) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while approval.pendingRequest == nil {
-            if ContinuousClock.now >= deadline { throw ApprovalNeverArrived() }
-            try await Task.sleep(for: .milliseconds(1))
-        }
-    }
-
-    private struct ApprovalNeverArrived: Error {}
 }
 
 /// Keychain double: the web-search key is irrelevant here, and the real

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -44,7 +44,7 @@ final class DeclinedToolDiagnosisTests {
 
     // MARK: - Declining the initial fetch
 
-    @Test("Clicking Don't allow on a browse prompt is a user decline, not a tool failure")
+    @Test("Clicking Don't allow on a browse prompt is a user decline, not a tool failure", .timeLimit(.minutes(1)))
     func declinedBrowseIsNotAFailure() async throws {
         let approval = BrowseApprovalStore(defaults: freshDefaults())
         async let pending = BrowseTool.run(
@@ -66,7 +66,7 @@ final class DeclinedToolDiagnosisTests {
         #expect(result.isError)
     }
 
-    @Test("A declined browse keeps its user-declined kind through tool dispatch")
+    @Test("A declined browse keeps its user-declined kind through tool dispatch", .timeLimit(.minutes(1)))
     func registryPreservesTheDeclinedKind() async throws {
         // ``BuiltinToolRegistry`` re-classifies every result at the dispatch
         // boundary. It must PREFER what the tool reported: re-deriving the kind
@@ -90,7 +90,7 @@ final class DeclinedToolDiagnosisTests {
 
     // MARK: - Only an actual "no" is a decline
 
-    @Test("A turn cancelled while the prompt is up is not blamed on the user")
+    @Test("A turn cancelled while the prompt is up is not blamed on the user", .timeLimit(.minutes(1)))
     func cancellationIsNotADecline() async throws {
         // Pressing Stop tears the approval sheet down. The store used to report
         // that as ``.deny``, which would now read back to the user as "you
@@ -112,7 +112,7 @@ final class DeclinedToolDiagnosisTests {
         #expect(result.isError)
     }
 
-    @Test("A second prompt while one is already open is refused, not counted as a decline")
+    @Test("A second prompt while one is already open is refused, not counted as a decline", .timeLimit(.minutes(1)))
     func reentrantApprovalIsNotADecline() async throws {
         // Tool execution is serial, so a second pending prompt means something
         // is wrong. The user never saw this URL, so the answer cannot be theirs.
@@ -135,7 +135,7 @@ final class DeclinedToolDiagnosisTests {
         #expect(decision == .allowOnce)
     }
 
-    @Test("Always allow approves the pending fetch and persists auto-approval")
+    @Test("Always allow approves the pending fetch and persists auto-approval", .timeLimit(.minutes(1)))
     func alwaysAllowPersistsAndSkipsFuturePrompts() async throws {
         let defaults = freshDefaults()
         let approval = BrowseApprovalStore(defaults: defaults)
@@ -161,7 +161,7 @@ final class DeclinedToolDiagnosisTests {
         #expect(restored.pendingRequest == nil)
     }
 
-    @Test("Cancelling a pending-request observer settles without a prompt")
+    @Test("Cancelling a pending-request observer settles without a prompt", .timeLimit(.minutes(1)))
     func cancelledPendingRequestObserverSettles() async {
         let approval = BrowseApprovalStore(defaults: freshDefaults())
         var observer: Task<Bool, Never>!
@@ -175,11 +175,17 @@ final class DeclinedToolDiagnosisTests {
         }
 
         observer.cancel()
+        async let pending = approval.requestApproval(
+            url: "https://example.com/after-cancel",
+            host: "example.com"
+        )
+        #expect(await approval.waitUntilPendingRequest())
         #expect(await observer.value == false)
-        #expect(approval.pendingRequest == nil)
+        approval.answer(.deny)
+        #expect(await pending == .deny)
     }
 
-    @Test("Publishing one prompt wakes every registered observer")
+    @Test("Publishing one prompt wakes every registered observer", .timeLimit(.minutes(1)))
     func pendingRequestPublicationWakesEveryObserver() async {
         let approval = BrowseApprovalStore(defaults: freshDefaults())
         var firstObserver: Task<Bool, Never>!


### PR DESCRIPTION
## Intention

Eliminate the three declined-tool approval false-reds under full parallel Swift load by observing the existing approval lifecycle deterministically.

Closes #2314.

## Scope

- Add a cancellation-safe, one-shot observation seam to `BrowseApprovalStore` for the existing `pendingRequest` publication.
- Replace the declined-tool tests' sleep/poll/deadline helper with that lifecycle observation.
- Pin observer cancellation, cancel-before-publication, and multi-observer wake-up behavior.

## Non-goals

- No timeout-based synchronization or production timeout/cadence change; a test-only hang watchdog may bound infrastructure failure.
- No sleep, polling, or global suite serialization.
- No production approval decision or UI change.
- No changes to the cache byte monitor or unrelated flakes.

## Evidence

- Baseline on main before editing: full parallel run failed 2/3 affected tests with `ApprovalNeverArrived` after 13.1s.
- Pre-rebase stress: affected suite passed in 10/10 repeated full-parallel runs with no `ApprovalNeverArrived`.
- Rebasing onto `main@cb317eca` produced an identical range-diff with no conflicts.
- Exact head `3eac4b1c`: `swift build` passed.
- Exact head: focused declined-tool suite passed 28/28.
- Exact head: full parallel Swift suite passed 2,817/2,817 across 242 suites; both declined-tool and cache-monitor suites passed.
- The automated review loop stopped under its repeated-finding rule; maintainer design audit accepted the framework-native one-minute test watchdog strictly as a hang bound, not synchronization.