### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -218,11 +218,9 @@ jobs:
   build:
     needs: changes
     if: needs.changes.outputs.desktop == 'true'
-    # macos-15 image; its default Xcode (16.4 / Swift 6.1) deterministically
-    # hangs one @MainActor UserDefaults test in this suite (#2366) that never
-    # hangs on Xcode 26.x, which is what the app is developed and released
-    # with. The step below pins the newest Xcode 26 the image ships.
-    # macos-latest still resolves to an older image on GitHub-hosted runners.
+    # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
+    # swift-tools-version and the release workflow's runner. macos-latest still
+    # resolves to macos-14 (Swift 5.x) on GitHub-hosted runners.
     runs-on: macos-15
     # A hung test would otherwise sit on the 6-hour default. The whole
     # job is ~2 min warm; 20 leaves room for a cold package resolve and
@@ -235,24 +233,6 @@ jobs:
         working-directory: apps/rapid-mac
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      # Pin the SwiftPM build/test toolchain to Xcode 26.3 (Swift 6.3). The
-      # image default (Xcode 16.4 / Swift 6.1) hangs `swift test` until the job
-      # timeout — see the runs-on comment above and #2366. Fail loudly if the
-      # image stops shipping this Xcode rather than silently falling back to
-      # the hanging default.
-      - name: select Xcode 26.3
-        run: |
-          set -euo pipefail
-          XCODE=/Applications/Xcode_26.3.app
-          if [ ! -d "$XCODE" ]; then
-            echo "::error::$XCODE not present on this runner image"
-            ls -d /Applications/Xcode*.app || true
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE"
-          xcodebuild -version
-          swift --version
 
       - name: swift build
         run: swift build

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -218,9 +218,11 @@ jobs:
   build:
     needs: changes
     if: needs.changes.outputs.desktop == 'true'
-    # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
-    # swift-tools-version and the release workflow's runner. macos-latest still
-    # resolves to macos-14 (Swift 5.x) on GitHub-hosted runners.
+    # macos-15 image; its default Xcode (16.4 / Swift 6.1) deterministically
+    # hangs one @MainActor UserDefaults test in this suite (#2366) that never
+    # hangs on Xcode 26.x, which is what the app is developed and released
+    # with. The step below pins the newest Xcode 26 the image ships.
+    # macos-latest still resolves to an older image on GitHub-hosted runners.
     runs-on: macos-15
     # A hung test would otherwise sit on the 6-hour default. The whole
     # job is ~2 min warm; 20 leaves room for a cold package resolve and
@@ -233,6 +235,24 @@ jobs:
         working-directory: apps/rapid-mac
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # Pin the SwiftPM build/test toolchain to Xcode 26.3 (Swift 6.3). The
+      # image default (Xcode 16.4 / Swift 6.1) hangs `swift test` until the job
+      # timeout — see the runs-on comment above and #2366. Fail loudly if the
+      # image stops shipping this Xcode rather than silently falling back to
+      # the hanging default.
+      - name: select Xcode 26.3
+        run: |
+          set -euo pipefail
+          XCODE=/Applications/Xcode_26.3.app
+          if [ ! -d "$XCODE" ]; then
+            echo "::error::$XCODE not present on this runner image"
+            ls -d /Applications/Xcode*.app || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+          swift --version
 
       - name: swift build
         run: swift build

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0-rc2</string>
+	<string>0.13.0</string>
 	<key>CFBundleVersion</key>
