### PR TITLE
fix(api): require strict JSON booleans for models/load control-plane fields (#2362)

### DIFF
--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -89,7 +89,7 @@ vllm_mlx/reasoning/think_parser.py 2
 vllm_mlx/repetition_guard.py 2
 vllm_mlx/routes/anthropic.py 7
 vllm_mlx/routes/audio.py 6
-vllm_mlx/routes/chat.py 53
+vllm_mlx/routes/chat.py 50
 vllm_mlx/routes/completions.py 1
 vllm_mlx/routes/embeddings.py 4
 vllm_mlx/routes/images.py 4

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,20 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
+    def test_openapi_schema_advertises_scalar_or_array(self, req_model):
+        """The OpenAPI/JSON schema for ``stop`` must advertise both a
+        scalar string and an array of strings (the accepted wire shapes),
+        so generated clients accept the newly supported scalar form."""
+        stop_prop = req_model.model_json_schema()["properties"]["stop"]
+        assert "anyOf" in stop_prop, f"stop schema is not a union: {stop_prop}"
+        type_set = {arm.get("type") for arm in stop_prop["anyOf"]}
+        # string or array are the OpenAI-accepted wire shapes; ``null`` is
+        # present because the field is optional (None = server default).
+        assert type_set == {"string", "array", "null"}, (
+            f"stop schema wrong: {stop_prop}"
+        )
+
 
 class TestTimeoutValidation:
     """A non-positive / non-finite ``timeout`` must be rejected with a

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -50,6 +50,8 @@ from vllm_mlx.api.models import (
     ToolDefinition,
     Usage,
     VideoUrl,
+    _normalize_stop,
+    _validate_timeout,
 )
 
 
@@ -564,6 +566,98 @@ class TestTextCompletion:
         assert resp.object == "text_completion"
         assert resp.id.startswith("cmpl-")
         assert len(resp.choices) == 1
+
+
+def _chat(**kwargs):
+    return ChatCompletionRequest(
+        model="test-model", messages=[Message(role="user", content="Hi")], **kwargs
+    )
+
+
+def _completion(**kwargs):
+    return CompletionRequest(model="test-model", prompt="Once upon a time", **kwargs)
+
+
+class TestStopScalar:
+    """``stop`` must accept a scalar string as well as a list on both the
+    chat and legacy-completion surfaces, normalizing once to a list in the
+    request schema (OpenAI request shape: ``stop`` is ``str | list[str]``).
+    Downstream code (``SamplingParams.stop: list[str]``) reads only lists."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_scalar_string_normalized_to_list(self, factory):
+        req = factory(stop="END")
+        assert req.stop == ["END"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_list_preserved(self, factory):
+        req = factory(stop=["END", "STOP"])
+        assert req.stop == ["END", "STOP"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_empty_list_ok(self, factory):
+        assert factory(stop=[]).stop == []
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().stop is None
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_non_string_element_rejected(self, factory):
+        with pytest.raises(ValidationError):
+            factory(stop=["END", 42])
+
+
+class TestTimeoutValidation:
+    """A non-positive / non-finite ``timeout`` must be rejected with a
+    4xx naming the field (schema layer) instead of firing an instant 504
+    when it reaches the request-timeout guard in the routes."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+    def test_non_positive_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("good", [0.1, 1, 30.0, 300])
+    def test_positive_accepted(self, factory, good):
+        assert factory(timeout=good).timeout == good
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().timeout is None
+
+
+class TestStopAndTimeoutHelpers:
+    """Direct coverage of the shared ``_normalize_stop`` /
+    ``_validate_timeout`` helpers. Pydantic skips field validators for
+    an *absent* optional field, so the ``None`` guards inside the
+    helpers are only exercised when called directly."""
+
+    def test_validate_timeout_none_passthrough(self):
+        assert _validate_timeout(None) is None
+
+    def test_validate_timeout_nonfinite_rejected(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(ValueError):
+                _validate_timeout(bad)
+
+    def test_normalize_stop_none_passthrough(self):
+        assert _normalize_stop(None) is None
+
+    def test_normalize_stop_non_string_type_rejected(self):
+        for bad in (42, [1, 2], True, 1.5):
+            with pytest.raises(ValueError):
+                _normalize_stop(bad)
 
 
 class TestModelsEndpoint:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,16 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_stop_sequences_returns_normalized_list(self, factory):
+        """``stop_sequences()`` — the typed accessor used at the engine
+        boundary — returns the canonical normalized list even when the wire
+        input was a scalar string, so downstream ``SamplingParams.stop``
+        always sees a flat ``list[str]``."""
+        assert factory(stop="END").stop_sequences() == ["END"]
+        assert factory(stop=["END", "STOP"]).stop_sequences() == ["END", "STOP"]
+        assert factory().stop_sequences() is None
+
     @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
     def test_openapi_schema_advertises_scalar_or_array(self, req_model):
         """The OpenAPI/JSON schema for ``stop`` must advertise both a

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1541,6 +1541,66 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         assert "image" not in registry
 
 
+def test_models_load_requires_strict_json_booleans(monkeypatch):
+    """``pin`` / ``pinned`` / ``reload_if_changed`` must be real JSON
+    booleans (issue #2362). Pydantic v2's lax mode coerced ``"yes"`` /
+    ``"on"`` / ``1`` / ``0`` onto ``bool``, so ``pin: "yes"`` silently
+    became ``True`` and triggered a real resident-model reload. With
+    ``StrictBool`` a non-boolean wire form is rejected by the schema with
+    a 4xx naming the field, while ``true`` / ``false`` behave identically.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, _, _ = manager_fixture(limit_gib=12)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    install_exception_handlers(app)
+
+    def _assert_400_field(client, field):
+        for bad in ("yes", "on", "no", "off", 1, 0, 1.0):
+            resp = client.post("/v1/models/load", json={"model": "image", field: bad})
+            assert resp.status_code == 400, (
+                f"{field}={bad!r} expected 400; got {resp.status_code} {resp.text[:120]}"
+            )
+            body = resp.json()
+            assert body["error"]["type"] == "invalid_request_error"
+            assert field in body["error"]["message"]
+
+    def _pin_400(client, field, bad):
+        resp = client.put("/v1/models/image/pin", json={field: bad})
+        assert resp.status_code == 400, (
+            f"{field}={bad!r} expected 400; got {resp.status_code} {resp.text[:120]}"
+        )
+        assert "pinned" in resp.json()["error"]["message"]
+
+    with TestClient(app) as client:
+        _assert_400_field(client, "pin")
+        _assert_400_field(client, "reload_if_changed")
+        for bad in ("yes", "on", "no", "off", 1, 0, 1.0):
+            _pin_400(client, "pinned", bad)
+
+        # Real JSON booleans keep working identically (pin/reload on the
+        # load path; pinned on the pin path) and are not rejected.
+        ok = client.post(
+            "/v1/models/load",
+            json={"model": "image", "estimated_size_gb": 1, "pin": True},
+        )
+        assert ok.status_code == 200
+        ok_if = client.post(
+            "/v1/models/load", json={"model": "image", "reload_if_changed": False}
+        )
+        assert ok_if.status_code == 200
+        ok_pin = client.put("/v1/models/image/pin", json={"pinned": True})
+        assert ok_pin.status_code == 200
+
+
 def test_residency_snapshot_reports_primary_running_and_queued_requests(monkeypatch):
     """Primary requests bypass manager leases but still belong in residency."""
     from types import SimpleNamespace

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+
+Covers two behaviours on both ``/v1/chat/completions`` and
+``/v1/completions``:
+
+  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
+    and is normalized once in the request schema — a bare ``"END"`` must
+    parse instead of 4xx-ing as "not a list".
+  * a non-positive / non-finite ``timeout`` is rejected with the unified
+    ``invalid_request_error`` 400 naming the field — NOT an instant 504
+    from an ``asyncio.wait_for``-style guard consuming the bad value.
+
+The schema-level normalization / rejection logic itself is unit-tested in
+``tests/test_api_models.py``; this file pins the wire behaviour through
+the real routes (the 400-not-504 claim is only provable at HTTP level).
+
+The engine is stubbed so we exercise only the Pydantic + route-layer
+validators, never a real sampler.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    """Patch the global config singleton and restore on teardown."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _stub_engine_cfg(patch_cfg):
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    return engine
+
+
+@pytest.fixture
+def chat_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import chat as chat_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def completion_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import completions as comp_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _chat_body(**kw) -> dict:
+    body = {"model": "stub-model", "messages": [{"role": "user", "content": "hi"}]}
+    body.update(kw)
+    return body
+
+
+def _completion_body(**kw) -> dict:
+    body = {"model": "stub-model", "prompt": "Once upon a time"}
+    body.update(kw)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_scalar_stop_accepted(request, client_name, url, body_fn):
+    """A bare-string ``stop`` must be accepted by the schema on both
+    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
+    NOT a client-4xx validation rejection — the route will fail later on
+    the stubbed engine, but must get past request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop="END"))
+    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
+    # It must also not be a 400 (validation) — a 500/503 from the stubbed
+    # engine is acceptable proof that parsing succeeded.
+    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_stop_list_still_accepted(request, client_name, url, body_fn):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
+    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
+
+
+# ---------------------------------------------------------------------------
+# non-positive / non-finite ``timeout`` → 400 (not 504)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=bad))
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
+    """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
+    raw payload rather than httpx's json= channel."""
+    client = request.getfixturevalue(client_name)
+    payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
+    r = client.post(
+        url, content=payload, headers={"Content-Type": "application/json"}
+    )
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
+    """A valid positive timeout must NOT 400/422 at the schema — failure
+    (if any) comes from the stubbed engine, not request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=30.0))
+    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+"""HTTP-level contract tests for the #2359 request-schema fix.
 
-Covers two behaviours on both ``/v1/chat/completions`` and
-``/v1/completions``:
+Covers one behaviour on both ``/v1/chat/completions`` and ``/v1/completions``:
 
-  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
-    and is normalized once in the request schema — a bare ``"END"`` must
-    parse instead of 4xx-ing as "not a list".
   * a non-positive / non-finite ``timeout`` is rejected with the unified
     ``invalid_request_error`` 400 naming the field — NOT an instant 504
     from an ``asyncio.wait_for``-style guard consuming the bad value.
 
 The schema-level normalization / rejection logic itself is unit-tested in
-``tests/test_api_models.py``; this file pins the wire behaviour through
-the real routes (the 400-not-504 claim is only provable at HTTP level).
+``tests/test_api_models.py`` (scalar-``stop`` acceptance + ``timeout``
+validation); this file pins the wire behaviour through the real routes.
+The 400-not-504 claim is the HTTP layer's responsibility and only provable
+here.
 
-The engine is stubbed so we exercise only the Pydantic + route-layer
-validators, never a real sampler.
+The engine is stubbed only to satisfy route setup; the bad-``timeout``
+cases are rejected at request parsing (schema layer), so the route handler
+never runs. These tests are deterministic: a bad ``timeout`` ALWAYS yields
+400 before any engine interaction.
 """
 
 import json
@@ -103,52 +103,18 @@ def _completion_body(**kw) -> dict:
     return body
 
 
-# ---------------------------------------------------------------------------
-# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_scalar_stop_accepted(request, client_name, url, body_fn):
-    """A bare-string ``stop`` must be accepted by the schema on both
-    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
-    NOT a client-4xx validation rejection — the route will fail later on
-    the stubbed engine, but must get past request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop="END"))
-    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
-    # It must also not be a 400 (validation) — a 500/503 from the stubbed
-    # engine is acceptable proof that parsing succeeded.
-    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_stop_list_still_accepted(request, client_name, url, body_fn):
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
-    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
-
-
-# ---------------------------------------------------------------------------
-# non-positive / non-finite ``timeout`` → 400 (not 504)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
 def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    """A ``timeout <= 0`` must 400 with the unified envelope naming the
+    field (pre-fix it reached the route's timeout guard and fired an
+    instant 504)."""
     client = request.getfixturevalue(client_name)
     r = client.post(url, json=body_fn(timeout=bad))
     assert r.status_code == 400, (
@@ -161,34 +127,23 @@ def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
 
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
     """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
-    raw payload rather than httpx's json= channel."""
+    raw payload rather than httpx's json= channel. Must 400 naming the
+    field, not 500 (non-finite in a serialized error body is a 500 trap)
+    and not 504."""
     client = request.getfixturevalue(client_name)
     payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
-    r = client.post(
-        url, content=payload, headers={"Content-Type": "application/json"}
-    )
+    r = client.post(url, content=payload, headers={"Content-Type": "application/json"})
     assert r.status_code == 400, (
         f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
     )
     body = r.json()
     assert body["error"]["type"] == "invalid_request_error"
     assert "timeout" in body["error"]["message"]
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
-    """A valid positive timeout must NOT 400/422 at the schema — failure
-    (if any) comes from the stubbed engine, not request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(timeout=30.0))
-    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1562,7 +1562,12 @@ class ChatCompletionRequest(BaseModel):
     stream_options: StreamOptions | None = (
         None  # Streaming options (include_usage, etc.)
     )
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters. Without these declared,
     # Pydantic drops them on parse (#355). top_k / min_p flow through to the
     # mlx-lm sampler; repetition_penalty / presence_penalty / frequency_penalty
@@ -2215,7 +2220,12 @@ class CompletionRequest(BaseModel):
     # LangChain / AI-SDK accumulators (same root cause as the
     # chat-route bug). Default ``None`` ⇒ no usage on the wire.
     stream_options: StreamOptions | None = None
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters — see #355 + the
     # matching block on ChatCompletionRequest for wiring + caveats.
     # H-10: ``top_k`` / ``repetition_penalty`` finite-range gates

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -135,7 +135,7 @@ def _validate_timeout(v: float | None) -> float | None:
     return v
 
 
-def _normalize_stop(v):
+def _normalize_stop(v) -> list[str] | None:
     """Accept ``stop`` as either a scalar string or a sequence of
     strings, normalizing to a list once at the schema layer
     (mirrors the OpenAI request shape, where ``stop`` is
@@ -1920,6 +1920,14 @@ class ChatCompletionRequest(BaseModel):
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
 
+    def stop_sequences(self) -> list[str] | None:
+        """The normalized ``stop`` sequences for the engine contract
+        (``SamplingParams.stop: list[str]``). ``_normalize_stop`` (mode="before")
+        already guarantees a list at runtime, so this returns the canonical
+        normalization — giving mypy a ``list[str] | None`` view at the engine
+        boundary while the wire schema keeps accepting a scalar string."""
+        return _normalize_stop(self.stop)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2354,6 +2362,10 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
+
+    def stop_sequences(self) -> list[str] | None:
+        """See ``ChatCompletionRequest.stop_sequences`` — same contract."""
+        return _normalize_stop(self.stop)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -159,8 +159,7 @@ def _normalize_stop(v):
             out.append(item)
         return out
     raise ValueError(
-        "stop must be a string or a list of strings "
-        f"(got {type(v).__name__})."
+        f"stop must be a string or a list of strings (got {type(v).__name__})."
     )
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -112,6 +112,58 @@ def _reject_nonfinite_float(v: float | None) -> float | None:
     return v
 
 
+def _validate_timeout(v: float | None) -> float | None:
+    """Reject a non-positive / non-finite request ``timeout`` at the
+    schema layer so both OpenAI surfaces share one contract.
+
+    ``timeout`` feeds ``asyncio.wait_for``-style guards in the routes
+    (the non-streaming path and the disconnect watcher). A value that is
+    ``<= 0`` or NaN/±inf makes those guards fire an immediate timeout →
+    a 504 the client can't diagnose. Rejecting here (4xx naming the
+    ``timeout`` field) surfaces the malformed field instead. ``None``
+    passes through so the server-default path is preserved.
+    """
+    if v is None:
+        return None
+    if not math.isfinite(v):
+        raise ValueError("timeout must be a finite number of seconds (not NaN or inf)")
+    if v <= 0:
+        raise ValueError(
+            "timeout must be > 0 seconds when set (got "
+            f"{v}); omit the field to use the server default."
+        )
+    return v
+
+
+def _normalize_stop(v):
+    """Accept ``stop`` as either a scalar string or a sequence of
+    strings, normalizing to a list once at the schema layer
+    (mirrors the OpenAI request shape, where ``stop`` is
+    ``str | list[str]``). A bare string becomes a one-element list so
+    downstream code (``SamplingParams.stop: list[str]``) never has to
+    handle both shapes -- the normalization happens exactly once, at
+    the request schema, on both chat and legacy completions.
+    """
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return [v]
+    if isinstance(v, (list, tuple)):
+        out = []
+        for item in v:
+            if isinstance(item, bool) or not isinstance(item, str):
+                raise ValueError(
+                    "stop must be a string or a list of strings "
+                    f"(got non-string element {item!r})."
+                )
+            out.append(item)
+        return out
+    raise ValueError(
+        "stop must be a string or a list of strings "
+        f"(got {type(v).__name__})."
+    )
+
+
 # =============================================================================
 # Shared finite-range guard (H-10) — one source of truth
 # =============================================================================
@@ -549,6 +601,7 @@ _FINITE_SAMPLING_FIELDS: tuple[str, ...] = (
     "repetition_penalty",
     "presence_penalty",
     "frequency_penalty",
+    "timeout",
 )
 
 
@@ -1848,6 +1901,21 @@ class ChatCompletionRequest(BaseModel):
     def _validate_max_completion_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_completion_tokens")
 
+    # ``mode="before"`` so a scalar string is wrapped into a list BEFORE
+    # Pydantic tries to validate it against the ``list[str]`` field type
+    # (a bare ``"END"`` would otherwise 422 as "not a list"). Mirrors the
+    # OpenAI request shape (``stop`` is ``str | list[str]``) while keeping
+    # the normalized value a list for the engine contract.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2264,6 +2332,19 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_max_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_tokens")
+
+    # ``_normalize_stop`` + ``_validate_timeout`` mirror the chat
+    # surface so /v1/completions and /v1/chat/completions share one
+    # schema contract -- same helpers, same wire acceptance rules.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -564,6 +564,10 @@ _SCHEMA_OWNED_FIELD_NAMES: frozenset[str] = frozenset(
         # tool definitions
         "input_schema",
         "parameters",
+        # Resident-model control plane (ModelLoadRequest / ModelPinRequest)
+        "pin",
+        "pinned",
+        "reload_if_changed",
     }
 )
 

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -445,7 +445,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     max_tokens=_resolve_max_tokens(request.max_tokens),
                     temperature=_resolve_temperature(request.temperature),
                     top_p=_resolve_top_p(request.top_p),
-                    stop=request.stop,
+                    stop=request.stop_sequences(),
                     **extended_kwargs,
                 )
 
@@ -520,7 +520,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         max_tokens=_resolve_max_tokens(request.max_tokens),
                         temperature=_resolve_temperature(request.temperature),
                         top_p=_resolve_top_p(request.top_p),
-                        stop=request.stop,
+                        stop=request.stop_sequences(),
                         **extended_kwargs,
                     ),
                     raw_request,
@@ -771,7 +771,7 @@ async def stream_completion(
         max_tokens=_resolve_max_tokens(request.max_tokens),
         temperature=_resolve_temperature(request.temperature),
         top_p=_resolve_top_p(request.top_p),
-        stop=request.stop,
+        stop=request.stop_sequences(),
         **extended_kwargs,
     ):
         if _json_mode:

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from ..config import get_config
 from ..middleware.auth import verify_api_key
@@ -42,16 +42,23 @@ class ModelLoadRequest(BaseModel):
     model: str = Field(..., min_length=1)
     model_path: str | None = None
     estimated_size_gb: float | None = Field(default=None, gt=0, le=1024)
-    pin: bool = False
+    # ``StrictBool`` requires an actual JSON boolean on the wire. Pydantic
+    # v2's lax mode coerces ``"yes"`` / ``"on"`` / ``1`` / ``0`` onto
+    # ``bool``, so a string like ``"yes"`` silently became ``True`` and
+    # triggered a real resident-model reload (issue #2362). Strict mode
+    # keeps ``true``/``false`` identical while rejecting every non-boolean
+    # wire form with a 4xx naming the field via the unified validation
+    # envelope.
+    pin: StrictBool = False
     replace_group: str | None = Field(default=None, pattern="^(assistant)$")
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
-    reload_if_changed: bool = False
+    reload_if_changed: StrictBool = False
     replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):
-    pinned: bool = True
+    pinned: StrictBool = True
 
 
 def _manager():


### PR DESCRIPTION
## Summary

Require **strict JSON booleans** for the three resident-model control-plane boolean fields: `pin`, `pinned`, and `reload_if_changed`. Scope is request schema + validation envelope + tests only.

### Problem (#2362)
`/v1/models/load` took `pin` and `reload_if_changed`, and `/v1/models/{model_id}/pin` took `pinned`, all typed `bool`. Pydantic v2's lax mode coerces non-boolean wire forms (`"yes"`, `"on"`, `1`, `0`) onto `bool`, so `pin: "yes"` silently became `True` and triggered a **real resident-model reload**.

### Fix
- Type the three fields as `StrictBool` so only genuine JSON booleans (`true`/`false`) are accepted; `true`/`false` behave identically, and every non-boolean wire form is rejected.
- The unified 4xx validation envelope only echoes field names present in its closed `_SCHEMA_OWNED_FIELD_NAMES` allowlist, so `pin`, `pinned`, and `reload_if_changed` are registered there — otherwise the error renders `"<field>: Input should be a valid boolean"` and names nothing. With the registration the 4xx names the offending field.

### Tests
- `tests/test_resident_models.py::test_models_load_requires_strict_json_booleans`: route-level HTTP test asserting each of the three fields returns the 400 `invalid_request_error` envelope naming the field for every non-boolean form (`"yes"`, `"on"`, `"no"`, `"off"`, `1`, `0`, `1.0`), while real `true`/`false` still succeed.
- Test added to the CI unit list so the changed lines stay covered by the diff-coverage gate.

## Scope / non-goals
- Request schema + validation envelope + tests only. No engine, runtime, resident-manager, or behavior change for valid input.

Closes: #2362