### PR TITLE
chore: bump version to 0.13.0-rc2

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,35 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.0-rc2] — 2026-08-25
+
+This second 0.13 release candidate focuses on the first-run and release-blocking
+issues found while testing rc1. It remains a prerelease and does not replace the
+stable updater feed.
+
+### Changed
+
+- **Memory guidance now follows the Mac in real time.** Onboarding and model
+  launch decisions refresh available-memory facts as apps open and close,
+  without letting stale or hidden probes overwrite the latest user decision.
+- **Voice input can coexist with the active conversation model.** Starting
+  dictation no longer evicts the LLM or vision model behind the current chat.
+- **Agent setup is useful before an engine is running.** The integration entry
+  point provides a clear setup path instead of depending on an already-loaded
+  model.
+
+### Fixed
+
+- Search-provider key failures preserve the actionable provider reason through
+  the Mac UI, and upgrades retain the selected dictation checkpoint.
+- Image generation shows a stable, evidence-based remaining-time estimate and
+  recovers stale aliases through the capability registry.
+- Release automation now validates the signed and notarized Desktop candidate
+  before claiming its immutable tag, binds publication to exact artifact bytes
+  and source SHA, and fails closed on stale, malformed, or mismatched reruns.
+- Parallel Desktop tests use deterministic lifecycle synchronization for cache
+  polling and declined-tool approval instead of timing assumptions.
+
 ## [0.13.0-rc1] — 2026-08-24
 
 This first 0.13 release candidate broadens model coverage, makes local tools

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0-rc1</string>
+	<string>0.13.0-rc2</string>
 	<key>CFBundleVersion</key>
-	<string>163</string>
+	<string>164</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.13.0-rc2.md
+++ b/docs/release-notes/v0.13.0-rc2.md
@@ -1,0 +1,30 @@
+Rapid-MLX 0.13.0-rc2 is a release-candidate follow-up focused on issues found
+while testing rc1. It improves first-run decisions, voice and agent workflows,
+image progress, and the exact provenance of Desktop release artifacts. Like
+rc1, it is a prerelease and does not replace the stable updater feed.
+
+## Highlights
+
+- **Live memory decisions.** First-run guidance and model launch checks refresh
+  available-memory facts as machine conditions change, while stale background
+  probes can no longer replace a newer user-visible result. ([#2309](https://github.com/raullenchai/Rapid-MLX/pull/2309))
+- **Dictation stays alongside chat.** Speech input can load and run without
+  evicting the LLM or vision model used by the active conversation, and an rc1
+  upgrade retains the selected dictation checkpoint. ([#2307](https://github.com/raullenchai/Rapid-MLX/pull/2307),
+  [#2303](https://github.com/raullenchai/Rapid-MLX/pull/2303))
+- **Clearer first-use integrations.** Agent setup works before an inference
+  engine is loaded, and search-key failures keep their actionable provider
+  reason in the Mac interface. ([#2308](https://github.com/raullenchai/Rapid-MLX/pull/2308),
+  [#2304](https://github.com/raullenchai/Rapid-MLX/pull/2304))
+- **Trustworthy image progress and recovery.** Remaining time is derived from
+  completed work and remains stable across slow later steps; stale image aliases
+  recover through the model capability registry. ([#2302](https://github.com/raullenchai/Rapid-MLX/pull/2302),
+  [#2311](https://github.com/raullenchai/Rapid-MLX/pull/2311))
+- **Release artifacts are bound to the candidate that passed validation.** The
+  protected release flow validates the signed and notarized Desktop candidate
+  before tag creation, then verifies source SHA, manifests, hashes, canonical
+  assets, and rerun ordering before publication. ([#2316](https://github.com/raullenchai/Rapid-MLX/pull/2316))
+
+This candidate also makes full-parallel Desktop test evidence deterministic for
+cache polling and tool-approval lifecycles, preserving a trustworthy release
+signal without timeout inflation or suite serialization.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.0-rc1"
+version = "0.13.0-rc2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

RC1 dogfood exposed release-blocking first-run, dictation, integration, image-progress, and artifact-provenance issues. Those fixes are now landed and all release blockers are closed, so RC2 is needed to deliver the corrected signed Desktop candidate to testers without changing the stable updater feed.

## Intention

Create the authorized 0.13.0-rc2 candidate from exact main after all release blockers closed. Align engine/Desktop versions, increment Desktop build to 164, and publish curated rc2 notes covering the user-visible fixes since rc1.

## Scope

- `pyproject.toml`: `0.13.0-rc2`
- Desktop plist: `0.13.0-rc2` / build `164`
- Desktop CHANGELOG and `docs/release-notes/v0.13.0-rc2.md`

## Non-goals

No product, engine, GUI, CI/workflow, dependency, protocol, signing, updater, or release-automation behavior changes. No manual tag or emergency release path.

## Acceptance

- engine/Desktop version sync and monotonic build
- release notes and changelog identify rc2
- documented M3 release gauntlet passes
- release/preflight contracts and exact-head PR validation/full-ci pass
- zero-behind canonical squash subject triggers protected auto-release
- candidate produces source-bound signed/notarized DMG with verified manifests/hashes

## Verification

- `python3.12 scripts/check_version_sync.py` — pass
- focused release Python contracts — 291 passed in sandbox; the one real-listener ownership contract passed separately with host process visibility
- every `tests/release/test_*.sh` — pass
- GHA pinning, Ruff check/format, Bash syntax, `git diff --check` — pass
- `make release-check-m3` — running on exclusive Studio GPU; evidence will be updated before merge