-	<string>164</string>
+	<string>165</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -114,7 +114,36 @@ final class DictationController {
     private let server: ServerManager
     private let client: AudioClient
     private let hotkey = DictationHotkey()
-    private let recorder = DictationRecorder()
+    /// Constructing `DictationRecorder` initializes AVAudioEngine/CoreAudio.
+    /// Keep that work behind the first real capture so state-only controllers
+    /// (including launch restore and tests) never claim audio resources.
+    private final class CaptureLifecycle: @unchecked Sendable {
+        var recorder: DictationRecorder?
+        var ticker: Timer?
+
+        deinit {
+            ticker?.invalidate()
+            recorder?.shutdown()
+        }
+    }
+
+    private let captureLifecycle = CaptureLifecycle()
+    private var recorderStorage: DictationRecorder? {
+        get { captureLifecycle.recorder }
+        set { captureLifecycle.recorder = newValue }
+    }
+    private var recorder: DictationRecorder {
+        if let recorderStorage { return recorderStorage }
+        let recorder = DictationRecorder()
+        recorder.onLevel = { [weak self] value in
+            Task { @MainActor in self?.level = value }
+        }
+        recorder.onFirstSample = { [weak self] in
+            Task { @MainActor in self?.markRecordingStarted() }
+        }
+        recorderStorage = recorder
+        return recorder
+    }
     private let hud = DictationHUD()
     /// `nil` means the catalog probe itself failed; an array is authoritative.
     /// Keeping those states distinct prevents a transient CLI failure from
@@ -128,7 +157,10 @@ final class DictationController {
     private let testingRecorderCancel: (@MainActor () -> Void)?
     private let testingTranscribeCancel: (@MainActor () -> Void)?
 
-    private var tickTimer: Timer?
+    private var tickTimer: Timer? {
+        get { captureLifecycle.ticker }
+        set { captureLifecycle.ticker = newValue }
+    }
     private var recordingStart: Date?
     private var capturingApp: String?
     private var level: Float = 0
@@ -218,12 +250,6 @@ final class DictationController {
         hotkey.trigger = trigger
         hotkey.onTap = { [weak self] in self?.handleHotkey() }
 
-        recorder.onLevel = { [weak self] value in
-            Task { @MainActor in self?.level = value }
-        }
-        recorder.onFirstSample = { [weak self] in
-            Task { @MainActor in self?.markRecordingStarted() }
-        }
     }
 
     // MARK: - Readiness
@@ -405,7 +431,7 @@ final class DictationController {
         enableRequestID = nil
         modelPreparationDeferred = false
         stopTicking()
-        recorder.shutdown()
+        recorderStorage?.shutdown()
         hud.hide()
         phase = .off
     }
@@ -422,7 +448,7 @@ final class DictationController {
             if let testingRecorderCancel {
                 testingRecorderCancel()
             } else {
-                recorder.cancelCapture()
+                recorderStorage?.cancelCapture()
             }
         } else if phase == .transcribing {
             testingTranscribeCancel?()
@@ -779,7 +805,7 @@ final class DictationController {
 
     private func finishRecording() {
         stopTicking()
-        let audio = recorder.stopCapture()
+        let audio = recorderStorage?.stopCapture()
         let duration = recordingStart.map { Date().timeIntervalSince($0) } ?? 0
         recordingStart = nil
 
@@ -957,6 +983,12 @@ final class DictationController {
         tickTimer?.invalidate()
         tickTimer = nil
     }
+
+    /// Lifecycle assertions for state-only tests. These intentionally expose
+    /// no way to drive capture; they only prove tests leave no run-loop or
+    /// CoreAudio work behind for the next MainActor test.
+    internal var testingHasActiveTicker: Bool { tickTimer?.isValid == true }
+    internal var testingHasRecorder: Bool { recorderStorage != nil }
 
     // MARK: - Text
 

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -147,6 +147,11 @@ final class DictationController {
     /// Invalidates stale `enable()` continuations when the model changes, the
     /// feature is disabled, or another enable attempt supersedes them.
     private var enableRequestID: UUID?
+    /// Launch restore arms the global shortcut before the primary model has
+    /// finished its potentially long health-check window, but must not let an
+    /// audio-only fallback race that primary launch. Cleared as soon as the
+    /// chat restore settles and normal voice-lane preparation begins.
+    private var modelPreparationDeferred = false
     /// alias → catalog facts. ``ensureServing`` needs the repo; readiness
     /// needs ``cached``. One `audioEntries` fetch fills both. The repo is
     /// only ever passed to the server for models already on disk — passing
@@ -174,6 +179,7 @@ final class DictationController {
         testingRecorderStart: (@MainActor () throws -> Void)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
         testingTranscribeCancel: (@MainActor () -> Void)? = nil,
+        testingInitialModelPreparationDeferred: Bool? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
             await ModelCatalog.audioEntriesIfAvailable(binary: $0)
         }
@@ -192,7 +198,13 @@ final class DictationController {
         self.testingTranscribeCancel = testingTranscribeCancel
 
         let defaults = UserDefaults.standard
-        self.isEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
+        let restoredIsEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
+        self.isEnabled = restoredIsEnabled
+        // Persisted enabled intent is a launch-time fact. Establish the same
+        // barrier synchronously with the controller so a mounted Audio view's
+        // revalidation cannot outrun ContentView's async session restore.
+        self.modelPreparationDeferred = testingInitialModelPreparationDeferred
+            ?? (testingEnabled == nil && restoredIsEnabled)
         self.trigger = DictationHotkey.Trigger(
             rawValue: defaults.string(forKey: Keys.trigger) ?? ""
         ) ?? .rightCommand
@@ -260,13 +272,36 @@ final class DictationController {
     /// that normally follows flipping the switch: the event tap was never
     /// installed, the banner still read "Ready", and the hotkey did nothing
     /// until the user toggled it off and on again.
-    func bootstrap() async {
+    func bootstrap(deferModelPreparation: Bool = false) async {
         guard isEnabled, phase == .off else { return }
+        await enable(deferModelPreparation: deferModelPreparation)
+    }
+
+    /// Finish the audio half of launch restore after the chat launch has
+    /// settled. The shortcut was already armed by ``bootstrap`` so a slow
+    /// primary launch never leaves the user's persisted global shortcut
+    /// silently unregistered.
+    func finishDeferredBootstrap() async {
+        guard isEnabled, modelPreparationDeferred else { return }
+        modelPreparationDeferred = false
+        // Cancellation still owns cleanup: leave the already-registered
+        // shortcut able to prepare on its next use, but do not start an audio
+        // model from a superseded launch task.
+        guard !Task.isCancelled else { return }
         await enable()
     }
 
-    func enable(replacingCurrentPrewarm: Bool = false) async {
+    func enable(
+        replacingCurrentPrewarm: Bool = false,
+        deferModelPreparation: Bool = false
+    ) async {
         guard isEnabled else { return }
+        // Establish the launch barrier before the first suspension. Catalog
+        // refresh is re-entrant: a model change or download completion can
+        // start another enable while this call awaits the subprocess.
+        if deferModelPreparation {
+            modelPreparationDeferred = true
+        }
         let requestID = UUID()
         enableRequestID = requestID
         // The on-disk bit comes from a catalog subprocess; fetch it before
@@ -294,6 +329,18 @@ final class DictationController {
             if disableIntent { isEnabled = false }
             return
         }
+        // Once launch restore establishes this barrier, every re-entrant
+        // enable path (model selection, download completion, activation) must
+        // inherit it. Only `finishDeferredBootstrap` clears it after chat has
+        // settled; otherwise a model change can start an audio-only fallback
+        // and tear down the still-starting primary child.
+        if deferModelPreparation || modelPreparationDeferred {
+            modelPreparationDeferred = true
+            guard registerHotkey() else { return }
+            enableRequestID = nil
+            return
+        }
+        modelPreparationDeferred = false
         hotkey.stop()
         phase = .preparingModel
         let preparingAlias = modelAlias
@@ -315,6 +362,12 @@ final class DictationController {
             }
             return
         }
+        guard registerHotkey() else { return }
+        enableRequestID = nil
+    }
+
+    @discardableResult
+    private func registerHotkey() -> Bool {
         guard testingHotkeyStart?() ?? hotkey.start() else {
             // macOS does not apply an Accessibility grant to an already-running
             // process, so this is the common shape right after the user flips
@@ -325,12 +378,12 @@ final class DictationController {
                 ? "Accessibility is granted, but this running copy hasn't picked it up. Relaunch Rapid to finish."
                 : "The dictation hotkey couldn't be registered."
             phase = .off
-            return
+            return false
         }
         accessibilityNeedsRelaunch = false
         lastError = nil
         phase = .idle
-        enableRequestID = nil
+        return true
     }
 
     func disable() {
@@ -350,6 +403,7 @@ final class DictationController {
         prewarmTask = nil
         prewarmRequestID = nil
         enableRequestID = nil
+        modelPreparationDeferred = false
         stopTicking()
         recorder.shutdown()
         hud.hide()
@@ -651,6 +705,10 @@ final class DictationController {
             return
         }
         let requestedAlias = modelAlias
+        guard !modelPreparationDeferred else {
+            lastError = "Dictation will be ready after your chat model finishes starting."
+            return
+        }
         guard server.isVoiceLaneReady(for: requestedAlias) else {
             hotkey.stop()
             phase = .preparingModel

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -361,11 +361,6 @@ struct RapidApp: App {
                 .environment(mcpTools)
                 .environment(perfConfig)
                 .task {
-                    // Dictation is a background service: arm it at launch so
-                    // the hotkey works without ever opening the Audio tab.
-                    await dictation.bootstrap()
-                }
-                .task {
                     // DEV-ONLY: render real screens to PNG when
                     // RAPID_DEV_SNAPSHOT_DIR is set, then quit. Inert
                     // (returns immediately) in normal use.

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -32,6 +32,15 @@ import Foundation
 actor ModelCatalogCache {
     static let shared = ModelCatalogCache()
 
+    typealias Loader = @Sendable (URL, URL?) async -> [ModelEntry]
+    private let loader: Loader
+
+    init(loader: @escaping Loader = { binary, override in
+        await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+    }) {
+        self.loader = loader
+    }
+
     /// Backstop for out-of-band changes (see above).
     ///
     /// Five minutes, not seconds: ``cacheGeneration`` already catches every
@@ -212,8 +221,9 @@ actor ModelCatalogCache {
         binary: URL, override: URL?, binaryPath: String,
         generation: UInt, overridePath: String?
     ) -> InFlight {
+        let loader = self.loader
         let task = Task<[ModelEntry], Never> {
-            await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+            await loader(binary, override)
         }
         nextInFlightID &+= 1
         let entry = InFlight(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -685,7 +685,7 @@ final class ServerManager {
     /// Persistence destination for lane-owned launch state. Production uses
     /// standard defaults; lifecycle tests inject an isolated suite while still
     /// driving the real spawn/health transition.
-    private let sessionDefaults: UserDefaults
+    private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
     /// original Start action when a later catalog subprocess fails.
@@ -962,13 +962,15 @@ final class ServerManager {
     /// child or relying on whatever ``rapid-mlx`` happens to be on
     /// disk. Not part of any production code path; the underscore
     /// prefix mirrors the Swift Standard Library convention for
-    /// "API kept around for testing only."
+    /// "API kept around for testing only." Session persistence is opt-in:
+    /// parallel fake-sidecar tests must not race through ``.standard`` or
+    /// mutate the app's real last-chat selection.
     internal init(
         testingState: ServerState,
         binaryPath: URL? = nil,
         residency: ModelResidencySnapshot = .empty,
         activeBearer: String? = nil,
-        sessionDefaults: UserDefaults = .standard
+        sessionDefaults: UserDefaults? = nil
     ) {
         self.state = testingState
         self.activeBearer = activeBearer
@@ -1012,6 +1014,7 @@ final class ServerManager {
         alias: String,
         catalogEntry: ModelEntry?
     ) {
+        guard let sessionDefaults else { return }
         SessionModelRestore.persistReadyAlias(
             alias,
             catalogEntry: catalogEntry,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -682,6 +682,14 @@ final class ServerManager {
 
     /// Interval between `/healthz` probes once the child is up.
     private let healthPollInterval: TimeInterval = 0.5
+    /// Persistence destination for lane-owned launch state. Production uses
+    /// standard defaults; lifecycle tests inject an isolated suite while still
+    /// driving the real spawn/health transition.
+    private let sessionDefaults: UserDefaults
+    /// Catalog provenance supplied by UI start paths. Retained by alias so a
+    /// memory-confirmation re-entry does not lose the proof carried by the
+    /// original Start action when a later catalog subprocess fails.
+    private var catalogProvenStartEntries: [String: ModelEntry] = [:]
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -937,6 +945,7 @@ final class ServerManager {
         self.binaryResolution = resolution
         self.binaryPath = resolution?.binary
         self.state = (resolution == nil) ? .missing : .idle
+        self.sessionDefaults = .standard
     }
 
     /// Wire the app's ``DownloadManager`` so ``start(alias:)`` can
@@ -958,12 +967,14 @@ final class ServerManager {
         testingState: ServerState,
         binaryPath: URL? = nil,
         residency: ModelResidencySnapshot = .empty,
-        activeBearer: String? = nil
+        activeBearer: String? = nil,
+        sessionDefaults: UserDefaults = .standard
     ) {
         self.state = testingState
         self.activeBearer = activeBearer
         self.binaryPath = binaryPath
         self.residency = residency
+        self.sessionDefaults = sessionDefaults
         self.binaryResolution = binaryPath.map {
             ServerLocator.Resolution(binary: $0, source: .unknown, version: nil)
         }
@@ -991,6 +1002,36 @@ final class ServerManager {
     /// stop landing mid-loop to pin the state-drift guard.
     internal func _testSetState(_ newState: ServerState) {
         self.state = newState
+    }
+
+    /// Publish the selection consequence of a successful health transition.
+    /// Kept as one lifecycle boundary so tests exercise the same call that the
+    /// real `/healthz` success path uses instead of calling persistence policy
+    /// in isolation.
+    internal func recordReadySelection(
+        alias: String,
+        catalogEntry: ModelEntry?
+    ) {
+        SessionModelRestore.persistReadyAlias(
+            alias,
+            catalogEntry: catalogEntry,
+            defaults: sessionDefaults
+        )
+    }
+
+    /// Prefer the start-time probe, but preserve catalog provenance already
+    /// held by the initiating UI when that probe transiently fails. The hint
+    /// is accepted only for the exact alias being launched.
+    internal static func readyCatalogEntry(
+        alias: String,
+        probed: ModelEntry?,
+        hint: ModelEntry?
+    ) -> ModelEntry? {
+        if let probed { return probed }
+        guard let hint,
+              hint.alias.caseInsensitiveCompare(alias) == .orderedSame
+        else { return nil }
+        return hint
     }
 
     /// Issue #1838 test seam — swap in a ``ServerResidencyClient`` whose
@@ -1084,13 +1125,15 @@ final class ServerManager {
 
     // MARK: - Persisted "last served" alias (v0.5.3 auto-restart)
 
-    /// UserDefaults key holding the alias of the model the user most
-    /// recently asked us to serve. Written on every transition into
-    /// ``.ready(alias:)`` and cleared on user-initiated ``stop()``.
+    /// UserDefaults key holding the alias of the chat model the user most
+    /// recently asked us to serve. Written only when authoritative catalog
+    /// metadata identifies the ready child as chat-capable; audio/image lane
+    /// process ownership must never replace the user's chat selection.
+    /// Cleared on user-initiated ``stop()``.
     /// ``RapidApp`` reads this on launch to decide whether to
     /// auto-resume the previous session's model (LM Studio shape:
     /// the loaded model survives an app restart).
-    nonisolated fileprivate static let lastServedAliasKey = "rapid.serve.lastAlias"
+    nonisolated fileprivate static let lastServedAliasKey = SessionModelRestore.chatAliasStorageKey
 
     /// Currently persisted last-served alias, if any. ``nil`` after a
     /// user-initiated Stop or a fresh install. Exposed as a static
@@ -1163,12 +1206,14 @@ final class ServerManager {
         estimatedMemoryGB: Double?,
         replacementGroup: ResidentModelReplacementGroup? = nil,
         imageMode: ResidentImageMode? = nil,
-        residencyEligible: Bool = true
+        residencyEligible: Bool = true,
+        catalogEntryHint: ModelEntry? = nil
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         let requestedPerformanceFlags = perfLaunchFlagsProvider?(trimmed) ?? []
         var requestedCatalogSupportsImageInput = false
+        var probedCatalogEntry: ModelEntry?
         // Cold start delegates to `start`, which resolves the same metadata
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
@@ -1180,12 +1225,18 @@ final class ServerManager {
                 $0.alias.caseInsensitiveCompare(trimmed) == .orderedSame
             }
             if Task.isCancelled || didSignalShutdown { return false }
+            probedCatalogEntry = entry
             requestedCatalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
                 forAlias: trimmed,
                 isBuiltinProfile: entry?.isBuiltinProfile,
                 isTextOnly: entry?.isTextOnly
             )
         }
+        let provenCatalogEntry = Self.readyCatalogEntry(
+            alias: trimmed,
+            probed: probedCatalogEntry,
+            hint: catalogEntryHint
+        )
         let requiresImageLaneRestart = Self.requiresProcessRestartForImageCapability(
             catalogSupportsImageInput: requestedCatalogSupportsImageInput,
             userOverrides: requestedPerformanceFlags,
@@ -1306,6 +1357,12 @@ final class ServerManager {
                 if replacementGroup != nil {
                     state = .ready(alias: trimmed)
                 }
+                if replacementGroup == .assistant {
+                    recordReadySelection(
+                        alias: trimmed,
+                        catalogEntry: provenCatalogEntry
+                    )
+                }
                 // A successful in-process load confirms the model is fine, so
                 // drop any (possibly concurrent) rejection recorded for it —
                 // but only if THIS attempt is still the newest for the alias.
@@ -1379,7 +1436,12 @@ final class ServerManager {
             await stop(preservingLastServedAlias: true)
         }
         let memoryRequestID = UUID()
-        await start(alias: trimmed, hfPath: hfPath, memoryRequestID: memoryRequestID)
+        await start(
+            alias: trimmed,
+            hfPath: hfPath,
+            memoryRequestID: memoryRequestID,
+            catalogEntryHint: provenCatalogEntry
+        )
         // ``start`` also returns without spawning when the pre-load
         // memory guard parks the load on a confirmation prompt. Reading
         // ``isServing`` now would report "couldn't start the model"
@@ -1713,7 +1775,8 @@ final class ServerManager {
         isAutoRespawn: Bool = false,
         bypassMemoryGuard: Bool = false,
         memoryRequestID: UUID? = nil,
-        isLaunchAutoStart: Bool = false
+        isLaunchAutoStart: Bool = false,
+        catalogEntryHint: ModelEntry? = nil
     ) async {
         // Issue #278: a manual restart is the user taking over the
         // lifecycle — reset the budget at entry so a previously
@@ -1748,6 +1811,13 @@ final class ServerManager {
                 message: "That model name isn't valid. Pick a model from the bar at the top."
             )
             return
+        }
+        if let hintedEntry = Self.readyCatalogEntry(
+            alias: trimmedAlias,
+            probed: nil,
+            hint: catalogEntryHint
+        ) {
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = hintedEntry
         }
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
@@ -1882,12 +1952,18 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let catalogEntry = await ModelCatalogCache.shared.entries(
+        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let catalogEntry = Self.readyCatalogEntry(
+            alias: trimmedAlias,
+            probed: probedCatalogEntry,
+            hint: catalogEntryHint
+                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
+        )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let catalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
@@ -2344,7 +2420,7 @@ final class ServerManager {
                 // overwrite the previous good-known value, so a
                 // crashed launch attempt doesn't strand the resume
                 // logic on a model the user can't actually load.
-                UserDefaults.standard.set(trimmedAlias, forKey: Self.lastServedAliasKey)
+                recordReadySelection(alias: trimmedAlias, catalogEntry: catalogEntry)
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that
                 // the child is ready, start the runtime health

--- a/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Lane-owned model selections restored when the Desktop launches.
+///
+/// The process-owning alias is not a user selection: an audio-only fallback
+/// may own the sidecar even though the user's chat choice is unchanged. Keep
+/// those facts separate so auxiliary lanes can never become the chat model.
+struct SessionModelRestore: Equatable, Sendable {
+    struct LaunchPlan: Equatable, Sendable {
+        let models: SessionModelRestore
+        let chatAliasResolved: Bool
+        let shouldAutoStart: Bool
+    }
+
+    /// Kept at the rc2 key for a migration without data loss; its semantic
+    /// owner is now explicitly the chat lane.
+    static let chatAliasStorageKey = "rapid.serve.lastAlias"
+
+    let chatAlias: String?
+    let dictationAlias: String?
+    let speechAlias: String?
+
+    /// A ready process may update chat intent only when the catalog proves it
+    /// belongs to the chat lane. Unknown direct aliases fail closed: process
+    /// ownership alone is never enough evidence to rewrite user selection.
+    static func shouldPersistChatAlias(catalogEntry: ModelEntry?) -> Bool {
+        catalogEntry?.kind == .chat
+    }
+
+    /// Record a successful ready transition without confusing the process
+    /// owner with the user's chat selection. `ServerManager.start` funnels
+    /// every ready child through here, including the audio-only fallback from
+    /// `ensureVoiceLane`.
+    static func persistReadyAlias(
+        _ alias: String,
+        catalogEntry: ModelEntry?,
+        defaults: UserDefaults = .standard
+    ) {
+        guard shouldPersistChatAlias(catalogEntry: catalogEntry) else { return }
+        defaults.set(alias, forKey: chatAliasStorageKey)
+    }
+
+    /// Resolve persisted aliases only through authoritative catalog lanes.
+    /// `legacyLastAlias` is the rc2-era `rapid.serve.lastAlias` value; accepting
+    /// it only as a chat-catalog member makes the migration safe without model
+    /// names, repository ids, or hashes.
+    static func resolve(
+        legacyLastAlias: String?,
+        dictationAlias: String?,
+        speechAlias: String?,
+        catalog: [ModelEntry]
+    ) -> SessionModelRestore {
+        let chatAliases = catalog.filter { $0.kind == .chat }.map(\.alias)
+        let audioAliases = catalog.filter { $0.kind == .audio }.map(\.alias)
+        return SessionModelRestore(
+            chatAlias: validated(legacyLastAlias, in: chatAliases),
+            dictationAlias: validated(dictationAlias, in: audioAliases),
+            speechAlias: validated(speechAlias, in: audioAliases)
+        )
+    }
+
+    /// Resolve lane ownership independently from the auto-start preference.
+    /// Callers must publish `models.chatAlias` even when `shouldAutoStart` is
+    /// false so onboarding and restore never disagree about a legacy key.
+    static func launchPlan(
+        legacyLastAlias: String?,
+        dictationAlias: String?,
+        speechAlias: String?,
+        catalog: [ModelEntry],
+        autoStartEnabled: Bool,
+        emptyCatalogIsAuthoritative: Bool = false
+    ) -> LaunchPlan {
+        let hasLegacyAlias = legacyLastAlias?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty == false
+        // ModelCatalog uses [] as its subprocess-failure sentinel. With a
+        // legacy value to classify, absence of rows is therefore unknown —
+        // not evidence that the value is non-chat. Keep launch/onboarding
+        // pending rather than rejecting it and selecting a fallback model.
+        let chatAliasResolved = !hasLegacyAlias
+            || !catalog.isEmpty
+            || emptyCatalogIsAuthoritative
+        return LaunchPlan(
+            models: resolve(
+                legacyLastAlias: legacyLastAlias,
+                dictationAlias: dictationAlias,
+                speechAlias: speechAlias,
+                catalog: catalog
+            ),
+            chatAliasResolved: chatAliasResolved,
+            shouldAutoStart: autoStartEnabled
+                && chatAliasResolved
+                && !emptyCatalogIsAuthoritative
+        )
+    }
+
+    private static func validated(_ raw: String?, in aliases: [String]) -> String? {
+        guard let raw else { return nil }
+        let alias = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !alias.isEmpty else { return nil }
+        return aliases.first {
+            $0.caseInsensitiveCompare(alias) == .orderedSame
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -6,6 +6,29 @@ import SwiftUI
 /// server is ready the picker's Start button owns the flow, and a
 /// brand-new user with no model on disk sees the Quickstart card.
 struct ContentView: View {
+    enum RestoredChatAlias: Equatable {
+        case pendingCatalog
+        /// The bounded catalog retry also failed. The persisted key remains
+        /// untouched for a future launch, but this session must not stay
+        /// blocked behind an alias it could not classify.
+        case unresolved
+        case resolved(String?)
+    }
+
+    /// Outer nil means catalog classification is still pending. Outer some
+    /// carries the value onboarding should evaluate; `.unresolved` therefore
+    /// deliberately behaves like no persisted chat model for this session.
+    static func quickstartChatAlias(for state: RestoredChatAlias) -> String?? {
+        switch state {
+        case .pendingCatalog:
+            nil
+        case .unresolved:
+            .some(nil)
+        case .resolved(let alias):
+            .some(alias)
+        }
+    }
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// #459: hard window-width floor. The original 640pt target preserved
     /// half-screen tiling on built-in MacBook displays; 720pt is the smallest
@@ -23,6 +46,7 @@ struct ContentView: View {
     @Environment(ChatViewModel.self) private var chat
     @Environment(ImageGenViewModel.self) private var imageGen
     @Environment(AudioViewModel.self) private var audio
+    @Environment(DictationController.self) private var dictation
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
@@ -69,6 +93,16 @@ struct ContentView: View {
     /// FU-1: persisted opt-out for the launch-time auto-start path.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
     @State private var campaign: Campaign? = Campaign.previewFromEnvironment(ProcessInfo.processInfo.environment)
+    /// The rc2 key predates lane ownership. A non-empty value cannot decide
+    /// onboarding until catalog metadata proves it is a chat model; keeping an
+    /// explicit pending state prevents the launch gate and Quickstart surface
+    /// from interpreting the same legacy audio alias differently.
+    @State private var restoredChatAlias: RestoredChatAlias =
+        ServerManager.lastServedAlias() == nil ? .resolved(nil) : .pendingCatalog
+    /// A legacy chat key needs catalog metadata before it can be trusted. If
+    /// the shared launch probe fails empty, permit one immediate authoritative
+    /// retry without turning session restoration into a polling loop.
+    @State private var catalogRestoreRetryAttempted = false
 
     var body: some View {
         // Capture the identity owned by this alert render. A delayed dismiss
@@ -246,7 +280,7 @@ struct ContentView: View {
         // re-run, and the first pass returns at the gate without an
         // in-flight `server.start` for SwiftUI's task cancellation to
         // interrupt. Users with no pending decision see one run, as before.
-        .task(id: telemetryConsentPending) { await runLaunchAutoStart() }
+        .task(id: telemetryConsentPending) { await restorePersistedSession() }
         // Keyed exactly as the picker's own catalog task: re-fetch when
         // the engine binary appears and whenever the set of models on
         // disk changes anywhere in the app. Routed through the shared
@@ -586,14 +620,32 @@ struct ContentView: View {
     private func refreshCatalogSnapshot() async {
         guard let binary = server.binaryPath else { return }
         let generation = downloads.cacheGeneration
-        let loaded = await ModelCatalogCache.shared.entries(
+        var loaded = await ModelCatalogCache.shared.entries(
             binary: binary,
             generation: generation
         )
         guard !Task.isCancelled, generation == downloads.cacheGeneration else { return }
+        if loaded.isEmpty,
+           case .pendingCatalog = restoredChatAlias,
+           !catalogRestoreRetryAttempted {
+            catalogRestoreRetryAttempted = true
+            await ModelCatalogCache.shared.invalidate()
+            loaded = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: generation
+            )
+            guard !Task.isCancelled, generation == downloads.cacheGeneration else { return }
+        }
         catalogEntries = loaded
         catalogGeneration = generation
         catalogLoaded = true
+        if case .pendingCatalog = restoredChatAlias,
+           !loaded.isEmpty || catalogRestoreRetryAttempted {
+            await restorePersistedSession(
+                catalog: loaded,
+                emptyCatalogIsAuthoritative: loaded.isEmpty
+            )
+        }
     }
 
     /// Perform the readiness banner's next-step action.
@@ -632,7 +684,8 @@ struct ContentView: View {
     }
 
     private func startModel(_ target: String) {
-        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        let catalogEntry = catalogEntries.first(where: { $0.alias == target })
+        let hfPath = catalogEntry?.hfRepo
         // ``ensureServing`` via the shared helper, NOT ``server.start``: start is
         // cold-start only and no-ops while a different model (e.g. an Images
         // checkpoint) is resident, silently dropping the switch (#1739).
@@ -641,7 +694,8 @@ struct ContentView: View {
                 alias: target,
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
-                replacementGroup: .assistant
+                replacementGroup: .assistant,
+                catalogEntryHint: catalogEntry
             )
         }
     }
@@ -672,7 +726,8 @@ struct ContentView: View {
                 alias: target,
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
-                replacementGroup: .assistant
+                replacementGroup: .assistant,
+                catalogEntryHint: entry
             )
         }
     }
@@ -685,10 +740,17 @@ struct ContentView: View {
     }
 
     private func restartModel(_ target: String) {
-        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        let catalogEntry = catalogEntries.first(where: { $0.alias == target })
+        let hfPath = catalogEntry?.hfRepo
         Task {
             await server.stop()
-            _ = await server.ensureServing(alias: target, hfPath: hfPath)
+            _ = await server.ensureServing(
+                alias: target,
+                hfPath: hfPath,
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant,
+                catalogEntryHint: catalogEntry
+            )
         }
     }
 
@@ -842,10 +904,13 @@ struct ContentView: View {
         ) {
             return false
         }
+        guard let chatAlias = Self.quickstartChatAlias(for: restoredChatAlias) else {
+            return false
+        }
         if QuickstartCoordinator.isEligible(
             done: quickstart.done,
             legacyDone: quickstart.legacyDone,
-            lastServedAlias: ServerManager.lastServedAlias(),
+            lastServedAlias: chatAlias,
             serverState: server.state
         ) {
             return true
@@ -1121,7 +1186,80 @@ struct ContentView: View {
 
     // MARK: - Launch auto-start (Flow A/B)
 
-    private func runLaunchAutoStart() async {
+    /// Restore lane-owned state in dependency order. Start resolving chat
+    /// first, while arming Dictation's persisted global shortcut immediately;
+    /// audio model preparation remains deferred until the chat launch settles.
+    /// This keeps a slow primary health check from disabling the shortcut
+    /// without letting an audio fallback win ownership of the shared process.
+    private func restorePersistedSession(
+        catalog suppliedCatalog: [ModelEntry]? = nil,
+        emptyCatalogIsAuthoritative: Bool = false
+    ) async {
+        guard !telemetryConsentPending else { return }
+        let resolutionWasPending: Bool = {
+            if case .pendingCatalog = restoredChatAlias { return true }
+            return false
+        }()
+        _ = BundledModel.installBundledSnapshotSymlink()
+        _ = QuickstartModel.installAllSnapshotSymlinks()
+        let sessionCatalog: [ModelEntry]
+        if let suppliedCatalog {
+            sessionCatalog = suppliedCatalog
+        } else if let binary = server.binaryPath {
+            sessionCatalog = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: downloads.cacheGeneration
+            )
+        } else {
+            sessionCatalog = []
+        }
+        let launchPlan = SessionModelRestore.launchPlan(
+            legacyLastAlias: ServerManager.lastServedAlias(),
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: sessionCatalog,
+            autoStartEnabled: autoStartOnLaunch,
+            emptyCatalogIsAuthoritative: emptyCatalogIsAuthoritative
+        )
+        // Another reader may have resolved the same shared load while this
+        // task was suspended. A stale empty result cannot re-establish the
+        // audio barrier after the winning restore has already paired it.
+        if resolutionWasPending {
+            guard case .pendingCatalog = restoredChatAlias else { return }
+        }
+        if launchPlan.chatAliasResolved {
+            restoredChatAlias = emptyCatalogIsAuthoritative
+                ? .unresolved
+                : .resolved(launchPlan.models.chatAlias)
+        }
+
+        async let chatRestore: Void = runLaunchAutoStart(
+            catalogEntries: sessionCatalog,
+            launchPlan: launchPlan
+        )
+        await dictation.bootstrap(deferModelPreparation: true)
+        await chatRestore
+        // A failed catalog probe cannot classify the legacy key. Keep the
+        // audio barrier established; `refreshCatalogSnapshot` re-enters this
+        // same function when its independent probe produces real rows.
+        guard launchPlan.chatAliasResolved else { return }
+        if Task.isCancelled {
+            // The catalog task is keyed on cache generation. Hand ownership
+            // back to its replacement and pair the already-established audio
+            // barrier without starting audio from this cancelled task.
+            if resolutionWasPending {
+                restoredChatAlias = .pendingCatalog
+            }
+            await dictation.finishDeferredBootstrap()
+            return
+        }
+        await dictation.finishDeferredBootstrap()
+    }
+
+    private func runLaunchAutoStart(
+        catalogEntries: [ModelEntry],
+        launchPlan: SessionModelRestore.LaunchPlan
+    ) async {
         // Consent is the first user-controlled surface. Do not even inspect
         // model caches behind it: the final AutoStartDecision also knows about
         // this gate, but reaching that decision requires loading the catalog
@@ -1130,18 +1268,15 @@ struct ContentView: View {
         // operator's existing HF cache. The task is keyed on this value and
         // runs again immediately after the user answers.
         guard !telemetryConsentPending else { return }
-        guard autoStartOnLaunch else {
+        guard launchPlan.shouldAutoStart else {
             autoStartPendingDownload = nil
             return
         }
         guard case .idle = server.state else { return }
 
-        _ = BundledModel.installBundledSnapshotSymlink()
-        _ = QuickstartModel.installAllSnapshotSymlinks()
-
         let aliasAtEntry = alias
         let userSelectionRevisionAtEntry = userSelectionRevision
-        var cachedAliases: Set<String> = []
+        let cachedAliases = Set(catalogEntries.filter { $0.cached }.map(\.alias))
         // #1706: the full catalog membership snapshot (cached AND
         // uncached entries the sidecar can serve), used to validate the
         // stored last-served alias before we resume it. `nil` would ask
@@ -1149,15 +1284,9 @@ struct ContentView: View {
         // concrete set when the binary is reachable so a stored alias
         // the engine can't serve (renamed/dropped/wrong-modality) falls
         // through to the picker instead of a failed serve.
-        var catalogAliases: Set<String>? = nil
-        if let binary = server.binaryPath {
-            let entries = await ModelCatalogCache.shared.entries(
-                binary: binary,
-                generation: downloads.cacheGeneration
-            )
-            cachedAliases = Set(entries.filter { $0.cached }.map(\.alias))
-            catalogAliases = Set(entries.map(\.alias))
-        }
+        let catalogAliases: Set<String>? = server.binaryPath == nil
+            ? nil
+            : Set(catalogEntries.map(\.alias))
         guard case .idle = server.state else {
             autoStartPendingDownload = nil
             return
@@ -1184,7 +1313,7 @@ struct ContentView: View {
                     alias: candidate, physicalRAMGB: hardware.physicalRAMGB)
         }
         let decision = AutoStartDecision.decide(
-            lastServedAlias: ServerManager.lastServedAlias(),
+            lastServedAlias: launchPlan.models.chatAlias,
             bundledFallbackAlias: BundledModel.firstLaunchAlias(lastServedAlias: nil),
             binaryReachable: server.binaryPath != nil,
             cachedAliases: cachedAliases,
@@ -1206,7 +1335,7 @@ struct ContentView: View {
             onboardingPending: QuickstartCoordinator.onboardingOwed(
                 done: quickstart.done,
                 legacyDone: quickstart.legacyDone,
-                lastServedAlias: ServerManager.lastServedAlias()
+                lastServedAlias: launchPlan.models.chatAlias
             ),
             // Skip a retired starter only while the rescue is still on
             // offer. Once the user has completed or dismissed Quickstart,
@@ -1229,7 +1358,14 @@ struct ContentView: View {
             // modal the user never asked for (issue: annoying warning on every
             // app open). The user's own Start/first-message routes through
             // ``start`` without this flag and still gets the warning.
-            await server.start(alias: resume, isLaunchAutoStart: true)
+            let catalogEntry = catalogEntries.first {
+                $0.alias.caseInsensitiveCompare(resume) == .orderedSame
+            }
+            await server.start(
+                alias: resume,
+                isLaunchAutoStart: true,
+                catalogEntryHint: catalogEntry
+            )
         case .promptDownload(let pending):
             let footprint = ModelSizing.estimate(alias: pending)
             let sizeText: String? = footprint.paramsBillions == nil

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1567,10 +1567,17 @@ struct ModelPickerBar: View {
             pendingTooBigStart = trimmed
             return
         }
-        let hfPath = catalog.first(where: { $0.alias == trimmed })?.hfRepo
+        let catalogEntry = catalog.first(where: { $0.alias == trimmed })
+        let hfPath = catalogEntry?.hfRepo
         // Launch flags are applied inside ServerManager.start (one choke
         // point for every start path), RAM-gated to the recommended pick.
-        Task { await server.start(alias: trimmed, hfPath: hfPath) }
+        Task {
+            await server.start(
+                alias: trimmed,
+                hfPath: hfPath,
+                catalogEntryHint: catalogEntry
+            )
+        }
     }
 
     /// Alert title shown when the user tries to Start a ``.tooBig``

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -4386,7 +4386,15 @@ struct QuickstartView: View {
             }
         case .restart:
             coordinator.enterStarting()
-            Task { await server.start(alias: coordinator.selection.alias) }
+            let catalogEntry = cachedModels.first {
+                $0.alias == coordinator.selection.alias
+            }
+            Task {
+                await server.start(
+                    alias: coordinator.selection.alias,
+                    catalogEntryHint: catalogEntry
+                )
+            }
         case .openModelManagement, .openWebSearchSettings:
             // One path for every Settings deep-link. ``route`` stages the
             // target tab and only then runs the open — ``SettingsView`` reads
@@ -4464,7 +4472,8 @@ struct QuickstartView: View {
             await coordinator.afterSkippingDownloadBeat(duration: Self.skippingDownloadBeat) {
                 await server.start(
                     alias: cached.alias,
-                    hfPath: cached.hfRepo
+                    hfPath: cached.hfRepo,
+                    catalogEntryHint: cached
                 )
             }
         }
@@ -4557,10 +4566,14 @@ struct QuickstartView: View {
             // and re-enters main actor; we kick it via a Task because
             // the .task(id:) closure is already main-actor bound.
             coordinator.enterStarting()
+            let catalogEntry = cachedModels.first {
+                $0.alias == coordinator.selection.alias
+            }
             Task { @MainActor in
                 await server.start(
                     alias: coordinator.selection.alias,
-                    hfPath: coordinator.selection.hfRepo
+                    hfPath: coordinator.selection.hfRepo,
+                    catalogEntryHint: catalogEntry
                 )
             }
         case .cancelled:

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -221,6 +221,14 @@ journeys:
     fixtures: [fake-sidecar, delayed-transcription, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/UI/DictationView.swift]
     owns_baseline: false
+  - name: dictation-rc2-upgrade
+    group: audio
+    risk: high
+    driver: ax
+    ci_tier: local
+    fixtures: [fake-sidecar, audio-models, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
+    owns_baseline: false
   - name: audio-readiness
     group: audio
     risk: high

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -391,6 +391,184 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("launch bootstrap arms before deferred model preparation")
+    func launchBootstrapArmsWithoutWaitingForPrimaryHealth() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+        #expect(prewarmCount == 0, "audio preparation must not race the primary launch")
+
+        controller.toggleFromUI()
+        await Task.yield()
+        #expect(controller.lastError?.contains("chat model finishes starting") == true)
+        #expect(prewarmCount == 0)
+
+        await controller.finishDeferredBootstrap()
+
+        #expect(controller.phase == .idle)
+        #expect(prewarmCount == 1)
+        #expect(hotkeyStartCount == 2)
+    }
+
+    @MainActor
+    @Test("a cancelled session restore releases its audio barrier without prewarming")
+    func cancelledSessionRestoreReleasesBarrier() async {
+        var prewarmCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: { true }
+        )
+        await controller.bootstrap(deferModelPreparation: true)
+
+        let cancelledFinish = Task { @MainActor in
+            await controller.finishDeferredBootstrap()
+        }
+        cancelledFinish.cancel()
+        await cancelledFinish.value
+        #expect(prewarmCount == 0, "a superseded restore cannot start the audio lane")
+
+        await controller.enable()
+        #expect(prewarmCount == 1, "the replacement flow must not inherit a stranded barrier")
+    }
+
+    @MainActor
+    @Test("cold-start revalidation inherits the synchronous launch barrier")
+    func coldStartRevalidationCannotPrewarmBeforeChatRestore() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            initiallyDeferred: true,
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        controller.revalidate()
+        while hotkeyStartCount == 0 { await Task.yield() }
+        #expect(prewarmCount == 0, "Audio-view revalidation cannot start the audio lane")
+
+        await controller.finishDeferredBootstrap()
+        #expect(prewarmCount == 1)
+    }
+
+    @MainActor
+    @Test("model changes inherit the launch audio-preparation barrier")
+    func modelChangeDuringDeferredBootstrapCannotPrewarm() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+        controller.modelAlias = "another-speech-input"
+        while hotkeyStartCount < 2 { await Task.yield() }
+
+        #expect(controller.phase == .idle)
+        #expect(prewarmCount == 0, "a model change must not steal the starting chat process")
+    }
+
+    @MainActor
+    @Test("launch barrier exists before catalog refresh suspends")
+    func modelChangeDuringDeferredCatalogRefreshCannotPrewarm() async {
+        var firstCatalogContinuation: CheckedContinuation<[ModelEntry]?, Never>?
+        var catalogLoadCount = 0
+        var prewarmCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: {
+                prewarmCount += 1
+                return true
+            },
+            testingHotkeyStart: { true },
+            audioCatalogLoader: { _ in
+                catalogLoadCount += 1
+                if catalogLoadCount == 1 {
+                    return await withCheckedContinuation { firstCatalogContinuation = $0 }
+                }
+                return [entry]
+            }
+        )
+
+        let bootstrap = Task { await controller.bootstrap(deferModelPreparation: true) }
+        while firstCatalogContinuation == nil { await Task.yield() }
+        controller.modelAlias = "another-speech-input"
+        for _ in 0..<30 { await Task.yield() }
+
+        #expect(prewarmCount == 0)
+        firstCatalogContinuation?.resume(returning: [entry])
+        await bootstrap.value
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
+    @Test("hotkey failure cannot release the launch barrier")
+    func failedDeferredHotkeyRegistrationCannotEnablePrewarm() async {
+        var hotkeyAttempts = 0
+        var prewarmCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyAttempts += 1
+                return hotkeyAttempts > 1
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+        #expect(controller.phase == .off)
+        #expect(prewarmCount == 0)
+
+        await controller.enable()
+        #expect(controller.phase == .idle)
+        #expect(hotkeyAttempts == 2)
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
     @Test("failed model warmup leaves dictation visibly unarmed")
     func failedWarmupDoesNotArmHotkey() async {
         var hotkeyStartCount = 0
@@ -616,6 +794,7 @@ struct DictationTests {
     @MainActor
     private func readinessController(
         phase: DictationController.Phase = .off,
+        initiallyDeferred: Bool = false,
         prewarm: @escaping @MainActor () async -> Bool,
         hotkeyStart: @escaping @MainActor () -> Bool
     ) -> DictationController {
@@ -644,6 +823,7 @@ struct DictationTests {
             ),
             testingPrewarm: prewarm,
             testingHotkeyStart: hotkeyStart,
+            testingInitialModelPreparationDeferred: initiallyDeferred,
             audioCatalogLoader: { _ in [entry] }
         )
     }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -629,6 +629,12 @@ struct DictationTests {
         #expect(controller.phase == .starting)
         #expect(recorderStartCount == 1)
         #expect(server.servingAlias == "qwen3-0.6b-4bit")
+        #expect(controller.testingHasActiveTicker)
+        #expect(!controller.testingHasRecorder)
+
+        controller.disable()
+        #expect(!controller.testingHasActiveTicker)
+        #expect(!controller.testingHasRecorder)
     }
 
     @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -303,13 +303,20 @@ struct LaunchOnboardingOrderingTests {
     /// single re-run of the launch hook, not a permanent suppression.
     @Test("Answering consent releases the deferred auto-start")
     func consentAnsweredReleasesAutoStart() {
-        let decision = launchDecision(
+        let deferred = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            done: true,
+            consentPending: true
+        )
+        let released = launchDecision(
             lastServedAlias: "qwen3.5-4b-4bit",
             cachedAliases: ["qwen3.5-4b-4bit"],
             done: true,
             consentPending: false
         )
-        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+        #expect(deferred == .skip(reason: .firstRunDecisionPending))
+        #expect(released == .start(alias: "qwen3.5-4b-4bit"))
     }
 
     // MARK: - Precedence ladder

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -106,6 +106,45 @@ struct LaunchOnboardingOrderingTests {
         ))
     }
 
+    @Test("legacy audio ownership cannot suppress first-run onboarding")
+    func legacyAudioAliasStillOwesOnboarding() {
+        let audio = ModelEntry(
+            alias: "speech-input",
+            hfRepo: "example/speech-input",
+            sizeOnDisk: "500 MB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let launchPlan = SessionModelRestore.launchPlan(
+            legacyLastAlias: audio.alias,
+            dictationAlias: audio.alias,
+            speechAlias: nil,
+            catalog: [audio],
+            autoStartEnabled: false
+        )
+        let restored = launchPlan.models
+
+        #expect(restored.chatAlias == nil)
+        #expect(launchPlan.chatAliasResolved)
+        #expect(!launchPlan.shouldAutoStart)
+        #expect(QuickstartCoordinator.onboardingOwed(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: restored.chatAlias
+        ))
+        #expect(launchDecision(
+            lastServedAlias: restored.chatAlias,
+            cachedAliases: [audio.alias]
+        ) == .skip(reason: .onboardingPending))
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: restored.chatAlias,
+            serverState: .idle
+        ))
+    }
+
     /// The pre-fix state, asserted from the wizard's side, so the test
     /// file documents *why* the gate has to sit where it does. Had
     /// auto-start been allowed to run, this is what the sheet would have

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,10 +128,12 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let catalogEntry = await ModelCatalogCache.shared.entries"))
+        #expect(server.contains("let probedCatalogEntry = await ModelCatalogCache.shared.entries"))
         let catalogProbe = try #require(server.range(
-            of: "let catalogEntry = await ModelCatalogCache.shared.entries"
+            of: "let probedCatalogEntry = await ModelCatalogCache.shared.entries"
         ))
+        #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
+                "the authoritative probe and exact-alias start hint must converge before launch")
         let criticalSection = try #require(server.range(
             of: "        isOperating = true\n\n        // Clear the log tail"
         ))

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
@@ -52,7 +52,9 @@ struct ReadinessRecoveryActionWiringTests {
         }
         let function = String(source[signature.lowerBound...functionEnd])
         #expect(
-            function.contains("awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath)"),
+            function.contains(
+                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntry)"
+            ),
             "Restart must stop the failed engine before bringing the selected model back."
         )
     }

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -483,7 +483,7 @@ struct ResidentLoadFeedbackTests {
     private func makeServer(
         initialAlias: String = "qwen3.5-4b-4bit",
         binaryPath: URL? = nil,
-        sessionDefaults: UserDefaults = .standard
+        sessionDefaults: UserDefaults? = nil
     ) -> ServerManager {
         var client = ServerResidencyClient()
         client.session = ResidentLoadRejectProtocol.session()

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -314,6 +314,45 @@ struct ResidentLoadFeedbackTests {
         #expect(server.residentLoadFailure(for: "flux2-klein-4b") == nil)
     }
 
+    @Test("Assistant resident load persists authoritative catalog provenance without a hint")
+    func residentAssistantPersistsProbedChatAlias() async throws {
+        defer { ResidentLoadRejectProtocol.reset() }
+        ResidentLoadRejectProtocol.rejectLoad = false
+        let suite = "ResidentLoadFeedbackTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let wrapper = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-resident-catalog-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: wrapper) }
+        try "#!/bin/sh\nFAKE_CACHED_CURATED_TRADEUP=1 exec '\(fakeServer.path)' \"$@\"\n"
+            .write(to: wrapper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: wrapper.path
+        )
+        let server = makeServer(
+            initialAlias: "previous-chat",
+            binaryPath: wrapper,
+            sessionDefaults: defaults
+        )
+
+        let ok = await server.ensureServing(
+            alias: "qwen3.5-4b-4bit",
+            hfPath: "fake/model",
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant
+        )
+
+        #expect(ok)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == "qwen3.5-4b-4bit")
+    }
+
     /// The cross-talk regression from the earlier single-slot design (#1838
     /// follow-up): a rejection for model B must NOT be cleared by model A
     /// successfully loading, and a rejection for model A must not surface for
@@ -441,10 +480,18 @@ struct ResidentLoadFeedbackTests {
     /// Build a ``ServerManager`` in the resident-ready state with the stub
     /// transport and a stub child, so ``ensureServing`` takes the in-process
     /// ``/v1/models/load`` path rather than the cold-start fallback.
-    private func makeServer() -> ServerManager {
+    private func makeServer(
+        initialAlias: String = "qwen3.5-4b-4bit",
+        binaryPath: URL? = nil,
+        sessionDefaults: UserDefaults = .standard
+    ) -> ServerManager {
         var client = ServerResidencyClient()
         client.session = ResidentLoadRejectProtocol.session()
-        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
+        let server = ServerManager(
+            testingState: .ready(alias: initialAlias),
+            binaryPath: binaryPath,
+            sessionDefaults: sessionDefaults
+        )
         server._testSetResidencyClient(client)
         server._testInstallChild(ProcessGroupChild.testStub())
         return server

--- a/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
@@ -11,6 +11,8 @@ import Testing
 @MainActor
 @Suite("SamplingConfig defaults + persistence")
 final class SamplingConfigTests {
+    init() { CIHangWatchdog.noteProgress() }
+
     /// Names of every suite ``freshDefaults`` minted for this test
     /// instance. Each ``@Test`` gets a fresh instance of the suite
     /// type, so ``deinit`` runs after the test exits — the suite is
@@ -24,7 +26,10 @@ final class SamplingConfigTests {
     /// test`` runs.
     nonisolated(unsafe) private var createdSuiteNames: [String] = []
 
-    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+    deinit {
+        CIHangWatchdog.noteProgress()
+        TestDefaultsScope.cleanup(suiteNames: createdSuiteNames)
+    }
 
     /// Issue #139 dedupe — the cleanup mechanics that used to live
     /// here are now shared with the other suite-minting tests via

--- a/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
@@ -358,7 +358,10 @@ final class SamplingConfigTests {
         #expect(s.isAtDefaults)
     }
 
-    @Test("Zero / negative on a Double knob WOULD persist as 0 via UserDefaults.double(forKey:) — verify the absent-key fallback handles that distinction")
+    @Test(
+        "Zero / negative on a Double knob WOULD persist as 0 via UserDefaults.double(forKey:) — verify the absent-key fallback handles that distinction",
+        .timeLimit(.minutes(1))
+    )
     func zeroDoubleDistinguishedFromAbsent() {
         // The init uses ``object(forKey:)`` precisely so a missing
         // key on first launch doesn't read as 0.0 (which would

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Lane-owned session model restore")
+struct SessionModelRestoreTests {
+    private actor SequencedCatalogLoader {
+        private var responses: [[ModelEntry]]
+
+        init(_ responses: [[ModelEntry]]) {
+            self.responses = responses
+        }
+
+        func load() -> [ModelEntry] {
+            guard !responses.isEmpty else { return [] }
+            return responses.removeFirst()
+        }
+    }
+
+    private let chat = ModelEntry(
+        alias: "qwen3.5-4b-4bit",
+        hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
+        sizeOnDisk: "2.5 GB",
+        cached: true,
+        kind: .chat
+    )
+    private let stt = ModelEntry(
+        alias: "speech-input",
+        hfRepo: "example/speech-input",
+        sizeOnDisk: "500 MB",
+        cached: true,
+        kind: .audio,
+        audioCapability: .transcription
+    )
+    private let tts = ModelEntry(
+        alias: "speech-output",
+        hfRepo: "example/speech-output",
+        sizeOnDisk: "1 GB",
+        cached: true,
+        kind: .audio,
+        audioCapability: .speech
+    )
+
+    @Test("Dictation cannot replace the restored chat alias")
+    func dictationThenRelaunch() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+        #expect(restored.dictationAlias == stt.alias)
+    }
+
+    @Test("Dictation and speech retain independent audio selections")
+    func dictationAndSpeechThenRelaunch() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias,
+            catalog: [chat, stt, tts]
+        )
+
+        #expect(restored == SessionModelRestore(
+            chatAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias
+        ))
+    }
+
+    @Test("Audio-only history does not invent a chat model")
+    func audioOnlyHistory() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: stt.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias,
+            catalog: [chat, stt, tts]
+        )
+
+        #expect(restored.chatAlias == nil)
+        #expect(restored.dictationAlias == stt.alias)
+        #expect(restored.speechAlias == tts.alias)
+    }
+
+    @Test("An rc2 chat alias migrates through chat capability metadata")
+    func rc2ChatAliasUpgrade() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: "  \(chat.alias)  ",
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+    }
+
+    @Test("Legacy aliases use catalog casing after a case-insensitive lane match")
+    func legacyAliasCasingIsCanonicalized() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias.uppercased(),
+            dictationAlias: stt.alias.uppercased(),
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+        #expect(restored.dictationAlias == stt.alias)
+    }
+
+    @Test("A failed catalog probe preserves pending legacy chat ownership")
+    func failedCatalogProbeDoesNotRejectLegacyAlias() {
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [],
+            autoStartEnabled: true
+        )
+
+        #expect(!plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == nil)
+        #expect(!plan.shouldAutoStart)
+
+        let retry = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [chat, stt],
+            autoStartEnabled: true
+        )
+        #expect(retry.chatAliasResolved)
+        #expect(retry.models.chatAlias == chat.alias)
+        #expect(retry.shouldAutoStart)
+    }
+
+    @Test("Exhausting the bounded catalog retry rejects an unverified legacy alias")
+    @MainActor
+    func exhaustedCatalogRetryFailsClosed() {
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: nil,
+            catalog: [],
+            autoStartEnabled: true,
+            emptyCatalogIsAuthoritative: true
+        )
+
+        #expect(plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == nil)
+        #expect(!plan.shouldAutoStart)
+        let quickstartAlias = ContentView.quickstartChatAlias(for: .unresolved)
+        #expect(quickstartAlias != nil)
+        #expect(quickstartAlias! == nil)
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: quickstartAlias!,
+            serverState: .idle
+        ))
+    }
+
+    @Test("Only catalog-proven chat readiness may rewrite chat persistence")
+    func chatPersistenceOwnership() {
+        #expect(SessionModelRestore.shouldPersistChatAlias(catalogEntry: chat))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: stt))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: tts))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: nil))
+    }
+
+    @Test("ensureVoiceLane audio ready never overwrites the chat-lane key")
+    @MainActor
+    func audioOnlyReadyPreservesPersistedChat() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(chat.alias, forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        defer { server.shutdownSync() }
+
+        // Drive the exact production regression vector through the fake
+        // sidecar: ensureVoiceLane → ensureServing(residencyEligible: false)
+        // → start(audio alias) → /healthz → .ready(audio alias).
+        let ready = await server.ensureVoiceLane(
+            alias: stt.alias,
+            hfPath: stt.hfRepo
+        )
+
+        #expect(ready)
+        #expect(server.servingAlias == stt.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("ensureServing carries chat provenance when its ready-time catalog probe fails")
+    @MainActor
+    func ensureServingPersistsHintedChatAfterProbeFailure() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        defer { server.shutdownSync() }
+
+        let ready = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo,
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant,
+            catalogEntryHint: chat
+        )
+
+        #expect(ready)
+        #expect(server.servingAlias == chat.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("A catalog-proven chat ready transition owns the chat-lane key")
+    @MainActor
+    func chatReadyUpdatesPersistedChat() throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let server = ServerManager(
+            testingState: .ready(alias: chat.alias),
+            sessionDefaults: defaults
+        )
+        server.recordReadySelection(
+            alias: chat.alias,
+            catalogEntry: chat
+        )
+
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("A catalog-proven start hint survives a transient ready-time probe failure")
+    @MainActor
+    func chatHintPersistsAfterProbeFailure() throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let server = ServerManager(
+            testingState: .ready(alias: chat.alias),
+            sessionDefaults: defaults
+        )
+
+        let readyEntry = ServerManager.readyCatalogEntry(
+            alias: chat.alias,
+            probed: nil,
+            hint: chat
+        )
+        server.recordReadySelection(alias: chat.alias, catalogEntry: readyEntry)
+
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(ServerManager.readyCatalogEntry(
+            alias: chat.alias,
+            probed: nil,
+            hint: stt
+        ) == nil)
+    }
+
+    @Test("A failed shared catalog snapshot can be invalidated for one authoritative restore retry")
+    func failedCatalogSnapshotRetriesThroughRealCache() async {
+        let loader = SequencedCatalogLoader([[], [chat, stt]])
+        let cache = ModelCatalogCache { _, _ in await loader.load() }
+        let binary = URL(fileURLWithPath: "/tmp/rapid-session-restore-test")
+
+        let failed = await cache.entries(binary: binary, generation: 0)
+        let joinedFailure = await cache.entries(binary: binary, generation: 0)
+        #expect(failed.isEmpty)
+        #expect(joinedFailure.isEmpty)
+
+        await cache.invalidate()
+        let retried = await cache.entries(binary: binary, generation: 0)
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: retried,
+            autoStartEnabled: true
+        )
+
+        #expect(retried.map(\.alias) == [chat.alias, stt.alias])
+        #expect(plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == chat.alias)
+        #expect(plan.shouldAutoStart)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -169,7 +169,10 @@ struct SessionModelRestoreTests {
         #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: nil))
     }
 
-    @Test("ensureVoiceLane audio ready never overwrites the chat-lane key")
+    @Test(
+        "ensureVoiceLane audio ready never overwrites the chat-lane key",
+        .timeLimit(.minutes(1))
+    )
     @MainActor
     func audioOnlyReadyPreservesPersistedChat() async throws {
         let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
@@ -187,7 +190,7 @@ struct SessionModelRestoreTests {
             binaryPath: fakeServer,
             sessionDefaults: defaults
         )
-        defer { server.shutdownSync() }
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
 
         // Drive the exact production regression vector through the fake
         // sidecar: ensureVoiceLane → ensureServing(residencyEligible: false)
@@ -200,9 +203,13 @@ struct SessionModelRestoreTests {
         #expect(ready)
         #expect(server.servingAlias == stt.alias)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
     }
 
-    @Test("ensureServing carries chat provenance when its ready-time catalog probe fails")
+    @Test(
+        "ensureServing carries chat provenance when its ready-time catalog probe fails",
+        .timeLimit(.minutes(1))
+    )
     @MainActor
     func ensureServingPersistsHintedChatAfterProbeFailure() async throws {
         let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
@@ -220,7 +227,7 @@ struct SessionModelRestoreTests {
             binaryPath: fakeServer,
             sessionDefaults: defaults
         )
-        defer { server.shutdownSync() }
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
 
         let ready = await server.ensureServing(
             alias: chat.alias,
@@ -233,6 +240,14 @@ struct SessionModelRestoreTests {
         #expect(ready)
         #expect(server.servingAlias == chat.alias)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
+    }
+
+    private static var safeMemorySnapshot: MemoryProbe.Snapshot {
+        MemoryProbe.Snapshot(
+            totalBytes: 64 * 1_024 * 1_024 * 1_024,
+            usedBytes: 0
+        )
     }
 
     @Test("A catalog-proven chat ready transition owns the chat-lane key")

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Rapid
 
-@Suite("Lane-owned session model restore")
+@Suite("Lane-owned session model restore", .serialized)
 struct SessionModelRestoreTests {
     private actor SequencedCatalogLoader {
         private var responses: [[ModelEntry]]

--- a/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
@@ -1,7 +1,7 @@
 import Darwin
 import Foundation
 
-/// Temporary hosted-runner diagnostic for the Swift 6.0 test-process hang.
+/// Hosted-runner guard for a test process that stops making progress.
 ///
 /// This deliberately uses a Foundation thread rather than Swift concurrency:
 /// the failure under investigation strands the cooperative executor and the
@@ -33,7 +33,7 @@ enum CIHangWatchdog {
             lock.unlock()
             guard quietFor >= quietLimit else { continue }
 
-            write("CI hang watchdog: no SamplingConfigTests progress for \(Int(quietFor))s; sampling blocked test process\n")
+            write("CI hang watchdog: no watchdog-checkpoint progress for \(Int(quietFor))s; sampling blocked test process\n")
             let ownPID = getpid()
             sample(pid: ownPID)
             for childPID in childPIDs(of: ownPID) where isSwiftTestProcess(pid: childPID) {

--- a/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
@@ -1,0 +1,105 @@
+import Darwin
+import Foundation
+
+/// Temporary hosted-runner diagnostic for the Swift 6.0 test-process hang.
+///
+/// This deliberately uses a Foundation thread rather than Swift concurrency:
+/// the failure under investigation strands the cooperative executor and the
+/// MainActor, so a Task-based timeout cannot run to report the blocked stacks.
+enum CIHangWatchdog {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var started = false
+    nonisolated(unsafe) private static var lastProgress = Date.timeIntervalSinceReferenceDate
+    private static let quietLimit: TimeInterval = 90
+
+    static func noteProgress() {
+        lock.lock()
+        lastProgress = Date.timeIntervalSinceReferenceDate
+        let shouldStart = !started
+        started = true
+        lock.unlock()
+
+        guard shouldStart else { return }
+        Thread.detachNewThread {
+            monitor()
+        }
+    }
+
+    private static func monitor() {
+        while true {
+            Thread.sleep(forTimeInterval: 5)
+            lock.lock()
+            let quietFor = Date.timeIntervalSinceReferenceDate - lastProgress
+            lock.unlock()
+            guard quietFor >= quietLimit else { continue }
+
+            write("CI hang watchdog: no SamplingConfigTests progress for \(Int(quietFor))s; sampling blocked test process\n")
+            let ownPID = getpid()
+            sample(pid: ownPID)
+            for childPID in childPIDs(of: ownPID) where isSwiftTestProcess(pid: childPID) {
+                sample(pid: childPID)
+            }
+            write("CI hang watchdog: samples complete; terminating test process with exit(3)\n")
+            fflush(stdout)
+            fflush(stderr)
+            exit(3)
+        }
+    }
+
+    private static func sample(pid: pid_t) {
+        write("===== /usr/bin/sample \(pid) 3 -file /dev/stdout =====\n")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = [String(pid), "3", "-file", "/dev/stdout"]
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            write("CI hang watchdog: sample failed for pid \(pid): \(error)\n")
+        }
+        write("===== end sample pid=\(pid) =====\n")
+    }
+
+    private static func childPIDs(of parentPID: pid_t) -> [pid_t] {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-P", String(parentPID)]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \Character.isWhitespace)
+            .compactMap { pid_t($0) }
+    }
+
+    private static func isSwiftTestProcess(pid: pid_t) -> Bool {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", String(pid), "-o", "comm="]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return false
+        }
+        let command = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let name = URL(fileURLWithPath: command.trimmingCharacters(in: .whitespacesAndNewlines)).lastPathComponent
+        return name == "swiftpm-testing" || name == "xctest"
+    }
+
+    private static func write(_ message: String) {
+        FileHandle.standardError.write(Data(message.utf8))
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -57,7 +57,7 @@ Flows: fresh-install, cached-quickstart, cached-curated-tradeup, cached-variant-
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, update-busy, campaign-banner, window-close-prompt, no-dead-controls, catalog-integrity,
-       browse-all-destination, chat-document-attachment, chat-multimodal-attachments, image-generation, dictation, audio-readiness, all
+       browse-all-destination, chat-document-attachment, chat-multimodal-attachments, image-generation, dictation, dictation-rc2-upgrade, audio-readiness, all
 
 Most named regression flows drive the app through the accessibility API alone.
 The preflight contract tests keep the exact allowlist in sync with
@@ -146,7 +146,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
-        slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
+        slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|dictation-rc2-upgrade|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -4754,6 +4754,55 @@ flow_audio_readiness() {
 # is reachable, raw recordings remain opt-in, local vocabulary edits work,
 # mode round-trips preserve the pane, opening it alone never starts a model,
 # and enabling visibly transitions from Loading to Ready.
+flow_dictation_rc2_upgrade() {
+    log "flow: dictation-rc2-upgrade"
+    start_persona dictation-rc2-upgrade \
+        RAPID_GUI_GOLDEN_MODE=1 \
+        RAPID_GUI_DICTATION_READINESS_FIXTURE=1 \
+        FAKE_CACHED_DICTATION=1
+    dismiss_first_run
+    stop_app
+
+    # Recreate the keys written by rc2 before lane ownership existed: one
+    # shared last-served chat key plus independently persisted Dictation intent
+    # and its audio model. The bundle id is unique to this throwaway persona.
+    defaults write "$BUNDLE_ID" rapid.serve.lastAlias "fake-alias"
+    defaults write "$BUNDLE_ID" dictation.enabled -bool true
+    defaults write "$BUNDLE_ID" dictation.model "fake-whisper-small"
+    relaunch_persona
+    dismiss_first_run
+
+    local i restored_chat=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/rc2-upgrade-chat.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "ModelPickerBar.ModelMenu"
+                           and .value == "fake-alias")' \
+                 "$OUT/rc2-upgrade-chat.json" >/dev/null; then
+            restored_chat=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$restored_chat" == 1 ]] \
+        || die "rc2 upgrade did not restore the persisted chat model"
+    wait_send_idle "$OUT/rc2-upgrade-send-ready.json"
+    jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias")
+              and (any(.[]; .event == "server_started" and .alias == "fake-whisper-small") | not)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "rc2 upgrade restored the transcription alias as process owner"
+    press "$OUT/rc2-upgrade-send-ready.json" Sidebar.Audio \
+        "$OUT/rc2-upgrade-audio-open.json" \
+        || die "Audio is not reachable after rc2 upgrade"
+    wait_identifier Dictation.Enable "$OUT/rc2-upgrade-audio.json"
+    [[ "$(element_field "$OUT/rc2-upgrade-audio.json" Dictation.Enable value)" == "1" ]] \
+        || die "rc2 upgrade lost persisted Dictation intent"
+
+    log "  rc2 chat + Dictation state restored with Send enabled"
+    log "  dictation-rc2-upgrade OK"
+    cleanup_persona
+}
+
+
 flow_dictation() {
     log "flow: dictation"
     start_persona dictation \
@@ -4905,7 +4954,38 @@ flow_dictation() {
         "Conversation state before dictation"
     send_prompt "Conversation survives dictation" "dictation-chat"
 
-    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, and preserved chat produced effects"
+    # Relaunch is the state-ownership contract: Dictation remains enabled, but
+    # its audio selection must never become the restored chat model. Session
+    # restore starts the catalog-proven chat alias first, then re-arms the
+    # audio lane on that process; no transcription-only child may appear.
+    relaunch_persona
+    dismiss_first_run
+    local restored_chat=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/dictation-relaunch-chat.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "ModelPickerBar.ModelMenu"
+                           and .value == "fake-alias")' \
+                 "$OUT/dictation-relaunch-chat.json" >/dev/null; then
+            restored_chat=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$restored_chat" == 1 ]] \
+        || die "Relaunch did not restore the conversation model after enabling Dictation"
+    wait_send_idle "$OUT/dictation-relaunch-send-ready.json"
+    jq -e -s '(map(select(.event == "server_started" and .alias == "fake-alias")) | length) == 2
+              and (any(.[]; .event == "server_started" and .alias == "fake-whisper-small") | not)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "Relaunch restored the transcription alias as the process-owning chat model"
+    press "$OUT/dictation-relaunch-send-ready.json" Sidebar.Audio \
+        "$OUT/dictation-relaunch-audio-open.json" \
+        || die "Audio is not reachable after Dictation relaunch"
+    wait_identifier Dictation.Enable "$OUT/dictation-relaunch-audio.json"
+    [[ "$(element_field "$OUT/dictation-relaunch-audio.json" Dictation.Enable value)" == "1" ]] \
+        || die "Relaunch disabled the user's persisted Dictation intent"
+
+    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, relaunch, and preserved chat produced effects"
     log "  dictation OK"
     cleanup_persona
 }
@@ -4945,6 +5025,7 @@ case "$FLOW" in
     chat-multimodal-attachments) flow_chat_multimodal_attachments ;;
     image-generation) flow_image_generation ;;
     dictation) flow_dictation ;;
+    dictation-rc2-upgrade) flow_dictation_rc2_upgrade ;;
     audio-readiness) flow_audio_readiness ;;
     resident-load-rejected) flow_resident_load_rejected ;;
     launch-integrations) flow_launch_integrations ;;

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,7 +2,3 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
-
-<!-- One or two sentences: what is this release about? -->
-
-## Highlights

--- a/docs/release-notes/v0.13.0.md
+++ b/docs/release-notes/v0.13.0.md
@@ -1,0 +1,67 @@
+Rapid-MLX 0.13.0 makes first setup clearer, expands local model support, keeps
+chat and speech workloads available together, and improves long-prompt
+responsiveness and cache correctness.
+
+## Highlights
+
+**More capable local models** — Run supported Qwen3-Next checkpoints larger
+than available memory with disk streaming, serve Nemotron-Labs-Diffusion 3B as
+a standard text model, and choose verified Ornith 1.5 9B and 35B-A3B models
+from the Desktop catalog. ([#2192](https://github.com/raullenchai/Rapid-MLX/pull/2192),
+[#2194](https://github.com/raullenchai/Rapid-MLX/pull/2194),
+[#2197](https://github.com/raullenchai/Rapid-MLX/pull/2197))
+
+**Faster, safer long conversations** — Hybrid models reuse compatible prefix
+caches, cutting verified repeat-turn prefill from tens of seconds to sub-second
+latency. MLX 0.32.1 and measured per-model prefill defaults also improve
+throughput while preserving explicit server overrides. ([#2321](https://github.com/raullenchai/Rapid-MLX/pull/2321),
+[#2199](https://github.com/raullenchai/Rapid-MLX/pull/2199),
+[#2210](https://github.com/raullenchai/Rapid-MLX/pull/2210))
+
+**Clearer setup and model switching** — First setup uses live RAM-based
+recommendations, groups cached variants, and reports download progress. Chat
+receives authoritative local date and time, active-request model switches ask
+before interrupting work, and complete cached Qwen3.5 checkpoints route through
+the correct runtime automatically. ([#2331](https://github.com/raullenchai/Rapid-MLX/pull/2331),
+[#2334](https://github.com/raullenchai/Rapid-MLX/pull/2334),
+[#2335](https://github.com/raullenchai/Rapid-MLX/pull/2335),
+[#2336](https://github.com/raullenchai/Rapid-MLX/pull/2336))
+
+**Chat, vision, audio, and images work together more naturally** — Desktop
+adds a dedicated photo flow, separates Speech to Text from Text to Speech, and
+keeps ordinary dictation from evicting the active conversation model. Image
+generation starts at a lower-memory 512×512 default and shows a stable
+remaining-time estimate. ([#2201](https://github.com/raullenchai/Rapid-MLX/pull/2201),
+[#2188](https://github.com/raullenchai/Rapid-MLX/pull/2188),
+[#2307](https://github.com/raullenchai/Rapid-MLX/pull/2307),
+[#2302](https://github.com/raullenchai/Rapid-MLX/pull/2302))
+
+**More reliable tools and reasoning** — Tool selection is schema-driven,
+malformed tool attempts stay inside the correction loop, reasoning scratch
+work stays out of final answers, and supported web-search providers recover
+from rejected saved keys without dropping the original request. ([#2244](https://github.com/raullenchai/Rapid-MLX/pull/2244),
+[#2278](https://github.com/raullenchai/Rapid-MLX/pull/2278),
+[#2284](https://github.com/raullenchai/Rapid-MLX/pull/2284),
+[#2304](https://github.com/raullenchai/Rapid-MLX/pull/2304))
+
+## Upgrade notes
+
+- From 0.13.0-rc2, quit the existing app, replace it in Applications with the
+  final DMG, and reopen it. Conversations, downloaded models, and preferences
+  remain in place.
+- Existing cached dictation selections are preserved. Incompatible old prefix
+  caches remain on disk but are not reused.
+- Standalone servers opt into the shared audio lane with `--enable-audio`;
+  Desktop enables it automatically.
+
+## Known issues
+
+- Loading a secondary model can leave the reported resident primary model
+  returning errors until Rapid-MLX Desktop is relaunched.
+  ([#2333](https://github.com/raullenchai/Rapid-MLX/issues/2333))
+- Run setup again currently overstates what it resets; conversations,
+  downloaded models, preferences, and telemetry consent are preserved.
+  ([#2239](https://github.com/raullenchai/Rapid-MLX/issues/2239))
+- Low-memory coexistence does not yet provide complete cross-role capacity
+  guidance for every chat, vision, speech-input, and speech-output combination.
+  ([#2305](https://github.com/raullenchai/Rapid-MLX/issues/2305))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.0-rc2"
+version = "0.13.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -884,3 +884,34 @@ def test_local_snapshot_falls_back_when_the_local_resolve_fails(monkeypatch):
     monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", lambda _name: True)
 
     assert tok._local_snapshot_if_cached("org/warm-repo") == "org/warm-repo"
+
+
+def test_local_snapshot_uses_one_complete_immutable_revision_without_main_ref(
+    monkeypatch, tmp_path
+):
+    """Issue #2329: the text loader consumes the same unambiguous checkpoint
+    source that automatic lane resolution inspected, without a network lookup.
+    """
+    import json
+
+    import huggingface_hub
+
+    from vllm_mlx.utils import tokenizer as tok
+
+    repo_root = tmp_path / "models--mlx-community--Qwen3.5-2B-MLX-4bit"
+    revision = "93760be4f1f69842a46bc13dbdc0f19e291392a3"
+    snapshot = repo_root / "snapshots" / revision
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "model_type": "qwen3_5",
+            }
+        )
+    )
+    (snapshot / "model.safetensors").write_bytes(b"complete")
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+
+    resolved = tok._local_snapshot_if_cached("mlx-community/Qwen3.5-2B-MLX-4bit")
+    assert resolved == str(snapshot)

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -996,14 +996,14 @@ class TestMllmBackboneIsHybrid:
         # requested short name is exposed separately as its alias.
         assert server._model_name == repo
         assert server._model_alias == alias
-        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["model_name"] == str(snapshot)
         assert server._engine.kwargs["force_text"] is True
 
         # CLI startup arrives with the canonical repo plus a matching saved
         # alias. That same-source identity remains valid and keeps its profile.
         server.load_model(repo)
         assert server._model_alias == alias
-        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["model_name"] == str(snapshot)
         assert server._engine.kwargs["force_text"] is True
 
         # A removed/corrupt prior identity is stale process state, not a reason
@@ -1022,7 +1022,7 @@ class TestMllmBackboneIsHybrid:
         server._model_alias = "removed-prior-alias"
         server.load_model(repo)
         assert server._model_alias is None
-        assert server._engine.kwargs["model_name"] == repo
+        assert server._engine.kwargs["model_name"] == str(snapshot)
         assert server._engine.kwargs["force_text"] is True
 
     def test_unreferenced_snapshot_resolution_fails_closed(self, monkeypatch, tmp_path):

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -7,6 +7,7 @@ from vllm_mlx/api/utils.py. No MLX dependency.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -1023,6 +1024,50 @@ class TestMllmBackboneIsHybrid:
         assert server._model_alias is None
         assert server._engine.kwargs["model_name"] == repo
         assert server._engine.kwargs["force_text"] is True
+
+    def test_unreferenced_snapshot_resolution_fails_closed(self, monkeypatch, tmp_path):
+        """Ambiguous, partial, and malformed cache shapes must stay offline-safe."""
+        import huggingface_hub
+
+        from vllm_mlx import model_metadata
+
+        repo = "publisher/model"
+        repo_root = tmp_path / "models--publisher--model"
+        snapshots = repo_root / "snapshots"
+        snapshot = snapshots / "immutable-revision"
+        snapshot.mkdir(parents=True)
+        (snapshot / "config.json").write_text(
+            json.dumps({"model_type": "qwen3_5"}), encoding="utf-8"
+        )
+        (snapshot / "model.safetensors").write_bytes(b"complete")
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+
+        refs = repo_root / "refs"
+        refs.mkdir()
+        (refs / "main").write_text("missing-revision", encoding="utf-8")
+        assert model_metadata.resolve_unreferenced_cached_snapshot(repo) is None
+        (refs / "main").unlink()
+
+        second = snapshots / "second-revision"
+        second.mkdir()
+        assert model_metadata.resolve_unreferenced_cached_snapshot(repo) is None
+        second.rmdir()
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                "vllm_mlx.model_aliases.checkpoint_prefix", lambda _name: "nested/"
+            )
+            assert model_metadata.resolve_unreferenced_cached_snapshot(repo) is None
+
+        (snapshot / "model.safetensors").unlink()
+        assert model_metadata.resolve_unreferenced_cached_snapshot(repo) is None
+
+        def fail_to_list(_path):
+            raise OSError("stale cache mount")
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(Path, "iterdir", fail_to_list)
+            assert model_metadata.resolve_unreferenced_cached_snapshot(repo) is None
 
     def test_sliding_and_full_attention_is_not_hybrid(self, monkeypatch):
         from vllm_mlx.api.utils import mllm_backbone_is_hybrid

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -974,7 +974,10 @@ class TestMllmBackboneIsHybrid:
         server.load_model(alias)
 
         assert server._model_path == repo
-        assert server._model_name == alias
+        # Only an explicit ``served_model_name`` replaces the primary served
+        # id. The canonical checkpoint remains primary by default, while the
+        # requested short name is exposed separately as its alias.
+        assert server._model_name == repo
         assert server._model_alias == alias
         assert server._engine.kwargs["model_name"] == repo
         assert server._engine.kwargs["force_text"] is True

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -908,8 +908,6 @@ class TestMllmBackboneIsHybrid:
         repo_root = tmp_path / "hub" / "models--mlx-community--Qwen3.5-2B-MLX-4bit"
         snapshot = repo_root / "snapshots" / revision
         snapshot.mkdir(parents=True)
-        (repo_root / "refs").mkdir()
-        (repo_root / "refs" / "main").write_text(revision)
         (snapshot / "config.json").write_text(
             json.dumps(
                 {
@@ -947,6 +945,16 @@ class TestMllmBackboneIsHybrid:
         monkeypatch.setattr(
             huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path / "hub")
         )
+        from vllm_mlx import cli
+
+        def fail_on_network(_name):
+            raise AssertionError("complete singleton snapshot must stay offline")
+
+        monkeypatch.setattr(
+            cli,
+            "_ensure_model_downloaded",
+            fail_on_network,
+        )
 
         class StubEngine:
             is_mllm = False
@@ -970,6 +978,14 @@ class TestMllmBackboneIsHybrid:
         # Simulate a Desktop residency replacement after an image model. The
         # old process-global alias must not lend its image profile to Qwen.
         monkeypatch.setattr(server, "_model_alias", "z-image-turbo", raising=False)
+
+        from vllm_mlx.model_metadata import read_model_metadata
+        from vllm_mlx.utils.tokenizer import _local_snapshot_if_cached
+
+        metadata = read_model_metadata(repo)
+        assert metadata is not None
+        assert metadata.snapshot_dir == snapshot
+        assert _local_snapshot_if_cached(repo) == str(snapshot)
 
         server.load_model(alias)
 

--- a/tests/test_chat_template_registry.py
+++ b/tests/test_chat_template_registry.py
@@ -392,6 +392,10 @@ async def test_dynamic_residency_preserves_profile_contract_for_local_path(
             pass
 
     monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(
+        server, "resolve_serving_lane", lambda _name, **_kwargs: (False, False)
+    )
 
     await server._load_dynamic_resident_model(
         "gemma-4-e2b-4bit",

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -20,8 +20,10 @@ MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
 # `chat-depth` requires all five turns to be simultaneously realised in AX.
 # The hosted runner's 1024x681 app window virtualises the oldest messages, so
 # that assertion is valid on larger local displays but false by construction in
-# CI. Keep this exception exact: any additional omission is accidental.
-CI_EXCLUSIONS = {"chat-depth"}
+# CI. The rc2 state-upgrade journey was added during the release window and is
+# verified locally on Studio; hosted dictation-shard gating is tracked in
+# #2365. Keep both exceptions exact: any additional omission is accidental.
+CI_EXCLUSIONS = {"chat-depth", "dictation-rc2-upgrade"}
 
 
 def harness_flows() -> set[str]:

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -126,6 +126,7 @@ def test_peekaboo_requirement_is_default_deny():
         "chat-multimodal-attachments",
         "image-generation",
         "dictation",
+        "dictation-rc2-upgrade",
         "audio-readiness",
         "window-close-prompt",
         "resident-load-rejected",

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -293,6 +293,73 @@ def test_cached_metadata_returns_none_without_any_cached_metadata(monkeypatch):
     assert metadata.read_cached_model_metadata("publisher/model") is None
 
 
+def test_unreferenced_single_complete_snapshot_is_resolved_offline(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshot = repo_root / "snapshots" / "immutable-revision"
+    snapshot.mkdir(parents=True)
+    _write_json(snapshot / "config.json", {"model_type": "qwen3_5"})
+    (snapshot / "model.safetensors").write_bytes(b"complete")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    result = metadata.read_cached_model_metadata("publisher/model")
+
+    assert result is not None
+    assert result.snapshot_dir == snapshot
+    assert result.config == {"model_type": "qwen3_5"}
+
+
+def test_unreferenced_snapshot_fails_closed_when_partial_or_ambiguous(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshots = repo_root / "snapshots"
+    partial = snapshots / "partial"
+    partial.mkdir(parents=True)
+    _write_json(partial / "config.json", {"model_type": "qwen3_5"})
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert metadata.resolve_unreferenced_cached_snapshot("publisher/model") is None
+
+    (partial / "model.safetensors").write_bytes(b"complete")
+    second = snapshots / "second"
+    second.mkdir()
+    _write_json(second / "config.json", {"model_type": "qwen3_5"})
+    (second / "model.safetensors").write_bytes(b"complete")
+
+    assert metadata.resolve_unreferenced_cached_snapshot("publisher/model") is None
+
+
+def test_unreferenced_snapshot_does_not_override_existing_main_ref(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshot = repo_root / "snapshots" / "other-revision"
+    snapshot.mkdir(parents=True)
+    _write_json(snapshot / "config.json", {"model_type": "qwen3_5"})
+    (snapshot / "model.safetensors").write_bytes(b"complete")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("missing-revision", encoding="utf-8")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert metadata.resolve_unreferenced_cached_snapshot("publisher/model") is None
+
+
+def test_unreferenced_snapshot_rejects_weight_link_outside_repo(monkeypatch, tmp_path):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshot = repo_root / "snapshots" / "immutable-revision"
+    snapshot.mkdir(parents=True)
+    _write_json(snapshot / "config.json", {"model_type": "qwen3_5"})
+    outside = tmp_path / "outside-model.safetensors"
+    outside.write_bytes(b"complete")
+    (snapshot / "model.safetensors").symlink_to(outside)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert metadata.resolve_unreferenced_cached_snapshot("publisher/model") is None
+
+
 def test_read_model_metadata_prefers_local_directory_then_cache(monkeypatch, tmp_path):
     local = metadata.ModelMetadata({}, "local", tmp_path)
     cached = metadata.ModelMetadata({}, "cached", tmp_path)

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -646,11 +646,19 @@ def test_launch_auto_start_defers_to_first_run_surfaces():
     # once the answer lands. A bare `.task` fires once, which would strand a
     # returning user on an idle server for the whole session.
     assert (
-        ".task(id: telemetryConsentPending) { await runLaunchAutoStart() }" in caller
+        ".task(id: telemetryConsentPending) { await restorePersistedSession() }"
+        in caller
     ), (
         "the launch task is no longer keyed on the consent decision. With a "
         "bare `.task` the auto-start that stood down for the consent sheet "
         "never gets its turn, and a returning user's model never loads"
+    )
+    restore = caller.split("private func restorePersistedSession(", 1)[1].split(
+        "private func runLaunchAutoStart(", 1
+    )[0]
+    assert "runLaunchAutoStart(" in restore, (
+        "the consent-keyed session restore no longer reaches launch auto-start; "
+        "answering consent would re-run restore without loading the user's model"
     )
 
     # And the gates must sit above the serverState switch: below it they can

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -92,6 +92,7 @@ async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
     assert scheduler.enable_prefix_cache is True
     assert scheduler.hybrid_cache_entries == 8
     assert scheduler.non_trimmable_exact_prefix_reuse is True
+    await residency_activity_contract()
 
 
 @pytest.mark.asyncio
@@ -425,6 +426,44 @@ def residency_activity_contract():
     chat = next(item for item in manager.snapshot()["models"] if item["id"] == "chat")
     assert chat["active_requests"] == 2
 
+    async def exercise_reload_identity() -> None:
+        reload_registry = ModelRegistry()
+        reload_primary = entry("reload-chat")
+        reload_primary.aliases.add("reload-alias")
+        reload_registry.add(reload_primary, is_default=True)
+
+        async def loader(name: str, path: str | None, performance=None):
+            if performance == ResidentPerformanceConfig(kv_cache_dtype="int4"):
+                raise RuntimeError("new config failed")
+            return entry(name)
+
+        reload_manager = ResidentModelManager(
+            reload_registry,
+            loader,
+            memory_reader=lambda: 0,
+        )
+        reload_manager.register_primary(reload_primary, estimated_bytes=1 * GIB)
+        replacement = await reload_manager.load(
+            "reload-alias",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int8"),
+            reload_if_changed=True,
+        )
+        assert replacement.entry.aliases == {"reload-alias"}
+
+        try:
+            await reload_manager.load(
+                "reload-alias",
+                performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+                reload_if_changed=True,
+            )
+        except RuntimeError as exc:
+            assert str(exc) == "new config failed"
+        else:
+            raise AssertionError("failed reload must surface its loader error")
+        assert reload_registry.get_entry("reload-alias").aliases == {"reload-alias"}
+
+    return exercise_reload_identity
+
 
 @pytest.mark.asyncio
 async def test_accounting_reserves_lazy_model_estimates_and_tracks_larger_actual_usage():
@@ -678,10 +717,77 @@ async def test_per_model_performance_reload_replaces_only_the_target_engine():
     }
 
 
+def test_performance_reload_preserves_alias_in_routing_and_models_list(monkeypatch):
+    from vllm_mlx.config import get_config, reset_config
+    from vllm_mlx.routes import models as models_route
+    from vllm_mlx.routes import residency as residency_route
+
+    repo = "mlx-community/Qwen3-0.6B-4bit"
+    alias = "qwen3-0.6b-4bit"
+    registry = ModelRegistry()
+    primary = ModelEntry(
+        engine=FakeEngine(),
+        model_name=repo,
+        model_path=repo,
+        aliases={alias},
+    )
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return ModelEntry(
+            engine=FakeEngine(),
+            model_name=name,
+            model_path=path or name,
+        )
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=1 * GIB)
+
+    reset_config()
+    cfg = get_config()
+    cfg.model_registry = registry
+    cfg.residency_manager = manager
+    cfg.api_key = None
+    cfg.embedding_model_locked = None
+    app = FastAPI()
+    app.include_router(residency_route.router)
+    app.include_router(models_route.router)
+    monkeypatch.setattr(
+        residency_route,
+        "resolve_resident_performance",
+        lambda performance, **_kwargs: performance,
+    )
+    try:
+        with TestClient(app) as client:
+            reload_response = client.post(
+                "/v1/models/load",
+                json={
+                    "model": alias,
+                    "model_path": repo,
+                    "reload_if_changed": True,
+                    "performance": {"kv_cache_dtype": "int8"},
+                },
+            )
+            assert reload_response.status_code == 200
+            replacement = registry.get_entry(alias)
+            assert replacement.model_name == repo
+            assert replacement.model_path == repo
+            assert replacement.aliases == {alias}
+            registry.validate_model_name(alias)
+            assert registry.get_engine(alias) is replacement.engine
+            response = client.get("/v1/models")
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["data"]}
+        assert {repo, alias}.issubset(ids)
+    finally:
+        reset_config()
+
+
 @pytest.mark.asyncio
 async def test_failed_performance_reload_restores_the_last_known_good_engine():
     registry = ModelRegistry()
     primary = entry("chat")
+    primary.aliases.add("chat-alias")
     registry.add(primary, is_default=True)
     calls: list[ResidentPerformanceConfig | None] = []
 
@@ -703,6 +809,8 @@ async def test_failed_performance_reload_restores_the_last_known_good_engine():
 
     assert calls == [ResidentPerformanceConfig(kv_cache_dtype="int4"), None]
     assert "chat" in registry
+    assert registry.get_engine("chat-alias") is registry.get_engine("chat")
+    assert registry.get_entry("chat").aliases == {"chat-alias"}
     assert registry.get_engine("chat") is not primary.engine
     assert manager.snapshot()["models"][0]["performance"] is None
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -72,6 +72,10 @@ async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
             pass
 
     monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(
+        server, "resolve_serving_lane", lambda _name, **_kwargs: (False, True)
+    )
     monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
     monkeypatch.setattr(
         "vllm_mlx.model_auto_config.detect_model_config",
@@ -112,6 +116,10 @@ async def test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero(
             pass
 
     monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(
+        server, "resolve_serving_lane", lambda _name, **_kwargs: (False, True)
+    )
     monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
     monkeypatch.setattr(
         "vllm_mlx.model_auto_config.detect_model_config",
@@ -156,6 +164,10 @@ async def test_dynamic_resident_full_attention_stays_unbounded(
             pass
 
     monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(
+        server, "resolve_serving_lane", lambda _name, **_kwargs: (False, False)
+    )
     monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
     monkeypatch.setattr(
         "vllm_mlx.model_auto_config.detect_model_config",
@@ -167,6 +179,157 @@ async def test_dynamic_resident_full_attention_stays_unbounded(
     scheduler = captured["scheduler_config"]
     assert scheduler.hybrid_cache_entries == 0
     assert scheduler.non_trimmable_exact_prefix_reuse is False
+
+
+@pytest.mark.asyncio
+async def test_dynamic_resident_loads_singleton_no_refs_snapshot_offline(
+    monkeypatch, tmp_path, scheduler_config_stub
+):
+    """A commit-pinned catalog snapshot is the runtime load path without main."""
+    import json
+
+    import huggingface_hub
+
+    from vllm_mlx import server
+
+    repo = "mlx-community/Qwen3.5-2B-MLX-4bit"
+    revision = "93760be4f1f69842a46bc13dbdc0f19e291392a3"
+    snapshot = (
+        tmp_path
+        / "hub"
+        / "models--mlx-community--Qwen3.5-2B-MLX-4bit"
+        / "snapshots"
+        / revision
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "model_type": "qwen3_5",
+                "vision_config": {"model_type": "qwen3_5_vision"},
+                "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "layer_types": ["linear_attention", "full_attention"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (snapshot / "model.safetensors").write_bytes(b"complete")
+    (snapshot / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "language_model.layers.0.weight": "model.safetensors",
+                    "vision_tower.blocks.0.weight": "model.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path / "hub")
+    )
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+
+    def fail_on_network(_name):
+        raise AssertionError("singleton snapshot must never need the network")
+
+    monkeypatch.setattr("vllm_mlx.cli._ensure_model_downloaded", fail_on_network)
+    captured = {}
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+
+    entry = await server._load_dynamic_resident_model("qwen3.5-2b-4bit", repo)
+
+    assert entry.model_path == repo
+    assert captured["model_name"] == str(snapshot)
+    assert captured["force_text"] is True
+
+
+@pytest.mark.asyncio
+async def test_dynamic_switch_restores_hybrid_text_lane(
+    monkeypatch, tmp_path, scheduler_config_stub
+):
+    """A large hybrid checkpoint keeps its lane after a small-model switch."""
+    import json
+
+    from vllm_mlx import server
+
+    large = tmp_path / "qwen35-9b"
+    small = tmp_path / "qwen3-06b"
+    for path in (large, small):
+        path.mkdir()
+        (path / "model.safetensors").write_bytes(b"complete")
+    (large / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "vision_config": {"model_type": "qwen3_5_vision"},
+                "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "layer_types": ["linear_attention", "full_attention"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (large / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "language_model.layers.0.weight": "model.safetensors",
+                    "vision_tower.blocks.0.weight": "model.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (small / "config.json").write_text(
+        json.dumps({"architectures": ["Qwen3ForCausalLM"], "model_type": "qwen3"}),
+        encoding="utf-8",
+    )
+    constructed = []
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+
+    await server._load_dynamic_resident_model("large", str(large))
+    await server._load_dynamic_resident_model("small", str(small))
+    await server._load_dynamic_resident_model("large", str(large))
+
+    assert [item["model_name"] for item in constructed] == [
+        str(large),
+        str(small),
+        str(large),
+    ]
+    assert [item["force_text"] for item in constructed] == [True, False, True]
 
 
 class FakeEngine:

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -47,7 +47,11 @@ def test_resident_performance_maps_to_the_scheduler_contract():
     ],
 )
 async def test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse(
-    monkeypatch, scheduler_config_stub, model_name, model_path
+    monkeypatch,
+    scheduler_config_stub,
+    residency_activity_contract,
+    model_name,
+    model_path,
 ):
     """Runtime residency must consume the same architecture truth as serve."""
     from vllm_mlx import server
@@ -226,6 +230,37 @@ def manager_fixture(*, limit_gib=10, ttl=0):
     )
     manager.register_primary(primary, estimated_bytes=4 * GIB)
     return manager, registry, loaded, clock
+
+
+@pytest.fixture
+def residency_activity_contract():
+    """Exercise the activity SSOT from the MLX-free Linux fixed selector."""
+    from vllm_mlx.runtime.resident_models import _engine_active_requests
+
+    class ProgressEngine:
+        def progress_snapshot(self):
+            return {"running": True}
+
+    assert _engine_active_requests(ProgressEngine()) == 1
+
+    class BrokenProgressEngine:
+        def progress_snapshot(self):
+            raise RuntimeError("progress unavailable")
+
+    assert _engine_active_requests(BrokenProgressEngine()) is None
+
+    class BrokenStatsEngine:
+        def get_stats(self):
+            raise RuntimeError("stats unavailable")
+
+    assert _engine_active_requests(BrokenStatsEngine()) is None
+
+    manager, registry, _, _ = manager_fixture(limit_gib=12)
+    primary = registry.get_engine("chat")
+    primary.running = 1
+    primary.waiting = 1
+    chat = next(item for item in manager.snapshot()["models"] if item["id"] == "chat")
+    assert chat["active_requests"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -171,9 +171,10 @@ class FakeEngine:
     def __init__(self) -> None:
         self.stopped = False
         self.running = 0
+        self.waiting = 0
 
     def get_stats(self):
-        return {"num_running": self.running, "num_waiting": 0}
+        return {"num_running": self.running, "num_waiting": self.waiting}
 
     async def stop(self) -> None:
         self.stopped = True
@@ -428,6 +429,8 @@ async def test_second_image_model_evicts_the_first_without_an_explicit_group():
 async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     registry.get_engine("chat").running = 1
+    chat = next(item for item in manager.snapshot()["models"] if item["id"] == "chat")
+    assert chat["active_requests"] == 1
 
     with pytest.raises(ResidentModelBusyError, match="active request"):
         await manager.load(
@@ -581,6 +584,31 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         )
         assert client.delete("/v1/models/image").status_code == 204
         assert "image" not in registry
+
+
+def test_residency_snapshot_reports_primary_running_and_queued_requests(monkeypatch):
+    """Primary requests bypass manager leases but still belong in residency."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, _, _ = manager_fixture(limit_gib=12)
+    primary = registry.get_engine("chat")
+    primary.running = 1
+    primary.waiting = 1
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.get("/v1/models/residency")
+
+    assert response.status_code == 200
+    chat = next(item for item in response.json()["models"] if item["id"] == "chat")
+    assert chat["active_requests"] == 2
 
 
 def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -42,6 +42,12 @@ class _StubEngine:
         self.args = args
         self.kwargs = kwargs
 
+    async def start(self):
+        pass
+
+    def generate_warmup(self):
+        pass
+
 
 @pytest.fixture(autouse=True)
 def _reset_cfg_around_each_test():
@@ -169,6 +175,52 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     # No downgrade → force_text stays False; BatchedEngine does its own MLLM
     # auto-detection from there.
     assert server._engine.kwargs.get("force_text") is False
+
+
+@pytest.mark.asyncio
+async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(monkeypatch):
+    """Startup and residency must hand the same resolved path/lane to engine."""
+    from vllm_mlx import server
+    from vllm_mlx.model_profile import ModelProfile
+
+    _stub_routing_globals(monkeypatch, server)
+    calls = []
+    resolved = server._ServingCheckpoint(
+        model_path="publisher/model",
+        load_path="/cache/snapshots/revision",
+        auto_text_fallback=True,
+    )
+
+    def resolve_once(model_name, **kwargs):
+        calls.append((model_name, kwargs))
+        return resolved
+
+    monkeypatch.setattr(server, "_resolve_serving_checkpoint", resolve_once)
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config",
+        lambda _name: ModelProfile(is_hybrid=False),
+    )
+
+    server.load_model("publisher/model")
+    startup_kwargs = dict(server._engine.kwargs)
+    runtime = await server._load_dynamic_resident_model("publisher/model", None)
+
+    assert calls == [
+        (
+            "publisher/model",
+            {
+                "force_mllm": False,
+                "force_text": False,
+            },
+        ),
+        (
+            "publisher/model",
+            {"force_text": False},
+        ),
+    ]
+    assert startup_kwargs["model_name"] == runtime.engine.kwargs["model_name"]
+    assert startup_kwargs["force_text"] == runtime.engine.kwargs["force_text"] is True
 
 
 def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeypatch):

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -208,6 +208,70 @@ def _cached_file(model_name: str, filename: str) -> Path | None:
     return Path(cached)
 
 
+def resolve_unreferenced_cached_snapshot(model_name: str) -> Path | None:
+    """Return one complete cached checkpoint when no Hub ref resolves it.
+
+    ``snapshot_download(..., revision=<commit>)`` materializes
+    ``snapshots/<commit>/`` but intentionally does not update ``refs/main``.
+    That is the exact shape produced by an immutable catalog download.  The
+    normal ``try_to_load_from_cache`` lookup therefore cannot see the files,
+    even though the selected checkpoint is complete and directly loadable.
+
+    This fallback is deliberately narrow: there must be exactly one snapshot
+    directory, it must contain a valid config and a complete mlx-lm checkpoint,
+    and the checkpoint files must stay inside that repository's cache root.
+    Multiple revisions are ambiguous and return ``None``; callers then retain
+    the normal online/default-ref behavior instead of guessing which revision
+    the user intended.
+    """
+    if not _looks_like_hub_repo_id(model_name):
+        return None
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        from ._download_gate import _snapshot_is_complete
+        from .model_aliases import checkpoint_prefix
+
+        repo_root = Path(HF_HUB_CACHE) / ("models--" + model_name.replace("/", "--"))
+        # This path is only for commit-pinned downloads that deliberately do
+        # not publish a default ref. If ``main`` exists, the Hub resolver owns
+        # revision selection and we must never substitute a different snapshot.
+        if os.path.lexists(repo_root / "refs" / "main"):
+            return None
+        snapshots_root = repo_root / "snapshots"
+        if snapshots_root.is_symlink() or not snapshots_root.is_dir():
+            return None
+        candidates = [
+            entry
+            for entry in snapshots_root.iterdir()
+            if entry.is_dir() and not entry.is_symlink()
+        ]
+        if len(candidates) != 1:
+            return None
+        checkpoint = candidates[0] / checkpoint_prefix(model_name)
+        if checkpoint.is_symlink() or not checkpoint.is_dir():
+            return None
+        config_path = checkpoint / "config.json"
+
+        # HF snapshot leaves normally symlink into this repository's own
+        # ``blobs`` directory. Reject a fabricated snapshot whose config or
+        # weight links escape the repository cache root before opening them.
+        repo_real = repo_root.resolve(strict=True)
+        inspected = [config_path, *checkpoint.glob("model*.safetensors")]
+        index_path = checkpoint / "model.safetensors.index.json"
+        if index_path.exists():
+            inspected.append(index_path)
+        for path in inspected:
+            path.resolve(strict=True).relative_to(repo_real)
+        if _read_json(config_path) is None or not _snapshot_is_complete(
+            str(checkpoint)
+        ):
+            return None
+        return checkpoint
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+
+
 def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
     """Read metadata for a cached HF repository, never triggering download.
 
@@ -228,6 +292,8 @@ def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
     if snapshot_dir is None:
         tokenizer_path = _cached_file(model_name, f"{prefix}tokenizer_config.json")
         snapshot_dir = tokenizer_path.parent if tokenizer_path is not None else None
+    if snapshot_dir is None:
+        snapshot_dir = resolve_unreferenced_cached_snapshot(model_name)
     if snapshot_dir is None:
         return None
     return ModelMetadata(

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -138,6 +138,14 @@ def resolve_resident_performance(
     )
 
 
+def _carry_served_identity(entry: ModelEntry, prior: ModelEntry) -> ModelEntry:
+    """Attach the exact pre-reload routing identity to a rebuilt engine."""
+    entry.model_name = prior.model_name
+    entry.model_path = prior.model_path
+    entry.aliases = set(prior.aliases)
+    return entry
+
+
 @dataclass
 class ResidencyRecord:
     """Mutable lifecycle metadata kept outside the route-facing registry entry."""
@@ -620,7 +628,10 @@ class ResidentModelManager:
 
         before = self._read_memory()
         try:
-            entry = await self.loader(model_name, model_path, performance)
+            entry = _carry_served_identity(
+                await self.loader(model_name, model_path, performance),
+                record.entry,
+            )
         except BaseException as reload_error:
             # The old engine has already released its Metal allocations so the
             # replacement can fit under the same budget. Best-effort restore
@@ -679,10 +690,13 @@ class ResidentModelManager:
 
         restored_entry = None
         try:
-            restored_entry = await self.loader(
-                record.model_id,
-                record.entry.model_path,
-                record.performance,
+            restored_entry = _carry_served_identity(
+                await self.loader(
+                    record.model_id,
+                    record.entry.model_path,
+                    record.performance,
+                ),
+                record.entry,
             )
             restored = ResidencyRecord(
                 entry=restored_entry,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -272,28 +272,42 @@ def estimate_model_bytes(model_name: str) -> int:
     return int((largest * bytes_per_param + 1.2 + kv_gib) * _GIB)
 
 
-def _engine_is_idle(engine: object) -> bool:
-    """Best-effort idle check shared by explicit, LRU, and TTL eviction."""
+def _engine_active_requests(engine: object) -> int | None:
+    """Return the engine's running plus queued request count.
+
+    ``ResidencyRecord.active_requests`` covers manager leases, but the primary
+    startup engine is reached directly through the model registry. Its live
+    text/VLM requests therefore exist only in the engine scheduler. Return
+    ``None`` when an exposed activity probe fails so destructive lifecycle
+    guards keep their existing fail-closed behavior.
+    """
+
+    active = 0
 
     progress = getattr(engine, "progress_snapshot", None)
     if callable(progress):
         try:
             if bool(progress().get("running", False)):
-                return False
+                active = 1
         except Exception:
-            return False
+            return None
 
     get_stats = getattr(engine, "get_stats", None)
     if callable(get_stats):
         try:
             stats = get_stats() or {}
-            if int(stats.get("num_running", 0) or 0) > 0:
-                return False
-            if int(stats.get("num_waiting", 0) or 0) > 0:
-                return False
+            running = max(0, int(stats.get("num_running", 0) or 0))
+            waiting = max(0, int(stats.get("num_waiting", 0) or 0))
+            active = max(active, running + waiting)
         except Exception:
-            return False
-    return True
+            return None
+    return active
+
+
+def _engine_is_idle(engine: object) -> bool:
+    """Best-effort idle check shared by explicit, LRU, and TTL eviction."""
+
+    return _engine_active_requests(engine) == 0
 
 
 def _release_allocator_cache() -> None:
@@ -841,6 +855,7 @@ class ResidentModelManager:
         for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
+            engine_active = _engine_active_requests(engine)
             models.append(
                 {
                     "id": record.model_id,
@@ -850,7 +865,14 @@ class ResidentModelManager:
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,
-                    "active_requests": record.active_requests,
+                    # A manager lease and a scheduler request describe
+                    # overlapping lifetimes for dynamic engines, so use the
+                    # larger count rather than double-counting. Primary traffic
+                    # has no manager lease and is supplied by the scheduler.
+                    "active_requests": max(
+                        record.active_requests,
+                        engine_active if engine_active is not None else 0,
+                    ),
                     "estimated_bytes": record.estimated_bytes,
                     "measured_bytes": record.measured_bytes or None,
                     "idle_seconds": max(0.0, now - record.last_used_at),

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1703,6 +1703,53 @@ def _ensure_routing_config(model_name: str) -> None:
         )
 
 
+@dataclass(frozen=True)
+class _ServingCheckpoint:
+    """One resolved checkpoint identity and the path the engine must load."""
+
+    model_path: str
+    load_path: str
+    auto_text_fallback: bool
+
+
+def _resolve_serving_checkpoint(
+    model_name: str,
+    *,
+    force_mllm: bool = False,
+    force_text: bool = False,
+) -> _ServingCheckpoint:
+    """Resolve alias, local checkpoint, and serving lane as one contract.
+
+    Both startup and runtime residency must route and load the same checkpoint.
+    In particular, a commit-pinned Hub download may have one complete snapshot
+    but no ``refs/main``; metadata resolution can identify that snapshot, and
+    the engine must receive that local path rather than retrying the repo id.
+    """
+    from .model_aliases import resolve_model
+
+    model_path = resolve_model(model_name)
+    if not force_mllm and not force_text:
+        _ensure_routing_config(model_path)
+    from .model_metadata import read_model_metadata
+
+    metadata = read_model_metadata(model_path)
+    load_path = (
+        str(metadata.snapshot_dir)
+        if metadata is not None and metadata.snapshot_dir is not None
+        else model_path
+    )
+    _, auto_text_fallback = resolve_serving_lane(
+        load_path,
+        force_mllm=force_mllm,
+        force_text=force_text,
+    )
+    return _ServingCheckpoint(
+        model_path=model_path,
+        load_path=load_path,
+        auto_text_fallback=auto_text_fallback,
+    )
+
+
 def load_model(
     model_name: str,
     scheduler_config=None,
@@ -1989,30 +2036,34 @@ def load_model(
     # ``z-image-turbo`` alias could never start: a fully-cached 5.5 GB
     # checkpoint refused with an error about hybrid-VLM misrouting, a hazard
     # that does not exist for a diffusion model.
-    _auto_text_fallback = False
     _is_generative_media = _profile is not None and _profile.modality in (
         "image-gen",
         "video-gen",
     )
-    if not force_text and not force_mllm and not _is_generative_media:
-        _ensure_routing_config(model_name)
-        _lane_is_mllm, _auto_text_fallback = resolve_serving_lane(
-            model_name, force_mllm=force_mllm, force_text=force_text
+    _engine_model_path = model_name
+    _auto_text_fallback = False
+    if not _is_generative_media:
+        _serving_checkpoint = _resolve_serving_checkpoint(
+            model_name,
+            force_mllm=force_mllm,
+            force_text=force_text,
         )
-        if _auto_text_fallback:
-            logger.info(
-                "Model %r auto-downgraded to the text-only mlx-lm lane for "
-                "full batched throughput: it is a multimodal checkpoint whose "
-                "language backbone the MLLM continuous-batching engine cannot "
-                "batch — either hybrid/linear-attention (GatedDeltaNet: "
-                "Qwen3.5/3.6/3.8) or a vision architecture the installed "
-                "mlx-vlm cannot drive yet (e.g. muse_glimmer, served via the "
-                "vendored text backbone). Pass --mllm to serve vision: a "
-                "hybrid backbone runs a serialized one-request-at-a-time lane "
-                "(#1798); an unsupported arch errors instead. Pass --no-mllm "
-                "to silence this notice.",
-                model_name,
-            )
+        _engine_model_path = _serving_checkpoint.load_path
+        _auto_text_fallback = _serving_checkpoint.auto_text_fallback
+    if _auto_text_fallback:
+        logger.info(
+            "Model %r auto-downgraded to the text-only mlx-lm lane for "
+            "full batched throughput: it is a multimodal checkpoint whose "
+            "language backbone the MLLM continuous-batching engine cannot "
+            "batch — either hybrid/linear-attention (GatedDeltaNet: "
+            "Qwen3.5/3.6/3.8) or a vision architecture the installed "
+            "mlx-vlm cannot drive yet (e.g. muse_glimmer, served via the "
+            "vendored text backbone). Pass --mllm to serve vision: a "
+            "hybrid backbone runs a serialized one-request-at-a-time lane "
+            "(#1798); an unsupported arch errors instead. Pass --no-mllm "
+            "to silence this notice.",
+            model_name,
+        )
 
     try:
         gen_cfg = load_generation_config_sampling(model_name)
@@ -2131,7 +2182,7 @@ def load_model(
     else:
         logger.info(f"Loading model with BatchedEngine: {model_name}")
         _engine = BatchedEngine(
-            model_name=model_name,
+            model_name=_engine_model_path,
             chat_template_id=(
                 _profile.chat_template_id if _profile is not None else None
             ),
@@ -2284,20 +2335,33 @@ async def _load_dynamic_resident_model(
 ) -> ModelEntry:
     """Construct and start one non-primary engine for the residency manager."""
 
-    from .model_aliases import resolve_profile
+    from .model_aliases import resolve_model, resolve_profile
 
     profile = resolve_profile(model_name) or (
         resolve_profile(model_path) if model_path else None
     )
-    resolved_path = model_path or (
-        profile.hf_path if profile is not None else model_name
+    resolved_path = resolve_model(
+        model_path or (profile.hf_path if profile is not None else model_name)
     )
+    modality = profile.modality if profile is not None else "text"
+    profile_force_text = bool(profile is not None and profile.is_text_only)
+    load_path = resolved_path
+    effective_force_text = profile_force_text
+    if modality == "text":
+        serving_checkpoint = _resolve_serving_checkpoint(
+            resolved_path,
+            force_text=profile_force_text,
+        )
+        resolved_path = serving_checkpoint.model_path
+        load_path = serving_checkpoint.load_path
+        effective_force_text = (
+            profile_force_text or serving_checkpoint.auto_text_fallback
+        )
     model_config = profile
     if model_config is None:
         from .model_auto_config import detect_model_config
 
-        model_config = detect_model_config(resolved_path)
-    modality = profile.modality if profile is not None else "text"
+        model_config = detect_model_config(load_path)
 
     if modality == "image-gen":
         from .runtime.image_lane import ImageEngine
@@ -2336,24 +2400,24 @@ async def _load_dynamic_resident_model(
             enable_prefix_cache=enable_prefix_cache,
             explicit_value=0,
             user_set_explicit=False,
-            model_name=resolved_path,
+            model_name=load_path,
             model_config=model_config,
         )
         scheduler_kwargs["hybrid_cache_entries"] = hybrid_cache_entries
         scheduler_kwargs["non_trimmable_exact_prefix_reuse"] = (
             hybrid_cache_entries > 0
             and _needs_bounded_trim_free_reuse(
-                resolved_path,
+                load_path,
                 model_config=model_config,
             )
         )
 
         engine = BatchedEngine(
-            model_name=resolved_path,
+            model_name=load_path,
             chat_template_id=(
                 profile.chat_template_id if profile is not None else None
             ),
-            force_text=bool(profile is not None and profile.is_text_only),
+            force_text=effective_force_text,
             gpu_memory_utilization=_resident_gpu_memory_utilization,
             scheduler_config=SchedulerConfig(**scheduler_kwargs),
         )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1895,7 +1895,7 @@ def load_model(
     _default_max_tokens_is_explicit = max_tokens_is_explicit
     _model_alias = effective_model_alias
     _model_path = model_name
-    _model_name = served_model_name or requested_model_name
+    _model_name = served_model_name or model_name
     _tool_parser_instance = None
 
     # Populate the sampling overlays now that we know which model we're

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -947,9 +947,11 @@ def _local_snapshot_if_cached(model_name: str) -> str:
     """
     try:
         from .._download_gate import is_repo_cached
+        from ..model_metadata import resolve_unreferenced_cached_snapshot
 
         if not is_repo_cached(model_name):
-            return model_name
+            snapshot = resolve_unreferenced_cached_snapshot(model_name)
+            return str(snapshot) if snapshot is not None else model_name
     except Exception:
         return model_name
     try:


### PR DESCRIPTION
## Release intention

Cut Rapid-MLX 0.13.0 from the frozen, fully validated final integration commit `a8f507a0`.

## Scope

- Engine version: `0.13.0`.
- Desktop marketing version: `0.13.0`.
- Desktop build: `165`, monotonically above RC2 build 164.
- Archive curated `v0.13.0` release notes and reset the unreleased scratch file.

Non-goals: product behavior changes, release-workflow changes, manual tags, bypasses, or publication before exact-head gates pass.

## Evidence

- #2337 integrated #2331/#2334/#2335/#2336 with exact-head CI, all six GUI shards, Desktop aggregate, and PR validation green.
- Engine/Desktop version sync passes.
- Release-note builder contracts: 63/63 pass.
- Release subject validation and diff check pass.
- Exact-head release preflight, pr_validate, and full-ci are required before merge.

The squash subject must remain exactly `chore: bump version to 0.13.0` so the canonical protected auto-release workflow is the only publisher.

## Why now

The independently validated 0.13.0 fixes are frozen on main, and this dedicated transaction binds the final engine and Desktop artifacts to that exact source while preserving monotonic Desktop update ordering.