### PR TITLE
feat(pull): select one variant of a multi-variant repo with --bits/--format (#2145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
             tests/test_alias_subfolder.py \
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_version_sync.py \
+            tests/test_pull_variant_selection.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -27,7 +27,6 @@ import argparse
 from unittest.mock import patch
 
 import pytest
-
 from huggingface_hub import RepoFile, RepoFolder
 
 from vllm_mlx import cli
@@ -53,7 +52,9 @@ def _pull_capturing(**flags):
         return "/cache/snapshot"
 
     with (
-        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
         patch.object(cli, "_try_mirror_prefetch", return_value=False) as mirror,
         patch("huggingface_hub.snapshot_download", fake_snapshot),
     ):
@@ -82,6 +83,12 @@ def test_resolve_returns_none_without_selector():
     assert cli._resolve_variant_allow_patterns("X/Y", None, None) is None
 
 
+def test_resolve_rejects_both_selectors():
+    """--bits and --format pick the same single variant; both is ambiguous."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        cli._resolve_variant_allow_patterns("X/Y", bits="4", fmt="gguf")
+
+
 def test_no_selector_still_consults_mirror():
     """Without --bits/--format the mirror-first behavior is unchanged."""
     args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
@@ -95,14 +102,18 @@ def test_no_selector_still_consults_mirror():
 
 def test_missing_variant_errors_with_available_folders(capsys):
     """--format gguf when the repo has no gguf/ fails loudly, listing folders."""
-    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="gguf")
+    args = argparse.Namespace(
+        model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="gguf"
+    )
     with (
-        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
         patch.object(cli, "_try_mirror_prefetch", return_value=False),
         patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
     ):
-        with pytest.raises(SystemExit):
-            cli.pull_command(args)
+        cli.pull_command(args)
     out = capsys.readouterr().out
     assert "no 'gguf' variant" in out
     assert "4bit" in out  # lists an available folder

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -95,6 +95,31 @@ def test_resolve_returns_none_without_selector():
     assert cli._resolve_variant_allow_patterns("X/Y", None, None) is None
 
 
+def test_escape_glob_literal_metachars():
+    """A folder name with glob metachars must match literally, not broaden."""
+    assert cli._escape_glob_literal("4bit") == "4bit"
+    assert cli._escape_glob_literal("[48]bit") == "[[]48[]]bit"
+    assert cli._escape_glob_literal("a*b?") == "a[*]b[?]"
+
+
+def test_variant_with_glob_metachars_escaped_in_allow_patterns():
+    """--format on a folder named with glob metachars pins to that folder."""
+    tricky_tree = [
+        RepoFolder(path="[48]bit", oid="a"),
+        RepoFolder(path="8bit", oid="b"),
+        RepoFile(path="README.md", size=100, oid="c"),
+    ]
+    args = argparse.Namespace(model="X/Y", bits=None, format="[48]bit")
+    with (
+        patch("huggingface_hub.HfApi.list_repo_tree", return_value=tricky_tree),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x") as snap,
+    ):
+        cli.pull_command(args)
+    # The pattern must not glob-broaden: the literal folder with brackets.
+    assert snap.call_args.kwargs["allow_patterns"] == ["[[]48[]]bit/*"]
+
+
 def test_parser_accepts_single_selector():
     """The pull parser exposes --bits/--format and parses a single one."""
     parser = cli.build_parser()
@@ -224,6 +249,26 @@ def test_no_selector_still_consults_mirror():
     ):
         cli.pull_command(args)
     assert mirror.call_count == 1
+
+
+def test_orphan_reap_announces_cleaned_files(capsys):
+    """Pull announces when it reclaims abandoned download scratch files."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch(
+            "vllm_mlx._download_gate.reap_orphan_incomplete_blobs",
+            return_value=(2, 512),
+        ),
+        patch(
+            "vllm_mlx._download_gate._format_size",
+            return_value="512 B",
+        ),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x"),
+    ):
+        cli.pull_command(args)
+    out = capsys.readouterr().out
+    assert "Cleaned up 2 abandoned download file(s)" in out
 
 
 def test_catalog_subfolder_narrowing_when_no_selector(capsys):

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -9,16 +9,19 @@ tests pin that ``--bits N`` / ``--format F``:
 1. narrow the HuggingFace ``snapshot_download`` to exactly that variant's
    ``allow_patterns`` (``["4bit/*"]`` etc.),
 2. bypass the whole-repo R2 mirror prefetch when a variant is requested (the
-   mirror has no narrow-to-variant mode; Vector's #2279 is unlanded),
+   mirror has no narrow-to-variant mode; Vector's #2279 is unlanded) with a
+   clear "mirror skipped" line,
 3. fail loudly with the available folders listed when the variant does not
    exist — before any weight download,
 4. leave the existing mirror-first behavior untouched when no selector is
-   given.
+   given,
+5. let the user flag override catalog ``resolve_subfolder`` narrowing (said so).
 
 The HuggingFace file listing (``list_repo_tree``), the R2 prefetch
-(``_try_mirror_prefetch``) and ``snapshot_download`` are all mocked; only the
-selection logic in ``pull_command`` / ``_resolve_variant_allow_patterns`` is
-exercised — no weights are ever touched.
+(``_try_mirror_prefetch``), the catalog narrowing (``resolve_subfolder``) and
+``snapshot_download`` are all mocked; only the selection logic in
+``pull_command`` / ``_resolve_variant_allow_patterns`` is exercised — no
+weights are ever touched.
 """
 
 from __future__ import annotations
@@ -30,6 +33,15 @@ import pytest
 from huggingface_hub import RepoFile, RepoFolder
 
 from vllm_mlx import cli
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response`` when constructing HF errors."""
+
+    status_code = 404
+    headers = {}
+    request = None
+    url = ""
 
 
 def _multi_variant_tree():
@@ -70,7 +82,7 @@ def test_bits_narrows_snapshot_and_bypasses_mirror(capsys):
     assert side["mirror_calls"] == 0
     # Refinement (1): a clear line explains that the mirror was skipped.
     out = capsys.readouterr().out
-    assert "mirror was skipped" in out or "R2 mirror skipped" in out
+    assert "R2 mirror skipped" in out
 
 
 def test_format_narrows_snapshot_by_folder_name():
@@ -83,6 +95,25 @@ def test_resolve_returns_none_without_selector():
     assert cli._resolve_variant_allow_patterns("X/Y", None, None) is None
 
 
+def test_parser_accepts_single_selector():
+    """The pull parser exposes --bits/--format and parses a single one."""
+    parser = cli.build_parser()
+    ns = parser.parse_args(["pull", "--bits", "4", "LiquidAI/LFM2.5-2.6B-MLX"])
+    assert ns.bits == "4"
+    assert ns.model == "LiquidAI/LFM2.5-2.6B-MLX"
+    ns = parser.parse_args(["pull", "--format", "mxfp4", "LiquidAI/LFM2.5-2.6B-MLX"])
+    assert ns.format == "mxfp4"
+
+
+def test_parser_rejects_both_selectors():
+    """--bits and --format are mutually exclusive; argparse rejects both."""
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["pull", "--bits", "4", "--format", "gguf", "LiquidAI/LFM2.5-2.6B-MLX"]
+        )
+
+
 def test_resolve_rejects_both_selectors():
     """--bits and --format pick the same single variant; both is ambiguous."""
     with pytest.raises(ValueError, match="mutually exclusive"):
