### PR TITLE
fix(mac): clarify system prompts and defer optional key access

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -2293,6 +2293,24 @@ final class ChatViewModel {
         return result
     }
 
+    /// Read-only preview of the Desktop-authored system prompt shared by
+    /// Settings and the per-conversation editor. It deliberately uses the
+    /// same assembly function as the wire path so displayed precedence and
+    /// automatic context cannot drift from what Rapid sends.
+    nonisolated static func effectiveSystemPrompt(
+        dateContext: String? = nil,
+        global: String,
+        conversation: String
+    ) -> String {
+        addingInstructionLayers(
+            to: [],
+            ambientPreamble: nil,
+            dateContext: dateContext ?? currentDateTimeContext(),
+            global: global,
+            conversation: conversation
+        ).first?.content ?? ""
+    }
+
     /// Request-time current-date context for the leading system row, so a small
     /// model does not guess "today" from training memory (issue #2330, where
     /// `qwen3.5-4b-4bit` answered "Friday, May 24, 2024" and then insisted it

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -34,6 +34,7 @@ extension KeychainStoring {
 protocol KeychainItemAccessing: Sendable {
     func query(account: String, service: String) -> KeychainReadResult
     func upsert(account: String, service: String, secret: String) -> Bool
+    func remove(account: String, service: String) -> Bool
 }
 
 /// Security.framework adapter. Every lookup/update explicitly suppresses
@@ -92,6 +93,19 @@ struct SecurityKeychainItems: KeychainItemAccessing {
         addQuery[kSecValueData as String] = data
         addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+    }
+
+    func remove(account: String, service: String) -> Bool {
+        let authenticationContext = LAContext()
+        authenticationContext.interactionNotAllowed = true
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecUseAuthenticationContext as String: authenticationContext,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
     }
 }
 
@@ -197,10 +211,17 @@ struct SystemKeychain: KeychainStoring {
 
     @discardableResult
     func delete(account: String) -> Bool {
-        // Store an empty current-identity item instead of deleting outright.
-        // It is a non-secret tombstone that prevents a legacy or ACL-mismatched
-        // value from resurfacing on the next launch.
-        write(account: account, secret: "")
+        let services = [recoveryService, primaryService, legacyMigrationService].compactMap { $0 }
+        let removedEverywhere = services
+            .map { items.remove(account: account, service: $0) }
+            .allSatisfy { $0 }
+        if removedEverywhere { return true }
+
+        // A mismatched ACL can make an old item impossible to remove without a
+        // system prompt. Mask it for this app with a non-secret tombstone, but
+        // report failure so Settings never claims the stored secret was erased.
+        _ = write(account: account, secret: "")
+        return false
     }
 
     private struct SigningIdentity {

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 /// Minimal Keychain wrapper for storing per-provider API keys.
@@ -71,7 +72,12 @@ struct SecurityKeychainItems: KeychainItemAccessing {
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ]
         var updateQuery = baseQuery
-        updateQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        // `Skip` is a match-only option. For update, Security.framework's
+        // current contract is an LAContext that forbids interaction; this is
+        // the non-deprecated equivalent of kSecUseAuthenticationUIFail.
+        let authenticationContext = LAContext()
+        authenticationContext.interactionNotAllowed = true
+        updateQuery[kSecUseAuthenticationContext as String] = authenticationContext
         let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttrs as CFDictionary)
         if updateStatus == errSecSuccess { return true }
         if updateStatus != errSecItemNotFound { return false }

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -9,8 +9,25 @@ import Security
 /// access, leak across test runs, and require manual cleanup).
 protocol KeychainStoring: Sendable {
     func read(account: String) -> String?
+    func readWithoutUserInteraction(account: String) -> KeychainReadResult
     @discardableResult func write(account: String, secret: String) -> Bool
     @discardableResult func delete(account: String) -> Bool
+}
+
+enum KeychainReadResult: Equatable, Sendable {
+    case found(String)
+    case missing
+    case unavailable
+}
+
+extension KeychainStoring {
+    /// Test doubles and non-system stores do not have an authentication UI.
+    /// The real Keychain implementation overrides this with a query that
+    /// explicitly forbids macOS from presenting one.
+    func readWithoutUserInteraction(account: String) -> KeychainReadResult {
+        if let value = read(account: account) { return .found(value) }
+        return .missing
+    }
 }
 
 /// Real-system implementation. Each entry is a ``kSecClassGenericPassword``
@@ -29,24 +46,69 @@ protocol KeychainStoring: Sendable {
 /// readable only while the screen is unlocked and only on the
 /// originating Mac.
 struct SystemKeychain: KeychainStoring {
-    static let service = "com.rapidmlx.rapid.api-keys"
+    /// The original unscoped service is read-only migration input. Local
+    /// ad-hoc builds used the same service as notarized releases, so an item
+    /// they created could carry an ACL that did not trust the release binary.
+    private static let legacyService = "com.rapidmlx.rapid.api-keys"
+
+    /// Namespace new items by the signing team. Notarized builds from the same
+    /// team keep a stable service across releases; ad-hoc developer builds use
+    /// an isolated namespace and can no longer create an item that later asks
+    /// the release app for the login-keychain password.
+    private static let teamIdentifier = currentTeamIdentifier()
+
+    static let service: String = {
+        if let teamIdentifier {
+            return "\(legacyService).\(teamIdentifier)"
+        }
+        return "\(legacyService).development"
+    }()
 
     func read(account: String) -> String? {
+        guard case .found(let value) = readWithoutUserInteraction(account: account) else {
+            return nil
+        }
+        return value.isEmpty ? nil : value
+    }
+
+    func readWithoutUserInteraction(account: String) -> KeychainReadResult {
+        let current = query(account: account, service: Self.service)
+        switch current {
+        case .found:
+            // An empty current-team item is a tombstone created by delete().
+            // It deliberately masks a legacy value that this identity may not
+            // be able to remove without showing a system authorization dialog.
+            return current
+        case .unavailable:
+            return .unavailable
+        case .missing:
+            // Only a signed release identity may inspect the historical
+            // shared namespace. Development builds must never touch it.
+            guard Self.teamIdentifier != nil else { return .missing }
+            return query(account: account, service: Self.legacyService)
+        }
+    }
+
+    private func query(account: String, service: String) -> KeychainReadResult {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
+            kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
+            // A credential lookup must never summon a system password dialog.
+            // Settings presents an inline recovery state instead.
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
         ]
         var item: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return .missing }
         guard status == errSecSuccess,
               let data = item as? Data,
               let value = String(data: data, encoding: .utf8) else {
-            return nil
+            return .unavailable
         }
-        return value
+        return .found(value)
     }
 
     @discardableResult
@@ -67,7 +129,9 @@ struct SystemKeychain: KeychainStoring {
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ]
-        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttrs as CFDictionary)
+        var updateQuery = baseQuery
+        updateQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttrs as CFDictionary)
         if updateStatus == errSecSuccess { return true }
         if updateStatus != errSecItemNotFound { return false }
 
@@ -80,13 +144,26 @@ struct SystemKeychain: KeychainStoring {
 
     @discardableResult
     func delete(account: String) -> Bool {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account,
-        ]
-        let status = SecItemDelete(query as CFDictionary)
-        return status == errSecSuccess || status == errSecItemNotFound
+        // Store an empty current-team item instead of deleting outright. It is
+        // a non-secret tombstone that prevents a legacy ACL-mismatched value
+        // from resurfacing on the next launch, and it can be written without
+        // asking the user to authorize access to that legacy item.
+        write(account: account, secret: "")
+    }
+
+    private static func currentTeamIdentifier() -> String? {
+        guard let executableURL = Bundle.main.executableURL else { return nil }
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(executableURL as CFURL, [], &code) == errSecSuccess,
+              let code else { return nil }
+        var signingInfo: CFDictionary?
+        guard SecCodeCopySigningInformation(code, SecCSFlags(rawValue: kSecCSSigningInformation), &signingInfo) == errSecSuccess,
+              let info = signingInfo as? [String: Any],
+              let team = info[kSecCodeInfoTeamIdentifier as String] as? String,
+              !team.isEmpty else {
+            return nil
+        }
+        return team
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -30,10 +30,63 @@ extension KeychainStoring {
     }
 }
 
