### PR TITLE
feat(server): add explicit assistant replacement policy

### DIFF
--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -413,12 +413,19 @@ class TestRequestManagement:
 
             # Get a few tokens
             token_count = 0
-            async for output in engine.stream_outputs(rid, timeout=30):
+            stream = engine.stream_outputs(rid, timeout=30)
+            async for output in stream:
                 token_count += len(output.new_token_ids)
                 if token_count >= 5:
                     # Abort after 5 tokens
                     await engine.abort_request(rid)
                     break
+
+            from vllm_mlx.request import InferenceAbortedError
+
+            with pytest.raises(InferenceAbortedError, match="cancellation"):
+                await anext(stream)
+            await stream.aclose()
 
             # Request should be aborted
             stats = engine.get_stats()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.engine.batched import BatchedEngine, _admission_token_context
+from vllm_mlx.engine_core import EngineCore
+from vllm_mlx.mllm_scheduler import MLLMScheduler
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.scheduler import BackpressureError, Scheduler
+
+
+def _engine(*, reservations: int = 0, running: dict | None = None):
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._is_mllm = False
+    engine._mllm_scheduler = None
+    engine._admission_lock = threading.Lock()
+    engine._admission_reservations = reservations
+    engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
+    _admission_token_context.set(
+        (id(engine), ("reserved-0",)) if reservations else None
+    )
+    engine._generation_paused = False
+    engine._generation_pause_mode = None
+    scheduler = SimpleNamespace(
+        requests=running or {},
+        running=running or {},
+        waiting=[],
+        config=SimpleNamespace(max_concurrent_requests=8),
+    )
+
+    def set_generation_paused(paused, *, add_allowance=0):
+        scheduler.generation_paused = paused
+        scheduler.add_allowance = add_allowance if paused else 0
+
+    scheduler.set_generation_paused = set_generation_paused
+    engine._engine = SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
+    engine.get_stats = lambda: {
+        "num_running": len(scheduler.running),
+        "num_waiting": len(scheduler.waiting),
+    }
+    return engine, scheduler
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_closes_admission_then_drains_existing_request():
+    engine, _ = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+    assert not pause.done()
+
+    engine.release_admission_reservation()
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert status["paused"] is True
+    assert status["admitted_requests"] == 0
+
+    await engine.resume_generation()
+    engine.check_admission()
+    engine.release_admission_reservation()
+
+
+@pytest.mark.asyncio
+async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
+    engine, scheduler = _engine(reservations=1)
+    aborted = []
+
+    async def abort_request(request_id):
+        aborted.append(request_id)
+        scheduler.requests.pop(request_id, None)
+        scheduler.running.pop(request_id, None)
+        engine.release_admission_reservation()
+        return True
+
+    engine.abort_request = abort_request
+    pause = asyncio.create_task(engine.pause_generation("abort"))
+    await asyncio.sleep(0)
+
+    # Simulate a route that reserved just before pause and reached the
+    # scheduler just after it. Abort mode must discover it on a later scan.
+    request = SimpleNamespace(request_id="late")
+    scheduler.requests["late"] = request
+    scheduler.running["late"] = request
+
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert aborted == ["late"]
+    assert status["running_requests"] == 0
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_allows_request_reserved_before_pause_to_enter_scheduler():
+    engine, scheduler = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    assert scheduler.generation_paused is True
+    assert scheduler.add_allowance == 1
+
+    # This request owns the one reservation captured at the pause edge.
+    scheduler.add_allowance -= 1
+    request = SimpleNamespace(request_id="reserved-before-pause")
+    scheduler.requests[request.request_id] = request
+    scheduler.running[request.request_id] = request
+    await asyncio.sleep(0)
+    assert not pause.done()
+
+    scheduler.requests.clear()
+    scheduler.running.clear()
+    engine.release_admission_reservation()
+    await asyncio.wait_for(pause, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_atomically_pauses_an_idle_engine():
+    engine, _ = _engine()
+
+    status = await engine.pause_generation("wait", timeout=0)
+
+    assert status["paused"] is True
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+
+
+def test_text_scheduler_rejects_direct_add_while_paused():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request(SimpleNamespace(request_id="direct"))
+
+
+def test_mllm_scheduler_rejects_direct_add_while_paused():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request("prompt", request_id="direct")
+
+
+def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+    engine._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+
+
+def test_unlimited_cap_still_tracks_lifecycle_reservation():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+
+
+def test_lifecycle_status_reports_each_owned_stage_and_total():
+    running = {"one": object(), "two": object()}
+    engine, scheduler = _engine(reservations=1, running=running)
+    scheduler.waiting.append(object())
+
+    status = engine.lifecycle_status()
+
+    assert status["admitted_requests"] == 1
+    assert status["running_requests"] == 2
+    assert status["queued_requests"] == 1
+    assert status["active_requests"] == 4
+
+
+def test_scheduler_transfer_releases_route_owned_reservation():
+    engine, _ = _engine()
+    engine.check_admission()
+    token = engine._current_admission_token()
+
+    engine._transfer_admission_to_scheduler(token)
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+@pytest.mark.parametrize("mode", ["wait", "abort"])
+def test_scheduler_pause_accepts_only_uncommitted_pre_pause_token(scheduler_type, mode):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {
+        "already-owned": SimpleNamespace(lifecycle_admission_token="owned")
+    }
+
+    scheduler.pause_generation_admission({"owned", "pending"}, mode)
+
+    assert scheduler._generation_paused is True
+    assert scheduler._paused_add_allowance == 1
+    assert scheduler._paused_admission_tokens == {"pending"}
+
+    scheduler.set_generation_paused(False)
+    assert scheduler._generation_paused is False
+    assert scheduler._paused_add_allowance == 0
+
+
+def test_same_context_admissions_release_as_a_token_stack():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+    engine.check_admission()
+    assert engine._admission_reservations == 2
+
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+
+
+def test_cross_context_release_preserves_legacy_release_contract():
+    engine, _ = _engine()
+    engine.check_admission()
+    _admission_token_context.set(None)
+
+    engine.release_admission_reservation()
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {}
+    start = threading.Event()
+
+    def mutate():
+        start.wait()
+        for index in range(2_000):
+            with scheduler._cancel_counter_lock:
+                scheduler.requests[str(index)] = index
+                if index:
+                    scheduler.requests.pop(str(index - 1), None)
+
+    writer = threading.Thread(target=mutate)
+    writer.start()
+    start.set()
+    for _ in range(2_000):
+        assert isinstance(scheduler.request_ids_snapshot(), tuple)
+    writer.join()
+
+
+@pytest.mark.asyncio
+async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
+    engine = EngineCore.__new__(EngineCore)
+    engine.scheduler = SimpleNamespace(abort_request=lambda _request_id: True)
+    engine._output_collectors = {
+        "active": RequestOutputCollector(aggregate=True),
+    }
+    engine._finished_events = {"active": asyncio.Event()}
+    engine._idle_event = asyncio.Event()
+
+    assert await engine.abort_request("active") is True
+    await asyncio.wait_for(engine._finished_events["active"].wait(), timeout=0.1)
+
+    terminal = engine._output_collectors["active"].get_nowait()
+    assert terminal is not None
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error
+    # The waiting stream/generate coroutine owns cleanup after consuming the
+    # terminal signal. Removing these here recreates the hung HTTP request.
+    assert "active" in engine._output_collectors
+    assert "active" in engine._finished_events
+
+
+def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler._aborted_queue_ids = {"active"}
+
+    scheduler._distribute_outputs(SimpleNamespace(outputs=[]))
+
+    terminal = scheduler.output_queues["active"].get_nowait()
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error
+
+
+def test_mllm_abort_remains_queued_until_terminal_delivery():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.waiting = []
+    scheduler.running = {}
+    scheduler.finished_req_ids = set()
+    scheduler._aborted_queue_ids = {"active"}
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.batch_generator = None
+    scheduler.vision_cache = None
+
+    assert scheduler.get_stats()["num_waiting"] == 1
+
+
+def test_mllm_terminal_delivery_is_counted_by_engine_lifecycle():
+    engine, _ = _engine()
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.waiting = []
+    scheduler.running = {}
+    scheduler.finished_req_ids = set()
+    scheduler._aborted_queue_ids = {"active"}
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.batch_generator = None
+    scheduler.vision_cache = None
+    engine._is_mllm = True
+    engine._mllm_scheduler = scheduler
+    engine._engine = None
+    engine.get_stats = scheduler.get_stats
+
+    status = engine.lifecycle_status()
+
+    assert status["queued_requests"] == 1
+    assert status["active_requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mllm_abort_unblocks_consumer_as_inference_error():
+    from vllm_mlx.request import InferenceAbortedError, RequestOutput
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler.output_queues["active"].put_nowait(
+        RequestOutput(
+            request_id="active",
+            finished=True,
+            finish_reason="length",
+            error="Inference aborted by a cancellation request",
+            error_kind="lifecycle",
+        )
+    )
+
+    with pytest.raises(InferenceAbortedError, match="cancellation"):
+        await anext(scheduler.stream_outputs("active"))
+    assert "active" not in scheduler.output_queues

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -86,7 +86,9 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         uid_only,
         pending_only,
     }
-    assert outputs[-1] is None
+    assert outputs[-1].request_id == aborted
+    assert outputs[-1].finished is True
+    assert outputs[-1].error_kind == "lifecycle"
     for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -54,6 +56,39 @@ class FakeEngine:
 
 class FakeImageEngine(FakeEngine):
     is_image_gen = True
+
+
+class FakeLifecycleEngine(FakeEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pauses: list[tuple[str, float | None]] = []
+        self.paused = False
+
+    async def pause_generation(self, mode="wait", *, timeout=None):
+        self.pauses.append((mode, timeout))
+        self.paused = True
+        if self.running and timeout == 0:
+            raise TimeoutError
+        self.running = 0
+        return self.lifecycle_status()
+
+    async def resume_generation(self):
+        self.paused = False
+        return self.lifecycle_status()
+
+    def lifecycle_status(self):
+        return {
+            "paused": self.paused,
+            "pause_mode": self.pauses[-1][0] if self.pauses else None,
+            "admitted_requests": self.running,
+            "running_requests": self.running,
+            "queued_requests": 0,
+        }
+
+
+class FailingResumeLifecycleEngine(FakeLifecycleEngine):
+    async def resume_generation(self):
+        raise RuntimeError("resume failed")
 
 
 class Clock:
@@ -316,6 +351,204 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("replace_mode", ["wait", "abort"])
+async def test_assistant_replacement_quiesces_before_primary_handoff(replace_mode):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    events: list[str] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    class Handoff:
+        def commit(self, _entry):
+            events.append("handoff-commit")
+
+        def rollback(self):
+            events.append("handoff-rollback")
+
+    def handoff(_entry):
+        events.append("handoff-start")
+        assert old_engine.paused is True
+        return Handoff()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=handoff,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new", replace_group="assistant", replace_mode=replace_mode
+    )
+
+    assert old_engine.pauses == [(replace_mode, None)]
+    assert old_engine.stopped is True
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert events == ["handoff-start", "handoff-commit"]
+
+
+@pytest.mark.asyncio
+async def test_replacement_does_not_publish_target_until_old_engine_drains():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    allow_drain = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.pauses.append((mode, timeout))
+        old_engine.paused = True
+        await allow_drain.wait()
+        old_engine.running = 0
+        return old_engine.lifecycle_status()
+
+    old_engine.pause_generation = pause_generation
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await asyncio.sleep(0)
+
+    assert "chat-new" not in registry
+    assert registry.default_name == "chat-old"
+
+    allow_drain.set()
+    await replacement
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizing():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    async with manager.lease("chat-old"):
+        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert old_engine.pauses == [("wait", None)]
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    draining = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.paused = True
+        draining.set()
+        await asyncio.Event().wait()
+
+    old_engine.pause_generation = pause_generation
+    loaded = None
+
+    async def loader(name: str, path: str | None, performance=None):
+        nonlocal loaded
+        loaded = entry(name)
+        return loaded
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await draining.wait()
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert "chat-new" not in registry
+    assert loaded is not None and loaded.engine.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_busy_replacement_reopens_engine_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await manager.load("chat-new", replace_group="assistant")
+
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+def test_residency_status_uses_engine_owned_request_counts():
+    registry = ModelRegistry()
+    engine = FakeLifecycleEngine()
+    engine.running = 2
+    primary = entry("chat", engine)
+    registry.add(primary, is_default=True)
+    manager = ResidentModelManager(
+        registry, lambda *_args: None, memory_reader=lambda: 0
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    model = manager.snapshot()["models"][0]
+
+    assert model["active_requests"] == 2
+    assert model["lifecycle"]["running_requests"] == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_attempts_every_engine_after_one_resume_fails():
+    manager, _, _, _ = manager_fixture()
+    engines = [
+        FakeLifecycleEngine(),
+        FailingResumeLifecycleEngine(),
+        FakeLifecycleEngine(),
+    ]
+    for engine in engines:
+        engine.paused = True
+
+    await manager._resume_engines(engines)  # noqa: SLF001
+
+    assert engines[0].paused is False
+    assert engines[2].paused is False
+
+
+@pytest.mark.asyncio
 async def test_per_model_performance_reload_replaces_only_the_target_engine():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     await manager.load("image", estimated_bytes=3 * GIB)
@@ -454,6 +687,43 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         )
         assert client.delete("/v1/models/image").status_code == 204
         assert "image" not in registry
+
+
+def test_residency_control_plane_forwards_abort_replacement_policy(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-new",
+                "replace_group": "assistant",
+                "replace_mode": "abort",
+            },
+        )
+
+    assert response.status_code == 200
+    assert old_engine.pauses == [("abort", None)]
+    assert registry.default_name == "chat-new"
 
 
 def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -993,7 +993,7 @@ class BatchedEngine(BaseEngine):
                     f"(currently {self._admission_reservations} in-flight)"
                 )
             self._admission_reservations += 1
