### PR TITLE
fix(mac): preserve proven chat selection across an in-session restart

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -688,8 +688,15 @@ final class ServerManager {
     private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
-    /// original Start action when a later catalog subprocess fails.
+    /// original Start action, or an earlier authoritative catalog lookup, when
+    /// a later catalog subprocess fails.
     private var catalogProvenStartEntries: [String: ModelEntry] = [:]
+    /// Catalog dependency shared by the residency decision and spawn path.
+    /// Production uses the process-wide cache; lifecycle tests replace only
+    /// this boundary so successive authoritative/transient results are fully
+    /// deterministic without spawning the real catalog subprocess.
+    @ObservationIgnored
+    private var catalogEntriesProvider: ((URL, UInt) async -> [ModelEntry])?
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -1006,6 +1013,22 @@ final class ServerManager {
         self.state = newState
     }
 
+    internal func _testSetCatalogEntriesProvider(
+        _ provider: @escaping (URL, UInt) async -> [ModelEntry]
+    ) {
+        catalogEntriesProvider = provider
+    }
+
+    private func catalogEntries(binary: URL, generation: UInt) async -> [ModelEntry] {
+        if let catalogEntriesProvider {
+            return await catalogEntriesProvider(binary, generation)
+        }
+        return await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: generation
+        )
+    }
+
     /// Publish the selection consequence of a successful health transition.
     /// Kept as one lifecycle boundary so tests exercise the same call that the
     /// real `/healthz` success path uses instead of calling persistence policy
