### PR TITLE
feat(server): make assistant replacement lifecycle explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,9 +319,7 @@ jobs:
             tests/test_pflash_server_module_wiring.py::test_server_module_strict_metadata_failure_propagates \
             tests/test_pflash_server_module_wiring.py::test_server_module_cache_metadata_failure_is_nonfatal \
             tests/test_pflash_server_module_wiring.py::test_server_module_missing_auto_config_module_degrades_to_no_default \
-            tests/test_resident_models.py::test_dynamic_resident_auto_detected_hybrid_gets_bounded_prefix_reuse \
-            tests/test_resident_models.py::test_dynamic_resident_prefix_disable_keeps_hybrid_entries_zero \
-            tests/test_resident_models.py::test_dynamic_resident_full_attention_stays_unbounded \
+            tests/test_resident_models.py \
             tests/test_serve_listen_fd.py::test_serve_command_threads_auto_detected_hybrid_into_cache_admission \
             tests/test_serve_listen_fd.py::test_serve_command_cache_is_first_metadata_consumer \
             tests/test_serve_listen_fd.py::test_serve_command_missing_auto_config_module_degrades_to_no_default \
@@ -364,6 +362,20 @@ jobs:
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \
+            --cov-report=term-missing \
+            --cov-report=xml
+
+          # Engine lifecycle contracts execute real engine methods but no tensor
+          # operations. Keep their inert MLX import seam in a separate process
+          # so optional-runtime discovery in the broader Linux suite stays real.
+          pytest \
+            tests/test_engine_lifecycle.py \
+            tests/test_mllm_process_loop_errors.py \
+            tests/test_disconnect_guard_aborts_scheduler.py \
+            tests/test_rst_mid_sse_zombie_kv.py \
+            -v --tb=short \
+            --cov=vllm_mlx \
+            --cov-append \
             --cov-report=term-missing \
             --cov-report=xml
 

--- a/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
+++ b/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
@@ -43,10 +43,14 @@ This keeps replacement policy scoped to the selected lifecycle group.
 2. Close admission on every old assistant engine and reach the selected
    reject/drain/abort boundary.
 3. Acquire the existing primary/audio-worker handoff lease.
-4. Publish the replacement as primary, retire old assistant engines, and
-   commit the worker handoff.
-5. On cancellation or failure, discard the unpublished replacement, reopen
-   old assistant admission, and roll back the audio-worker lease.
+4. Publish the replacement as primary and retire the old primary first. Until
+   that stop succeeds, failure restores the old primary and audio-worker lease.
+5. Successful primary retirement is the commit point. Commit the worker
+   handoff, remove every quiesced sibling from routing, and treat any later
+   sibling stop failure as cleanup rather than rolling routes back to an engine
+   that may already be stopped.
+6. Before the commit point, cancellation or failure discards the replacement,
+   reopens old assistant admission, and rolls back the audio-worker lease.
 
 No capacity, idle-TTL, audio-lane, scheduler, or Desktop policy is introduced
 by this decision.

--- a/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
+++ b/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
@@ -1,0 +1,59 @@
+# Assistant replacement and dictation coexistence
+
+## Status
+
+Accepted for the 0.13.1 implementation track. Desktop wiring is separate.
+
+## User contract
+
+Changing the Desktop assistant model does not restart the server. The caller
+chooses one explicit policy for work already owned by the current assistant:
+
+- `reject` (default) leaves the current assistant untouched when it is busy;
+- `wait` closes new assistant admission, drains admitted/running/queued work,
+  and then replaces it;
+- `abort` closes admission, terminates admitted/running/queued work, and then
+  replaces it. Streaming and non-streaming callers both receive a terminal
+  cancellation signal.
+
+Speech-to-text and text-to-speech are auxiliary audio lanes. They do not join
+the `assistant` replacement group. A completed assistant replacement changes
+the model worker through the existing audio-worker handoff transaction while
+preserving the audio lane's loaded model and lifecycle state. If audio work is
+active, the handoff fails closed: the assistant remains available, the audio
+request reaches its original terminal result, and no worker is stopped.
+
+## Ownership and state
+
+The inference engine owns assistant admission and scheduler state. Its
+lifecycle snapshot exposes `paused`, `pause_mode`, and admitted, queued,
+running, and total active request counts. The residency manager serializes the
+replacement transaction and publishes that engine-owned truth through
+`GET /v1/models/residency`.
+
+The audio-worker dispatcher remains the single source of truth for auxiliary
+lane residency and active work. The residency response appends its
+`audio_lanes` snapshot without folding audio activity into assistant counters.
+This keeps replacement policy scoped to the selected lifecycle group.
+
+## Transaction boundary
+
+1. Materialize the replacement through the existing runtime serving-lane
+   resolver, but do not publish it.
+2. Close admission on every old assistant engine and reach the selected
+   reject/drain/abort boundary.
+3. Acquire the existing primary/audio-worker handoff lease.
+4. Publish the replacement as primary, retire old assistant engines, and
+   commit the worker handoff.
+5. On cancellation or failure, discard the unpublished replacement, reopen
+   old assistant admission, and roll back the audio-worker lease.
+
+No capacity, idle-TTL, audio-lane, scheduler, or Desktop policy is introduced
+by this decision.
+
+## Verification
+
+Contract tests cover admission races, queued/running truth, wait/abort terminal
+behavior for streaming and non-streaming callers, replacement rollback, audio
+work blocking a worker handoff under every assistant replacement policy, and
+speech-to-text serving before and after a successful assistant replacement.

--- a/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
+++ b/docs/engineering/decisions/2026-08-25-assistant-replacement-and-dictation-coexistence.md
@@ -23,6 +23,12 @@ preserving the audio lane's loaded model and lifecycle state. If audio work is
 active, the handoff fails closed: the assistant remains available, the audio
 request reaches its original terminal result, and no worker is stopped.
 
+When dictation is enabled, its speech-to-text lane is process-wide protected
+state: every assistant load, replacement, reload, and switch back preserves the
+loaded STT engine. The residency response must show the assistant record and
+the STT lane together, and dictation must remain usable after each transition.
+An assistant lifecycle operation never calls an audio-lane unload path.
+
 ## Ownership and state
 
 The inference engine owns assistant admission and scheduler state. Its
@@ -52,12 +58,21 @@ This keeps replacement policy scoped to the selected lifecycle group.
 6. Before the commit point, cancellation or failure discards the replacement,
    reopens old assistant admission, and rolls back the audio-worker lease.
 
-No capacity, idle-TTL, audio-lane, scheduler, or Desktop policy is introduced
-by this decision.
+This decision does not invent capacity, idle-TTL, audio-lane, scheduler, or
+Desktop policy. Enforcing the same protection under a configured process memory
+ceiling requires the separate shared auxiliary-role budget: it must charge the
+resident STT role, mark it ineligible for assistant-driven eviction, and reject
+an assistant admission with an actionable capacity conflict when both cannot
+fit. Desktop presentation of a downgrade or model choice remains a separate UI
+contract. Until that budget lands, this decision guarantees lifecycle
+coexistence but does not claim combined LLM+STT capacity enforcement.
 
 ## Verification
 
 Contract tests cover admission races, queued/running truth, wait/abort terminal
 behavior for streaming and non-streaming callers, replacement rollback, audio
 work blocking a worker handoff under every assistant replacement policy, and
-speech-to-text serving before and after a successful assistant replacement.
+speech-to-text serving before and after successful assistant replacement,
+reload, and switch-back sequences. Release evidence additionally exercises a
+fresh process with cached chat and STT checkpoints; mocked lifecycle tests do
+not substitute for that model-worker validation.