-            tokens = getattr(self, "_admission_tokens", None)
+            tokens: set[str] | None = getattr(self, "_admission_tokens", None)
             if tokens is None:
                 tokens = set()
                 self._admission_tokens = tokens
@@ -1021,7 +1021,7 @@ class BatchedEngine(BaseEngine):
     ) -> None:
         """Release one route reservation while holding ``_admission_lock``."""
 
-        tokens = getattr(self, "_admission_tokens", set())
+        tokens: set[str] = getattr(self, "_admission_tokens", set())
         if token is not None and token in tokens:
             tokens.remove(token)
             self._admission_reservations -= 1

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -11,11 +11,14 @@ MLLMBatchGenerator. MLLM models only initialise the MLLM scheduler (not the
 LLM engine), so text-only requests must also be routed through it.
 """
 
+import asyncio
+import contextvars
 import functools
 import json
 import logging
 import threading
 import time
+import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -32,6 +35,9 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
+_admission_token_context: contextvars.ContextVar[tuple[int, tuple[str, ...]] | None] = (
+    contextvars.ContextVar("rapid_mlx_admission_token", default=None)
+)
 
 
 def _load_lazy_and_install_disk_stream(
@@ -891,6 +897,9 @@ class BatchedEngine(BaseEngine):
         # checks; an asyncio lock would only serialise the event loop.
         self._admission_lock = threading.Lock()
         self._admission_reservations = 0
+        self._admission_tokens: set[str] = set()
+        self._generation_paused = False
+        self._generation_pause_mode: str | None = None
 
     @property
     def model_name(self) -> str:
@@ -973,16 +982,26 @@ class BatchedEngine(BaseEngine):
             else:
                 cap = getattr(scheduler.config, "max_concurrent_requests", None)
 
-        if cap is None or cap <= 0:
-            return
-
         with self._admission_lock:
-            if self._admission_reservations >= cap:
+            if getattr(self, "_generation_paused", False):
+                raise BackpressureError(
+                    "generation is paused for a model lifecycle operation"
+                )
+            if cap is not None and cap > 0 and self._admission_reservations >= cap:
                 raise BackpressureError(
                     f"max_concurrent_requests={cap} reached "
                     f"(currently {self._admission_reservations} in-flight)"
                 )
             self._admission_reservations += 1
+            tokens = getattr(self, "_admission_tokens", None)
+            if tokens is None:
+                tokens = set()
+                self._admission_tokens = tokens
+            token = uuid.uuid4().hex
+            tokens.add(token)
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            _admission_token_context.set((id(self), (*stack, token)))
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -992,8 +1011,152 @@ class BatchedEngine(BaseEngine):
         cancellation) cannot corrupt the cap accounting.
         """
         with self._admission_lock:
