### PR TITLE
fix: preserve release notes artifact path

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -478,7 +478,11 @@ jobs:
           ACTOR: ${{ github.actor }}
           REASON: ${{ github.event.inputs.reason }}
           EVENT_SHA: ${{ github.sha }}
-          NOTES_FILE: ${{ runner.temp }}/release-notes.md
+          # Keep every file in the evidence artifact under one workspace root.
+          # upload-artifact preserves paths relative to the files' common
+          # ancestor; mixing runner.temp with workspace files nests the notes
+          # under _temp/ and makes the protected release job unable to find it.
+          NOTES_FILE: ${{ github.workspace }}/release-notes.md
         run: |
           set -euo pipefail
 
@@ -607,7 +611,7 @@ jobs:
           path: |
             release-blocker-evidence.txt
             main-head-evidence.txt
-            ${{ runner.temp }}/release-notes.md
+            release-notes.md
           if-no-files-found: error
 
   # 3b) Environment-gated production tag + engine release. The human approves

--- a/tests/release/test_create_release.sh
+++ b/tests/release/test_create_release.sh
@@ -50,6 +50,26 @@ contains "$(cat "$WORKFLOW")" "Tag v\$VERSION exists without a published Release
 contains "$(cat "$WORKFLOW")" "bash scripts/create_release.sh" \
   "release job invokes the atomic helper"
 
+# The pre-approval artifact must download release-notes.md at the exact path
+# consumed by the protected release job. All uploaded files therefore share
+# the workspace root; an absolute runner.temp path would be preserved beneath
+# an _temp/ directory by upload-artifact and strand the engine release after
+# the Desktop DMG has already published.
+BUILD_NOTES=$(sed -n '/- name: Build release notes/,/- name: Verify the accepted desktop candidate SHA/p' "$WORKFLOW")
+UPLOAD_EVIDENCE=$(sed -n '/- name: Upload release evidence + notes/,/^  # 3b)/p' "$WORKFLOW")
+DOWNLOAD_EVIDENCE=$(sed -n '/- name: Download the release evidence + notes/,/- name: Re-query release blockers/p' "$WORKFLOW")
+CREATE_RELEASE=$(sed -n '/- name: Create tag and release/,$p' "$WORKFLOW")
+contains "$BUILD_NOTES" 'NOTES_FILE: ${{ github.workspace }}/release-notes.md' \
+  "release notes are staged under the workspace artifact root"
+lacks "$UPLOAD_EVIDENCE" '${{ runner.temp }}/release-notes.md' \
+  "release evidence upload does not mix runner.temp with workspace paths"
+contains "$UPLOAD_EVIDENCE" 'release-notes.md' \
+  "release evidence artifact includes the workspace-relative notes"
+contains "$DOWNLOAD_EVIDENCE" 'path: evidence' \
+  "protected release job downloads evidence into its expected directory"
+contains "$CREATE_RELEASE" 'NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md' \
+  "engine release consumes the downloaded workspace-relative notes"
+
 # Run the script with a stateful mock ``gh``. Env vars:
 #   MOCK_RELEASE_VIEW   "yes" -> release view succeeds (Release exists)
 #   MOCK_RELEASE_DRAFT  "yes" -> existing Release is an unpublished draft


### PR DESCRIPTION
## Intention
Unblock the canonical RC2 recovery path after the protected release job downloaded its evidence artifact but could not find `evidence/release-notes.md`.

## Scope
- Stage release notes under the same workspace root as the other uploaded evidence files.
- Add an offline workflow contract binding the producer, artifact layout, download directory, and consumer path.

## Non-goals
- No tag movement or deletion.
- No Desktop artifact, updater, signing, notarization, product, or engine behavior change.
- No release bypass or manual publication path.

## Reproduction
Run 32874948717 downloaded artifact 9573964878 successfully, but its contents placed notes at `_temp/release-notes.md`; the protected job expected `evidence/release-notes.md` and stopped before the engine tag/Release. Desktop RC2 remains published and identity-verified.

## Verification
- Release Python contracts: 323 passed.
- All `tests/release/*.sh` contracts passed.
- Focused artifact-path assertions: 49 passed.
- YAML parse and `git diff --check` passed.

## Why
The release artifact uploader preserves paths relative to the common ancestor. Keeping every evidence file under the workspace root ensures the protected consumer receives the notes at the path it validates before publication.