--- a/tests/_headless_mlx.py
+++ b/tests/_headless_mlx.py
@@ -1,0 +1,47 @@
+"""Inert MLX import seam for lifecycle-only tests on Linux."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from unittest.mock import MagicMock
+
+
+def install_headless_mlx_import_stubs() -> None:
+    """Permit importing engine classes when tensor operations are never run."""
+
+    if importlib.util.find_spec("mlx") is not None:
+        return
+
+    module_names = (
+        "mlx",
+        "mlx.core",
+        "mlx.nn",
+        "mlx.utils",
+        "mlx_lm",
+        "mlx_lm.generate",
+        "mlx_lm.sample_utils",
+        "mlx_lm.tokenizer_utils",
+        "mlx_lm.models",
+        "mlx_lm.models.cache",
+        "mlx_lm.models.deepseek_v32",
+    )
+    for name in module_names:
+        module = MagicMock(name=name)
+        module.__name__ = name
+        module.__path__ = []
+        module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        sys.modules[name] = module
+
+    sys.modules["mlx"].core = sys.modules["mlx.core"]
+    sys.modules["mlx_lm.generate"].BatchGenerator = type("BatchGenerator", (), {})
+    sys.modules["mlx_lm.tokenizer_utils"].NaiveStreamingDetokenizer = type(
+        "NaiveStreamingDetokenizer", (), {}
+    )
+    cache_module = sys.modules["mlx_lm.models.cache"]
+    for class_name in ("MambaCache", "ArraysCache", "KVCache", "RotatingKVCache"):
+        setattr(cache_module, class_name, type(class_name, (), {}))
+    sys.modules["mlx_lm.models"].deepseek_v32 = sys.modules[
+        "mlx_lm.models.deepseek_v32"
+    ]

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1166,7 +1166,7 @@ async def test_primary_reload_releases_handoff_when_cleanup_and_restore_fail(
 
 
 @pytest.mark.asyncio
-async def test_primary_replacement_rolls_back_after_old_worker_stop_failure(
+async def test_primary_replacement_keeps_new_worker_after_old_stop_failure(
     monkeypatch,
 ):
     import vllm_mlx.server as server
@@ -1177,23 +1177,23 @@ async def test_primary_replacement_rolls_back_after_old_worker_stop_failure(
     manager, registry, loaded = _replacement_manager(server, old_worker)
     bind_audio_worker(old_worker)
     try:
-        with pytest.raises(RuntimeError, match="old stop failed"):
-            await manager.load(
-                "chat-new",
-                estimated_bytes=1,
-                replace_group="assistant",
-            )
+        replacement = await manager.load(
+            "chat-new",
+            estimated_bytes=1,
+            replace_group="assistant",
+        )
 
-        assert registry.default_name == "chat-old"
-        assert [entry.model_name for entry in registry.list_entries()] == ["chat-old"]
-        assert server._engine is old_worker
+        assert replacement.primary is True
+        assert registry.default_name == "chat-new"
+        assert [entry.model_name for entry in registry.list_entries()] == ["chat-new"]
+        assert server._engine is loaded["chat-new"]
         assert old_worker.stopped is False
-        assert loaded["chat-new"].stopped is True
+        assert loaded["chat-new"].stopped is False
         assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
             "after"
         )
-        assert old_worker.async_calls == 1
-        assert loaded["chat-new"].async_calls == 0
+        assert old_worker.async_calls == 0
+        assert loaded["chat-new"].async_calls == 1
     finally:
         bind_audio_worker(None)
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -744,7 +744,11 @@ async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
 @pytest.mark.asyncio
 async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch):
     import vllm_mlx.server as server
-    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.audio_worker import (
+        audio_worker,
+        bind_audio_worker,
+        run_audio_mlx,
+    )
 
     old_worker = _ReplacementWorker("chat-old")
     _configure_server_primary(monkeypatch, server, old_worker)
@@ -754,6 +758,11 @@ async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch
         assert (
             await run_audio_mlx("stt", "whisper", "infer", lambda: "before") == "before"
         )
+        stt_before = next(
+            lane for lane in audio_worker.snapshot() if lane["lane"] == "stt"
+        )
+        assert stt_before["model"] == "whisper"
+        assert stt_before["state"] == "resident"
 
         replacement = await manager.load(
             "chat-new",
@@ -770,13 +779,20 @@ async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch
         )
         assert old_worker.async_calls == 1
         assert loaded["chat-new"].async_calls == 1
+        stt_after = next(
+            lane for lane in audio_worker.snapshot() if lane["lane"] == "stt"
+        )
+        assert stt_after["model"] == "whisper"
+        assert stt_after["state"] == "resident"
     finally:
         bind_audio_worker(None)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("replace_mode", ["reject", "wait", "abort"])
 async def test_primary_replacement_rejects_active_audio_without_stopping_old_worker(
     monkeypatch,
+    replace_mode,
 ):
     import vllm_mlx.server as server
     from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
@@ -802,6 +818,7 @@ async def test_primary_replacement_rejects_active_audio_without_stopping_old_wor
                 "chat-new",
                 estimated_bytes=1,
                 replace_group="assistant",
+                replace_mode=replace_mode,
             )
 
         assert registry.default_name == "chat-old"

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1006,7 +1006,7 @@ async def test_primary_reload_restores_old_config_after_publication_failure(
 
 
 @pytest.mark.asyncio
-async def test_primary_reload_rolls_back_handoff_when_old_stop_fails(monkeypatch):
+async def test_primary_reload_rebuilds_handoff_when_old_stop_fails(monkeypatch):
     import vllm_mlx.server as server
     from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
     from vllm_mlx.runtime.resident_models import ResidentPerformanceConfig
@@ -1025,13 +1025,15 @@ async def test_primary_reload_rolls_back_handoff_when_old_stop_fails(monkeypatch
 
         assert old_worker.stop_calls == 1
         assert old_worker.stopped is False
-        assert loaded == {}
+        restored = loaded["chat-old"]
         assert registry.default_name == "chat-old"
-        assert registry.get_entry("chat-old").engine is old_worker
-        assert server._engine is old_worker
+        assert registry.get_entry("chat-old").engine is restored
+        assert server._engine is restored
         assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
             "after"
         )
+        assert old_worker.async_calls == 0
+        assert restored.async_calls == 1
     finally:
         bind_audio_worker(None)
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -784,6 +784,25 @@ async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch
         )
         assert stt_after["model"] == "whisper"
         assert stt_after["state"] == "resident"
+
+        # Switching again, including back to the original assistant identity,
+        # must only replace the assistant engine. Dictation is product-wide
+        # process state and remains resident across every picker transition.
+        switched_back = await manager.load(
+            "chat-old",
+            estimated_bytes=1,
+            replace_group="assistant",
+        )
+        assert registry.default_name == "chat-old"
+        assert server._engine is switched_back.entry.engine
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "back") == (
+            "back"
+        )
+        stt_switched_back = next(
+            lane for lane in audio_worker.snapshot() if lane["lane"] == "stt"
+        )
+        assert stt_switched_back["model"] == "whisper"
+        assert stt_switched_back["state"] == "resident"
     finally:
         bind_audio_worker(None)
 
@@ -878,7 +897,11 @@ async def test_primary_reload_rejects_active_audio_without_stopping_worker(
 @pytest.mark.asyncio
 async def test_primary_reload_commits_audio_worker_handoff(monkeypatch):
     import vllm_mlx.server as server
-    from vllm_mlx.runtime.audio_worker import bind_audio_worker, run_audio_mlx
+    from vllm_mlx.runtime.audio_worker import (
+        audio_worker,
+        bind_audio_worker,
+        run_audio_mlx,
+    )
     from vllm_mlx.runtime.resident_models import ResidentPerformanceConfig
 
     old_worker = _ReplacementWorker("chat-old")
@@ -886,6 +909,9 @@ async def test_primary_reload_commits_audio_worker_handoff(monkeypatch):
     manager, registry, loaded = _replacement_manager(server, old_worker)
     bind_audio_worker(old_worker)
     try:
+        assert await run_audio_mlx("stt", "whisper", "infer", lambda: "before") == (
+            "before"
+        )
         replacement = await manager.load(
             "chat-old",
             performance=ResidentPerformanceConfig(prefix_cache_enabled=True),
@@ -898,8 +924,13 @@ async def test_primary_reload_commits_audio_worker_handoff(monkeypatch):
         assert await run_audio_mlx("stt", "whisper", "infer", lambda: "after") == (
             "after"
         )
-        assert old_worker.async_calls == 0
+        assert old_worker.async_calls == 1
         assert loaded["chat-old"].async_calls == 1
+        stt_after = next(
+            lane for lane in audio_worker.snapshot() if lane["lane"] == "stt"
+        )
+        assert stt_after["model"] == "whisper"
+        assert stt_after["state"] == "resident"
     finally:
         bind_audio_worker(None)
 

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -421,9 +421,10 @@ class TestRequestManagement:
                     await engine.abort_request(rid)
                     break
 
-            from vllm_mlx.request import InferenceAbortedError
-
-            with pytest.raises(InferenceAbortedError, match="cancellation"):
+            terminal = await anext(stream)
+            assert terminal.finished is True
+            assert terminal.error is None
+            with pytest.raises(StopAsyncIteration):
                 await anext(stream)
             await stream.aclose()
 

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -413,12 +413,19 @@ class TestRequestManagement:
 
             # Get a few tokens
             token_count = 0
-            async for output in engine.stream_outputs(rid, timeout=30):
+            stream = engine.stream_outputs(rid, timeout=30)
+            async for output in stream:
                 token_count += len(output.new_token_ids)
                 if token_count >= 5:
                     # Abort after 5 tokens
                     await engine.abort_request(rid)
                     break
+
+            from vllm_mlx.request import InferenceAbortedError
+
+            with pytest.raises(InferenceAbortedError, match="cancellation"):
+                await anext(stream)
+            await stream.aclose()
 
             # Request should be aborted
             stats = engine.get_stats()

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import threading
 import time
 
 import pytest
@@ -713,13 +714,24 @@ async def test_batched_engine_publishes_request_id_into_holder():
     eng._stream_interval = 1
     eng._is_hybrid_model = lambda: False
     eng._create_output_router = lambda: None
+    eng._admission_lock = threading.Lock()
+    eng._admission_reservations = 0
+    eng._admission_tokens = set()
+    eng._admission_tasks = {}
+    eng._lifecycle_aborted_tasks = set()
+    eng._generation_paused = False
+    eng._generation_pause_mode = None
+    eng._scheduler_config = None
 
     # Fake AsyncEngineCore so add_request returns a concrete id and
     # stream_outputs yields one finished chunk.
     fake_engine = MagicMock()
-    fut: asyncio.Future = asyncio.Future()
-    fut.set_result("req-engine-issued-7777")
-    fake_engine.add_request = MagicMock(return_value=fut)
+
+    async def add_request(**kwargs):
+        kwargs["on_request_committed"]()
+        return "req-engine-issued-7777"
+
+    fake_engine.add_request = MagicMock(side_effect=add_request)
 
     async def stream_outputs(request_id):
         yield RequestOutput(
@@ -735,6 +747,7 @@ async def test_batched_engine_publishes_request_id_into_holder():
         )
 
     fake_engine.stream_outputs = stream_outputs
+    fake_engine.engine = None
     fake_engine.scheduler = MagicMock()
     fake_engine.scheduler.abort_request = MagicMock(return_value=True)
     fake_engine._cleanup_request = MagicMock()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -172,6 +172,48 @@ async def test_pre_scheduler_abort_returns_terminal_non_streaming_503():
 
 
 @pytest.mark.asyncio
+async def test_route_boundary_translates_lifecycle_abort_before_helper_binding():
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import _raise_lifecycle_cancel_or_reraise
+
+    engine, _ = _engine()
+    adapting = asyncio.Event()
+
+    async def route_boundary():
+        engine.check_admission()
+        try:
+            adapting.set()
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            _raise_lifecycle_cancel_or_reraise(engine, exc)
+        finally:
+            engine.release_admission_reservation()
+
+    response = asyncio.create_task(route_boundary())
+    await adapting.wait()
+    status = await asyncio.wait_for(engine.pause_generation("abort"), timeout=1)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await response
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Request cancelled by model replacement"
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_route_boundary_preserves_unowned_cancellation():
+    from vllm_mlx.service.helpers import _raise_lifecycle_cancel_or_reraise
+
+    engine, _ = _engine()
+    error = asyncio.CancelledError("client disconnected")
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        _raise_lifecycle_cancel_or_reraise(engine, error)
+    assert exc_info.value is error
+
+
+@pytest.mark.asyncio
 async def test_pre_scheduler_abort_emits_terminal_streaming_error():
     import json
 

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -20,6 +20,7 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._admission_lock = threading.Lock()
     engine._admission_reservations = reservations
     engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
+    engine._admission_tasks = {}
     _admission_token_context.set(
         (id(engine), ("reserved-0",)) if reservations else None
     )
@@ -36,7 +37,18 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
         scheduler.generation_paused = paused
         scheduler.add_allowance = add_allowance if paused else 0
 
+    def pause_generation_admission(tokens, mode):
+        scheduler.generation_paused = True
+        owned = {
+            getattr(request, "lifecycle_admission_token", None)
+            for request in scheduler.requests.values()
+        }
+        pending = set(tokens) - owned
+        scheduler._paused_admission_tokens = pending if mode == "wait" else set()
+        scheduler.add_allowance = len(scheduler._paused_admission_tokens)
+
     scheduler.set_generation_paused = set_generation_paused
+    scheduler.pause_generation_admission = pause_generation_admission
     engine._engine = SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
     engine.get_stats = lambda: {
         "num_running": len(scheduler.running),
@@ -91,6 +103,30 @@ async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
     status = await asyncio.wait_for(pause, timeout=1)
     assert aborted == ["late"]
     assert status["running_requests"] == 0
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_abort_pause_cancels_request_stalled_before_scheduler_commit():
+    engine, scheduler = _engine()
+    admitted = asyncio.Event()
+
+    async def stalled_request():
+        engine.check_admission()
+        admitted.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            engine.release_admission_reservation()
+
+    request = asyncio.create_task(stalled_request())
+    await admitted.wait()
+
+    status = await asyncio.wait_for(engine.pause_generation("abort"), timeout=1)
+
+    with pytest.raises(asyncio.CancelledError):
+        await request
+    assert scheduler._paused_admission_tokens == set()
     assert status["admitted_requests"] == 0
 
 
@@ -240,8 +276,9 @@ def test_scheduler_pause_accepts_only_uncommitted_pre_pause_token(scheduler_type
     scheduler.pause_generation_admission({"owned", "pending"}, mode)
 
     assert scheduler._generation_paused is True
-    assert scheduler._paused_add_allowance == 1
-    assert scheduler._paused_admission_tokens == {"pending"}
+    expected = {"pending"} if mode == "wait" else set()
+    assert scheduler._paused_add_allowance == len(expected)
+    assert scheduler._paused_admission_tokens == expected
 
     scheduler.set_generation_paused(False)
     assert scheduler._generation_paused is False

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -21,6 +21,7 @@ def _engine(*, reservations: int = 0, running: dict | None = None):
     engine._admission_reservations = reservations
     engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
     engine._admission_tasks = {}
+    engine._lifecycle_aborted_tasks = set()
     _admission_token_context.set(
         (id(engine), ("reserved-0",)) if reservations else None
     )
@@ -127,6 +128,91 @@ async def test_abort_pause_cancels_request_stalled_before_scheduler_commit():
     with pytest.raises(asyncio.CancelledError):
         await request
     assert scheduler._paused_admission_tokens == set()
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pre_scheduler_abort_returns_terminal_non_streaming_503():
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import _wait_with_disconnect
+
+    engine, _ = _engine()
+    preprocessing = asyncio.Event()
+
+    class RawRequest:
+        async def is_disconnected(self):
+            return False
+
+    async def stalled_generation():
+        preprocessing.set()
+        await asyncio.Event().wait()
+
+    async def request():
+        engine.check_admission()
+        try:
+            return await _wait_with_disconnect(
+                stalled_generation(),
+                RawRequest(),
+                timeout=5,
+                poll_interval=0.01,
+            )
+        finally:
+            engine.release_admission_reservation()
+
+    response = asyncio.create_task(request())
+    await preprocessing.wait()
+    status = await asyncio.wait_for(engine.pause_generation("abort"), timeout=1)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await response
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Request cancelled by model replacement"
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pre_scheduler_abort_emits_terminal_streaming_error():
+    import json
+
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine, _ = _engine()
+    preprocessing = asyncio.Event()
+
+    class RawRequest:
+        async def is_disconnected(self):
+            return False
+
+    async def stalled_stream():
+        preprocessing.set()
+        await asyncio.Event().wait()
+        yield "unreachable"
+
+    async def request():
+        engine.check_admission()
+        try:
+            return [
+                chunk
+                async for chunk in _disconnect_guard(
+                    stalled_stream(),
+                    RawRequest(),
+                    poll_interval=0.01,
+                    engine=engine,
+                    keepalive_seconds=0,
+                )
+            ]
+        finally:
+            engine.release_admission_reservation()
+
+    response = asyncio.create_task(request())
+    await preprocessing.wait()
+    status = await asyncio.wait_for(engine.pause_generation("abort"), timeout=1)
+    chunks = await response
+
+    payload = json.loads(chunks[0].removeprefix("data: "))
+    assert payload["error"]["code"] == "model_replacement"
+    assert chunks[-1] == "data: [DONE]\n\n"
     assert status["admitted_requests"] == 0
 
 

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -1374,14 +1374,29 @@ def test_mllm_commit_abort_distribution_cleanup_and_reset(monkeypatch):
     scheduler.requests = {"reset": object()}
     scheduler.running = {}
     scheduler.waiting = deque()
-    scheduler._pending_abort_ids = set()
-    scheduler._aborted_queue_ids = set()
-    scheduler._abort_error_kinds = {}
-    scheduler._cancelled_request_ids = set()
-    scheduler._disconnect_abort_ids = set()
-    monkeypatch.setattr(scheduler, "abort_request", lambda _request_id: True)
+    scheduler._pending_abort_ids = {"reset"}
+    scheduler._aborted_queue_ids = {"reset"}
+    scheduler._abort_error_kinds = {"reset": "lifecycle"}
+    scheduler._cancelled_request_ids = {"reset"}
+    scheduler._disconnect_abort_ids = {"reset"}
     scheduler.reset()
     assert scheduler.requests == {}
+    assert scheduler._pending_abort_ids == set()
+    assert scheduler._aborted_queue_ids == set()
+    assert scheduler._abort_error_kinds == {}
+    assert scheduler._cancelled_request_ids == set()
+    assert scheduler._disconnect_abort_ids == set()
+
+    # Reusing the same request ID after reset must receive ordinary abort
+    # semantics rather than the stale lifecycle-replacement terminal error.
+    reused = MLLMRequest(request_id="reset", prompt="again")
+    scheduler.requests = {"reset": reused}
+    scheduler.waiting = deque([reused])
+    scheduler.output_queues = {"reset": asyncio.Queue()}
+    assert scheduler.abort_request("reset") is True
+    scheduler._process_pending_aborts()
+    scheduler._distribute_outputs(MLLMSchedulerOutput(outputs=[]))
+    assert scheduler.output_queues["reset"].get_nowait() is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -84,7 +84,8 @@ async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
     engine, scheduler = _engine(reservations=1)
     aborted = []
 
-    async def abort_request(request_id):
+    async def abort_request(request_id, *, error_kind=None):
+        assert error_kind == "lifecycle"
         aborted.append(request_id)
         scheduler.requests.pop(request_id, None)
         scheduler.running.pop(request_id, None)
@@ -339,6 +340,100 @@ async def test_direct_non_stream_generation_transfers_admission_at_commit():
     generation.cancel()
     with pytest.raises(asyncio.CancelledError):
         await generation
+
+
+@pytest.mark.asyncio
+async def test_direct_stream_generation_reserves_until_scheduler_commit():
+    engine, scheduler = _engine()
+    committed = asyncio.Event()
+
+    class AsyncCoreStub:
+        def __init__(self):
+            self.engine = SimpleNamespace(scheduler=scheduler)
+
+        async def add_request(self, **kwargs):
+            assert engine._admission_reservations == 1
+            kwargs["on_request_committed"]()
+            committed.set()
+            return "streaming"
+
+        async def stream_outputs(self, _request_id):
+            await asyncio.Event().wait()
+            yield  # pragma: no cover - keeps this an async generator
+
+    engine._engine = AsyncCoreStub()
+    engine._loaded = True
+
+    stream = engine.stream_generate("prompt", max_tokens=1)
+    consumer = asyncio.create_task(anext(stream))
+    await committed.wait()
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+    assert engine._current_admission_token() is None
+
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_direct_stream_precommit_failure_releases_admission():
+    engine, scheduler = _engine()
+
+    class FailingCoreStub:
+        def __init__(self):
+            self.engine = SimpleNamespace(scheduler=scheduler)
+
+        async def add_request(self, **_kwargs):
+            raise RuntimeError("precommit failed")
+
+    engine._engine = FailingCoreStub()
+    engine._loaded = True
+
+    with pytest.raises(RuntimeError, match="precommit failed"):
+        await anext(engine.stream_generate("prompt", max_tokens=1))
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+@pytest.mark.asyncio
+async def test_direct_mllm_stream_transfers_admission_at_queue_commit():
+    engine, _ = _engine()
+    committed = asyncio.Event()
+
+    class MLLMSchedulerStub:
+        config = SimpleNamespace(max_concurrent_requests=8)
+
+        async def add_request_async(self, **kwargs):
+            assert engine._admission_reservations == 1
+            kwargs["on_request_committed"]()
+            committed.set()
+            return "mllm-streaming"
+
+        async def stream_outputs(self, _request_id):
+            await asyncio.Event().wait()
+            yield  # pragma: no cover - keeps this an async generator
+
+    engine._is_mllm = True
+    engine._mllm_scheduler = MLLMSchedulerStub()
+    engine._engine = None
+    engine._loaded = True
+
+    stream = engine.stream_generate("prompt", max_tokens=1)
+    consumer = asyncio.create_task(anext(stream))
+    await committed.wait()
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+    assert engine._current_admission_token() is None
+
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+    await stream.aclose()
 
 
 @pytest.mark.asyncio
@@ -623,7 +718,7 @@ async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
     engine._finished_events = {"active": asyncio.Event()}
     engine._idle_event = asyncio.Event()
 
-    assert await engine.abort_request("active") is True
+    assert await engine.abort_request("active", error_kind="lifecycle") is True
     await asyncio.wait_for(engine._finished_events["active"].wait(), timeout=0.1)
 
     terminal = engine._output_collectors["active"].get_nowait()
@@ -637,10 +732,39 @@ async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
     assert "active" in engine._finished_events
 
 
+@pytest.mark.asyncio
+async def test_text_ordinary_abort_preserves_non_lifecycle_cleanup():
+    engine = EngineCore.__new__(EngineCore)
+    engine.scheduler = SimpleNamespace(
+        abort_request=lambda _request_id: True,
+        remove_finished_request=lambda _request_id: None,
+    )
+    engine._output_collectors = {
+        "active": RequestOutputCollector(aggregate=True),
+    }
+    engine._stream_states = {"active": object()}
+    engine._stream_buffers = {"active": object()}
+    engine._finished_events = {"active": asyncio.Event()}
+    engine._idle_event = asyncio.Event()
+
+    assert await engine.abort_request("active") is True
+
+    await asyncio.wait_for(engine._finished_events["active"].wait(), timeout=0.1)
+    terminal = engine._output_collectors["active"].get_nowait()
+    assert terminal is not None
+    assert terminal.finished is True
+    assert terminal.error is None
+    assert terminal.error_kind is None
+    # The consumer still owns cleanup after receiving the ordinary terminal.
+    assert "active" in engine._output_collectors
+    assert "active" in engine._finished_events
+
+
 def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     scheduler.output_queues = {"active": asyncio.Queue()}
     scheduler._aborted_queue_ids = {"active"}
+    scheduler._abort_error_kinds = {"active": "lifecycle"}
 
     scheduler._distribute_outputs(SimpleNamespace(outputs=[]))
 
@@ -648,6 +772,33 @@ def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
     assert terminal.finished is True
     assert terminal.error_kind == "lifecycle"
     assert "cancellation" in terminal.error
+
+
+def test_mllm_ordinary_abort_preserves_non_lifecycle_queue_close():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler._aborted_queue_ids = {"active"}
+    scheduler._abort_error_kinds = {}
+
+    scheduler._distribute_outputs(SimpleNamespace(outputs=[]))
+
+    assert scheduler.output_queues["active"].get_nowait() is None
+
+
+def test_mllm_lifecycle_abort_records_reason_until_terminal_delivery():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {"active": object()}
+    scheduler.request_id_to_uid = {}
+    scheduler.running = {}
+    scheduler._pending_abort_ids = set()
+    scheduler._cancelled_request_ids = set()
+    scheduler._abort_error_kinds = {}
+    scheduler.num_requests_cancelled = 0
+
+    assert scheduler.abort_request("active", error_kind="lifecycle") is True
+
+    assert scheduler._abort_error_kinds == {"active": "lifecycle"}
 
 
 def test_mllm_abort_remains_queued_until_terminal_delivery():

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -419,6 +419,75 @@ def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
     writer.join()
 
 
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+def test_request_publication_is_atomic_with_wait_queue(scheduler_type):
+    class TracedLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self.contended = threading.Event()
+
+        def __enter__(self):
+            if self._lock.locked():
+                self.contended.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_args):
+            self._lock.release()
+
+    entered_append = threading.Event()
+    release_append = threading.Event()
+
+    class BlockingWaiting(list):
+        def append(self, request):
+            entered_append.set()
+            assert release_append.wait(timeout=1)
+            super().append(request)
+
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = TracedLock()
+    scheduler._generation_paused = False
+    scheduler._paused_admission_tokens = set()
+    scheduler._paused_add_allowance = 0
+    scheduler.requests = {}
+    scheduler.waiting = BlockingWaiting()
+    scheduler._cancelled_request_ids = set()
+    scheduler._disconnect_abort_ids = set()
+    scheduler._orphaned_running_candidates = {}
+    request = SimpleNamespace(request_id="publishing", lifecycle_admission_token=None)
+    errors = []
+
+    def publish():
+        try:
+            scheduler._commit_request(request)
+        except BaseException as exc:
+            errors.append(exc)
+
+    publisher = threading.Thread(target=publish)
+
+    def pause():
+        try:
+            scheduler.pause_generation_admission(set(), "wait")
+        except BaseException as exc:
+            errors.append(exc)
+
+    publisher.start()
+    assert entered_append.wait(timeout=1)
+    pauser = threading.Thread(target=pause)
+    pauser.start()
+
+    assert scheduler._cancel_counter_lock.contended.wait(timeout=1)
+    assert pauser.is_alive()
+    release_append.set()
+    publisher.join(timeout=1)
+    pauser.join(timeout=1)
+
+    assert errors == []
+    assert scheduler.requests == {"publishing": request}
+    assert scheduler.waiting == [request]
+    assert scheduler._generation_paused is True
+
+
 @pytest.mark.asyncio
 async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
     engine = EngineCore.__new__(EngineCore)

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -6,11 +6,18 @@ from types import SimpleNamespace
 
 import pytest
 
-from vllm_mlx.engine.batched import BatchedEngine, _admission_token_context
-from vllm_mlx.engine_core import EngineCore
-from vllm_mlx.mllm_scheduler import MLLMScheduler
-from vllm_mlx.output_collector import RequestOutputCollector
-from vllm_mlx.scheduler import BackpressureError, Scheduler
+from tests._headless_mlx import install_headless_mlx_import_stubs
+
+install_headless_mlx_import_stubs()
+
+from vllm_mlx.engine.batched import (  # noqa: E402
+    BatchedEngine,
+    _admission_token_context,
+)
+from vllm_mlx.engine_core import EngineCore  # noqa: E402
+from vllm_mlx.mllm_scheduler import MLLMScheduler  # noqa: E402
+from vllm_mlx.output_collector import RequestOutputCollector  # noqa: E402
+from vllm_mlx.scheduler import BackpressureError, Scheduler  # noqa: E402
 
 
 def _engine(*, reservations: int = 0, running: dict | None = None):
@@ -961,3 +968,473 @@ async def test_post_commit_lifecycle_abort_emits_model_replacement_sse():
         "code": "model_replacement",
     }
     assert chunks[-1] == "data: [DONE]\n\n"
+
+
+def test_headless_scheduler_initializers_publish_lifecycle_state(monkeypatch):
+    """The Linux contract lane must execute both real scheduler constructors."""
+
+    tokenizer = SimpleNamespace(eos_token_id=2, encode=lambda _text: [])
+    monkeypatch.setattr(
+        "vllm_mlx.mllm_scheduler.MultimodalProcessor",
+        lambda **_kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.mllm_scheduler.MLLMCacheManager", lambda **_kwargs: object()
+    )
+    text = Scheduler(SimpleNamespace(), tokenizer)
+    vision = MLLMScheduler(
+        SimpleNamespace(config=None), SimpleNamespace(tokenizer=tokenizer)
+    )
+
+    for scheduler in (text, vision):
+        assert scheduler._generation_paused is False
+        assert scheduler._paused_add_allowance == 0
+        assert scheduler._paused_admission_tokens == set()
+    assert vision._abort_error_kinds == {}
+    assert (
+        vision.add_request("hello", request_id="vision-admitted") == "vision-admitted"
+    )
+    assert "vision-admitted" in vision.requests
+
+
+@pytest.mark.asyncio
+async def test_admission_defensive_state_and_scheduler_variants():
+    engine, scheduler = _engine()
+    del engine._admission_tokens
+    del engine._admission_tasks
+    engine.check_admission()
+    token = engine._current_admission_token()
+    assert token in engine._admission_tokens
+    assert token in engine._admission_tasks
+    assert engine._ensure_generation_admission() == (token, False)
+    engine.release_admission_reservation()
+
+    engine._admission_reservations = 1
+    engine._admission_tokens = set()
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+    engine._transfer_admission_to_scheduler(None)
+
+    engine._engine = None
+    assert engine._lifecycle_request_ids() == set()
+    engine._engine = SimpleNamespace(
+        engine=SimpleNamespace(
+            scheduler=SimpleNamespace(request_ids_snapshot=lambda: (1, "two"))
+        )
+    )
+    assert engine._lifecycle_request_ids() == {"1", "two"}
+
+
+@pytest.mark.asyncio
+async def test_pause_validation_fallback_and_timeout_paths():
+    engine, scheduler = _engine(reservations=1)
+    with pytest.raises(ValueError, match="pause mode"):
+        await engine.pause_generation("invalid")
+
+    del scheduler.pause_generation_admission
+    engine._lifecycle_aborted_tasks = None
+    pause = asyncio.create_task(engine.pause_generation("abort", timeout=1))
+    await asyncio.sleep(0)
+    engine.release_admission_reservation()
+    status = await pause
+    assert status["admitted_requests"] == 0
+    assert scheduler.generation_paused is True
+
+
+@pytest.mark.asyncio
+async def test_batched_abort_routes_error_kind_to_each_backend():
+    engine, _ = _engine()
+    calls = []
+    engine._mllm_scheduler = SimpleNamespace(
+        abort_request=lambda request_id, **kwargs: (
+            calls.append((request_id, kwargs)) or True
+        )
+    )
+    assert await engine.abort_request("m0") is True
+    assert await engine.abort_request("m1", error_kind="lifecycle") is True
+
+    engine._mllm_scheduler = None
+
+    async def abort_request(request_id, **kwargs):
+        calls.append((request_id, kwargs))
+        return True
+
+    engine._engine = SimpleNamespace(abort_request=abort_request)
+    assert await engine.abort_request("t0") is True
+    assert await engine.abort_request("t1", error_kind="lifecycle") is True
+    assert calls == [
+        ("m0", {}),
+        ("m1", {"error_kind": "lifecycle"}),
+        ("t0", {}),
+        ("t1", {"error_kind": "lifecycle"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mllm_generation_precommit_failures_release_admission():
+    engine, _ = _engine()
+
+    class FailingMLLM:
+        config = SimpleNamespace(max_concurrent_requests=8)
+
+        async def generate(self, **_kwargs):
+            raise RuntimeError("non-stream precommit")
+
+        async def add_request_async(self, **_kwargs):
+            raise RuntimeError("stream precommit")
+
+    engine._loaded = True
+    engine._is_mllm = True
+    engine._mllm_scheduler = FailingMLLM()
+    engine._engine = None
+
+    with pytest.raises(RuntimeError, match="non-stream precommit"):
+        await engine.generate("prompt", max_tokens=1)
+    assert engine._admission_reservations == 0
+
+    with pytest.raises(RuntimeError, match="stream precommit"):
+        await anext(engine.stream_generate("prompt", max_tokens=1))
+    assert engine._admission_reservations == 0
+
+
+@pytest.mark.asyncio
+async def test_engine_core_error_and_async_abort_contracts():
+    from vllm_mlx.engine_core import AsyncEngineCore
+    from vllm_mlx.request import InferenceAbortedError, RequestOutput
+
+    core = EngineCore.__new__(EngineCore)
+
+    async def add_request(*_args, **_kwargs):
+        return "failed"
+
+    core.add_request = add_request
+    terminal = RequestOutput(
+        request_id="failed",
+        finished=True,
+        finish_reason="length",
+        error="cancelled",
+        error_kind="lifecycle",
+    )
+    collector = RequestOutputCollector(aggregate=True)
+    collector.put(terminal)
+    event = asyncio.Event()
+    event.set()
+    core._finished_events = {"failed": event}
+    core._output_collectors = {"failed": collector}
+    core._cleanup_request = lambda _request_id: None
+    with pytest.raises(InferenceAbortedError) as exc_info:
+        await core.generate("prompt", SimpleNamespace())
+    assert exc_info.value.error_kind == "lifecycle"
+
+    async_core = AsyncEngineCore.__new__(AsyncEngineCore)
+
+    async def abort(request_id, *, error_kind=None):
+        return request_id == "active" and error_kind == "lifecycle"
+
+    async_core.engine = SimpleNamespace(abort_request=abort)
+    assert await async_core.abort_request("active", error_kind="lifecycle") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module_name", "entrypoint", "request_factory", "cancel_target"),
+    [
+        (
+            "vllm_mlx.routes.chat",
+            "create_chat_completion",
+            lambda: (SimpleNamespace(model="gpt-5"), SimpleNamespace()),
+            "_create_chat_completion_impl",
+        ),
+        (
+            "vllm_mlx.routes.completions",
+            "create_completion",
+            lambda: ("completion-request", SimpleNamespace()),
+            "logger.info",
+        ),
+    ],
+)
+async def test_route_wrappers_translate_owned_cancellation(
+    monkeypatch, module_name, entrypoint, request_factory, cancel_target
+):
+    module = __import__(module_name, fromlist=[entrypoint])
+    engine = SimpleNamespace()
+    monkeypatch.setattr(module, "get_engine", lambda _model: engine)
+    monkeypatch.setattr(module, "_validate_model_name", lambda _model: None)
+    monkeypatch.setattr(module, "_check_admission_or_503", lambda _engine: None)
+    monkeypatch.setattr(
+        module, "_release_admission_unless_committed", lambda *_args: None
+    )
+
+    def translate(_engine, _exc):
+        raise RuntimeError("translated")
+
+    monkeypatch.setattr(module, "_raise_lifecycle_cancel_or_reraise", translate)
+    if cancel_target == "logger.info":
+        monkeypatch.setattr(
+            module.logger,
+            "info",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(asyncio.CancelledError()),
+        )
+    else:
+
+        async def cancel(*_args, **_kwargs):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(module, cancel_target, cancel)
+
+    args = request_factory()
+    if args[0] == "completion-request":
+        args = (module.CompletionRequest(model="gpt-5", prompt="hello"), args[1])
+    with pytest.raises(RuntimeError, match="translated"):
+        await getattr(module, entrypoint)(*args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module_name", "entrypoint", "body", "cancel_target"),
+    [
+        (
+            "vllm_mlx.routes.anthropic",
+            "create_anthropic_message",
+            {
+                "model": "claude-local",
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            "logger.info",
+        ),
+        (
+            "vllm_mlx.routes.responses",
+            "create_response",
+            {"model": "gpt-5", "input": "hello"},
+            "_log_request",
+        ),
+    ],
+)
+async def test_json_route_wrappers_translate_owned_cancellation(
+    monkeypatch, module_name, entrypoint, body, cancel_target
+):
+    module = __import__(module_name, fromlist=[entrypoint])
+    engine = SimpleNamespace()
+    monkeypatch.setattr(module, "get_engine", lambda _model: engine)
+    monkeypatch.setattr(module, "_check_admission_or_503", lambda _engine: None)
+    monkeypatch.setattr(
+        module, "_release_admission_unless_committed", lambda *_args: None
+    )
+
+    def translate(_engine, _exc):
+        raise RuntimeError("translated")
+
+    monkeypatch.setattr(module, "_raise_lifecycle_cancel_or_reraise", translate)
+    target_owner, target_name = (
+        (module.logger, "info")
+        if cancel_target == "logger.info"
+        else (module, cancel_target)
+    )
+    monkeypatch.setattr(
+        target_owner,
+        target_name,
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(asyncio.CancelledError()),
+    )
+
+    raw_request = SimpleNamespace(json=lambda: None)
+
+    async def json_body():
+        return body
+
+    raw_request.json = json_body
+    with pytest.raises(RuntimeError, match="translated"):
+        await getattr(module, entrypoint)(raw_request)
+
+
+def test_scheduler_commit_and_reset_lifecycle_edges():
+    from vllm_mlx.request import Request, SamplingParams
+
+    tokenizer = SimpleNamespace(eos_token_id=2, encode=lambda _text: [1, 2])
+    scheduler = Scheduler(SimpleNamespace(), tokenizer)
+    request = Request(
+        request_id="fresh", prompt="hello", sampling_params=SamplingParams(max_tokens=1)
+    )
+    scheduler.add_request(request)
+    assert scheduler.requests["fresh"] is request
+
+    scheduler.set_generation_paused(True)
+    rejected = Request(
+        request_id="rejected",
+        prompt="rejected",
+        prompt_token_ids=[1],
+        sampling_params=SamplingParams(max_tokens=1),
+    )
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler._commit_request(rejected)
+
+    scheduler._paused_admission_tokens = {"admitted"}
+    admitted = Request(
+        request_id="admitted",
+        prompt="admitted",
+        prompt_token_ids=[1],
+        sampling_params=SamplingParams(max_tokens=1),
+        lifecycle_admission_token="admitted",
+    )
+    scheduler._commit_request(admitted)
+    assert scheduler._paused_admission_tokens == set()
+    scheduler.reset()
+    assert scheduler.requests == {}
+
+
+def test_mllm_commit_abort_distribution_cleanup_and_reset(monkeypatch):
+    from collections import deque
+
+    from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMSchedulerOutput
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler._generation_paused = True
+    scheduler._paused_admission_tokens = set()
+    scheduler._paused_add_allowance = 0
+    scheduler.requests = {}
+    scheduler.waiting = deque()
+    scheduler.running = {}
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler._detokenizer_pool = {}
+    scheduler._cancelled_request_ids = set()
+    scheduler._disconnect_abort_ids = set()
+    scheduler._pending_abort_ids = set()
+    scheduler._aborted_queue_ids = set()
+    scheduler._abort_error_kinds = None
+    scheduler.finished_req_ids = set()
+    scheduler.output_queues = {}
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.batch_generator = None
+    scheduler.vision_cache = None
+
+    rejected = MLLMRequest(request_id="rejected", prompt="hello")
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler._commit_request(rejected)
+    scheduler._paused_admission_tokens = {"admitted"}
+    admitted = MLLMRequest(
+        request_id="admitted", prompt="hello", lifecycle_admission_token="admitted"
+    )
+    scheduler._commit_request(admitted)
+    assert scheduler._paused_admission_tokens == set()
+
+    assert scheduler.abort_request("admitted", error_kind="lifecycle") is True
+    assert scheduler._abort_error_kinds == {"admitted": "lifecycle"}
+
+    scheduler.running["admitted"] = admitted
+    scheduler._detokenizer_pool["admitted"] = object()
+    scheduler._do_abort_request("admitted")
+    assert "admitted" not in scheduler.requests
+
+    scheduler.running["finished"] = MLLMRequest(request_id="finished", prompt="x")
+    scheduler.requests["finished"] = scheduler.running["finished"]
+    scheduler.request_id_to_uid["finished"] = 7
+    scheduler.uid_to_request_id[7] = "finished"
+    scheduler._cleanup_finished({"finished"})
+    assert "finished" not in scheduler.requests
+
+    ordinary = asyncio.Queue(maxsize=1)
+    ordinary.put_nowait(object())
+    lifecycle = asyncio.Queue(maxsize=1)
+    lifecycle.put_nowait(object())
+    scheduler.output_queues = {"ordinary": ordinary, "lifecycle": lifecycle}
+    scheduler._aborted_queue_ids = {"ordinary", "lifecycle"}
+    scheduler._abort_error_kinds = {"lifecycle": "lifecycle"}
+    scheduler._distribute_outputs(MLLMSchedulerOutput(outputs=[]))
+    terminal = lifecycle.get_nowait()
+    assert terminal.error_kind == "lifecycle"
+
+    scheduler.requests = {"remove": object()}
+    assert scheduler.remove_finished_request("remove") is not None
+
+    scheduler.requests = {"generated": object()}
+
+    async def add_request_async(*_args, **_kwargs):
+        return "generated"
+
+    async def stream_outputs(_request_id):
+        from vllm_mlx.request import RequestOutput
+
+        yield RequestOutput(request_id="generated", finished=True)
+
+    scheduler.add_request_async = add_request_async
+    scheduler.stream_outputs = stream_outputs
+
+    async def exercise_generate():
+        await scheduler.generate("hello")
+
+    asyncio.run(exercise_generate())
+    assert "generated" not in scheduler.requests
+
+    scheduler.requests = {"reset": object()}
+    scheduler.running = {}
+    scheduler.waiting = deque()
+    scheduler._pending_abort_ids = set()
+    scheduler._aborted_queue_ids = set()
+    scheduler._abort_error_kinds = {}
+    scheduler._cancelled_request_ids = set()
+    scheduler._disconnect_abort_ids = set()
+    monkeypatch.setattr(scheduler, "abort_request", lambda _request_id: True)
+    scheduler.reset()
+    assert scheduler.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_helpers_preserve_non_lifecycle_failures():
+    from vllm_mlx.request import ClientRequestError
+    from vllm_mlx.service.helpers import _disconnect_guard, _wait_with_disconnect
+
+    engine, _ = _engine()
+
+    class RawRequest:
+        async def is_disconnected(self):
+            return False
+
+    async def cancelled_stream():
+        raise asyncio.CancelledError
+        yield  # pragma: no cover
+
+    with pytest.raises(asyncio.CancelledError):
+        await anext(
+            _disconnect_guard(
+                cancelled_stream(),
+                RawRequest(),
+                poll_interval=0.01,
+                engine=engine,
+                keepalive_seconds=0,
+            )
+        )
+
+    async def collect_error(exc):
+        async def failed():
+            raise exc
+            yield  # pragma: no cover
+
+        return [
+            chunk
+            async for chunk in _disconnect_guard(
+                failed(),
+                RawRequest(),
+                poll_interval=0.01,
+                engine=engine,
+                keepalive_seconds=0,
+            )
+        ]
+
+    client_chunks = await collect_error(ClientRequestError("bad image"))
+    internal_chunks = await collect_error(RuntimeError("secret"))
+    assert "invalid_request_error" in client_chunks[0]
+    assert "internal_error" in internal_chunks[0]
+
+    async def cancelled_value():
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await _wait_with_disconnect(
+            cancelled_value(), RawRequest(), timeout=1, poll_interval=0.01
+        )

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.engine.batched import BatchedEngine, _admission_token_context
+from vllm_mlx.engine_core import EngineCore
+from vllm_mlx.mllm_scheduler import MLLMScheduler
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.scheduler import BackpressureError, Scheduler
+
+
+def _engine(*, reservations: int = 0, running: dict | None = None):
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._is_mllm = False
+    engine._mllm_scheduler = None
+    engine._admission_lock = threading.Lock()
+    engine._admission_reservations = reservations
+    engine._admission_tokens = {f"reserved-{index}" for index in range(reservations)}
+    _admission_token_context.set(
+        (id(engine), ("reserved-0",)) if reservations else None
+    )
+    engine._generation_paused = False
+    engine._generation_pause_mode = None
+    scheduler = SimpleNamespace(
+        requests=running or {},
+        running=running or {},
+        waiting=[],
+        config=SimpleNamespace(max_concurrent_requests=8),
+    )
+
+    def set_generation_paused(paused, *, add_allowance=0):
+        scheduler.generation_paused = paused
+        scheduler.add_allowance = add_allowance if paused else 0
+
+    scheduler.set_generation_paused = set_generation_paused
+    engine._engine = SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
+    engine.get_stats = lambda: {
+        "num_running": len(scheduler.running),
+        "num_waiting": len(scheduler.waiting),
+    }
+    return engine, scheduler
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_closes_admission_then_drains_existing_request():
+    engine, _ = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+    assert not pause.done()
+
+    engine.release_admission_reservation()
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert status["paused"] is True
+    assert status["admitted_requests"] == 0
+
+    await engine.resume_generation()
+    engine.check_admission()
+    engine.release_admission_reservation()
+
+
+@pytest.mark.asyncio
+async def test_abort_pause_rechecks_requests_that_arrive_after_pause_edge():
+    engine, scheduler = _engine(reservations=1)
+    aborted = []
+
+    async def abort_request(request_id):
+        aborted.append(request_id)
+        scheduler.requests.pop(request_id, None)
+        scheduler.running.pop(request_id, None)
+        engine.release_admission_reservation()
+        return True
+
+    engine.abort_request = abort_request
+    pause = asyncio.create_task(engine.pause_generation("abort"))
+    await asyncio.sleep(0)
+
+    # Simulate a route that reserved just before pause and reached the
+    # scheduler just after it. Abort mode must discover it on a later scan.
+    request = SimpleNamespace(request_id="late")
+    scheduler.requests["late"] = request
+    scheduler.running["late"] = request
+
+    status = await asyncio.wait_for(pause, timeout=1)
+    assert aborted == ["late"]
+    assert status["running_requests"] == 0
+    assert status["admitted_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_pause_allows_request_reserved_before_pause_to_enter_scheduler():
+    engine, scheduler = _engine(reservations=1)
+
+    pause = asyncio.create_task(engine.pause_generation("wait"))
+    await asyncio.sleep(0)
+
+    assert scheduler.generation_paused is True
+    assert scheduler.add_allowance == 1
+
+    # This request owns the one reservation captured at the pause edge.
+    scheduler.add_allowance -= 1
+    request = SimpleNamespace(request_id="reserved-before-pause")
+    scheduler.requests[request.request_id] = request
+    scheduler.running[request.request_id] = request
+    await asyncio.sleep(0)
+    assert not pause.done()
+
+    scheduler.requests.clear()
+    scheduler.running.clear()
+    engine.release_admission_reservation()
+    await asyncio.wait_for(pause, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_atomically_pauses_an_idle_engine():
+    engine, _ = _engine()
+
+    status = await engine.pause_generation("wait", timeout=0)
+
+    assert status["paused"] is True
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+
+
+def test_text_scheduler_rejects_direct_add_while_paused():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request(SimpleNamespace(request_id="direct"))
+
+
+def test_mllm_scheduler_rejects_direct_add_while_paused():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        scheduler.add_request("prompt", request_id="direct")
+
+
+def test_paused_engine_rejects_even_when_concurrency_cap_is_unlimited():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+    engine._generation_paused = True
+
+    with pytest.raises(BackpressureError, match="paused"):
+        engine.check_admission()
+
+
+def test_unlimited_cap_still_tracks_lifecycle_reservation():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+
+
+def test_lifecycle_status_reports_each_owned_stage_and_total():
+    running = {"one": object(), "two": object()}
+    engine, scheduler = _engine(reservations=1, running=running)
+    scheduler.waiting.append(object())
+
+    status = engine.lifecycle_status()
+
+    assert status["admitted_requests"] == 1
+    assert status["running_requests"] == 2
+    assert status["queued_requests"] == 1
+    assert status["active_requests"] == 4
+
+
+def test_scheduler_transfer_releases_route_owned_reservation():
+    engine, _ = _engine()
+    engine.check_admission()
+    token = engine._current_admission_token()
+
+    engine._transfer_admission_to_scheduler(token)
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+@pytest.mark.parametrize("mode", ["wait", "abort"])
+def test_scheduler_pause_accepts_only_uncommitted_pre_pause_token(scheduler_type, mode):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {
+        "already-owned": SimpleNamespace(lifecycle_admission_token="owned")
+    }
+
+    scheduler.pause_generation_admission({"owned", "pending"}, mode)
+
+    assert scheduler._generation_paused is True
+    assert scheduler._paused_add_allowance == 1
+    assert scheduler._paused_admission_tokens == {"pending"}
+
+    scheduler.set_generation_paused(False)
+    assert scheduler._generation_paused is False
+    assert scheduler._paused_add_allowance == 0
+
+
+def test_same_context_admissions_release_as_a_token_stack():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+
+    engine.check_admission()
+    engine.check_admission()
+    assert engine._admission_reservations == 2
+
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 1
+    engine.release_admission_reservation()
+    assert engine._admission_reservations == 0
+
+
+def test_cross_context_release_preserves_legacy_release_contract():
+    engine, _ = _engine()
+    engine.check_admission()
+    _admission_token_context.set(None)
+
+    engine.release_admission_reservation()
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+
+
+@pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
+def test_request_id_snapshot_is_safe_during_concurrent_mutation(scheduler_type):
+    scheduler = scheduler_type.__new__(scheduler_type)
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.requests = {}
+    start = threading.Event()
+
+    def mutate():
+        start.wait()
+        for index in range(2_000):
+            with scheduler._cancel_counter_lock:
+                scheduler.requests[str(index)] = index
+                if index:
+                    scheduler.requests.pop(str(index - 1), None)
+
+    writer = threading.Thread(target=mutate)
+    writer.start()
+    start.set()
+    for _ in range(2_000):
+        assert isinstance(scheduler.request_ids_snapshot(), tuple)
+    writer.join()
+
+
+@pytest.mark.asyncio
+async def test_text_abort_wakes_non_streaming_consumer_with_terminal_error():
+    engine = EngineCore.__new__(EngineCore)
+    engine.scheduler = SimpleNamespace(abort_request=lambda _request_id: True)
+    engine._output_collectors = {
+        "active": RequestOutputCollector(aggregate=True),
+    }
+    engine._finished_events = {"active": asyncio.Event()}
+    engine._idle_event = asyncio.Event()
+
+    assert await engine.abort_request("active") is True
+    await asyncio.wait_for(engine._finished_events["active"].wait(), timeout=0.1)
+
+    terminal = engine._output_collectors["active"].get_nowait()
+    assert terminal is not None
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error
+    # The waiting stream/generate coroutine owns cleanup after consuming the
+    # terminal signal. Removing these here recreates the hung HTTP request.
+    assert "active" in engine._output_collectors
+    assert "active" in engine._finished_events
+
+
+def test_mllm_abort_delivers_terminal_error_instead_of_empty_success():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler._aborted_queue_ids = {"active"}
+
+    scheduler._distribute_outputs(SimpleNamespace(outputs=[]))
+
+    terminal = scheduler.output_queues["active"].get_nowait()
+    assert terminal.finished is True
+    assert terminal.error_kind == "lifecycle"
+    assert "cancellation" in terminal.error
+
+
+def test_mllm_abort_remains_queued_until_terminal_delivery():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.waiting = []
+    scheduler.running = {}
+    scheduler.finished_req_ids = set()
+    scheduler._aborted_queue_ids = {"active"}
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.batch_generator = None
+    scheduler.vision_cache = None
+
+    assert scheduler.get_stats()["num_waiting"] == 1
+
+
+def test_mllm_terminal_delivery_is_counted_by_engine_lifecycle():
+    engine, _ = _engine()
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.waiting = []
+    scheduler.running = {}
+    scheduler.finished_req_ids = set()
+    scheduler._aborted_queue_ids = {"active"}
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.batch_generator = None
+    scheduler.vision_cache = None
+    engine._is_mllm = True
+    engine._mllm_scheduler = scheduler
+    engine._engine = None
+    engine.get_stats = scheduler.get_stats
+
+    status = engine.lifecycle_status()
+
+    assert status["queued_requests"] == 1
+    assert status["active_requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mllm_abort_unblocks_consumer_as_inference_error():
+    from vllm_mlx.request import InferenceAbortedError, RequestOutput
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"active": asyncio.Queue()}
+    scheduler.output_queues["active"].put_nowait(
+        RequestOutput(
+            request_id="active",
+            finished=True,
+            finish_reason="length",
+            error="Inference aborted by a cancellation request",
+            error_kind="lifecycle",
+        )
+    )
+
+    with pytest.raises(InferenceAbortedError, match="cancellation"):
+        await anext(scheduler.stream_outputs("active"))
+    assert "active" not in scheduler.output_queues

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -189,6 +189,45 @@ def test_scheduler_transfer_releases_route_owned_reservation():
     assert engine._admission_tokens == set()
 
 
+@pytest.mark.asyncio
+async def test_stream_terminal_release_cannot_consume_concurrent_admission():
+    engine, scheduler = _engine()
+    scheduler.config.max_concurrent_requests = None
+    stream_transferred = asyncio.Event()
+    concurrent_reserved = asyncio.Event()
+    release_concurrent = asyncio.Event()
+    concurrent_token = None
+
+    async def streaming_request():
+        engine.check_admission()
+        token = engine._current_admission_token()
+        engine._transfer_admission_to_scheduler(token)
+        stream_transferred.set()
+        await concurrent_reserved.wait()
+        engine.release_admission_reservation()
+
+    async def concurrent_request():
+        nonlocal concurrent_token
+        await stream_transferred.wait()
+        engine.check_admission()
+        concurrent_token = engine._current_admission_token()
+        concurrent_reserved.set()
+        await release_concurrent.wait()
+        engine.release_admission_reservation()
+
+    stream = asyncio.create_task(streaming_request())
+    concurrent = asyncio.create_task(concurrent_request())
+    await stream
+
+    assert concurrent_token is not None
+    assert engine._admission_reservations == 1
+    assert engine._admission_tokens == {concurrent_token}
+
+    release_concurrent.set()
+    await concurrent
+    assert engine._admission_reservations == 0
+
+
 @pytest.mark.parametrize("scheduler_type", [Scheduler, MLLMScheduler])
 @pytest.mark.parametrize("mode", ["wait", "abort"])
 def test_scheduler_pause_accepts_only_uncommitted_pre_pause_token(scheduler_type, mode):

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -400,6 +400,44 @@ async def test_direct_stream_precommit_failure_releases_admission():
 
 
 @pytest.mark.asyncio
+async def test_engine_precommit_cleanup_preserves_lifecycle_route_translation():
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import _raise_lifecycle_cancel_or_reraise
+
+    engine, scheduler = _engine()
+    entered_precommit = asyncio.Event()
+
+    class StalledCoreStub:
+        def __init__(self):
+            self.engine = SimpleNamespace(scheduler=scheduler)
+
+        async def generate(self, **_kwargs):
+            entered_precommit.set()
+            await asyncio.Event().wait()
+
+    engine._engine = StalledCoreStub()
+    engine._loaded = True
+
+    async def route_boundary():
+        try:
+            await engine.generate("prompt", max_tokens=1)
+        except asyncio.CancelledError as exc:
+            _raise_lifecycle_cancel_or_reraise(engine, exc)
+
+    response = asyncio.create_task(route_boundary())
+    await entered_precommit.wait()
+    status = await asyncio.wait_for(engine.pause_generation("abort"), timeout=1)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await response
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Request cancelled by model replacement"
+    assert status["admitted_requests"] == 0
+    assert not engine._lifecycle_aborted_tasks
+
+
+@pytest.mark.asyncio
 async def test_direct_mllm_stream_transfers_admission_at_queue_commit():
     engine, _ = _engine()
     committed = asyncio.Event()

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -897,6 +897,67 @@ async def test_mllm_abort_unblocks_consumer_as_inference_error():
         )
     )
 
-    with pytest.raises(InferenceAbortedError, match="cancellation"):
+    with pytest.raises(InferenceAbortedError, match="cancellation") as exc_info:
         await anext(scheduler.stream_outputs("active"))
+    assert exc_info.value.error_kind == "lifecycle"
     assert "active" not in scheduler.output_queues
+
+
+@pytest.mark.asyncio
+async def test_text_abort_preserves_lifecycle_reason_through_stream_consumer():
+    from vllm_mlx.request import InferenceAbortedError
+
+    engine = EngineCore.__new__(EngineCore)
+    engine.scheduler = SimpleNamespace(abort_request=lambda _request_id: True)
+    engine._output_collectors = {
+        "active": RequestOutputCollector(aggregate=True),
+    }
+    engine._finished_events = {"active": asyncio.Event()}
+    engine._idle_event = asyncio.Event()
+    engine._cleanup_request = lambda _request_id: None
+
+    assert await engine.abort_request("active", error_kind="lifecycle") is True
+
+    with pytest.raises(InferenceAbortedError, match="cancellation") as exc_info:
+        await anext(engine.stream_outputs("active"))
+    assert exc_info.value.error_kind == "lifecycle"
+
+
+@pytest.mark.asyncio
+async def test_post_commit_lifecycle_abort_emits_model_replacement_sse():
+    import json
+
+    from vllm_mlx.request import InferenceAbortedError
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    engine, _ = _engine()
+
+    class RawRequest:
+        async def is_disconnected(self):
+            return False
+
+    async def aborted_stream():
+        raise InferenceAbortedError(
+            "Inference aborted by a cancellation request",
+            error_kind="lifecycle",
+        )
+        yield "unreachable"  # pragma: no cover
+
+    chunks = [
+        chunk
+        async for chunk in _disconnect_guard(
+            aborted_stream(),
+            RawRequest(),
+            poll_interval=0.01,
+            engine=engine,
+            keepalive_seconds=0,
+        )
+    ]
+
+    payload = json.loads(chunks[0].removeprefix("data: "))
+    assert payload["error"] == {
+        "message": "Request cancelled by model replacement",
+        "type": "server_error",
+        "code": "model_replacement",
+    }
+    assert chunks[-1] == "data: [DONE]\n\n"

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -217,6 +217,89 @@ async def test_pre_scheduler_abort_emits_terminal_streaming_error():
 
 
 @pytest.mark.asyncio
+async def test_text_core_reports_scheduler_commit_before_waiting_for_output():
+    from vllm_mlx.request import SamplingParams
+
+    core = EngineCore.__new__(EngineCore)
+    committed = []
+
+    class SchedulerStub:
+        def __init__(self):
+            self.requests = {}
+
+        def add_request(self, request):
+            self.requests[request.request_id] = request
+
+    core.scheduler = SchedulerStub()
+    core._hybrid_throttle = False
+    core._output_collectors = {}
+    core._stream_states = {}
+    core._finished_events = {}
+    core._mlx_executor = None
+    core._idle_event = asyncio.Event()
+    core.config = SimpleNamespace(stream_interval=1)
+
+    request_id = await core.add_request(
+        "prompt",
+        SamplingParams(max_tokens=1),
+        request_id="committed",
+        on_request_committed=lambda: committed.append(
+            "committed" if "committed" in core.scheduler.requests else "too-early"
+        ),
+    )
+
+    assert request_id == "committed"
+    assert committed == ["committed"]
+
+
+@pytest.mark.asyncio
+async def test_mllm_reports_commit_after_output_queue_is_ready():
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {}
+    scheduler.add_request = lambda **_kwargs: "committed"
+    committed = []
+
+    request_id = await scheduler.add_request_async(
+        "prompt",
+        on_request_committed=lambda: committed.append(
+            "committed" if "committed" in scheduler.output_queues else "too-early"
+        ),
+    )
+
+    assert request_id == "committed"
+    assert committed == ["committed"]
+
+
+@pytest.mark.asyncio
+async def test_direct_non_stream_generation_transfers_admission_at_commit():
+    engine, scheduler = _engine()
+    committed = asyncio.Event()
+
+    class AsyncCoreStub:
+        def __init__(self):
+            self.engine = SimpleNamespace(scheduler=scheduler)
+
+        async def generate(self, **kwargs):
+            kwargs["on_request_committed"]()
+            committed.set()
+            await asyncio.Event().wait()
+
+    engine._engine = AsyncCoreStub()
+    engine._loaded = True
+
+    generation = asyncio.create_task(engine.generate("prompt", max_tokens=1))
+    await committed.wait()
+
+    assert engine._admission_reservations == 0
+    assert engine._admission_tokens == set()
+    assert engine._current_admission_token() is None
+
+    generation.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await generation
+
+
+@pytest.mark.asyncio
 async def test_wait_pause_allows_request_reserved_before_pause_to_enter_scheduler():
     engine, scheduler = _engine(reservations=1)
 

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -23,6 +23,7 @@ This module pins behaviour at three layers:
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -230,6 +231,11 @@ async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
     engine._loaded = True
     engine._is_mllm = True
     engine._mllm_scheduler = MagicMock()
+    engine._mllm_scheduler.config.max_concurrent_requests = 256
+    engine._admission_lock = threading.Lock()
+    engine._admission_reservations = 0
+    engine._admission_tokens = set()
+    engine._admission_tasks = {}
     captured: dict = {}
 
     async def _fake_add(**kw):

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -8,7 +8,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
+from tests._headless_mlx import install_headless_mlx_import_stubs
+
+install_headless_mlx_import_stubs()
+
+from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -86,7 +86,9 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         uid_only,
         pending_only,
     }
-    assert outputs[-1] is None
+    assert outputs[-1].request_id == aborted
+    assert outputs[-1].finished is True
+    assert outputs[-1].error_kind == "lifecycle"
     for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -42,6 +42,7 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     scheduler._detokenizer_pool = {running.request_id: object()}
     scheduler._pending_abort_ids = {running.request_id, pending_only}
     scheduler._aborted_queue_ids = {aborted}
+    scheduler._abort_error_kinds = {aborted: "lifecycle"}
     scheduler.finished_req_ids = set()
     scheduler._running = True
     scheduler._injected_step_executor = None

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1310,8 +1310,8 @@ async def test_failed_performance_reload_restores_the_last_known_good_engine():
 
 
 @pytest.mark.asyncio
-async def test_failed_stop_keeps_the_existing_engine_registered():
-    manager, registry, _, _ = manager_fixture(limit_gib=20)
+async def test_failed_stop_rebuilds_the_existing_engine_before_rerouting():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     old_engine = registry.get_engine("chat")
 
     async def failed_stop():
@@ -1325,8 +1325,65 @@ async def test_failed_stop_keeps_the_existing_engine_registered():
             reload_if_changed=True,
         )
 
-    assert registry.get_engine("chat") is old_engine
+    assert registry.get_engine("chat") is loaded["chat"]
+    assert registry.get_engine("chat") is not old_engine
     assert manager.snapshot()["models"][0]["id"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_reload_waits_for_admitted_precommit_request_before_stop():
+    admitted = asyncio.Event()
+    drained = asyncio.Event()
+
+    class PrecommitEngine(FakeLifecycleEngine):
+        def lifecycle_status(self):
+            status = super().lifecycle_status()
+            status["active_requests"] = 1 if admitted.is_set() else 0
+            status["admitted_requests"] = 1 if admitted.is_set() else 0
+            return status
+
+        async def pause_generation(self, mode="wait", *, timeout=None):
+            self.pauses.append((mode, timeout))
+            self.paused = True
+            if admitted.is_set():
+                await drained.wait()
+                admitted.clear()
+            return self.lifecycle_status()
+
+    registry = ModelRegistry()
+    old_engine = PrecommitEngine()
+    primary = entry("chat", old_engine)
+    registry.add(primary, is_default=True)
+    loaded: list[FakeEngine] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        replacement = FakeEngine()
+        loaded.append(replacement)
+        return entry(name, replacement)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    admitted.set()
+
+    reload_task = asyncio.create_task(
+        manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int8"),
+            reload_if_changed=True,
+            replace_mode="wait",
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert reload_task.done() is False
+    assert old_engine.stopped is False
+    assert loaded == []
+
+    drained.set()
+    replacement = await asyncio.wait_for(reload_task, timeout=1)
+    assert old_engine.stopped is True
+    assert replacement.entry.engine is loaded[0]
+    assert registry.default_name == "chat"
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -352,6 +354,39 @@ class FakeImageEngine(FakeEngine):
     is_image_gen = True
 
 
+class FakeLifecycleEngine(FakeEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pauses: list[tuple[str, float | None]] = []
+        self.paused = False
+
+    async def pause_generation(self, mode="wait", *, timeout=None):
+        self.pauses.append((mode, timeout))
+        self.paused = True
+        if self.running and timeout == 0:
+            raise TimeoutError
+        self.running = 0
+        return self.lifecycle_status()
+
+    async def resume_generation(self):
+        self.paused = False
+        return self.lifecycle_status()
+
+    def lifecycle_status(self):
+        return {
+            "paused": self.paused,
+            "pause_mode": self.pauses[-1][0] if self.pauses else None,
+            "admitted_requests": self.running,
+            "running_requests": self.running,
+            "queued_requests": 0,
+        }
+
+
+class FailingResumeLifecycleEngine(FakeLifecycleEngine):
+    async def resume_generation(self):
+        raise RuntimeError("resume failed")
+
+
 class Clock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -683,6 +718,204 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("replace_mode", ["wait", "abort"])
+async def test_assistant_replacement_quiesces_before_primary_handoff(replace_mode):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    events: list[str] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    class Handoff:
+        def commit(self, _entry):
+            events.append("handoff-commit")
+
+        def rollback(self):
+            events.append("handoff-rollback")
+
+    def handoff(_entry):
+        events.append("handoff-start")
+        assert old_engine.paused is True
+        return Handoff()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=handoff,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new", replace_group="assistant", replace_mode=replace_mode
+    )
+
+    assert old_engine.pauses == [(replace_mode, None)]
+    assert old_engine.stopped is True
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert events == ["handoff-start", "handoff-commit"]
+
+
+@pytest.mark.asyncio
+async def test_replacement_does_not_publish_target_until_old_engine_drains():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    allow_drain = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.pauses.append((mode, timeout))
+        old_engine.paused = True
+        await allow_drain.wait()
+        old_engine.running = 0
+        return old_engine.lifecycle_status()
+
+    old_engine.pause_generation = pause_generation
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await asyncio.sleep(0)
+
+    assert "chat-new" not in registry
+    assert registry.default_name == "chat-old"
+
+    allow_drain.set()
+    await replacement
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizing():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    async with manager.lease("chat-old"):
+        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    assert old_engine.pauses == [("wait", None)]
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    draining = asyncio.Event()
+
+    async def pause_generation(mode="wait", *, timeout=None):
+        old_engine.paused = True
+        draining.set()
+        await asyncio.Event().wait()
+
+    old_engine.pause_generation = pause_generation
+    loaded = None
+
+    async def loader(name: str, path: str | None, performance=None):
+        nonlocal loaded
+        loaded = entry(name)
+        return loaded
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await draining.wait()
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert "chat-new" not in registry
+    assert loaded is not None and loaded.engine.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_busy_replacement_reopens_engine_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await manager.load("chat-new", replace_group="assistant")
+
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+def test_residency_status_uses_engine_owned_request_counts():
+    registry = ModelRegistry()
+    engine = FakeLifecycleEngine()
+    engine.running = 2
+    primary = entry("chat", engine)
+    registry.add(primary, is_default=True)
+    manager = ResidentModelManager(
+        registry, lambda *_args: None, memory_reader=lambda: 0
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    model = manager.snapshot()["models"][0]
+
+    assert model["active_requests"] == 2
+    assert model["lifecycle"]["running_requests"] == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_attempts_every_engine_after_one_resume_fails():
+    manager, _, _, _ = manager_fixture()
+    engines = [
+        FakeLifecycleEngine(),
+        FailingResumeLifecycleEngine(),
+        FakeLifecycleEngine(),
+    ]
+    for engine in engines:
+        engine.paused = True
+
+    await manager._resume_engines(engines)  # noqa: SLF001
+
+    assert engines[0].paused is False
+    assert engines[2].paused is False
+
+
+@pytest.mark.asyncio
 async def test_per_model_performance_reload_replaces_only_the_target_engine():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     await manager.load("image", estimated_bytes=3 * GIB)
@@ -915,6 +1148,43 @@ def test_residency_snapshot_reports_primary_running_and_queued_requests(monkeypa
     assert response.status_code == 200
     chat = next(item for item in response.json()["models"] if item["id"] == "chat")
     assert chat["active_requests"] == 2
+
+
+def test_residency_control_plane_forwards_abort_replacement_policy(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-new",
+                "replace_group": "assistant",
+                "replace_mode": "abort",
+            },
+        )
+
+    assert response.status_code == 200
+    assert old_engine.pauses == [("abort", None)]
+    assert registry.default_name == "chat-new"
 
 
 def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
 from vllm_mlx.runtime.resident_models import (
+    ResidencyRecord,
     ResidentModelBusyError,
     ResidentModelCapacityError,
     ResidentModelManager,
@@ -713,8 +714,58 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
 
     assert "chat" in registry
     assert "chat-new" not in registry
-    assert loaded["chat-new"].stopped is True
+    assert "chat-new" not in loaded
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
+
+
+@pytest.mark.asyncio
+async def test_busy_reject_precedes_unrelated_capacity_eviction():
+    registry = ModelRegistry()
+    chat_engine = FakeLifecycleEngine()
+    chat_engine.running = 1
+    primary = entry("chat", chat_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
+    registry.add(primary, is_default=True)
+    registry.add(image)
+    loaded = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        loaded.append(name)
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=8 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=3 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            replace_mode="reject",
+        )
+
+    assert loaded == []
+    assert registry.default_name == "chat"
+    assert {item["id"] for item in manager.snapshot()["models"]} == {
+        "chat",
+        "image",
+    }
+    assert chat_engine.stopped is False
+    assert image_engine.stopped is False
 
 
 @pytest.mark.asyncio
@@ -855,7 +906,7 @@ async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
     assert old_engine.paused is False
     assert old_engine.stopped is False
     assert "chat-new" not in registry
-    assert loaded is not None and loaded.engine.stopped is True
+    assert loaded is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -11,6 +11,7 @@ from vllm_mlx.runtime.resident_models import (
     ResidencyRecord,
     ResidentModelBusyError,
     ResidentModelCapacityError,
+    ResidentModelError,
     ResidentModelManager,
     ResidentPerformanceConfig,
     resident_scheduler_kwargs,
@@ -438,7 +439,7 @@ def manager_fixture(*, limit_gib=10, ttl=0):
 
 
 @pytest.fixture
-def residency_activity_contract():
+def residency_activity_contract(monkeypatch):
     """Exercise the activity SSOT from the MLX-free Linux fixed selector."""
     from vllm_mlx.runtime.resident_models import _engine_active_requests
 
@@ -490,6 +491,7 @@ def residency_activity_contract():
             reload_if_changed=True,
         )
         assert replacement.entry.aliases == {"reload-alias"}
+        assert (await reload_manager.load("reload-alias", pin=True)).pinned is True
 
         try:
             await reload_manager.load(
@@ -502,6 +504,62 @@ def residency_activity_contract():
         else:
             raise AssertionError("failed reload must surface its loader error")
         assert reload_registry.get_entry("reload-alias").aliases == {"reload-alias"}
+
+        with pytest.raises(KeyError):
+            await reload_manager.unload("missing")
+
+        with pytest.raises(ResidentModelError, match="does not belong"):
+            await reload_manager._quiesce_group_locked(replacement, "image", "reject")
+
+        busy = await reload_manager.load("busy")
+        busy.entry.engine.running = 1
+        busy.active_requests = 1
+        with pytest.raises(ResidentModelBusyError, match="active request"):
+            await reload_manager._quiesce_replacement_group_locked(
+                "assistant", "wait", exclude_model_id=replacement.model_id
+            )
+        with pytest.raises(ResidentModelBusyError, match="active request"):
+            await reload_manager.unload("busy")
+        busy.active_requests = 0
+        busy.entry.engine.running = 0
+        busy.state = "evicting"
+        with pytest.raises(ResidentModelBusyError, match="being evicted"):
+            async with reload_manager.lease("busy"):
+                pass
+        busy.state = "resident"
+
+        pinned = await reload_manager.load("pinned-secondary", pin=True)
+        pinned.primary = False
+        with pytest.raises(ResidentModelError, match="pinned model"):
+            reload_manager._replacement_candidates_locked("assistant")
+
+        rollback_engine = FakeLifecycleEngine()
+        resumed = []
+
+        async def quiesce(*_args, **_kwargs):
+            rollback_engine.paused = True
+            return [], [rollback_engine]
+
+        async def fail_commit(*_args, **_kwargs):
+            raise RuntimeError("commit failed")
+
+        original_resume = rollback_engine.resume_generation
+
+        async def resume():
+            resumed.append(True)
+            return await original_resume()
+
+        rollback_engine.resume_generation = resume
+        with monkeypatch.context() as scoped:
+            scoped.setattr(reload_manager, "_quiesce_group_locked", quiesce)
+            scoped.setattr(
+                reload_manager, "_commit_group_replacement_locked", fail_commit
+            )
+            with pytest.raises(RuntimeError, match="commit failed"):
+                await reload_manager._replace_group_locked(
+                    replacement, "assistant", "wait"
+                )
+        assert resumed == [True]
 
     return exercise_reload_identity
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1082,6 +1082,51 @@ async def test_task_cancel_after_primary_commit_preserves_new_route():
 
 
 @pytest.mark.asyncio
+async def test_task_cancel_during_sibling_cleanup_reopens_remaining_sibling():
+    registry = ModelRegistry()
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", primary_engine)
+    blocking_engine = BlockingStopLifecycleEngine()
+    blocking = entry("chat-blocking", blocking_engine)
+    remaining_engine = FakeLifecycleEngine()
+    remaining = entry("chat-remaining", remaining_engine)
+    registry.add(primary, is_default=True)
+    registry.add(blocking)
+    registry.add(remaining)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    for sibling in (blocking, remaining):
+        manager._index_record(
+            ResidencyRecord(
+                entry=sibling,
+                estimated_bytes=4 * GIB,
+                loaded_at=0,
+                last_used_at=0,
+            )
+        )
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await blocking_engine.stop_started.wait()
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert registry.default_name == "chat-new"
+    assert [item.model_name for item in registry.list_entries()] == [
+        "chat-remaining",
+        "chat-new",
+    ]
+    assert remaining_engine.paused is False
+
+
+@pytest.mark.asyncio
 async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizing():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -391,7 +391,14 @@ class FailingResumeLifecycleEngine(FakeLifecycleEngine):
 
 class FailingStopLifecycleEngine(FakeLifecycleEngine):
     async def stop(self) -> None:
+        self.stopped = True
         raise RuntimeError("stop failed")
+
+
+class CancellingStopLifecycleEngine(FakeLifecycleEngine):
+    async def stop(self) -> None:
+        self.stopped = True
+        raise asyncio.CancelledError
 
 
 class Clock:
@@ -523,6 +530,10 @@ def residency_activity_contract(monkeypatch):
 
         with pytest.raises(ResidentModelError, match="does not belong"):
             await reload_manager._quiesce_group_locked(replacement, "image", "reject")
+        with pytest.raises(ResidentModelError, match="unsupported replacement mode"):
+            reload_manager._replacement_candidates_locked(
+                "assistant", replace_mode="invalid"
+            )
 
         busy = await reload_manager.load("busy")
         busy.entry.engine.running = 1
@@ -992,6 +1003,49 @@ async def test_committed_replacement_does_not_rollback_to_stopped_sibling(caplog
     assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
     assert "Failed to stop replaced model 'chat-sibling'" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "engine_type", [FailingStopLifecycleEngine, CancellingStopLifecycleEngine]
+)
+async def test_primary_stop_failure_keeps_committed_replacement_routable(
+    caplog, engine_type
+):
+    registry = ModelRegistry()
+    old_engine = engine_type()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    handoff_events: list[str] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    class Handoff:
+        def commit(self, committed):
+            handoff_events.append(f"commit:{committed.model_name}")
+
+        def rollback(self):
+            handoff_events.append("rollback")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: Handoff(),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new", replace_group="assistant", replace_mode="wait"
+    )
+
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
+    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
+    assert handoff_events == ["commit:chat-new"]
+    assert "Failed to stop replaced primary 'chat-old'" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -534,6 +534,8 @@ def residency_activity_contract(monkeypatch):
             reload_manager._replacement_candidates_locked(
                 "assistant", replace_mode="invalid"
             )
+        with pytest.raises(ResidentModelError, match="unsupported replacement mode"):
+            await reload_manager._quiesce_records_locked([], "invalid")
 
         busy = await reload_manager.load("busy")
         busy.entry.engine.running = 1
@@ -1384,6 +1386,26 @@ async def test_reload_waits_for_admitted_precommit_request_before_stop():
     assert old_engine.stopped is True
     assert replacement.entry.engine is loaded[0]
     assert registry.default_name == "chat"
+
+
+@pytest.mark.asyncio
+async def test_reload_quiesces_and_retires_the_rest_of_explicit_group():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=20)
+    sibling = await manager.load("chat-sibling")
+
+    replacement = await manager.load(
+        "chat",
+        performance=ResidentPerformanceConfig(kv_cache_dtype="int8"),
+        reload_if_changed=True,
+        replace_group="assistant",
+        replace_mode="wait",
+    )
+
+    assert replacement.primary is True
+    assert registry.default_name == "chat"
+    assert [item.model_name for item in registry.list_entries()] == ["chat"]
+    assert sibling.entry.engine.stopped is True
+    assert loaded["chat"].stopped is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -395,10 +395,15 @@ class FailingStopLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("stop failed")
 
 
-class CancellingStopLifecycleEngine(FakeLifecycleEngine):
+class BlockingStopLifecycleEngine(FakeLifecycleEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stop_started = asyncio.Event()
+
     async def stop(self) -> None:
         self.stopped = True
-        raise asyncio.CancelledError
+        self.stop_started.set()
+        await asyncio.Event().wait()
 
 
 class Clock:
@@ -1008,14 +1013,11 @@ async def test_committed_replacement_does_not_rollback_to_stopped_sibling(caplog
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "engine_type", [FailingStopLifecycleEngine, CancellingStopLifecycleEngine]
-)
 async def test_primary_stop_failure_keeps_committed_replacement_routable(
-    caplog, engine_type
+    caplog,
 ):
     registry = ModelRegistry()
-    old_engine = engine_type()
+    old_engine = FailingStopLifecycleEngine()
     primary = entry("chat-old", old_engine)
     registry.add(primary, is_default=True)
     handoff_events: list[str] = []
@@ -1048,6 +1050,35 @@ async def test_primary_stop_failure_keeps_committed_replacement_routable(
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
     assert handoff_events == ["commit:chat-new"]
     assert "Failed to stop replaced primary 'chat-old'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_after_primary_commit_preserves_new_route():
+    registry = ModelRegistry()
+    old_engine = BlockingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loaded: dict[str, FakeEngine] = {}
+
+    async def loader(name: str, path: str | None, performance=None):
+        loaded[name] = FakeEngine()
+        return entry(name, loaded[name])
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await old_engine.stop_started.wait()
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    assert registry.default_name == "chat-new"
+    assert registry.get_engine("chat-new") is loaded["chat-new"]
+    assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
+    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -783,6 +783,8 @@ async def test_assistant_replacement_quiesces_before_primary_handoff(replace_mod
     events: list[str] = []
 
     async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.pauses == []
+        events.append("loaded")
         return entry(name)
 
     class Handoff:
@@ -813,7 +815,39 @@ async def test_assistant_replacement_quiesces_before_primary_handoff(replace_mod
     assert old_engine.stopped is True
     assert replacement.primary is True
     assert registry.default_name == "chat-new"
-    assert events == ["handoff-start", "handoff-commit"]
+    assert events == ["loaded", "handoff-start", "handoff-commit"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replace_mode", ["wait", "abort"])
+async def test_failed_replacement_load_does_not_quiesce_active_assistant(
+    replace_mode,
+):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    old_engine.running = 1
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        raise ImportError("replacement checkpoint is unavailable")
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ImportError, match="unavailable"):
+        await manager.load(
+            "chat-invalid",
+            replace_group="assistant",
+            replace_mode=replace_mode,
+        )
+
+    assert old_engine.pauses == []
+    assert old_engine.running == 1
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-old"]
 
 
 @pytest.mark.asyncio
@@ -956,7 +990,8 @@ async def test_cancelled_replacement_resumes_old_engine_and_discards_target():
     assert old_engine.paused is False
     assert old_engine.stopped is False
     assert "chat-new" not in registry
-    assert loaded is None
+    assert loaded is not None
+    assert loaded.engine.stopped is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -388,6 +388,11 @@ class FailingResumeLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("resume failed")
 
 
+class FailingStopLifecycleEngine(FakeLifecycleEngine):
+    async def stop(self) -> None:
+        raise RuntimeError("stop failed")
+
+
 class Clock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -846,6 +851,42 @@ async def test_replacement_does_not_publish_target_until_old_engine_drains():
     allow_drain.set()
     await replacement
     assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_committed_replacement_does_not_rollback_to_stopped_sibling(caplog):
+    registry = ModelRegistry()
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    sibling_engine = FailingStopLifecycleEngine()
+    sibling = entry("chat-sibling", sibling_engine)
+    registry.add(primary, is_default=True)
+    registry.add(sibling)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=sibling,
+            estimated_bytes=4 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new", replace_group="assistant", replace_mode="wait"
+    )
+
+    assert primary_engine.stopped is True
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
+    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
+    assert "Failed to stop replaced model 'chat-sibling'" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -508,6 +508,19 @@ def residency_activity_contract(monkeypatch):
         with pytest.raises(KeyError):
             await reload_manager.unload("missing")
 
+        async def image_loader(name: str, path: str | None, performance=None):
+            return entry(name, FakeImageEngine())
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(reload_manager, "loader", image_loader)
+            with pytest.raises(ResidentModelError, match="image-gen.*assistant"):
+                await reload_manager.load("wrong-new-group", replace_group="assistant")
+            assert "wrong-new-group" not in reload_registry
+
+            image = await reload_manager.load("resident-image")
+            with pytest.raises(ResidentModelError, match="image-gen.*assistant"):
+                await reload_manager.load(image.model_id, replace_group="assistant")
+
         with pytest.raises(ResidentModelError, match="does not belong"):
             await reload_manager._quiesce_group_locked(replacement, "image", "reject")
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -863,9 +863,18 @@ async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizin
     manager.register_primary(primary, estimated_bytes=4 * GIB)
 
     async with manager.lease("chat-old"):
-        await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+        replacement = asyncio.create_task(
+            manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+        )
+        await asyncio.sleep(0)
 
-    assert old_engine.pauses == [("wait", None)]
+        assert replacement.done() is False
+        assert old_engine.pauses == [("wait", None)]
+        assert old_engine.stopped is False
+        assert registry.default_name == "chat-old"
+
+    await asyncio.wait_for(replacement, timeout=1)
+
     assert old_engine.stopped is True
     assert registry.default_name == "chat-new"
 

--- a/tests/test_rst_mid_sse_zombie_kv.py
+++ b/tests/test_rst_mid_sse_zombie_kv.py
@@ -250,6 +250,11 @@ async def test_stream_generate_finally_is_double_safety_net():
     # stream_outputs yields ONE chunk and then awaits forever so we
     # can close the generator after the first yield.
     fake_engine = MagicMock()
+    # ``BatchedEngine`` reaches the real scheduler through
+    # ``AsyncEngineCore.engine``. This focused double intentionally has no
+    # inner core, so admission must use the configured fallback instead of a
+    # recursively-created ``MagicMock`` scheduler/config tree.
+    fake_engine.engine = None
     fake_engine.add_request = MagicMock(return_value=_completed_future("req-xyz"))
 
     async def stream_outputs(request_id):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -993,7 +993,7 @@ class BatchedEngine(BaseEngine):
                     f"(currently {self._admission_reservations} in-flight)"
                 )
             self._admission_reservations += 1
-            tokens = getattr(self, "_admission_tokens", None)
+            tokens: set[str] | None = getattr(self, "_admission_tokens", None)
             if tokens is None:
                 tokens = set()
                 self._admission_tokens = tokens
@@ -1021,7 +1021,7 @@ class BatchedEngine(BaseEngine):
     ) -> None:
         """Release one route reservation while holding ``_admission_lock``."""
 
-        tokens = getattr(self, "_admission_tokens", set())
+        tokens: set[str] = getattr(self, "_admission_tokens", set())
         if token is not None and token in tokens:
             tokens.remove(token)
             self._admission_reservations -= 1

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -898,6 +898,7 @@ class BatchedEngine(BaseEngine):
         self._admission_lock = threading.Lock()
         self._admission_reservations = 0
         self._admission_tokens: set[str] = set()
+        self._admission_tasks: dict[str, asyncio.Task] = {}
         self._generation_paused = False
         self._generation_pause_mode: str | None = None
 
@@ -999,6 +1000,18 @@ class BatchedEngine(BaseEngine):
                 self._admission_tokens = tokens
             token = uuid.uuid4().hex
             tokens.add(token)
+            try:
+                owner = asyncio.current_task()
+            except RuntimeError:
+                owner = None
+            if owner is not None:
+                tasks: dict[str, asyncio.Task] | None = getattr(
+                    self, "_admission_tasks", None
+                )
+                if tasks is None:
+                    tasks = {}
+                    self._admission_tasks = tasks
+                tasks[token] = owner
             context = _admission_token_context.get()
             stack = context[1] if context is not None and context[0] == id(self) else ()
             _admission_token_context.set((id(self), (*stack, token)))
@@ -1026,18 +1039,22 @@ class BatchedEngine(BaseEngine):
         """Release one route reservation while holding ``_admission_lock``."""
 
         tokens: set[str] = getattr(self, "_admission_tokens", set())
+        consumed_token: str | None = None
         if token is not None and token in tokens:
             tokens.remove(token)
+            consumed_token = token
             self._admission_reservations -= 1
         elif token is None and tokens:
             # The historical API permits release from a task that did not
             # inherit the reservation context.
-            tokens.pop()
+            consumed_token = tokens.pop()
             self._admission_reservations -= 1
         elif not tokens and self._admission_reservations > 0:
             # Minimal engine doubles created before lifecycle tokens still
             # exercise the public counter-based release contract.
             self._admission_reservations -= 1
+        if consumed_token is not None:
+            getattr(self, "_admission_tasks", {}).pop(consumed_token, None)
         if clear_context and token is not None and token in context_stack:
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)
@@ -1109,10 +1126,20 @@ class BatchedEngine(BaseEngine):
             raise ValueError("pause mode must be 'wait' or 'abort'")
 
         scheduler = self._lifecycle_scheduler()
+        admitted_tasks: tuple[asyncio.Task, ...] = ()
         with self._admission_lock:
             self._generation_paused = True
             self._generation_pause_mode = mode
             admitted_tokens = set(getattr(self, "_admission_tokens", set()))
+            if mode == "abort":
+                task_by_token: dict[str, asyncio.Task] = getattr(
+                    self, "_admission_tasks", {}
+                )
+                admitted_tasks = tuple(
+                    task_by_token[token]
+                    for token in admitted_tokens
+                    if token in task_by_token
+                )
             pause_admission = getattr(scheduler, "pause_generation_admission", None)
             if callable(pause_admission):
                 pause_admission(admitted_tokens, mode)
@@ -1128,6 +1155,12 @@ class BatchedEngine(BaseEngine):
                             else 0
                         ),
                     )
+
+        if mode == "abort":
+            current = asyncio.current_task()
+            for task in admitted_tasks:
+                if task is not current and not task.done():
+                    task.cancel("request aborted for model replacement")
 
         async def _drain() -> dict[str, object]:
             while True:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1074,6 +1074,19 @@ class BatchedEngine(BaseEngine):
             return None
         return context[1][-1]
 
+    def _ensure_generation_admission(self) -> tuple[str, bool]:
+        """Return an active token, reserving one for direct/repeated calls."""
+
+        token = self._current_admission_token()
+        with self._admission_lock:
+            if token is not None and token in self._admission_tokens:
+                return token, False
+        self.check_admission()
+        token = self._current_admission_token()
+        if token is None:  # pragma: no cover - check_admission always publishes it
+            raise RuntimeError("admission reservation did not publish a token")
+        return token, True
+
     def bind_admission_task(self, task: asyncio.Task) -> None:
         """Transfer a route reservation to its actual generation task."""
 
@@ -1096,7 +1109,9 @@ class BatchedEngine(BaseEngine):
             aborted.remove(task)
             return True
 
-    def _transfer_admission_to_scheduler(self, token: str | None) -> None:
+    def _transfer_admission_to_scheduler(
+        self, token: str | None, *, clear_context: bool = False
+    ) -> None:
         """End route ownership once the scheduler has committed the request."""
 
         if token is None:
@@ -1104,11 +1119,13 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             context = _admission_token_context.get()
             stack = context[1] if context is not None and context[0] == id(self) else ()
-            # The streaming route still calls release in its terminal guard.
-            # Keep this task's consumed token in context as a tombstone so that
-            # terminal release is an exact no-op instead of popping a token
-            # owned by a concurrent request with a different context.
-            self._consume_admission_token_locked(token, stack, clear_context=False)
+            # Route-owned streaming requests still release in their terminal
+            # guard, so their consumed token remains as a tombstone and makes
+            # that release an exact no-op. Direct/repeated generate calls own
+            # their token and clear it at commit.
+            self._consume_admission_token_locked(
+                token, stack, clear_context=clear_context
+            )
 
     def lifecycle_status(self) -> dict[str, object]:
         """Return engine-owned admission and scheduler activity."""
@@ -2052,7 +2069,12 @@ class BatchedEngine(BaseEngine):
         """
         if not self._loaded:
             await self.start()