+protocol KeychainItemAccessing: Sendable {
+    func query(account: String, service: String) -> KeychainReadResult
+    func upsert(account: String, service: String, secret: String) -> Bool
+}
+
+/// Security.framework adapter. Every lookup/update explicitly suppresses
+/// authentication UI; an authorization failure is state for the app to
+/// explain, never permission for SecurityAgent to interrupt the user.
+struct SecurityKeychainItems: KeychainItemAccessing {
+    func query(account: String, service: String) -> KeychainReadResult {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+        ]
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return .missing }
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return .unavailable
+        }
+        return .found(value)
+    }
+
+    func upsert(account: String, service: String, secret: String) -> Bool {
+        guard let data = secret.data(using: .utf8) else { return false }
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let updateAttrs: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+        var updateQuery = baseQuery
+        updateQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttrs as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+        if updateStatus != errSecItemNotFound { return false }
+
+        var addQuery = baseQuery
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+    }
+}
+
 /// Real-system implementation. Each entry is a ``kSecClassGenericPassword``
-/// keyed by ``service = SystemKeychain.service`` + ``account``. We
-/// use the generic-password class (not internet-password) because
-/// Brave/Tavily keys are static credentials, not per-URL secrets.
+/// keyed by a code-identity-scoped service + provider account. We use the
+/// generic-password class (not internet-password) because provider keys are
+/// static credentials, not per-URL secrets.
 ///
 /// Codex audit batch 6 finding (KeychainStore.swift:63, P2):
 /// access policy is ``kSecAttrAccessibleWhenUnlockedThisDeviceOnly``.