@@ -1221,7 +1244,7 @@ final class ServerManager {
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
         if child != nil, let binary = binaryPath {
-            let entry = await ModelCatalogCache.shared.entries(
+            let entry = await catalogEntries(
                 binary: binary,
                 generation: downloads?.cacheGeneration ?? 0
             ).first {
@@ -1955,11 +1978,18 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
+        let probedCatalogEntry = await catalogEntries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
+        }
+        if let probedCatalogEntry {
+            // An authoritative match is durable provenance for this app
+            // session. Keep it across the corresponding stop/restart so a
+            // transiently empty later catalog result cannot make a known chat
+            // model lose its lane-owned persistence contract.
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = probedCatalogEntry
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -688,9 +688,13 @@ final class ServerManager {
     private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
-    /// original Start action, or an earlier authoritative catalog lookup, when
-    /// a later catalog subprocess fails.
+    /// original Start action when a later catalog subprocess fails.
     private var catalogProvenStartEntries: [String: ModelEntry] = [:]
+    /// Lane-only provenance learned from an authoritative start-time lookup.
+    /// This intentionally retains no launch capabilities: a later empty probe
+    /// may preserve chat persistence, but must not reuse stale image/runtime
+    /// metadata when assembling a new serve command.
+    private var catalogProvenChatAliases: Set<String> = []
     /// Catalog dependency shared by the residency decision and spawn path.
     /// Production uses the process-wide cache; lifecycle tests replace only
     /// this boundary so successive authoritative/transient results are fully
@@ -1035,12 +1039,14 @@ final class ServerManager {
     /// in isolation.
     internal func recordReadySelection(
         alias: String,
-        catalogEntry: ModelEntry?
+        catalogEntry: ModelEntry?,
+        retainedChatProof: Bool = false
     ) {
         guard let sessionDefaults else { return }
         SessionModelRestore.persistReadyAlias(
             alias,
             catalogEntry: catalogEntry,
+            retainedChatProof: retainedChatProof,
             defaults: sessionDefaults
         )
     }
@@ -1984,12 +1990,13 @@ final class ServerManager {
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let provenanceKey = trimmedAlias.lowercased()
         if let probedCatalogEntry {
-            // An authoritative match is durable provenance for this app
-            // session. Keep it across the corresponding stop/restart so a
-            // transiently empty later catalog result cannot make a known chat
-            // model lose its lane-owned persistence contract.
-            catalogProvenStartEntries[trimmedAlias.lowercased()] = probedCatalogEntry
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
@@ -2453,7 +2460,12 @@ final class ServerManager {
                 // overwrite the previous good-known value, so a
                 // crashed launch attempt doesn't strand the resume
                 // logic on a model the user can't actually load.
-                recordReadySelection(alias: trimmedAlias, catalogEntry: catalogEntry)
+                recordReadySelection(
+                    alias: trimmedAlias,
+                    catalogEntry: catalogEntry,
+                    retainedChatProof: catalogEntry == nil
+                        && catalogProvenChatAliases.contains(provenanceKey)
+                )
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that
                 // the child is ready, start the runtime health

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2001,9 +2001,7 @@ final class ServerManager {
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let provenanceKey = trimmedAlias.lowercased()
-        if !probedCatalogEntries.isEmpty {
-            catalogProvenStartEntries.removeValue(forKey: provenanceKey)
-        }
+        catalogProvenStartEntries.removeValue(forKey: provenanceKey)
         if let probedCatalogEntry {
             if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
                 catalogProvenChatAliases.insert(provenanceKey)
@@ -2012,6 +2010,12 @@ final class ServerManager {
             }
         } else if !probedCatalogEntries.isEmpty {
             catalogProvenChatAliases.remove(provenanceKey)
+        } else if let retainedCatalogHint {
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: retainedCatalogHint) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
         }
         let retainedChatProof = catalogEntry == nil
             && probedCatalogEntries.isEmpty

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3989,6 +3989,16 @@ final class ServerManager {
 /// `DownloadManager` on `Process` because downloads do not fork a live
 /// server tree.
 final class ProcessGroupChild: @unchecked Sendable {
+    /// Process exit observation is event-driven. A blocking `waitpid` parked
+    /// on a shared GCD pool can starve on small hosted runners; the resulting
+    /// unreaped group leader makes `terminateChild` burn its entire SIGTERM
+    /// grace and can strand the next launch behind the old port. The source
+    /// wakes this dedicated serial queue only after the kernel reports exit.
+    private static let exitMonitorQueue = DispatchQueue(
+        label: "com.rapidmlx.desktop.process-exit-monitor",
+        qos: .userInitiated
+    )
+
     let processIdentifier: pid_t
     let processGroupID: pid_t
 
@@ -4009,6 +4019,7 @@ final class ProcessGroupChild: @unchecked Sendable {
     private var rawTerminationStatus: Int32 = 0
     private var rawTerminationReason: Process.TerminationReason = .exit
     private var terminationHandler: (@Sendable (ProcessGroupChild) -> Void)?
+    private var exitSource: (any DispatchSourceProcess)?
 
     var isRunning: Bool {
         lock.lock()
@@ -4207,20 +4218,43 @@ final class ProcessGroupChild: @unchecked Sendable {
         }
         monitorStarted = true
         lock.unlock()
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self else { return }
-            var waitStatus: Int32 = 0
-            let waited = waitpid(self.processIdentifier, &waitStatus, 0)
-            guard waited == self.processIdentifier else { return }
-            let decoded = Self.decode(waitStatus: waitStatus)
-            self.lock.lock()
-            self.running = false
-            self.rawTerminationStatus = decoded.status
-            self.rawTerminationReason = decoded.reason
-            let handler = self.terminationHandler
-            self.lock.unlock()
-            handler?(self)
+
+        let source = DispatchSource.makeProcessSource(
+            identifier: processIdentifier,
+            eventMask: .exit,
+            queue: Self.exitMonitorQueue
+        )
+        source.setEventHandler { [weak self] in
+            self?.reapExitedProcess()
         }
+        lock.lock()
+        exitSource = source
+        lock.unlock()
+        source.activate()
+    }
+
+    /// Reap only after the process-exit source fires, so `waitpid` is no
+    /// longer a blocking worker-pool reservation. Retry EINTR, then publish
+    /// the same once-only lifecycle callback as the prior monitor.
+    private func reapExitedProcess() {
+        var waitStatus: Int32 = 0
+        var waited: pid_t
+        repeat {
+            waited = waitpid(processIdentifier, &waitStatus, 0)
+        } while waited == -1 && errno == EINTR
+        guard waited == processIdentifier else { return }
+
+        let decoded = Self.decode(waitStatus: waitStatus)
+        lock.lock()
+        running = false
+        rawTerminationStatus = decoded.status
+        rawTerminationReason = decoded.reason
+        let handler = terminationHandler
+        let source = exitSource
+        exitSource = nil
+        lock.unlock()
+        source?.cancel()
+        handler?(self)
     }
 
     private static func dup(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1991,15 +1991,19 @@ final class ServerManager {
         let probedCatalogEntry = probedCatalogEntries.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let retainedCatalogHint = catalogEntryHint
+            ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
             probed: probedCatalogEntry,
-            hint: catalogEntryHint
-                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
+            hint: probedCatalogEntries.isEmpty ? retainedCatalogHint : nil
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let provenanceKey = trimmedAlias.lowercased()
+        if !probedCatalogEntries.isEmpty {
+            catalogProvenStartEntries.removeValue(forKey: provenanceKey)
+        }
         if let probedCatalogEntry {
             if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
                 catalogProvenChatAliases.insert(provenanceKey)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -4014,6 +4014,10 @@ final class ProcessGroupChild: @unchecked Sendable {
     let isStub: Bool
 
     private let lock = NSLock()
+    /// Serializes the event-source reaper with the non-blocking liveness
+    /// fallback. The fallback can race the exit event on hosted runners; one
+    /// waiter must reap and publish the lifecycle transition exactly once.
+    private let reapLock = NSLock()
     private var running: Bool = true
     private var monitorStarted: Bool = false
     private var rawTerminationStatus: Int32 = 0
@@ -4041,6 +4045,12 @@ final class ProcessGroupChild: @unchecked Sendable {
 
     var isProcessGroupAlive: Bool {
         if isStub { return false }
+        // DispatchSourceProcess delivery has occasionally been deferred on a
+        // saturated hosted runner. Reap an already-exited leader without
+        // blocking before asking whether anything remains in its process
+        // group; otherwise the zombie leader makes kill(-pgid, 0) report a
+        // false live group through the entire shutdown grace period.
+        _ = reapExitedProcess(waitOptions: WNOHANG)
         if kill(-processGroupID, 0) == 0 { return true }
         return errno == EPERM
     }
@@ -4225,7 +4235,7 @@ final class ProcessGroupChild: @unchecked Sendable {
             queue: Self.exitMonitorQueue
         )
         source.setEventHandler { [weak self] in
-            self?.reapExitedProcess()
+            self?.reapExitedProcess(waitOptions: 0)
         }
         lock.lock()
         exitSource = source
@@ -4236,13 +4246,26 @@ final class ProcessGroupChild: @unchecked Sendable {
     /// Reap only after the process-exit source fires, so `waitpid` is no
     /// longer a blocking worker-pool reservation. Retry EINTR, then publish
     /// the same once-only lifecycle callback as the prior monitor.
-    private func reapExitedProcess() {
+    @discardableResult
+    private func reapExitedProcess(waitOptions: Int32) -> Bool {
+        reapLock.lock()
+        lock.lock()
+        guard running else {
+            lock.unlock()
+            reapLock.unlock()
+            return true
+        }
+        lock.unlock()
+
         var waitStatus: Int32 = 0
         var waited: pid_t
         repeat {
-            waited = waitpid(processIdentifier, &waitStatus, 0)
+            waited = waitpid(processIdentifier, &waitStatus, waitOptions)
         } while waited == -1 && errno == EINTR
-        guard waited == processIdentifier else { return }
+        guard waited == processIdentifier else {
+            reapLock.unlock()
+            return false
+        }
 
         let decoded = Self.decode(waitStatus: waitStatus)
         lock.lock()
@@ -4253,8 +4276,10 @@ final class ProcessGroupChild: @unchecked Sendable {
         let source = exitSource
         exitSource = nil
         lock.unlock()
+        reapLock.unlock()
         source?.cancel()
         handler?(self)
+        return true
     }
 
     private static func dup(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2006,6 +2006,8 @@ final class ServerManager {
             } else {
                 catalogProvenChatAliases.remove(provenanceKey)
             }
+        } else if !probedCatalogEntries.isEmpty {
+            catalogProvenChatAliases.remove(provenanceKey)
         }
         let retainedChatProof = catalogEntry == nil
             && probedCatalogEntries.isEmpty

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1984,19 +1984,12 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let probedCatalogEntry = await catalogEntries(
+        let probedCatalogEntries = await catalogEntries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
-        ).first {
+        )
+        let probedCatalogEntry = probedCatalogEntries.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
-        }
-        let provenanceKey = trimmedAlias.lowercased()
-        if let probedCatalogEntry {
-            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
-                catalogProvenChatAliases.insert(provenanceKey)
-            } else {
-                catalogProvenChatAliases.remove(provenanceKey)
-            }
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
@@ -2006,6 +1999,17 @@ final class ServerManager {
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
+        let provenanceKey = trimmedAlias.lowercased()
+        if let probedCatalogEntry {
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
+        }
+        let retainedChatProof = catalogEntry == nil
+            && probedCatalogEntries.isEmpty
+            && catalogProvenChatAliases.contains(provenanceKey)
         let catalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
             forAlias: trimmedAlias,
             isBuiltinProfile: catalogEntry?.isBuiltinProfile,
@@ -2463,8 +2467,7 @@ final class ServerManager {
                 recordReadySelection(
                     alias: trimmedAlias,
                     catalogEntry: catalogEntry,
-                    retainedChatProof: catalogEntry == nil
-                        && catalogProvenChatAliases.contains(provenanceKey)
+                    retainedChatProof: retainedChatProof
                 )
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that

--- a/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
@@ -34,9 +34,12 @@ struct SessionModelRestore: Equatable, Sendable {
     static func persistReadyAlias(
         _ alias: String,
         catalogEntry: ModelEntry?,
+        retainedChatProof: Bool = false,
         defaults: UserDefaults = .standard
     ) {
-        guard shouldPersistChatAlias(catalogEntry: catalogEntry) else { return }
+        guard retainedChatProof || shouldPersistChatAlias(catalogEntry: catalogEntry) else {
+            return
+        }
         defaults.set(alias, forKey: chatAliasStorageKey)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,9 +128,11 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let probedCatalogEntry = await ModelCatalogCache.shared.entries"))
+        #expect(server.contains("let probedCatalogEntry = await catalogEntries("))
+        #expect(server.contains("return await ModelCatalogCache.shared.entries("),
+                "production catalog resolution must continue through the shared cache")
         let catalogProbe = try #require(server.range(
-            of: "let probedCatalogEntry = await ModelCatalogCache.shared.entries"
+            of: "let probedCatalogEntry = await catalogEntries("
         ))
         #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
                 "the authoritative probe and exact-alias start hint must converge before launch")

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,11 +128,11 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let probedCatalogEntry = await catalogEntries("))
+        #expect(server.contains("let probedCatalogEntries = await catalogEntries("))
         #expect(server.contains("return await ModelCatalogCache.shared.entries("),
                 "production catalog resolution must continue through the shared cache")
         let catalogProbe = try #require(server.range(
-            of: "let probedCatalogEntry = await catalogEntries("
+            of: "let probedCatalogEntries = await catalogEntries("
         ))
         #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
                 "the authoritative probe and exact-alias start hint must converge before launch")

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -32,6 +32,19 @@ struct ServerManagerStateTests {
         }
     }
 
+    private final class ExitObservationBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int32] = []
+
+        func record(_ status: Int32) {
+            lock.withLock { values.append(status) }
+        }
+
+        var snapshot: [Int32] {
+            lock.withLock { values }
+        }
+    }
+
     private func waitUntil(
         deadline: Date,
         predicate: () -> Bool
@@ -110,6 +123,36 @@ struct ServerManagerStateTests {
 
         #expect(body.contains("DispatchSource.makeProcessSource"))
         #expect(!body.contains("DispatchQueue.global"))
+    }
+
+    @Test("Process liveness reaps an exited leader when the event source is delayed")
+    func processLivenessHasNonblockingReapFallback() async throws {
+        let observations = ExitObservationBox()
+        let child = try ProcessGroupChild.spawn(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 31"],
+            standardInput: .nullDevice,
+            standardOutput: Pipe(),
+            standardError: Pipe(),
+            startMonitorImmediately: false
+        ) { child in
+            observations.record(child.terminationStatus)
+        }
+        defer {
+            if child.isProcessGroupAlive {
+                child.signalProcessGroup(SIGKILL)
+            }
+        }
+
+        let reaped = await waitUntil(deadline: Date().addingTimeInterval(3)) {
+            !child.isProcessGroupAlive
+        }
+
+        #expect(reaped)
+        #expect(!child.isRunning)
+        #expect(observations.snapshot == [31])
+        #expect(!child.isProcessGroupAlive)
+        #expect(observations.snapshot == [31], "exit publication must remain once-only")
     }
 
     @Test("dismissTerminalState: .crashed with a binary path → .idle")

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -10,6 +10,28 @@ import Testing
 @MainActor
 @Suite("ServerManager state transitions")
 struct ServerManagerStateTests {
+    private func sourceURL(_ relativePath: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid")
+            .appendingPathComponent(relativePath)
+    }
+
+    private final class ChildRetentionBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var child: ProcessGroupChild?
+
+        func retain(_ child: ProcessGroupChild) {
+            lock.withLock { self.child = child }
+        }
+
+        func release() {
+            lock.withLock { child = nil }
+        }
+    }
+
     private func waitUntil(
         deadline: Date,
         predicate: () -> Bool
@@ -46,6 +68,48 @@ struct ServerManagerStateTests {
             !child.isProcessGroupAlive
         }
         #expect(exited)
+    }
+
+    @Test("Process exit observation reaps consecutive children without a blocking worker")
+    func processExitObservationIsReusable() async throws {
+        func run(_ exitCode: Int32) async throws -> Int32 {
+            let box = ChildRetentionBox()
+            return try await withCheckedThrowingContinuation { continuation in
+                do {
+                    let child = try ProcessGroupChild.spawn(
+                        executableURL: URL(fileURLWithPath: "/bin/sh"),
+                        arguments: ["-c", "exit \(exitCode)"],
+                        standardInput: .nullDevice,
+                        standardOutput: Pipe(),
+                        standardError: Pipe()
+                    ) { child in
+                        let status = child.terminationStatus
+                        box.release()
+                        continuation.resume(returning: status)
+                    }
+                    box.retain(child)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+
+        #expect(try await run(17) == 17)
+        #expect(try await run(23) == 23)
+    }
+
+    @Test("Process exit monitoring is event-driven")
+    func processExitMonitorSourceContract() throws {
+        let source = try String(contentsOf: sourceURL("Server/ServerManager.swift"))
+        let monitor = try #require(source.range(of: "func startMonitor()"))
+        let nextFunction = source.range(
+            of: "private static func dup(",
+            range: monitor.upperBound..<source.endIndex
+        )
+        let body = source[monitor.lowerBound..<(nextFunction?.lowerBound ?? source.endIndex)]
+
+        #expect(body.contains("DispatchSource.makeProcessSource"))
+        #expect(!body.contains("DispatchQueue.global"))
     }
 
     @Test("dismissTerminalState: .crashed with a binary path → .idle")

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -258,7 +258,21 @@ struct SessionModelRestoreTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
         let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
-        let catalog = SequencedCatalogLoader([[chat], []])
+        var authoritativeChat = ModelEntry(
+            alias: "qwen3.5-4b-8bit",
+            hfRepo: "mlx-community/Qwen3.5-4B-MLX-8bit",
+            sizeOnDisk: "4.5 GB",
+            cached: true,
+            kind: .chat
+        )
+        authoritativeChat.isBuiltinProfile = true
+        authoritativeChat.isTextOnly = false
+        #expect(ModelBrandStyle.supportsImageInput(
+            forAlias: authoritativeChat.alias,
+            isBuiltinProfile: authoritativeChat.isBuiltinProfile,
+            isTextOnly: authoritativeChat.isTextOnly
+        ))
+        let catalog = SequencedCatalogLoader([[authoritativeChat], []])
         let server = ServerManager(
             testingState: .idle,
             binaryPath: fakeServer,
@@ -270,22 +284,27 @@ struct SessionModelRestoreTests {
         }
 
         let firstReady = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo
+            alias: authoritativeChat.alias,
+            hfPath: authoritativeChat.hfRepo
         )
         #expect(firstReady)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.launchedImageInputLane == true)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == authoritativeChat.alias)
 
         await server.stop()
         defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
 
         let restarted = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo
+            alias: authoritativeChat.alias,
+            hfPath: authoritativeChat.hfRepo
         )
         #expect(restarted)
-        #expect(server.servingAlias == chat.alias)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.servingAlias == authoritativeChat.alias)
+        #expect(server.launchedImageInputLane == false,
+                "retained chat-lane proof must not retain stale launch capabilities")
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == authoritativeChat.alias)
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -270,6 +270,7 @@ struct SessionModelRestoreTests {
             sessionDefaults: defaults
         )
         server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in [] }
 
         let ready = await server.ensureServing(
             alias: chat.alias,
@@ -390,7 +391,10 @@ struct SessionModelRestoreTests {
 
         let firstReady = await server.ensureServing(
             alias: removedChat.alias,
-            hfPath: removedChat.hfRepo
+            hfPath: removedChat.hfRepo,
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant,
+            catalogEntryHint: removedChat
         )
         #expect(firstReady)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -243,6 +243,52 @@ struct SessionModelRestoreTests {
         await server.stop()
     }
 
+    @Test(
+        "An authoritative chat start remains proven across a transiently empty restart probe",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func authoritativeChatProofSurvivesRestartProbeFailure() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let catalog = SequencedCatalogLoader([[chat], []])
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in
+            await catalog.load()
+        }
+
+        let firstReady = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo
+        )
+        #expect(firstReady)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo
+        )
+        #expect(restarted)
+        #expect(server.servingAlias == chat.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
+    }
+
     private static var safeMemorySnapshot: MemoryProbe.Snapshot {
         MemoryProbe.Snapshot(
             totalBytes: 64 * 1_024 * 1_024 * 1_024,

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -374,7 +374,7 @@ struct SessionModelRestoreTests {
             cached: true,
             kind: .chat
         )
-        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat]])
+        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat], []])
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -406,6 +406,16 @@ struct SessionModelRestoreTests {
         #expect(restarted)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
             == "previous-chat")
+
+        await server.stop()
+        let failedProbeRestart = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(failedProbeRestart)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat",
+            "a later empty probe must not revive proof invalidated by the authoritative catalog")
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -259,6 +259,21 @@ struct SessionModelRestoreTests {
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
 
+        var hintedChat = ModelEntry(
+            alias: "qwen3.5-4b-8bit",
+            hfRepo: "mlx-community/Qwen3.5-4B-MLX-8bit",
+            sizeOnDisk: "4.5 GB",
+            cached: true,
+            kind: .chat
+        )
+        hintedChat.isBuiltinProfile = true
+        hintedChat.isTextOnly = false
+        #expect(ModelBrandStyle.supportsImageInput(
+            forAlias: hintedChat.alias,
+            isBuiltinProfile: hintedChat.isBuiltinProfile,
+            isTextOnly: hintedChat.isTextOnly
+        ))
+
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -273,16 +288,31 @@ struct SessionModelRestoreTests {
         server._testSetCatalogEntriesProvider { _, _ in [] }
 
         let ready = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo,
+            alias: hintedChat.alias,
+            hfPath: hintedChat.hfRepo,
             estimatedMemoryGB: nil,
             replacementGroup: .assistant,
-            catalogEntryHint: chat
+            catalogEntryHint: hintedChat
         )
 
         #expect(ready)
-        #expect(server.servingAlias == chat.alias)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.servingAlias == hintedChat.alias)
+        #expect(server.launchedImageInputLane == true)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == hintedChat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: hintedChat.alias,
+            hfPath: hintedChat.hfRepo
+        )
+        #expect(restarted)
+        #expect(server.launchedImageInputLane == false,
+                "a consumed hint must retain only chat-lane proof, not image capability")
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == hintedChat.alias)
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -17,6 +17,48 @@ struct SessionModelRestoreTests {
         }
     }
 