-            if self._admission_reservations > 0:
-                self._admission_reservations -= 1
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            token = stack[-1] if stack else None
+            self._consume_admission_token_locked(token, stack)
+
+    def _consume_admission_token_locked(
+        self, token: str | None, context_stack: tuple[str, ...]
+    ) -> None:
+        """Release one route reservation while holding ``_admission_lock``."""
+
+        tokens = getattr(self, "_admission_tokens", set())
+        if token is not None and token in tokens:
+            tokens.remove(token)
+            self._admission_reservations -= 1
+        elif token is None and tokens:
+            # The historical API permits release from a task that did not
+            # inherit the reservation context.
+            tokens.pop()
+            self._admission_reservations -= 1
+        elif not tokens and self._admission_reservations > 0:
+            # Minimal engine doubles created before lifecycle tokens still
+            # exercise the public counter-based release contract.
+            self._admission_reservations -= 1
+        if token is not None and token in context_stack:
+            remaining = tuple(value for value in context_stack if value != token)
+            _admission_token_context.set((id(self), remaining) if remaining else None)
+
+    def _current_admission_token(self) -> str | None:
+        context = _admission_token_context.get()
+        if context is None or context[0] != id(self) or not context[1]:
+            return None
+        return context[1][-1]
+
+    def _transfer_admission_to_scheduler(self, token: str | None) -> None:
+        """End route ownership once the scheduler has committed the request."""
+
+        if token is None:
+            return
+        with self._admission_lock:
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            self._consume_admission_token_locked(token, stack)
+
+    def lifecycle_status(self) -> dict[str, object]:
+        """Return engine-owned admission and scheduler activity."""
+
+        with self._admission_lock:
+            paused = getattr(self, "_generation_paused", False)
+            pause_mode = getattr(self, "_generation_pause_mode", None)
+            admitted = getattr(self, "_admission_reservations", 0)
+        stats = self.get_stats()
+        running = int(stats.get("num_running", 0) or 0)
+        queued = int(stats.get("num_waiting", 0) or 0)
+        return {
+            "paused": paused,
+            "pause_mode": pause_mode,
+            "active_requests": admitted + running + queued,
+            "admitted_requests": admitted,
+            "running_requests": running,
+            "queued_requests": queued,
+        }
+
+    def _lifecycle_scheduler(self):
+        scheduler = self._mllm_scheduler
+        if scheduler is None and self._engine is not None:
+            scheduler = getattr(
+                getattr(self._engine, "engine", None), "scheduler", None
+            )
+        return scheduler
+
+    def _lifecycle_request_ids(self) -> set[str]:
+        """Snapshot request IDs owned by either scheduler implementation."""
+
+        scheduler = self._lifecycle_scheduler()
+        if scheduler is None:
+            return set()
+        snapshot = getattr(scheduler, "request_ids_snapshot", None)
+        if callable(snapshot):
+            return {str(request_id) for request_id in snapshot()}
+        return {str(request_id) for request_id in (scheduler.requests or {})}
+
+    async def pause_generation(
+        self, mode: str = "wait", *, timeout: float | None = None
+    ) -> dict[str, object]:
+        """Close admission, then drain or abort scheduler-owned work."""
+
+        if mode not in {"wait", "abort"}:
+            raise ValueError("pause mode must be 'wait' or 'abort'")
+
+        scheduler = self._lifecycle_scheduler()
+        with self._admission_lock:
+            self._generation_paused = True
+            self._generation_pause_mode = mode
+            admitted_tokens = set(getattr(self, "_admission_tokens", set()))
+            pause_admission = getattr(scheduler, "pause_generation_admission", None)
+            if callable(pause_admission):
+                pause_admission(admitted_tokens, mode)
+            else:
+                set_paused = getattr(scheduler, "set_generation_paused", None)
+                if callable(set_paused):
+                    scheduler_owned = len(self._lifecycle_request_ids())
+                    set_paused(
+                        True,
+                        add_allowance=(
+                            max(0, len(admitted_tokens) - scheduler_owned)
+                            if mode == "wait"
+                            else 0
+                        ),
+                    )
+
+        async def _drain() -> dict[str, object]:
+            while True:
+                if mode == "abort":
+                    for request_id in self._lifecycle_request_ids():
+                        await self.abort_request(request_id)
+                status = self.lifecycle_status()
+                if (
+                    status["admitted_requests"] == 0
+                    and status["running_requests"] == 0
+                    and status["queued_requests"] == 0
+                ):
+                    return status
+                await asyncio.sleep(0.01)
+
+        initial = self.lifecycle_status()
+        if (
+            initial["admitted_requests"] == 0
+            and initial["running_requests"] == 0
+            and initial["queued_requests"] == 0
+        ):
+            return initial
+        if timeout is None:
+            return await _drain()
+        return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+
+    async def resume_generation(self) -> dict[str, object]:
+        """Reopen route and scheduler admission after a failed transaction."""
+
+        with self._admission_lock:
+            self._generation_paused = False
+            self._generation_pause_mode = None
+        scheduler = self._lifecycle_scheduler()
+        set_paused = getattr(scheduler, "set_generation_paused", None)
+        if callable(set_paused):
+            set_paused(False)
+        return self.lifecycle_status()
 
     @property
     def tokenizer(self) -> Any:
@@ -1808,6 +1971,7 @@ class BatchedEngine(BaseEngine):
         """
         if not self._loaded:
             await self.start()
+        admission_token = self._current_admission_token()
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all requests when model is multimodal.
@@ -1845,6 +2009,7 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
             mllm_full_text = output.output_text or ""
@@ -1948,6 +2113,7 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=admission_token,
         )
 
         if assistant_text_prefix:
@@ -2043,6 +2209,7 @@ class BatchedEngine(BaseEngine):
         # disconnect. Popped from kwargs so it never reaches the
         # scheduler's add_request (which would reject unknown kwargs).
         request_id_holder = kwargs.pop("request_id_holder", None)
+        admission_token = self._current_admission_token()
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -2063,8 +2230,10 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
+            self._transfer_admission_to_scheduler(admission_token)
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.
             if request_id_holder is not None:
@@ -2154,7 +2323,9 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=admission_token,
         )
+        self._transfer_admission_to_scheduler(admission_token)
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly
         # on client disconnect.

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1090,6 +1090,7 @@ class EngineCore:
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
+        lifecycle_admission_token: str | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -1135,6 +1136,7 @@ class EngineCore:
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=lifecycle_admission_token,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).
@@ -1303,9 +1305,26 @@ class EngineCore:
         return request_id
 
     async def abort_request(self, request_id: str) -> bool:
-        """Abort a request."""
+        """Abort scheduler work and wake its streaming or aggregate consumer."""
+
         result = self.scheduler.abort_request(request_id)
-        self._cleanup_request(request_id)
+        if result:
+            event = self._finished_events.get(request_id)
+            if event is not None and not event.is_set():
+                collector = self._output_collectors.get(request_id)
+                if collector is not None:
+                    collector.put(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
+                event.set()
+            if self._idle_event is not None:
+                self._idle_event.set()
         return result
 
     def _cleanup_request(self, request_id: str) -> None:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -156,6 +156,7 @@ class MLLMRequest:
     # Token counts
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
+    lifecycle_admission_token: str | None = None
 
 
 def _find_stop_match_in_new_window(
@@ -302,6 +303,9 @@ class MLLMScheduler:
         self.waiting: deque[MLLMRequest] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, MLLMRequest] = {}  # Running requests by ID
         self.requests: dict[str, MLLMRequest] = {}  # All requests by ID
+        self._generation_paused = False
+        self._paused_add_allowance = 0
+        self._paused_admission_tokens: set[str] = set()
         self.finished_req_ids: set[str] = set()  # Recently finished
 
         # Mapping between our request IDs and BatchGenerator UIDs
@@ -523,6 +527,16 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
+        with self._request_state_lock():
+            if getattr(self, "_generation_paused", False):
+                from .scheduler import BackpressureError
+
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = kwargs.get("lifecycle_admission_token")
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -573,6 +587,7 @@ class MLLMScheduler:
             stop=stop or [],
             video_fps=video_fps,
             video_max_frames=video_max_frames,
+            lifecycle_admission_token=kwargs.pop("lifecycle_admission_token", None),
         )
 
         # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
@@ -590,6 +605,15 @@ class MLLMScheduler:
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
         with self._cancel_counter_lock:
+            if getattr(self, "_generation_paused", False):
+                from .scheduler import BackpressureError
+
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                if request.lifecycle_admission_token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
+                allowed.remove(request.lifecycle_admission_token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request
@@ -610,6 +634,43 @@ class MLLMScheduler:
         )
 
         return request_id
+
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
+        """Close or reopen scheduler admission for model replacement."""
+
+        with self._request_state_lock():
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
+
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+        """Close admission and preserve only pre-pause route reservations."""
+
+        del mode
+        with self._request_state_lock():
+            self._generation_paused = True
+            owned = {
+                request.lifecycle_admission_token
+                for request in self.requests.values()
+                if request.lifecycle_admission_token is not None
+            }
+            self._paused_admission_tokens = set(admission_tokens) - owned
+            self._paused_add_allowance = len(self._paused_admission_tokens)
+
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return a lock-protected snapshot of queued and running IDs."""
+
+        with self._request_state_lock():
+            return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, including for minimal test doubles."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -741,7 +802,7 @@ class MLLMScheduler:
         # ``via_disconnect_total <= cancelled_total`` and the
         # "exactly one tick per abort" contract that three personas
         # independently observed broken on PyPI 0.8.2.
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.pop(request_id, None)
             self._detokenizer_pool.pop(request_id, None)
 
