### PR TITLE
fix(cache): reuse prefixes for auto-detected hybrid models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart
+          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart uvicorn websockets
 
       - name: Run unit tests (no MLX required)
         # NOTE: tests in this list MUST not import mlx / mlx_lm at module
@@ -296,6 +296,38 @@ jobs:
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
             tests/test_harmony_parsers.py \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_auto_detected_hybrid_metadata_defaults_entries \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_auto_detected_hybrid_metadata_respects_explicit_zero \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_direct_hf_metadata_detection_reaches_admission \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_direct_local_metadata_detection_reaches_admission \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_linear_attention_wrapper_reuses_model_config_contract \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_turboquant_lazy_default_remains_available \
+            tests/test_hybrid_prefix_cache_auto_default.py::TestResolveHybridCacheEntries::test_turboquant_missing_auto_config_module_degrades_to_off \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_unknown_linear_attention_checkpoint_is_hybrid \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_metadata_detection_logs_when_called_directly \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_pattern_match_preserves_authoritative_hybrid_metadata \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_pattern_match_preserves_dense_nonhybrid_safety_pin \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_known_family_parser_has_priority_over_metadata_template \
+            tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35 \
+            tests/test_model_auto_config.py::TestDetectModelConfig::test_deepseek_coder_v2_routes_to_v3_parser \
+            tests/test_model_auto_config.py::TestDetectModelConfig::test_deepseek_r1_distill_does_not_advertise_tool_calls \
+            tests/test_model_auto_config.py::TestMistralFamilyToolParser::test_auto_detect_resolves_to_mistral_parser \
+            tests/test_pflash_cli_wiring.py::test_serve_command_routes_pflash_through_resolve_pflash_config \
+            tests/test_pflash_server_module_wiring.py::test_server_module_applies_detected_hybrid_cache_default \
+            tests/test_pflash_server_module_wiring.py::test_server_module_keeps_dense_cache_default_zero \
+            tests/test_pflash_server_module_wiring.py::test_server_module_lazy_metadata_consumers_share_one_result \
+            tests/test_pflash_server_module_wiring.py::test_server_module_strict_metadata_failure_propagates \
+            tests/test_pflash_server_module_wiring.py::test_server_module_cache_metadata_failure_is_nonfatal \
+            tests/test_pflash_server_module_wiring.py::test_server_module_missing_auto_config_module_degrades_to_no_default \
+            tests/test_resident_models.py::test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse \
+            tests/test_resident_models.py::test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero \
+            tests/test_resident_models.py::test_dynamic_resident_full_attention_stays_unbounded \
+            tests/test_serve_listen_fd.py::test_serve_command_threads_auto_detected_hybrid_into_cache_admission \
+            tests/test_serve_listen_fd.py::test_serve_command_cache_is_first_metadata_consumer \
+            tests/test_serve_listen_fd.py::test_serve_command_missing_auto_config_module_degrades_to_no_default \
+            tests/test_serve_listen_fd.py::test_serve_command_explicit_zero_wins_over_auto_detected_hybrid \
+            tests/test_serve_listen_fd.py::test_serve_command_all_explicit_defaults_skip_model_detection \
+            tests/test_serve_listen_fd.py::test_strict_auto_default_retries_failed_nonfatal_parser_detection \
             tests/test_tool_calling.py \
             tests/test_tool_injection.py \
             tests/test_streaming_latency.py \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,50 @@ script modules themselves don't take a runtime ``import pytest``
 dependency (pytest is dev-only; codex R3 closure)."""
 
 
+@pytest.fixture
+def scheduler_config_stub(monkeypatch):
+    """Exercise scheduler wiring without importing the Apple-only runtime."""
+    import importlib.machinery
+    import importlib.util
+    import sys
+    import types
+
+    turboquant_was_loaded = "vllm_mlx.turboquant" in sys.modules
+    if importlib.util.find_spec("mlx") is None:
+        # Import the server/tool-parser surface before installing the narrow
+        # array shim, otherwise optional-dependency discovery could mistake
+        # the shim for a complete MLX runtime.
+        import numpy as np
+
+        import vllm_mlx.server  # noqa: F401
+
+        mlx = types.ModuleType("mlx")
+        mlx.__path__ = []
+        mlx.__spec__ = importlib.machinery.ModuleSpec("mlx", loader=None)
+        mlx_core = types.ModuleType("mlx.core")
+        mlx_core.__spec__ = importlib.machinery.ModuleSpec("mlx.core", loader=None)
+        mlx_core.array = np.array
+        mlx_core.float16 = np.float16
+        mlx.core = mlx_core
+        monkeypatch.setitem(sys.modules, "mlx", mlx)
+        monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+
+    scheduler = types.ModuleType("vllm_mlx.scheduler")
+
+    class SchedulerConfig:
+        def __init__(self, **kwargs):
+            self.enable_prefix_cache = True
+            self.hybrid_cache_entries = 0
+            self.non_trimmable_exact_prefix_reuse = False
+            self.__dict__.update(kwargs)
+
+    scheduler.SchedulerConfig = SchedulerConfig
+    monkeypatch.setitem(sys.modules, "vllm_mlx.scheduler", scheduler)
+    yield SchedulerConfig
+    if not turboquant_was_loaded:
+        sys.modules.pop("vllm_mlx.turboquant", None)
+
+
 @pytest.fixture(autouse=True)
 def _reset_global_parser_state_after_each_test():
     """Keep the process-global parser state hermetic across tests.

--- a/tests/test_chat_template_registry.py
+++ b/tests/test_chat_template_registry.py
@@ -373,7 +373,7 @@ async def test_mllm_start_resolves_profile_template_at_processor_load(
 
 @pytest.mark.asyncio
 async def test_dynamic_residency_preserves_profile_contract_for_local_path(
-    monkeypatch,
+    monkeypatch, scheduler_config_stub
 ) -> None:
     pytest.importorskip("uvicorn")
     from vllm_mlx import server

--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -12,10 +12,14 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 from vllm_mlx.cli import _DEFAULT_HYBRID_CACHE_ENTRIES, _resolve_hybrid_cache_entries
 from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+from vllm_mlx.model_auto_config import detect_model_config
+from vllm_mlx.model_metadata import ModelMetadata
+from vllm_mlx.model_profile import ModelProfile
 
 # ---------------------------------------------------------------------------
 # Mock cache layers (mirrors test_hybrid_prefix_cache_growth.py)
@@ -128,6 +132,101 @@ class TestResolveHybridCacheEntries:
             model_name="qwen3.5-9b-4bit",
         )
         assert result == _DEFAULT_HYBRID_CACHE_ENTRIES
+
+    def test_auto_detected_hybrid_metadata_defaults_entries(self, monkeypatch):
+        """The already-resolved checkpoint architecture must reach admission."""
+        monkeypatch.setattr(
+            "vllm_mlx.model_aliases.resolve_profile", lambda _name: None
+        )
+        result = _resolve_hybrid_cache_entries(
+            enable_prefix_cache=True,
+            explicit_value=0,
+            user_set_explicit=False,
+            model_name="publisher/opaque-checkpoint",
+            model_config=ModelProfile(
+                is_hybrid=True,
+                is_hybrid_explicit=True,
+                supports_spec_decode=False,
+            ),
+        )
+        assert result == _DEFAULT_HYBRID_CACHE_ENTRIES
+
+    def test_auto_detected_hybrid_metadata_respects_explicit_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            "vllm_mlx.model_aliases.resolve_profile", lambda _name: None
+        )
+        result = _resolve_hybrid_cache_entries(
+            enable_prefix_cache=True,
+            explicit_value=0,
+            user_set_explicit=True,
+            model_name="publisher/opaque-checkpoint",
+            model_config=ModelProfile(
+                is_hybrid=True,
+                is_hybrid_explicit=True,
+                supports_spec_decode=False,
+            ),
+        )
+        assert result == 0
+
+    def test_direct_hf_metadata_detection_reaches_admission(self, monkeypatch):
+        """An unprofiled HF id is classified from offline checkpoint metadata."""
+        import vllm_mlx.model_auto_config as auto_config
+
+        monkeypatch.setattr(auto_config, "resolve_profile", lambda _name: None)
+        monkeypatch.setattr(
+            auto_config,
+            "read_model_metadata",
+            lambda _name: ModelMetadata(
+                config={
+                    "model_type": "publisher_novel_architecture",
+                    "layer_types": ["linear_attention", "full_attention"],
+                },
+                chat_template=None,
+                snapshot_dir=None,
+            ),
+        )
+        model_name = "publisher/opaque-hybrid-checkpoint"
+        model_config = detect_model_config(model_name)
+
+        assert model_config is not None
+        assert (
+            _resolve_hybrid_cache_entries(
+                enable_prefix_cache=True,
+                explicit_value=0,
+                user_set_explicit=False,
+                model_name=model_name,
+                model_config=model_config,
+            )
+            == _DEFAULT_HYBRID_CACHE_ENTRIES
+        )
+
+    def test_direct_local_metadata_detection_reaches_admission(self, tmp_path):
+        """A direct local path uses its config without an alias or network."""
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "publisher_novel_architecture",
+                    "text_config": {
+                        "model_type": "publisher_novel_text",
+                        "layer_types": ["linear_attention", "full_attention"],
+                    },
+                }
+            )
+        )
+        model_name = str(tmp_path)
+        model_config = detect_model_config(model_name)
+
+        assert model_config is not None
+        assert (
+            _resolve_hybrid_cache_entries(
+                enable_prefix_cache=True,
+                explicit_value=0,
+                user_set_explicit=False,
+                model_name=model_name,
+                model_config=model_config,
+            )
+            == _DEFAULT_HYBRID_CACHE_ENTRIES
+        )
 
     def test_no_auto_default_for_non_hybrid(self, monkeypatch):
         """Non-hybrid model → stays 0."""