-        admission_token = self._current_admission_token()
+        admission_token, owns_admission = self._ensure_generation_admission()
+
+        def request_committed() -> None:
+            self._transfer_admission_to_scheduler(
+                admission_token, clear_context=owns_admission
+            )
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all requests when model is multimodal.
@@ -2080,19 +2102,25 @@ class BatchedEngine(BaseEngine):
                 for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
                 if k in kwargs
             }
-            output = await self._mllm_scheduler.generate(
-                prompt=prompt,
-                images=images,
-                videos=videos,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                stop=stop,
-                video_fps=kwargs.pop("video_fps", None),
-                video_max_frames=kwargs.pop("video_max_frames", None),
-                lifecycle_admission_token=admission_token,
-                **_mllm_penalty_kwargs,
-            )
+            try:
+                output = await self._mllm_scheduler.generate(
+                    prompt=prompt,
+                    images=images,
+                    videos=videos,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    stop=stop,
+                    video_fps=kwargs.pop("video_fps", None),
+                    video_max_frames=kwargs.pop("video_max_frames", None),
+                    lifecycle_admission_token=admission_token,
+                    on_request_committed=request_committed,
+                    **_mllm_penalty_kwargs,
+                )
+            except BaseException:
+                if owns_admission:
+                    self.release_admission_reservation()
+                raise
             mllm_full_text = output.output_text or ""
             if mllm_assistant_text_prefix:
                 mllm_full_text = mllm_assistant_text_prefix + mllm_full_text