@@ -1139,7 +1200,8 @@ class MLLMScheduler:
 
             # Track as finished
             self.finished_req_ids.add(request_id)
-            self.requests.pop(request_id, None)
+            with self._request_state_lock():
+                self.requests.pop(request_id, None)
 
     def _step_no_queue(self) -> MLLMSchedulerOutput:
         """Execute one scheduling step WITHOUT queue distribution.
@@ -1290,9 +1352,30 @@ class MLLMScheduler:
             queue = self.output_queues.get(request_id)
             if queue is not None:
                 try:
-                    queue.put_nowait(None)
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
                 except asyncio.QueueFull:
-                    pass
+                    while not queue.empty():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:  # pragma: no cover - race
+                            break
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
 
     def _fail_all_inflight(self, exc: Exception) -> MLLMSchedulerOutput:
         """Fail and detach every request after an unexpected step exception.
@@ -1353,7 +1436,8 @@ class MLLMScheduler:
             self.batch_generator = None
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._request_state_lock():
+            self.requests.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
@@ -1385,7 +1469,8 @@ class MLLMScheduler:
 
     def remove_finished_request(self, request_id: str) -> MLLMRequest | None:
         """Remove a finished request from tracking."""
-        return self.requests.pop(request_id, None)
+        with self._request_state_lock():
+            return self.requests.pop(request_id, None)
 
     # ========== Async API (for streaming) ==========
 