--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -228,6 +228,51 @@ class TestResolveHybridCacheEntries:
             == _DEFAULT_HYBRID_CACHE_ENTRIES
         )
 
+    def test_linear_attention_wrapper_reuses_model_config_contract(self):
+        from vllm_mlx.cli import _config_declares_linear_attention
+
+        assert _config_declares_linear_attention(
+            {"text_config": {"layer_types": ["linear_attention"]}}
+        )
+        assert not _config_declares_linear_attention(None)
+
+    def test_turboquant_lazy_default_remains_available(self, scheduler_config_stub):
+        from types import SimpleNamespace
+
+        from vllm_mlx.turboquant import resolve_turboquant_mode_default
+
+        args = SimpleNamespace(
+            kv_cache_turboquant=None,
+            kv_cache_quantization=False,
+        )
+        assert (
+            resolve_turboquant_mode_default(args, model_name="qwen3.5-9b-4bit")
+            == "k8v4"
+        )
+
+    def test_turboquant_missing_auto_config_module_degrades_to_off(
+        self, monkeypatch, scheduler_config_stub
+    ):
+        import builtins
+        from types import SimpleNamespace
+
+        from vllm_mlx.turboquant import resolve_turboquant_mode_default
+
+        real_import = builtins.__import__
+
+        def block_auto_config(name, globals=None, locals=None, fromlist=(), level=0):
+            if level == 1 and name == "model_auto_config":
+                raise ImportError("model auto-config unavailable")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", block_auto_config)
+        args = SimpleNamespace(
+            kv_cache_turboquant=None,
+            kv_cache_quantization=False,
+        )
+
+        assert resolve_turboquant_mode_default(args, model_name="opaque") is None
+
     def test_no_auto_default_for_non_hybrid(self, monkeypatch):
         """Non-hybrid model → stays 0."""
         _patch_resolve_profile(monkeypatch, is_hybrid=False)

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2380,6 +2380,45 @@ class TestCheckpointMetadataFallback:
         assert config.is_hybrid_explicit is True
         assert config.supports_spec_decode is False
 
+    def test_pattern_match_preserves_authoritative_hybrid_metadata(self, monkeypatch):
+        """A family parser fallback must not hide checkpoint architecture."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({"model_type": "qwen3_5_moe"}, None),
+        )
+
+        config = detect_model_config("publisher/Qwen3.5-private-repack")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser == "qwen3"
+        assert config.is_hybrid is True
+        assert config.is_hybrid_explicit is True
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
+    def test_pattern_match_preserves_dense_nonhybrid_safety_pin(self, monkeypatch):
+        """Architecture enrichment must retain the dense recurrent routing pin."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "qwen3_5",
+                    "layer_types": ["linear_attention", "full_attention"],
+                },
+                None,
+            ),
+        )
+
+        config = detect_model_config("publisher/Qwen3.5-private-dense-repack")
+
+        assert config is not None
+        assert config.is_hybrid is False
+        assert config.is_hybrid_explicit is True
+        assert config.supports_spec_decode is False
+
     def test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35(self, monkeypatch):
         """Qwen3.8 reuses qwen3_5 model_type but is a hybrid MTP target."""
         monkeypatch.setattr(
@@ -2747,14 +2786,13 @@ class TestCheckpointMetadataFallback:
         assert config.tool_call_parser == "hermes"
         assert config.reasoning_parser is None
 
-    def test_known_family_has_priority_over_generic_template_fallback(
-        self, monkeypatch
-    ):
-        def unexpected_metadata_read(name):
-            raise AssertionError("known-family detection must not read metadata")
-
+    def test_known_family_parser_has_priority_over_metadata_template(self, monkeypatch):
         monkeypatch.setattr(
-            auto_config_mod, "read_model_metadata", unexpected_metadata_read
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "publisher_full_attention"}, self._XML_TOOLS
+            ),
         )
 
         config = detect_model_config("Qwen/Qwen3-Coder-Next")

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2356,6 +2356,30 @@ class TestCheckpointMetadataFallback:
         assert config.is_moe is True
         assert config.supports_spec_decode is False
 
+    def test_unknown_linear_attention_checkpoint_is_hybrid(self, monkeypatch):
+        """Architecture metadata, not a family/name rule, owns hybrid truth."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "publisher_novel_architecture",
+                    "text_config": {
+                        "model_type": "publisher_novel_text",
+                        "layer_types": ["linear_attention", "full_attention"],
+                    },
+                },
+                None,
+            ),
+        )
+
+        config = detect_model_config("publisher/opaque-checkpoint")
+
+        assert config is not None
+        assert config.is_hybrid is True
+        assert config.is_hybrid_explicit is True
+        assert config.supports_spec_decode is False
+
     def test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35(self, monkeypatch):
         """Qwen3.8 reuses qwen3_5 model_type but is a hybrid MTP target."""
         monkeypatch.setattr(

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1,6 +1,7 @@
 """Tests for model auto-config detection."""
 
 import logging
+from unittest import mock
 
 import pytest
 
@@ -2379,6 +2380,21 @@ class TestCheckpointMetadataFallback:
         assert config.is_hybrid is True
         assert config.is_hybrid_explicit is True
         assert config.supports_spec_decode is False
+
+    def test_metadata_detection_logs_when_called_directly(self, monkeypatch):
+        log = mock.Mock()
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda _name: self._metadata({"model_type": "qwen3_next"}, None),
+        )
+        monkeypatch.setattr(auto_config_mod, "_log_resolution_once", log)
+
+        config = auto_config_mod._detect_metadata_config("publisher/opaque")
+
+        assert config is not None
+        assert config.is_hybrid is True
+        log.assert_called_once()
 
     def test_pattern_match_preserves_authoritative_hybrid_metadata(self, monkeypatch):
         """A family parser fallback must not hide checkpoint architecture."""

--- a/tests/test_pflash_cli_wiring.py
+++ b/tests/test_pflash_cli_wiring.py
@@ -39,9 +39,10 @@ def _run_serve_capturing_pflash(argv: list[str], *, lane=(False, False)) -> dict
     first element is what serve must forward as ``is_multimodal``."""
     seen: dict = {}
 
-    def _stub(args, *, model_name, is_multimodal=False):
+    def _stub(args, *, model_name, is_multimodal=False, _detected_config=None):
         seen["model_name"] = model_name
         seen["is_multimodal"] = is_multimodal
+        seen["detected_config"] = _detected_config
         seen["args_is"] = args
         raise _StopError
 
@@ -73,6 +74,7 @@ def test_serve_command_routes_pflash_through_resolve_pflash_config():
     assert seen.get("model_name") == resolve_model("bonsai-27b-2bit")
     # Text-lane model → serve forwards is_multimodal=False.
     assert seen.get("is_multimodal") is False
+    assert seen.get("detected_config") is not None
 
 
 def test_serve_command_forwards_multimodal_lane_verdict():

--- a/tests/test_pflash_cli_wiring.py
+++ b/tests/test_pflash_cli_wiring.py
@@ -16,6 +16,7 @@ error so nothing past it (engine boot, uvicorn, weight load) runs.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from unittest import mock
 
@@ -23,8 +24,10 @@ import pytest
 
 import vllm_mlx.cli as cli
 
-# Bind the real engine_core before any test patches scheduler internals.
-import vllm_mlx.engine_core as _engine_core  # noqa: E402,F401
+# Bind the real engine_core on MLX hosts before any test patches scheduler
+# internals. Linux contract lanes deliberately have no MLX runtime.
+if importlib.util.find_spec("mlx") is not None:
+    import vllm_mlx.engine_core as _engine_core  # noqa: E402,F401
 
 
 class _StopError(Exception):
@@ -64,7 +67,9 @@ def _run_serve_capturing_pflash(argv: list[str], *, lane=(False, False)) -> dict
     return seen
 
 
-def test_serve_command_routes_pflash_through_resolve_pflash_config():
+def test_serve_command_routes_pflash_through_resolve_pflash_config(
+    scheduler_config_stub,
+):
     from vllm_mlx.model_aliases import resolve_model
 
     seen = _run_serve_capturing_pflash(["serve", "bonsai-27b-2bit"])

--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -210,6 +210,7 @@ def test_server_module_applies_detected_hybrid_cache_default():
 
     assert scheduler.enable_prefix_cache is True
     assert scheduler.hybrid_cache_entries == 8
+    assert scheduler.non_trimmable_exact_prefix_reuse is True
     assert detect_calls == 1
 
 
@@ -226,4 +227,5 @@ def test_server_module_keeps_dense_cache_default_zero():
 
     assert scheduler.enable_prefix_cache is True
     assert scheduler.hybrid_cache_entries == 0
+    assert scheduler.non_trimmable_exact_prefix_reuse is False
     assert detect_calls == 1

--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -132,6 +132,35 @@ def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
     return captured
 
 