@@ -2185,17 +2213,23 @@ class BatchedEngine(BaseEngine):
                     has_tools=False,
                     as_token_ids=False,
                 )
-        output = await self._engine.generate(
-            prompt=prompt,
-            sampling_params=sampling_params,
-            prefix_boundary=prefix_boundary,
-            has_tools=has_tools,
-            requires_prompt_integrity=requires_prompt_integrity,
-            grammar_logits_processor=grammar_logits_processor,
-            reasoning_budget_logits_processor=reasoning_budget_logits_processor,
-            suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
-            lifecycle_admission_token=admission_token,
-        )
+        try:
+            output = await self._engine.generate(
+                prompt=prompt,
+                sampling_params=sampling_params,
+                prefix_boundary=prefix_boundary,
+                has_tools=has_tools,
+                requires_prompt_integrity=requires_prompt_integrity,
+                grammar_logits_processor=grammar_logits_processor,
+                reasoning_budget_logits_processor=reasoning_budget_logits_processor,
+                suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+                lifecycle_admission_token=admission_token,
+                on_request_committed=request_committed,
+            )
+        except BaseException:
+            if owns_admission:
+                self.release_admission_reservation()
+            raise
 
         if assistant_text_prefix:
             # Prepend the forced prefix to the raw text so the tool

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -11,11 +11,14 @@ MLLMBatchGenerator. MLLM models only initialise the MLLM scheduler (not the
 LLM engine), so text-only requests must also be routed through it.
 """
 
+import asyncio
+import contextvars
 import functools
 import json
 import logging
 import threading
 import time
+import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -32,6 +35,9 @@ logger = logging.getLogger(__name__)
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
 # an optimistic boundary that the next request cannot reuse.
 _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
+_admission_token_context: contextvars.ContextVar[tuple[int, tuple[str, ...]] | None] = (
+    contextvars.ContextVar("rapid_mlx_admission_token", default=None)
+)
 
 
 def _load_lazy_and_install_disk_stream(
@@ -891,6 +897,9 @@ class BatchedEngine(BaseEngine):
         # checks; an asyncio lock would only serialise the event loop.
         self._admission_lock = threading.Lock()
         self._admission_reservations = 0
+        self._admission_tokens: set[str] = set()
+        self._generation_paused = False
+        self._generation_pause_mode: str | None = None
 
     @property
     def model_name(self) -> str:
@@ -973,16 +982,26 @@ class BatchedEngine(BaseEngine):
             else:
                 cap = getattr(scheduler.config, "max_concurrent_requests", None)
 
-        if cap is None or cap <= 0:
-            return
-
         with self._admission_lock:
-            if self._admission_reservations >= cap:
+            if getattr(self, "_generation_paused", False):
+                raise BackpressureError(
+                    "generation is paused for a model lifecycle operation"
+                )
+            if cap is not None and cap > 0 and self._admission_reservations >= cap:
                 raise BackpressureError(
                     f"max_concurrent_requests={cap} reached "
                     f"(currently {self._admission_reservations} in-flight)"
                 )
             self._admission_reservations += 1
+            tokens = getattr(self, "_admission_tokens", None)
+            if tokens is None:
+                tokens = set()
+                self._admission_tokens = tokens
+            token = uuid.uuid4().hex
+            tokens.add(token)
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            _admission_token_context.set((id(self), (*stack, token)))
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -992,8 +1011,152 @@ class BatchedEngine(BaseEngine):
         cancellation) cannot corrupt the cap accounting.
         """
         with self._admission_lock:
-            if self._admission_reservations > 0:
-                self._admission_reservations -= 1
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            token = stack[-1] if stack else None
+            self._consume_admission_token_locked(token, stack)
+
+    def _consume_admission_token_locked(
+        self, token: str | None, context_stack: tuple[str, ...]
+    ) -> None:
+        """Release one route reservation while holding ``_admission_lock``."""
+
+        tokens = getattr(self, "_admission_tokens", set())
+        if token is not None and token in tokens:
+            tokens.remove(token)
+            self._admission_reservations -= 1
+        elif token is None and tokens:
+            # The historical API permits release from a task that did not
+            # inherit the reservation context.
+            tokens.pop()
+            self._admission_reservations -= 1
+        elif not tokens and self._admission_reservations > 0:
+            # Minimal engine doubles created before lifecycle tokens still
+            # exercise the public counter-based release contract.
+            self._admission_reservations -= 1
+        if token is not None and token in context_stack:
+            remaining = tuple(value for value in context_stack if value != token)
+            _admission_token_context.set((id(self), remaining) if remaining else None)
+
+    def _current_admission_token(self) -> str | None:
+        context = _admission_token_context.get()
+        if context is None or context[0] != id(self) or not context[1]:
+            return None
+        return context[1][-1]
+
+    def _transfer_admission_to_scheduler(self, token: str | None) -> None:
+        """End route ownership once the scheduler has committed the request."""
+
+        if token is None:
+            return
+        with self._admission_lock:
+            context = _admission_token_context.get()
+            stack = context[1] if context is not None and context[0] == id(self) else ()
+            self._consume_admission_token_locked(token, stack)
+
+    def lifecycle_status(self) -> dict[str, object]:
+        """Return engine-owned admission and scheduler activity."""
+
+        with self._admission_lock:
+            paused = getattr(self, "_generation_paused", False)
+            pause_mode = getattr(self, "_generation_pause_mode", None)
+            admitted = getattr(self, "_admission_reservations", 0)
+        stats = self.get_stats()
+        running = int(stats.get("num_running", 0) or 0)
+        queued = int(stats.get("num_waiting", 0) or 0)
+        return {
+            "paused": paused,
+            "pause_mode": pause_mode,
+            "active_requests": admitted + running + queued,
+            "admitted_requests": admitted,
+            "running_requests": running,
+            "queued_requests": queued,
+        }
+
+    def _lifecycle_scheduler(self):
+        scheduler = self._mllm_scheduler
+        if scheduler is None and self._engine is not None:
+            scheduler = getattr(
+                getattr(self._engine, "engine", None), "scheduler", None
+            )
+        return scheduler
+
+    def _lifecycle_request_ids(self) -> set[str]:
+        """Snapshot request IDs owned by either scheduler implementation."""
+
+        scheduler = self._lifecycle_scheduler()
+        if scheduler is None:
+            return set()
+        snapshot = getattr(scheduler, "request_ids_snapshot", None)
+        if callable(snapshot):
+            return {str(request_id) for request_id in snapshot()}
+        return {str(request_id) for request_id in (scheduler.requests or {})}
+
+    async def pause_generation(
+        self, mode: str = "wait", *, timeout: float | None = None
+    ) -> dict[str, object]:
+        """Close admission, then drain or abort scheduler-owned work."""
+
+        if mode not in {"wait", "abort"}:
+            raise ValueError("pause mode must be 'wait' or 'abort'")
+
+        scheduler = self._lifecycle_scheduler()
+        with self._admission_lock:
+            self._generation_paused = True
+            self._generation_pause_mode = mode
+            admitted_tokens = set(getattr(self, "_admission_tokens", set()))
+            pause_admission = getattr(scheduler, "pause_generation_admission", None)
+            if callable(pause_admission):
+                pause_admission(admitted_tokens, mode)
+            else:
+                set_paused = getattr(scheduler, "set_generation_paused", None)
+                if callable(set_paused):
+                    scheduler_owned = len(self._lifecycle_request_ids())
+                    set_paused(
+                        True,
+                        add_allowance=(
+                            max(0, len(admitted_tokens) - scheduler_owned)
+                            if mode == "wait"
+                            else 0
+                        ),
+                    )
+
+        async def _drain() -> dict[str, object]:
+            while True:
+                if mode == "abort":
+                    for request_id in self._lifecycle_request_ids():
+                        await self.abort_request(request_id)
+                status = self.lifecycle_status()
+                if (
+                    status["admitted_requests"] == 0
+                    and status["running_requests"] == 0
+                    and status["queued_requests"] == 0
+                ):
+                    return status
+                await asyncio.sleep(0.01)
+
+        initial = self.lifecycle_status()
+        if (
+            initial["admitted_requests"] == 0
+            and initial["running_requests"] == 0
+            and initial["queued_requests"] == 0
+        ):
+            return initial
+        if timeout is None:
+            return await _drain()
+        return await asyncio.wait_for(_drain(), timeout=max(0.0, timeout))
+
+    async def resume_generation(self) -> dict[str, object]:
+        """Reopen route and scheduler admission after a failed transaction."""
+
+        with self._admission_lock:
+            self._generation_paused = False
+            self._generation_pause_mode = None
+        scheduler = self._lifecycle_scheduler()
+        set_paused = getattr(scheduler, "set_generation_paused", None)
+        if callable(set_paused):
+            set_paused(False)
+        return self.lifecycle_status()
 
     @property
     def tokenizer(self) -> Any:
@@ -1808,6 +1971,7 @@ class BatchedEngine(BaseEngine):
         """
         if not self._loaded:
             await self.start()
+        admission_token = self._current_admission_token()
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all requests when model is multimodal.
@@ -1845,6 +2009,7 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
             mllm_full_text = output.output_text or ""
@@ -1948,6 +2113,7 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=admission_token,
         )
 
         if assistant_text_prefix:
@@ -2043,6 +2209,7 @@ class BatchedEngine(BaseEngine):
         # disconnect. Popped from kwargs so it never reaches the
         # scheduler's add_request (which would reject unknown kwargs).
         request_id_holder = kwargs.pop("request_id_holder", None)
+        admission_token = self._current_admission_token()
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -2063,8 +2230,10 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                lifecycle_admission_token=admission_token,
                 **_mllm_penalty_kwargs,
             )
+            self._transfer_admission_to_scheduler(admission_token)
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.
             if request_id_holder is not None:
@@ -2154,7 +2323,9 @@ class BatchedEngine(BaseEngine):
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=admission_token,
         )
+        self._transfer_admission_to_scheduler(admission_token)
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly
         # on client disconnect.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -38,6 +38,9 @@ _PREFIX_BOUNDARY_REPLAY_TOKENS = 8
 _admission_token_context: contextvars.ContextVar[tuple[int, tuple[str, ...]] | None] = (
     contextvars.ContextVar("rapid_mlx_admission_token", default=None)
 )
+_admission_engine_context: contextvars.ContextVar["BatchedEngine | None"] = (
+    contextvars.ContextVar("rapid_mlx_admission_engine", default=None)
+)
 
 
 def _load_lazy_and_install_disk_stream(
@@ -899,6 +902,7 @@ class BatchedEngine(BaseEngine):
         self._admission_reservations = 0
         self._admission_tokens: set[str] = set()
         self._admission_tasks: dict[str, asyncio.Task] = {}
+        self._lifecycle_aborted_tasks: set[asyncio.Task] = set()
         self._generation_paused = False
         self._generation_pause_mode: str | None = None
 
@@ -1015,6 +1019,7 @@ class BatchedEngine(BaseEngine):
             context = _admission_token_context.get()
             stack = context[1] if context is not None and context[0] == id(self) else ()
             _admission_token_context.set((id(self), (*stack, token)))
+            _admission_engine_context.set(self)
 
     def release_admission_reservation(self) -> None:
         """Release a slot reserved by ``check_admission``.
@@ -1054,16 +1059,42 @@ class BatchedEngine(BaseEngine):
             # exercise the public counter-based release contract.
             self._admission_reservations -= 1
         if consumed_token is not None:
-            getattr(self, "_admission_tasks", {}).pop(consumed_token, None)
+            owner = getattr(self, "_admission_tasks", {}).pop(consumed_token, None)
+            if owner is not None:
+                getattr(self, "_lifecycle_aborted_tasks", set()).discard(owner)
         if clear_context and token is not None and token in context_stack:
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)
+            if not remaining:
+                _admission_engine_context.set(None)
 
     def _current_admission_token(self) -> str | None:
         context = _admission_token_context.get()
         if context is None or context[0] != id(self) or not context[1]:
             return None
         return context[1][-1]
+
+    def bind_admission_task(self, task: asyncio.Task) -> None:
+        """Transfer a route reservation to its actual generation task."""
+
+        token = self._current_admission_token()
+        if token is None:
+            return
+        with self._admission_lock:
+            if token in getattr(self, "_admission_tokens", set()):
+                self._admission_tasks[token] = task
+
+    def consume_lifecycle_task_abort(self, task: asyncio.Task) -> bool:
+        """Return whether ``task`` was cancelled by lifecycle replacement."""
+
+        with self._admission_lock:
+            aborted: set[asyncio.Task] = getattr(
+                self, "_lifecycle_aborted_tasks", set()
+            )
+            if task not in aborted:
+                return False
+            aborted.remove(task)
+            return True
 
     def _transfer_admission_to_scheduler(self, token: str | None) -> None:
         """End route ownership once the scheduler has committed the request."""
@@ -1136,10 +1167,19 @@ class BatchedEngine(BaseEngine):
                     self, "_admission_tasks", {}
                 )
                 admitted_tasks = tuple(
-                    task_by_token[token]
-                    for token in admitted_tokens
-                    if token in task_by_token
+                    {
+                        task_by_token[token]
+                        for token in admitted_tokens
+                        if token in task_by_token
+                    }
                 )
+                aborted_tasks: set[asyncio.Task] | None = getattr(
+                    self, "_lifecycle_aborted_tasks", None
+                )
+                if aborted_tasks is None:
+                    aborted_tasks = set()
+                    self._lifecycle_aborted_tasks = aborted_tasks
+                aborted_tasks.update(admitted_tasks)
             pause_admission = getattr(scheduler, "pause_generation_admission", None)
             if callable(pause_admission):
                 pause_admission(admitted_tokens, mode)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1017,7 +1017,11 @@ class BatchedEngine(BaseEngine):
             self._consume_admission_token_locked(token, stack)
 
     def _consume_admission_token_locked(
-        self, token: str | None, context_stack: tuple[str, ...]
+        self,
+        token: str | None,
+        context_stack: tuple[str, ...],
+        *,
+        clear_context: bool = True,
     ) -> None:
         """Release one route reservation while holding ``_admission_lock``."""
 
@@ -1034,7 +1038,7 @@ class BatchedEngine(BaseEngine):
             # Minimal engine doubles created before lifecycle tokens still
             # exercise the public counter-based release contract.
             self._admission_reservations -= 1
-        if token is not None and token in context_stack:
+        if clear_context and token is not None and token in context_stack:
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)
 
@@ -1052,7 +1056,11 @@ class BatchedEngine(BaseEngine):
         with self._admission_lock:
             context = _admission_token_context.get()
             stack = context[1] if context is not None and context[0] == id(self) else ()
