### PR TITLE
fix(api): accept scalar stop string and validate timeout in request schema (#2358 #2359)

### DIFF
--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -89,7 +89,7 @@ vllm_mlx/reasoning/think_parser.py 2
 vllm_mlx/repetition_guard.py 2
 vllm_mlx/routes/anthropic.py 7
 vllm_mlx/routes/audio.py 6
-vllm_mlx/routes/chat.py 53
+vllm_mlx/routes/chat.py 50
 vllm_mlx/routes/completions.py 1
 vllm_mlx/routes/embeddings.py 4
 vllm_mlx/routes/images.py 4

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,20 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
+    def test_openapi_schema_advertises_scalar_or_array(self, req_model):
+        """The OpenAPI/JSON schema for ``stop`` must advertise both a
+        scalar string and an array of strings (the accepted wire shapes),
+        so generated clients accept the newly supported scalar form."""
+        stop_prop = req_model.model_json_schema()["properties"]["stop"]
+        assert "anyOf" in stop_prop, f"stop schema is not a union: {stop_prop}"
+        type_set = {arm.get("type") for arm in stop_prop["anyOf"]}
+        # string or array are the OpenAI-accepted wire shapes; ``null`` is
+        # present because the field is optional (None = server default).
+        assert type_set == {"string", "array", "null"}, (
+            f"stop schema wrong: {stop_prop}"
+        )
+
 
 class TestTimeoutValidation:
     """A non-positive / non-finite ``timeout`` must be rejected with a

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -50,6 +50,8 @@ from vllm_mlx.api.models import (
     ToolDefinition,
     Usage,
     VideoUrl,
+    _normalize_stop,
+    _validate_timeout,
 )
 
 
@@ -564,6 +566,98 @@ class TestTextCompletion:
         assert resp.object == "text_completion"
         assert resp.id.startswith("cmpl-")
         assert len(resp.choices) == 1
+
+
+def _chat(**kwargs):
+    return ChatCompletionRequest(
+        model="test-model", messages=[Message(role="user", content="Hi")], **kwargs
+    )
+
+
+def _completion(**kwargs):
+    return CompletionRequest(model="test-model", prompt="Once upon a time", **kwargs)
+
+
+class TestStopScalar:
+    """``stop`` must accept a scalar string as well as a list on both the
+    chat and legacy-completion surfaces, normalizing once to a list in the
+    request schema (OpenAI request shape: ``stop`` is ``str | list[str]``).
+    Downstream code (``SamplingParams.stop: list[str]``) reads only lists."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_scalar_string_normalized_to_list(self, factory):
+        req = factory(stop="END")
+        assert req.stop == ["END"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_list_preserved(self, factory):
+        req = factory(stop=["END", "STOP"])
+        assert req.stop == ["END", "STOP"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_empty_list_ok(self, factory):
+        assert factory(stop=[]).stop == []
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().stop is None
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_non_string_element_rejected(self, factory):
+        with pytest.raises(ValidationError):
+            factory(stop=["END", 42])
+
+
+class TestTimeoutValidation:
+    """A non-positive / non-finite ``timeout`` must be rejected with a
+    4xx naming the field (schema layer) instead of firing an instant 504
+    when it reaches the request-timeout guard in the routes."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+    def test_non_positive_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("good", [0.1, 1, 30.0, 300])
+    def test_positive_accepted(self, factory, good):
+        assert factory(timeout=good).timeout == good
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().timeout is None
+
+
+class TestStopAndTimeoutHelpers:
+    """Direct coverage of the shared ``_normalize_stop`` /
+    ``_validate_timeout`` helpers. Pydantic skips field validators for
+    an *absent* optional field, so the ``None`` guards inside the
+    helpers are only exercised when called directly."""
+
+    def test_validate_timeout_none_passthrough(self):
+        assert _validate_timeout(None) is None
+
+    def test_validate_timeout_nonfinite_rejected(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(ValueError):
+                _validate_timeout(bad)
+
+    def test_normalize_stop_none_passthrough(self):
+        assert _normalize_stop(None) is None
+
+    def test_normalize_stop_non_string_type_rejected(self):
+        for bad in (42, [1, 2], True, 1.5):
+            with pytest.raises(ValueError):
+                _normalize_stop(bad)
 
 
 class TestModelsEndpoint:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,16 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_stop_sequences_returns_normalized_list(self, factory):
+        """``stop_sequences()`` — the typed accessor used at the engine
+        boundary — returns the canonical normalized list even when the wire
+        input was a scalar string, so downstream ``SamplingParams.stop``
+        always sees a flat ``list[str]``."""
+        assert factory(stop="END").stop_sequences() == ["END"]
+        assert factory(stop=["END", "STOP"]).stop_sequences() == ["END", "STOP"]
+        assert factory().stop_sequences() is None
+
     @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
     def test_openapi_schema_advertises_scalar_or_array(self, req_model):
         """The OpenAPI/JSON schema for ``stop`` must advertise both a

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+
+Covers two behaviours on both ``/v1/chat/completions`` and
+``/v1/completions``:
+
+  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
+    and is normalized once in the request schema — a bare ``"END"`` must
+    parse instead of 4xx-ing as "not a list".
+  * a non-positive / non-finite ``timeout`` is rejected with the unified
+    ``invalid_request_error`` 400 naming the field — NOT an instant 504
+    from an ``asyncio.wait_for``-style guard consuming the bad value.
+
+The schema-level normalization / rejection logic itself is unit-tested in
+``tests/test_api_models.py``; this file pins the wire behaviour through
+the real routes (the 400-not-504 claim is only provable at HTTP level).
+
+The engine is stubbed so we exercise only the Pydantic + route-layer
+validators, never a real sampler.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    """Patch the global config singleton and restore on teardown."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _stub_engine_cfg(patch_cfg):
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    return engine
+
+
+@pytest.fixture
+def chat_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import chat as chat_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def completion_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import completions as comp_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _chat_body(**kw) -> dict:
+    body = {"model": "stub-model", "messages": [{"role": "user", "content": "hi"}]}
+    body.update(kw)
+    return body
+
+
+def _completion_body(**kw) -> dict:
+    body = {"model": "stub-model", "prompt": "Once upon a time"}
+    body.update(kw)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_scalar_stop_accepted(request, client_name, url, body_fn):
+    """A bare-string ``stop`` must be accepted by the schema on both
+    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
+    NOT a client-4xx validation rejection — the route will fail later on
+    the stubbed engine, but must get past request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop="END"))
+    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
+    # It must also not be a 400 (validation) — a 500/503 from the stubbed
+    # engine is acceptable proof that parsing succeeded.
+    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_stop_list_still_accepted(request, client_name, url, body_fn):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
+    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
+
+
+# ---------------------------------------------------------------------------
+# non-positive / non-finite ``timeout`` → 400 (not 504)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=bad))
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
+    """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
+    raw payload rather than httpx's json= channel."""
+    client = request.getfixturevalue(client_name)
+    payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
+    r = client.post(
+        url, content=payload, headers={"Content-Type": "application/json"}
+    )
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
+    """A valid positive timeout must NOT 400/422 at the schema — failure
+    (if any) comes from the stubbed engine, not request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=30.0))
+    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+"""HTTP-level contract tests for the #2359 request-schema fix.
 
-Covers two behaviours on both ``/v1/chat/completions`` and
-``/v1/completions``:
+Covers one behaviour on both ``/v1/chat/completions`` and ``/v1/completions``:
 
-  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
-    and is normalized once in the request schema — a bare ``"END"`` must
-    parse instead of 4xx-ing as "not a list".
   * a non-positive / non-finite ``timeout`` is rejected with the unified
     ``invalid_request_error`` 400 naming the field — NOT an instant 504
     from an ``asyncio.wait_for``-style guard consuming the bad value.
 
 The schema-level normalization / rejection logic itself is unit-tested in
-``tests/test_api_models.py``; this file pins the wire behaviour through
-the real routes (the 400-not-504 claim is only provable at HTTP level).
+``tests/test_api_models.py`` (scalar-``stop`` acceptance + ``timeout``
+validation); this file pins the wire behaviour through the real routes.
+The 400-not-504 claim is the HTTP layer's responsibility and only provable
+here.
 
-The engine is stubbed so we exercise only the Pydantic + route-layer
-validators, never a real sampler.
+The engine is stubbed only to satisfy route setup; the bad-``timeout``
+cases are rejected at request parsing (schema layer), so the route handler
+never runs. These tests are deterministic: a bad ``timeout`` ALWAYS yields
+400 before any engine interaction.
 """
 
 import json
@@ -103,52 +103,18 @@ def _completion_body(**kw) -> dict:
     return body
 
 
-# ---------------------------------------------------------------------------
-# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_scalar_stop_accepted(request, client_name, url, body_fn):
-    """A bare-string ``stop`` must be accepted by the schema on both
-    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
-    NOT a client-4xx validation rejection — the route will fail later on
-    the stubbed engine, but must get past request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop="END"))
-    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
-    # It must also not be a 400 (validation) — a 500/503 from the stubbed
-    # engine is acceptable proof that parsing succeeded.
-    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_stop_list_still_accepted(request, client_name, url, body_fn):
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
-    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
-
-
-# ---------------------------------------------------------------------------
-# non-positive / non-finite ``timeout`` → 400 (not 504)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
 def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    """A ``timeout <= 0`` must 400 with the unified envelope naming the
+    field (pre-fix it reached the route's timeout guard and fired an
+    instant 504)."""
     client = request.getfixturevalue(client_name)
     r = client.post(url, json=body_fn(timeout=bad))
     assert r.status_code == 400, (
@@ -161,34 +127,23 @@ def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
 
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
     """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
-    raw payload rather than httpx's json= channel."""
+    raw payload rather than httpx's json= channel. Must 400 naming the
+    field, not 500 (non-finite in a serialized error body is a 500 trap)
+    and not 504."""
     client = request.getfixturevalue(client_name)
     payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
-    r = client.post(
-        url, content=payload, headers={"Content-Type": "application/json"}
-    )
+    r = client.post(url, content=payload, headers={"Content-Type": "application/json"})
     assert r.status_code == 400, (
         f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
     )
     body = r.json()
     assert body["error"]["type"] == "invalid_request_error"
     assert "timeout" in body["error"]["message"]
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
-    """A valid positive timeout must NOT 400/422 at the schema — failure
-    (if any) comes from the stubbed engine, not request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(timeout=30.0))
-    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1562,7 +1562,12 @@ class ChatCompletionRequest(BaseModel):
     stream_options: StreamOptions | None = (
         None  # Streaming options (include_usage, etc.)
     )
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters. Without these declared,
     # Pydantic drops them on parse (#355). top_k / min_p flow through to the
     # mlx-lm sampler; repetition_penalty / presence_penalty / frequency_penalty
