### PR TITLE
docs: add 0.13.0 changelog

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,53 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-08-26
+
+Rapid-MLX 0.13.0 makes first setup clearer, expands local model support, keeps
+chat and speech workloads available together, and improves long-prompt
+responsiveness and cache correctness.
+
+### Added
+
+- **More capable local models.** Supported Qwen3-Next checkpoints can stream
+  experts from disk, Nemotron Labs Diffusion 3B can generate images, and
+  verified Ornith 1.5 models are available from the Desktop catalog.
+- **Chat understands the current local date and time.** Questions about today
+  no longer depend on the model's training cutoff or require a web search.
+- **Desktop workflows cover more of the local stack.** Attachments, dedicated
+  photo input, separate Speech to Text and Text to Speech controls, and clearer
+  agent setup make multimodal and tool-assisted work easier to configure.
+
+### Changed
+
+- **Repeated long prompts start much faster on hybrid models.** Compatible
+  prefix caches are reused, reducing verified repeat-turn prefill from tens of
+  seconds to sub-second latency.
+- **Setup guidance follows current memory conditions.** First-run
+  recommendations are re-evaluated as available memory changes instead of
+  retaining a stale verdict.
+- **Active work is protected during model switches.** Desktop asks for
+  confirmation before a switch interrupts requests already in progress.
+
+### Fixed
+
+- Runtime model switches now choose the same serving lane as startup, including
+  complete cached checkpoints that need the text-only lane.
+- Performance reloads preserve the model's served names and aliases, so clients
+  can continue using the same identifier after settings change.
+- Relaunching with dictation enabled restores the conversation model before the
+  speech lane, preventing an audio model from replacing the active chat model.
+- Search-provider key failures, model readiness progress, image-generation
+  recovery, tool-call correction, reasoning privacy, and release validation
+  received the fixes exercised across the 0.13 release candidates.
+
+### Known issues
+
+- If both a resident model's performance reload and its rollback fail, residency
+  status and request routing can disagree until the server is relaunched. This
+  recovery edge case is planned for 0.13.1
+  ([#2360](https://github.com/raullenchai/Rapid-MLX/issues/2360)).
+
 ## [0.13.0-rc2] — 2026-08-25
 
 This second 0.13 release candidate focuses on the first-run and release-blocking

--- a/docs/release-notes/v0.13.0.md
+++ b/docs/release-notes/v0.13.0.md
@@ -18,6 +18,10 @@ throughput while preserving explicit server overrides. ([#2321](https://github.c
 [#2199](https://github.com/raullenchai/Rapid-MLX/pull/2199),
 [#2210](https://github.com/raullenchai/Rapid-MLX/pull/2210))
 
+**Runtime model changes keep the same identity** — Models loaded after startup
+use the same serving-lane resolution as the initial model, and performance
+reloads preserve the names and aliases clients already use. ([#2339](https://github.com/raullenchai/Rapid-MLX/pull/2339))
+
 **Clearer setup and model switching** — First setup uses live RAM-based
 recommendations, groups cached variants, and reports download progress. Chat
 receives authoritative local date and time, active-request model switches ask
@@ -29,12 +33,14 @@ the correct runtime automatically. ([#2331](https://github.com/raullenchai/Rapid
 
 **Chat, vision, audio, and images work together more naturally** — Desktop
 adds a dedicated photo flow, separates Speech to Text from Text to Speech, and
-keeps ordinary dictation from evicting the active conversation model. Image
-generation starts at a lower-memory 512×512 default and shows a stable
-remaining-time estimate. ([#2201](https://github.com/raullenchai/Rapid-MLX/pull/2201),
+keeps ordinary dictation from evicting the active conversation model. Relaunch
+also restores chat before the enabled dictation lane, so speech cannot replace
+the selected conversation model. Image generation starts at a lower-memory
+512×512 default and shows a stable remaining-time estimate. ([#2201](https://github.com/raullenchai/Rapid-MLX/pull/2201),
 [#2188](https://github.com/raullenchai/Rapid-MLX/pull/2188),
 [#2307](https://github.com/raullenchai/Rapid-MLX/pull/2307),
-[#2302](https://github.com/raullenchai/Rapid-MLX/pull/2302))
+[#2302](https://github.com/raullenchai/Rapid-MLX/pull/2302),
+[#2339](https://github.com/raullenchai/Rapid-MLX/pull/2339))
 
 **More reliable tools and reasoning** — Tool selection is schema-driven,
 malformed tool attempts stay inside the correction loop, reasoning scratch
@@ -56,6 +62,10 @@ from rejected saved keys without dropping the original request. ([#2244](https:/
 
 ## Known issues
 
+- If both a resident model's performance reload and its rollback fail,
+  residency status and request routing can disagree until the server is
+  relaunched. This recovery edge case is planned for 0.13.1.
+  ([#2360](https://github.com/raullenchai/Rapid-MLX/issues/2360))
 - Loading a secondary model can leave the reported resident primary model
   returning errors until Rapid-MLX Desktop is relaunched.
   ([#2333](https://github.com/raullenchai/Rapid-MLX/issues/2333))


### PR DESCRIPTION
## Rationale

The 0.13.0 auto-release pre-check correctly stopped because the Desktop changelog had no stable `0.13.0` section. This PR adds the missing stable Desktop changelog and completes the curated release body that auto-release prepends to the GitHub Release.

## Review contract

- **User-visible goal:** ship accurate, non-empty 0.13.0 Desktop and engine release notes.
- **Allowed scope:** `apps/rapid-mac/CHANGELOG.md` and `docs/release-notes/v0.13.0.md` only.
- **Non-goals:** product code, versioning, tags, workflows, CI gates, or release execution.
- **Required content:** hybrid prefix reuse, live onboarding memory guidance, current local date/time, active-request model-switch confirmation, runtime serving-lane parity, alias-preserving reload, dictation relaunch recovery, and known issue #2360.
- **Acceptance:** the exact stable heading is present, the curated release body is non-empty, wording is user-facing and accurate, and release-note generation tests pass.
- **Review limit:** one Codex reviewer request maximum for this release-blocking documentation PR.

## Validation

- `bash tests/release/test_build_release_notes.sh` — 63 passed
- Exact auto-release changelog-heading pre-check — passed
- `git diff --check` — passed