+def _run_server_main_capturing_scheduler(argv: list[str], *, detected_config):
+    """Drive ``server.main()`` through scheduler construction, offline."""
+    captured: dict = {}
+    detect = mock.Mock(return_value=detected_config)
+
+    def _capture_load_model(_model, *, scheduler_config, **_kwargs):
+        captured["scheduler_config"] = scheduler_config
+        raise _StopError
+
+    server = _server_module()
+    with (
+        mock.patch("vllm_mlx.cli._port_preflight_or_die", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server._ensure_routing_config", lambda *a, **k: None),
+        mock.patch(
+            "vllm_mlx.server.resolve_serving_lane", lambda _name, **_kw: (False, False)
+        ),
+        mock.patch(
+            "vllm_mlx.model_auto_config.detect_model_config",
+            detect,
+        ),
+        mock.patch("vllm_mlx.pflash.validate_model_support", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server.load_model", _capture_load_model),
+        mock.patch.object(sys, "argv", ["vllm_mlx.server", *argv]),
+        pytest.raises(_StopError),
+    ):
+        server.main()
+    return captured["scheduler_config"], detect.call_count
+
+
 def test_server_module_applies_per_alias_keep_ratio_override():
     # bonsai-27b-2bit pins pflash_tier=verified + pflash_keep_ratio=0.50.
     # Text lane (is_mllm False) → verified tier auto-enables PFlash "always".
@@ -165,3 +194,36 @@ def test_server_module_forwards_multimodal_lane_verdict():
     assert cfg is not None
     assert captured["is_mllm"] is True
     assert cfg.mode == "off"
+
+
+def test_server_module_applies_detected_hybrid_cache_default():
+    from vllm_mlx.model_profile import ModelProfile
+
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        ["--model", "/models/linear-checkpoint"],
+        detected_config=ModelProfile(
+            hf_path="/models/linear-checkpoint",
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+        ),
+    )
+
+    assert scheduler.enable_prefix_cache is True
+    assert scheduler.hybrid_cache_entries == 8
+    assert detect_calls == 1
+
+
+def test_server_module_keeps_dense_cache_default_zero():
+    from vllm_mlx.model_profile import ModelProfile
+
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        ["--model", "/models/dense-checkpoint"],
+        detected_config=ModelProfile(
+            hf_path="/models/dense-checkpoint",
+            is_hybrid=False,
+        ),
+    )
+
+    assert scheduler.enable_prefix_cache is True
+    assert scheduler.hybrid_cache_entries == 0
+    assert detect_calls == 1

--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -132,17 +133,40 @@ def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
     return captured
 
 
-def _run_server_main_capturing_scheduler(argv: list[str], *, detected_config):
+def _run_server_main_capturing_scheduler(
+    argv: list[str],
+    *,
+    detected_config,
+    expected_exception=_StopError,
+    block_auto_config_import=False,
+):
     """Drive ``server.main()`` through scheduler construction, offline."""
     captured: dict = {}
-    detect = mock.Mock(return_value=detected_config)
+    detect = (
+        mock.Mock(side_effect=detected_config)
+        if isinstance(detected_config, BaseException)
+        else mock.Mock(return_value=detected_config)
+    )
 
     def _capture_load_model(_model, *, scheduler_config, **_kwargs):
         captured["scheduler_config"] = scheduler_config
         raise _StopError
 
     server = _server_module()
+    real_import = __import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 1 and name == "model_auto_config":
+            raise ImportError("model auto-config unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    import_guard = (
+        mock.patch("builtins.__import__", blocked_import)
+        if block_auto_config_import
+        else nullcontext()
+    )
     with (
+        import_guard,
         mock.patch("vllm_mlx.cli._port_preflight_or_die", lambda *a, **k: None),
         mock.patch("vllm_mlx.server._ensure_routing_config", lambda *a, **k: None),
         mock.patch(
@@ -155,10 +179,10 @@ def _run_server_main_capturing_scheduler(argv: list[str], *, detected_config):
         mock.patch("vllm_mlx.pflash.validate_model_support", lambda *a, **k: None),
         mock.patch("vllm_mlx.server.load_model", _capture_load_model),
         mock.patch.object(sys, "argv", ["vllm_mlx.server", *argv]),
-        pytest.raises(_StopError),
+        pytest.raises(expected_exception),
     ):
         server.main()
-    return captured["scheduler_config"], detect.call_count
+    return captured.get("scheduler_config"), detect.call_count
 
 
 def test_server_module_applies_per_alias_keep_ratio_override():
@@ -196,7 +220,7 @@ def test_server_module_forwards_multimodal_lane_verdict():
     assert cfg.mode == "off"
 
 
-def test_server_module_applies_detected_hybrid_cache_default():
+def test_server_module_applies_detected_hybrid_cache_default(scheduler_config_stub):
     from vllm_mlx.model_profile import ModelProfile
 
     scheduler, detect_calls = _run_server_main_capturing_scheduler(
@@ -214,7 +238,7 @@ def test_server_module_applies_detected_hybrid_cache_default():
     assert detect_calls == 1
 
 
-def test_server_module_keeps_dense_cache_default_zero():
+def test_server_module_keeps_dense_cache_default_zero(scheduler_config_stub):
     from vllm_mlx.model_profile import ModelProfile
 
     scheduler, detect_calls = _run_server_main_capturing_scheduler(
@@ -229,3 +253,92 @@ def test_server_module_keeps_dense_cache_default_zero():
     assert scheduler.hybrid_cache_entries == 0
     assert scheduler.non_trimmable_exact_prefix_reuse is False
     assert detect_calls == 1
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--tool-call-parser", "hermes", "--reasoning-parser", "qwen3"],
+        [
+            "--tool-call-parser",
+            "hermes",
+            "--reasoning-parser",
+            "qwen3",
+            "--pflash",
+            "off",
+            "--pflash-keep-ratio",
+            "0.2",
+        ],
+        [
+            "--tool-call-parser",
+            "hermes",
+            "--reasoning-parser",
+            "qwen3",
+            "--pflash",
+            "off",
+            "--pflash-keep-ratio",
+            "0.2",
+            "--kv-cache-turboquant",
+            "none",
+        ],
+    ],
+)
+def test_server_module_lazy_metadata_consumers_share_one_result(
+    scheduler_config_stub, argv
+):
+    from vllm_mlx.model_profile import ModelProfile
+
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        ["--model", "/models/linear-checkpoint", *argv],
+        detected_config=ModelProfile(is_hybrid=True, is_hybrid_explicit=True),
+    )
+
+    assert scheduler.hybrid_cache_entries == 8
+    assert detect_calls == 1
+
+
+def test_server_module_strict_metadata_failure_propagates(scheduler_config_stub):
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        ["--model", "/models/broken-checkpoint"],
+        detected_config=RuntimeError("broken metadata"),
+        expected_exception=RuntimeError,
+    )
+
+    assert scheduler is None
+    assert detect_calls == 1
+
+
+def test_server_module_cache_metadata_failure_is_nonfatal(scheduler_config_stub):
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        [
+            "--model",
+            "/models/broken-checkpoint",
+            "--tool-call-parser",
+            "hermes",
+            "--reasoning-parser",
+            "qwen3",
+            "--pflash",
+            "off",
+            "--pflash-keep-ratio",
+            "0.2",
+            "--kv-cache-turboquant",
+            "none",
+        ],
+        detected_config=RuntimeError("broken metadata"),
+    )
+
+    assert scheduler.hybrid_cache_entries == 0
+    assert detect_calls == 1
+
+
+def test_server_module_missing_auto_config_module_degrades_to_no_default(
+    scheduler_config_stub,
+):
+    scheduler, detect_calls = _run_server_main_capturing_scheduler(
+        ["--model", "/models/opaque-checkpoint"],
+        detected_config=None,
+        block_auto_config_import=True,
+    )
+
+    assert scheduler.hybrid_cache_entries == 0
+    assert detect_calls == 0

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -38,6 +38,125 @@ def test_resident_performance_maps_to_the_scheduler_contract():
     }
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_name", "model_path"),
+    [
+        ("publisher/opaque-hybrid", None),
+        ("opaque-local-hybrid", "/private/cache/opaque-hybrid/snapshot"),
+    ],
+)
+async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
+    monkeypatch, model_name, model_path
+):
+    """Runtime residency must consume the same architecture truth as serve."""
+    from vllm_mlx import server
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        ),
+    )
+
+    await server._load_dynamic_resident_model(model_name, model_path)
+
+    scheduler = captured["scheduler_config"]
+    assert scheduler.enable_prefix_cache is True
+    assert scheduler.hybrid_cache_entries == 8
+
+
+@pytest.mark.asyncio
+async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(monkeypatch):
+    from vllm_mlx import server
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        ),
+    )
+
+    await server._load_dynamic_resident_model(
+        "publisher/opaque-hybrid",
+        None,
+        ResidentPerformanceConfig(prefix_cache_enabled=False),
+    )
+
+    scheduler = captured["scheduler_config"]
+    assert scheduler.enable_prefix_cache is False
+    assert scheduler.hybrid_cache_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_dynamic_resident_full_attention_stays_unbounded(monkeypatch):
+    from vllm_mlx import server
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(is_hybrid=False),
+    )
+
+    await server._load_dynamic_resident_model("publisher/full-attention", None)
+
+    assert captured["scheduler_config"].hybrid_cache_entries == 0
+
+
 class FakeEngine:
     is_mllm = False
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -47,7 +47,7 @@ def test_resident_performance_maps_to_the_scheduler_contract():
     ],
 )
 async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
-    monkeypatch, model_name, model_path
+    monkeypatch, scheduler_config_stub, model_name, model_path
 ):
     """Runtime residency must consume the same architecture truth as serve."""
     from vllm_mlx import server
@@ -87,7 +87,9 @@ async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
 
 
 @pytest.mark.asyncio
-async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(monkeypatch):
+async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(
+    monkeypatch, scheduler_config_stub
+):
     from vllm_mlx import server
     from vllm_mlx.model_profile import ModelProfile
 
@@ -129,7 +131,9 @@ async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_dynamic_resident_full_attention_stays_unbounded(monkeypatch):
+async def test_dynamic_resident_full_attention_stays_unbounded(
+    monkeypatch, scheduler_config_stub
+):
     from vllm_mlx import server
     from vllm_mlx.model_profile import ModelProfile
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -83,6 +83,7 @@ async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
     scheduler = captured["scheduler_config"]
     assert scheduler.enable_prefix_cache is True
     assert scheduler.hybrid_cache_entries == 8