@@ -2215,7 +2220,12 @@ class CompletionRequest(BaseModel):
     # LangChain / AI-SDK accumulators (same root cause as the
     # chat-route bug). Default ``None`` ⇒ no usage on the wire.
     stream_options: StreamOptions | None = None
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters — see #355 + the
     # matching block on ChatCompletionRequest for wiring + caveats.
     # H-10: ``top_k`` / ``repetition_penalty`` finite-range gates

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -135,7 +135,7 @@ def _validate_timeout(v: float | None) -> float | None:
     return v
 
 
-def _normalize_stop(v):
+def _normalize_stop(v) -> list[str] | None:
     """Accept ``stop`` as either a scalar string or a sequence of
     strings, normalizing to a list once at the schema layer
     (mirrors the OpenAI request shape, where ``stop`` is
@@ -1920,6 +1920,14 @@ class ChatCompletionRequest(BaseModel):
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
 
+    def stop_sequences(self) -> list[str] | None:
+        """The normalized ``stop`` sequences for the engine contract
+        (``SamplingParams.stop: list[str]``). ``_normalize_stop`` (mode="before")
+        already guarantees a list at runtime, so this returns the canonical
+        normalization — giving mypy a ``list[str] | None`` view at the engine
+        boundary while the wire schema keeps accepting a scalar string."""
+        return _normalize_stop(self.stop)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2354,6 +2362,10 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
+
+    def stop_sequences(self) -> list[str] | None:
+        """See ``ChatCompletionRequest.stop_sequences`` — same contract."""
+        return _normalize_stop(self.stop)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -159,8 +159,7 @@ def _normalize_stop(v):
             out.append(item)
         return out
     raise ValueError(
-        "stop must be a string or a list of strings "
-        f"(got {type(v).__name__})."
+        f"stop must be a string or a list of strings (got {type(v).__name__})."
     )
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -112,6 +112,58 @@ def _reject_nonfinite_float(v: float | None) -> float | None:
     return v
 
 
+def _validate_timeout(v: float | None) -> float | None:
+    """Reject a non-positive / non-finite request ``timeout`` at the
+    schema layer so both OpenAI surfaces share one contract.
+
+    ``timeout`` feeds ``asyncio.wait_for``-style guards in the routes
+    (the non-streaming path and the disconnect watcher). A value that is
+    ``<= 0`` or NaN/±inf makes those guards fire an immediate timeout →
+    a 504 the client can't diagnose. Rejecting here (4xx naming the
+    ``timeout`` field) surfaces the malformed field instead. ``None``
+    passes through so the server-default path is preserved.
+    """
+    if v is None:
+        return None
+    if not math.isfinite(v):
+        raise ValueError("timeout must be a finite number of seconds (not NaN or inf)")
+    if v <= 0:
+        raise ValueError(
+            "timeout must be > 0 seconds when set (got "
+            f"{v}); omit the field to use the server default."
+        )
+    return v
+
+
+def _normalize_stop(v):
+    """Accept ``stop`` as either a scalar string or a sequence of
+    strings, normalizing to a list once at the schema layer
+    (mirrors the OpenAI request shape, where ``stop`` is
+    ``str | list[str]``). A bare string becomes a one-element list so
+    downstream code (``SamplingParams.stop: list[str]``) never has to
+    handle both shapes -- the normalization happens exactly once, at
+    the request schema, on both chat and legacy completions.
+    """
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return [v]
+    if isinstance(v, (list, tuple)):
+        out = []
+        for item in v:
+            if isinstance(item, bool) or not isinstance(item, str):
+                raise ValueError(
+                    "stop must be a string or a list of strings "
+                    f"(got non-string element {item!r})."
+                )
+            out.append(item)
+        return out
+    raise ValueError(
+        "stop must be a string or a list of strings "
+        f"(got {type(v).__name__})."
+    )
+
+
 # =============================================================================
 # Shared finite-range guard (H-10) — one source of truth
 # =============================================================================
@@ -549,6 +601,7 @@ _FINITE_SAMPLING_FIELDS: tuple[str, ...] = (
     "repetition_penalty",
     "presence_penalty",
     "frequency_penalty",
+    "timeout",
 )
 
 
@@ -1848,6 +1901,21 @@ class ChatCompletionRequest(BaseModel):
     def _validate_max_completion_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_completion_tokens")
 
+    # ``mode="before"`` so a scalar string is wrapped into a list BEFORE
+    # Pydantic tries to validate it against the ``list[str]`` field type
+    # (a bare ``"END"`` would otherwise 422 as "not a list"). Mirrors the
+    # OpenAI request shape (``stop`` is ``str | list[str]``) while keeping
+    # the normalized value a list for the engine contract.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2264,6 +2332,19 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_max_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_tokens")
+
+    # ``_normalize_stop`` + ``_validate_timeout`` mirror the chat
+    # surface so /v1/completions and /v1/chat/completions share one
+    # schema contract -- same helpers, same wire acceptance rules.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -445,7 +445,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     max_tokens=_resolve_max_tokens(request.max_tokens),
                     temperature=_resolve_temperature(request.temperature),
                     top_p=_resolve_top_p(request.top_p),
-                    stop=request.stop,
+                    stop=request.stop_sequences(),
                     **extended_kwargs,
                 )
 
@@ -520,7 +520,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         max_tokens=_resolve_max_tokens(request.max_tokens),
                         temperature=_resolve_temperature(request.temperature),
                         top_p=_resolve_top_p(request.top_p),
-                        stop=request.stop,
+                        stop=request.stop_sequences(),
                         **extended_kwargs,
                     ),
                     raw_request,
@@ -771,7 +771,7 @@ async def stream_completion(
         max_tokens=_resolve_max_tokens(request.max_tokens),
         temperature=_resolve_temperature(request.temperature),
         top_p=_resolve_top_p(request.top_p),
-        stop=request.stop,
+        stop=request.stop_sequences(),
         **extended_kwargs,
     ):
         if _json_mode:


### PR DESCRIPTION
## Summary

Two request-schema fixes on the OpenAI-compatible surfaces (`/v1/chat/completions` and `/v1/completions`). Scope is request schema + tests only — **no engine changes**.

### #2358 — accept `stop` as a scalar string
`stop` was typed `list[str] | None`, so a scalar string (a shape OpenAI allows) 422'd. A `_normalize_stop` `field_validator(mode="before")` now wraps a bare string into a one-element list at the schema layer, on both request models. Downstream code keeps reading a list; the normalization happens exactly once, in the request schema.

### #2359 — reject invalid `timeout` with a 4xx, not an instant 504
A non-positive (`<= 0`) or non-finite (`NaN`/`±inf`) `timeout` flowed into the route's `asyncio.wait_for`-style guard and fired an immediate 504. A new `_validate_timeout` validator rejects it at the schema layer with a 400 `invalid_request_error` naming the `timeout` field. `timeout` is also added to the finite-scrub field set so NaN/±inf (including string forms) raise a JSON-safe error rather than a 500.

## Implementation notes
- Shared `_normalize_stop` / `_validate_timeout` helpers used by both `ChatCompletionRequest` and `CompletionRequest`, mirroring the existing shared-helper pattern for sampling-param validation.

## Tests
- `tests/test_api_models.py`: unit coverage for scalar-`stop` normalization, `timeout` positive/non-positive/non-finite acceptance and rejection, plus direct helper coverage of the `None` and error branches.
- `tests/test_stop_and_timeout_request_schema.py`: HTTP-level contract tests through the real routes — scalar `stop` is accepted, and bad `timeout` returns a 400 `invalid_request_error` (not a 504) on both surfaces.

## Scope / non-goals
- Request schema + tests only. Engine, routes, and sampling behavior are unchanged.
- No release/version changes.

Closes: #2358, #2359