@@ -1841,6 +1926,10 @@ class MLLMScheduler:
                     # Mark finished BEFORE raising so the finally block
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
+                    if output.error_kind == "lifecycle":
+                        from .request import InferenceAbortedError
+
+                        raise InferenceAbortedError(output.error)
                     if output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
                     raise ValueError(output.error)
@@ -1906,8 +1995,8 @@ class MLLMScheduler:
             )
 
         # Cleanup
-        if request_id in self.requests:
-            del self.requests[request_id]
+        with self._request_state_lock():
+            self.requests.pop(request_id, None)
 
         return final_output
 
@@ -1916,7 +2005,9 @@ class MLLMScheduler:
     def get_stats(self) -> dict[str, Any]:
         """Get scheduler statistics."""
         stats = {
-            "num_waiting": len(self.waiting),
+            # Abort ownership ends after the event-loop queue receives its
+            # terminal object, not when the worker removes scheduler state.
+            "num_waiting": len(self.waiting) + len(self._aborted_queue_ids),
             "num_running": len(self.running),
             "num_finished": len(self.finished_req_ids),
             "num_requests_processed": self.num_requests_processed,
@@ -1962,7 +2053,8 @@ class MLLMScheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._request_state_lock():
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -531,7 +531,7 @@ class MLLMScheduler:
             if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                allowed: set[str] = getattr(self, "_paused_admission_tokens", set())
                 token = kwargs.get("lifecycle_admission_token")
                 if token not in allowed:
                     raise BackpressureError(
@@ -608,12 +608,15 @@ class MLLMScheduler:
             if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                if request.lifecycle_admission_token not in allowed:
+                commit_tokens: set[str] = getattr(
+                    self, "_paused_admission_tokens", set()
+                )
+                token = request.lifecycle_admission_token
+                if token is None or token not in commit_tokens:
                     raise BackpressureError(
                         "generation is paused for a model lifecycle operation"
                     )
-                allowed.remove(request.lifecycle_admission_token)
+                commit_tokens.remove(token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -169,6 +169,7 @@ class Request:
     # Routing hints used by PFlash to decide whether to compress (#287).
     has_tools: bool = False
     requires_prompt_integrity: bool = False
+    lifecycle_admission_token: str | None = None
 
     # Grammar-constrained tool calling (#558). Optional per-request logits
     # processor that masks decoding to a tool-call grammar. Set by the chat

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -47,6 +47,7 @@ class ModelLoadRequest(BaseModel):
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: bool = False
+    replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):
@@ -128,6 +129,7 @@ async def load_resident_model(request: ModelLoadRequest):
             image_mode=request.image_mode,
             performance=performance,
             reload_if_changed=request.reload_if_changed,
+            replace_mode=request.replace_mode,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -508,6 +508,7 @@ class ResidentModelManager:
         image_mode: str | None = None,
         performance: ResidentPerformanceConfig | None = None,
         reload_if_changed: bool = False,
+        replace_mode: str = "reject",
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -525,7 +526,7 @@ class ResidentModelManager:
                     record.pinned = True
                 group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    await self._replace_group_locked(record, group, replace_mode)
                 return record
 
             await self._evict_for_locked(estimate, exclude={model_name})
@@ -548,20 +549,43 @@ class ResidentModelManager:
                 pinned=pin,
                 performance=performance,
             )
-            self.registry.add(entry)
-            self._index_record(record)
-            self.loads_total += 1
-
+            group = _effective_replace_group(record.entry, replace_group)
+            candidates: list[ResidencyRecord] = []
+            paused_engines: list[object] = []
             try:
-                await self._evict_for_locked(0, exclude={record.model_id})
-                group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    candidates, paused_engines = await self._quiesce_group_locked(
+                        record, group, replace_mode
+                    )
+                # Keep the replacement private until the old inference engines
+                # have reached the policy boundary. Publication only makes the
+                # already-quiesced replacement visible to residency readers.
+                self.registry.add(entry)
+                self._index_record(record)
+                self.loads_total += 1
+                await self._evict_for_locked(0, exclude={record.model_id})
+                if group is not None:
+                    await self._commit_group_replacement_locked(
+                        record, group, candidates
+                    )
             except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
-                await self._evict_locked(record, reason="load_rollback", count=False)
+                try:
+                    if record.model_id in self._records:
+                        await self._evict_locked(
+                            record, reason="load_rollback", count=False
+                        )
+                    else:
+                        stop = getattr(record.entry.engine, "stop", None)
+                        if callable(stop):
+                            result = stop()
+                            if asyncio.iscoroutine(result):
+                                await result
+                        _release_allocator_cache()
+                finally:
+                    await self._resume_engines(paused_engines)
                 raise
             return record
 
@@ -692,7 +716,12 @@ class ResidentModelManager:
             if handoff is not None:
                 handoff.commit(restored_entry)
 
-    async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
+    async def _replace_group_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        replace_mode: str = "reject",
+    ) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.
 
         The desktop uses the ``assistant`` group for its chat picker: changing