-            self._consume_admission_token_locked(token, stack)
+            # The streaming route still calls release in its terminal guard.
+            # Keep this task's consumed token in context as a tombstone so that
+            # terminal release is an exact no-op instead of popping a token
+            # owned by a concurrent request with a different context.
+            self._consume_admission_token_locked(token, stack, clear_context=False)
 
     def lifecycle_status(self) -> dict[str, object]:
         """Return engine-owned admission and scheduler activity."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -19,6 +19,7 @@ import logging
 import threading
 import time
 import uuid
+import weakref
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -902,7 +903,7 @@ class BatchedEngine(BaseEngine):
         self._admission_reservations = 0
         self._admission_tokens: set[str] = set()
         self._admission_tasks: dict[str, asyncio.Task] = {}
-        self._lifecycle_aborted_tasks: set[asyncio.Task] = set()
+        self._lifecycle_aborted_tasks: weakref.WeakSet[asyncio.Task] = weakref.WeakSet()
         self._generation_paused = False
         self._generation_pause_mode: str | None = None
 
@@ -1009,6 +1010,11 @@ class BatchedEngine(BaseEngine):
             except RuntimeError:
                 owner = None
             if owner is not None:
+                # A task may survive a handled cancellation and later make a
+                # new request. Do not let an old replacement marker bleed into
+                # the new admission; the active cancellation path consumes it
+                # at the route boundary before it can re-enter here.
+                getattr(self, "_lifecycle_aborted_tasks", set()).discard(owner)
                 tasks: dict[str, asyncio.Task] | None = getattr(
                     self, "_admission_tasks", None
                 )
@@ -1059,9 +1065,7 @@ class BatchedEngine(BaseEngine):
             # exercise the public counter-based release contract.
             self._admission_reservations -= 1
         if consumed_token is not None:
-            owner = getattr(self, "_admission_tasks", {}).pop(consumed_token, None)
-            if owner is not None:
-                getattr(self, "_lifecycle_aborted_tasks", set()).discard(owner)
+            getattr(self, "_admission_tasks", {}).pop(consumed_token, None)
         if clear_context and token is not None and token in context_stack:
             remaining = tuple(value for value in context_stack if value != token)
             _admission_token_context.set((id(self), remaining) if remaining else None)
@@ -1190,11 +1194,9 @@ class BatchedEngine(BaseEngine):
                         if token in task_by_token
                     }
                 )
-                aborted_tasks: set[asyncio.Task] | None = getattr(
-                    self, "_lifecycle_aborted_tasks", None
-                )
+                aborted_tasks = getattr(self, "_lifecycle_aborted_tasks", None)
                 if aborted_tasks is None:
-                    aborted_tasks = set()
+                    aborted_tasks = weakref.WeakSet()
                     self._lifecycle_aborted_tasks = aborted_tasks
                 aborted_tasks.update(admitted_tasks)
             pause_admission = getattr(scheduler, "pause_generation_admission", None)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1223,7 +1223,7 @@ class BatchedEngine(BaseEngine):
             while True:
                 if mode == "abort":
                     for request_id in self._lifecycle_request_ids():
-                        await self.abort_request(request_id)
+                        await self.abort_request(request_id, error_kind="lifecycle")
                 status = self.lifecycle_status()
                 if (
                     status["admitted_requests"] == 0
@@ -2324,7 +2324,19 @@ class BatchedEngine(BaseEngine):
         # disconnect. Popped from kwargs so it never reaches the
         # scheduler's add_request (which would reject unknown kwargs).
         request_id_holder = kwargs.pop("request_id_holder", None)
-        admission_token = self._current_admission_token()
+        admission_token, owns_admission = self._ensure_generation_admission()
+        request_committed = False
+
+        def commit_admission() -> None:
+            nonlocal request_committed
+            self._transfer_admission_to_scheduler(
+                admission_token, clear_context=owns_admission
+            )
+            request_committed = True
+
+        def release_uncommitted_admission() -> None:
+            if owns_admission and not request_committed:
+                self.release_admission_reservation()
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
@@ -2335,20 +2347,24 @@ class BatchedEngine(BaseEngine):
                 for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
                 if k in kwargs
             }
-            request_id = await self._mllm_scheduler.add_request_async(
-                prompt=prompt,
-                images=images,
-                videos=videos,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                stop=stop,
-                video_fps=kwargs.pop("video_fps", None),
-                video_max_frames=kwargs.pop("video_max_frames", None),
-                lifecycle_admission_token=admission_token,
-                **_mllm_penalty_kwargs,
-            )
-            self._transfer_admission_to_scheduler(admission_token)
+            try:
+                request_id = await self._mllm_scheduler.add_request_async(
+                    prompt=prompt,
+                    images=images,
+                    videos=videos,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    stop=stop,
+                    video_fps=kwargs.pop("video_fps", None),
+                    video_max_frames=kwargs.pop("video_max_frames", None),
+                    lifecycle_admission_token=admission_token,
+                    on_request_committed=commit_admission,
+                    **_mllm_penalty_kwargs,
+                )
+            except BaseException:
+                release_uncommitted_admission()
+                raise
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.
             if request_id_holder is not None:
@@ -2409,38 +2425,44 @@ class BatchedEngine(BaseEngine):
             )
             if k in kwargs
         }
-        sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            stop=stop or [],
-            **_sp_kwargs,
-        )
+        try:
+            sampling_params = SamplingParams(
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                stop=stop or [],
+                **_sp_kwargs,
+            )
 
-        prefix_boundary = kwargs.pop("prefix_boundary", 0)
-        # PFlash routing hints (#287) — parity with generate().
-        has_tools = bool(kwargs.pop("has_tools", False))
-        requires_prompt_integrity = bool(kwargs.pop("requires_prompt_integrity", False))
-        # Grammar-constrained tool calling (#558) — streaming parity.
-        grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
-        reasoning_budget_logits_processor = kwargs.pop(
-            "reasoning_budget_logits_processor", None
-        )
-        suppressed_tokens_logits_processor = kwargs.pop(
-            "suppressed_tokens_logits_processor", None
-        )
-        request_id = await self._engine.add_request(
-            prompt=prompt,
-            sampling_params=sampling_params,
-            prefix_boundary=prefix_boundary,
-            has_tools=has_tools,
-            requires_prompt_integrity=requires_prompt_integrity,
-            grammar_logits_processor=grammar_logits_processor,
-            reasoning_budget_logits_processor=reasoning_budget_logits_processor,
-            suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
-            lifecycle_admission_token=admission_token,
-        )
-        self._transfer_admission_to_scheduler(admission_token)
+            prefix_boundary = kwargs.pop("prefix_boundary", 0)
+            # PFlash routing hints (#287) — parity with generate().
+            has_tools = bool(kwargs.pop("has_tools", False))
+            requires_prompt_integrity = bool(
+                kwargs.pop("requires_prompt_integrity", False)
+            )
+            # Grammar-constrained tool calling (#558) — streaming parity.
+            grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
+            reasoning_budget_logits_processor = kwargs.pop(
+                "reasoning_budget_logits_processor", None
+            )
+            suppressed_tokens_logits_processor = kwargs.pop(
+                "suppressed_tokens_logits_processor", None
+            )
+            request_id = await self._engine.add_request(
+                prompt=prompt,
+                sampling_params=sampling_params,
+                prefix_boundary=prefix_boundary,
+                has_tools=has_tools,
+                requires_prompt_integrity=requires_prompt_integrity,
+                grammar_logits_processor=grammar_logits_processor,
+                reasoning_budget_logits_processor=reasoning_budget_logits_processor,
+                suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+                lifecycle_admission_token=admission_token,
+                on_request_committed=commit_admission,
+            )
+        except BaseException:
+            release_uncommitted_admission()
+            raise
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly
         # on client disconnect.
@@ -3478,7 +3500,9 @@ class BatchedEngine(BaseEngine):
             return self._engine.clear_prefix_cache(reset_stats=reset_stats)
         return False
 
-    async def abort_request(self, request_id: str) -> bool:
+    async def abort_request(
+        self, request_id: str, *, error_kind: str | None = None
+    ) -> bool:
         """Abort an active or queued batched request by request ID.
 
         Routes to whichever backend is loaded:
@@ -3491,9 +3515,14 @@ class BatchedEngine(BaseEngine):
         import inspect
 
         if self._mllm_scheduler is not None:
-            return self._mllm_scheduler.abort_request(request_id)
+            if error_kind is None:
+                return self._mllm_scheduler.abort_request(request_id)
+            return self._mllm_scheduler.abort_request(request_id, error_kind=error_kind)
         if self._engine is not None and hasattr(self._engine, "abort_request"):
-            result = self._engine.abort_request(request_id)
+            if error_kind is None:
+                result = self._engine.abort_request(request_id)
+            else:
+                result = self._engine.abort_request(request_id, error_kind=error_kind)
             if inspect.isawaitable(result):
                 return await result
             return result

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1308,8 +1308,10 @@ class EngineCore:
 
         return request_id
 
-    async def abort_request(self, request_id: str) -> bool:
-        """Abort scheduler work and wake its streaming or aggregate consumer."""
+    async def abort_request(
+        self, request_id: str, *, error_kind: str | None = None
+    ) -> bool:
+        """Abort work, preserving the caller-selected terminal semantics."""
 
         result = self.scheduler.abort_request(request_id)
         if result:
@@ -1322,8 +1324,14 @@ class EngineCore:
                             request_id=request_id,
                             finished=True,
                             finish_reason="length",
-                            error="Inference aborted by a cancellation request",
-                            error_kind="lifecycle",
+                            error=(
+                                "Inference aborted by a cancellation request"
+                                if error_kind == "lifecycle"
+                                else None
+                            ),
+                            error_kind=(
+                                "lifecycle" if error_kind == "lifecycle" else None
+                            ),
                         )
                     )
                 event.set()
@@ -1919,9 +1927,11 @@ class AsyncEngineCore:
             **kwargs,
         )
 
-    async def abort_request(self, request_id: str) -> bool:
+    async def abort_request(
+        self, request_id: str, *, error_kind: str | None = None
+    ) -> bool:
         """Abort a request."""
-        return await self.engine.abort_request(request_id)
+        return await self.engine.abort_request(request_id, error_kind=error_kind)
 
     async def stream_outputs(
         self,

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1496,7 +1496,10 @@ class EngineCore:
                             logger.warning(
                                 f"[stream_outputs] {request_id[:12]} engine aborted: {output.error}"
                             )
-                            raise InferenceAbortedError(output.error)
+                            raise InferenceAbortedError(
+                                output.error,
+                                error_kind=output.error_kind,
+                            )
 
                     yield output
 
@@ -1610,7 +1613,10 @@ class EngineCore:
 
                 from .request import InferenceAbortedError
 
-                raise InferenceAbortedError(final_output.error)
+                raise InferenceAbortedError(
+                    final_output.error,
+                    error_kind=final_output.error_kind,
+                )
 
             return final_output
 

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1090,6 +1090,7 @@ class EngineCore:
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
+        lifecycle_admission_token: str | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -1135,6 +1136,7 @@ class EngineCore:
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
             suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
+            lifecycle_admission_token=lifecycle_admission_token,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).
@@ -1303,9 +1305,26 @@ class EngineCore:
         return request_id
 
     async def abort_request(self, request_id: str) -> bool:
-        """Abort a request."""
+        """Abort scheduler work and wake its streaming or aggregate consumer."""
+
         result = self.scheduler.abort_request(request_id)
-        self._cleanup_request(request_id)
+        if result:
+            event = self._finished_events.get(request_id)
+            if event is not None and not event.is_set():
+                collector = self._output_collectors.get(request_id)
+                if collector is not None:
+                    collector.put(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
+                event.set()
+            if self._idle_event is not None:
+                self._idle_event.set()
         return result
 
     def _cleanup_request(self, request_id: str) -> None:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -20,7 +20,7 @@ import os
 import sys
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -1091,6 +1091,7 @@ class EngineCore:
         reasoning_budget_logits_processor: Any | None = None,
         suppressed_tokens_logits_processor: Any | None = None,
         lifecycle_admission_token: str | None = None,
+        on_request_committed: Callable[[], None] | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -1295,6 +1296,9 @@ class EngineCore:
                 raise
         else:
             self.scheduler.add_request(request)
+
+        if on_request_committed is not None:
+            on_request_committed()
 
         # Wake the engine loop if it's blocked on the idle event.
         # asyncio.Event.set() is loop-thread-safe when called from coros

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1951,7 +1951,10 @@ class MLLMScheduler:
                     if output.error_kind == "lifecycle":
                         from .request import InferenceAbortedError
 
-                        raise InferenceAbortedError(output.error)
+                        raise InferenceAbortedError(
+                            output.error,
+                            error_kind=output.error_kind,
+                        )
                     if output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
                     raise ValueError(output.error)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -649,7 +649,6 @@ class MLLMScheduler:
     def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
         """Close admission and preserve only pre-pause route reservations."""
 
-        del mode
         with self._request_state_lock():
             self._generation_paused = True
             owned = {
@@ -657,7 +656,8 @@ class MLLMScheduler:
                 for request in self.requests.values()
                 if request.lifecycle_admission_token is not None
             }
-            self._paused_admission_tokens = set(admission_tokens) - owned
+            pending = set(admission_tokens) - owned
+            self._paused_admission_tokens = pending if mode == "wait" else set()
             self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -24,7 +24,7 @@ import threading
 import time
 import uuid
 from collections import deque
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -1862,6 +1862,7 @@ class MLLMScheduler:
         stop: list[str] | None = None,
         video_fps: float | None = None,
         video_max_frames: int | None = None,
+        on_request_committed: Callable[[], None] | None = None,
         **kwargs,
     ) -> str:
         """
@@ -1897,6 +1898,8 @@ class MLLMScheduler:
 
         # Create output queue for streaming
         self.output_queues[request_id] = asyncio.Queue()
+        if on_request_committed is not None:
+            on_request_committed()
 
         return request_id
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -156,6 +156,7 @@ class MLLMRequest:
     # Token counts
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
+    lifecycle_admission_token: str | None = None
 
 
 def _find_stop_match_in_new_window(
@@ -302,6 +303,9 @@ class MLLMScheduler:
         self.waiting: deque[MLLMRequest] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, MLLMRequest] = {}  # Running requests by ID
         self.requests: dict[str, MLLMRequest] = {}  # All requests by ID
+        self._generation_paused = False
+        self._paused_add_allowance = 0
+        self._paused_admission_tokens: set[str] = set()
         self.finished_req_ids: set[str] = set()  # Recently finished
 
         # Mapping between our request IDs and BatchGenerator UIDs
@@ -523,6 +527,16 @@ class MLLMScheduler:
         Returns:
             Request ID for tracking
         """
+        with self._request_state_lock():
+            if getattr(self, "_generation_paused", False):
+                from .scheduler import BackpressureError
+
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = kwargs.get("lifecycle_admission_token")
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
         if request_id is None:
             request_id = str(uuid.uuid4())
 
@@ -573,6 +587,7 @@ class MLLMScheduler:
             stop=stop or [],
             video_fps=video_fps,
             video_max_frames=video_max_frames,
+            lifecycle_admission_token=kwargs.pop("lifecycle_admission_token", None),
         )
 
         # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
@@ -590,6 +605,15 @@ class MLLMScheduler:
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
         with self._cancel_counter_lock:
+            if getattr(self, "_generation_paused", False):
+                from .scheduler import BackpressureError
+
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                if request.lifecycle_admission_token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
+                allowed.remove(request.lifecycle_admission_token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request
@@ -610,6 +634,43 @@ class MLLMScheduler:
         )
 
         return request_id
+
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
+        """Close or reopen scheduler admission for model replacement."""
+
+        with self._request_state_lock():
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
+
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+        """Close admission and preserve only pre-pause route reservations."""
+
+        del mode
+        with self._request_state_lock():
+            self._generation_paused = True
+            owned = {
+                request.lifecycle_admission_token
+                for request in self.requests.values()
+                if request.lifecycle_admission_token is not None
+            }
+            self._paused_admission_tokens = set(admission_tokens) - owned
+            self._paused_add_allowance = len(self._paused_admission_tokens)
+
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return a lock-protected snapshot of queued and running IDs."""
+
+        with self._request_state_lock():
+            return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, including for minimal test doubles."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -741,7 +802,7 @@ class MLLMScheduler:
         # ``via_disconnect_total <= cancelled_total`` and the
         # "exactly one tick per abort" contract that three personas
         # independently observed broken on PyPI 0.8.2.
-        with self._cancel_counter_lock:
+        with self._request_state_lock():
             self.requests.pop(request_id, None)
             self._detokenizer_pool.pop(request_id, None)
 
@@ -1139,7 +1200,8 @@ class MLLMScheduler:
 
             # Track as finished
             self.finished_req_ids.add(request_id)
-            self.requests.pop(request_id, None)
+            with self._request_state_lock():
+                self.requests.pop(request_id, None)
 
     def _step_no_queue(self) -> MLLMSchedulerOutput:
         """Execute one scheduling step WITHOUT queue distribution.
@@ -1290,9 +1352,30 @@ class MLLMScheduler:
             queue = self.output_queues.get(request_id)
             if queue is not None:
                 try:
-                    queue.put_nowait(None)
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
                 except asyncio.QueueFull:
-                    pass
+                    while not queue.empty():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:  # pragma: no cover - race
+                            break
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            finished=True,
+                            finish_reason="length",
+                            error="Inference aborted by a cancellation request",
+                            error_kind="lifecycle",
+                        )
+                    )
 
     def _fail_all_inflight(self, exc: Exception) -> MLLMSchedulerOutput:
         """Fail and detach every request after an unexpected step exception.
@@ -1353,7 +1436,8 @@ class MLLMScheduler:
             self.batch_generator = None
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._request_state_lock():
+            self.requests.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
@@ -1385,7 +1469,8 @@ class MLLMScheduler:
 
     def remove_finished_request(self, request_id: str) -> MLLMRequest | None:
         """Remove a finished request from tracking."""
-        return self.requests.pop(request_id, None)
+        with self._request_state_lock():
+            return self.requests.pop(request_id, None)
 
     # ========== Async API (for streaming) ==========
 
@@ -1841,6 +1926,10 @@ class MLLMScheduler:
                     # Mark finished BEFORE raising so the finally block
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
+                    if output.error_kind == "lifecycle":
+                        from .request import InferenceAbortedError
+
+                        raise InferenceAbortedError(output.error)
                     if output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
                     raise ValueError(output.error)
@@ -1906,8 +1995,8 @@ class MLLMScheduler:
             )
 
         # Cleanup
-        if request_id in self.requests:
-            del self.requests[request_id]
+        with self._request_state_lock():
+            self.requests.pop(request_id, None)
 
         return final_output
 
@@ -1916,7 +2005,9 @@ class MLLMScheduler:
     def get_stats(self) -> dict[str, Any]:
         """Get scheduler statistics."""
         stats = {
-            "num_waiting": len(self.waiting),
+            # Abort ownership ends after the event-loop queue receives its
+            # terminal object, not when the worker removes scheduler state.
+            "num_waiting": len(self.waiting) + len(self._aborted_queue_ids),
             "num_running": len(self.running),
             "num_finished": len(self.finished_req_ids),
             "num_requests_processed": self.num_requests_processed,
@@ -1962,7 +2053,8 @@ class MLLMScheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._request_state_lock():
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -531,7 +531,7 @@ class MLLMScheduler:
             if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                allowed: set[str] = getattr(self, "_paused_admission_tokens", set())
                 token = kwargs.get("lifecycle_admission_token")
                 if token not in allowed:
                     raise BackpressureError(
@@ -608,12 +608,15 @@ class MLLMScheduler:
             if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
-                allowed = getattr(self, "_paused_admission_tokens", set())
-                if request.lifecycle_admission_token not in allowed:
+                commit_tokens: set[str] = getattr(
+                    self, "_paused_admission_tokens", set()
+                )
+                token = request.lifecycle_admission_token
+                if token is None or token not in commit_tokens:
                     raise BackpressureError(
                         "generation is paused for a model lifecycle operation"
                     )
-                allowed.remove(request.lifecycle_admission_token)
+                commit_tokens.remove(token)
             self._cancelled_request_ids.discard(request_id)
             self._disconnect_abort_ids.discard(request_id)
             self.requests[request_id] = request

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -817,11 +817,11 @@ class MLLMScheduler:
         with self._request_state_lock():
             self.requests.pop(request_id, None)
             self._detokenizer_pool.pop(request_id, None)
-
-        # Do NOT write to output_queues here — this may run on the
-        # executor thread where asyncio.Queue is not safe.  Mark for
-        # signaling on the event loop thread via _distribute_outputs.
-        self._aborted_queue_ids.add(request_id)
+            # Do NOT write to output_queues here — this may run on the
+            # executor thread where asyncio.Queue is not safe. Mark for
+            # signaling on the event-loop thread while holding the same lock
+            # reset() uses to clear the reason and delivery ledgers.
+            self._aborted_queue_ids.add(request_id)
 
         logger.debug(f"Aborted request {request_id}")
         mx.clear_cache()
@@ -1359,9 +1359,14 @@ class MLLMScheduler:
                         queue.put_nowait(req_output)
 
         # Signal queues for requests aborted during this step
-        while self._aborted_queue_ids:
-            request_id = self._aborted_queue_ids.pop()
-            error_kind = getattr(self, "_abort_error_kinds", {}).pop(request_id, None)
+        while True:
+            with self._request_state_lock():
+                if not self._aborted_queue_ids:
+                    break
+                request_id = self._aborted_queue_ids.pop()
+                error_kind = getattr(self, "_abort_error_kinds", {}).pop(
+                    request_id, None
+                )
             queue = self.output_queues.get(request_id)
             if queue is not None:
                 if error_kind != "lifecycle":
@@ -2080,6 +2085,11 @@ class MLLMScheduler:
         self.running.clear()
         with self._request_state_lock():
             self.requests.clear()
+            self._pending_abort_ids.clear()
+            self._aborted_queue_ids.clear()
+            self._abort_error_kinds.clear()
+            self._cancelled_request_ids.clear()
+            self._disconnect_abort_ids.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
@@ -2092,10 +2102,6 @@ class MLLMScheduler:
         # in-flight request can't interleave inconsistently, AND
         # under the lock so the clear is atomic against any
         # concurrent abort-path mutation.
-        with self._cancel_counter_lock:
-            self._cancelled_request_ids.clear()
-            self._disconnect_abort_ids.clear()
-
         if self.batch_generator is not None:
             self.batch_generator.close()
             self.batch_generator = None

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -604,7 +604,25 @@ class MLLMScheduler:
         # abort+cleanup window; see
         # ``Scheduler.remove_finished_request`` docstring for the
         # multi-branch race repro the persistence plugs.
-        with self._cancel_counter_lock:
+        self._commit_request(request)
+        # Wake the idle scheduler loop immediately (see ``_new_request_event``)
+        # instead of letting it sleep out its poll tick. Safe from here: both
+        # request collections were published atomically above.
+        new_request_event = getattr(self, "_new_request_event", None)
+        if new_request_event is not None:
+            new_request_event.set()
+
+        logger.debug(
+            f"Added MLLM request {request_id}: "
+            f"{len(images or [])} images, {len(videos or [])} videos"
+        )
+
+        return request_id
+
+    def _commit_request(self, request: MLLMRequest) -> None:
+        """Atomically publish a request to lifecycle truth and the run queue."""
+
+        with self._request_state_lock():
             if getattr(self, "_generation_paused", False):
                 from .scheduler import BackpressureError
 
@@ -617,26 +635,10 @@ class MLLMScheduler:
                         "generation is paused for a model lifecycle operation"
                     )
                 commit_tokens.remove(token)
-            self._cancelled_request_ids.discard(request_id)
-            self._disconnect_abort_ids.discard(request_id)
-            self.requests[request_id] = request
-        self.waiting.append(request)
-        # Wake the idle scheduler loop immediately (see ``_new_request_event``)
-        # instead of letting it sleep out its poll tick. Safe from here: both
-        # this append and the loop's wait run on the event-loop thread.
-        # ``getattr`` keeps ``add_request`` callable on the minimally
-        # constructed schedulers unit tests build via ``__new__`` (which set
-        # only ``config`` and skip ``__init__``); the live loop always has it.
-        new_request_event = getattr(self, "_new_request_event", None)
-        if new_request_event is not None:
-            new_request_event.set()
-
-        logger.debug(
-            f"Added MLLM request {request_id}: "
-            f"{len(images or [])} images, {len(videos or [])} videos"
-        )
-
-        return request_id
+            self._cancelled_request_ids.discard(request.request_id)
+            self._disconnect_abort_ids.discard(request.request_id)
+            self.requests[request.request_id] = request
+            self.waiting.append(request)
 
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model replacement."""

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -346,6 +346,7 @@ class MLLMScheduler:
         self._cancel_counter_lock = threading.Lock()
         # Aborted request IDs that need queue signaling (executor → event loop).
         self._aborted_queue_ids: set[str] = set()
