### PR TITLE
fix(mac): preserve the chat model across dictation relaunch

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -114,7 +114,36 @@ final class DictationController {
     private let server: ServerManager
     private let client: AudioClient
     private let hotkey = DictationHotkey()
-    private let recorder = DictationRecorder()
+    /// Constructing `DictationRecorder` initializes AVAudioEngine/CoreAudio.
+    /// Keep that work behind the first real capture so state-only controllers
+    /// (including launch restore and tests) never claim audio resources.
+    private final class CaptureLifecycle: @unchecked Sendable {
+        var recorder: DictationRecorder?
+        var ticker: Timer?
+
+        deinit {
+            ticker?.invalidate()
+            recorder?.shutdown()
+        }
+    }
+
+    private let captureLifecycle = CaptureLifecycle()
+    private var recorderStorage: DictationRecorder? {
+        get { captureLifecycle.recorder }
+        set { captureLifecycle.recorder = newValue }
+    }
+    private var recorder: DictationRecorder {
+        if let recorderStorage { return recorderStorage }
+        let recorder = DictationRecorder()
+        recorder.onLevel = { [weak self] value in
+            Task { @MainActor in self?.level = value }
+        }
+        recorder.onFirstSample = { [weak self] in
+            Task { @MainActor in self?.markRecordingStarted() }
+        }
+        recorderStorage = recorder
+        return recorder
+    }
     private let hud = DictationHUD()
     /// `nil` means the catalog probe itself failed; an array is authoritative.
     /// Keeping those states distinct prevents a transient CLI failure from
@@ -128,7 +157,10 @@ final class DictationController {
     private let testingRecorderCancel: (@MainActor () -> Void)?
     private let testingTranscribeCancel: (@MainActor () -> Void)?
 
-    private var tickTimer: Timer?
+    private var tickTimer: Timer? {
+        get { captureLifecycle.ticker }
+        set { captureLifecycle.ticker = newValue }
+    }
     private var recordingStart: Date?
     private var capturingApp: String?
     private var level: Float = 0
@@ -218,12 +250,6 @@ final class DictationController {
         hotkey.trigger = trigger
         hotkey.onTap = { [weak self] in self?.handleHotkey() }
 
-        recorder.onLevel = { [weak self] value in
-            Task { @MainActor in self?.level = value }
-        }
-        recorder.onFirstSample = { [weak self] in
-            Task { @MainActor in self?.markRecordingStarted() }
-        }
     }
 
     // MARK: - Readiness
@@ -405,7 +431,7 @@ final class DictationController {
         enableRequestID = nil
         modelPreparationDeferred = false
         stopTicking()
-        recorder.shutdown()
+        recorderStorage?.shutdown()
         hud.hide()
         phase = .off
     }
@@ -422,7 +448,7 @@ final class DictationController {
             if let testingRecorderCancel {
                 testingRecorderCancel()
             } else {
-                recorder.cancelCapture()
+                recorderStorage?.cancelCapture()
             }
         } else if phase == .transcribing {
             testingTranscribeCancel?()
@@ -779,7 +805,7 @@ final class DictationController {
 
     private func finishRecording() {
         stopTicking()
-        let audio = recorder.stopCapture()
+        let audio = recorderStorage?.stopCapture()
         let duration = recordingStart.map { Date().timeIntervalSince($0) } ?? 0
         recordingStart = nil
 
@@ -957,6 +983,12 @@ final class DictationController {
         tickTimer?.invalidate()
         tickTimer = nil
     }
+
+    /// Lifecycle assertions for state-only tests. These intentionally expose
+    /// no way to drive capture; they only prove tests leave no run-loop or
+    /// CoreAudio work behind for the next MainActor test.
+    internal var testingHasActiveTicker: Bool { tickTimer?.isValid == true }
+    internal var testingHasRecorder: Bool { recorderStorage != nil }
 
     // MARK: - Text
 

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -147,6 +147,11 @@ final class DictationController {
     /// Invalidates stale `enable()` continuations when the model changes, the
     /// feature is disabled, or another enable attempt supersedes them.
     private var enableRequestID: UUID?
+    /// Launch restore arms the global shortcut before the primary model has
+    /// finished its potentially long health-check window, but must not let an
+    /// audio-only fallback race that primary launch. Cleared as soon as the
+    /// chat restore settles and normal voice-lane preparation begins.
+    private var modelPreparationDeferred = false
     /// alias → catalog facts. ``ensureServing`` needs the repo; readiness
     /// needs ``cached``. One `audioEntries` fetch fills both. The repo is
     /// only ever passed to the server for models already on disk — passing
@@ -174,6 +179,7 @@ final class DictationController {
         testingRecorderStart: (@MainActor () throws -> Void)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
         testingTranscribeCancel: (@MainActor () -> Void)? = nil,
+        testingInitialModelPreparationDeferred: Bool? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
             await ModelCatalog.audioEntriesIfAvailable(binary: $0)
         }
@@ -192,7 +198,13 @@ final class DictationController {
         self.testingTranscribeCancel = testingTranscribeCancel
 
         let defaults = UserDefaults.standard
-        self.isEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
+        let restoredIsEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
+        self.isEnabled = restoredIsEnabled
+        // Persisted enabled intent is a launch-time fact. Establish the same
+        // barrier synchronously with the controller so a mounted Audio view's
+        // revalidation cannot outrun ContentView's async session restore.
+        self.modelPreparationDeferred = testingInitialModelPreparationDeferred
+            ?? (testingEnabled == nil && restoredIsEnabled)
         self.trigger = DictationHotkey.Trigger(
             rawValue: defaults.string(forKey: Keys.trigger) ?? ""
         ) ?? .rightCommand
@@ -260,13 +272,36 @@ final class DictationController {
     /// that normally follows flipping the switch: the event tap was never
     /// installed, the banner still read "Ready", and the hotkey did nothing
     /// until the user toggled it off and on again.
-    func bootstrap() async {
+    func bootstrap(deferModelPreparation: Bool = false) async {
         guard isEnabled, phase == .off else { return }
+        await enable(deferModelPreparation: deferModelPreparation)
+    }
+
+    /// Finish the audio half of launch restore after the chat launch has
+    /// settled. The shortcut was already armed by ``bootstrap`` so a slow
+    /// primary launch never leaves the user's persisted global shortcut
+    /// silently unregistered.
+    func finishDeferredBootstrap() async {
+        guard isEnabled, modelPreparationDeferred else { return }
+        modelPreparationDeferred = false
+        // Cancellation still owns cleanup: leave the already-registered
+        // shortcut able to prepare on its next use, but do not start an audio
+        // model from a superseded launch task.
+        guard !Task.isCancelled else { return }
         await enable()
     }
 
-    func enable(replacingCurrentPrewarm: Bool = false) async {
+    func enable(
+        replacingCurrentPrewarm: Bool = false,
+        deferModelPreparation: Bool = false
+    ) async {
         guard isEnabled else { return }
+        // Establish the launch barrier before the first suspension. Catalog
+        // refresh is re-entrant: a model change or download completion can
+        // start another enable while this call awaits the subprocess.
+        if deferModelPreparation {
+            modelPreparationDeferred = true
+        }
         let requestID = UUID()
         enableRequestID = requestID
         // The on-disk bit comes from a catalog subprocess; fetch it before
@@ -294,6 +329,18 @@ final class DictationController {
             if disableIntent { isEnabled = false }
             return
         }
+        // Once launch restore establishes this barrier, every re-entrant
+        // enable path (model selection, download completion, activation) must
+        // inherit it. Only `finishDeferredBootstrap` clears it after chat has
+        // settled; otherwise a model change can start an audio-only fallback
+        // and tear down the still-starting primary child.
+        if deferModelPreparation || modelPreparationDeferred {
+            modelPreparationDeferred = true
+            guard registerHotkey() else { return }
+            enableRequestID = nil
+            return
+        }
+        modelPreparationDeferred = false
         hotkey.stop()
         phase = .preparingModel
         let preparingAlias = modelAlias
@@ -315,6 +362,12 @@ final class DictationController {
             }
             return
         }
+        guard registerHotkey() else { return }
+        enableRequestID = nil
+    }
+
+    @discardableResult
+    private func registerHotkey() -> Bool {
         guard testingHotkeyStart?() ?? hotkey.start() else {
             // macOS does not apply an Accessibility grant to an already-running
             // process, so this is the common shape right after the user flips
@@ -325,12 +378,12 @@ final class DictationController {
                 ? "Accessibility is granted, but this running copy hasn't picked it up. Relaunch Rapid to finish."
                 : "The dictation hotkey couldn't be registered."
             phase = .off
-            return
+            return false
         }
         accessibilityNeedsRelaunch = false
         lastError = nil
         phase = .idle
-        enableRequestID = nil
+        return true
     }
 
     func disable() {
@@ -350,6 +403,7 @@ final class DictationController {
         prewarmTask = nil
         prewarmRequestID = nil
         enableRequestID = nil
+        modelPreparationDeferred = false
         stopTicking()
         recorder.shutdown()
         hud.hide()
@@ -651,6 +705,10 @@ final class DictationController {
             return
         }
         let requestedAlias = modelAlias
+        guard !modelPreparationDeferred else {
+            lastError = "Dictation will be ready after your chat model finishes starting."
+            return
+        }
         guard server.isVoiceLaneReady(for: requestedAlias) else {
             hotkey.stop()
             phase = .preparingModel

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -361,11 +361,6 @@ struct RapidApp: App {
                 .environment(mcpTools)
                 .environment(perfConfig)
                 .task {
-                    // Dictation is a background service: arm it at launch so
-                    // the hotkey works without ever opening the Audio tab.
-                    await dictation.bootstrap()
-                }
-                .task {
                     // DEV-ONLY: render real screens to PNG when
                     // RAPID_DEV_SNAPSHOT_DIR is set, then quit. Inert
                     // (returns immediately) in normal use.

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -32,6 +32,15 @@ import Foundation
 actor ModelCatalogCache {
     static let shared = ModelCatalogCache()
 
+    typealias Loader = @Sendable (URL, URL?) async -> [ModelEntry]
+    private let loader: Loader
+
+    init(loader: @escaping Loader = { binary, override in
+        await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+    }) {
+        self.loader = loader
+    }
+
     /// Backstop for out-of-band changes (see above).
     ///
     /// Five minutes, not seconds: ``cacheGeneration`` already catches every
@@ -212,8 +221,9 @@ actor ModelCatalogCache {
         binary: URL, override: URL?, binaryPath: String,
         generation: UInt, overridePath: String?
     ) -> InFlight {
+        let loader = self.loader
         let task = Task<[ModelEntry], Never> {
-            await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+            await loader(binary, override)
         }
         nextInFlightID &+= 1
         let entry = InFlight(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -685,7 +685,7 @@ final class ServerManager {
     /// Persistence destination for lane-owned launch state. Production uses
     /// standard defaults; lifecycle tests inject an isolated suite while still
     /// driving the real spawn/health transition.
-    private let sessionDefaults: UserDefaults
+    private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
     /// original Start action when a later catalog subprocess fails.
@@ -962,13 +962,15 @@ final class ServerManager {
     /// child or relying on whatever ``rapid-mlx`` happens to be on
     /// disk. Not part of any production code path; the underscore
     /// prefix mirrors the Swift Standard Library convention for
-    /// "API kept around for testing only."
+    /// "API kept around for testing only." Session persistence is opt-in:
+    /// parallel fake-sidecar tests must not race through ``.standard`` or
+    /// mutate the app's real last-chat selection.
     internal init(
         testingState: ServerState,
         binaryPath: URL? = nil,
         residency: ModelResidencySnapshot = .empty,
         activeBearer: String? = nil,
-        sessionDefaults: UserDefaults = .standard
+        sessionDefaults: UserDefaults? = nil
     ) {
         self.state = testingState
         self.activeBearer = activeBearer
@@ -1012,6 +1014,7 @@ final class ServerManager {
         alias: String,
         catalogEntry: ModelEntry?
     ) {
+        guard let sessionDefaults else { return }
         SessionModelRestore.persistReadyAlias(
             alias,
             catalogEntry: catalogEntry,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -682,6 +682,14 @@ final class ServerManager {
 
     /// Interval between `/healthz` probes once the child is up.
     private let healthPollInterval: TimeInterval = 0.5
+    /// Persistence destination for lane-owned launch state. Production uses
+    /// standard defaults; lifecycle tests inject an isolated suite while still
+    /// driving the real spawn/health transition.
+    private let sessionDefaults: UserDefaults
+    /// Catalog provenance supplied by UI start paths. Retained by alias so a
+    /// memory-confirmation re-entry does not lose the proof carried by the
+    /// original Start action when a later catalog subprocess fails.
+    private var catalogProvenStartEntries: [String: ModelEntry] = [:]
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -937,6 +945,7 @@ final class ServerManager {
         self.binaryResolution = resolution
         self.binaryPath = resolution?.binary
         self.state = (resolution == nil) ? .missing : .idle
+        self.sessionDefaults = .standard
     }
 
     /// Wire the app's ``DownloadManager`` so ``start(alias:)`` can
@@ -958,12 +967,14 @@ final class ServerManager {
         testingState: ServerState,
         binaryPath: URL? = nil,
         residency: ModelResidencySnapshot = .empty,
-        activeBearer: String? = nil
+        activeBearer: String? = nil,
+        sessionDefaults: UserDefaults = .standard
     ) {
         self.state = testingState
         self.activeBearer = activeBearer
         self.binaryPath = binaryPath
         self.residency = residency
+        self.sessionDefaults = sessionDefaults
         self.binaryResolution = binaryPath.map {
             ServerLocator.Resolution(binary: $0, source: .unknown, version: nil)
         }
@@ -991,6 +1002,36 @@ final class ServerManager {
     /// stop landing mid-loop to pin the state-drift guard.
     internal func _testSetState(_ newState: ServerState) {
         self.state = newState
+    }
+
+    /// Publish the selection consequence of a successful health transition.
+    /// Kept as one lifecycle boundary so tests exercise the same call that the
+    /// real `/healthz` success path uses instead of calling persistence policy
+    /// in isolation.
+    internal func recordReadySelection(
+        alias: String,
+        catalogEntry: ModelEntry?
+    ) {
+        SessionModelRestore.persistReadyAlias(
+            alias,
+            catalogEntry: catalogEntry,
+            defaults: sessionDefaults
+        )
+    }
+
+    /// Prefer the start-time probe, but preserve catalog provenance already
+    /// held by the initiating UI when that probe transiently fails. The hint
+    /// is accepted only for the exact alias being launched.
+    internal static func readyCatalogEntry(
+        alias: String,
+        probed: ModelEntry?,
+        hint: ModelEntry?
+    ) -> ModelEntry? {
+        if let probed { return probed }
+        guard let hint,
+              hint.alias.caseInsensitiveCompare(alias) == .orderedSame
+        else { return nil }
+        return hint
     }
 
     /// Issue #1838 test seam — swap in a ``ServerResidencyClient`` whose
@@ -1084,13 +1125,15 @@ final class ServerManager {
 
     // MARK: - Persisted "last served" alias (v0.5.3 auto-restart)
 
-    /// UserDefaults key holding the alias of the model the user most
-    /// recently asked us to serve. Written on every transition into
-    /// ``.ready(alias:)`` and cleared on user-initiated ``stop()``.
+    /// UserDefaults key holding the alias of the chat model the user most
+    /// recently asked us to serve. Written only when authoritative catalog
+    /// metadata identifies the ready child as chat-capable; audio/image lane
+    /// process ownership must never replace the user's chat selection.
+    /// Cleared on user-initiated ``stop()``.
     /// ``RapidApp`` reads this on launch to decide whether to
     /// auto-resume the previous session's model (LM Studio shape:
     /// the loaded model survives an app restart).
-    nonisolated fileprivate static let lastServedAliasKey = "rapid.serve.lastAlias"
+    nonisolated fileprivate static let lastServedAliasKey = SessionModelRestore.chatAliasStorageKey
 
     /// Currently persisted last-served alias, if any. ``nil`` after a
     /// user-initiated Stop or a fresh install. Exposed as a static
@@ -1163,12 +1206,14 @@ final class ServerManager {
         estimatedMemoryGB: Double?,
         replacementGroup: ResidentModelReplacementGroup? = nil,
         imageMode: ResidentImageMode? = nil,
-        residencyEligible: Bool = true
+        residencyEligible: Bool = true,
+        catalogEntryHint: ModelEntry? = nil
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         let requestedPerformanceFlags = perfLaunchFlagsProvider?(trimmed) ?? []
         var requestedCatalogSupportsImageInput = false
+        var probedCatalogEntry: ModelEntry?
         // Cold start delegates to `start`, which resolves the same metadata
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
@@ -1180,12 +1225,18 @@ final class ServerManager {
                 $0.alias.caseInsensitiveCompare(trimmed) == .orderedSame
             }
             if Task.isCancelled || didSignalShutdown { return false }
+            probedCatalogEntry = entry
             requestedCatalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
                 forAlias: trimmed,
                 isBuiltinProfile: entry?.isBuiltinProfile,
                 isTextOnly: entry?.isTextOnly
             )
         }
+        let provenCatalogEntry = Self.readyCatalogEntry(
+            alias: trimmed,
+            probed: probedCatalogEntry,
+            hint: catalogEntryHint
+        )
         let requiresImageLaneRestart = Self.requiresProcessRestartForImageCapability(
             catalogSupportsImageInput: requestedCatalogSupportsImageInput,
             userOverrides: requestedPerformanceFlags,
@@ -1306,6 +1357,12 @@ final class ServerManager {
                 if replacementGroup != nil {
                     state = .ready(alias: trimmed)
                 }
+                if replacementGroup == .assistant {
+                    recordReadySelection(
+                        alias: trimmed,
+                        catalogEntry: provenCatalogEntry
+                    )
+                }
                 // A successful in-process load confirms the model is fine, so
                 // drop any (possibly concurrent) rejection recorded for it —
                 // but only if THIS attempt is still the newest for the alias.
@@ -1379,7 +1436,12 @@ final class ServerManager {
             await stop(preservingLastServedAlias: true)
         }
         let memoryRequestID = UUID()
-        await start(alias: trimmed, hfPath: hfPath, memoryRequestID: memoryRequestID)
+        await start(
+            alias: trimmed,
+            hfPath: hfPath,
+            memoryRequestID: memoryRequestID,
+            catalogEntryHint: provenCatalogEntry
+        )
         // ``start`` also returns without spawning when the pre-load
         // memory guard parks the load on a confirmation prompt. Reading
         // ``isServing`` now would report "couldn't start the model"
@@ -1713,7 +1775,8 @@ final class ServerManager {
         isAutoRespawn: Bool = false,
         bypassMemoryGuard: Bool = false,
         memoryRequestID: UUID? = nil,
-        isLaunchAutoStart: Bool = false
+        isLaunchAutoStart: Bool = false,
+        catalogEntryHint: ModelEntry? = nil
     ) async {
         // Issue #278: a manual restart is the user taking over the
         // lifecycle — reset the budget at entry so a previously
@@ -1748,6 +1811,13 @@ final class ServerManager {
                 message: "That model name isn't valid. Pick a model from the bar at the top."
             )
             return
+        }
+        if let hintedEntry = Self.readyCatalogEntry(
+            alias: trimmedAlias,
+            probed: nil,
+            hint: catalogEntryHint
+        ) {
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = hintedEntry
         }
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
@@ -1882,12 +1952,18 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let catalogEntry = await ModelCatalogCache.shared.entries(
+        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let catalogEntry = Self.readyCatalogEntry(
+            alias: trimmedAlias,
+            probed: probedCatalogEntry,
+            hint: catalogEntryHint
+                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
+        )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let catalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
@@ -2344,7 +2420,7 @@ final class ServerManager {
                 // overwrite the previous good-known value, so a
                 // crashed launch attempt doesn't strand the resume
                 // logic on a model the user can't actually load.
-                UserDefaults.standard.set(trimmedAlias, forKey: Self.lastServedAliasKey)
+                recordReadySelection(alias: trimmedAlias, catalogEntry: catalogEntry)
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that
                 // the child is ready, start the runtime health

--- a/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Lane-owned model selections restored when the Desktop launches.
+///
+/// The process-owning alias is not a user selection: an audio-only fallback
+/// may own the sidecar even though the user's chat choice is unchanged. Keep
+/// those facts separate so auxiliary lanes can never become the chat model.
+struct SessionModelRestore: Equatable, Sendable {
+    struct LaunchPlan: Equatable, Sendable {
+        let models: SessionModelRestore
+        let chatAliasResolved: Bool
+        let shouldAutoStart: Bool
+    }
+
+    /// Kept at the rc2 key for a migration without data loss; its semantic
+    /// owner is now explicitly the chat lane.
+    static let chatAliasStorageKey = "rapid.serve.lastAlias"
+
+    let chatAlias: String?
+    let dictationAlias: String?
+    let speechAlias: String?
+
+    /// A ready process may update chat intent only when the catalog proves it
+    /// belongs to the chat lane. Unknown direct aliases fail closed: process
+    /// ownership alone is never enough evidence to rewrite user selection.
+    static func shouldPersistChatAlias(catalogEntry: ModelEntry?) -> Bool {
+        catalogEntry?.kind == .chat
+    }
+
+    /// Record a successful ready transition without confusing the process
+    /// owner with the user's chat selection. `ServerManager.start` funnels
+    /// every ready child through here, including the audio-only fallback from
+    /// `ensureVoiceLane`.
+    static func persistReadyAlias(
+        _ alias: String,
+        catalogEntry: ModelEntry?,
+        defaults: UserDefaults = .standard
+    ) {
+        guard shouldPersistChatAlias(catalogEntry: catalogEntry) else { return }
+        defaults.set(alias, forKey: chatAliasStorageKey)
+    }
+
+    /// Resolve persisted aliases only through authoritative catalog lanes.
+    /// `legacyLastAlias` is the rc2-era `rapid.serve.lastAlias` value; accepting
+    /// it only as a chat-catalog member makes the migration safe without model
+    /// names, repository ids, or hashes.
+    static func resolve(
+        legacyLastAlias: String?,
+        dictationAlias: String?,
+        speechAlias: String?,
+        catalog: [ModelEntry]
+    ) -> SessionModelRestore {
+        let chatAliases = catalog.filter { $0.kind == .chat }.map(\.alias)
+        let audioAliases = catalog.filter { $0.kind == .audio }.map(\.alias)
+        return SessionModelRestore(
+            chatAlias: validated(legacyLastAlias, in: chatAliases),
+            dictationAlias: validated(dictationAlias, in: audioAliases),
+            speechAlias: validated(speechAlias, in: audioAliases)
+        )
+    }
+
+    /// Resolve lane ownership independently from the auto-start preference.
+    /// Callers must publish `models.chatAlias` even when `shouldAutoStart` is
+    /// false so onboarding and restore never disagree about a legacy key.
+    static func launchPlan(
+        legacyLastAlias: String?,
+        dictationAlias: String?,
+        speechAlias: String?,
+        catalog: [ModelEntry],
+        autoStartEnabled: Bool,
+        emptyCatalogIsAuthoritative: Bool = false
+    ) -> LaunchPlan {
+        let hasLegacyAlias = legacyLastAlias?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty == false
+        // ModelCatalog uses [] as its subprocess-failure sentinel. With a
+        // legacy value to classify, absence of rows is therefore unknown —
+        // not evidence that the value is non-chat. Keep launch/onboarding
+        // pending rather than rejecting it and selecting a fallback model.
+        let chatAliasResolved = !hasLegacyAlias
+            || !catalog.isEmpty
+            || emptyCatalogIsAuthoritative
+        return LaunchPlan(
+            models: resolve(
+                legacyLastAlias: legacyLastAlias,
+                dictationAlias: dictationAlias,
+                speechAlias: speechAlias,
+                catalog: catalog
+            ),
+            chatAliasResolved: chatAliasResolved,
+            shouldAutoStart: autoStartEnabled
+                && chatAliasResolved
+                && !emptyCatalogIsAuthoritative
+        )
+    }
+
+    private static func validated(_ raw: String?, in aliases: [String]) -> String? {
+        guard let raw else { return nil }
+        let alias = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !alias.isEmpty else { return nil }
+        return aliases.first {
+            $0.caseInsensitiveCompare(alias) == .orderedSame
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -6,6 +6,29 @@ import SwiftUI
 /// server is ready the picker's Start button owns the flow, and a
 /// brand-new user with no model on disk sees the Quickstart card.
 struct ContentView: View {
+    enum RestoredChatAlias: Equatable {
+        case pendingCatalog
+        /// The bounded catalog retry also failed. The persisted key remains
+        /// untouched for a future launch, but this session must not stay
+        /// blocked behind an alias it could not classify.
+        case unresolved
+        case resolved(String?)
+    }
+
+    /// Outer nil means catalog classification is still pending. Outer some
+    /// carries the value onboarding should evaluate; `.unresolved` therefore
+    /// deliberately behaves like no persisted chat model for this session.
+    static func quickstartChatAlias(for state: RestoredChatAlias) -> String?? {
+        switch state {
+        case .pendingCatalog:
+            nil
+        case .unresolved:
+            .some(nil)
+        case .resolved(let alias):
+            .some(alias)
+        }
+    }
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// #459: hard window-width floor. The original 640pt target preserved
     /// half-screen tiling on built-in MacBook displays; 720pt is the smallest
@@ -23,6 +46,7 @@ struct ContentView: View {
     @Environment(ChatViewModel.self) private var chat
     @Environment(ImageGenViewModel.self) private var imageGen
     @Environment(AudioViewModel.self) private var audio
+    @Environment(DictationController.self) private var dictation
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
@@ -69,6 +93,16 @@ struct ContentView: View {
     /// FU-1: persisted opt-out for the launch-time auto-start path.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
     @State private var campaign: Campaign? = Campaign.previewFromEnvironment(ProcessInfo.processInfo.environment)
+    /// The rc2 key predates lane ownership. A non-empty value cannot decide
+    /// onboarding until catalog metadata proves it is a chat model; keeping an
+    /// explicit pending state prevents the launch gate and Quickstart surface
+    /// from interpreting the same legacy audio alias differently.
+    @State private var restoredChatAlias: RestoredChatAlias =
+        ServerManager.lastServedAlias() == nil ? .resolved(nil) : .pendingCatalog
+    /// A legacy chat key needs catalog metadata before it can be trusted. If
+    /// the shared launch probe fails empty, permit one immediate authoritative
+    /// retry without turning session restoration into a polling loop.
+    @State private var catalogRestoreRetryAttempted = false
 
     var body: some View {
         // Capture the identity owned by this alert render. A delayed dismiss
@@ -246,7 +280,7 @@ struct ContentView: View {
         // re-run, and the first pass returns at the gate without an
         // in-flight `server.start` for SwiftUI's task cancellation to
         // interrupt. Users with no pending decision see one run, as before.
-        .task(id: telemetryConsentPending) { await runLaunchAutoStart() }
+        .task(id: telemetryConsentPending) { await restorePersistedSession() }
         // Keyed exactly as the picker's own catalog task: re-fetch when
         // the engine binary appears and whenever the set of models on
         // disk changes anywhere in the app. Routed through the shared
@@ -586,14 +620,32 @@ struct ContentView: View {
     private func refreshCatalogSnapshot() async {
         guard let binary = server.binaryPath else { return }
         let generation = downloads.cacheGeneration
-        let loaded = await ModelCatalogCache.shared.entries(
+        var loaded = await ModelCatalogCache.shared.entries(
             binary: binary,
             generation: generation
         )
         guard !Task.isCancelled, generation == downloads.cacheGeneration else { return }
+        if loaded.isEmpty,
+           case .pendingCatalog = restoredChatAlias,
+           !catalogRestoreRetryAttempted {
+            catalogRestoreRetryAttempted = true
+            await ModelCatalogCache.shared.invalidate()
+            loaded = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: generation
+            )
+            guard !Task.isCancelled, generation == downloads.cacheGeneration else { return }
+        }
         catalogEntries = loaded
         catalogGeneration = generation
         catalogLoaded = true
+        if case .pendingCatalog = restoredChatAlias,
+           !loaded.isEmpty || catalogRestoreRetryAttempted {
+            await restorePersistedSession(
+                catalog: loaded,
+                emptyCatalogIsAuthoritative: loaded.isEmpty
+            )
+        }
     }
 
     /// Perform the readiness banner's next-step action.
@@ -632,7 +684,8 @@ struct ContentView: View {
     }
 
     private func startModel(_ target: String) {
-        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        let catalogEntry = catalogEntries.first(where: { $0.alias == target })
+        let hfPath = catalogEntry?.hfRepo
         // ``ensureServing`` via the shared helper, NOT ``server.start``: start is
         // cold-start only and no-ops while a different model (e.g. an Images
         // checkpoint) is resident, silently dropping the switch (#1739).
@@ -641,7 +694,8 @@ struct ContentView: View {
                 alias: target,
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
-                replacementGroup: .assistant
+                replacementGroup: .assistant,
+                catalogEntryHint: catalogEntry
             )
         }
     }
@@ -672,7 +726,8 @@ struct ContentView: View {
                 alias: target,
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
-                replacementGroup: .assistant
+                replacementGroup: .assistant,
+                catalogEntryHint: entry
             )
         }
     }
@@ -685,10 +740,17 @@ struct ContentView: View {
     }
 
     private func restartModel(_ target: String) {
-        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        let catalogEntry = catalogEntries.first(where: { $0.alias == target })
+        let hfPath = catalogEntry?.hfRepo
         Task {
             await server.stop()
-            _ = await server.ensureServing(alias: target, hfPath: hfPath)
+            _ = await server.ensureServing(
+                alias: target,
+                hfPath: hfPath,
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant,
+                catalogEntryHint: catalogEntry
+            )
         }
     }
 
@@ -842,10 +904,13 @@ struct ContentView: View {
         ) {
             return false
         }
+        guard let chatAlias = Self.quickstartChatAlias(for: restoredChatAlias) else {
+            return false
+        }
         if QuickstartCoordinator.isEligible(
             done: quickstart.done,
             legacyDone: quickstart.legacyDone,
-            lastServedAlias: ServerManager.lastServedAlias(),
+            lastServedAlias: chatAlias,
             serverState: server.state
         ) {
             return true
@@ -1121,7 +1186,80 @@ struct ContentView: View {
 
     // MARK: - Launch auto-start (Flow A/B)
 
-    private func runLaunchAutoStart() async {
+    /// Restore lane-owned state in dependency order. Start resolving chat
+    /// first, while arming Dictation's persisted global shortcut immediately;
+    /// audio model preparation remains deferred until the chat launch settles.
+    /// This keeps a slow primary health check from disabling the shortcut
+    /// without letting an audio fallback win ownership of the shared process.
+    private func restorePersistedSession(
+        catalog suppliedCatalog: [ModelEntry]? = nil,
+        emptyCatalogIsAuthoritative: Bool = false
+    ) async {
+        guard !telemetryConsentPending else { return }
+        let resolutionWasPending: Bool = {
+            if case .pendingCatalog = restoredChatAlias { return true }
+            return false
+        }()
+        _ = BundledModel.installBundledSnapshotSymlink()
+        _ = QuickstartModel.installAllSnapshotSymlinks()
+        let sessionCatalog: [ModelEntry]
+        if let suppliedCatalog {
+            sessionCatalog = suppliedCatalog
+        } else if let binary = server.binaryPath {
+            sessionCatalog = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: downloads.cacheGeneration
+            )
+        } else {
+            sessionCatalog = []
+        }
+        let launchPlan = SessionModelRestore.launchPlan(
+            legacyLastAlias: ServerManager.lastServedAlias(),
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: sessionCatalog,
+            autoStartEnabled: autoStartOnLaunch,
+            emptyCatalogIsAuthoritative: emptyCatalogIsAuthoritative
+        )
+        // Another reader may have resolved the same shared load while this
+        // task was suspended. A stale empty result cannot re-establish the
+        // audio barrier after the winning restore has already paired it.
+        if resolutionWasPending {
+            guard case .pendingCatalog = restoredChatAlias else { return }
+        }
+        if launchPlan.chatAliasResolved {
+            restoredChatAlias = emptyCatalogIsAuthoritative
+                ? .unresolved
+                : .resolved(launchPlan.models.chatAlias)
+        }
+
+        async let chatRestore: Void = runLaunchAutoStart(
+            catalogEntries: sessionCatalog,
+            launchPlan: launchPlan
+        )
+        await dictation.bootstrap(deferModelPreparation: true)
+        await chatRestore
+        // A failed catalog probe cannot classify the legacy key. Keep the
+        // audio barrier established; `refreshCatalogSnapshot` re-enters this
+        // same function when its independent probe produces real rows.
+        guard launchPlan.chatAliasResolved else { return }
+        if Task.isCancelled {
+            // The catalog task is keyed on cache generation. Hand ownership
+            // back to its replacement and pair the already-established audio
+            // barrier without starting audio from this cancelled task.
+            if resolutionWasPending {
+                restoredChatAlias = .pendingCatalog
+            }
+            await dictation.finishDeferredBootstrap()
+            return
+        }
+        await dictation.finishDeferredBootstrap()
+    }
+
+    private func runLaunchAutoStart(
+        catalogEntries: [ModelEntry],
+        launchPlan: SessionModelRestore.LaunchPlan
+    ) async {
         // Consent is the first user-controlled surface. Do not even inspect
         // model caches behind it: the final AutoStartDecision also knows about
         // this gate, but reaching that decision requires loading the catalog
@@ -1130,18 +1268,15 @@ struct ContentView: View {
         // operator's existing HF cache. The task is keyed on this value and
         // runs again immediately after the user answers.
         guard !telemetryConsentPending else { return }
-        guard autoStartOnLaunch else {
+        guard launchPlan.shouldAutoStart else {
             autoStartPendingDownload = nil
             return
         }
         guard case .idle = server.state else { return }
 
-        _ = BundledModel.installBundledSnapshotSymlink()
-        _ = QuickstartModel.installAllSnapshotSymlinks()
-
         let aliasAtEntry = alias
         let userSelectionRevisionAtEntry = userSelectionRevision
-        var cachedAliases: Set<String> = []
+        let cachedAliases = Set(catalogEntries.filter { $0.cached }.map(\.alias))
         // #1706: the full catalog membership snapshot (cached AND
         // uncached entries the sidecar can serve), used to validate the
         // stored last-served alias before we resume it. `nil` would ask
@@ -1149,15 +1284,9 @@ struct ContentView: View {
         // concrete set when the binary is reachable so a stored alias
         // the engine can't serve (renamed/dropped/wrong-modality) falls
         // through to the picker instead of a failed serve.
-        var catalogAliases: Set<String>? = nil
-        if let binary = server.binaryPath {
-            let entries = await ModelCatalogCache.shared.entries(
-                binary: binary,
-                generation: downloads.cacheGeneration
-            )
-            cachedAliases = Set(entries.filter { $0.cached }.map(\.alias))
-            catalogAliases = Set(entries.map(\.alias))
-        }
+        let catalogAliases: Set<String>? = server.binaryPath == nil
+            ? nil
+            : Set(catalogEntries.map(\.alias))
         guard case .idle = server.state else {
             autoStartPendingDownload = nil
             return
@@ -1184,7 +1313,7 @@ struct ContentView: View {
                     alias: candidate, physicalRAMGB: hardware.physicalRAMGB)
         }
         let decision = AutoStartDecision.decide(
-            lastServedAlias: ServerManager.lastServedAlias(),
+            lastServedAlias: launchPlan.models.chatAlias,
             bundledFallbackAlias: BundledModel.firstLaunchAlias(lastServedAlias: nil),
             binaryReachable: server.binaryPath != nil,
             cachedAliases: cachedAliases,
@@ -1206,7 +1335,7 @@ struct ContentView: View {
             onboardingPending: QuickstartCoordinator.onboardingOwed(
                 done: quickstart.done,
                 legacyDone: quickstart.legacyDone,
-                lastServedAlias: ServerManager.lastServedAlias()
+                lastServedAlias: launchPlan.models.chatAlias
             ),
             // Skip a retired starter only while the rescue is still on
             // offer. Once the user has completed or dismissed Quickstart,
@@ -1229,7 +1358,14 @@ struct ContentView: View {
             // modal the user never asked for (issue: annoying warning on every
             // app open). The user's own Start/first-message routes through
             // ``start`` without this flag and still gets the warning.
-            await server.start(alias: resume, isLaunchAutoStart: true)
+            let catalogEntry = catalogEntries.first {
+                $0.alias.caseInsensitiveCompare(resume) == .orderedSame
+            }
+            await server.start(
+                alias: resume,
+                isLaunchAutoStart: true,
+                catalogEntryHint: catalogEntry
+            )
         case .promptDownload(let pending):
             let footprint = ModelSizing.estimate(alias: pending)
             let sizeText: String? = footprint.paramsBillions == nil

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1567,10 +1567,17 @@ struct ModelPickerBar: View {
             pendingTooBigStart = trimmed
             return
         }
-        let hfPath = catalog.first(where: { $0.alias == trimmed })?.hfRepo
+        let catalogEntry = catalog.first(where: { $0.alias == trimmed })
+        let hfPath = catalogEntry?.hfRepo
         // Launch flags are applied inside ServerManager.start (one choke
         // point for every start path), RAM-gated to the recommended pick.
-        Task { await server.start(alias: trimmed, hfPath: hfPath) }
+        Task {
+            await server.start(
+                alias: trimmed,
+                hfPath: hfPath,
+                catalogEntryHint: catalogEntry
+            )
+        }
     }
 
     /// Alert title shown when the user tries to Start a ``.tooBig``

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -4386,7 +4386,15 @@ struct QuickstartView: View {
             }
         case .restart:
             coordinator.enterStarting()
-            Task { await server.start(alias: coordinator.selection.alias) }
+            let catalogEntry = cachedModels.first {
+                $0.alias == coordinator.selection.alias
+            }
+            Task {
+                await server.start(
+                    alias: coordinator.selection.alias,
+                    catalogEntryHint: catalogEntry
+                )
+            }
         case .openModelManagement, .openWebSearchSettings:
             // One path for every Settings deep-link. ``route`` stages the
             // target tab and only then runs the open — ``SettingsView`` reads
@@ -4464,7 +4472,8 @@ struct QuickstartView: View {
             await coordinator.afterSkippingDownloadBeat(duration: Self.skippingDownloadBeat) {
                 await server.start(
                     alias: cached.alias,
-                    hfPath: cached.hfRepo
+                    hfPath: cached.hfRepo,
+                    catalogEntryHint: cached
                 )
             }
         }
@@ -4557,10 +4566,14 @@ struct QuickstartView: View {
             // and re-enters main actor; we kick it via a Task because
             // the .task(id:) closure is already main-actor bound.
             coordinator.enterStarting()
+            let catalogEntry = cachedModels.first {
+                $0.alias == coordinator.selection.alias
+            }
             Task { @MainActor in
                 await server.start(
                     alias: coordinator.selection.alias,
-                    hfPath: coordinator.selection.hfRepo
+                    hfPath: coordinator.selection.hfRepo,
+                    catalogEntryHint: catalogEntry
                 )
             }
         case .cancelled:

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -221,6 +221,14 @@ journeys:
     fixtures: [fake-sidecar, delayed-transcription, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/UI/DictationView.swift]
     owns_baseline: false
+  - name: dictation-rc2-upgrade
+    group: audio
+    risk: high
+    driver: ax
+    ci_tier: local
+    fixtures: [fake-sidecar, audio-models, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
+    owns_baseline: false
   - name: audio-readiness
     group: audio
     risk: high

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -391,6 +391,184 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("launch bootstrap arms before deferred model preparation")
+    func launchBootstrapArmsWithoutWaitingForPrimaryHealth() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+        #expect(prewarmCount == 0, "audio preparation must not race the primary launch")
+
+        controller.toggleFromUI()
+        await Task.yield()
+        #expect(controller.lastError?.contains("chat model finishes starting") == true)
+        #expect(prewarmCount == 0)
+
+        await controller.finishDeferredBootstrap()
+
+        #expect(controller.phase == .idle)
+        #expect(prewarmCount == 1)
+        #expect(hotkeyStartCount == 2)
+    }
+
+    @MainActor
+    @Test("a cancelled session restore releases its audio barrier without prewarming")
+    func cancelledSessionRestoreReleasesBarrier() async {
+        var prewarmCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: { true }
+        )
+        await controller.bootstrap(deferModelPreparation: true)
+
+        let cancelledFinish = Task { @MainActor in
+            await controller.finishDeferredBootstrap()
+        }
+        cancelledFinish.cancel()
+        await cancelledFinish.value
+        #expect(prewarmCount == 0, "a superseded restore cannot start the audio lane")
+
+        await controller.enable()
+        #expect(prewarmCount == 1, "the replacement flow must not inherit a stranded barrier")
+    }
+
+    @MainActor
+    @Test("cold-start revalidation inherits the synchronous launch barrier")
+    func coldStartRevalidationCannotPrewarmBeforeChatRestore() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            initiallyDeferred: true,
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        controller.revalidate()
+        while hotkeyStartCount == 0 { await Task.yield() }
+        #expect(prewarmCount == 0, "Audio-view revalidation cannot start the audio lane")
+
+        await controller.finishDeferredBootstrap()
+        #expect(prewarmCount == 1)
+    }
+
+    @MainActor
+    @Test("model changes inherit the launch audio-preparation barrier")
+    func modelChangeDuringDeferredBootstrapCannotPrewarm() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+        controller.modelAlias = "another-speech-input"
+        while hotkeyStartCount < 2 { await Task.yield() }
+
+        #expect(controller.phase == .idle)
+        #expect(prewarmCount == 0, "a model change must not steal the starting chat process")
+    }
+
+    @MainActor
+    @Test("launch barrier exists before catalog refresh suspends")
+    func modelChangeDuringDeferredCatalogRefreshCannotPrewarm() async {
+        var firstCatalogContinuation: CheckedContinuation<[ModelEntry]?, Never>?
+        var catalogLoadCount = 0
+        var prewarmCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: {
+                prewarmCount += 1
+                return true
+            },
+            testingHotkeyStart: { true },
+            audioCatalogLoader: { _ in
+                catalogLoadCount += 1
+                if catalogLoadCount == 1 {
+                    return await withCheckedContinuation { firstCatalogContinuation = $0 }
+                }
+                return [entry]
+            }
+        )
+
+        let bootstrap = Task { await controller.bootstrap(deferModelPreparation: true) }
+        while firstCatalogContinuation == nil { await Task.yield() }
+        controller.modelAlias = "another-speech-input"
+        for _ in 0..<30 { await Task.yield() }
+
+        #expect(prewarmCount == 0)
+        firstCatalogContinuation?.resume(returning: [entry])
+        await bootstrap.value
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
+    @Test("hotkey failure cannot release the launch barrier")
+    func failedDeferredHotkeyRegistrationCannotEnablePrewarm() async {
+        var hotkeyAttempts = 0
+        var prewarmCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyAttempts += 1
+                return hotkeyAttempts > 1
+            }
+        )
+
+        await controller.bootstrap(deferModelPreparation: true)
+        #expect(controller.phase == .off)
+        #expect(prewarmCount == 0)
+
+        await controller.enable()
+        #expect(controller.phase == .idle)
+        #expect(hotkeyAttempts == 2)
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
     @Test("failed model warmup leaves dictation visibly unarmed")
     func failedWarmupDoesNotArmHotkey() async {
         var hotkeyStartCount = 0
@@ -616,6 +794,7 @@ struct DictationTests {
     @MainActor
     private func readinessController(
         phase: DictationController.Phase = .off,
+        initiallyDeferred: Bool = false,
         prewarm: @escaping @MainActor () async -> Bool,
         hotkeyStart: @escaping @MainActor () -> Bool
     ) -> DictationController {
@@ -644,6 +823,7 @@ struct DictationTests {
             ),
             testingPrewarm: prewarm,
             testingHotkeyStart: hotkeyStart,
+            testingInitialModelPreparationDeferred: initiallyDeferred,
             audioCatalogLoader: { _ in [entry] }
         )
     }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -629,6 +629,12 @@ struct DictationTests {
         #expect(controller.phase == .starting)
         #expect(recorderStartCount == 1)
         #expect(server.servingAlias == "qwen3-0.6b-4bit")
+        #expect(controller.testingHasActiveTicker)
+        #expect(!controller.testingHasRecorder)
+
+        controller.disable()
+        #expect(!controller.testingHasActiveTicker)
+        #expect(!controller.testingHasRecorder)
     }
 
     @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -303,13 +303,20 @@ struct LaunchOnboardingOrderingTests {
     /// single re-run of the launch hook, not a permanent suppression.
     @Test("Answering consent releases the deferred auto-start")
     func consentAnsweredReleasesAutoStart() {
-        let decision = launchDecision(
+        let deferred = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            done: true,
+            consentPending: true
+        )
+        let released = launchDecision(
             lastServedAlias: "qwen3.5-4b-4bit",
             cachedAliases: ["qwen3.5-4b-4bit"],
             done: true,
             consentPending: false
         )
-        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+        #expect(deferred == .skip(reason: .firstRunDecisionPending))
+        #expect(released == .start(alias: "qwen3.5-4b-4bit"))
     }
 
     // MARK: - Precedence ladder

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -106,6 +106,45 @@ struct LaunchOnboardingOrderingTests {
         ))
     }
 
+    @Test("legacy audio ownership cannot suppress first-run onboarding")
+    func legacyAudioAliasStillOwesOnboarding() {
+        let audio = ModelEntry(
+            alias: "speech-input",
+            hfRepo: "example/speech-input",
+            sizeOnDisk: "500 MB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let launchPlan = SessionModelRestore.launchPlan(
+            legacyLastAlias: audio.alias,
+            dictationAlias: audio.alias,
+            speechAlias: nil,
+            catalog: [audio],
+            autoStartEnabled: false
+        )
+        let restored = launchPlan.models
+
+        #expect(restored.chatAlias == nil)
+        #expect(launchPlan.chatAliasResolved)
+        #expect(!launchPlan.shouldAutoStart)
+        #expect(QuickstartCoordinator.onboardingOwed(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: restored.chatAlias
+        ))
+        #expect(launchDecision(
+            lastServedAlias: restored.chatAlias,
+            cachedAliases: [audio.alias]
+        ) == .skip(reason: .onboardingPending))
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: restored.chatAlias,
+            serverState: .idle
+        ))
+    }
+
     /// The pre-fix state, asserted from the wizard's side, so the test
     /// file documents *why* the gate has to sit where it does. Had
     /// auto-start been allowed to run, this is what the sheet would have

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,10 +128,12 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let catalogEntry = await ModelCatalogCache.shared.entries"))
+        #expect(server.contains("let probedCatalogEntry = await ModelCatalogCache.shared.entries"))
         let catalogProbe = try #require(server.range(
-            of: "let catalogEntry = await ModelCatalogCache.shared.entries"
+            of: "let probedCatalogEntry = await ModelCatalogCache.shared.entries"
         ))
+        #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
+                "the authoritative probe and exact-alias start hint must converge before launch")
         let criticalSection = try #require(server.range(
             of: "        isOperating = true\n\n        // Clear the log tail"
         ))

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
@@ -52,7 +52,9 @@ struct ReadinessRecoveryActionWiringTests {
         }
         let function = String(source[signature.lowerBound...functionEnd])
         #expect(
-            function.contains("awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath)"),
+            function.contains(
+                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntry)"
+            ),
             "Restart must stop the failed engine before bringing the selected model back."
         )
     }

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -483,7 +483,7 @@ struct ResidentLoadFeedbackTests {
     private func makeServer(
         initialAlias: String = "qwen3.5-4b-4bit",
         binaryPath: URL? = nil,
-        sessionDefaults: UserDefaults = .standard
+        sessionDefaults: UserDefaults? = nil
     ) -> ServerManager {
         var client = ServerResidencyClient()
         client.session = ResidentLoadRejectProtocol.session()

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -314,6 +314,45 @@ struct ResidentLoadFeedbackTests {
         #expect(server.residentLoadFailure(for: "flux2-klein-4b") == nil)
     }
 
+    @Test("Assistant resident load persists authoritative catalog provenance without a hint")
+    func residentAssistantPersistsProbedChatAlias() async throws {
+        defer { ResidentLoadRejectProtocol.reset() }
+        ResidentLoadRejectProtocol.rejectLoad = false
+        let suite = "ResidentLoadFeedbackTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let wrapper = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-resident-catalog-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: wrapper) }
+        try "#!/bin/sh\nFAKE_CACHED_CURATED_TRADEUP=1 exec '\(fakeServer.path)' \"$@\"\n"
+            .write(to: wrapper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: wrapper.path
+        )
+        let server = makeServer(
+            initialAlias: "previous-chat",
+            binaryPath: wrapper,
+            sessionDefaults: defaults
+        )
+
+        let ok = await server.ensureServing(
+            alias: "qwen3.5-4b-4bit",
+            hfPath: "fake/model",
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant
+        )
+
+        #expect(ok)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == "qwen3.5-4b-4bit")
+    }
+
     /// The cross-talk regression from the earlier single-slot design (#1838
     /// follow-up): a rejection for model B must NOT be cleared by model A
     /// successfully loading, and a rejection for model A must not surface for
@@ -441,10 +480,18 @@ struct ResidentLoadFeedbackTests {
     /// Build a ``ServerManager`` in the resident-ready state with the stub
     /// transport and a stub child, so ``ensureServing`` takes the in-process
     /// ``/v1/models/load`` path rather than the cold-start fallback.
-    private func makeServer() -> ServerManager {
+    private func makeServer(
+        initialAlias: String = "qwen3.5-4b-4bit",
+        binaryPath: URL? = nil,
+        sessionDefaults: UserDefaults = .standard
+    ) -> ServerManager {
         var client = ServerResidencyClient()
         client.session = ResidentLoadRejectProtocol.session()
-        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
+        let server = ServerManager(
+            testingState: .ready(alias: initialAlias),
+            binaryPath: binaryPath,
+            sessionDefaults: sessionDefaults
+        )
         server._testSetResidencyClient(client)
         server._testInstallChild(ProcessGroupChild.testStub())
         return server

--- a/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
@@ -11,6 +11,8 @@ import Testing
 @MainActor
 @Suite("SamplingConfig defaults + persistence")
 final class SamplingConfigTests {
+    init() { CIHangWatchdog.noteProgress() }
+
     /// Names of every suite ``freshDefaults`` minted for this test
     /// instance. Each ``@Test`` gets a fresh instance of the suite
     /// type, so ``deinit`` runs after the test exits — the suite is
@@ -24,7 +26,10 @@ final class SamplingConfigTests {
     /// test`` runs.
     nonisolated(unsafe) private var createdSuiteNames: [String] = []
 
-    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+    deinit {
+        CIHangWatchdog.noteProgress()
+        TestDefaultsScope.cleanup(suiteNames: createdSuiteNames)
+    }
 
     /// Issue #139 dedupe — the cleanup mechanics that used to live
     /// here are now shared with the other suite-minting tests via

--- a/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SamplingConfigTests.swift
@@ -358,7 +358,10 @@ final class SamplingConfigTests {
         #expect(s.isAtDefaults)
     }
 
-    @Test("Zero / negative on a Double knob WOULD persist as 0 via UserDefaults.double(forKey:) — verify the absent-key fallback handles that distinction")
+    @Test(
+        "Zero / negative on a Double knob WOULD persist as 0 via UserDefaults.double(forKey:) — verify the absent-key fallback handles that distinction",
+        .timeLimit(.minutes(1))
+    )
     func zeroDoubleDistinguishedFromAbsent() {
         // The init uses ``object(forKey:)`` precisely so a missing
         // key on first launch doesn't read as 0.0 (which would

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Lane-owned session model restore")
+struct SessionModelRestoreTests {
+    private actor SequencedCatalogLoader {
+        private var responses: [[ModelEntry]]
+
+        init(_ responses: [[ModelEntry]]) {
+            self.responses = responses
+        }
+
+        func load() -> [ModelEntry] {
+            guard !responses.isEmpty else { return [] }
+            return responses.removeFirst()
+        }
+    }
+
+    private let chat = ModelEntry(
+        alias: "qwen3.5-4b-4bit",
+        hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
+        sizeOnDisk: "2.5 GB",
+        cached: true,
+        kind: .chat
+    )
+    private let stt = ModelEntry(
+        alias: "speech-input",
+        hfRepo: "example/speech-input",
+        sizeOnDisk: "500 MB",
+        cached: true,
+        kind: .audio,
+        audioCapability: .transcription
+    )
+    private let tts = ModelEntry(
+        alias: "speech-output",
+        hfRepo: "example/speech-output",
+        sizeOnDisk: "1 GB",
+        cached: true,
+        kind: .audio,
+        audioCapability: .speech
+    )
+
+    @Test("Dictation cannot replace the restored chat alias")
+    func dictationThenRelaunch() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+        #expect(restored.dictationAlias == stt.alias)
+    }
+
+    @Test("Dictation and speech retain independent audio selections")
+    func dictationAndSpeechThenRelaunch() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias,
+            catalog: [chat, stt, tts]
+        )
+
+        #expect(restored == SessionModelRestore(
+            chatAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias
+        ))
+    }
+
+    @Test("Audio-only history does not invent a chat model")
+    func audioOnlyHistory() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: stt.alias,
+            dictationAlias: stt.alias,
+            speechAlias: tts.alias,
+            catalog: [chat, stt, tts]
+        )
+
+        #expect(restored.chatAlias == nil)
+        #expect(restored.dictationAlias == stt.alias)
+        #expect(restored.speechAlias == tts.alias)
+    }
+
+    @Test("An rc2 chat alias migrates through chat capability metadata")
+    func rc2ChatAliasUpgrade() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: "  \(chat.alias)  ",
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+    }
+
+    @Test("Legacy aliases use catalog casing after a case-insensitive lane match")
+    func legacyAliasCasingIsCanonicalized() {
+        let restored = SessionModelRestore.resolve(
+            legacyLastAlias: chat.alias.uppercased(),
+            dictationAlias: stt.alias.uppercased(),
+            speechAlias: nil,
+            catalog: [chat, stt]
+        )
+
+        #expect(restored.chatAlias == chat.alias)
+        #expect(restored.dictationAlias == stt.alias)
+    }
+
+    @Test("A failed catalog probe preserves pending legacy chat ownership")
+    func failedCatalogProbeDoesNotRejectLegacyAlias() {
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [],
+            autoStartEnabled: true
+        )
+
+        #expect(!plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == nil)
+        #expect(!plan.shouldAutoStart)
+
+        let retry = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: [chat, stt],
+            autoStartEnabled: true
+        )
+        #expect(retry.chatAliasResolved)
+        #expect(retry.models.chatAlias == chat.alias)
+        #expect(retry.shouldAutoStart)
+    }
+
+    @Test("Exhausting the bounded catalog retry rejects an unverified legacy alias")
+    @MainActor
+    func exhaustedCatalogRetryFailsClosed() {
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: stt.alias,
+            speechAlias: nil,
+            catalog: [],
+            autoStartEnabled: true,
+            emptyCatalogIsAuthoritative: true
+        )
+
+        #expect(plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == nil)
+        #expect(!plan.shouldAutoStart)
+        let quickstartAlias = ContentView.quickstartChatAlias(for: .unresolved)
+        #expect(quickstartAlias != nil)
+        #expect(quickstartAlias! == nil)
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            legacyDone: false,
+            lastServedAlias: quickstartAlias!,
+            serverState: .idle
+        ))
+    }
+
+    @Test("Only catalog-proven chat readiness may rewrite chat persistence")
+    func chatPersistenceOwnership() {
+        #expect(SessionModelRestore.shouldPersistChatAlias(catalogEntry: chat))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: stt))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: tts))
+        #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: nil))
+    }
+
+    @Test("ensureVoiceLane audio ready never overwrites the chat-lane key")
+    @MainActor
+    func audioOnlyReadyPreservesPersistedChat() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(chat.alias, forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        defer { server.shutdownSync() }
+
+        // Drive the exact production regression vector through the fake
+        // sidecar: ensureVoiceLane → ensureServing(residencyEligible: false)
+        // → start(audio alias) → /healthz → .ready(audio alias).
+        let ready = await server.ensureVoiceLane(
+            alias: stt.alias,
+            hfPath: stt.hfRepo
+        )
+
+        #expect(ready)
+        #expect(server.servingAlias == stt.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("ensureServing carries chat provenance when its ready-time catalog probe fails")
+    @MainActor
+    func ensureServingPersistsHintedChatAfterProbeFailure() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        defer { server.shutdownSync() }
+
+        let ready = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo,
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant,
+            catalogEntryHint: chat
+        )
+
+        #expect(ready)
+        #expect(server.servingAlias == chat.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("A catalog-proven chat ready transition owns the chat-lane key")
+    @MainActor
+    func chatReadyUpdatesPersistedChat() throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let server = ServerManager(
+            testingState: .ready(alias: chat.alias),
+            sessionDefaults: defaults
+        )
+        server.recordReadySelection(
+            alias: chat.alias,
+            catalogEntry: chat
+        )
+
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+    }
+
+    @Test("A catalog-proven start hint survives a transient ready-time probe failure")
+    @MainActor
+    func chatHintPersistsAfterProbeFailure() throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let server = ServerManager(
+            testingState: .ready(alias: chat.alias),
+            sessionDefaults: defaults
+        )
+
+        let readyEntry = ServerManager.readyCatalogEntry(
+            alias: chat.alias,
+            probed: nil,
+            hint: chat
+        )
+        server.recordReadySelection(alias: chat.alias, catalogEntry: readyEntry)
+
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(ServerManager.readyCatalogEntry(
+            alias: chat.alias,
+            probed: nil,
+            hint: stt
+        ) == nil)
+    }
+
+    @Test("A failed shared catalog snapshot can be invalidated for one authoritative restore retry")
+    func failedCatalogSnapshotRetriesThroughRealCache() async {
+        let loader = SequencedCatalogLoader([[], [chat, stt]])
+        let cache = ModelCatalogCache { _, _ in await loader.load() }
+        let binary = URL(fileURLWithPath: "/tmp/rapid-session-restore-test")
+
+        let failed = await cache.entries(binary: binary, generation: 0)
+        let joinedFailure = await cache.entries(binary: binary, generation: 0)
+        #expect(failed.isEmpty)
+        #expect(joinedFailure.isEmpty)
+
+        await cache.invalidate()
+        let retried = await cache.entries(binary: binary, generation: 0)
+        let plan = SessionModelRestore.launchPlan(
+            legacyLastAlias: chat.alias,
+            dictationAlias: nil,
+            speechAlias: nil,
+            catalog: retried,
+            autoStartEnabled: true
+        )
+
+        #expect(retried.map(\.alias) == [chat.alias, stt.alias])
+        #expect(plan.chatAliasResolved)
+        #expect(plan.models.chatAlias == chat.alias)
+        #expect(plan.shouldAutoStart)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -169,7 +169,10 @@ struct SessionModelRestoreTests {
         #expect(!SessionModelRestore.shouldPersistChatAlias(catalogEntry: nil))
     }
 
-    @Test("ensureVoiceLane audio ready never overwrites the chat-lane key")
+    @Test(
+        "ensureVoiceLane audio ready never overwrites the chat-lane key",
+        .timeLimit(.minutes(1))
+    )
     @MainActor
     func audioOnlyReadyPreservesPersistedChat() async throws {
         let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
@@ -187,7 +190,7 @@ struct SessionModelRestoreTests {
             binaryPath: fakeServer,
             sessionDefaults: defaults
         )
-        defer { server.shutdownSync() }
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
 
         // Drive the exact production regression vector through the fake
         // sidecar: ensureVoiceLane → ensureServing(residencyEligible: false)
@@ -200,9 +203,13 @@ struct SessionModelRestoreTests {
         #expect(ready)
         #expect(server.servingAlias == stt.alias)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
     }
 
-    @Test("ensureServing carries chat provenance when its ready-time catalog probe fails")
+    @Test(
+        "ensureServing carries chat provenance when its ready-time catalog probe fails",
+        .timeLimit(.minutes(1))
+    )
     @MainActor
     func ensureServingPersistsHintedChatAfterProbeFailure() async throws {
         let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
@@ -220,7 +227,7 @@ struct SessionModelRestoreTests {
             binaryPath: fakeServer,
             sessionDefaults: defaults
         )
-        defer { server.shutdownSync() }
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
 
         let ready = await server.ensureServing(
             alias: chat.alias,
@@ -233,6 +240,14 @@ struct SessionModelRestoreTests {
         #expect(ready)
         #expect(server.servingAlias == chat.alias)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
+    }
+
+    private static var safeMemorySnapshot: MemoryProbe.Snapshot {
+        MemoryProbe.Snapshot(
+            totalBytes: 64 * 1_024 * 1_024 * 1_024,
+            usedBytes: 0
+        )
     }
 
     @Test("A catalog-proven chat ready transition owns the chat-lane key")

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Rapid
 
-@Suite("Lane-owned session model restore")
+@Suite("Lane-owned session model restore", .serialized)
 struct SessionModelRestoreTests {
     private actor SequencedCatalogLoader {
         private var responses: [[ModelEntry]]

--- a/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
@@ -1,7 +1,7 @@
 import Darwin
 import Foundation
 
-/// Temporary hosted-runner diagnostic for the Swift 6.0 test-process hang.
+/// Hosted-runner guard for a test process that stops making progress.
 ///
 /// This deliberately uses a Foundation thread rather than Swift concurrency:
 /// the failure under investigation strands the cooperative executor and the
@@ -33,7 +33,7 @@ enum CIHangWatchdog {
             lock.unlock()
             guard quietFor >= quietLimit else { continue }
 
-            write("CI hang watchdog: no SamplingConfigTests progress for \(Int(quietFor))s; sampling blocked test process\n")
+            write("CI hang watchdog: no watchdog-checkpoint progress for \(Int(quietFor))s; sampling blocked test process\n")
             let ownPID = getpid()
             sample(pid: ownPID)
             for childPID in childPIDs(of: ownPID) where isSwiftTestProcess(pid: childPID) {

--- a/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/CIHangWatchdog.swift
@@ -1,0 +1,105 @@
+import Darwin
+import Foundation
+
+/// Temporary hosted-runner diagnostic for the Swift 6.0 test-process hang.
+///
+/// This deliberately uses a Foundation thread rather than Swift concurrency:
+/// the failure under investigation strands the cooperative executor and the
+/// MainActor, so a Task-based timeout cannot run to report the blocked stacks.
+enum CIHangWatchdog {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var started = false
+    nonisolated(unsafe) private static var lastProgress = Date.timeIntervalSinceReferenceDate
+    private static let quietLimit: TimeInterval = 90
+
+    static func noteProgress() {
+        lock.lock()
+        lastProgress = Date.timeIntervalSinceReferenceDate
+        let shouldStart = !started
+        started = true
+        lock.unlock()
+
+        guard shouldStart else { return }
+        Thread.detachNewThread {
+            monitor()
+        }
+    }
+
+    private static func monitor() {
+        while true {
+            Thread.sleep(forTimeInterval: 5)
+            lock.lock()
+            let quietFor = Date.timeIntervalSinceReferenceDate - lastProgress
+            lock.unlock()
+            guard quietFor >= quietLimit else { continue }
+
+            write("CI hang watchdog: no SamplingConfigTests progress for \(Int(quietFor))s; sampling blocked test process\n")
+            let ownPID = getpid()
+            sample(pid: ownPID)
+            for childPID in childPIDs(of: ownPID) where isSwiftTestProcess(pid: childPID) {
+                sample(pid: childPID)
+            }
+            write("CI hang watchdog: samples complete; terminating test process with exit(3)\n")
+            fflush(stdout)
+            fflush(stderr)
+            exit(3)
+        }
+    }
+
+    private static func sample(pid: pid_t) {
+        write("===== /usr/bin/sample \(pid) 3 -file /dev/stdout =====\n")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = [String(pid), "3", "-file", "/dev/stdout"]
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            write("CI hang watchdog: sample failed for pid \(pid): \(error)\n")
+        }
+        write("===== end sample pid=\(pid) =====\n")
+    }
+
+    private static func childPIDs(of parentPID: pid_t) -> [pid_t] {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-P", String(parentPID)]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \Character.isWhitespace)
+            .compactMap { pid_t($0) }
+    }
+
+    private static func isSwiftTestProcess(pid: pid_t) -> Bool {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", String(pid), "-o", "comm="]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return false
+        }
+        let command = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let name = URL(fileURLWithPath: command.trimmingCharacters(in: .whitespacesAndNewlines)).lastPathComponent
+        return name == "swiftpm-testing" || name == "xctest"
+    }
+
+    private static func write(_ message: String) {
+        FileHandle.standardError.write(Data(message.utf8))
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -57,7 +57,7 @@ Flows: fresh-install, cached-quickstart, cached-curated-tradeup, cached-variant-
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, update-busy, campaign-banner, window-close-prompt, no-dead-controls, catalog-integrity,
-       browse-all-destination, chat-document-attachment, chat-multimodal-attachments, image-generation, dictation, audio-readiness, all
+       browse-all-destination, chat-document-attachment, chat-multimodal-attachments, image-generation, dictation, dictation-rc2-upgrade, audio-readiness, all
 
 Most named regression flows drive the app through the accessibility API alone.
 The preflight contract tests keep the exact allowlist in sync with
@@ -146,7 +146,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
-        slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
+        slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|dictation-rc2-upgrade|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -4754,6 +4754,55 @@ flow_audio_readiness() {
 # is reachable, raw recordings remain opt-in, local vocabulary edits work,
 # mode round-trips preserve the pane, opening it alone never starts a model,
 # and enabling visibly transitions from Loading to Ready.
+flow_dictation_rc2_upgrade() {
+    log "flow: dictation-rc2-upgrade"
+    start_persona dictation-rc2-upgrade \
+        RAPID_GUI_GOLDEN_MODE=1 \
+        RAPID_GUI_DICTATION_READINESS_FIXTURE=1 \
+        FAKE_CACHED_DICTATION=1
+    dismiss_first_run
+    stop_app
+
+    # Recreate the keys written by rc2 before lane ownership existed: one
+    # shared last-served chat key plus independently persisted Dictation intent
+    # and its audio model. The bundle id is unique to this throwaway persona.
+    defaults write "$BUNDLE_ID" rapid.serve.lastAlias "fake-alias"
+    defaults write "$BUNDLE_ID" dictation.enabled -bool true
+    defaults write "$BUNDLE_ID" dictation.model "fake-whisper-small"
+    relaunch_persona
+    dismiss_first_run
+
+    local i restored_chat=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/rc2-upgrade-chat.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "ModelPickerBar.ModelMenu"
+                           and .value == "fake-alias")' \
+                 "$OUT/rc2-upgrade-chat.json" >/dev/null; then
+            restored_chat=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$restored_chat" == 1 ]] \
+        || die "rc2 upgrade did not restore the persisted chat model"
+    wait_send_idle "$OUT/rc2-upgrade-send-ready.json"
+    jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias")
+              and (any(.[]; .event == "server_started" and .alias == "fake-whisper-small") | not)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "rc2 upgrade restored the transcription alias as process owner"
+    press "$OUT/rc2-upgrade-send-ready.json" Sidebar.Audio \
+        "$OUT/rc2-upgrade-audio-open.json" \
+        || die "Audio is not reachable after rc2 upgrade"
+    wait_identifier Dictation.Enable "$OUT/rc2-upgrade-audio.json"
+    [[ "$(element_field "$OUT/rc2-upgrade-audio.json" Dictation.Enable value)" == "1" ]] \
+        || die "rc2 upgrade lost persisted Dictation intent"
+
+    log "  rc2 chat + Dictation state restored with Send enabled"
+    log "  dictation-rc2-upgrade OK"
+    cleanup_persona
+}
+
+
 flow_dictation() {
     log "flow: dictation"
     start_persona dictation \
@@ -4905,7 +4954,38 @@ flow_dictation() {
         "Conversation state before dictation"
     send_prompt "Conversation survives dictation" "dictation-chat"
 
-    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, and preserved chat produced effects"
+    # Relaunch is the state-ownership contract: Dictation remains enabled, but
+    # its audio selection must never become the restored chat model. Session
+    # restore starts the catalog-proven chat alias first, then re-arms the
+    # audio lane on that process; no transcription-only child may appear.
+    relaunch_persona
+    dismiss_first_run
+    local restored_chat=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/dictation-relaunch-chat.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "ModelPickerBar.ModelMenu"
+                           and .value == "fake-alias")' \
+                 "$OUT/dictation-relaunch-chat.json" >/dev/null; then
+            restored_chat=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$restored_chat" == 1 ]] \
+        || die "Relaunch did not restore the conversation model after enabling Dictation"
+    wait_send_idle "$OUT/dictation-relaunch-send-ready.json"
+    jq -e -s '(map(select(.event == "server_started" and .alias == "fake-alias")) | length) == 2
+              and (any(.[]; .event == "server_started" and .alias == "fake-whisper-small") | not)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "Relaunch restored the transcription alias as the process-owning chat model"
+    press "$OUT/dictation-relaunch-send-ready.json" Sidebar.Audio \
+        "$OUT/dictation-relaunch-audio-open.json" \
+        || die "Audio is not reachable after Dictation relaunch"
+    wait_identifier Dictation.Enable "$OUT/dictation-relaunch-audio.json"
+    [[ "$(element_field "$OUT/dictation-relaunch-audio.json" Dictation.Enable value)" == "1" ]] \
+        || die "Relaunch disabled the user's persisted Dictation intent"
+
+    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, relaunch, and preserved chat produced effects"
     log "  dictation OK"
     cleanup_persona
 }
@@ -4945,6 +5025,7 @@ case "$FLOW" in
     chat-multimodal-attachments) flow_chat_multimodal_attachments ;;
     image-generation) flow_image_generation ;;
     dictation) flow_dictation ;;
+    dictation-rc2-upgrade) flow_dictation_rc2_upgrade ;;
     audio-readiness) flow_audio_readiness ;;
     resident-load-rejected) flow_resident_load_rejected ;;
     launch-integrations) flow_launch_integrations ;;

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -20,8 +20,10 @@ MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
 # `chat-depth` requires all five turns to be simultaneously realised in AX.
 # The hosted runner's 1024x681 app window virtualises the oldest messages, so
 # that assertion is valid on larger local displays but false by construction in
-# CI. Keep this exception exact: any additional omission is accidental.
-CI_EXCLUSIONS = {"chat-depth"}
+# CI. The rc2 state-upgrade journey was added during the release window and is
+# verified locally on Studio; hosted dictation-shard gating is tracked in
+# #2365. Keep both exceptions exact: any additional omission is accidental.
+CI_EXCLUSIONS = {"chat-depth", "dictation-rc2-upgrade"}
 
 
 def harness_flows() -> set[str]:

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -126,6 +126,7 @@ def test_peekaboo_requirement_is_default_deny():
         "chat-multimodal-attachments",
         "image-generation",
         "dictation",
+        "dictation-rc2-upgrade",
         "audio-readiness",
         "window-close-prompt",
         "resident-load-rejected",

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -646,11 +646,19 @@ def test_launch_auto_start_defers_to_first_run_surfaces():
     # once the answer lands. A bare `.task` fires once, which would strand a
     # returning user on an idle server for the whole session.
     assert (
-        ".task(id: telemetryConsentPending) { await runLaunchAutoStart() }" in caller
+        ".task(id: telemetryConsentPending) { await restorePersistedSession() }"
+        in caller
     ), (
         "the launch task is no longer keyed on the consent decision. With a "
         "bare `.task` the auto-start that stood down for the consent sheet "
         "never gets its turn, and a returning user's model never loads"
+    )
+    restore = caller.split("private func restorePersistedSession(", 1)[1].split(
+        "private func runLaunchAutoStart(", 1
+    )[0]
+    assert "runLaunchAutoStart(" in restore, (
+        "the consent-keyed session restore no longer reaches launch auto-start; "
+        "answering consent would re-run restore without loading the user's model"
     )
 
     # And the gates must sit above the serverState switch: below it they can


### PR DESCRIPTION
## Why

The final 0.13.0 candidate could restore a transcription-only model as the chat model after Dictation was enabled and the app relaunched. The composer was then disabled, blocking chat. This was requested by the maintainer during final candidate dogfood.

## What

- Make the persisted last-served alias chat-lane state, written only for a catalog-proven chat model.
- Validate legacy rc2 state through case-insensitive catalog capability metadata, without alias-name or repository heuristics; preserve pending ownership while probing, perform one bounded authoritative retry after an empty shared launch snapshot, then fail closed to an explicit terminal unresolved state if that retry also fails.
- In the terminal unresolved state, preserve the persisted key for the next launch while treating this session as having no restored chat model: no auto-start, onboarding available, Dictation barrier paired.
- Establish persisted-enabled Dictation launch deferral synchronously when the controller is created, so Audio-view revalidation cannot start its model before chat restore.
- Preserve exact-alias catalog provenance through start and ensureServing. An authoritative catalog row takes precedence; a caller-owned exact-alias hint is used only when that row is unavailable.
- Share the validated chat outcome between auto-start and first-run onboarding decisions.
- Start chat restore first, arm the persisted Dictation shortcut without starting its audio model, then prepare the audio lane only after chat restore settles; cancellation releases the barrier without starting audio from a superseded task.
- Cover both fresh selection and legacy rc2 persisted state through quit and relaunch.

## Non-goals

- No server or serve-command changes.
- No audio residency redesign or new settings.
- No model-name, hash, or prefix heuristics.
- No polling, timed retry, background catalog refresh, or second retry.

## Exact-head evidence

Head: `f2cd5e9b7f76cd07c35af38f4f129cd7becf93fb`

- Focused restore, ensureServing lifecycle/residency, catalog-cache retry/exhaustion, onboarding, auto-start, Dictation, voice co-load, picker/Quickstart, and AX inventory: 252 passed across 14 suites.
- Release-config app build with strict local bundle assembly: passed.
- Fresh selection → Dictation enabled → quit → relaunch: original chat restored, Send enabled, Dictation retained; passed.
- Legacy rc2 persisted chat + Dictation state → launch: chat restored, Send enabled, Dictation retained, transcription alias never became process owner; passed.