@@ -702,10 +731,29 @@ class ResidentModelManager:
         legacy health/cache routes never retain a reference to unloaded weights.
         """
 
+        candidates, paused_engines = await self._quiesce_group_locked(
+            target, group, replace_mode
+        )
+        try:
+            await self._commit_group_replacement_locked(target, group, candidates)
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+
+    async def _quiesce_group_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        replace_mode: str,
+    ) -> tuple[list[ResidencyRecord], list[object]]:
+        """Atomically close admission and reach the requested policy boundary."""
+
         if group != _replacement_group(target.entry):
             raise ResidentModelError(
                 f"model {target.model_id!r} does not belong to replacement group {group!r}"
             )
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
 
         candidates = [
             record
@@ -714,12 +762,58 @@ class ResidentModelManager:
             and _replacement_group(record.entry) == group
         ]
         for record in candidates:
-            if record.active_requests or not _engine_is_idle(record.entry.engine):
-                raise ResidentModelBusyError("model is serving an active request")
             if record.pinned and not record.primary:
                 raise ResidentModelError(
                     f"pinned model {record.model_id!r} cannot be replaced"
                 )
+
+        paused_engines: list[object] = []
+        try:
+            for record in candidates:
+                engine = record.entry.engine
+                pause = getattr(engine, "pause_generation", None)
+                if record.active_requests and (
+                    replace_mode == "reject" or not callable(pause)
+                ):
+                    raise ResidentModelBusyError("model is serving an active request")
+                if callable(pause):
+                    paused_engines.append(engine)
+                    try:
+                        await pause(
+                            "wait" if replace_mode == "reject" else replace_mode,
+                            timeout=0 if replace_mode == "reject" else None,
+                        )
+                    except TimeoutError as exc:
+                        raise ResidentModelBusyError(
+                            "model is serving an active request"
+                        ) from exc
+                elif not _engine_is_idle(engine):
+                    raise ResidentModelBusyError("model is serving an active request")
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+        return candidates, paused_engines
+
+    async def _resume_engines(self, engines: list[object]) -> None:
+        """Best-effort reopen every engine paused by a failed transaction."""
+
+        for engine in reversed(engines):
+            resume = getattr(engine, "resume_generation", None)
+            if callable(resume):
+                try:
+                    await resume()
+                except BaseException:
+                    logger.exception(
+                        "Failed to resume a model engine after replacement rollback"
+                    )
+
+    async def _commit_group_replacement_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        candidates: list[ResidencyRecord],
+    ) -> None:
+        """Apply the existing primary/audio handoff to quiesced engines."""
 
         old_primary = next((record for record in candidates if record.primary), None)
         handoff = None
@@ -751,7 +845,11 @@ class ResidentModelManager:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(target.entry)
             for record in ordered_candidates:
-                await self._evict_locked(record, reason=f"replace_{group}")
+                await self._evict_locked(
+                    record,
+                    reason=f"replace_{group}",
+                    allow_active_lease=True,
+                )
         except BaseException:
             if old_primary is not None:
                 try:
@@ -797,9 +895,14 @@ class ResidentModelManager:
             await self._evict_locked(record, reason="explicit")
 
     async def _evict_locked(
-        self, record: ResidencyRecord, *, reason: str, count: bool = True
+        self,
+        record: ResidencyRecord,
+        *,
+        reason: str,
+        count: bool = True,
+        allow_active_lease: bool = False,
     ) -> None:
-        if record.active_requests:
+        if record.active_requests and not allow_active_lease:
             raise ResidentModelBusyError("model is serving an active request")
         record.state = "evicting"
         self.registry.remove(record.model_id)
@@ -841,6 +944,20 @@ class ResidentModelManager:
         for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
+            lifecycle = (
+                engine.lifecycle_status()
+                if callable(getattr(engine, "lifecycle_status", None))
+                else None
+            )
+            active_requests = record.active_requests
+            if lifecycle is not None:
+                active_requests = max(
+                    active_requests,
+                    int(lifecycle.get("active_requests", 0) or 0),
+                    int(lifecycle.get("admitted_requests", 0) or 0),
+                    int(lifecycle.get("running_requests", 0) or 0),
+                    int(lifecycle.get("queued_requests", 0) or 0),
+                )
             models.append(
                 {
                     "id": record.model_id,
@@ -850,7 +967,8 @@ class ResidentModelManager:
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,
-                    "active_requests": record.active_requests,
+                    "active_requests": active_requests,
+                    "lifecycle": lifecycle,
                     "estimated_bytes": record.estimated_bytes,
                     "measured_bytes": record.measured_bytes or None,
                     "idle_seconds": max(0.0, now - record.last_used_at),

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -944,11 +944,8 @@ class ResidentModelManager:
         for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
-            lifecycle = (
-                engine.lifecycle_status()
-                if callable(getattr(engine, "lifecycle_status", None))
-                else None
-            )
+            lifecycle_status = getattr(engine, "lifecycle_status", None)
+            lifecycle = lifecycle_status() if callable(lifecycle_status) else None
             active_requests = record.active_requests
             if lifecycle is not None:
                 active_requests = max(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5861,7 +5861,7 @@ class Scheduler:
         """
         with self._request_state_lock():
             if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                allowed: set[str] = getattr(self, "_paused_admission_tokens", set())
                 token = getattr(request, "lifecycle_admission_token", None)
                 if token not in allowed:
                     raise BackpressureError(
@@ -6082,13 +6082,15 @@ class Scheduler:
         # stays effective.
         with self._cancel_counter_lock:
             if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                commit_tokens: set[str] = getattr(
+                    self, "_paused_admission_tokens", set()
+                )
                 token = getattr(request, "lifecycle_admission_token", None)
-                if token not in allowed:
+                if not isinstance(token, str) or token not in commit_tokens:
                     raise BackpressureError(
                         "generation is paused for a model lifecycle operation"
                     )
-                allowed.remove(token)
+                commit_tokens.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3036,6 +3036,9 @@ class Scheduler:
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, Request] = {}  # Running requests by ID
         self.requests: dict[str, Request] = {}  # All requests by ID
