### PR TITLE
fix(mac): confirm before switching a model that is serving active requests

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -424,13 +424,13 @@ final class ServerManager {
     private func approveModelSwitchIfNeeded(
         from currentAlias: String,
         to targetAlias: String
-    ) async -> Bool {
+    ) async -> ModelSwitchDecision {
         await refreshResidency()
         guard let risk = ModelSwitchRisk.evaluate(
             currentAlias: currentAlias,
             targetAlias: targetAlias,
             residency: residency
-        ) else { return true }
+        ) else { return .notNeeded }
 
         let request = PendingModelSwitch(id: UUID(), risk: risk)
         if pendingModelSwitch == nil {
@@ -444,10 +444,12 @@ final class ServerManager {
                 try await Task.sleep(nanoseconds: 200_000_000)
             } catch {
                 abandonModelSwitchWaiter(request.id)
-                return false
+                return .cancelled
             }
         }
-        return modelSwitchDecisions.removeValue(forKey: request.id) ?? false
+        return modelSwitchDecisions.removeValue(forKey: request.id) == true
+            ? .approved
+            : .cancelled
     }
 
     /// Alias of the child that currently owns the runtime — for BOTH
@@ -1200,15 +1202,18 @@ final class ServerManager {
         // process without reaching the legacy stop/start fallback below. Ask
         // before either destructive route so picker activation and every
         // other `ensureServing` caller share one guard.
-        var modelSwitchApproved = false
+        var modelSwitchGuardEvaluated = false
+        var destructiveModelSwitchApproved = false
         if replacementGroup != nil,
            let currentAlias = launchedChildAlias,
            currentAlias != trimmed {
-            guard await approveModelSwitchIfNeeded(
+            let decision = await approveModelSwitchIfNeeded(
                 from: currentAlias,
                 to: trimmed
-            ) else { return false }
-            modelSwitchApproved = true
+            )
+            guard decision != .cancelled else { return false }
+            modelSwitchGuardEvaluated = true
+            destructiveModelSwitchApproved = decision.requiresProcessRestart
         }
 
         // Any fresh load attempt — resident, cold start, or the legacy
@@ -1236,9 +1241,15 @@ final class ServerManager {
         // surface as a hard failure instead of the process swap they actually
         // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
         let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
+        // The resident loader deliberately refuses to replace a busy model.
+        // Once the user approves the destructive action, bypass that route and
+        // use the existing process stop/start fallback so "Switch" performs
+        // the interruption it just disclosed instead of returning a busy
+        // rejection.
         if Self.residencyLoadApplies(
             residencyEligible: residencyEligible && !speculativeRequested
-                && !speculativeSettingChanged && !requiresImageLaneRestart,
+                && !speculativeSettingChanged && !requiresImageLaneRestart
+                && !destructiveModelSwitchApproved,
             readyWithChild: readyWithChild
         ) {
             // Publish before crossing the network await so SwiftUI replaces
@@ -1326,13 +1337,14 @@ final class ServerManager {
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
         if child != nil {
-            if !modelSwitchApproved,
+            if !modelSwitchGuardEvaluated,
                let currentAlias = launchedChildAlias,
                currentAlias != trimmed {
-                guard await approveModelSwitchIfNeeded(
+                let decision = await approveModelSwitchIfNeeded(
                     from: currentAlias,
                     to: trimmed
-                ) else { return false }
+                )
+                guard decision != .cancelled else { return false }
             }
             await stop(preservingLastServedAlias: true)
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -210,6 +210,11 @@ enum ServerState: Equatable {
 @MainActor
 @Observable
 final class ServerManager {
+    struct PendingModelSwitch: Identifiable, Equatable, Sendable {
+        let id: UUID
+        let risk: ModelSwitchRisk
+    }
+
     // MARK: - Public state (read by SwiftUI)
 
     /// Current lifecycle phase. Drives all UI state controls.
@@ -218,6 +223,18 @@ final class ServerManager {
     /// Models currently held by the one sidecar process, plus total process
     /// memory against its configured ceiling.
     private(set) var residency: ModelResidencySnapshot = .empty
+
+    /// Alias replacements wait here only when the latest residency snapshot
+    /// reports in-flight requests for the current model. This is presentation
+    /// state for the existing lifecycle choke point, not another lifecycle
+    /// source of truth.
+    private(set) var pendingModelSwitch: PendingModelSwitch?
+
+    @ObservationIgnored
+    private var queuedModelSwitches: [PendingModelSwitch] = []
+
+    @ObservationIgnored
+    private var modelSwitchDecisions: [UUID: Bool] = [:]
 
     @ObservationIgnored
     private var residencyClient = ServerResidencyClient()
@@ -367,6 +384,70 @@ final class ServerManager {
             bearer: activeBearer
         ) else { return }
         residency = snapshot
+    }
+
+    func confirmPendingModelSwitch(_ request: PendingModelSwitch) {
+        resolvePendingModelSwitch(request, approved: true)
+    }
+
+    func cancelPendingModelSwitch(_ request: PendingModelSwitch) {
+        resolvePendingModelSwitch(request, approved: false)
+    }
+
+    private func resolvePendingModelSwitch(
+        _ request: PendingModelSwitch,
+        approved: Bool
+    ) {
+        guard pendingModelSwitch?.id == request.id else { return }
+        modelSwitchDecisions[request.id] = approved
+        pendingModelSwitch = queuedModelSwitches.isEmpty
+            ? nil
+            : queuedModelSwitches.removeFirst()
+    }
+
+    private func abandonModelSwitchWaiter(_ requestID: UUID) {
+        modelSwitchDecisions.removeValue(forKey: requestID)
+        if pendingModelSwitch?.id == requestID {
+            pendingModelSwitch = queuedModelSwitches.isEmpty
+                ? nil
+                : queuedModelSwitches.removeFirst()
+        } else {
+            queuedModelSwitches.removeAll { $0.id == requestID }
+        }
+    }
+
+    /// Refreshing `/v1/models/residency` is a cheap local request and gives the
+    /// decision the freshest available active-request count. A failed refresh
+    /// preserves the latest successful snapshot. The server offers no atomic
+    /// check-and-switch operation, so this is an advisory guard, not a drain
+    /// policy.
+    private func approveModelSwitchIfNeeded(
+        from currentAlias: String,
+        to targetAlias: String
+    ) async -> Bool {
+        await refreshResidency()
+        guard let risk = ModelSwitchRisk.evaluate(
+            currentAlias: currentAlias,
+            targetAlias: targetAlias,
+            residency: residency
+        ) else { return true }
+
+        let request = PendingModelSwitch(id: UUID(), risk: risk)
+        if pendingModelSwitch == nil {
+            pendingModelSwitch = request
+        } else {
+            queuedModelSwitches.append(request)
+        }
+
+        while modelSwitchDecisions[request.id] == nil {
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                abandonModelSwitchWaiter(request.id)
+                return false
+            }
+        }
+        return modelSwitchDecisions.removeValue(forKey: request.id) ?? false
     }
 
     /// Alias of the child that currently owns the runtime — for BOTH
@@ -1115,6 +1196,21 @@ final class ServerManager {
             return true
         }
 
+        // A replacement-group load can switch the assistant inside the live
+        // process without reaching the legacy stop/start fallback below. Ask
+        // before either destructive route so picker activation and every
+        // other `ensureServing` caller share one guard.
+        var modelSwitchApproved = false
+        if replacementGroup != nil,
+           let currentAlias = launchedChildAlias,
+           currentAlias != trimmed {
+            guard await approveModelSwitchIfNeeded(
+                from: currentAlias,
+                to: trimmed
+            ) else { return false }
+            modelSwitchApproved = true
+        }
+
         // Any fresh load attempt — resident, cold start, or the legacy
         // stop/start fallback — supersedes a stale rejection for THIS alias so
         // the surface stops showing last round's result while this load is in
@@ -1230,6 +1326,14 @@ final class ServerManager {
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
         if child != nil {
+            if !modelSwitchApproved,
+               let currentAlias = launchedChildAlias,
+               currentAlias != trimmed {
+                guard await approveModelSwitchIfNeeded(
+                    from: currentAlias,
+                    to: trimmed
+                ) else { return false }
+            }
             await stop(preservingLastServedAlias: true)
         }
         let memoryRequestID = UUID()

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1355,6 +1355,16 @@ final class ServerManager {
                 guard decision != .cancelled else { return false }
                 validatedStopAlias = currentAlias
             }
+            if let currentAlias = launchedChildAlias,
+               !ModelSwitchDecision.requiresStop(
+                   liveAlias: currentAlias,
+                   targetAlias: trimmed
+               ) {
+                if case .starting(let alias) = state, alias == trimmed {
+                    await awaitStartupSettled(alias: trimmed)
+                }
+                return isServing(trimmed)
+            }
             await stop(preservingLastServedAlias: true)
         }
         let memoryRequestID = UUID()

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1202,7 +1202,7 @@ final class ServerManager {
         // process without reaching the legacy stop/start fallback below. Ask
         // before either destructive route so picker activation and every
         // other `ensureServing` caller share one guard.
-        var modelSwitchGuardEvaluated = false
+        var validatedStopAlias: String?
         var destructiveModelSwitchApproved = false
         if replacementGroup != nil,
            let currentAlias = launchedChildAlias,
@@ -1212,8 +1212,10 @@ final class ServerManager {
                 to: trimmed
             )
             guard decision != .cancelled else { return false }
-            modelSwitchGuardEvaluated = true
-            destructiveModelSwitchApproved = decision.requiresProcessRestart
+            validatedStopAlias = currentAlias
+            if decision.requiresProcessRestart {
+                destructiveModelSwitchApproved = true
+            }
         }
 
         // Any fresh load attempt — resident, cold start, or the legacy
@@ -1337,14 +1339,21 @@ final class ServerManager {
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
         if child != nil {
-            if !modelSwitchGuardEvaluated,
-               let currentAlias = launchedChildAlias,
-               currentAlias != trimmed {
+            // `ensureServing` can re-enter while a dialog or residency refresh
+            // is awaiting. Repeat until the alias we validated is still the
+            // live child; a stale A→C answer must never authorize stopping B.
+            while let currentAlias = launchedChildAlias,
+                  currentAlias != trimmed,
+                  ModelSwitchDecision.requiresRevalidation(
+                      validatedAlias: validatedStopAlias,
+                      liveAlias: currentAlias
+                  ) {
                 let decision = await approveModelSwitchIfNeeded(
                     from: currentAlias,
                     to: trimmed
                 )
                 guard decision != .cancelled else { return false }
+                validatedStopAlias = currentAlias
             }
             await stop(preservingLastServedAlias: true)
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -136,6 +136,37 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
     }
 }
 
+/// User-visible risk carried by an alias-replacing model activation.
+/// Missing residency data deliberately means zero active requests so an older
+/// sidecar or failed refresh cannot invent a busy state.
+struct ModelSwitchRisk: Equatable, Sendable {
+    let currentAlias: String
+    let targetAlias: String
+    let activeRequests: Int
+
+    static func evaluate(
+        currentAlias: String,
+        targetAlias: String,
+        residency: ModelResidencySnapshot?
+    ) -> ModelSwitchRisk? {
+        guard currentAlias != targetAlias else { return nil }
+        let activeRequests = residency?.models.first {
+            $0.matches(currentAlias) && $0.state != "evicting"
+        }?.activeRequests ?? 0
+        guard activeRequests > 0 else { return nil }
+        return ModelSwitchRisk(
+            currentAlias: currentAlias,
+            targetAlias: targetAlias,
+            activeRequests: activeRequests
+        )
+    }
+
+    var title: String {
+        let noun = activeRequests == 1 ? "request" : "requests"
+        return "Model \(currentAlias) is serving \(activeRequests) active \(noun). Switch anyway?"
+    }
+}
+
 enum ResidentModelLoadResult: Sendable, Equatable {
     case loaded(ResidentModelStatus)
     case unsupported

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -176,6 +176,16 @@ enum ModelSwitchDecision: Equatable, Sendable {
     case cancelled
 
     var requiresProcessRestart: Bool { self == .approved }
+
+    /// A residency decision applies only to the model it inspected.
+    /// `ensureServing` is actor-reentrant while the refresh or dialog is
+    /// awaiting, so a different live alias needs its own fresh decision.
+    static func requiresRevalidation(
+        validatedAlias: String?,
+        liveAlias: String
+    ) -> Bool {
+        validatedAlias != liveAlias
+    }
 }
 
 enum ResidentModelLoadResult: Sendable, Equatable {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -186,6 +186,12 @@ enum ModelSwitchDecision: Equatable, Sendable {
     ) -> Bool {
         validatedAlias != liveAlias
     }
+
+    /// A concurrent switch may finish while this request is waiting on its
+    /// prompt. The newly live target is success, never a child to tear down.
+    static func requiresStop(liveAlias: String, targetAlias: String) -> Bool {
+        liveAlias != targetAlias
+    }
 }
 
 enum ResidentModelLoadResult: Sendable, Equatable {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -167,6 +167,17 @@ struct ModelSwitchRisk: Equatable, Sendable {
     }
 }
 
+/// Result of the Desktop's advisory active-request guard. An explicit user
+/// approval must use the existing stop/start path because the resident loader
+/// correctly refuses to evict a model while it is serving a request.
+enum ModelSwitchDecision: Equatable, Sendable {
+    case notNeeded
+    case approved
+    case cancelled
+
+    var requiresProcessRestart: Bool { self == .approved }
+}
+
 enum ResidentModelLoadResult: Sendable, Equatable {
     case loaded(ResidentModelStatus)
     case unsupported

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -75,6 +75,7 @@ struct ContentView: View {
         // callback must not cancel a newer warning that has reached the queue
         // head in the meantime (#1463).
         let displayedMemoryWarning = server.pendingMemoryWarning
+        let displayedModelSwitch = server.pendingModelSwitch
         // Ollama-style layout: a left sidebar (New Chat / Launch / — later —
         // history) + a detail pane. No top model-control bar; the model
         // picker lives inline in the compose box (see ChatView) and the
@@ -196,6 +197,36 @@ struct ContentView: View {
             .accessibilityIdentifier("MemoryWarning.Confirm")
         } message: { warning in
             Text(warning.message)
+        }
+        .confirmationDialog(
+            displayedModelSwitch?.risk.title ?? "",
+            isPresented: Binding(
+                get: { server.pendingModelSwitch != nil },
+                set: {
+                    if !$0, let request = displayedModelSwitch {
+                        if alias == request.risk.targetAlias {
+                            alias = request.risk.currentAlias
+                        }
+                        server.cancelPendingModelSwitch(request)
+                    }
+                }
+            ),
+            titleVisibility: .visible,
+            presenting: displayedModelSwitch
+        ) { request in
+            Button("Switch", role: .destructive) {
+                server.confirmPendingModelSwitch(request)
+            }
+            .accessibilityIdentifier("ModelSwitchGuard.Confirm")
+            Button("Cancel", role: .cancel) {
+                if alias == request.risk.targetAlias {
+                    alias = request.risk.currentAlias
+                }
+                server.cancelPendingModelSwitch(request)
+            }
+            .accessibilityIdentifier("ModelSwitchGuard.Cancel")
+        } message: { request in
+            Text("Switching to \(request.risk.targetAlias) may interrupt those responses.")
         }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -24,6 +24,18 @@ import Testing
 @Suite("Accessibility identifier inventory")
 struct AccessibilityIdentifierInventoryTests {
 
+    @Test("Model switch guard names its destructive and cancel controls")
+    func modelSwitchGuardIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""ModelSwitchGuard.Confirm""#,
+                #""ModelSwitchGuard.Cancel""#,
+            ],
+            in: "Sources/Rapid/UI/ContentView.swift",
+            surface: "Active-request model switch confirmation"
+        )
+    }
+
     @Test("Settings → App names the re-onboarding confirmation controls")
     func settingsAppReonboardingIdentifiers() throws {
         try assertDeclared(

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -131,6 +131,9 @@ struct ModelResidencyTests {
             targetAlias: "qwen3.5-4b-4bit",
             residency: snapshot(activeRequests: 2)
         ) == nil)
+        #expect(ModelSwitchDecision.approved.requiresProcessRestart)
+        #expect(!ModelSwitchDecision.notNeeded.requiresProcessRestart)
+        #expect(!ModelSwitchDecision.cancelled.requiresProcessRestart)
     }
 
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -146,6 +146,14 @@ struct ModelResidencyTests {
             validatedAlias: nil,
             liveAlias: "qwen3.5-4b-4bit"
         ))
+        #expect(!ModelSwitchDecision.requiresStop(
+            liveAlias: "gemma-4-12b-4bit",
+            targetAlias: "gemma-4-12b-4bit"
+        ))
+        #expect(ModelSwitchDecision.requiresStop(
+            liveAlias: "qwen3.5-4b-4bit",
+            targetAlias: "gemma-4-12b-4bit"
+        ))
     }
 
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -78,6 +78,61 @@ struct ModelResidencyTests {
         #expect(status.displayName(preferredAlias: "qwen3.5-4b-4bit") == "qwen3.5-4b-4bit")
     }
 
+    @Test("Model switch guard prompts only for a different model with active requests")
+    func modelSwitchRiskUsesActiveRequestContract() {
+        func snapshot(activeRequests: Int) -> ModelResidencySnapshot {
+            let current = ResidentModelStatus(
+                id: "mlx-community/Qwen3.5-4B-MLX-4bit",
+                modelPath: "mlx-community/Qwen3.5-4B-MLX-4bit",
+                aliases: ["qwen3.5-4b-4bit"],
+                modality: "text",
+                state: "resident",
+                pinned: true,
+                primary: true,
+                activeRequests: activeRequests,
+                estimatedBytes: 1,
+                measuredBytes: nil,
+                idleSeconds: 0
+            )
+            return ModelResidencySnapshot(
+                memoryLimitBytes: 1,
+                memoryUsedBytes: 1,
+                memoryAvailableBytes: 0,
+                idleTTLSeconds: 1,
+                loadsTotal: 1,
+                evictionsTotal: 0,
+                models: [current]
+            )
+        }
+
+        let busy = ModelSwitchRisk.evaluate(
+            currentAlias: "qwen3.5-4b-4bit",
+            targetAlias: "gemma-4-12b-4bit",
+            residency: snapshot(activeRequests: 2)
+        )
+        #expect(busy?.activeRequests == 2)
+        #expect(
+            busy?.title
+                == "Model qwen3.5-4b-4bit is serving 2 active requests. Switch anyway?"
+        )
+
+        #expect(ModelSwitchRisk.evaluate(
+            currentAlias: "qwen3.5-4b-4bit",
+            targetAlias: "gemma-4-12b-4bit",
+            residency: snapshot(activeRequests: 0)
+        ) == nil)
+        #expect(ModelSwitchRisk.evaluate(
+            currentAlias: "qwen3.5-4b-4bit",
+            targetAlias: "gemma-4-12b-4bit",
+            residency: nil
+        ) == nil)
+        #expect(ModelSwitchRisk.evaluate(
+            currentAlias: "qwen3.5-4b-4bit",
+            targetAlias: "qwen3.5-4b-4bit",
+            residency: snapshot(activeRequests: 2)
+        ) == nil)
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -134,6 +134,18 @@ struct ModelResidencyTests {
         #expect(ModelSwitchDecision.approved.requiresProcessRestart)
         #expect(!ModelSwitchDecision.notNeeded.requiresProcessRestart)
         #expect(!ModelSwitchDecision.cancelled.requiresProcessRestart)
+        #expect(!ModelSwitchDecision.requiresRevalidation(
+            validatedAlias: "qwen3.5-4b-4bit",
+            liveAlias: "qwen3.5-4b-4bit"
+        ))
+        #expect(ModelSwitchDecision.requiresRevalidation(
+            validatedAlias: "qwen3.5-4b-4bit",
+            liveAlias: "gemma-4-12b-4bit"
+        ))
+        #expect(ModelSwitchDecision.requiresRevalidation(
+            validatedAlias: nil,
+            liveAlias: "qwen3.5-4b-4bit"
+        ))
     }
 
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")