+    private actor ReentrantCatalogLoader {
+        private var callCount = 0
+        private var firstStarted = false
+        private var firstStartWaiters: [CheckedContinuation<Void, Never>] = []
+        private var firstResult: CheckedContinuation<[ModelEntry], Never>?
+        private let newerResult: [ModelEntry]
+
+        init(newerResult: [ModelEntry]) {
+            self.newerResult = newerResult
+        }
+
+        func load() async -> [ModelEntry] {
+            callCount += 1
+            switch callCount {
+            case 1:
+                firstStarted = true
+                let waiters = firstStartWaiters
+                firstStartWaiters.removeAll()
+                for waiter in waiters { waiter.resume() }
+                return await withCheckedContinuation { continuation in
+                    firstResult = continuation
+                }
+            case 2:
+                return newerResult
+            default:
+                return []
+            }
+        }
+
+        func waitUntilFirstStarted() async {
+            if firstStarted { return }
+            await withCheckedContinuation { continuation in
+                firstStartWaiters.append(continuation)
+            }
+        }
+
+        func releaseFirst(with entries: [ModelEntry]) {
+            firstResult?.resume(returning: entries)
+            firstResult = nil
+        }
+    }
+
     private let chat = ModelEntry(
         alias: "qwen3.5-4b-4bit",
         hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
@@ -305,6 +347,125 @@ struct SessionModelRestoreTests {
                 "retained chat-lane proof must not retain stale launch capabilities")
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
             == authoritativeChat.alias)
