### PR TITLE
fix(routing): resolve aliases before lane selection

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -886,6 +886,125 @@ class TestMllmBackboneIsHybrid:
         )
         assert mllm_backbone_is_hybrid("any/qwen3.5-like") is True
 
+    def test_user_alias_load_resolves_exact_qwen35_checkpoint_before_routing(
+        self, monkeypatch, tmp_path
+    ):
+        """Issue #2329: residency callers bypass ``cli.main`` alias resolution.
+
+        The exact cached checkpoint selected by Desktop must be the common
+        source for config materialization, automatic lane selection, and the
+        loader. The immutable snapshot remains trusted through ``refs/main``;
+        the fix must not guess among unreferenced revisions.
+        """
+        import json
+
+        import huggingface_hub
+
+        from vllm_mlx import server
+
+        alias = "qwen3.5-2b-4bit"
+        repo = "mlx-community/Qwen3.5-2B-MLX-4bit"
+        revision = "93760be4f1f69842a46bc13dbdc0f19e291392a3"
+        repo_root = tmp_path / "hub" / "models--mlx-community--Qwen3.5-2B-MLX-4bit"
+        snapshot = repo_root / "snapshots" / revision
+        snapshot.mkdir(parents=True)
+        (repo_root / "refs").mkdir()
+        (repo_root / "refs" / "main").write_text(revision)
+        (snapshot / "config.json").write_text(
+            json.dumps(
+                {
+                    "architectures": ["Qwen3_5ForConditionalGeneration"],
+                    "model_type": "qwen3_5",
+                    "vision_config": {"model_type": "qwen3_5_vision"},
+                    "text_config": {
+                        "model_type": "qwen3_5_text",
+                        "layer_types": [
+                            "linear_attention",
+                            "linear_attention",
+                            "linear_attention",
+                            "full_attention",
+                        ],
+                    },
+                }
+            )
+        )
+        (snapshot / "model.safetensors").write_bytes(b"complete")
+        (snapshot / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {
+                        "language_model.layers.0.weight": "model.safetensors",
+                        "vision_tower.blocks.0.weight": "model.safetensors",
+                    }
+                }
+            )
+        )
+        alias_file = tmp_path / "user-aliases.json"
+        alias_file.write_text(
+            json.dumps({"version": 1, "aliases": {alias: repo}}) + "\n"
+        )
+        monkeypatch.setenv("RAPID_MLX_USER_ALIASES_FILE", str(alias_file))
+        monkeypatch.setattr(
+            huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path / "hub")
+        )
+
+        class StubEngine:
+            is_mllm = False
+            preserve_native_tool_format = False
+            _tokenizer = None
+            _tool_logits_processor_factory = None
+
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(server, "BatchedEngine", StubEngine)
+        monkeypatch.setattr(server, "_engine", None, raising=False)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False, raising=False)
+        monkeypatch.setattr(server, "_tool_call_parser", None, raising=False)
+        monkeypatch.setattr(server, "_reasoning_parser_name", None, raising=False)
+        monkeypatch.setattr(server, "_reasoning_parser", None, raising=False)
+        monkeypatch.setattr(server, "_tool_parser_instance", None, raising=False)
+        monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+        monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
+        # Simulate a Desktop residency replacement after an image model. The
+        # old process-global alias must not lend its image profile to Qwen.
+        monkeypatch.setattr(server, "_model_alias", "z-image-turbo", raising=False)
+
+        server.load_model(alias)
+
+        assert server._model_path == repo
+        assert server._model_name == alias
+        assert server._model_alias == alias
+        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["force_text"] is True
+
+        # CLI startup arrives with the canonical repo plus a matching saved
+        # alias. That same-source identity remains valid and keeps its profile.
+        server.load_model(repo)
+        assert server._model_alias == alias
+        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["force_text"] is True
+
+        # A removed/corrupt prior identity is stale process state, not a reason
+        # to reject a valid current canonical request.
+        from vllm_mlx import model_aliases
+        from vllm_mlx.user_aliases import UserAliasError
+
+        real_resolve_model = model_aliases.resolve_model
+
+        def resolve_with_stale_prior(name):
+            if name == "removed-prior-alias":
+                raise UserAliasError("prior alias no longer exists")
+            return real_resolve_model(name)
+
+        monkeypatch.setattr(model_aliases, "resolve_model", resolve_with_stale_prior)
+        server._model_alias = "removed-prior-alias"
+        server.load_model(repo)
+        assert server._model_alias is None
+        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["force_text"] is True
+
     def test_sliding_and_full_attention_is_not_hybrid(self, monkeypatch):
         from vllm_mlx.api.utils import mllm_backbone_is_hybrid
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1856,6 +1856,7 @@ def load_model(
 
     global \
         _engine, \
+        _model_alias, \
         _model_name, \
         _model_path, \
         _default_max_tokens, \
@@ -1864,23 +1865,49 @@ def load_model(
         _alias_recommended_sampling, \
         _generation_config_sampling
 
+    # ``load_model`` is also the engine-owned residency entry point; callers
+    # outside the CLI (including Desktop model replacement) can pass an alias
+    # that has not gone through ``cli.main``. Resolve that alias once, before
+    # config materialization, lane selection, and the loader consume it. This
+    # keeps those three decisions on the same checkpoint source instead of
+    # probing the alias spelling as though it were a Hub repository.
+    from .model_aliases import resolve_model, resolve_profile
+
+    requested_model_name = model_name
+    model_name = resolve_model(model_name)
+
+    # A direct alias in this request is authoritative. CLI startup reaches
+    # here with an already-canonical path, so only in that case may its saved
+    # alias be reused—and only when it still resolves to this same checkpoint.
+    # A prior resident model's alias must never lend its profile or registry
+    # identity to a replacement model.
+    effective_model_alias = (
+        requested_model_name if requested_model_name != model_name else None
+    )
+    if effective_model_alias is None and _model_alias is not None:
+        try:
+            if resolve_model(_model_alias) == model_name:
+                effective_model_alias = _model_alias
+        except Exception:  # stale prior identity; current request still owns load
+            pass
+
     _default_max_tokens = max_tokens
     _default_max_tokens_is_explicit = max_tokens_is_explicit
+    _model_alias = effective_model_alias
     _model_path = model_name
-    _model_name = served_model_name or model_name
+    _model_name = served_model_name or requested_model_name
     _tool_parser_instance = None
 
     # Populate the sampling overlays now that we know which model we're
     # serving. Both are best-effort — an alias without curated sampling
     # or a model missing generation_config.json simply contributes an
     # empty layer to the cascade in service/helpers.py.
-    from .model_aliases import resolve_profile
     from .utils.generation_config import load_generation_config_sampling
 
     _alias_recommended_sampling = None
     # resolve_profile handles both alias-name and HF-path lookups, so a
     # single call suffices regardless of which form load_model was passed.
-    _profile = resolve_profile(_model_alias or model_name)
+    _profile = resolve_profile(effective_model_alias or requested_model_name)
     if _profile is not None and _profile.recommended_sampling:
         _alias_recommended_sampling = dict(_profile.recommended_sampling)
 
@@ -2004,7 +2031,7 @@ def load_model(
         check_from_profile(
             model_name=model_name,
             profile=_profile,
-            alias=_model_alias,
+            alias=effective_model_alias,
         )
     except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders
         logger.debug(f"mxfp4/moe guardrail probe failed (non-fatal): {_e}")
@@ -2213,8 +2240,8 @@ def load_model(
 
     # Register in multi-model registry
     aliases = set()
-    if _model_alias and _model_alias != _model_name:
-        aliases.add(_model_alias)
+    if effective_model_alias and effective_model_alias != _model_name:
+        aliases.add(effective_model_alias)
     entry = ModelEntry(
         engine=_engine,
         model_name=_model_name,


### PR DESCRIPTION
## Intention

A complete cached catalog checkpoint selected from **Already on this Mac** must load through automatic lane resolution without a manual `--no-mllm` override.

Fixes #2329.

## Scope

- Resolve an alias once at the engine-owned model-load boundary.
- Feed the same canonical checkpoint source to config materialization, automatic lane selection, and the loader.
- Preserve the requested alias as the served model identity.
- Add an offline regression using the exact Qwen3.5 2B checkpoint metadata and revision.

## Non-goals

- No catalog or model-default changes.
- No model-name, revision-shape, or cache-directory heuristic.
- No scheduler, cache, GUI, or public API redesign.

## Evidence

The Desktop/residency load entry can receive a private alias directly, without the alias normalization performed by `cli.main`. Before this fix, config materialization treated `qwen3.5-2b-4bit` as the checkpoint source instead of its registered `mlx-community/Qwen3.5-2B-MLX-4bit` target, so automatic MLLM-versus-text routing failed even though the exact revision was complete and trusted by `refs/main`. The manual `--no-mllm` CLI control both bypassed automatic routing and normalized the alias, explaining why the same artifact loaded there.

After the fix, a direct engine-owned load of that alias under `HF_HUB_OFFLINE=1` resolves revision `93760be4f1f69842a46bc13dbdc0f19e291392a3`, selects the supported text lane, and loads with `BatchedEngine` while preserving `qwen3.5-2b-4bit` as the served identity.

Local verification:

- Focused routing/cache/server suite: 289 passed.
- Exact real cached model load through the programmatic residency entry: passed offline, text lane selected.
- Ruff format/check: passed.
- Local package build: sdist and wheel built successfully.

Hosted exact-head gates and independent review are pending.