@@ -51,18 +104,36 @@ struct SystemKeychain: KeychainStoring {
     /// they created could carry an ACL that did not trust the release binary.
     private static let legacyService = "com.rapidmlx.rapid.api-keys"
 
-    /// Namespace new items by the signing team. Notarized builds from the same
-    /// team keep a stable service across releases; ad-hoc developer builds use
-    /// an isolated namespace and can no longer create an item that later asks
-    /// the release app for the login-keychain password.
-    private static let teamIdentifier = currentTeamIdentifier()
+    private static let signingIdentity = currentSigningIdentity()
+    static let service = serviceNamespace(
+        teamIdentifier: signingIdentity.teamIdentifier,
+        isDeveloperIDApplication: signingIdentity.isDeveloperIDApplication
+    )
 
-    static let service: String = {
-        if let teamIdentifier {
-            return "\(legacyService).\(teamIdentifier)"
-        }
-        return "\(legacyService).development"
-    }()
+    private let items: any KeychainItemAccessing
+    private let primaryService: String
+    private let legacyMigrationService: String?
+    private var recoveryService: String { "\(primaryService).recovery" }
+
+    init() {
+        items = SecurityKeychainItems()
+        primaryService = Self.service
+        // Apple Development and ad-hoc builds must never inspect production's
+        // historical namespace, even when they carry the same Team ID.
+        legacyMigrationService = Self.signingIdentity.isDeveloperIDApplication
+            ? Self.legacyService
+            : nil
+    }
+
+    init(
+        items: any KeychainItemAccessing,
+        primaryService: String,
+        legacyMigrationService: String? = nil
+    ) {
+        self.items = items
+        self.primaryService = primaryService
+        self.legacyMigrationService = legacyMigrationService
+    }
 
     func read(account: String) -> String? {
         guard case .found(let value) = readWithoutUserInteraction(account: account) else {
@@ -72,98 +143,91 @@ struct SystemKeychain: KeychainStoring {
     }
 
     func readWithoutUserInteraction(account: String) -> KeychainReadResult {
-        let current = query(account: account, service: Self.service)
-        switch current {
-        case .found:
-            // An empty current-team item is a tombstone created by delete().
-            // It deliberately masks a legacy value that this identity may not
-            // be able to remove without showing a system authorization dialog.
-            return current
-        case .unavailable:
-            return .unavailable
-        case .missing:
-            // Only a signed release identity may inspect the historical
-            // shared namespace. Development builds must never touch it.
-            guard Self.teamIdentifier != nil else { return .missing }
-            return query(account: account, service: Self.legacyService)
-        }
+        let recovery = items.query(account: account, service: recoveryService)
+        if recovery != .missing { return recovery }
+
+        let current = items.query(account: account, service: primaryService)
+        if current != .missing { return current }
+
+        guard let legacyMigrationService else { return .missing }
+        return items.query(account: account, service: legacyMigrationService)
     }
 
-    private func query(account: String, service: String) -> KeychainReadResult {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            // A credential lookup must never summon a system password dialog.
-            // Settings presents an inline recovery state instead.
-            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
-        ]
-        var item: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        if status == errSecItemNotFound { return .missing }
-        guard status == errSecSuccess,
-              let data = item as? Data,
-              let value = String(data: data, encoding: .utf8) else {
-            return .unavailable
+    static func serviceNamespace(
+        teamIdentifier: String?,
+        isDeveloperIDApplication: Bool
+    ) -> String {
+        guard isDeveloperIDApplication,
+              let teamIdentifier,
+              !teamIdentifier.isEmpty else {
+            return "\(legacyService).development"
         }
-        return .found(value)
+        return "\(legacyService).release.\(teamIdentifier)"
     }
 
     @discardableResult
     func write(account: String, secret: String) -> Bool {
-        guard let data = secret.data(using: .utf8) else { return false }
-        let baseQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account,
-        ]
-        // Try update first; if there's no existing item, fall
-        // through to add. This is the canonical pattern for
-        // "upsert" against the Keychain API. Update also bumps
-        // the accessibility class so a pre-existing item written
-        // with the prior (weaker) policy migrates forward on the
-        // first write.
-        let updateAttrs: [String: Any] = [
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-        ]
-        var updateQuery = baseQuery
-        updateQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttrs as CFDictionary)
-        if updateStatus == errSecSuccess { return true }
-        if updateStatus != errSecItemNotFound { return false }
-
-        var addQuery = baseQuery
-        addQuery[kSecValueData as String] = data
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        return addStatus == errSecSuccess
+        // Once a replacement slot exists it remains authoritative. Otherwise
+        // try the normal release-identity slot, then create the replacement
+        // slot if that update is denied by a stale/mismatched ACL.
+        switch items.query(account: account, service: recoveryService) {
+        case .found:
+            return items.upsert(account: account, service: recoveryService, secret: secret)
+        case .unavailable:
+            return false
+        case .missing:
+            if items.upsert(account: account, service: primaryService, secret: secret) {
+                return true
+            }
+            return items.upsert(account: account, service: recoveryService, secret: secret)
+        }
     }
 
     @discardableResult
     func delete(account: String) -> Bool {
-        // Store an empty current-team item instead of deleting outright. It is
-        // a non-secret tombstone that prevents a legacy ACL-mismatched value
-        // from resurfacing on the next launch, and it can be written without
-        // asking the user to authorize access to that legacy item.
+        // Store an empty current-identity item instead of deleting outright.
+        // It is a non-secret tombstone that prevents a legacy or ACL-mismatched
+        // value from resurfacing on the next launch.
         write(account: account, secret: "")
     }
 
-    private static func currentTeamIdentifier() -> String? {
-        guard let executableURL = Bundle.main.executableURL else { return nil }
+    private struct SigningIdentity {
+        let teamIdentifier: String?
+        let isDeveloperIDApplication: Bool
+    }
+
+    private static func currentSigningIdentity() -> SigningIdentity {
+        guard let executableURL = Bundle.main.executableURL else {
+            return SigningIdentity(teamIdentifier: nil, isDeveloperIDApplication: false)
+        }
         var code: SecStaticCode?
         guard SecStaticCodeCreateWithPath(executableURL as CFURL, [], &code) == errSecSuccess,
-              let code else { return nil }
+              let code else {
+            return SigningIdentity(teamIdentifier: nil, isDeveloperIDApplication: false)
+        }
         var signingInfo: CFDictionary?
         guard SecCodeCopySigningInformation(code, SecCSFlags(rawValue: kSecCSSigningInformation), &signingInfo) == errSecSuccess,
-              let info = signingInfo as? [String: Any],
-              let team = info[kSecCodeInfoTeamIdentifier as String] as? String,
-              !team.isEmpty else {
-            return nil
+              let info = signingInfo as? [String: Any] else {
+            return SigningIdentity(teamIdentifier: nil, isDeveloperIDApplication: false)
         }
-        return team
+        let team = info[kSecCodeInfoTeamIdentifier as String] as? String
+        let certificate = (info[kSecCodeInfoCertificates as String] as? [SecCertificate])?.first
+        return SigningIdentity(
+            teamIdentifier: team,
+            isDeveloperIDApplication: certificate.map { isDeveloperIDApplication($0) } ?? false
+        )
+    }
+
+    private static func isDeveloperIDApplication(_ certificate: SecCertificate) -> Bool {
+        // Apple's Developer ID Application certificate extension. Unlike an
+        // authority display name, the extension is a machine-readable signing
+        // contract and distinguishes release identities from Apple Development.
+        let developerIDApplicationOID = "1.2.840.113635.100.6.1.13" as CFString
+        return SecCertificateCopyValues(
+            certificate,
+            [developerIDApplicationOID] as CFArray,
+            nil
+        ) != nil
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -223,30 +223,34 @@ struct SystemKeychain: KeychainStoring {
             return SigningIdentity(teamIdentifier: nil, isDeveloperIDApplication: false)
         }
         let team = info[kSecCodeInfoTeamIdentifier as String] as? String
-        let certificate = (info[kSecCodeInfoCertificates as String] as? [SecCertificate])?.first
         return SigningIdentity(
             teamIdentifier: team,
-            isDeveloperIDApplication: certificate.map { isDeveloperIDApplication($0) } ?? false
+            isDeveloperIDApplication: isDeveloperIDApplication(code)
         )
     }
 
-    private static func isDeveloperIDApplication(_ certificate: SecCertificate) -> Bool {
-        // Apple's Developer ID Application certificate extension. Unlike an
-        // authority display name, the extension is a machine-readable signing
-        // contract and distinguishes release identities from Apple Development.
-        let developerIDApplicationOID = "1.2.840.113635.100.6.1.13" as CFString
-        guard let values = SecCertificateCopyValues(
-            certificate,
-            [developerIDApplicationOID] as CFArray,
-            nil
-        ) as? [String: Any] else {
-            return false
+    private static let developerIDApplicationRequirement =
+        "anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+
+    private static func developerIDApplicationCodeRequirement() -> SecRequirement? {
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            developerIDApplicationRequirement as CFString,
+            [],
+            &requirement
+        ) == errSecSuccess else {
+            return nil
         }
-        return hasDeveloperIDApplicationExtension(in: values)
+        return requirement
     }
 
-    static func hasDeveloperIDApplicationExtension(in certificateValues: [String: Any]) -> Bool {
-        certificateValues["1.2.840.113635.100.6.1.13"] != nil
+    private static func isDeveloperIDApplication(_ code: SecStaticCode) -> Bool {
+        guard let requirement = developerIDApplicationCodeRequirement() else { return false }
+        return SecStaticCodeCheckValidity(code, [], requirement) == errSecSuccess
+    }
+
+    static func developerIDApplicationRequirementCompiles() -> Bool {
+        developerIDApplicationCodeRequirement() != nil
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -223,11 +223,18 @@ struct SystemKeychain: KeychainStoring {
         // authority display name, the extension is a machine-readable signing
         // contract and distinguishes release identities from Apple Development.
         let developerIDApplicationOID = "1.2.840.113635.100.6.1.13" as CFString
-        return SecCertificateCopyValues(
+        guard let values = SecCertificateCopyValues(
             certificate,
             [developerIDApplicationOID] as CFArray,
             nil
-        ) != nil
+        ) as? [String: Any] else {
+            return false
+        }
+        return hasDeveloperIDApplicationExtension(in: values)
+    }
+
+    static func hasDeveloperIDApplicationExtension(in certificateValues: [String: Any]) -> Bool {
+        certificateValues["1.2.840.113635.100.6.1.13"] != nil
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -41,19 +41,25 @@ protocol KeychainItemAccessing: Sendable {
 /// explain, never permission for SecurityAgent to interrupt the user.
 struct SecurityKeychainItems: KeychainItemAccessing {
     func query(account: String, service: String) -> KeychainReadResult {
+        let authenticationContext = LAContext()
+        authenticationContext.interactionNotAllowed = true
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+            kSecUseAuthenticationContext as String: authenticationContext,
         ]
         var item: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
+        return Self.readResult(status: status, data: item as? Data)
+    }
+
+    static func readResult(status: OSStatus, data: Data?) -> KeychainReadResult {
         if status == errSecItemNotFound { return .missing }
         guard status == errSecSuccess,
-              let data = item as? Data,
+              let data,
               let value = String(data: data, encoding: .utf8) else {
             return .unavailable
         }

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -208,6 +208,10 @@ final class WebSearchConfig {
     /// looked" from "looked, no secret stored" — the latter must
     /// short-circuit ``apiKey(for:)`` without another keychain hit.
     private var probedAccounts: Set<String> = []
+    /// Accounts whose no-UI Keychain lookup was refused. Kept distinct from
+    /// ordinary absence so Settings can ask for re-entry without ever causing
+    /// the macOS login-keychain password dialog.
+    private var unavailableAccounts: Set<String> = []
     /// Process-local mutation generation per Keychain account. Value equality
     /// cannot detect an ABA replacement (K → another value → K), so callers
     /// that act on an async response capture this revision with the key.
@@ -248,12 +252,17 @@ final class WebSearchConfig {
             // HTTP header has to land clean or the upstream rejects.
             return keyCache[account]?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
         }
-        let value = keychain.read(account: account)
+        let result = keychain.readWithoutUserInteraction(account: account)
         probedAccounts.insert(account)
-        if let value, !value.isEmpty {
+        guard case .found(let value) = result else {
+            if result == .unavailable { unavailableAccounts.insert(account) }
+            return nil
+        }
+        unavailableAccounts.remove(account)
+        if !value.isEmpty {
             keyCache[account] = value
         }
-        return value?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
     }
 
     /// Atomically capture the cached credential value and its mutation
@@ -314,6 +323,7 @@ final class WebSearchConfig {
             // disk.
             if keychain.delete(account: account) {
                 keyCache.removeValue(forKey: account)
+                unavailableAccounts.remove(account)
                 probedAccounts.insert(account)
                 keyRevisions[account, default: 0] &+= 1
                 return true
@@ -337,6 +347,7 @@ final class WebSearchConfig {
             // disk, silently disabling the provider until restart.
             if keychain.write(account: account, secret: trimmed) {
                 keyCache[account] = trimmed
+                unavailableAccounts.remove(account)
                 probedAccounts.insert(account)
                 keyRevisions[account, default: 0] &+= 1
                 // Auto-promote happens AFTER a successful keychain
@@ -364,14 +375,13 @@ final class WebSearchConfig {
         !provider.requiresKey || apiKey(for: provider) != nil
     }
 
-    // MARK: - Async prefetch (cycle-12 P3: Settings → Web Search blocked
-    // the UI on tab construction because the panel's view-builder asked
-    // ``apiKey(for:)`` for both Brave and Tavily — each call synchronously
-    // crosses the securityd XPC hop, and the first cross-process Keychain
-    // access against a ``kSecAttrAccessibleWhenUnlockedThisDeviceOnly``
-    // item can surface a system permission modal. The UI now warms the
-    // cache off the main actor before reading the cache; these two
-    // helpers are the seam.
+    // MARK: - Lazy async lookup
+    //
+    // Settings must not touch Keychain merely because its Tools page opened.
+    // A required-key backend selection or an API-key field focus calls the
+    // single-provider helper below; actual tool dispatch can also resolve its
+    // selected provider through ``apiKey(for:)``. Both routes use the same
+    // no-authentication-UI storage contract.
     //
     // The pre-existing positive/negative cache contracts in
     // ``WebSearchKeyCacheTests`` are preserved verbatim: ``apiKey(for:)``
@@ -397,6 +407,7 @@ final class WebSearchConfig {
     func cachedKeyState(for provider: WebSearchProvider) -> CachedKeyState {
         guard let account = provider.keychainAccount else { return .absent }
         guard probedAccounts.contains(account) else { return .unknown }
+        if unavailableAccounts.contains(account) { return .unavailable }
         if let trimmed = keyCache[account]?
             .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
             return .present(trimmed)
@@ -404,7 +415,7 @@ final class WebSearchConfig {
         return .absent
     }
 
-    /// Warm ``cachedKeyState(for:)`` for ``provider`` without blocking
+    /// Resolve ``cachedKeyState(for:)`` for ``provider`` without blocking
     /// the calling actor on the Keychain XPC hop. Returns after the
     /// cache + probed set have been populated. Safe to call repeatedly;
     /// a probed provider short-circuits without re-reading Keychain.
@@ -442,8 +453,8 @@ final class WebSearchConfig {
         // which it isn't (it's main-actor isolated for the @Observable
         // reasons above).
         let keychain = self.keychain
-        let value = await Task.detached(priority: .userInitiated) {
-            keychain.read(account: account)
+        let result = await Task.detached(priority: .userInitiated) {
+            keychain.readWithoutUserInteraction(account: account)
         }.value
         // codex r1 MAJOR: discard the result if our parent task was
         // cancelled while we were waiting on the detached read — the
@@ -457,25 +468,13 @@ final class WebSearchConfig {
         // read / write is authoritative (the write path also primes
         // the cache directly).
         if probedAccounts.contains(account) { return }
-        if let value, !value.isEmpty {
+        if case .found(let value) = result, !value.isEmpty {
             keyCache[account] = value
         }
+        if result == .unavailable { unavailableAccounts.insert(account) }
         probedAccounts.insert(account)
     }
 
-    /// Convenience: warm every keyed provider in parallel. Used by the
-    /// Settings → Web Search panel's ``.task`` so the cache is populated
-    /// once, off the main actor, before the panel re-renders.
-    func prefetchAllAPIKeys() async {
-        await withTaskGroup(of: Void.self) { group in
-            // ``acceptsKey``, not ``requiresKey``: Keenable's key is
-            // optional but still lives in the Keychain and still
-            // needs warming before the Settings key row renders.
-            for provider in WebSearchProvider.allCases where provider.acceptsKey {
-                group.addTask { await self.prefetchAPIKey(for: provider) }
-            }
-        }
-    }
 }
 
 /// Result of ``WebSearchConfig.cachedKeyState(for:)``. ``.unknown``
@@ -486,6 +485,7 @@ enum CachedKeyState: Equatable, Sendable {
     case unknown
     case absent
     case present(String)
+    case unavailable
 
     var hasKey: Bool {
         if case .present = self { return true }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -747,12 +747,13 @@ struct ChatView: View {
             }
             .buttonStyle(.plain)
             .disabled(viewModel.isStreaming)
-            .help("Conversation instructions")
-            .accessibilityLabel("Conversation instructions")
+            .help("Conversation system prompt")
+            .accessibilityLabel("Conversation system prompt")
             .accessibilityIdentifier("ChatView.ConversationInstructions")
             .popover(isPresented: $showsConversationInstructions, arrowEdge: .bottom) {
                 ConversationInstructionsPopover(
                     draft: $conversationInstructionsDraft,
+                    global: viewModel.customInstructions.global,
                     onSave: { value in
                         viewModel.setConversationInstructions(value)
                         showsConversationInstructions = false

--- a/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
@@ -168,8 +168,20 @@ struct EffectiveSystemPromptDisclosure: View {
 
     @State private var expanded = false
 
-    private var prompt: String {
+    /// One clock sample for the preview. Keeping this pure lets the rollover
+    /// contract prove the displayed prompt uses the same date-context helper
+    /// as request assembly without waiting for wall-clock time in a UI test.
+    nonisolated static func prompt(
+        at now: Date,
+        calendar: Calendar,
+        global: String,
+        conversation: String
+    ) -> String {
         ChatViewModel.effectiveSystemPrompt(
+            dateContext: ChatViewModel.currentDateTimeContext(
+                now: now,
+                calendar: calendar
+            ),
             global: global,
             conversation: conversation
         )
@@ -181,23 +193,30 @@ struct EffectiveSystemPromptDisclosure: View {
                 Text("Preview includes current automatic context. Tool and attachment context may be added when you send.")
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textSecondary)
-                ScrollView {
-                    Text(prompt)
-                        .font(RapidFont.code)
-                        .foregroundStyle(RapidTheme.textPrimary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(RapidTheme.Space.md)
-                        .accessibilityIdentifier(accessibilityIdentifier)
-                }
-                .frame(maxHeight: 180)
-                .background(
-                    RoundedRectangle(
-                        cornerRadius: RapidTheme.Radius.input,
-                        style: .continuous
+                TimelineView(.periodic(from: .now, by: 60)) { context in
+                    ScrollView {
+                        Text(Self.prompt(
+                            at: context.date,
+                            calendar: .autoupdatingCurrent,
+                            global: global,
+                            conversation: conversation
+                        ))
+                            .font(RapidFont.code)
+                            .foregroundStyle(RapidTheme.textPrimary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(RapidTheme.Space.md)
+                            .accessibilityIdentifier(accessibilityIdentifier)
+                    }
+                    .frame(maxHeight: 180)
+                    .background(
+                        RoundedRectangle(
+                            cornerRadius: RapidTheme.Radius.input,
+                            style: .continuous
+                        )
+                        .fill(RapidTheme.surfaceCode)
                     )
-                    .fill(RapidTheme.surfaceCode)
-                )
+                }
             }
             .padding(.top, RapidTheme.Space.sm)
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
@@ -45,7 +45,7 @@ struct InstructionTextEditor: View {
         )
         .onTapGesture { focused = true }
         .overlay(alignment: .bottomTrailing) {
-            Text("\(text.count) / \(CustomInstructionsConfig.maximumLength)")
+            Text("\(text.count) of \(CustomInstructionsConfig.maximumLength) characters")
                 .font(RapidFont.caption)
                 .foregroundStyle(RapidTheme.textTertiary)
                 .padding(RapidTheme.Space.sm)
@@ -89,7 +89,7 @@ struct InstructionEditorSection<Content: View>: View {
             SectionHeader(title, subtitle: subtitle, emphasis: .section) {
                 QuietIconButton(
                     symbol: "trash",
-                    label: "Clear global instructions",
+                    label: "Clear global system prompt",
                     action: onClear
                 )
                 .disabled(!clearEnabled)
@@ -102,22 +102,23 @@ struct InstructionEditorSection<Content: View>: View {
 
 struct ConversationInstructionsPopover: View {
     @Binding var draft: String
+    let global: String
     let onSave: (String) -> Void
     let onCancel: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
             VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
-                Text("Conversation Instructions")
+                Text("Conversation System Prompt")
                     .font(RapidFont.sectionTitle)
                     .foregroundStyle(RapidTheme.textPrimary)
-                Text("Applied only to this conversation, after global instructions.")
+                Text("Sent only with this conversation. If it conflicts with the global default, this prompt wins.")
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textSecondary)
             }
             InstructionTextEditor(
                 text: $draft,
-                placeholder: "Add instructions for this conversation.",
+                placeholder: "Add a system prompt for this conversation.",
                 height: 160,
                 accessibilityIdentifier: "ChatView.ConversationInstructions.Editor",
                 autoFocus: true
@@ -130,8 +131,8 @@ struct ConversationInstructionsPopover: View {
                         Image(systemName: "trash")
                     }
                     .buttonStyle(.rapidSecondaryCompact)
-                    .help("Clear instructions")
-                    .accessibilityLabel("Clear instructions")
+                    .help("Clear conversation system prompt")
+                    .accessibilityLabel("Clear conversation system prompt")
                     .accessibilityIdentifier("ChatView.ConversationInstructions.Clear")
                 }
                 Spacer(minLength: 0)
@@ -144,9 +145,63 @@ struct ConversationInstructionsPopover: View {
                     .keyboardShortcut(.defaultAction)
                     .accessibilityIdentifier("ChatView.ConversationInstructions.Save")
             }
+            EffectiveSystemPromptDisclosure(
+                global: global,
+                conversation: draft,
+                accessibilityIdentifier: "ChatView.SystemPrompt.EffectivePreview"
+            )
         }
         .padding(RapidTheme.Space.xl)
         .frame(width: 440)
         .background(RapidTheme.surfaceOverlay)
+    }
+}
+
+/// Progressive disclosure for the exact Desktop-authored base prompt. The
+/// server or request path may append tool and attachment context at send time,
+/// which the explanatory copy states instead of pretending the preview owns
+/// those dynamic layers.
+struct EffectiveSystemPromptDisclosure: View {
+    let global: String
+    let conversation: String
+    let accessibilityIdentifier: String
+
+    @State private var expanded = false
+
+    private var prompt: String {
+        ChatViewModel.effectiveSystemPrompt(
+            global: global,
+            conversation: conversation
+        )
+    }
+
+    var body: some View {
+        DisclosureGroup("Effective System Prompt", isExpanded: $expanded) {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                Text("Preview includes current automatic context. Tool and attachment context may be added when you send.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                ScrollView {
+                    Text(prompt)
+                        .font(RapidFont.code)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(RapidTheme.Space.md)
+                        .accessibilityIdentifier(accessibilityIdentifier)
+                }
+                .frame(maxHeight: 180)
+                .background(
+                    RoundedRectangle(
+                        cornerRadius: RapidTheme.Radius.input,
+                        style: .continuous
+                    )
+                    .fill(RapidTheme.surfaceCode)
+                )
+            }
+            .padding(.top, RapidTheme.Space.sm)
+        }
+        .font(RapidFont.body)
+        .accessibilityIdentifier("\(accessibilityIdentifier).Disclosure")
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -22,6 +22,7 @@ struct SettingsToolsPanel: View {
     @State private var keyDraftEdited: Bool = false
     @State private var saveFeedback: SettingsView.WebSearchKeySaveFeedback?
     @State private var feedbackGeneration: Int = 0
+    @FocusState private var focusedKeyProvider: WebSearchProvider?
     /// Which tool rows have their technical detail open. Session state:
     /// a disclosure is a reading aid, not a preference, so it
     /// deliberately does not persist.
@@ -45,12 +46,6 @@ struct SettingsToolsPanel: View {
             toolsSection
             webSearchSection
             browseSection
-        }
-        .task {
-            // Warm the Keychain cache off the main actor before the key rows
-            // render — a cold `SecItemCopyMatching` crosses securityd XPC and
-            // can stall the panel's first paint.
-            await webSearch.prefetchAllAPIKeys()
         }
     }
 
@@ -278,8 +273,13 @@ struct SettingsToolsPanel: View {
                     .controlSize(.small)
                     .tint(nil)
                     .accessibilityIdentifier("Settings.Tools.WebSearch.Backend")
-                    .onChange(of: config.provider) { _, _ in
+                    .onChange(of: config.provider) { _, provider in
                         resetKeyDraft()
+                        // This is a user-driven provider selection, not view
+                        // appearance. Required-key backends may now inspect
+                        // their one account without presenting auth UI.
+                        guard provider.requiresKey else { return }
+                        Task { await webSearch.prefetchAPIKey(for: provider) }
                     }
 
                     Text(config.provider.subtitle)
@@ -309,6 +309,13 @@ struct SettingsToolsPanel: View {
                     .textFieldStyle(.roundedBorder)
                     .font(RapidFont.body)
                     .frame(minHeight: RapidTheme.ControlHeight.small)
+                    .focused($focusedKeyProvider, equals: provider)
+                    .onChange(of: focusedKeyProvider) { _, focused in
+                        guard focused == provider else { return }
+                        // Optional-key providers (notably Keenable) stay truly
+                        // zero-touch until the user enters their key field.
+                        Task { await webSearch.prefetchAPIKey(for: provider) }
+                    }
                     .onChange(of: keyDraft) { _, _ in keyDraftEdited = true }
                     .onSubmit { commitKey(for: provider) }
                     .accessibilityIdentifier(
@@ -341,6 +348,14 @@ struct SettingsToolsPanel: View {
                             : RapidTheme.textSecondary
                     )
                     .fixedSize(horizontal: false, vertical: true)
+            } else if webSearch.cachedKeyState(for: provider) == .unavailable {
+                Text("The saved key can’t be accessed. Enter it again and save to replace it.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.statusError)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier(
+                        "Settings.Tools.WebSearch.KeyUnavailable.\(provider.id)"
+                    )
             } else if webSearch.cachedKeyState(for: provider).hasKey {
                 Text("A key is stored for \(provider.displayName).")
                     .font(RapidFont.caption)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -356,6 +356,11 @@ struct SettingsToolsPanel: View {
                     .accessibilityIdentifier(
                         "Settings.Tools.WebSearch.KeyUnavailable.\(provider.id)"
                     )
+            } else if webSearch.cachedKeyState(for: provider) == .unknown {
+                Text("Saved key status hasn’t been checked. Select this backend or focus the field to check it.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             } else if webSearch.cachedKeyState(for: provider).hasKey {
                 Text("A key is stored for \(provider.displayName).")
                     .font(RapidFont.caption)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -66,8 +66,8 @@ struct SettingsView: View {
         /// the older stand-alone "Models" tab was folded in here so
         /// users don't face two competing model surfaces.
         case modelManagement
-        /// Instructions applied to every chat before any conversation-specific
-        /// override. Stored locally in UserDefaults.
+        /// Global system-prompt default applied before any conversation-specific
+        /// override. Stored locally in UserDefaults under the legacy key.
         case instructions
         /// Built-in tools the model can call: on/off per tool, the
         /// web-search backend + key, and the browse approval mode.
@@ -102,7 +102,7 @@ struct SettingsView: View {
         var title: String {
             switch self {
             case .modelManagement: return "Model Management"
-            case .instructions: return "Instructions"
+            case .instructions: return "System Prompt"
             case .tools: return "Tools"
             case .connectors: return "Connectors"
             case .performance: return "Performance"
@@ -502,23 +502,28 @@ struct SettingsView: View {
         @Bindable var config = customInstructions
         return VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
             SectionHeader(
-                "Custom Instructions",
-                subtitle: "Set preferences for how the assistant responds in every conversation.",
+                "System Prompt",
+                subtitle: "Sent as a system message with every conversation. Conversation prompts can override it.",
                 emphasis: .page
             )
             InstructionEditorSection(
-                "Global",
-                subtitle: "Used in every conversation. A conversation can add more specific direction.",
+                "Global default",
+                subtitle: "Used when a conversation has no conflicting prompt. Stored only on this Mac.",
                 clearEnabled: CustomInstructionsConfig.normalized(config.global) != nil,
                 onClear: { config.global = "" }
             ) {
                 InstructionTextEditor(
                     text: $config.global,
-                    placeholder: "For example: Be concise, use plain language, and include code examples when useful.",
+                    placeholder: "For example: Answer concisely, use plain language, and include code examples when useful.",
                     height: 172,
                     accessibilityIdentifier: "Settings.Instructions.GlobalEditor"
                 )
             }
+            EffectiveSystemPromptDisclosure(
+                global: config.global,
+                conversation: "",
+                accessibilityIdentifier: "Settings.SystemPrompt.EffectivePreview"
+            )
         }
     }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -127,7 +127,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -127,7 +127,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
             AXPopover
               AXGroup subrole=AXHostingView
                 AXStaticText value=text enabled=true
@@ -47,9 +47,10 @@ AXApplication title="Rapid-MLX"
                 AXScrollArea
                   AXTextArea id="ChatView.ConversationInstructions.Editor" value=text
                 AXStaticText id="ChatView.ConversationInstructions.Editor.Count" value=text enabled=true
-                AXButton id="ChatView.ConversationInstructions.Clear" desc="Clear instructions" help="Clear instructions" enabled=true
+                AXButton id="ChatView.ConversationInstructions.Clear" desc="Clear conversation system prompt" help="Clear conversation system prompt" enabled=true
                 AXButton id="ChatView.ConversationInstructions.Cancel" desc="Cancel" enabled=true
                 AXButton id="ChatView.ConversationInstructions.Save" desc="Save" enabled=true
+                AXDisclosureTriangle id="ChatView.SystemPrompt.EffectivePreview.Disclosure" desc="Effective System Prompt" value=bool:false enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -36,7 +36,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -22,7 +22,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-1b-4bit before sending." enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start qwen3.8-27b-4bit before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
@@ -70,12 +70,13 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.app" desc="App" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
-        AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true
-        AXHeading desc="Global, Used in every conversation. A conversation can add more specific direction." enabled=true
-        AXButton id="Settings.Instructions.Clear" desc="Clear global instructions" help="Clear global instructions" enabled=true
+        AXHeading desc="System Prompt, Sent as a system message with every conversation. Conversation prompts can override it." enabled=true
+        AXHeading desc="Global default, Used when a conversation has no conflicting prompt. Stored only on this Mac." enabled=true
+        AXButton id="Settings.Instructions.Clear" desc="Clear global system prompt" help="Clear global system prompt" enabled=true
         AXScrollArea
           AXTextArea id="Settings.Instructions.GlobalEditor" value=text
         AXStaticText id="Settings.Instructions.GlobalEditor.Count" value=text enabled=true
+        AXDisclosureTriangle id="Settings.SystemPrompt.EffectivePreview.Disclosure" desc="Effective System Prompt" value=bool:false enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXZoomButton enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
@@ -70,12 +70,13 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.app" desc="App" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
-        AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true
-        AXHeading desc="Global, Used in every conversation. A conversation can add more specific direction." enabled=true
-        AXButton id="Settings.Instructions.Clear" desc="Clear global instructions" help="Clear global instructions" enabled=true
+        AXHeading desc="System Prompt, Sent as a system message with every conversation. Conversation prompts can override it." enabled=true
+        AXHeading desc="Global default, Used when a conversation has no conflicting prompt. Stored only on this Mac." enabled=true
+        AXButton id="Settings.Instructions.Clear" desc="Clear global system prompt" help="Clear global system prompt" enabled=true
         AXScrollArea
           AXTextArea id="Settings.Instructions.GlobalEditor" value=text
         AXStaticText id="Settings.Instructions.GlobalEditor.Count" value=text enabled=true
+        AXDisclosureTriangle id="Settings.SystemPrompt.EffectivePreview.Disclosure" desc="Effective System Prompt" value=bool:false enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXZoomButton enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -21,7 +21,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add photos or files" enabled=true
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
@@ -49,7 +49,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+              AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -157,6 +157,7 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Tools.WebSearch.Backend.\(provider.id)""#,
                 #""Settings.Tools.WebSearch.KeyField.\(provider.id)""#,
                 #""Settings.Tools.WebSearch.SaveKey.\(provider.id)""#,
+                #""Settings.Tools.WebSearch.KeyUnavailable.\(provider.id)""#,
                 // The "Get a <provider> key" Link is interactive too — it
                 // opens the provider's dashboard. It was missed on the first
                 // pass precisely because it only renders for a provider that

--- a/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
@@ -113,6 +113,48 @@ struct CustomInstructionsTests {
             < preview.range(of: "Use bullet points.")!.lowerBound)
     }
 
+    @Test("Effective prompt preview refreshes across midnight and time-zone changes")
+    func effectivePromptPreviewFollowsClockAndZone() throws {
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let beforeMidnight = try #require(
+            utc.date(from: DateComponents(
+                year: 2026, month: 8, day: 25, hour: 23, minute: 59
+            ))
+        )
+        let afterMidnight = beforeMidnight.addingTimeInterval(120)
+
+        let before = EffectiveSystemPromptDisclosure.prompt(
+            at: beforeMidnight,
+            calendar: utc,
+            global: "Global",
+            conversation: "Conversation"
+        )
+        let after = EffectiveSystemPromptDisclosure.prompt(
+            at: afterMidnight,
+            calendar: utc,
+            global: "Global",
+            conversation: "Conversation"
+        )
+
+        #expect(before.contains("Tuesday, August 25, 2026"))
+        #expect(before.contains("11:59 PM (GMT, GMT)"))
+        #expect(after.contains("Wednesday, August 26, 2026"))
+        #expect(after.contains("12:01 AM (GMT, GMT)"))
+
+        var tokyo = utc
+        tokyo.timeZone = try #require(TimeZone(identifier: "Asia/Tokyo"))
+        let tokyoPreview = EffectiveSystemPromptDisclosure.prompt(
+            at: beforeMidnight,
+            calendar: tokyo,
+            global: "Global",
+            conversation: "Conversation"
+        )
+        #expect(tokyoPreview.contains("Wednesday, August 26, 2026"))
+        #expect(tokyoPreview.contains("8:59 AM (GMT+9, Asia/Tokyo)"))
+        #expect(tokyoPreview != before)
+    }
+
     @Test("System prompt UI names global and conversation precedence explicitly")
     func systemPromptTerminologyAndPreviewWiring() throws {
         let settings = try Self.source("Sources/Rapid/UI/SettingsView.swift")
@@ -126,6 +168,9 @@ struct CustomInstructionsTests {
         #expect(editor.contains("this prompt wins."))
         #expect(editor.contains("DisclosureGroup(\"Effective System Prompt\""))
         #expect(editor.contains("Tool and attachment context may be added when you send."))
+        #expect(editor.contains("TimelineView(.periodic(from: .now, by: 60))"))
+        #expect(editor.contains("at: context.date"))
+        #expect(editor.contains("calendar: .autoupdatingCurrent"))
         #expect(editor.contains("ChatViewModel.effectiveSystemPrompt"))
         #expect(editor.contains("ChatView.SystemPrompt.EffectivePreview"))
 

--- a/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
@@ -96,6 +96,44 @@ struct CustomInstructionsTests {
         #expect(result.last?.id == user.id)
     }
 
+    @Test("Effective prompt preview uses the wire assembly and includes automatic context")
+    func effectivePromptPreviewUsesWireAssembly() {
+        let preview = ChatViewModel.effectiveSystemPrompt(
+            dateContext: "[CURRENT DATE AND TIME]\nToday is Tuesday, August 25, 2026.",
+            global: "Reply in plain language.",
+            conversation: "Use bullet points."
+        )
+
+        #expect(preview.hasPrefix("[CURRENT DATE AND TIME]"))
+        #expect(preview.contains("[GLOBAL USER INSTRUCTIONS]"))
+        #expect(preview.contains("Reply in plain language."))
+        #expect(preview.contains("[CONVERSATION INSTRUCTIONS - HIGHEST USER PRIORITY]"))
+        #expect(preview.contains("Use bullet points."))
+        #expect(preview.range(of: "Reply in plain language.")!.lowerBound
+            < preview.range(of: "Use bullet points.")!.lowerBound)
+    }
+
+    @Test("System prompt UI names global and conversation precedence explicitly")
+    func systemPromptTerminologyAndPreviewWiring() throws {
+        let settings = try Self.source("Sources/Rapid/UI/SettingsView.swift")
+        #expect(settings.contains("case .instructions: return \"System Prompt\""))
+        #expect(settings.contains("\"Global default\""))
+        #expect(settings.contains("Conversation prompts can override it."))
+        #expect(settings.contains("Settings.SystemPrompt.EffectivePreview"))
+
+        let editor = try Self.source("Sources/Rapid/UI/InstructionTextEditor.swift")
+        #expect(editor.contains("Text(\"Conversation System Prompt\")"))
+        #expect(editor.contains("this prompt wins."))
+        #expect(editor.contains("DisclosureGroup(\"Effective System Prompt\""))
+        #expect(editor.contains("Tool and attachment context may be added when you send."))
+        #expect(editor.contains("ChatViewModel.effectiveSystemPrompt"))
+        #expect(editor.contains("ChatView.SystemPrompt.EffectivePreview"))
+
+        let chat = try Self.source("Sources/Rapid/UI/ChatView.swift")
+        #expect(chat.contains(".accessibilityLabel(\"Conversation system prompt\")"))
+        #expect(chat.contains("global: viewModel.customInstructions.global"))
+    }
+
     @Test("Conversation instructions explicitly override conflicting global preferences")
     func conversationLayerHasExplicitPrecedence() {
         let result = ChatViewModel.addingInstructionLayers(

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -115,6 +115,37 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(store.readWithoutUserInteraction(account: account) == .found("replacement-key"))
     }
 
+    @Test("Security status distinguishes a missing item from denied non-interactive access")
+    func securityReadStatusMapping() {
+        #expect(SecurityKeychainItems.readResult(status: errSecItemNotFound, data: nil) == .missing)
+        #expect(SecurityKeychainItems.readResult(status: errSecInteractionNotAllowed, data: nil) == .unavailable)
+        #expect(SecurityKeychainItems.readResult(
+            status: errSecSuccess,
+            data: Data("saved-key".utf8)
+        ) == .found("saved-key"))
+    }
+
+    @Test("An inaccessible current item never falls back to a stale legacy credential")
+    func inaccessibleCurrentSlotStopsLegacyFallback() {
+        let account = "rapid.web-search.parallel"
+        let primary = "test.release"
+        let legacy = "test.legacy"
+        let items = SettingsKeychainItems(
+            states: [
+                "\(primary)|\(account)": .unavailable,
+                "\(legacy)|\(account)": .found("stale-key"),
+            ],
+            rejectedServices: []
+        )
+        let store = SystemKeychain(
+            items: items,
+            primaryService: primary,
+            legacyMigrationService: legacy
+        )
+
+        #expect(store.readWithoutUserInteraction(account: account) == .unavailable)
+    }
+
     @Test("Tools page has no appearance-time Keychain read and wires only user-driven probes")
     func toolsPageUsesLazyReadTriggers() throws {
         let panel = try String(
@@ -131,9 +162,9 @@ struct SettingsWebSearchKeyDraftTests {
             contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/Tools/KeychainStore.swift"),
             encoding: .utf8
         )
-        #expect(store.contains("kSecUseAuthenticationUISkip"))
         #expect(store.contains("kSecUseAuthenticationContext"))
         #expect(store.contains("interactionNotAllowed = true"))
+        #expect(!store.contains("kSecUseAuthenticationUISkip"))
         #expect(store.contains("legacyService).development"))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -132,6 +132,8 @@ struct SettingsWebSearchKeyDraftTests {
             encoding: .utf8
         )
         #expect(store.contains("kSecUseAuthenticationUISkip"))
+        #expect(store.contains("kSecUseAuthenticationContext"))
+        #expect(store.contains("interactionNotAllowed = true"))
         #expect(store.contains("legacyService).development"))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -89,6 +89,17 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(release != development)
     }
 
+    @Test("Certificate parsing succeeds only when Developer ID Application OID is present")
+    func developerIDExtensionMustBePresent() {
+        #expect(!SystemKeychain.hasDeveloperIDApplicationExtension(in: [:]))
+        #expect(!SystemKeychain.hasDeveloperIDApplicationExtension(in: [
+            "1.2.840.113635.100.6.1.12": ["label": "Apple Development"]
+        ]))
+        #expect(SystemKeychain.hasDeveloperIDApplicationExtension(in: [
+            "1.2.840.113635.100.6.1.13": ["label": "Developer ID Application"]
+        ]))
+    }
+
     @Test("Explicit save recovers from an inaccessible current-identity item")
     func inaccessibleCurrentSlotUsesRecoverySlot() {
         let account = "rapid.web-search.parallel"

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -39,6 +39,14 @@ private final class SettingsKeychainItems: KeychainItemAccessing, @unchecked Sen
             return true
         }
     }
+
+    func remove(account: String, service: String) -> Bool {
+        lock.withLock {
+            guard !rejectedServices.contains(service) else { return false }
+            states.removeValue(forKey: "\(service)|\(account)")
+            return true
+        }
+    }
 }
 
 @MainActor
@@ -138,6 +146,47 @@ struct SettingsWebSearchKeyDraftTests {
         )
 
         #expect(store.readWithoutUserInteraction(account: account) == .unavailable)
+    }
+
+    @Test("Clearing removes migrated legacy and recovery credentials")
+    func clearDeletesEveryAccessibleCredentialSlot() {
+        let account = "rapid.web-search.parallel"
+        let primary = "test.release"
+        let legacy = "test.legacy"
+        let items = SettingsKeychainItems(
+            states: [
+                "\(primary).recovery|\(account)": .found("replacement-key"),
+                "\(legacy)|\(account)": .found("migrated-key"),
+            ],
+            rejectedServices: []
+        )
+        let store = SystemKeychain(
+            items: items,
+            primaryService: primary,
+            legacyMigrationService: legacy
+        )
+
+        #expect(store.delete(account: account))
+        #expect(store.readWithoutUserInteraction(account: account) == .missing)
+    }
+
+    @Test("A denied removal is masked but never reported as erased")
+    func deniedClearUsesTombstoneAndReportsFailure() {
+        let account = "rapid.web-search.parallel"
+        let primary = "test.release"
+        let legacy = "test.legacy"
+        let items = SettingsKeychainItems(
+            states: ["\(legacy)|\(account)": .found("inaccessible-key")],
+            rejectedServices: [legacy]
+        )
+        let store = SystemKeychain(
+            items: items,
+            primaryService: primary,
+            legacyMigrationService: legacy
+        )
+
+        #expect(!store.delete(account: account))
+        #expect(store.read(account: account) == nil)
     }
 
     @Test("Tools page has no appearance-time Keychain read and wires only user-driven probes")

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -89,15 +89,9 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(release != development)
     }
 
-    @Test("Certificate parsing succeeds only when Developer ID Application OID is present")
-    func developerIDExtensionMustBePresent() {
-        #expect(!SystemKeychain.hasDeveloperIDApplicationExtension(in: [:]))
-        #expect(!SystemKeychain.hasDeveloperIDApplicationExtension(in: [
-            "1.2.840.113635.100.6.1.12": ["label": "Apple Development"]
-        ]))
-        #expect(SystemKeychain.hasDeveloperIDApplicationExtension(in: [
-            "1.2.840.113635.100.6.1.13": ["label": "Developer ID Application"]
-        ]))
+    @Test("Developer ID Application uses a valid system code requirement")
+    func developerIDRequirementCompiles() {
+        #expect(SystemKeychain.developerIDApplicationRequirementCompiles())
     }
 
     @Test("Explicit save recovers from an inaccessible current-identity item")

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -18,6 +18,29 @@ private final class SettingsKeychainProbe: KeychainStoring, @unchecked Sendable 
     func delete(account: String) -> Bool { true }
 }
 
+private final class SettingsKeychainItems: KeychainItemAccessing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [String: KeychainReadResult]
+    private let rejectedServices: Set<String>
+
+    init(states: [String: KeychainReadResult], rejectedServices: Set<String>) {
+        self.states = states
+        self.rejectedServices = rejectedServices
+    }
+
+    func query(account: String, service: String) -> KeychainReadResult {
+        lock.withLock { states["\(service)|\(account)"] ?? .missing }
+    }
+
+    func upsert(account: String, service: String, secret: String) -> Bool {
+        lock.withLock {
+            guard !rejectedServices.contains(service) else { return false }
+            states["\(service)|\(account)"] = .found(secret)
+            return true
+        }
+    }
+}
+
 @MainActor
 @Suite("Settings web-search key draft commit")
 struct SettingsWebSearchKeyDraftTests {
@@ -50,6 +73,37 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(keychain.readCount == 1, "the denied result is cached instead of repeatedly consulting Security.framework")
     }
 
+    @Test("Developer ID releases and development builds use different services")
+    func codeIdentityNamespacesAreSeparated() {
+        let release = SystemKeychain.serviceNamespace(
+            teamIdentifier: "TEAM123",
+            isDeveloperIDApplication: true
+        )
+        let development = SystemKeychain.serviceNamespace(
+            teamIdentifier: "TEAM123",
+            isDeveloperIDApplication: false
+        )
+
+        #expect(release == "com.rapidmlx.rapid.api-keys.release.TEAM123")
+        #expect(development == "com.rapidmlx.rapid.api-keys.development")
+        #expect(release != development)
+    }
+
+    @Test("Explicit save recovers from an inaccessible current-identity item")
+    func inaccessibleCurrentSlotUsesRecoverySlot() {
+        let account = "rapid.web-search.parallel"
+        let primary = "test.release"
+        let items = SettingsKeychainItems(
+            states: ["\(primary)|\(account)": .unavailable],
+            rejectedServices: [primary]
+        )
+        let store = SystemKeychain(items: items, primaryService: primary)
+
+        #expect(store.readWithoutUserInteraction(account: account) == .unavailable)
+        #expect(store.write(account: account, secret: "replacement-key"))
+        #expect(store.readWithoutUserInteraction(account: account) == .found("replacement-key"))
+    }
+
     @Test("Tools page has no appearance-time Keychain read and wires only user-driven probes")
     func toolsPageUsesLazyReadTriggers() throws {
         let panel = try String(
@@ -60,6 +114,7 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(panel.contains("guard provider.requiresKey else { return }"))
         #expect(panel.contains("focusedKeyProvider"))
         #expect(panel.contains("prefetchAPIKey(for: provider)"))
+        #expect(panel.contains("Saved key status hasn’t been checked."))
 
         let store = try String(
             contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/Tools/KeychainStore.swift"),

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -1,9 +1,74 @@
+import Foundation
 import Testing
 @testable import Rapid
+
+private final class SettingsKeychainProbe: KeychainStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var reads = 0
+    var result: KeychainReadResult = .missing
+
+    var readCount: Int { lock.withLock { reads } }
+
+    func read(account: String) -> String? { nil }
+    func readWithoutUserInteraction(account: String) -> KeychainReadResult {
+        lock.withLock { reads += 1 }
+        return result
+    }
+    func write(account: String, secret: String) -> Bool { true }
+    func delete(account: String) -> Bool { true }
+}
 
 @MainActor
 @Suite("Settings web-search key draft commit")
 struct SettingsWebSearchKeyDraftTests {
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    @Test("Constructing the Tools configuration never reads Keychain")
+    func constructionIsKeychainLazy() {
+        let keychain = SettingsKeychainProbe()
+        _ = WebSearchConfig(defaults: .standard, keychain: keychain)
+        #expect(keychain.readCount == 0)
+    }
+
+    @Test("An explicit lazy probe preserves the denied state for inline recovery")
+    func deniedProbeBecomesInlineState() async {
+        let keychain = SettingsKeychainProbe()
+        keychain.result = .unavailable
+        let config = WebSearchConfig(defaults: .standard, keychain: keychain)
+
+        #expect(config.cachedKeyState(for: .parallel) == .unknown)
+        await config.prefetchAPIKey(for: .parallel)
+
+        #expect(keychain.readCount == 1)
+        #expect(config.cachedKeyState(for: .parallel) == .unavailable)
+        #expect(config.apiKey(for: .parallel) == nil)
+        #expect(keychain.readCount == 1, "the denied result is cached instead of repeatedly consulting Security.framework")
+    }
+
+    @Test("Tools page has no appearance-time Keychain read and wires only user-driven probes")
+    func toolsPageUsesLazyReadTriggers() throws {
+        let panel = try String(
+            contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/UI/SettingsToolsPanel.swift"),
+            encoding: .utf8
+        )
+        #expect(!panel.contains("prefetchAllAPIKeys"))
+        #expect(panel.contains("guard provider.requiresKey else { return }"))
+        #expect(panel.contains("focusedKeyProvider"))
+        #expect(panel.contains("prefetchAPIKey(for: provider)"))
+
+        let store = try String(
+            contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/Tools/KeychainStore.swift"),
+            encoding: .utf8
+        )
+        #expect(store.contains("kSecUseAuthenticationUISkip"))
+        #expect(store.contains("legacyService).development"))
+    }
+
     @Test("Untouched empty SecureField does not clear an existing stored key")
     func untouchedDraftIsUnchanged() {
         #expect(SettingsView.webSearchKeyCommitAction(draft: "", wasEdited: false) == .unchanged)


### PR DESCRIPTION
## Why

Maintainer dogfood found two trust problems in Desktop settings: the existing “Custom Instructions” label obscured that the value is sent as a system message, and merely opening Settings → Tools could trigger a macOS Keychain password dialog even when the selected web-search backend needed no key.

## What

- Rename the existing global and per-conversation instruction surfaces to **System Prompt**, state precedence explicitly, and add a read-only effective-prompt preview assembled through the same Desktop wire helper (including clock-refreshed automatic date/time context).
- Preserve the existing preference/conversation storage keys and the 4,000-character boundary.
- Remove Tools-page-wide Keychain prefetch. Read only after a user selects a required-key backend, focuses a key field, or the selected backend actually needs its credential.
- Forbid authentication UI on credential lookup and present an inline re-entry state when a saved key is inaccessible.
- Isolate new generic-password items by signing identity, retain the historical service as signed-release migration input, and keep development items separate.
- Add focused assembly, rollover/time-zone, lazy-access, denied-state, migration/removal, copy, and accessibility inventory contracts.

## Scope

Desktop only. No server changes, backend roster changes, assistants/personas, other Settings redesign, release workflow, or CI-gate changes.

## Local evidence

- Focused System Prompt, web-search credential/provider, current-date, and AX suites: **93 passed**.
- `swift build -c release`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Rebased cleanly onto `origin/main@4f9f9165`.
- Codex R8: **LGTM** on exact head `a5d02afa`.

CI is allowed on the current head. This PR remains draft and held until the post-release landing window opens.