### PR TITLE
fix(mac): onboarding 'Before loading' memory verdict re-evaluates live (ONBOARD-MEM-LIVE)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -5,7 +5,18 @@ import Observation
 /// FIFO state machine for memory-risk confirmations. A request token is
 /// present for ``ensureServing`` callers that must await their own answer;
 /// direct ``start`` calls still queue a prompt but retain no result.
-struct MemoryLoadConfirmationQueue {
+///
+/// Referenced type (``@Observable`` class, not a struct) so that replacing the
+/// head warning's measured facts — e.g. the 3s live memory refresh in
+/// ``ServerManager/refreshPendingMemoryWarning()`` — fires SwiftUI observation
+/// and the "Before loading" verdict re-renders live. With a plain value type,
+/// an in-place mutation of `pending[0].warning` inside a stored, value-typed
+/// property does NOT invalidate the ``@Observable`` owner, so the card kept
+/// showing the original parked snapshot even as free memory changed
+/// (ONBOARD-MEM-LIVE). Mirrors how ``DownloadManager``/``Job`` stay
+/// ``@Observable`` so nested `status`/`progress` mutations re-render.
+@Observable
+final class MemoryLoadConfirmationQueue {
     enum Decision: Equatable {
         case confirmed(sequence: Int)
         case cancelled
@@ -32,13 +43,13 @@ struct MemoryLoadConfirmationQueue {
         return pending.first?.warning
     }
 
-    mutating func enqueue(warning: ModelSizing.MemoryWarning, requestID: UUID?) {
+    func enqueue(warning: ModelSizing.MemoryWarning, requestID: UUID?) {
         pending.append(Pending(warning: warning, requestID: requestID))
     }
 
     /// Replace the measured facts for the visible decision without changing
     /// its identity, waiter ownership, or queue position.
-    mutating func refreshCurrentWarning(
+    func refreshCurrentWarning(
         snapshot: MemoryProbe.Snapshot
     ) -> (old: ModelSizing.MemoryWarning, new: ModelSizing.MemoryWarning)? {
         guard pending.first?.phase == .awaitingDecision,
@@ -54,7 +65,7 @@ struct MemoryLoadConfirmationQueue {
         }
     }
 
-    mutating func resolveCurrent(
+    func resolveCurrent(
         warningID: UUID,
         decision: Decision
     ) -> ModelSizing.MemoryWarning? {
@@ -73,14 +84,14 @@ struct MemoryLoadConfirmationQueue {
         return currentWarning
     }
 
-    mutating func beginChecking(warningID: UUID) -> Bool {
+    func beginChecking(warningID: UUID) -> Bool {
         guard pending.first?.warning.id == warningID,
               pending.first?.phase == .awaitingDecision else { return false }
         pending[0].phase = .checkingDecision
         return true
     }
 
-    mutating func checkingWarning(
+    func checkingWarning(
         warningID: UUID,
         snapshot: MemoryProbe.Snapshot?
     ) -> ModelSizing.MemoryWarning? {
@@ -92,13 +103,13 @@ struct MemoryLoadConfirmationQueue {
         return pending[0].warning
     }
 
-    mutating func restoreAwaiting(warningID: UUID) {
+    func restoreAwaiting(warningID: UUID) {
         guard pending.first?.warning.id == warningID,
               pending.first?.phase == .checkingDecision else { return }
         pending[0].phase = .awaitingDecision
     }
 
-    mutating func confirmChecking(
+    func confirmChecking(
         warningID: UUID,
         sequence: Int
     ) -> ModelSizing.MemoryWarning? {
@@ -112,14 +123,14 @@ struct MemoryLoadConfirmationQueue {
         return warning
     }
 
-    mutating func resolveCurrent(
+    func resolveCurrent(
         warning: ModelSizing.MemoryWarning,
         decision: Decision
     ) -> Bool {
         resolveCurrent(warningID: warning.id, decision: decision) != nil
     }
 
-    mutating func completeConfirmedLaunch(warningID: UUID) {
+    func completeConfirmedLaunch(warningID: UUID) {
         guard pending.first?.warning.id == warningID,
               pending.first?.phase == .launching else { return }
         pending[0].launchComplete = true
@@ -130,7 +141,7 @@ struct MemoryLoadConfirmationQueue {
         pending.removeFirst()
     }
 
-    mutating func takeDecision(for requestID: UUID) -> Decision? {
+    func takeDecision(for requestID: UUID) -> Decision? {
         let decision = decisions.removeValue(forKey: requestID)
         if pending.first?.requestID == requestID,
            pending.first?.launchComplete == true {
@@ -139,7 +150,7 @@ struct MemoryLoadConfirmationQueue {
         return decision
     }
 
-    mutating func abandonWaiter(_ requestID: UUID) {
+    func abandonWaiter(_ requestID: UUID) {
         decisions.removeValue(forKey: requestID)
         guard let index = pending.firstIndex(where: { $0.requestID == requestID }) else {
             return

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import Testing
 
 @testable import Rapid

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -235,6 +235,46 @@ struct LaunchAutoStartMemoryTests {
         snapshots.releaseActivationSample()
         _ = await load.value
     }
+
+    @MainActor
+    @Test("a live memory refresh invalidates the view-bound pendingMemoryWarning (observation fires)")
+    func liveRefreshInvalidatesPendingMemoryWarningObservation() async throws {
+        // ONBOARD-MEM-LIVE regression pin. The queue used to be a plain value type
+        // stored in the @Observable ServerManager, so refreshCurrentWarning's in-place
+        // `pending[0].warning` replacement never fired withMutation — the "Before
+        // loading" verdict stayed frozen on its original snapshot even as free memory
+        // changed. With MemoryLoadConfirmationQueue now an @Observable reference type,
+        // replacing the head warning MUST invalidate the exact property the card binds:
+        // server.pendingMemoryWarning. That is what makes red-to-green (and green-to-red)
+        // actually re-render rather than update an invisible value.
+        let gib = UInt64(1_073_741_824)
+        let snapshots = LockedMemorySnapshots(
+            .init(totalBytes: 32 * gib, usedBytes: 30 * gib)
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        server.memorySnapshotProvider = { snapshots.current }
+
+        await server.start(alias: "qwen3.5-9b-4bit")
+        #expect(server.pendingMemoryWarning?.severity == .unsafe)
+
+        let changed = LockedCompletionFlag()
+        withObservationTracking {
+            _ = server.pendingMemoryWarning
+        } onChange: {
+            changed.markComplete()
+        }
+
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        _ = await server.refreshPendingMemoryWarning()
+        #expect(server.pendingMemoryWarning?.severity == .safe)
+        #expect(
+            changed.isComplete,
+            "replacing the parked warning must invalidate server.pendingMemoryWarning so the onboarding verdict re-renders live"
+        )
+    }
 }
 
 private final class LockedMemorySnapshots: @unchecked Sendable {


### PR DESCRIPTION
## Why

rc2 dogfood bug (ONBOARD-MEM-LIVE): onboarding step 4 "Before loading" does not re-evaluate live. On an 18 GB Mac with `lfm2.5-1b-4bit`, after the user closed apps and FREE NOW rose to 5 GB, the verdict/headline/percent/hint/NEEDS colour/top icon all stayed in the original red state. Expected: when free memory becomes sufficient, every visible element updates together, and the reverse when memory drops.

## Root cause

The 3s live memory refresh correctly recomputed `severity` + `freeGB` from one fresh probe snapshot (that data logic is tested), but the refreshed value **never reached SwiftUI**. `pendingMemoryWarning` is a computed property over a plain value-typed `MemoryLoadConfirmationQueue` stored in the `@Observable ServerManager`. In Swift Observation, an in-place mutation of an element inside a stored **value-type** property does NOT fire `withMutation` on the owner — so the card kept rendering the original parked snapshot. (This is exactly why the codebase already makes `DownloadManager`/`Job` `@Observable` classes — see the `@Observable is load-bearing` comment near `Job.progress`.)

## Fix (smallest, no redesign)

Turn `MemoryLoadConfirmationQueue` into an `@Observable` reference type (all method bodies unchanged, `mutating` → `func`). Now replacing the head warning's measured facts fires observation, so the "Before loading" card re-renders live from the same latest probe snapshot — verdict, headline, percent, hint, NEEDS colour and the top icon all flip together on any true red→green / green→red crossing. The 85% headroom rule is unchanged; no other onboarding steps touched.

## Evidence (before/after)

Before (the frozen red state, driven by the bug numbers 18 GB / 5 GB free / 3 GB model): severity `.unsafe` → title "may crash your Mac right now", message "…about 89% of 18 GB…", NEEDS 3 GB red, `exclamationmark.triangle` icon. **Before the fix these are computed but never render after the refresh** — the card is frozen.

After (free ≥ the 7.5 GB crossing threshold on 18 GB): severity `.safe` → title "ready to load", green checkmark, green NEEDS — all elements flip together in place as the live probe updates each 3 s tick.

A focused regression test pins the mechanism: `withObservationTracking` on the exact view-bound property `server.pendingMemoryWarning` proves a live refresh with injected memory facts **invalidates observation** (the verdict would re-render), not merely updates an invisible value.

Note on "screenshots": the card is a rare blocking state reachable only through a real parked unsafe load, so a pixel capture isn't reproducibly captured here; the before/after is instead pinned deterministically (field-level rendering above + the observation-invalidation test). No visual redesign was made, so rendering is byte-identical; the change is purely that the verdict now updates live.

## Tests

- New: `LaunchAutoStartMemoryTests/liveRefreshInvalidatesPendingMemoryWarningObservation` — live refresh invalidates the view-bound property (observation fires).
- Existing, still green: `MemoryLoadConfirmationQueueTests` (10, incl. red→green→red), `LaunchAutoStartMemoryTests` (7, incl. "parked warning re-samples the injected probe in both directions"), `OnboardingWontFitReviewTests` + `OnboardingRecoveryBehaviorTests` (86). 103 tests in the combined surface all pass.

Non-goals respected: no threshold/85% change, no other onboarding steps, no release/rc2 files.