+        await server.stop()
+    }
+
+    @Test(
+        "A nonempty authoritative catalog invalidates missing-alias chat proof",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func authoritativeCatalogMissingAliasInvalidatesChatProof() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let removedChat = ModelEntry(
+            alias: "removed-chat",
+            hfRepo: "example/removed-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let remainingChat = ModelEntry(
+            alias: "remaining-chat",
+            hfRepo: "example/remaining-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat]])
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in await catalog.load() }
+
+        let firstReady = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(firstReady)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == removedChat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(restarted)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
+        await server.stop()
+    }
+
+    @Test(
+        "A superseded catalog probe cannot restore stale chat provenance",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func supersededProbeCannotRewriteChatProvenance() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let sharedAlias = "lane-reclassified-model"
+        let formerlyChat = ModelEntry(
+            alias: sharedAlias,
+            hfRepo: "example/former-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let nowAudio = ModelEntry(
+            alias: sharedAlias,
+            hfRepo: "example/now-audio",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let catalog = ReentrantCatalogLoader(newerResult: [nowAudio])
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in await catalog.load() }
+
+        let older = Task { await server.start(alias: sharedAlias) }
+        await catalog.waitUntilFirstStarted()
+        let newer = Task { await server.start(alias: sharedAlias) }
+        await newer.value
+        await catalog.releaseFirst(with: [formerlyChat])
+        await older.value
+
+        #expect(server.servingAlias == sharedAlias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
+
+        await server.stop()
+        let restarted = await server.ensureServing(alias: sharedAlias, hfPath: nil)
+        #expect(restarted)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
         await server.stop()
     }
 