+        self._generation_paused = False
+        self._paused_add_allowance = 0
+        self._paused_admission_tokens: set[str] = set()
         self.finished_req_ids: set[str] = set()  # Recently finished
         # Debug aid (#1878): resolved ONCE — an os.environ lookup per
         # step would put dict access on the decode hot path advertised
@@ -5856,6 +5859,14 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
+        with self._request_state_lock():
+            if getattr(self, "_generation_paused", False):
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6070,6 +6081,14 @@ class Scheduler:
         # the ledger intact and the prior lifetime's dedupe
         # stays effective.
         with self._cancel_counter_lock:
+            if getattr(self, "_generation_paused", False):
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
+                allowed.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
@@ -6079,6 +6098,43 @@ class Scheduler:
         logger.debug(
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
+
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
+        """Close or reopen scheduler admission for model replacement."""
+
+        with self._request_state_lock():
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
+
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+        """Close admission and preserve only pre-pause route reservations."""
+
+        del mode  # Both policies close admission; mode controls draining above.
+        with self._request_state_lock():
+            self._generation_paused = True
+            owned = {
+                getattr(request, "lifecycle_admission_token", None)
+                for request in self.requests.values()
+                if getattr(request, "lifecycle_admission_token", None) is not None
+            }
+            self._paused_admission_tokens = set(admission_tokens) - owned
+            self._paused_add_allowance = len(self._paused_admission_tokens)
+
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return a lock-protected snapshot of queued and running IDs."""
+
+        with self._cancel_counter_lock:
+            return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, including for minimal test doubles."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -8331,7 +8387,8 @@ class Scheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._cancel_counter_lock:
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()


### PR DESCRIPTION
## User-visible goal

Let a running Desktop server replace its loaded text or multimodal assistant model without restarting the server. The caller chooses an explicit lifecycle policy:

- `reject` (default): refuse replacement while inference is active.
- `wait`: close admission, drain accepted work, then replace.
- `abort`: close admission, cancel accepted work with a terminal client-visible failure, then replace.

Residency status reports whether generation is paused and separates admitted, queued, and running work.

## Why

The server already owns model residency and primary handoff, but replacement requests had no engine-level policy for in-flight inference. As a result, callers could only reject a busy model or rely on process replacement. Closing admission in the engine before drain or cancellation makes the lifecycle boundary atomic, preserves server and conversation identity, and keeps explicit operator control.

## Scope

- Engine-owned admission closure, drain, and abort for text and multimodal schedulers.
- Opaque admission tokens for requests that legitimately cross the pause boundary.
- Terminal cancellation delivery to streaming and non-streaming clients.
- `replace_mode` wiring on the existing residency load route.
- Integration with the existing primary-model handoff and rollback transaction.
- Focused engine/server lifecycle and regression tests.

## Non-goals

- Scheduler or cache redesign.
- Desktop/UI changes.
- Audio-lane lifecycle changes.
- Capacity, TTL, or eviction-policy changes.
- Changes to release or CI workflows.

## Acceptance evidence

- Baseline: the server exposed no engine pause/status contract and discarded `replace_mode` from residency load requests.
- Focused lifecycle/residency/audio suite: 126 passed, 1 existing xpass.
- Cancellation, engine-failure, SSE, and request regression suite: 90 passed.
- Ruff check and format: passed.
- Source distribution and wheel build: passed.

The PR is intentionally draft while exact-head review and PR validation run. It must not receive the held full-CI label and is targeted for the 0.13.1 landing window.