+    assert scheduler.non_trimmable_exact_prefix_reuse is True
 
 
 @pytest.mark.asyncio
@@ -124,6 +125,7 @@ async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(monkeyp
     scheduler = captured["scheduler_config"]
     assert scheduler.enable_prefix_cache is False
     assert scheduler.hybrid_cache_entries == 0
+    assert scheduler.non_trimmable_exact_prefix_reuse is False
 
 
 @pytest.mark.asyncio
@@ -154,7 +156,9 @@ async def test_dynamic_resident_full_attention_stays_unbounded(monkeypatch):
 
     await server._load_dynamic_resident_model("publisher/full-attention", None)
 
-    assert captured["scheduler_config"].hybrid_cache_entries == 0
+    scheduler = captured["scheduler_config"]
+    assert scheduler.hybrid_cache_entries == 0
+    assert scheduler.non_trimmable_exact_prefix_reuse is False
 
 
 class FakeEngine:

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -352,7 +352,7 @@ def test_serve_command_dispatches_uvicorn_with_fd_when_listen_fd_set(
 
 
 def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
-    stub_heavy_serve_deps, monkeypatch
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):
     """The unified serve entrypoint must consume its one resolved profile."""
     from vllm_mlx import server as server_mod
@@ -369,6 +369,8 @@ def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
     def detect_model_config(model_name):
         detected_models.append(model_name)
         return ModelProfile(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
             is_hybrid=True,
             is_hybrid_explicit=True,
             supports_spec_decode=False,
@@ -391,8 +393,76 @@ def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
     assert scheduler.non_trimmable_exact_prefix_reuse is True
 
 
+def test_serve_command_cache_is_first_metadata_consumer(
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
+):
+    """Fully pinned adjacent defaults leave cache admission as first reader."""
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+    monkeypatch.setattr(
+        server_mod,
+        "load_model",
+        lambda *_args, scheduler_config, **_kwargs: captured.update(
+            scheduler_config=scheduler_config
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(is_hybrid=True, is_hybrid_explicit=True),
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns(port=_free_tcp_port())
+    ns.model = "publisher/cache-only-metadata"
+    ns._original_alias = None
+    ns.pflash = "off"
+    ns.pflash_keep_ratio = 0.2
+    ns.tool_call_parser = "hermes"
+    ns.reasoning_parser = "qwen3"
+    ns.kv_cache_turboquant = "none"
+
+    cli.serve_command(ns)
+
+    assert captured["scheduler_config"].hybrid_cache_entries == 8
+
+
+def test_serve_command_missing_auto_config_module_degrades_to_no_default(
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
+):
+    """A partial install keeps the pre-existing optional-default fallback."""
+    import builtins
+
+    from vllm_mlx import server as server_mod
+
+    captured = {}
+    monkeypatch.setattr(
+        server_mod,
+        "load_model",
+        lambda *_args, scheduler_config, **_kwargs: captured.update(
+            scheduler_config=scheduler_config
+        ),
+    )
+    real_import = builtins.__import__
+
+    def block_auto_config(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 1 and name == "model_auto_config":
+            raise ImportError("model auto-config unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", block_auto_config)
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns(port=_free_tcp_port())
+    ns.model = "publisher/opaque-checkpoint"
+    ns._original_alias = None
+
+    cli.serve_command(ns)
+
+    assert captured["scheduler_config"].hybrid_cache_entries == 0
+
+
 def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
-    stub_heavy_serve_deps, monkeypatch
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):
     from vllm_mlx import server as server_mod
     from vllm_mlx.model_profile import ModelProfile
@@ -435,7 +505,7 @@ def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
 
 
 def test_serve_command_all_explicit_defaults_skip_model_detection(
-    stub_heavy_serve_deps, monkeypatch
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):
     """Explicit operator choices must not make metadata availability fatal."""
 
@@ -471,7 +541,7 @@ def test_serve_command_all_explicit_defaults_skip_model_detection(
 
 
 def test_strict_auto_default_retries_failed_nonfatal_parser_detection(
-    stub_heavy_serve_deps, monkeypatch
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):
     """A parser probe failure must not suppress a later strict consumer."""
     attempts = []

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -247,16 +247,19 @@ def stub_heavy_serve_deps(monkeypatch):
     so the test stays faithful to the real execution path.
     """
     from vllm_mlx import _version_check
-    from vllm_mlx import cli as cli_mod
     from vllm_mlx import server as server_mod
 
     monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", lambda: False)
     monkeypatch.setattr(
         _version_check, "print_staleness_warning_if_any", lambda **_kwargs: None
     )
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", lambda model: None)
-    monkeypatch.setattr(cli_mod, "_check_memory_capacity", lambda *a, **kw: None)
-    monkeypatch.setattr(cli_mod, "_check_disk_space", lambda *a, **kw: None)
+    # Patch the exact module object this test file calls. Earlier suites may
+    # deliberately reload ``vllm_mlx.cli`` and replace the package attribute;
+    # re-importing it here would patch that new object while the file-level
+    # ``cli`` reference below still invokes the old one.
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda model: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
     monkeypatch.setattr(server_mod, "configure_logging", lambda level: "info")
     monkeypatch.setattr(server_mod, "load_model", lambda *a, **kw: None)
     # ``serve_command`` calls ``server.configure_cors`` which does an

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -348,6 +348,87 @@ def test_serve_command_dispatches_uvicorn_with_fd_when_listen_fd_set(
     assert cfg.bind_port is None
 
 
+def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
+    stub_heavy_serve_deps, monkeypatch
+):
+    """The unified serve entrypoint must consume its one resolved profile."""
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+    detected_models = []
+
+    def capture_load_model(*_args, scheduler_config, **_kwargs):
+        captured["scheduler_config"] = scheduler_config
+
+    monkeypatch.setattr(server_mod, "load_model", capture_load_model)
+
+    def detect_model_config(model_name):
+        detected_models.append(model_name)
+        return ModelProfile(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        )
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config", detect_model_config
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns()
+    ns.model = "publisher/opaque-hybrid-checkpoint"
+    ns._original_alias = None
+
+    cli.serve_command(ns)
+
+    scheduler = captured["scheduler_config"]
+    assert detected_models == ["publisher/opaque-hybrid-checkpoint"]
+    assert scheduler.enable_prefix_cache is True
+    assert scheduler.hybrid_cache_entries == 8
+
+
+def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
+    stub_heavy_serve_deps, monkeypatch
+):
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.model_profile import ModelProfile
+
+    captured = {}
+
+    def capture_load_model(*_args, scheduler_config, **_kwargs):
+        captured["scheduler_config"] = scheduler_config
+
+    monkeypatch.setattr(server_mod, "load_model", capture_load_model)
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        ),
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns()
+    ns.model = "publisher/opaque-hybrid-checkpoint"
+    ns._original_alias = None
+    ns.hybrid_cache_entries = 0
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "serve",
+            "publisher/opaque-hybrid-checkpoint",
+            "--hybrid-cache-entries",
+            "0",
+        ],
+    ):
+        cli.serve_command(ns)
+
+    assert captured["scheduler_config"].hybrid_cache_entries == 0
+
+
 def test_serve_command_dispatches_uvicorn_with_host_port_when_listen_fd_unset(
     stub_heavy_serve_deps,
 ):

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -468,6 +468,36 @@ def test_serve_command_all_explicit_defaults_skip_model_detection(
         cli.serve_command(ns)
 
 
+def test_strict_auto_default_retries_failed_nonfatal_parser_detection(
+    stub_heavy_serve_deps, monkeypatch
+):
+    """A parser probe failure must not suppress a later strict consumer."""
+    attempts = []
+
+    def broken_detection(model_name):
+        attempts.append(model_name)
+        raise RuntimeError("broken checkpoint metadata")
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config", broken_detection
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns()
+    ns.model = "publisher/broken-checkpoint"
+    ns._original_alias = None
+    ns.pflash = "off"
+    ns.pflash_keep_ratio = 0.2  # Make parser detection the first metadata probe.
+    ns.kv_cache_turboquant = None  # TurboQuant remains a strict consumer.
+
+    with pytest.raises(RuntimeError, match="broken checkpoint metadata"):
+        cli.serve_command(ns)
+
+    assert attempts == [
+        "publisher/broken-checkpoint",
+        "publisher/broken-checkpoint",
+    ]
+
+
 def test_serve_command_dispatches_uvicorn_with_host_port_when_listen_fd_unset(
     stub_heavy_serve_deps,
 ):

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -388,6 +388,7 @@ def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
     assert detected_models == ["publisher/opaque-hybrid-checkpoint"]
     assert scheduler.enable_prefix_cache is True
     assert scheduler.hybrid_cache_entries == 8
+    assert scheduler.non_trimmable_exact_prefix_reuse is True
 
 
 def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
@@ -430,6 +431,7 @@ def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
         cli.serve_command(ns)
 
     assert captured["scheduler_config"].hybrid_cache_entries == 0
+    assert captured["scheduler_config"].non_trimmable_exact_prefix_reuse is False
 
 
 def test_serve_command_all_explicit_defaults_skip_model_detection(

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -429,6 +429,42 @@ def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
     assert captured["scheduler_config"].hybrid_cache_entries == 0
 
 
+def test_serve_command_all_explicit_defaults_skip_model_detection(
+    stub_heavy_serve_deps, monkeypatch
+):
+    """Explicit operator choices must not make metadata availability fatal."""
+
+    def unexpected_detection(_model_name):
+        raise AssertionError("fully explicit serve must not detect model metadata")
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config", unexpected_detection
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns()
+    ns.model = "publisher/explicitly-configured-checkpoint"
+    ns._original_alias = None
+    ns.pflash = "off"
+    ns.pflash_keep_ratio = 0.2
+    ns.tool_call_parser = "hermes"
+    ns.reasoning_parser = "qwen3"
+    ns.kv_cache_turboquant = "none"
+    ns.hybrid_cache_entries = 0
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "serve",
+            "publisher/explicitly-configured-checkpoint",
+            "--hybrid-cache-entries",
+            "0",
+        ],
+    ):
+        cli.serve_command(ns)
+
+
 def test_serve_command_dispatches_uvicorn_with_host_port_when_listen_fd_unset(
     stub_heavy_serve_deps,
 ):

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -378,7 +378,7 @@ def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
         "vllm_mlx.model_auto_config.detect_model_config", detect_model_config
     )
     _capture_uvicorn_run(monkeypatch)
-    ns = _minimal_serve_ns()
+    ns = _minimal_serve_ns(port=_free_tcp_port())
     ns.model = "publisher/opaque-hybrid-checkpoint"
     ns._original_alias = None
 
@@ -411,7 +411,7 @@ def test_serve_command_explicit_zero_wins_over_auto_detected_hybrid(
         ),
     )
     _capture_uvicorn_run(monkeypatch)
-    ns = _minimal_serve_ns()
+    ns = _minimal_serve_ns(port=_free_tcp_port())
     ns.model = "publisher/opaque-hybrid-checkpoint"
     ns._original_alias = None
     ns.hybrid_cache_entries = 0
@@ -444,7 +444,7 @@ def test_serve_command_all_explicit_defaults_skip_model_detection(
         "vllm_mlx.model_auto_config.detect_model_config", unexpected_detection
     )
     _capture_uvicorn_run(monkeypatch)
-    ns = _minimal_serve_ns()
+    ns = _minimal_serve_ns(port=_free_tcp_port())
     ns.model = "publisher/explicitly-configured-checkpoint"
     ns._original_alias = None
     ns.pflash = "off"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3213,6 +3213,7 @@ def serve_command(args):
             if not non_fatal:
                 raise
             logger.debug(f"Auto-detection failed (non-fatal): {e}")
+            return None
         auto_config_resolved = True
         return auto_config
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3190,17 +3190,31 @@ def serve_command(args):
         validate_model_support,
     )
 
-    # Resolve checkpoint/profile metadata once for every serve-time default
-    # below. PFlash historically treated malformed alias metadata as fatal, so
-    # retain that behavior on its lane; the DFlash lane skips PFlash and keeps
-    # parser auto-detection's existing non-fatal fallback.
+    # Lazily resolve checkpoint/profile metadata at most once for the serve-time
+    # defaults below. Fully explicit startup must not inspect metadata at all.
+    # PFlash/TurboQuant historically propagate inspection failures (while a
+    # missing import degrades to no default); parser/cache detection is
+    # non-fatal. The first consumer keeps its established error policy.
     auto_config = None
     auto_config_resolved = False
-    if not args.enable_dflash:
-        from .model_auto_config import detect_model_config
 
-        auto_config = detect_model_config(args.model)
+    def resolve_auto_config(*, non_fatal: bool):
+        nonlocal auto_config, auto_config_resolved
+        if auto_config_resolved:
+            return auto_config
+        try:
+            from .model_auto_config import detect_model_config
+        except ImportError:
+            auto_config_resolved = True
+            return None
+        try:
+            auto_config = detect_model_config(args.model)
+        except Exception as e:
+            if not non_fatal:
+                raise
+            logger.debug(f"Auto-detection failed (non-fatal): {e}")
         auto_config_resolved = True
+        return auto_config
 
     # Resolve the FINAL serving lane ONCE (the model is already downloaded by
     # ``_ensure_model_downloaded`` above, so the offline probes have real
@@ -3218,11 +3232,16 @@ def serve_command(args):
         # bonsai-27b-2bit → always @ 0.50) and build the config in one shared
         # helper; an explicit --pflash / --pflash-keep-ratio still wins inside.
         try:
+            pflash_detection = {}
+            if args.pflash is None or args.pflash_keep_ratio is None:
+                pflash_detection["_detected_config"] = resolve_auto_config(
+                    non_fatal=False
+                )
             pflash_config = resolve_pflash_config(
                 args,
                 model_name=args.model,
                 is_multimodal=_serve_is_mllm,
-                _detected_config=auto_config,
+                **pflash_detection,
             )
             validate_model_support(
                 pflash_config,
@@ -3264,13 +3283,10 @@ def serve_command(args):
     # warning grounded in user intent even if a helper-side regression
     # ever started flagging in-spec cases.)
     _user_explicit_tool_call_parser = bool(args.tool_call_parser)
-    if not auto_config_resolved:
-        try:
-            from .model_auto_config import detect_model_config
-
-            auto_config = detect_model_config(args.model)
-        except Exception as e:
-            logger.debug(f"Auto-detection failed (non-fatal): {e}")
+    if not auto_config_resolved and (
+        not args.tool_call_parser or not args.reasoning_parser
+    ):
+        resolve_auto_config(non_fatal=True)
     if auto_config:
         if (
             not args.tool_call_parser
@@ -3790,8 +3806,15 @@ def serve_command(args):
         turboquant_scheduler_kwargs as _turboquant_scheduler_kwargs,
     )
 
+    turboquant_detection = {}
+    if auto_config_resolved:
+        turboquant_detection["_detected_config"] = auto_config
+    elif getattr(args, "kv_cache_turboquant", None) is None and not getattr(
+        args, "kv_cache_quantization", False
+    ):
+        turboquant_detection["_detected_config"] = resolve_auto_config(non_fatal=False)
     args.kv_cache_turboquant = resolve_turboquant_mode_default(
-        args, model_name=args.model, _detected_config=auto_config
+        args, model_name=args.model, **turboquant_detection
     )
 
     # Reject conflicting KV-cache flag combinations before anything else in
@@ -3892,11 +3915,21 @@ def serve_command(args):
     # #1122: when prefix cache is enabled for a hybrid model and the user
     # did NOT explicitly pass --hybrid-cache-entries, auto-default to 8 so
     # the cache actually stores entries instead of silently dropping them.
+    hybrid_cache_user_explicit = "--hybrid-cache-entries" in sys.argv or any(
+        a.startswith("--hybrid-cache-entries=") for a in sys.argv
+    )
+    hybrid_cache_explicit_value = getattr(args, "hybrid_cache_entries", 0)
+    if (
+        not auto_config_resolved
+        and enable_prefix_cache
+        and hybrid_cache_explicit_value == 0
+        and not hybrid_cache_user_explicit
+    ):
+        resolve_auto_config(non_fatal=True)
     _hybrid_cache_entries = _resolve_hybrid_cache_entries(
         enable_prefix_cache=enable_prefix_cache,
-        explicit_value=getattr(args, "hybrid_cache_entries", 0),
-        user_set_explicit="--hybrid-cache-entries" in sys.argv
-        or any(a.startswith("--hybrid-cache-entries=") for a in sys.argv),
+        explicit_value=hybrid_cache_explicit_value,
+        user_set_explicit=hybrid_cache_user_explicit,
         model_name=getattr(args, "_original_alias", None) or args.model,
         model_config=auto_config,
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -22,6 +22,7 @@ import sys
 from collections.abc import Callable
 
 from vllm_mlx._completion import alias_completer
+from vllm_mlx.model_profile import ModelProfile
 
 # Project-default mirror for ``RAPID_MLX_MODEL_MIRROR`` (consumed by
 # ``_try_mirror_prefetch``). Public Cloudflare Worker → R2 bucket, with
@@ -2500,6 +2501,7 @@ def _resolve_hybrid_cache_entries(
     explicit_value: int,
     user_set_explicit: bool,
     model_name: str,
+    model_config: ModelProfile | None = None,
 ) -> int:
     """Return the effective ``hybrid_cache_entries`` value.
 
@@ -2513,7 +2515,9 @@ def _resolve_hybrid_cache_entries(
     if not enable_prefix_cache or explicit_value != 0 or user_set_explicit:
         return explicit_value
 
-    needs_bounded_reuse = _needs_bounded_trim_free_reuse(model_name)
+    needs_bounded_reuse = _needs_bounded_trim_free_reuse(
+        model_name, model_config=model_config
+    )
     if needs_bounded_reuse:
         _logging.getLogger(__name__).info(
             "Non-trimmable model cache detected with --enable-prefix-cache: "
@@ -2615,28 +2619,9 @@ def _config_declares_linear_attention(config: dict | None) -> bool:
     variant accepts an already-resolved config so aliases and bare local paths
     can share the serve prefill policy without another metadata lookup.
     """
-    if not isinstance(config, dict):
-        return False
+    from .model_auto_config import config_declares_linear_attention
 
-    text_config = config.get("text_config")
-    language_config = text_config if isinstance(text_config, dict) else config
-    layer_types = language_config.get("layer_types") or []
-    if any(
-        isinstance(layer_type, str)
-        and any(
-            marker in layer_type.lower() for marker in ("linear", "mamba", "recurrent")
-        )
-        for layer_type in layer_types
-    ):
-        return True
-    return any(
-        isinstance(model_type, str)
-        and any(
-            marker in model_type.lower()
-            for marker in ("mamba", "recurrent", "qwen3_next")
-        )
-        for model_type in (language_config.get("model_type"), config.get("model_type"))
-    )
+    return config_declares_linear_attention(config)
 
 
 def _prefers_recurrent_prefill_chunks(model_name: str) -> bool:
@@ -2693,12 +2678,14 @@ def _resolve_vision_prefill_token_budget(
     return max(prefill_step_size, mllm_default)
 
 
-def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
+def _needs_bounded_trim_free_reuse(
+    model_name: str, *, model_config: ModelProfile | None = None
+) -> bool:
     """Whether this model's cache can reuse prefixes but not trim exact hits."""
     from .model_aliases import resolve_profile as _resolve_alias
     from .utils.deepseek_v4_0731 import is_deepseek_v4_0731
 
-    profile = _resolve_alias(model_name)
+    profile = model_config if model_config is not None else _resolve_alias(model_name)
     if profile is not None:
         if profile.is_hybrid:
             return True
@@ -3203,6 +3190,18 @@ def serve_command(args):
         validate_model_support,
     )
 
+    # Resolve checkpoint/profile metadata once for every serve-time default
+    # below. PFlash historically treated malformed alias metadata as fatal, so
+    # retain that behavior on its lane; the DFlash lane skips PFlash and keeps
+    # parser auto-detection's existing non-fatal fallback.
+    auto_config = None
+    auto_config_resolved = False
+    if not args.enable_dflash:
+        from .model_auto_config import detect_model_config
+
+        auto_config = detect_model_config(args.model)
+        auto_config_resolved = True
+
     # Resolve the FINAL serving lane ONCE (the model is already downloaded by
     # ``_ensure_model_downloaded`` above, so the offline probes have real
     # evidence). PFlash defaulting and ``validate_model_support`` must both see
@@ -3220,7 +3219,10 @@ def serve_command(args):
         # helper; an explicit --pflash / --pflash-keep-ratio still wins inside.
         try:
             pflash_config = resolve_pflash_config(
-                args, model_name=args.model, is_multimodal=_serve_is_mllm
+                args,
+                model_name=args.model,
+                is_multimodal=_serve_is_mllm,
+                _detected_config=auto_config,
             )
             validate_model_support(
                 pflash_config,
@@ -3262,34 +3264,34 @@ def serve_command(args):
     # warning grounded in user intent even if a helper-side regression
     # ever started flagging in-spec cases.)
     _user_explicit_tool_call_parser = bool(args.tool_call_parser)
-    if not args.tool_call_parser or not args.reasoning_parser:
+    if not auto_config_resolved:
         try:
             from .model_auto_config import detect_model_config
 
             auto_config = detect_model_config(args.model)
-            if auto_config:
-                if (
-                    not args.tool_call_parser
-                    and not _opt_out_tool
-                    and auto_config.tool_call_parser
-                ):
-                    args.tool_call_parser = auto_config.tool_call_parser
-                    args.enable_auto_tool_choice = True
-                    logger.info(
-                        f"Auto-configured --tool-call-parser {auto_config.tool_call_parser}"
-                    )
-                if (
-                    not args.reasoning_parser
-                    and not _opt_out_reasoning
-                    and not args.no_thinking
-                    and auto_config.reasoning_parser
-                ):
-                    args.reasoning_parser = auto_config.reasoning_parser
-                    logger.info(
-                        f"Auto-configured --reasoning-parser {auto_config.reasoning_parser}"
-                    )
         except Exception as e:
             logger.debug(f"Auto-detection failed (non-fatal): {e}")
+    if auto_config:
+        if (
+            not args.tool_call_parser
+            and not _opt_out_tool
+            and auto_config.tool_call_parser
+        ):
+            args.tool_call_parser = auto_config.tool_call_parser
+            args.enable_auto_tool_choice = True
+            logger.info(
+                f"Auto-configured --tool-call-parser {auto_config.tool_call_parser}"
+            )
+        if (
+            not args.reasoning_parser
+            and not _opt_out_reasoning
+            and not args.no_thinking
+            and auto_config.reasoning_parser
+        ):
+            args.reasoning_parser = auto_config.reasoning_parser
+            logger.info(
+                f"Auto-configured --reasoning-parser {auto_config.reasoning_parser}"
+            )
     if _opt_out_tool:
         logger.info(
             "Tool-call parser auto-detection disabled via --no-tool-call-parser"
@@ -3789,7 +3791,7 @@ def serve_command(args):
     )
 
     args.kv_cache_turboquant = resolve_turboquant_mode_default(
-        args, model_name=args.model
+        args, model_name=args.model, _detected_config=auto_config
     )
 
     # Reject conflicting KV-cache flag combinations before anything else in
@@ -3896,6 +3898,7 @@ def serve_command(args):
         user_set_explicit="--hybrid-cache-entries" in sys.argv
         or any(a.startswith("--hybrid-cache-entries=") for a in sys.argv),
         model_name=getattr(args, "_original_alias", None) or args.model,
+        model_config=auto_config,
     )
     _prefill_user_set_explicit = "--prefill-step-size" in sys.argv or any(
         a.startswith("--prefill-step-size=") for a in sys.argv

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3992,7 +3992,8 @@ def serve_command(args):
         non_trimmable_exact_prefix_reuse=(
             _hybrid_cache_entries > 0
             and _needs_bounded_trim_free_reuse(
-                getattr(args, "_original_alias", None) or args.model
+                getattr(args, "_original_alias", None) or args.model,
+                model_config=auto_config,
             )
         ),
         # Opt-in prompt-deterministic response cache (exact-match short-circuit).

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3200,7 +3200,7 @@ def serve_command(args):
 
     def resolve_auto_config(*, non_fatal: bool):
         nonlocal auto_config, auto_config_resolved
-        if auto_config_resolved:
+        if auto_config_resolved:  # pragma: no cover - callers guard resolved state
             return auto_config
         try:
             from .model_auto_config import detect_model_config

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1163,7 +1163,9 @@ def _template_injects_qwen_thinking(template: str | None) -> bool:
     return "enable_thinking" in variables and "<think>" in source
 
 
-def _detect_metadata_config(model_path: str) -> ModelConfig | None:
+def _detect_metadata_config(
+    model_path: str, *, log_resolution: bool = True
+) -> ModelConfig | None:
     """Infer a safe fallback profile from an already-downloaded checkpoint.
 
     This is deliberately lower priority than an alias or a dedicated family
@@ -1235,14 +1237,38 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
     if not settings:
         return None
     profile = ModelConfig(**settings)
-    _log_resolution_once(
-        model_path,
-        "Auto-detected checkpoint metadata for "
-        f"'{model_path}' → tool_call_parser={profile.tool_call_parser}, "
-        f"reasoning_parser={profile.reasoning_parser}, "
-        f"is_hybrid={profile.is_hybrid} ({', '.join(reasons)})",
-    )
+    if log_resolution:
+        _log_resolution_once(
+            model_path,
+            "Auto-detected checkpoint metadata for "
+            f"'{model_path}' → tool_call_parser={profile.tool_call_parser}, "
+            f"reasoning_parser={profile.reasoning_parser}, "
+            f"is_hybrid={profile.is_hybrid} ({', '.join(reasons)})",
+        )
     return profile
+
+
+def _with_checkpoint_architecture(
+    family_config: ModelConfig, metadata_config: ModelConfig | None
+) -> ModelConfig:
+    """Overlay authoritative checkpoint architecture onto a family fallback.
+
+    Name-family fallbacks still own parser and reasoning defaults. When the
+    checkpoint itself explicitly establishes recurrent/hybrid routing,
+    however, that architecture truth must reach every downstream consumer
+    even when the path also happens to match a known family name.
+    """
+    if metadata_config is None or not metadata_config.is_hybrid_explicit:
+        return family_config
+    return replace(
+        family_config,
+        is_hybrid=metadata_config.is_hybrid,
+        is_hybrid_explicit=True,
+        is_moe=family_config.is_moe or metadata_config.is_moe,
+        supports_spec_decode=(
+            family_config.supports_spec_decode and metadata_config.supports_spec_decode
+        ),
+    )
 
 
 def detect_model_config(model_path: str) -> ModelConfig | None:
@@ -1291,6 +1317,11 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
         # consumers that index by workload key use ``.speedup_dict``.
         return profile
 
+    # Read offline checkpoint metadata once. Family-name fallbacks still own
+    # parser defaults, while explicit architecture fields from this profile
+    # enrich those fallbacks before they reach serving policy.
+    metadata_cfg = _detect_metadata_config(model_path, log_resolution=False)
+
     # DeepSeek-Coder-V2 / V2-Lite routing — handled here (not in the
     # ``_MODEL_PATTERNS`` regex table) because the decision MUST be scoped
     # to the extracted model-name SEGMENT, exactly like the misbind
@@ -1318,8 +1349,14 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     # attention Qwen3 model.  Known aliases returned above remain the SSOT;
     # this is only the direct-HF/local-path fallback.
     if re.search(r"qwen[._-]?3[._]8(?=$|[^0-9])", model_path, re.I):
-        metadata_cfg = _detect_metadata_config(model_path)
         if metadata_cfg is not None:
+            _log_resolution_once(
+                model_path,
+                "Auto-detected checkpoint metadata for "
+                f"'{model_path}' → tool_call_parser={metadata_cfg.tool_call_parser}, "
+                f"reasoning_parser={metadata_cfg.reasoning_parser}, "
+                f"is_hybrid={metadata_cfg.is_hybrid}",
+            )
             return metadata_cfg
         return ModelConfig(
             tool_call_parser="hermes",
@@ -1352,6 +1389,7 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             f"tool_call_parser={cfg.tool_call_parser}, "
             f"reasoning_parser={cfg.reasoning_parser} ({note})",
         )
+        cfg = _with_checkpoint_architecture(cfg, metadata_cfg)
         return cfg
 
     for pattern, config in _MODEL_PATTERNS:
@@ -1374,7 +1412,7 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
                 "tool_call_parser=None, "
                 "reasoning_parser=deepseek_r1_distill",
             )
-            return cfg
+            return _with_checkpoint_architecture(cfg, metadata_cfg)
         # #1071: the Mistral-family entry is a full-path pre-filter that
         # delegates to a MODEL-NAME-SEGMENT-scoped resolver. This keeps the
         # family at its original precedence (so a compound name like
@@ -1393,17 +1431,26 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
                 f"tool_call_parser={mistral_cfg.tool_call_parser}, "
                 f"reasoning_parser={mistral_cfg.reasoning_parser}",
             )
-            return mistral_cfg
+            return _with_checkpoint_architecture(mistral_cfg, metadata_cfg)
+        resolved = _with_checkpoint_architecture(config, metadata_cfg)
         _log_resolution_once(
             model_path,
             f"Auto-detected model family '{pattern.pattern}' → "
-            f"tool_call_parser={config.tool_call_parser}, "
-            f"reasoning_parser={config.reasoning_parser}, "
-            f"is_hybrid={config.is_hybrid}, "
-            f"supports_spec_decode={config.supports_spec_decode}",
+            f"tool_call_parser={resolved.tool_call_parser}, "
+            f"reasoning_parser={resolved.reasoning_parser}, "
+            f"is_hybrid={resolved.is_hybrid}, "
+            f"supports_spec_decode={resolved.supports_spec_decode}",
         )
-        return config
-    return _detect_metadata_config(model_path)
+        return resolved
+    if metadata_cfg is not None:
+        _log_resolution_once(
+            model_path,
+            "Auto-detected checkpoint metadata for "
+            f"'{model_path}' → tool_call_parser={metadata_cfg.tool_call_parser}, "
+            f"reasoning_parser={metadata_cfg.reasoning_parser}, "
+            f"is_hybrid={metadata_cfg.is_hybrid}",
+        )
+    return metadata_cfg
 
 
 # DeepSeek V3-template wire-shape parsers, by the sub-family each one

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -759,6 +759,37 @@ def _metadata_model_types(config: dict[str, Any]) -> frozenset[str]:
     return frozenset(types)
 
 
+def config_declares_linear_attention(config: dict | None) -> bool:
+    """Whether the language backbone declares recurrent/linear attention.
+
+    This architecture signal is shared by model auto-detection and prefix-cache
+    admission. Keeping it beside checkpoint metadata resolution prevents those
+    consumers from independently classifying the same config.
+    """
+    if not isinstance(config, dict):
+        return False
+
+    text_config = config.get("text_config")
+    language_config = text_config if isinstance(text_config, dict) else config
+    layer_types = language_config.get("layer_types") or []
+    if any(
+        isinstance(layer_type, str)
+        and any(
+            marker in layer_type.lower() for marker in ("linear", "mamba", "recurrent")
+        )
+        for layer_type in layer_types
+    ):
+        return True
+    return any(
+        isinstance(model_type, str)
+        and any(
+            marker in model_type.lower()
+            for marker in ("mamba", "recurrent", "qwen3_next")
+        )
+        for model_type in (language_config.get("model_type"), config.get("model_type"))
+    )
+
+
 def _chat_template_environment():
     """Build a Jinja environment that PARSES Transformers chat templates.
 
@@ -1184,6 +1215,13 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
             supports_spec_decode=False,
         )
         reasons.append("dense Qwen3.5 architecture")
+    elif config_declares_linear_attention(config):
+        settings.update(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("linear/recurrent attention architecture")
 
     if _template_uses_parameterized_xml_tools(metadata.chat_template):
         settings["tool_call_parser"] = "hermes"

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -293,7 +293,11 @@ def resolve_pflash_keep_ratio_default(
 
 
 def resolve_pflash_config(
-    args: Any, *, model_name: str, is_multimodal: bool = False
+    args: Any,
+    *,
+    model_name: str,
+    is_multimodal: bool = False,
+    _detected_config: Any = _DETECT,
 ) -> PFlashConfig:
     """Resolve BOTH per-alias PFlash defaults (mode + keep_ratio) and build the
     validated :class:`PFlashConfig`. This is the single wiring shared by the
@@ -306,12 +310,16 @@ def resolve_pflash_config(
     the CLI None-sentinels until now) so any later reader sees the resolved
     values, then returns the built config. ``validate_model_support`` is left
     to the caller because its ``is_mllm`` verdict and error handling differ
-    between the two commands.
+    between the two commands. ``_detected_config`` lets the serve entrypoint
+    share its single resolved checkpoint profile with other startup defaults;
+    the private sentinel preserves lazy detection for existing callers.
     """
     # Detect the alias profile ONCE and share it with both resolvers (each
     # would otherwise re-detect on the no-flag path). Skip detection entirely
     # when the user pinned both flags — neither resolver would consult it.
-    if args.pflash is None or args.pflash_keep_ratio is None:
+    if _detected_config is not _DETECT:
+        detected = _detected_config
+    elif args.pflash is None or args.pflash_keep_ratio is None:
         detected = _detect_or(model_name, _DETECT)
     else:
         detected = _DETECT

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2296,7 +2296,10 @@ async def _load_dynamic_resident_model(
             f"runtime residency loading is not available for modality {modality!r}"
         )
     else:
-        from .cli import _resolve_hybrid_cache_entries
+        from .cli import (
+            _needs_bounded_trim_free_reuse,
+            _resolve_hybrid_cache_entries,
+        )
         from .runtime.resident_models import resident_scheduler_kwargs
         from .scheduler import SchedulerConfig
 
@@ -2307,6 +2310,12 @@ async def _load_dynamic_resident_model(
             explicit_value=0,
             user_set_explicit=False,
             model_name=resolved_path,
+            model_config=model_config,
+        )
+        scheduler_kwargs["non_trimmable_exact_prefix_reuse"] = scheduler_kwargs[
+            "hybrid_cache_entries"
+        ] > 0 and _needs_bounded_trim_free_reuse(
+            resolved_path,
             model_config=model_config,
         )
 
@@ -3345,7 +3354,10 @@ Examples:
 
     if not auto_config_resolved:
         resolve_auto_config(non_fatal=True)
-    from .cli import _resolve_hybrid_cache_entries
+    from .cli import (
+        _needs_bounded_trim_free_reuse,
+        _resolve_hybrid_cache_entries,
+    )
 
     hybrid_cache_entries = _resolve_hybrid_cache_entries(
         enable_prefix_cache=True,
@@ -3361,6 +3373,13 @@ Examples:
         vision_min_pixels=args.vision_min_pixels,
         vision_max_pixels=args.vision_max_pixels,
         hybrid_cache_entries=hybrid_cache_entries,
+        non_trimmable_exact_prefix_reuse=(
+            hybrid_cache_entries > 0
+            and _needs_bounded_trim_free_reuse(
+                args.model,
+                model_config=auto_config,
+            )
+        ),
         pflash_config=server_pflash_config,
         **_server_turboquant_scheduler_kwargs(args),
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3146,6 +3146,7 @@ Examples:
             if not non_fatal:
                 raise
             logger.debug("Auto-detection failed (non-fatal): %s", exc)
+            return None
         auto_config_resolved = True
         return auto_config
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3144,7 +3144,7 @@ Examples:
 
     def resolve_auto_config(*, non_fatal: bool):
         nonlocal auto_config, auto_config_resolved
-        if auto_config_resolved:
+        if auto_config_resolved:  # pragma: no cover - callers guard resolved state
             return auto_config
         try:
             from .model_auto_config import detect_model_config

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3124,6 +3124,31 @@ Examples:
     if args.mcp_config:
         os.environ["RAPID_MLX_MCP_CONFIG"] = args.mcp_config
 
+    # Resolve checkpoint/profile metadata lazily and at most once for every
+    # standalone-server default below. Cache admission is best-effort; parser,
+    # PFlash, and TurboQuant retain their existing error policy when they are
+    # the first consumer.
+    auto_config = None
+    auto_config_resolved = False
+
+    def resolve_auto_config(*, non_fatal: bool):
+        nonlocal auto_config, auto_config_resolved
+        if auto_config_resolved:
+            return auto_config
+        try:
+            from .model_auto_config import detect_model_config
+        except ImportError:
+            auto_config_resolved = True
+            return None
+        try:
+            auto_config = detect_model_config(args.model)
+        except Exception as exc:
+            if not non_fatal:
+                raise
+            logger.debug("Auto-detection failed (non-fatal): %s", exc)
+        auto_config_resolved = True
+        return auto_config
+
     # Auto-detect parser config from model name when not explicitly set.
     # SOP §10: honor --no-tool-call-parser / --no-reasoning-parser opt-
     # outs so this entrypoint matches the unified CLI behavior.
@@ -3138,9 +3163,7 @@ Examples:
             "--reasoning-parser and --no-reasoning-parser are mutually exclusive"
         )
     if not args.tool_call_parser or not args.reasoning_parser:
-        from .model_auto_config import detect_model_config
-
-        auto_config = detect_model_config(args.model)
+        resolve_auto_config(non_fatal=False)
         if auto_config:
             if (
                 not args.tool_call_parser
@@ -3253,8 +3276,16 @@ Examples:
     # two serving entrypoints must not drift. It mutates ``args.pflash`` and
     # ``args.pflash_keep_ratio`` in place so later readers see resolved values.
     try:
+        pflash_detection = {}
+        if auto_config_resolved:
+            pflash_detection["_detected_config"] = auto_config
+        elif args.pflash is None or args.pflash_keep_ratio is None:
+            pflash_detection["_detected_config"] = resolve_auto_config(non_fatal=False)
         server_pflash_config = _server_pflash_resolve_config(
-            args, model_name=args.model, is_multimodal=_srv_is_mllm
+            args,
+            model_name=args.model,
+            is_multimodal=_srv_is_mllm,
+            **pflash_detection,
         )
         _server_pflash_validate(
             server_pflash_config,
@@ -3278,8 +3309,15 @@ Examples:
         turboquant_scheduler_kwargs as _server_turboquant_scheduler_kwargs,
     )
 
+    turboquant_detection = {}
+    if auto_config_resolved:
+        turboquant_detection["_detected_config"] = auto_config
+    elif getattr(args, "kv_cache_turboquant", None) is None and not getattr(
+        args, "kv_cache_quantization", False
+    ):
+        turboquant_detection["_detected_config"] = resolve_auto_config(non_fatal=False)
     args.kv_cache_turboquant = _server_turboquant_resolve_default(
-        args, model_name=args.model
+        args, model_name=args.model, **turboquant_detection
     )
 
     if args.vision_min_pixels < 0 or args.vision_max_pixels < 0:
@@ -3304,11 +3342,24 @@ Examples:
     if vision_prefill_token_budget <= 0:
         parser.error("--vision-prefill-token-budget must be positive")
 
+    if not auto_config_resolved:
+        resolve_auto_config(non_fatal=True)
+    from .cli import _resolve_hybrid_cache_entries
+
+    hybrid_cache_entries = _resolve_hybrid_cache_entries(
+        enable_prefix_cache=True,
+        explicit_value=0,
+        user_set_explicit=False,
+        model_name=args.model,
+        model_config=auto_config,
+    )
+
     scheduler_config = SchedulerConfig(
         prefill_step_size=args.prefill_step_size,
         vision_prefill_token_budget=vision_prefill_token_budget,
         vision_min_pixels=args.vision_min_pixels,
         vision_max_pixels=args.vision_max_pixels,
+        hybrid_cache_entries=hybrid_cache_entries,
         pflash_config=server_pflash_config,
         **_server_turboquant_scheduler_kwargs(args),
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2265,6 +2265,11 @@ async def _load_dynamic_resident_model(
     resolved_path = model_path or (
         profile.hf_path if profile is not None else model_name
     )
+    model_config = profile
+    if model_config is None:
+        from .model_auto_config import detect_model_config
+
+        model_config = detect_model_config(resolved_path)
     modality = profile.modality if profile is not None else "text"
 
     if modality == "image-gen":
@@ -2291,8 +2296,19 @@ async def _load_dynamic_resident_model(
             f"runtime residency loading is not available for modality {modality!r}"
         )
     else:
+        from .cli import _resolve_hybrid_cache_entries
         from .runtime.resident_models import resident_scheduler_kwargs
         from .scheduler import SchedulerConfig
+
+        scheduler_kwargs = resident_scheduler_kwargs(performance)
+        enable_prefix_cache = bool(scheduler_kwargs.get("enable_prefix_cache", True))
+        scheduler_kwargs["hybrid_cache_entries"] = _resolve_hybrid_cache_entries(
+            enable_prefix_cache=enable_prefix_cache,
+            explicit_value=0,
+            user_set_explicit=False,
+            model_name=resolved_path,
+            model_config=model_config,
+        )
 
         engine = BatchedEngine(
             model_name=resolved_path,
@@ -2301,7 +2317,7 @@ async def _load_dynamic_resident_model(
             ),
             force_text=bool(profile is not None and profile.is_text_only),
             gpu_memory_utilization=_resident_gpu_memory_utilization,
-            scheduler_config=SchedulerConfig(**resident_scheduler_kwargs(performance)),
+            scheduler_config=SchedulerConfig(**scheduler_kwargs),
         )
         await engine.start()
         try:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2305,18 +2305,20 @@ async def _load_dynamic_resident_model(
 
         scheduler_kwargs = resident_scheduler_kwargs(performance)
         enable_prefix_cache = bool(scheduler_kwargs.get("enable_prefix_cache", True))
-        scheduler_kwargs["hybrid_cache_entries"] = _resolve_hybrid_cache_entries(
+        hybrid_cache_entries = _resolve_hybrid_cache_entries(
             enable_prefix_cache=enable_prefix_cache,
             explicit_value=0,
             user_set_explicit=False,
             model_name=resolved_path,
             model_config=model_config,
         )
-        scheduler_kwargs["non_trimmable_exact_prefix_reuse"] = scheduler_kwargs[
-            "hybrid_cache_entries"
-        ] > 0 and _needs_bounded_trim_free_reuse(
-            resolved_path,
-            model_config=model_config,
+        scheduler_kwargs["hybrid_cache_entries"] = hybrid_cache_entries
+        scheduler_kwargs["non_trimmable_exact_prefix_reuse"] = (
+            hybrid_cache_entries > 0
+            and _needs_bounded_trim_free_reuse(
+                resolved_path,
+                model_config=model_config,
+            )
         )
 
         engine = BatchedEngine(

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -58,7 +58,12 @@ TURBOQUANT_MODES: tuple[str, ...] = ("v4", "k8v4")
 DEFAULT_TURBOQUANT_MODE = "v4"
 
 
-def resolve_turboquant_mode_default(args: Any, *, model_name: str) -> str | None:
+_DETECT = object()
+
+
+def resolve_turboquant_mode_default(
+    args: Any, *, model_name: str, _detected_config: Any = _DETECT
+) -> str | None:
     """Resolve ``args.kv_cache_turboquant`` when the operator passed no flag.
 
     Returns ``args.kv_cache_turboquant`` unchanged when set; ``None``
@@ -71,6 +76,8 @@ def resolve_turboquant_mode_default(args: Any, *, model_name: str) -> str | None
     bypasses the ``k8v4_verified`` auto-resolution and returns
     ``None`` so the engine boots with the bare FP16 KV path. This
     is the A/B knob for the ``k8v4_verified`` decode-ratio gate.
+    ``_detected_config`` is private startup plumbing for callers that already
+    resolved the same checkpoint profile; omitting it retains lazy detection.
     """
     raw = getattr(args, "kv_cache_turboquant", None)
     if raw == "none":
@@ -84,11 +91,14 @@ def resolve_turboquant_mode_default(args: Any, *, model_name: str) -> str | None
         return raw
     if getattr(args, "kv_cache_quantization", False):
         return None
-    try:
-        from .model_auto_config import detect_model_config
-    except ImportError:
-        return None
-    cfg = detect_model_config(model_name)
+    if _detected_config is _DETECT:
+        try:
+            from .model_auto_config import detect_model_config
+        except ImportError:
+            return None
+        cfg = detect_model_config(model_name)
+    else:
+        cfg = _detected_config
     if cfg is not None and cfg.turboquant_tier == "k8v4_verified":
         logger.info(
             "TurboQuant default: alias %r is turboquant_tier=k8v4_verified "


### PR DESCRIPTION
## What does this PR do?

Threads one resolved model profile through serve-time defaults and the existing bounded non-trimmable prefix-cache admission path. Auto-detected recurrent or hybrid checkpoints now receive the existing eight-entry default when prefix caching is enabled. Unified CLI serving, the standalone server entrypoint, and dynamic model residency use the same admission contract.

Explicit `--hybrid-cache-entries 0`, prefix-cache disable, pure full-attention models, known profiles, the cache bound, and eviction behavior remain unchanged. Failed non-fatal metadata probes are not cached as successful resolution, so later strict configuration consumers preserve their existing failure behavior.

Fixes #2310.

## Why is this needed?

Direct checkpoint IDs and local paths can be correctly classified from checkpoint architecture metadata but previously lost that result before cache admission. Their recurrent cache entries were dropped, so every follow-up turn re-prefilled the accumulated conversation.

On an already-cached 9B recurrent checkpoint served by direct local path on Apple M3 Ultra with Hub access disabled, the same approximately 4.86k-token two-turn conversation measured:

- Base: turn 1 TTFT 4.375 s; turn 2 TTFT 4.198 s; radix hits 0; saved tokens 0.
- Fix: turn 1 TTFT 4.448 s; turn 2 TTFT 0.207 s; radix hits 1; saved tokens 4,850.

This local result validates the control-flow fix; it does not claim identical timing for other checkpoints or hardware.

## AI assistance disclosure

Codex implemented and reviewed the changes in `vllm_mlx/cli.py`, `vllm_mlx/model_auto_config.py`, `vllm_mlx/pflash.py`, `vllm_mlx/server.py`, `vllm_mlx/turboquant.py`, and the focused tests. Every change was inspected against the issue contract and verified with network-free unit tests, proportional cache/server tests, an exact-head full local non-integration suite, a local wheel build, and real-model base/head evidence. The independent review finished LGTM at round 6.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- Pre-edit regression: five expected failures across architecture detection, CLI admission, and dynamic residency; prefix-disabled control passed.
- Standalone server pre-edit regression: detected hybrid reached `hybrid_cache_entries=0`; fixed path reaches 8, pure full-attention remains 0, and metadata is resolved once.
- Failed-probe ordering pre-edit regression: a non-fatal parser metadata failure suppressed the later strict consumer; fixed path retries and raises.
- Exact-head focused metadata/CLI/server/residency/default-consumer suite: 463 passed.
- Proportional cache/scheduler/server suite: 410 passed, 3 deselected.
- Exact-head local suite: 18,652 passed, 97 skipped, 22 deselected, 6 xfailed, 1 xpassed.
- Ruff check and format check passed; `git diff --check` passed.
- Focused changed-line coverage was 96%. The hosted fixed Linux test list does not include these focused files and currently reports 5%; no shared workflow change or full-CI is requested while the release gate is active.
- Exact-head local wheel build succeeded.
- Real cached-model two-turn base/head comparison recorded above with Hub access disabled.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate <PR#>`
- [x] New critical-path tests were confirmed red before the production edit
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