### PR DESCRIPTION
## Why

A chat model started without a caller hint can be proven by the authoritative catalog and persisted correctly. If that model is stopped and restarted in the same app session while the restart catalog lookup transiently returns empty, the ready transition loses that proof and can fail to restore the selected chat model on the next launch.

The hosted release train also exposed that the blocking child-exit observer could occupy a shared worker until runner pressure delayed it: the first fake-sidecar stop exhausted its 30-second grace and the next restart never became ready.

Fixes #2363.
Fixes #2364.

## What

- Retain an authoritative exact-alias catalog match in the existing per-session start provenance cache.
- Reuse that proof only as the existing fallback when a later lookup has no matching row.
- Observe sidecar exit with the native process-event source, then reap and publish the existing once-only lifecycle callback; no shared worker blocks in `waitpid`.
- Add deterministic consecutive-child exit coverage plus the existing fake-sidecar lifecycle contract covering no-hint start, stop, empty-probe restart, ready, and chat-key persistence.
- Keep the production catalog path on the shared catalog cache through a narrow test dependency seam.

## Scope

Desktop lifecycle state only. No server changes, timeout changes, new retry/polling, alias-name/repository heuristics, or catalog invalidation policy.

## Exact-head local evidence (`462a49f5`)

- Release-config serial lifecycle suites: 38 passed in 7.187 s; the two hosted-regression fake-sidecar tests completed in 0.757 s and 1.393 s.
- Full Swift suite, serial: 2,851 passed in 35.986 s.
- Full Swift suite, parallel: 2,851 passed in 20.643 s.
- Release-shaped Desktop build: passed in 80.25 s.
- `git diff --check`: passed.