+        self._abort_error_kinds: dict[str, str] = {}
 
         # Async processing control
         self._running = False
@@ -677,7 +678,7 @@ class MLLMScheduler:
             self._cancel_counter_lock = lock
         return lock
 
-    def abort_request(self, request_id: str) -> bool:
+    def abort_request(self, request_id: str, *, error_kind: str | None = None) -> bool:
         """
         Queue request for abort.  Thread-safe (called from event loop).
 
@@ -718,6 +719,12 @@ class MLLMScheduler:
             already_counted = request_id in self._cancelled_request_ids
             self._cancelled_request_ids.add(request_id)
             self._pending_abort_ids.add(request_id)
+            if error_kind is not None:
+                abort_error_kinds = getattr(self, "_abort_error_kinds", None)
+                if abort_error_kinds is None:
+                    abort_error_kinds = {}
+                    self._abort_error_kinds = abort_error_kinds
+                abort_error_kinds[request_id] = error_kind
             if not already_counted:
                 self.num_requests_cancelled += 1
         logger.debug(f"Enqueued abort for request {request_id}")
@@ -1354,8 +1361,15 @@ class MLLMScheduler:
         # Signal queues for requests aborted during this step
         while self._aborted_queue_ids:
             request_id = self._aborted_queue_ids.pop()
+            error_kind = getattr(self, "_abort_error_kinds", {}).pop(request_id, None)
             queue = self.output_queues.get(request_id)
             if queue is not None:
+                if error_kind != "lifecycle":
+                    try:
+                        queue.put_nowait(None)
+                    except asyncio.QueueFull:
+                        pass
+                    continue
                 try:
                     queue.put_nowait(
                         RequestOutput(

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -169,6 +169,7 @@ class Request:
     # Routing hints used by PFlash to decide whether to compress (#287).
     has_tools: bool = False
     requires_prompt_integrity: bool = False
+    lifecycle_admission_token: str | None = None
 
     # Grammar-constrained tool calling (#558). Optional per-request logits
     # processor that masks decoding to a tool-call grammar. Set by the chat

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -279,6 +279,10 @@ class InferenceAbortedError(RuntimeError):
     handle a retry against a smaller request.
     """
 
+    def __init__(self, message: str, *, error_kind: str | None = None) -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+
 
 class ClientRequestError(ValueError):
     """A request rejection whose message is explicitly safe for clients.

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Anthropic Messages API endpoints — /v1/messages."""
 
+import asyncio
 import json
 import logging
 import time
@@ -48,6 +49,7 @@ from ..service.helpers import (
     _effective_enable_thinking,
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
+    _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
@@ -1131,6 +1133,8 @@ async def create_anthropic_message(
             content=anthropic_response.model_dump_json(exclude_none=True),
             media_type="application/json",
         )
+    except asyncio.CancelledError as exc:
+        _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
         _release_admission_unless_committed(engine, _admission_committed)
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -90,6 +90,7 @@ from ..service.helpers import (
     _is_structured_output_requested,
     _maybe_pin_system_prompt,
     _parse_tool_calls_with_parser,
+    _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
@@ -3253,6 +3254,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         return await _create_chat_completion_impl(
             request, raw_request, engine, _commit_state, _admission_acquired
         )
+    except asyncio.CancelledError as exc:
+        _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
         if _admission_acquired[0]:
             _release_admission_unless_committed(engine, _commit_state[0])

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Text completion endpoints — /v1/completions."""
 
+import asyncio
 import inspect
 import json
 import logging
@@ -27,6 +28,7 @@ from ..service.helpers import (
     _check_admission_or_503,
     _disconnect_guard,
     _extract_streaming_token_logprobs,
+    _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -652,6 +654,8 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             content=comp_response.model_dump_json(exclude_none=True),
             media_type="application/json",
         )
+    except asyncio.CancelledError as exc:
+        _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
         _release_admission_unless_committed(engine, _admission_committed)
 

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -47,6 +47,7 @@ class ModelLoadRequest(BaseModel):
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: bool = False
+    replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):
@@ -128,6 +129,7 @@ async def load_resident_model(request: ModelLoadRequest):
             image_mode=request.image_mode,
             performance=performance,
             reload_if_changed=request.reload_if_changed,
+            replace_mode=request.replace_mode,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -94,6 +94,7 @@ from ..service.helpers import (
     _finalize_content_and_reasoning,
     _is_structured_output_requested,
     _parse_tool_calls_with_parser,
+    _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -1421,6 +1422,8 @@ async def create_response(request: Request):
             explicit_no_thinking=explicit_no_thinking,
             namespace_by_tool=namespace_by_tool,
         )
+    except asyncio.CancelledError as exc:
+        _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
         _release_admission_unless_committed(engine, _admission_committed)
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -34,6 +34,10 @@ class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
 
 
+class _CommittedReplacementCancelled(asyncio.CancelledError):
+    """Cancellation observed after replacement routing became authoritative."""
+
+
 @dataclass(frozen=True)
 class ResidentPerformanceConfig:
     """Audited scheduler overrides attached to one resident text model.
@@ -667,6 +671,12 @@ class ResidentModelManager:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
+            except _CommittedReplacementCancelled:
+                # Routing already names the new target. Preserve that truth,
+                # reopen any sibling engines not yet retired, and propagate
+                # cancellation without treating the target as a failed load.
+                await self._resume_engines(paused_engines)
+                raise
             except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
@@ -1010,7 +1020,13 @@ class ResidentModelManager:
                         old_primary,
                         reason=f"replace_{group}",
                     )
-                except (Exception, asyncio.CancelledError):
+                except asyncio.CancelledError as exc:
+                    logger.warning(
+                        "Primary retirement cancelled after routing commit: %r",
+                        old_primary.model_id,
+                    )
+                    raise _CommittedReplacementCancelled from exc
+                except Exception:
                     logger.exception(
                         "Failed to stop replaced primary %r after routing commit",
                         old_primary.model_id,
@@ -1027,7 +1043,13 @@ class ResidentModelManager:
                         record,
                         reason=f"replace_{group}",
                     )
-                except (Exception, asyncio.CancelledError):
+                except asyncio.CancelledError as exc:
+                    logger.warning(
+                        "Replacement cleanup cancelled after routing commit: %r",
+                        record.model_id,
+                    )
+                    raise _CommittedReplacementCancelled from exc
+                except Exception:
                     logger.exception(
                         "Failed to stop replaced model %r after routing retirement",
                         record.model_id,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -551,31 +551,47 @@ class ResidentModelManager:
                     await self._replace_group_locked(record, group, replace_mode)
                 return record
 
-            await self._evict_for_locked(estimate, exclude={model_name})
-            before = self._read_memory()
-            if image_mode is None:
-                entry = await self.loader(model_name, model_path, performance)
-            else:
-                entry = await self.loader(
-                    model_name, model_path, performance, image_mode
-                )
-            now = self._clock()
-            after = self._read_memory()
-            delta = max(0, after - before) if before and after else 0
-            record = ResidencyRecord(
-                entry=entry,
-                estimated_bytes=estimate,
-                measured_bytes=delta,
-                loaded_at=now,
-                last_used_at=now,
-                pinned=pin,
-                performance=performance,
-            )
-            group = _effective_replace_group(record.entry, replace_group)
+            record: ResidencyRecord | None = None
             candidates: list[ResidencyRecord] = []
             paused_engines: list[object] = []
             try:
-                if group is not None:
+                if replace_group is not None:
+                    (
+                        candidates,
+                        paused_engines,
+                    ) = await self._quiesce_replacement_group_locked(
+                        replace_group, replace_mode
+                    )
+                await self._evict_for_locked(
+                    estimate,
+                    exclude={model_name, *(item.model_id for item in candidates)},
+                )
+                before = self._read_memory()
+                if image_mode is None:
+                    entry = await self.loader(model_name, model_path, performance)
+                else:
+                    entry = await self.loader(
+                        model_name, model_path, performance, image_mode
+                    )
+                now = self._clock()
+                after = self._read_memory()
+                delta = max(0, after - before) if before and after else 0
+                record = ResidencyRecord(
+                    entry=entry,
+                    estimated_bytes=estimate,
+                    measured_bytes=delta,
+                    loaded_at=now,
+                    last_used_at=now,
+                    pinned=pin,
+                    performance=performance,
+                )
+                group = _effective_replace_group(record.entry, replace_group)
+                if replace_group is not None and group != replace_group:
+                    raise ResidentModelError(
+                        f"model {record.model_id!r} does not belong to replacement "
+                        f"group {replace_group!r}"
+                    )
+                if group is not None and replace_group is None:
                     candidates, paused_engines = await self._quiesce_group_locked(
                         record, group, replace_mode
                     )
@@ -595,11 +611,11 @@ class ResidentModelManager:
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
                 try:
-                    if record.model_id in self._records:
+                    if record is not None and record.model_id in self._records:
                         await self._evict_locked(
                             record, reason="load_rollback", count=False
                         )
-                    else:
+                    elif record is not None:
                         stop = getattr(record.entry.engine, "stop", None)
                         if callable(stop):
                             result = stop()
@@ -780,13 +796,26 @@ class ResidentModelManager:
             raise ResidentModelError(
                 f"model {target.model_id!r} does not belong to replacement group {group!r}"
             )
+        return await self._quiesce_replacement_group_locked(
+            group, replace_mode, exclude_model_id=target.model_id
+        )
+
+    async def _quiesce_replacement_group_locked(
+        self,
+        group: str,
+        replace_mode: str,
+        *,
+        exclude_model_id: str | None = None,
+    ) -> tuple[list[ResidencyRecord], list[object]]:
+        """Close one group before any externally visible lifecycle mutation."""
+
         if replace_mode not in {"reject", "wait", "abort"}:
             raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
 
         candidates = [
             record
             for record in self._records.values()
-            if record.model_id != target.model_id
+            if record.model_id != exclude_model_id
             and _replacement_group(record.entry) == group
         ]
         for record in candidates:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -891,14 +891,6 @@ class ResidentModelManager:
             target_primary = target.primary
             target_pinned = target.pinned
 
-        # Stop the old primary last. Until it returns successfully, rollback
-        # can restore a live worker and coherent routing if any eviction fails.
-        ordered_candidates = [
-            record for record in candidates if record is not old_primary
-        ]
-        if old_primary is not None:
-            ordered_candidates.append(old_primary)
-
         try:
             if old_primary is not None:
                 old_primary.primary = False
@@ -908,9 +900,11 @@ class ResidentModelManager:
                 self.registry.set_default(target.model_id)
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(target.entry)
-            for record in ordered_candidates:
+                # This is the transaction's only fallible retirement. Stop it
+                # before touching sibling candidates so rollback always points
+                # at a live primary/audio worker.
                 await self._evict_locked(
-                    record,
+                    old_primary,
                     reason=f"replace_{group}",
                 )
         except BaseException:
@@ -930,8 +924,27 @@ class ResidentModelManager:
                         handoff.rollback()
             raise
         else:
+            # Once the old primary is stopped (or the group had none), routing
+            # publication is committed and cannot truthfully roll back. Finish
+            # retiring secondary candidates as non-failing cleanup: each is
+            # already quiesced and removed from routing before stop(), so a
+            # cleanup failure may leak resources but cannot resurrect a dead
+            # route or undo the committed primary handoff.
             if handoff is not None:
                 handoff.commit(target.entry)
+            for record in candidates:
+                if record is old_primary:
+                    continue
+                try:
+                    await self._evict_locked(
+                        record,
+                        reason=f"replace_{group}",
+                    )
+                except (Exception, asyncio.CancelledError):
+                    logger.exception(
+                        "Failed to stop replaced model %r after routing retirement",
+                        record.model_id,
+                    )
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -944,13 +944,6 @@ class ResidentModelManager:
                 self.registry.set_default(target.model_id)
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(target.entry)
-                # This is the transaction's only fallible retirement. Stop it
-                # before touching sibling candidates so rollback always points
-                # at a live primary/audio worker.
-                await self._evict_locked(
-                    old_primary,
-                    reason=f"replace_{group}",
-                )
         except BaseException:
             if old_primary is not None:
                 try:
@@ -968,14 +961,26 @@ class ResidentModelManager:
                         handoff.rollback()
             raise
         else:
-            # Once the old primary is stopped (or the group had none), routing
-            # publication is committed and cannot truthfully roll back. Finish
-            # retiring secondary candidates as non-failing cleanup: each is
-            # already quiesced and removed from routing before stop(), so a
-            # cleanup failure may leak resources but cannot resurrect a dead
-            # route or undo the committed primary handoff.
+            # Publishing the target is the point of no return. ``stop()`` may
+            # mutate an engine incrementally before raising or being cancelled,
+            # so no stop-attempted engine can truthfully be restored as primary.
             if handoff is not None:
                 handoff.commit(target.entry)
+            if old_primary is not None:
+                try:
+                    await self._evict_locked(
+                        old_primary,
+                        reason=f"replace_{group}",
+                    )
+                except (Exception, asyncio.CancelledError):
+                    logger.exception(
+                        "Failed to stop replaced primary %r after routing commit",
+                        old_primary.model_id,
+                    )
+            # Finish retiring secondary candidates as non-failing cleanup: each
+            # is already quiesced and removed from routing before stop(), so a
+            # cleanup failure may leak resources but cannot resurrect a dead
+            # route or undo the committed primary handoff.
             for record in candidates:
                 if record is old_primary:
                     continue

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -973,11 +973,8 @@ class ResidentModelManager:
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
             engine_active = _engine_active_requests(engine)
-            lifecycle = (
-                engine.lifecycle_status()
-                if callable(getattr(engine, "lifecycle_status", None))
-                else None
-            )
+            lifecycle_status = getattr(engine, "lifecycle_status", None)
+            lifecycle = lifecycle_status() if callable(lifecycle_status) else None
             active_requests = max(
                 record.active_requests,
                 engine_active if engine_active is not None else 0,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -545,16 +545,20 @@ class ResidentModelManager:
         async with self._lock:
             canonical = self._canonical(model_name)
             if canonical is not None:
-                record = self._records[canonical]
-                if reload_if_changed and record.performance != performance:
-                    record = await self._reload_locked(record, performance)
-                record.last_used_at = self._clock()
+                existing_record = self._records[canonical]
+                if reload_if_changed and existing_record.performance != performance:
+                    existing_record = await self._reload_locked(
+                        existing_record, performance
+                    )
+                existing_record.last_used_at = self._clock()
                 if pin:
-                    record.pinned = True
-                group = _effective_replace_group(record.entry, replace_group)
+                    existing_record.pinned = True
+                group = _effective_replace_group(existing_record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group, replace_mode)
-                return record
+                    await self._replace_group_locked(
+                        existing_record, group, replace_mode
+                    )
+                return existing_record
 
             record: ResidencyRecord | None = None
             candidates: list[ResidencyRecord] = []
@@ -601,7 +605,12 @@ class ResidentModelManager:
                     performance=performance,
                 )
                 group = _effective_replace_group(record.entry, replace_group)
-                if replace_group is not None and group != replace_group:
+                # ``_effective_replace_group`` returns an explicit group
+                # verbatim, so this is unreachable through every loader caller;
+                # retain the defensive invariant for future resolver changes.
+                if (
+                    replace_group is not None and group != replace_group
+                ):  # pragma: no cover
                     raise ResidentModelError(
                         f"model {record.model_id!r} does not belong to replacement "
                         f"group {replace_group!r}"

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -561,12 +561,22 @@ class ResidentModelManager:
             paused_engines: list[object] = []
             try:
                 if replace_group is not None:
-                    (
-                        candidates,
-                        paused_engines,
-                    ) = await self._quiesce_replacement_group_locked(
-                        replace_group, replace_mode
-                    )
+                    if replace_mode == "reject":
+                        # Reject is a non-destructive preflight: close admission
+                        # only after proving the old assistant is already idle,
+                        # so a busy rejection cannot evict unrelated residents.
+                        (
+                            candidates,
+                            paused_engines,
+                        ) = await self._quiesce_replacement_group_locked(
+                            replace_group, replace_mode
+                        )
+                    else:
+                        # Wait/abort may drain or terminate live traffic. Merely
+                        # identify the protected group here; do not mutate the
+                        # healthy assistant until the replacement has actually
+                        # materialized and passed its modality contract.
+                        candidates = self._replacement_candidates_locked(replace_group)
                 await self._evict_for_locked(
                     estimate,
                     exclude={model_name, *(item.model_id for item in candidates)},
@@ -596,7 +606,15 @@ class ResidentModelManager:
                         f"model {record.model_id!r} does not belong to replacement "
                         f"group {replace_group!r}"
                     )
-                if group is not None and replace_group is None:
+                if replace_group is not None and replace_mode != "reject":
+                    (
+                        candidates,
+                        paused_engines,
+                    ) = await self._quiesce_replacement_group_locked(
+                        replace_group,
+                        replace_mode,
+                    )
+                elif group is not None and replace_group is None:
                     candidates, paused_engines = await self._quiesce_group_locked(
                         record, group, replace_mode
                     )
@@ -606,7 +624,13 @@ class ResidentModelManager:
                 self.registry.add(entry)
                 self._index_record(record)
                 self.loads_total += 1
-                await self._evict_for_locked(0, exclude={record.model_id})
+                await self._evict_for_locked(
+                    0,
+                    exclude={
+                        record.model_id,
+                        *(item.model_id for item in candidates),
+                    },
+                )
                 if group is not None:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
@@ -814,20 +838,11 @@ class ResidentModelManager:
     ) -> tuple[list[ResidencyRecord], list[object]]:
         """Close one group before any externally visible lifecycle mutation."""
 
-        if replace_mode not in {"reject", "wait", "abort"}:
-            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
-
-        candidates = [
-            record
-            for record in self._records.values()
-            if record.model_id != exclude_model_id
-            and _replacement_group(record.entry) == group
-        ]
-        for record in candidates:
-            if record.pinned and not record.primary:
-                raise ResidentModelError(
-                    f"pinned model {record.model_id!r} cannot be replaced"
-                )
+        candidates = self._replacement_candidates_locked(
+            group,
+            exclude_model_id=exclude_model_id,
+            replace_mode=replace_mode,
+        )
 
         paused_engines: list[object] = []
         try:
@@ -857,6 +872,31 @@ class ResidentModelManager:
             await self._resume_engines(paused_engines)
             raise
         return candidates, paused_engines
+
+    def _replacement_candidates_locked(
+        self,
+        group: str,
+        *,
+        exclude_model_id: str | None = None,
+        replace_mode: str = "reject",
+    ) -> list[ResidencyRecord]:
+        """Validate and identify a group without changing engine admission."""
+
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
+
+        candidates = [
+            record
+            for record in self._records.values()
+            if record.model_id != exclude_model_id
+            and _replacement_group(record.entry) == group
+        ]
+        for record in candidates:
+            if record.pinned and not record.primary:
+                raise ResidentModelError(
+                    f"pinned model {record.model_id!r} cannot be replaced"
+                )
+        return candidates
 
     async def _resume_engines(self, engines: list[object]) -> None:
         """Best-effort reopen every engine paused by a failed transaction."""

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -530,6 +530,7 @@ class ResidentModelManager:
         image_mode: str | None = None,
         performance: ResidentPerformanceConfig | None = None,
         reload_if_changed: bool = False,
+        replace_mode: str = "reject",
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -547,7 +548,7 @@ class ResidentModelManager:
                     record.pinned = True
                 group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    await self._replace_group_locked(record, group, replace_mode)
                 return record
 
             await self._evict_for_locked(estimate, exclude={model_name})
@@ -570,20 +571,43 @@ class ResidentModelManager:
                 pinned=pin,
                 performance=performance,
             )
-            self.registry.add(entry)
-            self._index_record(record)
-            self.loads_total += 1
-
+            group = _effective_replace_group(record.entry, replace_group)
+            candidates: list[ResidencyRecord] = []
+            paused_engines: list[object] = []
             try:
-                await self._evict_for_locked(0, exclude={record.model_id})
-                group = _effective_replace_group(record.entry, replace_group)
                 if group is not None:
-                    await self._replace_group_locked(record, group)
+                    candidates, paused_engines = await self._quiesce_group_locked(
+                        record, group, replace_mode
+                    )
+                # Keep the replacement private until the old inference engines
+                # have reached the policy boundary. Publication only makes the
+                # already-quiesced replacement visible to residency readers.
+                self.registry.add(entry)
+                self._index_record(record)
+                self.loads_total += 1
+                await self._evict_for_locked(0, exclude={record.model_id})
+                if group is not None:
+                    await self._commit_group_replacement_locked(
+                        record, group, candidates
+                    )
             except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model
                 # resident even though the control-plane request was rejected.
-                await self._evict_locked(record, reason="load_rollback", count=False)
+                try:
+                    if record.model_id in self._records:
+                        await self._evict_locked(
+                            record, reason="load_rollback", count=False
+                        )
+                    else:
+                        stop = getattr(record.entry.engine, "stop", None)
+                        if callable(stop):
+                            result = stop()
+                            if asyncio.iscoroutine(result):
+                                await result
+                        _release_allocator_cache()
+                finally:
+                    await self._resume_engines(paused_engines)
                 raise
             return record
 
@@ -720,7 +744,12 @@ class ResidentModelManager:
             if handoff is not None:
                 handoff.commit(restored_entry)
 
-    async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
+    async def _replace_group_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        replace_mode: str = "reject",
+    ) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.
 
         The desktop uses the ``assistant`` group for its chat picker: changing