### PR DESCRIPTION
## Why

Switching models tears down or replaces the serving model while the app already decodes `activeRequests`. In-flight API and SSE clients can be interrupted, or a successful switch can silently change the model behind a live client. This was requested by the maintainer during 0.13.0-rc2 dogfood.

## What

- Refresh the existing residency snapshot at the centralized `ensureServing` alias-change boundary.
- Pass silently for zero/missing active-request data; show a native destructive confirmation when the current model is serving one or more requests.
- Cover in-process resident replacement and the shared stop/start fallback, including picker, image, and audio activation through the same lifecycle boundary.
- Bind approval to the inspected live alias, revalidate after actor reentrancy, and preserve a concurrently completed target switch.
- Restore the picker selection when the user cancels.
- Add pure lifecycle contracts and stable accessibility identifiers.

## Non-goals

- No server/API changes.
- No request drain, wait, or abort policy.
- No new settings or model-picker redesign.

## Exact-head local evidence

Head: `b08fdb2a`

- Desktop Swift suite: 2819 passed in 242 suites.
- `ModelResidencyTests`: 10 passed.
- `AccessibilityIdentifierInventoryTests`: 19 passed.
- Release-shaped Desktop build completed locally on the parent implementation; exact-head Swift compilation and full suite are green.
- `git diff --check` clean.
- Codex review: round 4 LGTM.