### PR TITLE
fix(mac): give Chat authoritative current local date/time context (issue #2330)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1850,6 +1850,7 @@ final class ChatViewModel {
             history = ChatViewModel.addingInstructionLayers(
                 to: history,
                 ambientPreamble: ambientPreamble,
+                dateContext: ChatViewModel.currentDateTimeContext(),
                 global: globalInstruction,
                 conversation: conversationInstruction
             )
@@ -2251,18 +2252,24 @@ final class ChatViewModel {
         return [ChatMessage(role: .system, content: toolGuidancePreamble, status: .complete)]
     }
 
-    /// Merge app, pre-existing, global, and conversation instruction layers
-    /// into one leading system row. Local chat templates often reject a second
-    /// system message, so every caller must go through this transformation.
+    /// Merge current-date context, ambient, pre-existing, global, and
+    /// conversation layers into one leading system row. Local chat templates
+    /// often reject a second system message, so every caller must go through
+    /// this transformation.
     nonisolated static func addingInstructionLayers(
         to messages: [ChatMessage],
         ambientPreamble: String?,
+        dateContext: String? = nil,
         global: String,
         conversation: String
     ) -> [ChatMessage] {
         var result = messages
         let existing = result.first?.role == .system ? result.removeFirst().content : nil
-        var parts = [ambientPreamble, existing]
+        // The ambient preamble stays the LEADING component (so
+        // ``removingLeadingSystemComponent`` can strip it when context
+        // trimming drops the tool result that armed it); the date context
+        // rides below it because it is valid regardless of tool presence.
+        var parts = [ambientPreamble, dateContext, existing]
             .compactMap { $0.flatMap(normalizedInstruction) }
         if let global = normalizedInstruction(global) {
             parts.append("""
@@ -2284,6 +2291,46 @@ final class ChatViewModel {
             at: 0
         )
         return result
+    }
+
+    /// Request-time current-date context for the leading system row, so a small
+    /// model does not guess "today" from training memory (issue #2330, where
+    /// `qwen3.5-4b-4bit` answered "Friday, May 24, 2024" and then insisted it
+    /// had no way to know the date). This supplies the Mac's authoritative
+    /// local date/time as a system-prompt template variable at request time —
+    /// the pattern peer desktop chat products use — rather than relying on the
+    /// model to infer it must search for the date, and without adding a
+    /// local-clock tool or touching tool routing.
+    ///
+    /// Injected per `send` (each request recomputes it against the live clock),
+    /// so it cannot go stale across midnight, a time-zone change, a restored
+    /// conversation, or a long-lived session. `now` and the calendar's
+    /// time zone are injectable so tests can pin the exact output and cover
+    /// rollover.
+    nonisolated static func currentDateTimeContext(
+        now: Date = Date(),
+        calendar inputCalendar: Calendar = .autoupdatingCurrent
+    ) -> String {
+        // Fixed gregorian calendar + en_US_POSIX so output never depends on the
+        // user's locale for date/time names or AM/PM rendering.
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = inputCalendar.timeZone
+        let zone = inputCalendar.timeZone
+        let formatter = DateFormatter()
+        formatter.calendar = gregorian
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = zone
+
+        formatter.dateFormat = "EEEE, MMMM d, yyyy"
+        let dateText = formatter.string(from: now)
+        formatter.dateFormat = "h:mm a"
+        let timeText = formatter.string(from: now)
+
+        let abbreviation = zone.abbreviation(for: now) ?? zone.identifier
+        return """
+        [CURRENT DATE AND TIME]
+        Today is \(dateText). The current local time is \(timeText) (\(abbreviation), \(zone.identifier)).
+        """
     }
 
     /// Remove an exact first component from the merged system row. Used when

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Issue #2330 — Desktop Chat had no authoritative current-date context. A
+/// small model answered "what is the date today" with a training-memory date
+/// ("Friday, May 24, 2024") and then claimed it could not know today's date.
+///
+/// The fix injects the Mac's local date/time/time-zone into the leading
+/// system prompt row as a request-time template variable (the established
+/// desktop-chat pattern), so the model never has to guess the date or infer it
+/// must search for it. These tests pin the pure formatter with an injected
+/// clock/time-zone and prove it stays correct across time zones, midnight
+/// rollover, and a restored conversation.
+@Suite("Current date context")
+struct CurrentDateTimeContextTests {
+
+    private static func calendar(_ timeZoneID: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: timeZoneID)
+            ?? TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private static var iso: ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }
+
+    private static func instant(_ string: String) -> Date {
+        // Force-unwrap: the test inputs are fixed literals.
+        iso.date(from: string)!
+    }
+
+    @Test("The injected clock/time-zone pins today's local date, time, and zone")
+    func pinnedLocalDateTime() {
+        let calendar = Self.calendar("America/Los_Angeles")
+        let out = ChatViewModel.currentDateTimeContext(
+            now: Self.instant("2026-08-25T14:37:00Z"),
+            calendar: calendar
+        )
+        #expect(out.contains("[CURRENT DATE AND TIME]"))
+        #expect(out.contains(
+            "Today is Tuesday, August 25, 2026. The current local time is 7:37 AM"
+        ))
+        #expect(out.contains("(PDT, America/Los_Angeles)"))
+    }
+
+    @Test("The same instant reads a different local date across time zones")
+    func timeZoneChangesTheLocalDate() {
+        let instant = Self.instant("2026-08-25T06:00:00Z")
+        let la = ChatViewModel.currentDateTimeContext(
+            now: instant, calendar: Self.calendar("America/Los_Angeles")
+        )
+        let tokyo = ChatViewModel.currentDateTimeContext(
+            now: instant, calendar: Self.calendar("Asia/Tokyo")
+        )
+        // 06:00Z is still August 24 in Los Angeles but already August 25 in
+        // Tokyo — the injected zone is authoritative, not UTC.
+        #expect(la.contains("Monday, August 24, 2026"))
+        #expect(tokyo.contains("Tuesday, August 25, 2026"))
+        #expect(la.contains("America/Los_Angeles"))
+        #expect(tokyo.contains("Asia/Tokyo"))
+    }
+
+    @Test("The context rolls over to a new date across local midnight")
+    func dateRollsOverAtLocalMidnight() {
+        let before = ChatViewModel.currentDateTimeContext(
+            now: Self.instant("2026-08-25T06:59:59Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        let after = ChatViewModel.currentDateTimeContext(
+            now: Self.instant("2026-08-25T07:00:01Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        // 23:59 PDT is still Monday Aug 24; 00:00 PDT is Tuesday Aug 25.
+        #expect(before.contains("Monday, August 24, 2026"))
+        #expect(before.contains("11:59 PM"))
+        #expect(after.contains("Tuesday, August 25, 2026"))
+        #expect(after.contains("12:00 AM"))
+        #expect(before != after)
+    }
+
+    @Test("Date context merges into a restored conversation's single system row")
+    func restoredConversationMergesIntoOneSystemRow() {
+        // A restored conversation already carries a leading app/system row.
+        let restored = ChatMessage(
+            role: .system,
+            content: "App system context", status: .complete
+        )
+        let user = ChatMessage(role: .user, content: "Hello", status: .complete)
+        let dateContext = ChatViewModel.currentDateTimeContext(
+            now: Self.instant("2026-08-25T14:37:00Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        let result = ChatViewModel.addingInstructionLayers(
+            to: [restored, user],
+            ambientPreamble: nil,
+            dateContext: dateContext,
+            global: "",
+            conversation: ""
+        )
+
+        #expect(result.filter { $0.role == .system }.count == 1,
+                "restored + date context must stay one system row")
+        let content = result.first?.content ?? ""
+        #expect(content.contains("[CURRENT DATE AND TIME]"))
+        #expect(content.contains("Today is Tuesday, August 25, 2026"))
+        #expect(content.contains("App system context"))
+        #expect(result.last?.id == user.id)
+    }
+}
+
+/// Wire-side capture mirroring ``CustomInstructionsCaptureProtocol`` so the
+/// production `send` path is exercised with the real `ChatViewModel` and the
+/// date context is asserted to actually reach the request body's single system
+/// row (not just a helper in isolation).
+private final class DateContextWireCaptureProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var lastRequestBody: Data?
+
+    static func reset() { lastRequestBody = nil }
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [DateContextWireCaptureProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastRequestBody = Self.bodyData(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let body = """
+        data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n
+        data: [DONE]\n
+        """.data(using: .utf8)!
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        guard let stream = request.httpBodyStream else { return request.httpBody }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBufferPointer { pointer in
+                stream.read(pointer.baseAddress!, maxLength: pointer.count)
+            }
+            if count > 0 { data.append(buffer, count: count) }
+            if count == 0 { return data }
+            if count < 0 { return nil }
+        }
+    }
+}
+
+@MainActor
+@Suite("Current date context on the wire")
+struct CurrentDateContextWireTests {
+
+    @Test("A send puts the current-date block in the wire system message")
+    func sendIncludesCurrentDateOnWire() async throws {
+        DateContextWireCaptureProtocol.reset()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://date-context")!,
+                session: DateContextWireCaptureProtocol.session()
+            ),
+            persistsConversations: false
+        )
+
+        model.send("what is the date today", alias: "test-model")
+        for _ in 0..<200 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        let body = try #require(DateContextWireCaptureProtocol.lastRequestBody)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        #expect(messages.filter { $0["role"] as? String == "system" }.count == 1)
+        let system = try #require(messages.first?["content"] as? String)
+        #expect(system.contains("[CURRENT DATE AND TIME]"))
+        #expect(system.contains("Today is "))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -112,14 +112,41 @@ struct CurrentDateTimeContextTests {
     }
 }
 
-/// Wire-side capture mirroring ``CustomInstructionsCaptureProtocol`` so the
-/// production `send` path is exercised with the real `ChatViewModel` and the
-/// date context is asserted to actually reach the request body's single system
-/// row (not just a helper in isolation).
-private final class DateContextWireCaptureProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var lastRequestBody: Data?
+/// Wire-side capture so the production `send` path is exercised with the real
+/// `ChatViewModel` and the date context is asserted to actually reach the
+/// request body's single system row (not just a helper in isolation).
+///
+/// The stored body is written on the `URLProtocol` loading thread and read from
+/// the main actor after the stream completes, so it is guarded by an ``NSLock``
+/// (the pattern other test captures here use) rather than an unsynchronized
+/// static — the write/read happen on different threads.
+/// Lock-guarded body store. `URLProtocol` writes on its loading thread and the
+/// main actor reads afterward, so the pair is boxed behind ``@unchecked
+/// Sendable`` (Swift 6 rejects a bare lock-protected mutable global); all access
+/// funnels through the lock.
+private final class BodyStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var body: Data?
 
-    static func reset() { lastRequestBody = nil }
+    func get() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return body
+    }
+
+    func set(_ value: Data?) {
+        lock.lock()
+        defer { lock.unlock() }
+        body = value
+    }
+}
+
+private final class DateContextWireCaptureProtocol: URLProtocol, @unchecked Sendable {
+    private static let store = BodyStore()
+
+    static var lastRequestBody: Data? { store.get() }
+
+    static func reset() { store.set(nil) }
 
     static func session() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
@@ -131,7 +158,7 @@ private final class DateContextWireCaptureProtocol: URLProtocol, @unchecked Send
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        Self.lastRequestBody = Self.bodyData(from: request)
+        Self.store.set(Self.bodyData(from: request))
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: 200,


### PR DESCRIPTION
## What does this PR do?

Injects the Mac authoritative local date/time/time-zone into the leading chat
system prompt row as a request-time template variable (the established
desktop-chat pattern), so the model always knows "today". No new tool, no
tool-routing change — smallest change in the existing prompt-assembly path.

- `ChatViewModel.currentDateTimeContext(now:calendar:)` — pure, locale-independent
  formatter with an injectable clock/time-zone.
- `addingInstructionLayers` gains a `dateContext:` part merged into the single
  system row local chat templates require, inserted below the ambient preamble
  (which must stay leading for ambient-removal) and above the user instruction
  layers.
- The context is recomputed on every `send`, so it cannot go stale across
  midnight, a time-zone change, a restored conversation, or a long-lived session.

## Why is this needed?

fixes #2330 — in `0.13.0-rc2`, `qwen3.5-4b-4bit` answered *"what is the date
today"* with a training-memory date (**Friday, May 24, 2024**) and then claimed
it had no access to the current date. The Desktop supplied neither local
date/time context nor a local-clock tool, and the model did not select a
live-data tool under `tool_choice=auto` (the same session *did* run `web_search`
for a live-evidence prompt, so search was healthy). The assistant confidently
fabricates a basic fact the Mac already knows.

## AI assistance disclosure

- Claude wrote the implementation (`ChatViewModel.swift`) and the tests
  (`CurrentDateTimeContextTests.swift`) end-to-end; I reviewed every line
  against the issue acceptance criteria before committing.
- Verified: `swift build` clean; `swift test --filter "CurrentDate"` → 5/5 pass;
  existing `Custom instructions`/`Custom` suite → 13/13 pass (no regression from
  the `addingInstructionLayers` signature change).

## Test plan

- `swift build` — clean.
- `swift test --filter "CurrentDate"` — 5 tests pass: injected clock/time-zone
  pins exact local date/time; same instant reads a different local date across
  LA vs Tokyo; LA midnight rollover flips the date; a restored conversation
  merges the date context into the single system row; end-to-end wire capture
  proves the block reaches the request body.
- `swift test --filter "Custom"` — 13 pass (ambient/global/conversation layer
  merge unaffected).

## Checklist

- [x] Tests pass (Swift Desktop suite — `swift test`, not pytest; this package has no tests/ dir)
- [x] Self-validated intent/behavior against issue #2330 acceptance criteria
- [x] `pr_validate` on exact head (completed for this PR)
- [x] If new tests touch a critical path: the wire-message test fails if the
      production `dateContext` injection is removed (verified against the real
      send path)
- [x] No docs change needed (feature is invisible to the user; system-prompt only)
- [x] No breaking API change