@@ -93,6 +124,21 @@ def test_resolve_rejects_empty_selector():
     """An explicit-but-empty selector is a user error, not 'no selector'."""
     with pytest.raises(ValueError, match="empty"):
         cli._resolve_variant_allow_patterns("X/Y", bits=None, fmt="")
+
+
+def test_resolve_reraise_repo_not_found():
+    """A missing repo passes the cause through (caller surfaces it)."""
+    from huggingface_hub.errors import RepositoryNotFoundError
+
+    err = RepositoryNotFoundError("no repo", response=_FakeResponse())
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree",
+            side_effect=err,
+        ),
+        pytest.raises(RepositoryNotFoundError),
+    ):
+        cli._resolve_variant_allow_patterns("nope/nope", bits="4", fmt=None)
 
 
 def test_empty_selector_errors_cleanly(capsys):
@@ -110,18 +156,7 @@ def test_empty_selector_errors_cleanly(capsys):
     assert "empty" in capsys.readouterr().out
 
 
-def test_no_selector_still_consults_mirror():
-    """Without --bits/--format the mirror-first behavior is unchanged."""
-    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
-    with (
-        patch.object(cli, "_try_mirror_prefetch", return_value=True) as mirror,
-        patch("huggingface_hub.snapshot_download"),
-    ):
-        cli.pull_command(args)
-    assert mirror.call_count == 1
-
-
-def test_missing_variant_errors_with_available_folders(capsys):
+def test_missing_variant_shows_available_folders(capsys):
     """--format gguf when the repo has no gguf/ fails loudly, listing folders."""
     args = argparse.Namespace(
         model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="gguf"
@@ -139,3 +174,102 @@ def test_missing_variant_errors_with_available_folders(capsys):
     assert "no 'gguf' variant" in out
     assert "4bit" in out  # lists an available folder
     assert "8bit" in out
+
+
+def test_missing_variant_uses_original_alias(capsys):
+    """Error message names the caller-supplied alias, not the resolved repo."""
+    args = argparse.Namespace(
+        model="LiquidAI/LFM2.5-2.6B-MLX",
+        bits=None,
+        format="gguf",
+        _original_alias="my-alias",
+    )
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        cli.pull_command(args)
+    out = capsys.readouterr().out
+    assert "my-alias" in out
+    assert "has no 'gguf' variant" in out
+
+
+def test_missing_variant_no_folders(capsys):
+    """A single-variant repo (no folders) says so instead of listing folders."""
+    args = argparse.Namespace(
+        model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="gguf"
+    )
+    flat = [RepoFile(path="model.safetensors", size=100, oid="a")]
+    with (
+        patch("huggingface_hub.HfApi.list_repo_tree", return_value=flat),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        cli.pull_command(args)
+    out = capsys.readouterr().out
+    assert "single-variant repo" in out
+
+
+def test_no_selector_still_consults_mirror():
+    """Without --bits/--format the mirror-first behavior is unchanged."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=True) as mirror,
+        patch("huggingface_hub.snapshot_download"),
+    ):
+        cli.pull_command(args)
+    assert mirror.call_count == 1
+
+
+def test_catalog_subfolder_narrowing_when_no_selector(capsys):
+    """No selector + a catalog subfolder narrows to it (existing behavior)."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("vllm_mlx.model_aliases.resolve_subfolder", return_value="4bit"),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x") as snap,
+    ):
+        cli.pull_command(args)
+    # snapshot_download called with allow_patterns=["4bit/*"].
+    assert snap.call_args.kwargs["allow_patterns"] == ["4bit/*"]
+    assert "ships one checkpoint per quantization" in capsys.readouterr().out
+
+
+def test_user_flag_overrides_catalog_subfolder(capsys):
+    """--bits/--format wins over catalog resolve_subfolder narrowing (said so)."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits="8", format=None)
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("vllm_mlx.model_aliases.resolve_subfolder", return_value="4bit"),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x") as snap,
+    ):
+        cli.pull_command(args)
+    assert snap.call_args.kwargs["allow_patterns"] == ["8bit/*"]
+    out = capsys.readouterr().out
+    assert "8bit" in out
+    assert "overrides" in out
+    assert "4bit" in out
+
+
+def test_user_flag_equal_to_catalog_subfolder_no_override(capsys):
+    """When the flag matches the catalog subfolder, no override line is shown."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits="4", format=None)
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("vllm_mlx.model_aliases.resolve_subfolder", return_value="4bit"),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x") as snap,
+    ):
+        cli.pull_command(args)
+    assert snap.call_args.kwargs["allow_patterns"] == ["4bit/*"]
+    assert "overrides" not in capsys.readouterr().out

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for #2145 ``rapid-mlx pull --bits/--format`` variant selection.
+
+A multi-variant repo ships every quantization side by side as top-level
+folders (e.g. ``LiquidAI/LFM2.5-2.6B-MLX`` holds ``4bit/ 5bit/ 6bit/ 8bit/
+mxfp4/ ...``). Without selection ``pull <repo>`` fetches ALL of them. These
+tests pin that ``--bits N`` / ``--format F``:
+
+1. narrow the HuggingFace ``snapshot_download`` to exactly that variant's
+   ``allow_patterns`` (``["4bit/*"]`` etc.),
+2. bypass the whole-repo R2 mirror prefetch when a variant is requested (the
+   mirror has no narrow-to-variant mode; Vector's #2279 is unlanded),
+3. fail loudly with the available folders listed when the variant does not
+   exist — before any weight download,
+4. leave the existing mirror-first behavior untouched when no selector is
+   given.
+
+The HuggingFace file listing (``list_repo_tree``), the R2 prefetch
+(``_try_mirror_prefetch``) and ``snapshot_download`` are all mocked; only the
+selection logic in ``pull_command`` / ``_resolve_variant_allow_patterns`` is
+exercised — no weights are ever touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from huggingface_hub import RepoFile, RepoFolder
+
+from vllm_mlx import cli
+
+
+def _multi_variant_tree():
+    return [
+        RepoFolder(path="4bit", oid="a"),
+        RepoFolder(path="8bit", oid="b"),
+        RepoFile(path="README.md", size=100, oid="c"),
+    ]
+
+
+def _pull_capturing(**flags):
+    """Drive ``pull_command`` with mocked listing+mirror, returning the
+    ``allow_patterns`` passed to ``snapshot_download`` and the mirror call
+    count via a mutable dict ``side``."""
+    side = {}
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", **flags)
+
+    def fake_snapshot(*a, **kw):
+        side["allow"] = kw.get("allow_patterns")
+        return "/cache/snapshot"
+
+    with (
+        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False) as mirror,
+        patch("huggingface_hub.snapshot_download", fake_snapshot),
+    ):
+        cli.pull_command(args)
+        side["mirror_calls"] = len(mirror.call_args_list)
+    return side
+
+
+def test_bits_narrows_snapshot_and_bypasses_mirror(capsys):
+    side = _pull_capturing(bits="4", format=None)
+    assert side["allow"] == ["4bit/*"]
+    # An explicit variant bypasses the whole-repo mirror prefetch (option B).
+    assert side["mirror_calls"] == 0
+    # Refinement (1): a clear line explains that the mirror was skipped.
+    out = capsys.readouterr().out
+    assert "mirror was skipped" in out or "R2 mirror skipped" in out
+
+
+def test_format_narrows_snapshot_by_folder_name():
+    # "8bit" is both a valid format-style folder key here.
+    side = _pull_capturing(bits=None, format="8bit")
+    assert side["allow"] == ["8bit/*"]
+
+
+def test_resolve_returns_none_without_selector():
+    assert cli._resolve_variant_allow_patterns("X/Y", None, None) is None
+
+
+def test_no_selector_still_consults_mirror():
+    """Without --bits/--format the mirror-first behavior is unchanged."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=True) as mirror,
+        patch("huggingface_hub.snapshot_download"),
+    ):
+        cli.pull_command(args)
+    assert mirror.call_count == 1
+
+
+def test_missing_variant_errors_with_available_folders(capsys):
+    """--format gguf when the repo has no gguf/ fails loudly, listing folders."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="gguf")
+    with (
+        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
+    ):
+        with pytest.raises(SystemExit):
+            cli.pull_command(args)
+    out = capsys.readouterr().out
+    assert "no 'gguf' variant" in out
+    assert "4bit" in out  # lists an available folder
+    assert "8bit" in out

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -99,7 +99,9 @@ def test_empty_selector_errors_cleanly(capsys):
     """pull --format \"\" exits with a clear message, not an unrestricted pull."""
     args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="")
     with (
-        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
         patch.object(cli, "_try_mirror_prefetch", return_value=False),
         patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
         pytest.raises(SystemExit),

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -89,6 +89,25 @@ def test_resolve_rejects_both_selectors():
         cli._resolve_variant_allow_patterns("X/Y", bits="4", fmt="gguf")
 
 
+def test_resolve_rejects_empty_selector():
+    """An explicit-but-empty selector is a user error, not 'no selector'."""
+    with pytest.raises(ValueError, match="empty"):
+        cli._resolve_variant_allow_patterns("X/Y", bits=None, fmt="")
+
+
+def test_empty_selector_errors_cleanly(capsys):
+    """pull --format \"\" exits with a clear message, not an unrestricted pull."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format="")
+    with (
+        patch("huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch.object(cli.sys, "exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        cli.pull_command(args)
+    assert "empty" in capsys.readouterr().out
+
+
 def test_no_selector_still_consults_mirror():
     """Without --bits/--format the mirror-first behavior is unchanged."""
     args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=None, format=None)

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -102,7 +102,7 @@ def test_escape_glob_literal_metachars():
     assert cli._escape_glob_literal("a*b?") == "a[*]b[?]"
 
 
-def test_variant_with_glob_metachars_escaped_in_allow_patterns():
+def test_variant_with_glob_metachars_escaped_in_allow_patterns(capsys):
     """--format on a folder named with glob metachars pins to that folder."""
     tricky_tree = [
         RepoFolder(path="[48]bit", oid="a"),
@@ -118,6 +118,10 @@ def test_variant_with_glob_metachars_escaped_in_allow_patterns():
         cli.pull_command(args)
     # The pattern must not glob-broaden: the literal folder with brackets.
     assert snap.call_args.kwargs["allow_patterns"] == ["[[]48[]]bit/*"]
+    # The user-facing message must show the real folder name, not the escaping.
+    out = capsys.readouterr().out
+    assert "[48]bit" in out
+    assert "[[]48[]]bit" not in out
 
 
 def test_parser_accepts_single_selector():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6443,6 +6443,23 @@ def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
     )
 
 
+def _escape_glob_literal(name: str) -> str:
+    """Make ``name`` match literally in a fnmatch ``allow_patterns`` string.
+
+    ``snapshot_download``'s ``allow_patterns`` are fnmatch-style globs, so a
+    folder whose name happens to contain a glob metacharacter (``[``, ``]``,
+    ``*``, ``?``) would otherwise broaden the match to other folders. Wrapping
+    each metacharacter in a one-character character class (``[[]`` matches a
+    literal ``[``) pins the pattern to exactly that folder. Real quant names
+    (``4bit``, ``mxfp4``) never hit this, but the selector claims to handle
+    arbitrary multi-variant repos, so it must not corrupt their folder names.
+    """
+    out: list[str] = []
+    for ch in name:
+        out.append(f"[{ch}]" if ch in "[]*?" else ch)
+    return "".join(out)
+
+
 def _resolve_variant_allow_patterns(
     repo_id: str, bits: str | None, fmt: str | None
 ) -> list[str] | None:
@@ -6490,7 +6507,9 @@ def _resolve_variant_allow_patterns(
     folders = sorted(e.path for e in tree if isinstance(e, RepoFolder))
     if requested not in folders:
         raise VariantNotFoundError(repo_id, requested, available=folders)
-    return [f"{requested}/*"]
+    # The folder is validated to exist literally; escape glob metacharacters so
+    # a weird folder name can't broaden the match to other siblings.
+    return [f"{_escape_glob_literal(requested)}/*"]
 
 
 class VariantNotFoundError(Exception):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6443,6 +6443,51 @@ def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
     )
 
 
+def _resolve_variant_allow_patterns(
+    repo_id: str, bits: str | None, fmt: str | None
+) -> list[str] | None:
+    """Map ``--bits``/``--format`` to ``snapshot_download`` patterns.
+
+    A multi-variant repo ships every quantization side by side as TOP-LEVEL
+    folders (``LiquidAI/LFM2.5-2.6B-MLX`` holds ``4bit/ 5bit/ 6bit/ 8bit/
+    bf16/ mxfp4/ mxfp8/ nvfp4/``). ``--bits N`` or ``--format F`` selects the
+    ``<N>bit`` / ``<F>`` folder so a constrained Mac fetches only that
+    variant instead of all of them (~20 GB in the LFM case).
+
+    Returns ``[f"{folder}/*"]`` for the requested variant, or ``None`` when no
+    selector was given (caller keeps the existing catalog-driven narrowing).
+    Raises ``VariantNotFoundError`` with the available folders when the
+    requested variant does not exist — so we fail clearly and cheaply (a file
+    listing, not a download) before touching any weights. The enumeration uses
+    the same top-level ``list_repo_tree`` read the mirror/catalog already rely
+    on; only folder names are inspected, never file bytes.
+    """
+    if not bits and not fmt:
+        return None
+    from huggingface_hub import HfApi, RepoFolder
+    from huggingface_hub.errors import RepositoryNotFoundError
+
+    requested = f"{bits}bit" if bits else (fmt or "")
+    try:
+        tree = list(HfApi().list_repo_tree(repo_id, recursive=False))
+    except RepositoryNotFoundError:
+        raise
+    folders = sorted(e.path for e in tree if isinstance(e, RepoFolder))
+    if requested not in folders:
+        raise VariantNotFoundError(repo_id, requested, available=folders)
+    return [f"{requested}/*"]
+
+
+class VariantNotFoundError(Exception):
+    """The user asked for a variant a multi-variant repo does not ship."""
+
+    def __init__(self, repo_id: str, requested: str, available: list[str]):
+        self.repo_id = repo_id
+        self.requested = requested
+        self.available = available
+        super().__init__(f"no '{requested}' variant in {repo_id}")
+
+
 def pull_command(args):
     """Download a model to the HuggingFace cache without serving."""
     import time
@@ -6453,6 +6498,28 @@ def pull_command(args):
 
     repo_id = args.model  # already alias-resolved by main()
     t0 = time.monotonic()
+
+    # #2145: resolve an explicit ``--bits``/``--format`` variant up front via a
+    # cheap file listing (no weight download). A requested variant that the
+    # repo does not ship fails here with the available folders listed, before
+    # any weights are touched.
+    _bits = getattr(args, "bits", None)
+    _fmt = getattr(args, "format", None)
+    try:
+        variant_allow = _resolve_variant_allow_patterns(repo_id, _bits, _fmt)
+    except VariantNotFoundError as e:
+        shown = getattr(args, "_original_alias", repo_id)
+        print(f"\n  Error: '{shown}' has no '{e.requested}' variant.")
+        if e.available:
+            print(
+                "  Available variant folder(s): "
+                + ", ".join(e.available)
+                + "."
+            )
+        else:
+            print("  The repo exposes no variant folders — it is a single-variant repo.")
+        print("  Pick one with --bits <N> or --format <name>, or pull the repo without a selector.")
+        sys.exit(1)
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
     # before adding more. huggingface_hub gives each attempt a uniquely-named
@@ -6475,7 +6542,18 @@ def pull_command(args):
     # R2-first / HuggingFace-fallback per file. Default mirror is
     # ``https://models.rapidmlx.com``; set ``RAPID_MLX_MODEL_MIRROR=""``
     # to force HF only. The function prints its own progress + summary.
-    if _try_mirror_prefetch(repo_id):
+    # #2145: when the user explicitly selected a variant (--bits/--format), the
+    # mirror prefetch has no narrow-to-variant mode yet (Vector's #2279 adds
+    # allow_patterns there, unlanded) — it would pull the WHOLE (or catalog
+    # subfolder) repo and defeat the selection. So a requested variant bypasses
+    # the mirror and goes straight to the narrowed HF snapshot_download below.
+    # Revisit once #2279 lands allow_patterns in the mirror path.
+    if variant_allow is not None:
+        print(
+            "  R2 mirror skipped: a --bits/--format variant was requested "
+            "(the mirror cannot narrow to one variant yet)."
+        )
+    if variant_allow is None and _try_mirror_prefetch(repo_id):
         from pathlib import Path
 
         try:
@@ -6526,13 +6604,33 @@ def pull_command(args):
         # checkpoints on disk that nothing can serve. It is announced
         # rather than silent so ``pull <repo-id>`` never quietly does
         # something narrower than it was asked.
-        _subfolder = resolve_subfolder(repo_id)
-        if _subfolder:
+        # An explicit --bits/--format selection (variant_allow) always wins over
+        # the catalog-driven subfolder narrowing; otherwise fall back to the
+        # catalog subfolder (one checkpoint per quantization).
+        if variant_allow is not None:
+            _allow = variant_allow
+            _variant_name = _allow[0][:-2]  # "4bit" from "4bit/*"
+            # The explicit --bits/--format selection wins over any catalog
+            # alias narrowing (resolve_subfolder); say so so the override is
+            # visible rather than silent.
+            _alias_subfolder = resolve_subfolder(repo_id)
+            if _alias_subfolder and _alias_subfolder != _variant_name:
+                print(
+                    f"  User --bits/--format '{_variant_name}' overrides the "
+                    f"catalog's '{_alias_subfolder}/' alias narrowing."
+                )
             print(
-                f"  This repo ships one checkpoint per quantization; "
-                f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
+                f"  Fetching only the {_variant_name}/ variant "
+                f"(selected with --bits/--format)."
             )
-        _allow = [f"{_subfolder}/*"] if _subfolder else None
+        else:
+            _subfolder = resolve_subfolder(repo_id)
+            if _subfolder:
+                print(
+                    f"  This repo ships one checkpoint per quantization; "
+                    f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
+                )
+            _allow = [f"{_subfolder}/*"] if _subfolder else None
         path = (
             snapshot_download(repo_id, allow_patterns=_allow)
             if _allow
@@ -10726,6 +10824,26 @@ Examples:
     pull_parser.add_argument(
         "model", help="Model alias (e.g. qwen3.5-4b-4bit) or HF repo (org/name)"
     ).completer = alias_completer
+    # #2145: a multi-variant repo ships every quantization side by side as
+    # top-level folders (e.g. LiquidAI/LFM2.5-2.6B-MLX holds 4bit/ 5bit/ 6bit/
+    # 8bit/ mxfp4/...). Without selection, `pull <repo>` fetches ALL of them.
+    # These flags let a constrained Mac fetch only the variant it can serve.
+    pull_parser.add_argument(
+        "--bits",
+        metavar="2|4|6|8",
+        help=(
+            "Pull only the <N>bit variant of a multi-variant repo "
+            "(e.g. --bits 4 fetches only 4bit/)."
+        ),
+    )
+    pull_parser.add_argument(
+        "--format",
+        metavar="mlx|gguf|safetensors",
+        help=(
+            "Pull only the named format variant of a multi-variant repo "
+            "(e.g. --format mxfp4 or --format gguf, when the repo ships one)."
+        ),
+    )
     rm_parser = subparsers.add_parser(
         "rm", help="Remove a cached model from the HuggingFace cache"
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6466,14 +6466,20 @@ def _resolve_variant_allow_patterns(
     folder), so the CLI exposes them as a mutually exclusive group; this helper
     rejects both being set as a defensive guard for programmatic callers.
     """
-    if not bits and not fmt:
+    if bits is None and fmt is None:
         return None
     if bits and fmt:
         raise ValueError("--bits and --format are mutually exclusive; pick one")
+    # An explicit-but-empty selector (e.g. ``--format ""``) is a user error, not
+    # "no selector" — reject it instead of silently doing an unrestricted pull.
+    if bits == "" or fmt == "":
+        raise ValueError(
+            "--bits/--format was supplied but is empty; pass a value or drop the flag"
+        )
     from huggingface_hub import HfApi, RepoFolder
     from huggingface_hub.errors import RepositoryNotFoundError
 
-    requested = f"{bits}bit" if bits else (fmt or "")
+    requested = f"{bits}bit" if bits else fmt
     try:
         tree = list(HfApi().list_repo_tree(repo_id, recursive=False))
     except RepositoryNotFoundError:
@@ -6513,6 +6519,9 @@ def pull_command(args):
     _fmt = getattr(args, "format", None)
     try:
         variant_allow = _resolve_variant_allow_patterns(repo_id, _bits, _fmt)
+    except ValueError as e:
+        print(f"\n  Error: {e}")
+        sys.exit(1)
     except VariantNotFoundError as e:
         shown = getattr(args, "_original_alias", repo_id)
         print(f"\n  Error: '{shown}' has no '{e.requested}' variant.")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6479,7 +6479,10 @@ def _resolve_variant_allow_patterns(
     from huggingface_hub import HfApi, RepoFolder
     from huggingface_hub.errors import RepositoryNotFoundError
 
-    requested = f"{bits}bit" if bits else fmt
+    # At this point exactly one of bits/fmt is a truthy non-empty value (the
+    # None/empty/both cases all returned or raised above), so ``requested`` is
+    # a real folder name string.
+    requested = f"{bits}bit" if bits else (fmt or "")
     try:
         tree = list(HfApi().list_repo_tree(repo_id, recursive=False))
     except RepositoryNotFoundError:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6646,7 +6646,11 @@ def pull_command(args):
         # catalog subfolder (one checkpoint per quantization).
         if variant_allow is not None:
             _allow = variant_allow
-            _variant_name = _allow[0][:-2]  # "4bit" from "4bit/*"
+            # Literal folder name the user asked for (e.g. "4bit"). Derived
+            # from the raw selectors, NOT from the (glob-escaped) pattern, so
+            # user-facing messages and catalog comparison show the real name
+            # even when it contains glob metacharacters.
+            _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
             # The explicit --bits/--format selection wins over any catalog
             # alias narrowing (resolve_subfolder); say so so the override is
             # visible rather than silent.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6461,9 +6461,15 @@ def _resolve_variant_allow_patterns(
     listing, not a download) before touching any weights. The enumeration uses
     the same top-level ``list_repo_tree`` read the mirror/catalog already rely
     on; only folder names are inspected, never file bytes.
+
+    ``--bits`` and ``--format`` select the SAME dimension (a single variant
+    folder), so the CLI exposes them as a mutually exclusive group; this helper
+    rejects both being set as a defensive guard for programmatic callers.
     """
     if not bits and not fmt:
         return None
+    if bits and fmt:
+        raise ValueError("--bits and --format are mutually exclusive; pick one")
     from huggingface_hub import HfApi, RepoFolder
     from huggingface_hub.errors import RepositoryNotFoundError
 
@@ -6511,14 +6517,14 @@ def pull_command(args):
         shown = getattr(args, "_original_alias", repo_id)
         print(f"\n  Error: '{shown}' has no '{e.requested}' variant.")
         if e.available:
-            print(
-                "  Available variant folder(s): "
-                + ", ".join(e.available)
-                + "."
-            )
+            print("  Available variant folder(s): " + ", ".join(e.available) + ".")
         else:
-            print("  The repo exposes no variant folders — it is a single-variant repo.")
-        print("  Pick one with --bits <N> or --format <name>, or pull the repo without a selector.")
+            print(
+                "  The repo exposes no variant folders — it is a single-variant repo."
+            )
+        print(
+            "  Pick one with --bits <N> or --format <name>, or pull the repo without a selector."
+        )
         sys.exit(1)
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
@@ -10828,17 +10834,21 @@ Examples:
     # top-level folders (e.g. LiquidAI/LFM2.5-2.6B-MLX holds 4bit/ 5bit/ 6bit/
     # 8bit/ mxfp4/...). Without selection, `pull <repo>` fetches ALL of them.
     # These flags let a constrained Mac fetch only the variant it can serve.
-    pull_parser.add_argument(
+    # They select the SAME dimension (one variant folder), so --bits and
+    # --format are mutually exclusive — passing both would be ambiguous about
+    # which single variant the caller wants.
+    _variant_group = pull_parser.add_mutually_exclusive_group()
+    _variant_group.add_argument(
         "--bits",
-        metavar="2|4|6|8",
+        metavar="N",
         help=(
             "Pull only the <N>bit variant of a multi-variant repo "
-            "(e.g. --bits 4 fetches only 4bit/)."
+            "(e.g. --bits 4 fetches only 4bit/; any N the repo ships works)."
         ),
     )
-    pull_parser.add_argument(
+    _variant_group.add_argument(
         "--format",
-        metavar="mlx|gguf|safetensors",
+        metavar="name",
         help=(
             "Pull only the named format variant of a multi-variant repo "
             "(e.g. --format mxfp4 or --format gguf, when the repo ships one)."


### PR DESCRIPTION
## What

`rapid-mlx pull <repo>` on a multi-variant HuggingFace repo fetches **all** quantizations side by side (e.g. `LiquidAI/LFM2.5-2.6B-MLX` ships `4bit/ 5bit/ 6bit/ 8bit/ bf16/ mxfp4/ mxfp8/ nvfp4/` — ~20 GB). This adds variant selection so a constrained Mac pulls only the variant it can serve:

- `--bits N` → fetches `<N>bit/`
- `--format name` → fetches the named variant folder

`--bits` and `--format` are a mutually explicit argparse group (they select the same single variant).

## Why

For multi-variant repos, unconditional full-repo pull wastes bandwidth, disk, and time. Selecting exactly the served variant keeps `pull` usable on constrained hardware.

Per Atlas's OPT-B-2145 directive:
1. When a variant is requested, the R2 mirror prefetch is **bypassed** (it has no narrow-to-variant mode until #2279 lands), with a clear one-line "R2 mirror skipped" notice.
2. A requested variant the repo does **not** ship fails loudly before any weight download, listing available variant folders.
3. The user flag **wins** over catalog `resolve_subfolder` narrowing, and the message says so.

## Implementation

- `_resolve_variant_allow_patterns(repo_id, bits, fmt)` — resolves the variant via a cheap `list_repo_tree` file listing (folder names only, no weights) → `["<variant>/*"]`.
- `VariantNotFoundError` — raised for a missing variant; `pull_command` lists available folders and exits 1.
- `pull_command` — wires `allow_patterns` into `snapshot_download`; mirror-bypass + override messages per OPT-B.

## Codex review findings (documented-defer per Atlas READY-2338)

- **[deferred → follow-up #2340]** serve-side variant persistence: after `pull --bits 4 <repo>`, a later `serve <repo>` resolves the repo root (no catalog alias), not `4bit/`, so it can't pick the pulled variant. This is outside the pull-only #2145 contract (serve-side selection = separate design; GGUF runtime/serving selectors are non-goals). Evidence filed in #2340.
- **[non-blocking, resolved by evidence]** `allow_patterns=["<variant>/*"]` and root metadata: I listed `LiquidAI/LFM2.5-2.6B-MLX` — each quant folder is **self-contained** (`4bit/` holds its own `config.json`, `tokenizer.json`, `tokenizer_config.json`, `generation_config.json`, `chat_template.jinja`, weights); the repo ROOT holds only `LICENSE`, `README.md`, `.gitattributes`. So a variant-only pull is complete and servable. This matches the existing production `subfolder_allow_patterns` (`[f"{subfolder}/*"]`) behavior.

## Verification

- New `tests/test_pull_variant_selection.py` (19 tests) — **100% diff-cover** on the changed lines. Includes an adversarial case where the variant name contains glob metacharacters (bracketed quants like `[48]bit`) — now escaped to match literally.
- Existing pull/mirror suites green: 171 passed, 1 skipped total.
- mypy shrink-only budget: no growth in `vllm_mlx/cli.py` (fixed the 27→28 regressions).
- `pull --help` renders both flags; passing both is rejected by argparse.

## Follow-up

Per Atlas: threading the variant into the mirror path for whole-repo R2 pulls is deferred (references #2279). Serve-side variant selection after `pull --bits` is tracked in #2340 (references #2145 + #2338).

**Merge gate:** held for release-cut sequencing (tracked on #2145); no explicit reviewer action is requested here.