@@ -730,10 +759,29 @@ class ResidentModelManager:
         legacy health/cache routes never retain a reference to unloaded weights.
         """
 
+        candidates, paused_engines = await self._quiesce_group_locked(
+            target, group, replace_mode
+        )
+        try:
+            await self._commit_group_replacement_locked(target, group, candidates)
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+
+    async def _quiesce_group_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        replace_mode: str,
+    ) -> tuple[list[ResidencyRecord], list[object]]:
+        """Atomically close admission and reach the requested policy boundary."""
+
         if group != _replacement_group(target.entry):
             raise ResidentModelError(
                 f"model {target.model_id!r} does not belong to replacement group {group!r}"
             )
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
 
         candidates = [
             record
@@ -742,12 +790,58 @@ class ResidentModelManager:
             and _replacement_group(record.entry) == group
         ]
         for record in candidates:
-            if record.active_requests or not _engine_is_idle(record.entry.engine):
-                raise ResidentModelBusyError("model is serving an active request")
             if record.pinned and not record.primary:
                 raise ResidentModelError(
                     f"pinned model {record.model_id!r} cannot be replaced"
                 )
+
+        paused_engines: list[object] = []
+        try:
+            for record in candidates:
+                engine = record.entry.engine
+                pause = getattr(engine, "pause_generation", None)
+                if record.active_requests and (
+                    replace_mode == "reject" or not callable(pause)
+                ):
+                    raise ResidentModelBusyError("model is serving an active request")
+                if callable(pause):
+                    paused_engines.append(engine)
+                    try:
+                        await pause(
+                            "wait" if replace_mode == "reject" else replace_mode,
+                            timeout=0 if replace_mode == "reject" else None,
+                        )
+                    except TimeoutError as exc:
+                        raise ResidentModelBusyError(
+                            "model is serving an active request"
+                        ) from exc
+                elif not _engine_is_idle(engine):
+                    raise ResidentModelBusyError("model is serving an active request")
+        except BaseException:
+            await self._resume_engines(paused_engines)
+            raise
+        return candidates, paused_engines
+
+    async def _resume_engines(self, engines: list[object]) -> None:
+        """Best-effort reopen every engine paused by a failed transaction."""
+
+        for engine in reversed(engines):
+            resume = getattr(engine, "resume_generation", None)
+            if callable(resume):
+                try:
+                    await resume()
+                except BaseException:
+                    logger.exception(
+                        "Failed to resume a model engine after replacement rollback"
+                    )
+
+    async def _commit_group_replacement_locked(
+        self,
+        target: ResidencyRecord,
+        group: str,
+        candidates: list[ResidencyRecord],
+    ) -> None:
+        """Apply the existing primary/audio handoff to quiesced engines."""
 
         old_primary = next((record for record in candidates if record.primary), None)
         handoff = None
@@ -779,7 +873,11 @@ class ResidentModelManager:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(target.entry)
             for record in ordered_candidates:
-                await self._evict_locked(record, reason=f"replace_{group}")
+                await self._evict_locked(
+                    record,
+                    reason=f"replace_{group}",
+                    allow_active_lease=True,
+                )
         except BaseException:
             if old_primary is not None:
                 try:
@@ -825,9 +923,14 @@ class ResidentModelManager:
             await self._evict_locked(record, reason="explicit")
 
     async def _evict_locked(
-        self, record: ResidencyRecord, *, reason: str, count: bool = True
+        self,
+        record: ResidencyRecord,
+        *,
+        reason: str,
+        count: bool = True,
+        allow_active_lease: bool = False,
     ) -> None:
-        if record.active_requests:
+        if record.active_requests and not allow_active_lease:
             raise ResidentModelBusyError("model is serving an active request")
         record.state = "evicting"
         self.registry.remove(record.model_id)
@@ -870,6 +973,23 @@ class ResidentModelManager:
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
             engine_active = _engine_active_requests(engine)
+            lifecycle = (
+                engine.lifecycle_status()
+                if callable(getattr(engine, "lifecycle_status", None))
+                else None
+            )
+            active_requests = max(
+                record.active_requests,
+                engine_active if engine_active is not None else 0,
+            )
+            if lifecycle is not None:
+                active_requests = max(
+                    active_requests,
+                    int(lifecycle.get("active_requests", 0) or 0),
+                    int(lifecycle.get("admitted_requests", 0) or 0),
+                    int(lifecycle.get("running_requests", 0) or 0),
+                    int(lifecycle.get("queued_requests", 0) or 0),
+                )
             models.append(
                 {
                     "id": record.model_id,
@@ -883,10 +1003,8 @@ class ResidentModelManager:
                     # overlapping lifetimes for dynamic engines, so use the
                     # larger count rather than double-counting. Primary traffic
                     # has no manager lease and is supplied by the scheduler.
-                    "active_requests": max(
-                        record.active_requests,
-                        engine_active if engine_active is not None else 0,
-                    ),
+                    "active_requests": active_requests,
+                    "lifecycle": lifecycle,
                     "estimated_bytes": record.estimated_bytes,
                     "measured_bytes": record.measured_bytes or None,
                     "idle_seconds": max(0.0, now - record.last_used_at),

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -551,15 +551,43 @@ class ResidentModelManager:
             canonical = self._canonical(model_name)
             if canonical is not None:
                 existing_record = self._records[canonical]
+                group = _effective_replace_group(existing_record.entry, replace_group)
+                did_reload = False
                 if reload_if_changed and existing_record.performance != performance:
-                    existing_record = await self._reload_locked(
-                        existing_record, performance
-                    )
+                    reload_candidates: list[ResidencyRecord] = []
+                    reload_paused_engines: list[object] = []
+                    try:
+                        if group is not None:
+                            (
+                                group_records,
+                                reload_paused_engines,
+                            ) = await self._quiesce_replacement_group_locked(
+                                group, replace_mode
+                            )
+                            reload_candidates = [
+                                candidate
+                                for candidate in group_records
+                                if candidate is not existing_record
+                            ]
+                        else:
+                            reload_paused_engines = await self._quiesce_records_locked(
+                                [existing_record], replace_mode
+                            )
+                        existing_record = await self._reload_locked(
+                            existing_record, performance
+                        )
+                        did_reload = True
+                        if group is not None:
+                            await self._commit_group_replacement_locked(
+                                existing_record, group, reload_candidates
+                            )
+                    except BaseException:
+                        await self._resume_engines(reload_paused_engines)
+                        raise
                 existing_record.last_used_at = self._clock()
                 if pin:
                     existing_record.pinned = True
-                group = _effective_replace_group(existing_record.entry, replace_group)
-                if group is not None:
+                if group is not None and not did_reload:
                     await self._replace_group_locked(
                         existing_record, group, replace_mode
                     )
@@ -689,14 +717,12 @@ class ResidentModelManager:
                 result = stop()
                 if asyncio.iscoroutine(result):
                     await result
-        except BaseException:
-            # A failed stop must not also make the still-existing engine
-            # disappear from routing and residency accounting.
-            self.registry.add(record.entry, is_default=primary)
-            self._index_record(record)
-            if handoff is not None:
-                handoff.rollback()
-            raise
+        except BaseException as stop_error:
+            # A stop attempt may already have disabled part of the engine.
+            # Rebuild the last known-good configuration instead of routing a
+            # possibly half-stopped worker after rollback.
+            await self._restore_reload_locked(record, handoff)
+            raise stop_error
         _release_allocator_cache()
 
         before = self._read_memory()
@@ -848,9 +874,21 @@ class ResidentModelManager:
             replace_mode=replace_mode,
         )
 
+        paused_engines = await self._quiesce_records_locked(candidates, replace_mode)
+        return candidates, paused_engines
+
+    async def _quiesce_records_locked(
+        self,
+        records: list[ResidencyRecord],
+        replace_mode: str,
+    ) -> list[object]:
+        """Close admission and drain/abort exact records before mutation."""
+
+        if replace_mode not in {"reject", "wait", "abort"}:
+            raise ResidentModelError(f"unsupported replacement mode {replace_mode!r}")
         paused_engines: list[object] = []
         try:
-            for record in candidates:
+            for record in records:
                 engine = record.entry.engine
                 pause = getattr(engine, "pause_generation", None)
                 if record.active_requests and (
@@ -875,7 +913,7 @@ class ResidentModelManager:
         except BaseException:
             await self._resume_engines(paused_engines)
             raise
-        return candidates, paused_engines
+        return paused_engines
 
     def _replacement_candidates_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -218,14 +218,19 @@ def _effective_replace_group(
 ) -> str | None:
     """Resolve the replacement group to enforce for a just-touched model.
 
-    An explicit ``replace_group`` always wins. Otherwise a generative-media
-    entry derives its own single-slot group; everything else stays unmanaged
-    (``None``) so a bare text load never evicts a sibling.
+    An explicit group must match the entry's actual modality group. Otherwise
+    a generative-media entry derives its own single-slot group; everything else
+    stays unmanaged (``None``) so a bare text load never evicts a sibling.
     """
 
-    if replace_group is not None:
-        return replace_group
     derived = _replacement_group(entry)
+    if replace_group is not None:
+        if replace_group != derived:
+            raise ResidentModelError(
+                f"model {entry.model_name!r} belongs to replacement group "
+                f"{derived!r}, not {replace_group!r}"
+            )
+        return replace_group
     return derived if derived in _SINGLE_SLOT_MEDIA_GROUPS else None
 
 
@@ -605,16 +610,6 @@ class ResidentModelManager:
                     performance=performance,
                 )
                 group = _effective_replace_group(record.entry, replace_group)
-                # ``_effective_replace_group`` returns an explicit group
-                # verbatim, so this is unreachable through every loader caller;
-                # retain the defensive invariant for future resolver changes.
-                if (
-                    replace_group is not None and group != replace_group
-                ):  # pragma: no cover
-                    raise ResidentModelError(
-                        f"model {record.model_id!r} does not belong to replacement "
-                        f"group {replace_group!r}"
-                    )
                 if replace_group is not None and replace_mode != "reject":
                     (
                         candidates,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -9,7 +9,7 @@ import re
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 from .model_registry import ModelEntry, ModelRegistry
@@ -160,6 +160,11 @@ class ResidencyRecord:
     state: str = "resident"
     measured_bytes: int = 0
     performance: ResidentPerformanceConfig | None = None
+    lease_idle: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.active_requests == 0:
+            self.lease_idle.set()
 
     @property
     def model_id(self) -> str:
@@ -846,6 +851,8 @@ class ResidentModelManager:
                         ) from exc
                 elif not _engine_is_idle(engine):
                     raise ResidentModelBusyError("model is serving an active request")
+                if record.active_requests:
+                    await record.lease_idle.wait()
         except BaseException:
             await self._resume_engines(paused_engines)
             raise
@@ -905,7 +912,6 @@ class ResidentModelManager:
                 await self._evict_locked(
                     record,
                     reason=f"replace_{group}",
-                    allow_active_lease=True,
                 )
         except BaseException:
             if old_primary is not None:
@@ -957,9 +963,8 @@ class ResidentModelManager:
         *,
         reason: str,
         count: bool = True,
-        allow_active_lease: bool = False,
     ) -> None:
-        if record.active_requests and not allow_active_lease:
+        if record.active_requests:
             raise ResidentModelBusyError("model is serving an active request")
         record.state = "evicting"
         self.registry.remove(record.model_id)
@@ -984,16 +989,21 @@ class ResidentModelManager:
             if record.state != "resident":
                 raise ResidentModelBusyError("model is being evicted")
             record.active_requests += 1
+            record.lease_idle.clear()
             record.last_used_at = self._clock()
             engine = record.entry.engine
         try:
             yield engine
         finally:
-            async with self._lock:
-                current = self._records.get(canonical)
-                if current is not None:
-                    current.active_requests = max(0, current.active_requests - 1)
-                    current.last_used_at = self._clock()
+            # Replacement may be holding the manager lock while it waits for
+            # this lease to finish. These synchronous event-loop operations
+            # are the release edge; no residency mutation can interleave.
+            current = self._records.get(canonical)
+            if current is record:
+                current.active_requests = max(0, current.active_requests - 1)
+                current.last_used_at = self._clock()
+                if current.active_requests == 0:
+                    current.lease_idle.set()
 
     def snapshot(self) -> dict:
         now = self._clock()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6112,7 +6112,6 @@ class Scheduler:
     def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
         """Close admission and preserve only pre-pause route reservations."""
 
-        del mode  # Both policies close admission; mode controls draining above.
         with self._request_state_lock():
             self._generation_paused = True
             owned = {
@@ -6120,7 +6119,8 @@ class Scheduler:
                 for request in self.requests.values()
                 if getattr(request, "lifecycle_admission_token", None) is not None
             }
-            self._paused_admission_tokens = set(admission_tokens) - owned
+            pending = set(admission_tokens) - owned
+            self._paused_admission_tokens = pending if mode == "wait" else set()
             self._paused_add_allowance = len(self._paused_admission_tokens)
 
     def request_ids_snapshot(self) -> tuple[str, ...]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5861,7 +5861,7 @@ class Scheduler:
         """
         with self._request_state_lock():
             if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                allowed: set[str] = getattr(self, "_paused_admission_tokens", set())
                 token = getattr(request, "lifecycle_admission_token", None)
                 if token not in allowed:
                     raise BackpressureError(
@@ -6082,13 +6082,15 @@ class Scheduler:
         # stays effective.
         with self._cancel_counter_lock:
             if getattr(self, "_generation_paused", False):
-                allowed = getattr(self, "_paused_admission_tokens", set())
+                commit_tokens: set[str] = getattr(
+                    self, "_paused_admission_tokens", set()
+                )
                 token = getattr(request, "lifecycle_admission_token", None)
-                if token not in allowed:
+                if not isinstance(token, str) or token not in commit_tokens:
                     raise BackpressureError(
                         "generation is paused for a model lifecycle operation"
                     )
-                allowed.remove(token)
+                commit_tokens.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6080,7 +6080,16 @@ class Scheduler:
         # exception path between admission and tracking leaves
         # the ledger intact and the prior lifetime's dedupe
         # stays effective.
-        with self._cancel_counter_lock:
+        self._commit_request(request)
+
+        logger.debug(
+            f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
+        )
+
+    def _commit_request(self, request: Request) -> None:
+        """Atomically publish a request to lifecycle truth and the run queue."""
+
+        with self._request_state_lock():
             if getattr(self, "_generation_paused", False):
                 commit_tokens: set[str] = getattr(
                     self, "_paused_admission_tokens", set()
@@ -6095,11 +6104,7 @@ class Scheduler:
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
             self.requests[request.request_id] = request
-        self.waiting.append(request)
-
-        logger.debug(
-            f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
-        )
+            self.waiting.append(request)
 
     def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
         """Close or reopen scheduler admission for model replacement."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3036,6 +3036,9 @@ class Scheduler:
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, Request] = {}  # Running requests by ID
         self.requests: dict[str, Request] = {}  # All requests by ID
+        self._generation_paused = False
+        self._paused_add_allowance = 0
+        self._paused_admission_tokens: set[str] = set()
         self.finished_req_ids: set[str] = set()  # Recently finished
         # Debug aid (#1878): resolved ONCE — an os.environ lookup per
         # step would put dict access on the decode hot path advertised
@@ -5856,6 +5859,14 @@ class Scheduler:
                 above ``config.max_concurrent_requests``. Routes catch
                 this and return 503 with Retry-After.
         """
+        with self._request_state_lock():
+            if getattr(self, "_generation_paused", False):
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
         if request.request_id in self.requests:
             raise ValueError(f"Request {request.request_id} already exists")
 
@@ -6070,6 +6081,14 @@ class Scheduler:
         # the ledger intact and the prior lifetime's dedupe
         # stays effective.
         with self._cancel_counter_lock:
+            if getattr(self, "_generation_paused", False):
+                allowed = getattr(self, "_paused_admission_tokens", set())
+                token = getattr(request, "lifecycle_admission_token", None)
+                if token not in allowed:
+                    raise BackpressureError(
+                        "generation is paused for a model lifecycle operation"
+                    )
+                allowed.remove(token)
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
             self._orphaned_running_candidates.pop(request.request_id, None)
@@ -6079,6 +6098,43 @@ class Scheduler:
         logger.debug(
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
+
+    def set_generation_paused(self, paused: bool, *, add_allowance: int = 0) -> None:
+        """Close or reopen scheduler admission for model replacement."""
+
+        with self._request_state_lock():
+            self._generation_paused = bool(paused)
+            self._paused_add_allowance = max(0, int(add_allowance)) if paused else 0
+            self._paused_admission_tokens = set()
+
+    def pause_generation_admission(self, admission_tokens: set[str], mode: str) -> None:
+        """Close admission and preserve only pre-pause route reservations."""
+
+        del mode  # Both policies close admission; mode controls draining above.
+        with self._request_state_lock():
+            self._generation_paused = True
+            owned = {
+                getattr(request, "lifecycle_admission_token", None)
+                for request in self.requests.values()
+                if getattr(request, "lifecycle_admission_token", None) is not None
+            }
+            self._paused_admission_tokens = set(admission_tokens) - owned
+            self._paused_add_allowance = len(self._paused_admission_tokens)
+
+    def request_ids_snapshot(self) -> tuple[str, ...]:
+        """Return a lock-protected snapshot of queued and running IDs."""
+
+        with self._cancel_counter_lock:
+            return tuple(self.requests)
+
+    def _request_state_lock(self):
+        """Return the request lock, including for minimal test doubles."""
+
+        lock = getattr(self, "_cancel_counter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._cancel_counter_lock = lock
+        return lock
 
     def abort_request(self, request_id: str) -> bool:
         """
@@ -8331,7 +8387,8 @@ class Scheduler:
 
         self.waiting.clear()
         self.running.clear()
-        self.requests.clear()
+        with self._cancel_counter_lock:
+            self.requests.clear()
         self.finished_req_ids.clear()
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3923,6 +3923,9 @@ async def _disconnect_guard(
             #     existing future. The wait below ignores it.
             if anext_task is None or anext_task.done():
                 anext_task = asyncio.ensure_future(aiter.__anext__())
+                bind_task = getattr(engine, "bind_admission_task", None)
+                if callable(bind_task):
+                    bind_task(anext_task)
             wait_kwargs: dict = {"return_when": asyncio.FIRST_COMPLETED}
             if keepalive_enabled:
                 wait_kwargs["timeout"] = keepalive_seconds
@@ -3990,6 +3993,25 @@ async def _disconnect_guard(
                 # generator already drained, the scheduler already
                 # marked the request as finished — a defensive abort
                 # here would only pollute logs.
+                finished_normally = True
+                break
+            except asyncio.CancelledError:
+                consume_abort = getattr(engine, "consume_lifecycle_task_abort", None)
+                if not callable(consume_abort) or not consume_abort(anext_task):
+                    raise
+                import json as _json
+
+                error_data = _json.dumps(
+                    {
+                        "error": {
+                            "message": "Request cancelled by model replacement",
+                            "type": "server_error",
+                            "code": "model_replacement",
+                        }
+                    }
+                )
+                yield f"data: {error_data}\n\n"
+                yield "data: [DONE]\n\n"
                 finished_normally = True
                 break
             except Exception as exc:
@@ -4225,7 +4247,13 @@ async def _wait_with_disconnect(
 
     _t0 = _time.monotonic()
 
+    from ..engine.batched import _admission_engine_context
+
+    engine = _admission_engine_context.get()
     task = asyncio.ensure_future(coro)
+    bind_task = getattr(engine, "bind_admission_task", None)
+    if callable(bind_task):
+        bind_task(task)
 
     async def _wait_disconnect():
         poll_count = 0
@@ -4275,6 +4303,14 @@ async def _wait_with_disconnect(
 
         try:
             return task.result()
+        except asyncio.CancelledError:
+            consume_abort = getattr(engine, "consume_lifecycle_task_abort", None)
+            if callable(consume_abort) and consume_abort(task):
+                raise HTTPException(
+                    status_code=503,
+                    detail="Request cancelled by model replacement",
+                )
+            raise
         except BackpressureError as exc:
             _raise_backpressure_503(exc)
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -155,6 +155,19 @@ def _release_admission_unless_committed(engine, committed: bool) -> None:
         )
 
 
+def _raise_lifecycle_cancel_or_reraise(engine, exc: asyncio.CancelledError) -> None:
+    """Translate only engine-owned route cancellation into terminal HTTP."""
+
+    task = asyncio.current_task()
+    consume_abort = getattr(engine, "consume_lifecycle_task_abort", None)
+    if task is not None and callable(consume_abort) and consume_abort(task):
+        raise HTTPException(
+            status_code=503,
+            detail="Request cancelled by model replacement",
+        ) from exc
+    raise exc
+
+
 def _raise_backpressure_503(exc: Exception) -> None:
     """Convert ``BackpressureError`` from the scheduler into HTTP 503
     with a Retry-After header (RFC 9110 §10.2.4).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -4066,24 +4066,38 @@ async def _disconnect_guard(
                 # message substring: arbitrary internal exceptions may contain
                 # caller text or local paths. Every other fault remains under
                 # F-131's generic sanitisation.
-                from ..request import ClientRequestError
+                from ..request import ClientRequestError, InferenceAbortedError
 
-                if isinstance(exc, ClientRequestError):
+                if (
+                    isinstance(exc, InferenceAbortedError)
+                    and exc.error_kind == "lifecycle"
+                ):
+                    _sse_type = "server_error"
+                    _sse_message = "Request cancelled by model replacement"
+                    _sse_code = "model_replacement"
+                elif isinstance(exc, ClientRequestError):
                     _sse_type = "invalid_request_error"
                     _sse_message = str(exc)
+                    _sse_code = None
                 else:
                     _sse_type = "internal_error"
                     _sse_message = "Internal error during streaming"
+                    _sse_code = None
+                error = {
+                    "message": _sse_message,
+                    "type": _sse_type,
+                }
+                if _sse_code is not None:
+                    error["code"] = _sse_code
                 error_data = _json.dumps(
                     {
-                        "error": {
-                            "message": _sse_message,
-                            "type": _sse_type,
-                        }
+                        "error": error,
                     }
                 )
                 yield f"data: {error_data}\n\n"
                 yield "data: [DONE]\n\n"
+                if _sse_code == "model_replacement":
+                    finished_normally = True
                 break
             chunk_count += 1
             if chunk_count == 1:


### PR DESCRIPTION
## Why

Changing the selected assistant currently requires a server restart or risks replacing a model while it still owns work. This change makes replacement an explicit engine-owned transaction so chat continuity, terminal client behavior, and auxiliary speech residency remain coherent.

## Intention

Let the Desktop assistant picker replace the loaded text or multimodal model without restarting the server. The caller selects reject (default), wait, or abort semantics for active assistant work. When dictation is enabled, its speech-to-text lane is process-wide protected state: every assistant load, replacement, reload, and switch-back preserves the loaded STT engine and keeps dictation usable.

## Scope

- engine-owned admission, drain, abort, and terminal client signaling
- transactional assistant residency replacement and rollback
- residency API truth for admitted, paused, queued, running, and audio-lane work
- contract coverage for streaming, non-streaming, assistant reload/switch-back, and audio coexistence
- an internal architecture decision recording the ownership boundary

This is an intent-first successor to #2226 and #2328, reconciled with the lifecycle and audio-worker transactions already on main.

## Non-goals

No Desktop wiring, new audio runtime, combined capacity/idle-TTL policy, scheduler redesign, release plumbing, or model-specific heuristic. Combined LLM+STT memory admission and Desktop downgrade/choice presentation remain separately gated work; this PR does not claim that capacity enforcement.

## Acceptance

- reject is the default and preserves a busy assistant
- wait drains old assistant work before publication
- abort terminates streaming and non-streaming clients before publication
- failed or cancelled replacement restores old routing and admission before the commit point
- successful primary retirement commits routing; later sibling cleanup cannot roll back to stopped engines
- active audio work blocks the worker handoff without stopping either lane
- resident speech-to-text state survives every successful assistant load, replacement, reload, and switch-back
- residency reports assistant lifecycle truth and the resident STT lane together
- assistant lifecycle paths never invoke audio-lane unload

## Local evidence

Focused exact-head suite: 153 passed, 1 expected xpass across engine lifecycle, residency, audio-worker handoff, deterministic batching, MLLM failure delivery, cancel/auth, disconnect, penalty passthrough, and reset cleanup contracts. Two stale direct-engine doubles exposed by the full suite were updated to the real admission shape. Ruff lint/format and diff check passed. A fresh-process cached-model sequence and the complete proportional suite remain required before landing.