### PR TITLE
docs(perf): compare PyPI 0.13.0 with 0.12.18

### DIFF
--- a/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
+++ b/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
@@ -68,19 +68,21 @@ are therefore a new, separately labeled observation and are not a historical
 comparison metric from that report.
 
 The same benchmark command and prompts were instrumented with
-[`perf_spot_first_token.py`](perf_spot_first_token.py). The script records the
-wall time from engine request admission to the first non-empty streamed token.
-Because `--max-num-seqs 1` queues later prompts, only the first request in each
-fresh process is counted. The values are medians of three independent
-processes; lower is better.
+[`perf_spot_first_token.py`](perf_spot_first_token.py). The script starts the
+clock immediately before the first request enters `add_request`, pins that
+request's ID, and stops at the first non-empty producer output entering the
+request output collector. This includes request admission but is independent of
+later admissions and consumer-side buffering. Because `--max-num-seqs 1`
+queues later prompts, only the first request in each fresh process is counted.
+The values are medians of three independent processes; lower is better.
 
 | Checkpoint | 0.12.18 first token | 0.13.0 first token | Delta |
 | --- | ---: | ---: | ---: |
-| Qwen3 0.6B 4-bit | 0.073 s | 0.074 s | +1.10% |
-| Qwen3 1.7B 4-bit | 0.108 s | 0.110 s | +1.41% |
-| Qwen3.5 4B 4-bit | 0.206 s | 0.190 s | -7.93% |
-| Qwen3.5 9B 4-bit | 0.338 s | 0.305 s | -9.58% |
-| Gemma 4 12B 4-bit | 2.098 s | 2.098 s | -0.02% |
+| Qwen3 0.6B 4-bit | 0.074 s | 0.074 s | -0.04% |
+| Qwen3 1.7B 4-bit | 0.114 s | 0.112 s | -1.90% |
+| Qwen3.5 4B 4-bit | 0.205 s | 0.189 s | -8.01% |
+| Qwen3.5 9B 4-bit | 0.338 s | 0.309 s | -8.75% |
+| Gemma 4 12B 4-bit | 2.098 s | 2.113 s | +0.75% |
 
 Run the first-token observation with the same arguments:
 
@@ -98,16 +100,16 @@ tok/s, output tok/s, peak RSS GiB, and first-token seconds.
 
 | Version | Checkpoint | Overall tok/s | Output tok/s | RSS GiB | First token s |
 | --- | --- | --- | --- | --- | --- |
-| 0.12.18 | Qwen3 0.6B | 243.50 / 262.78 / 261.82 | 237.02 / 255.78 / 254.85 | 0.66 / 0.66 / 0.66 | 0.076 / 0.073 / 0.070 |
-| 0.13.0 | Qwen3 0.6B | 247.07 / 258.33 / 258.76 | 240.50 / 251.45 / 251.88 | 0.66 / 0.66 / 0.66 | 0.074 / 0.075 / 0.073 |
-| 0.12.18 | Qwen3 1.7B | 134.08 / 134.60 / 134.29 | 130.51 / 131.01 / 130.71 | 1.25 / 1.25 / 1.25 | 0.107 / 0.110 / 0.108 |
-| 0.13.0 | Qwen3 1.7B | 133.38 / 133.54 / 133.91 | 129.83 / 129.98 / 130.35 | 1.25 / 1.25 / 1.25 | 0.110 / 0.107 / 0.114 |
-| 0.12.18 | Qwen3.5 4B | 59.20 / 60.29 / 60.37 | 57.62 / 57.88 / 58.26 | 2.80 / 2.80 / 2.79 | 0.202 / 0.206 / 0.206 |
-| 0.13.0 | Qwen3.5 4B | 57.13 / 60.65 / 60.66 | 55.30 / 59.03 / 59.05 | 2.80 / 2.82 / 2.81 | 0.190 / 0.189 / 0.192 |
-| 0.12.18 | Qwen3.5 9B | 35.64 / 35.52 / 35.52 | 34.02 / 34.05 / 33.60 | 5.28 / 5.29 / 5.28 | 0.338 / 0.328 / 0.341 |
-| 0.13.0 | Qwen3.5 9B | 36.02 / 35.97 / 35.94 | 34.86 / 34.64 / 34.18 | 5.30 / 5.28 / 5.30 | 0.305 / 0.317 / 0.301 |
-| 0.12.18 | Gemma 4 12B | 21.31 / 21.38 / 21.39 | 20.74 / 20.81 / 20.82 | 6.71 / 6.71 / 6.71 | 2.098 / 2.087 / 2.100 |
-| 0.13.0 | Gemma 4 12B | 21.01 / 21.47 / 21.47 | 20.45 / 20.89 / 20.89 | 6.72 / 6.71 / 6.71 | 2.090 / 2.099 / 2.098 |
+| 0.12.18 | Qwen3 0.6B | 243.50 / 262.78 / 261.82 | 237.02 / 255.78 / 254.85 | 0.66 / 0.66 / 0.66 | 0.077 / 0.074 / 0.071 |
+| 0.13.0 | Qwen3 0.6B | 247.07 / 258.33 / 258.76 | 240.50 / 251.45 / 251.88 | 0.66 / 0.66 / 0.66 | 0.081 / 0.071 / 0.074 |
+| 0.12.18 | Qwen3 1.7B | 134.08 / 134.60 / 134.29 | 130.51 / 131.01 / 130.71 | 1.25 / 1.25 / 1.25 | 0.110 / 0.114 / 0.120 |
+| 0.13.0 | Qwen3 1.7B | 133.38 / 133.54 / 133.91 | 129.83 / 129.98 / 130.35 | 1.25 / 1.25 / 1.25 | 0.098 / 0.112 / 0.112 |
+| 0.12.18 | Qwen3.5 4B | 59.20 / 60.29 / 60.37 | 57.62 / 57.88 / 58.26 | 2.80 / 2.80 / 2.79 | 0.205 / 0.200 / 0.206 |
+| 0.13.0 | Qwen3.5 4B | 57.13 / 60.65 / 60.66 | 55.30 / 59.03 / 59.05 | 2.80 / 2.82 / 2.81 | 0.189 / 0.188 / 0.192 |
+| 0.12.18 | Qwen3.5 9B | 35.64 / 35.52 / 35.52 | 34.02 / 34.05 / 33.60 | 5.28 / 5.29 / 5.28 | 0.338 / 0.338 / 0.339 |
+| 0.13.0 | Qwen3.5 9B | 36.02 / 35.97 / 35.94 | 34.86 / 34.64 / 34.18 | 5.30 / 5.28 / 5.30 | 0.317 / 0.309 / 0.308 |
+| 0.12.18 | Gemma 4 12B | 21.31 / 21.38 / 21.39 | 20.74 / 20.81 / 20.82 | 6.71 / 6.71 / 6.71 | 2.098 / 2.106 / 2.093 |
+| 0.13.0 | Gemma 4 12B | 21.01 / 21.47 / 21.47 | 20.45 / 20.89 / 20.89 | 6.72 / 6.71 / 6.71 | 2.117 / 2.113 / 2.095 |
 
 ## Coverage and limitations
 

--- a/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
+++ b/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
@@ -87,7 +87,8 @@ The values are medians of three independent processes; lower is better.
 Run the first-token observation with the same arguments:
 
 ```bash
-/usr/bin/time -lp python perf_spot_first_token.py bench MODEL \
+/usr/bin/time -lp python \
+  docs/engineering/performance/perf_spot_first_token.py bench MODEL \
   --num-prompts 3 \
   --max-tokens 256 \
   --max-num-seqs 1

--- a/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
+++ b/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
@@ -2,10 +2,11 @@
 
 ## Result
 
-No reproducible short-context decode or resident-memory regression was found in
+No reproducible short-context output-token throughput or resident-memory
+regression was found in
 the five cached checkpoints tested on an M2 Pro Mac mini. Across three fresh
 processes per version and model, median overall throughput changed by -1.33% to
-+1.27%, median output-token decode rate changed by -1.33% to +1.99%, and median
++1.27%, median output-token throughput changed by -1.33% to +1.99%, and median
 peak RSS changed by less than 0.45%.
 
 This is a reduced, consumer-hardware spot check, not a broad performance claim.
@@ -44,13 +45,15 @@ shape from the earlier spot check, with `/usr/bin/time -lp` added for peak RSS:
   --max-num-seqs 1
 ```
 
-`Overall tok/s` is the command's reported `Throughput`; `decode tok/s` is its
-reported `Tokens/second`, which counts output tokens. Peak RSS is the maximum
-resident set size from the same primary process.
+`Overall tok/s` is the command's reported `Throughput`; `output tok/s` is its
+reported `Tokens/second`, which divides completion tokens by the full benchmark
+wall time. It therefore includes admission, prompt prefill, queueing, and decode
+rather than isolating the model's decode phase. Peak RSS is the maximum resident
+set size from the same primary process.
 
 ## Comparable results
 
-| Checkpoint | 0.12.18 overall tok/s | 0.13.0 overall tok/s | Delta | 0.12.18 decode tok/s | 0.13.0 decode tok/s | Delta | 0.12.18 RSS GiB | 0.13.0 RSS GiB | Delta |
+| Checkpoint | 0.12.18 overall tok/s | 0.13.0 overall tok/s | Delta | 0.12.18 output tok/s | 0.13.0 output tok/s | Delta | 0.12.18 RSS GiB | 0.13.0 RSS GiB | Delta |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Qwen3 0.6B 4-bit | 261.82 | 258.33 | -1.33% | 254.85 | 251.45 | -1.33% | 0.662 | 0.661 | -0.06% |
 | Qwen3 1.7B 4-bit | 134.29 | 133.54 | -0.56% | 130.71 | 129.98 | -0.56% | 1.250 | 1.250 | +0.04% |
@@ -91,9 +94,9 @@ Run the first-token observation with the same arguments:
 ## Raw samples
 
 Values below are the three process samples in run order. Each row lists overall
-tok/s, decode tok/s, peak RSS GiB, and first-token seconds.
+tok/s, output tok/s, peak RSS GiB, and first-token seconds.
 
-| Version | Checkpoint | Overall tok/s | Decode tok/s | RSS GiB | First token s |
+| Version | Checkpoint | Overall tok/s | Output tok/s | RSS GiB | First token s |
 | --- | --- | --- | --- | --- | --- |
 | 0.12.18 | Qwen3 0.6B | 243.50 / 262.78 / 261.82 | 237.02 / 255.78 / 254.85 | 0.66 / 0.66 / 0.66 | 0.076 / 0.073 / 0.070 |
 | 0.13.0 | Qwen3 0.6B | 247.07 / 258.33 / 258.76 | 240.50 / 251.45 / 251.88 | 0.66 / 0.66 / 0.66 | 0.074 / 0.075 / 0.073 |

--- a/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
+++ b/docs/engineering/performance/2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md
@@ -1,0 +1,127 @@
+# PyPI v0.13.0 versus v0.12.18 Mac mini spot check
+
+## Result
+
+No reproducible short-context decode or resident-memory regression was found in
+the five cached checkpoints tested on an M2 Pro Mac mini. Across three fresh
+processes per version and model, median overall throughput changed by -1.33% to
++1.27%, median output-token decode rate changed by -1.33% to +1.99%, and median
+peak RSS changed by less than 0.45%.
+
+This is a reduced, consumer-hardware spot check, not a broad performance claim.
+It covers five of the ten checkpoints in the earlier main-versus-v0.12.18
+report because only those five exact checkpoints were already cached. No model
+weights were downloaded to produce the reported samples.
+
+## Environment
+
+- Date: 2026-08-25 (America/Los_Angeles)
+- Host: Mac mini, Apple M2 Pro, 32 GB memory, arm64
+- OS: macOS 26.5.2 (25F84)
+- Python: 3.12.13, one fresh virtual environment per version
+- Candidate: PyPI `rapid-mlx==0.13.0`, wheel SHA-256
+  `98a647929303af4f602cc157027d44ba6073b61993a12e5d0004b8ae051c4843`
+- Baseline: PyPI `rapid-mlx==0.12.18`, wheel SHA-256
+  `37b3dbcb04a0fbe57b5cdc8a412ef96aeb33f6f895e8098180a302c9a0673fed`
+- Candidate runtime: MLX 0.32.2, mlx-lm 0.31.3, transformers 5.12.1
+- Baseline runtime: MLX 0.31.2, mlx-lm 0.31.3, transformers 5.12.1
+
+A separate installation check created a fresh Python 3.12 virtual environment,
+installed the candidate from PyPI, served the cached Qwen3 0.6B alias, and
+received HTTP 200 with a non-empty chat completion. This verifies that the
+measured candidate was the published package, rather than a source checkout.
+
+## Method
+
+Each table cell is the median of three samples. Every sample ran in a fresh
+process. The primary, directly comparable measurement kept the exact command
+shape from the earlier spot check, with `/usr/bin/time -lp` added for peak RSS:
+
+```bash
+/usr/bin/time -lp python -m vllm_mlx.cli bench MODEL \
+  --num-prompts 3 \
+  --max-tokens 256 \
+  --max-num-seqs 1
+```
+
+`Overall tok/s` is the command's reported `Throughput`; `decode tok/s` is its
+reported `Tokens/second`, which counts output tokens. Peak RSS is the maximum
+resident set size from the same primary process.
+
+## Comparable results
+
+| Checkpoint | 0.12.18 overall tok/s | 0.13.0 overall tok/s | Delta | 0.12.18 decode tok/s | 0.13.0 decode tok/s | Delta | 0.12.18 RSS GiB | 0.13.0 RSS GiB | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Qwen3 0.6B 4-bit | 261.82 | 258.33 | -1.33% | 254.85 | 251.45 | -1.33% | 0.662 | 0.661 | -0.06% |
+| Qwen3 1.7B 4-bit | 134.29 | 133.54 | -0.56% | 130.71 | 129.98 | -0.56% | 1.250 | 1.250 | +0.04% |
+| Qwen3.5 4B 4-bit | 60.29 | 60.65 | +0.60% | 57.88 | 59.03 | +1.99% | 2.796 | 2.808 | +0.45% |
+| Qwen3.5 9B 4-bit | 35.52 | 35.97 | +1.27% | 34.02 | 34.64 | +1.82% | 5.283 | 5.298 | +0.29% |
+| Gemma 4 12B 4-bit | 21.38 | 21.47 | +0.42% | 20.81 | 20.89 | +0.38% | 6.710 | 6.713 | +0.05% |
+
+## New first-token observation
+
+The earlier spot check did not measure time to first token. The results below
+are therefore a new, separately labeled observation and are not a historical
+comparison metric from that report.
+
+The same benchmark command and prompts were instrumented with
+[`perf_spot_first_token.py`](perf_spot_first_token.py). The script records the
+wall time from engine request admission to the first non-empty streamed token.
+Because `--max-num-seqs 1` queues later prompts, only the first request in each
+fresh process is counted. The values are medians of three independent
+processes; lower is better.
+
+| Checkpoint | 0.12.18 first token | 0.13.0 first token | Delta |
+| --- | ---: | ---: | ---: |
+| Qwen3 0.6B 4-bit | 0.073 s | 0.074 s | +1.10% |
+| Qwen3 1.7B 4-bit | 0.108 s | 0.110 s | +1.41% |
+| Qwen3.5 4B 4-bit | 0.206 s | 0.190 s | -7.93% |
+| Qwen3.5 9B 4-bit | 0.338 s | 0.305 s | -9.58% |
+| Gemma 4 12B 4-bit | 2.098 s | 2.098 s | -0.02% |
+
+Run the first-token observation with the same arguments:
+
+```bash
+/usr/bin/time -lp python perf_spot_first_token.py bench MODEL \
+  --num-prompts 3 \
+  --max-tokens 256 \
+  --max-num-seqs 1
+```
+
+## Raw samples
+
+Values below are the three process samples in run order. Each row lists overall
+tok/s, decode tok/s, peak RSS GiB, and first-token seconds.
+
+| Version | Checkpoint | Overall tok/s | Decode tok/s | RSS GiB | First token s |
+| --- | --- | --- | --- | --- | --- |
+| 0.12.18 | Qwen3 0.6B | 243.50 / 262.78 / 261.82 | 237.02 / 255.78 / 254.85 | 0.66 / 0.66 / 0.66 | 0.076 / 0.073 / 0.070 |
+| 0.13.0 | Qwen3 0.6B | 247.07 / 258.33 / 258.76 | 240.50 / 251.45 / 251.88 | 0.66 / 0.66 / 0.66 | 0.074 / 0.075 / 0.073 |
+| 0.12.18 | Qwen3 1.7B | 134.08 / 134.60 / 134.29 | 130.51 / 131.01 / 130.71 | 1.25 / 1.25 / 1.25 | 0.107 / 0.110 / 0.108 |
+| 0.13.0 | Qwen3 1.7B | 133.38 / 133.54 / 133.91 | 129.83 / 129.98 / 130.35 | 1.25 / 1.25 / 1.25 | 0.110 / 0.107 / 0.114 |
+| 0.12.18 | Qwen3.5 4B | 59.20 / 60.29 / 60.37 | 57.62 / 57.88 / 58.26 | 2.80 / 2.80 / 2.79 | 0.202 / 0.206 / 0.206 |
+| 0.13.0 | Qwen3.5 4B | 57.13 / 60.65 / 60.66 | 55.30 / 59.03 / 59.05 | 2.80 / 2.82 / 2.81 | 0.190 / 0.189 / 0.192 |
+| 0.12.18 | Qwen3.5 9B | 35.64 / 35.52 / 35.52 | 34.02 / 34.05 / 33.60 | 5.28 / 5.29 / 5.28 | 0.338 / 0.328 / 0.341 |
+| 0.13.0 | Qwen3.5 9B | 36.02 / 35.97 / 35.94 | 34.86 / 34.64 / 34.18 | 5.30 / 5.28 / 5.30 | 0.305 / 0.317 / 0.301 |
+| 0.12.18 | Gemma 4 12B | 21.31 / 21.38 / 21.39 | 20.74 / 20.81 / 20.82 | 6.71 / 6.71 / 6.71 | 2.098 / 2.087 / 2.100 |
+| 0.13.0 | Gemma 4 12B | 21.01 / 21.47 / 21.47 | 20.45 / 20.89 / 20.89 | 6.72 / 6.71 / 6.71 | 2.090 / 2.099 / 2.098 |
+
+## Coverage and limitations
+
+- Exact checkpoints: `mlx-community/Qwen3-0.6B-4bit`,
+  `mlx-community/Qwen3-1.7B-4bit`,
+  `mlx-community/Qwen3.5-4B-MLX-4bit`,
+  `mlx-community/Qwen3.5-9B-4bit`, and
+  `mlx-community/gemma-4-12B-it-4bit`.
+- The uncached 3B, 8B, 20B, 27B, and 35B checkpoints from the earlier report
+  were intentionally omitted. Results must not be extrapolated to them.
+- This measures batch size 1, short prompts, and up to 256 generated tokens. It
+  does not measure long-context prefill, concurrency, multimodal lanes, audio,
+  power, or sustained thermals.
+- The published packages resolve different MLX versions, so the comparison
+  intentionally includes the runtime dependency change users receive.
+- Cold compilation and filesystem-cache effects remain visible in some first
+  samples. Three-run medians reduce, but do not eliminate, that noise.
+
+Within this limited matrix, v0.13.0 remains performance-compatible with
+v0.12.18 for single-request short-context text generation on the tested mini.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -9,3 +9,4 @@ summary statistics, and limitations.
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)
 - [Qwen3.5-9B engine comparison on M2 Pro](2026-08-21-qwen3.5-9b-engine-comparison.md)
 - [Rapid-MLX 0.12.18 performance release gate](2026-08-22-release-0.12.18-perf-gate.md)
+- [PyPI v0.13.0 versus v0.12.18 Mac mini spot check](2026-08-25-v0.13.0-vs-v0.12.18-mini-spotcheck.md)

--- a/docs/engineering/performance/perf_spot_first_token.py
+++ b/docs/engineering/performance/perf_spot_first_token.py
@@ -3,37 +3,68 @@
 
 import sys
 import time
-
-from vllm_mlx.engine_core import AsyncEngineCore
-
-_add_request = AsyncEngineCore.add_request
-_stream_outputs = AsyncEngineCore.stream_outputs
-_request_starts: dict[str, float] = {}
+from collections.abc import Callable
 
 
-async def _observed_add_request(self, *args, **kwargs):
-    request_id = await _add_request(self, *args, **kwargs)
-    _request_starts[request_id] = time.perf_counter()
-    return request_id
+class FirstRequestTTFT:
+    """Measure the first non-empty token for only the first admitted request."""
+
+    def __init__(self, clock: Callable[[], float] = time.perf_counter) -> None:
+        self._clock = clock
+        self._request_id: str | None = None
+        self._started_at: float | None = None
+        self._emitted = False
+
+    def admitted(self, request_id: str) -> None:
+        if self._request_id is None:
+            self._request_id = request_id
+            self._started_at = self._clock()
+
+    def observe(self, request_id: str, *, has_token: bool) -> float | None:
+        if (
+            request_id != self._request_id
+            or not has_token
+            or self._emitted
+            or self._started_at is None
+        ):
+            return None
+        self._emitted = True
+        return self._clock() - self._started_at
 
 
-async def _observed_stream_outputs(self, request_id, *args, **kwargs):
-    observed_first_token = False
-    async for output in _stream_outputs(self, request_id, *args, **kwargs):
-        if not observed_first_token and (output.new_token_ids or output.new_text):
-            observed_first_token = True
-            elapsed = time.perf_counter() - _request_starts[request_id]
-            print(
-                f"PERF_TTFT request_id={request_id} seconds={elapsed:.9f}",
-                file=sys.stderr,
-                flush=True,
+def main() -> None:
+    from vllm_mlx.engine_core import AsyncEngineCore
+
+    add_request = AsyncEngineCore.add_request
+    stream_outputs = AsyncEngineCore.stream_outputs
+    observer = FirstRequestTTFT()
+
+    async def observed_add_request(self, *args, **kwargs):
+        request_id = await add_request(self, *args, **kwargs)
+        observer.admitted(request_id)
+        return request_id
+
+    async def observed_stream_outputs(self, request_id, *args, **kwargs):
+        async for output in stream_outputs(self, request_id, *args, **kwargs):
+            elapsed = observer.observe(
+                request_id,
+                has_token=bool(output.new_token_ids or output.new_text),
             )
-        yield output
+            if elapsed is not None:
+                print(
+                    f"PERF_TTFT request_id={request_id} seconds={elapsed:.9f}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            yield output
+
+    AsyncEngineCore.add_request = observed_add_request
+    AsyncEngineCore.stream_outputs = observed_stream_outputs
+
+    from vllm_mlx.cli import cli_entrypoint
+
+    cli_entrypoint()
 
 
-AsyncEngineCore.add_request = _observed_add_request
-AsyncEngineCore.stream_outputs = _observed_stream_outputs
-
-from vllm_mlx.cli import cli_entrypoint  # noqa: E402
-
-cli_entrypoint()
+if __name__ == "__main__":
+    main()

--- a/docs/engineering/performance/perf_spot_first_token.py
+++ b/docs/engineering/performance/perf_spot_first_token.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Observe first-token timing without changing CLI benchmark semantics."""
+
+import sys
+import time
+
+from vllm_mlx.engine_core import AsyncEngineCore
+
+_add_request = AsyncEngineCore.add_request
+_stream_outputs = AsyncEngineCore.stream_outputs
+_request_starts: dict[str, float] = {}
+
+
+async def _observed_add_request(self, *args, **kwargs):
+    request_id = await _add_request(self, *args, **kwargs)
+    _request_starts[request_id] = time.perf_counter()
+    return request_id
+
+
+async def _observed_stream_outputs(self, request_id, *args, **kwargs):
+    observed_first_token = False
+    async for output in _stream_outputs(self, request_id, *args, **kwargs):
+        if not observed_first_token and (output.new_token_ids or output.new_text):
+            observed_first_token = True
+            elapsed = time.perf_counter() - _request_starts[request_id]
+            print(
+                f"PERF_TTFT request_id={request_id} seconds={elapsed:.9f}",
+                file=sys.stderr,
+                flush=True,
+            )
+        yield output
+
+
+AsyncEngineCore.add_request = _observed_add_request
+AsyncEngineCore.stream_outputs = _observed_stream_outputs
+
+from vllm_mlx.cli import cli_entrypoint  # noqa: E402
+
+cli_entrypoint()

--- a/docs/engineering/performance/perf_spot_first_token.py
+++ b/docs/engineering/performance/perf_spot_first_token.py
@@ -3,6 +3,7 @@
 
 import sys
 import time
+import uuid
 from collections.abc import Callable
 
 
@@ -15,7 +16,11 @@ class FirstRequestTTFT:
         self._started_at: float | None = None
         self._emitted = False
 
-    def admitted(self, request_id: str) -> None:
+    @property
+    def started(self) -> bool:
+        return self._request_id is not None
+
+    def begin(self, request_id: str) -> None:
         if self._request_id is None:
             self._request_id = request_id
             self._started_at = self._clock()
@@ -32,34 +37,59 @@ class FirstRequestTTFT:
         return self._clock() - self._started_at
 
 
-def main() -> None:
-    from vllm_mlx.engine_core import AsyncEngineCore
+def install_observer(
+    engine_class,
+    collector_class,
+    *,
+    clock: Callable[[], float] = time.perf_counter,
+    emit: Callable[[str, float], None],
+) -> FirstRequestTTFT:
+    """Observe producer-side first output without changing bench scheduling."""
 
-    add_request = AsyncEngineCore.add_request
-    stream_outputs = AsyncEngineCore.stream_outputs
-    observer = FirstRequestTTFT()
+    add_request = engine_class.add_request
+    put_output = collector_class.put
+    observer = FirstRequestTTFT(clock=clock)
 
     async def observed_add_request(self, *args, **kwargs):
-        request_id = await add_request(self, *args, **kwargs)
-        observer.admitted(request_id)
-        return request_id
+        if not observer.started:
+            # The CLI does not supply request IDs. Pin one before entering
+            # add_request so the boundary includes admission and producer-side
+            # output can be attributed even if it is buffered before return.
+            request_id = kwargs.get("request_id") or str(uuid.uuid4())
+            kwargs["request_id"] = request_id
+            observer.begin(request_id)
+        return await add_request(self, *args, **kwargs)
 
-    async def observed_stream_outputs(self, request_id, *args, **kwargs):
-        async for output in stream_outputs(self, request_id, *args, **kwargs):
-            elapsed = observer.observe(
-                request_id,
-                has_token=bool(output.new_token_ids or output.new_text),
-            )
-            if elapsed is not None:
-                print(
-                    f"PERF_TTFT request_id={request_id} seconds={elapsed:.9f}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-            yield output
+    def observed_put_output(self, output):
+        elapsed = observer.observe(
+            output.request_id,
+            has_token=bool(output.new_token_ids or output.new_text),
+        )
+        if elapsed is not None:
+            emit(output.request_id, elapsed)
+        return put_output(self, output)
 
-    AsyncEngineCore.add_request = observed_add_request
-    AsyncEngineCore.stream_outputs = observed_stream_outputs
+    engine_class.add_request = observed_add_request
+    collector_class.put = observed_put_output
+    return observer
+
+
+def main() -> None:
+    from vllm_mlx.engine_core import AsyncEngineCore
+    from vllm_mlx.output_collector import RequestOutputCollector
+
+    def emit(request_id: str, elapsed: float) -> None:
+        print(
+            f"PERF_TTFT request_id={request_id} seconds={elapsed:.9f}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    install_observer(
+        AsyncEngineCore,
+        RequestOutputCollector,
+        emit=emit,
+    )
 
     from vllm_mlx.cli import cli_entrypoint
 

--- a/tests/test_perf_spot_first_token.py
+++ b/tests/test_perf_spot_first_token.py
@@ -18,10 +18,62 @@ def test_observer_emits_once_for_only_first_admitted_request() -> None:
     times = iter((10.0, 12.5))
     observer = MODULE.FirstRequestTTFT(clock=lambda: next(times))
 
-    observer.admitted("first")
-    observer.admitted("second")
+    observer.begin("first")
+    observer.begin("second")
 
     assert observer.observe("second", has_token=True) is None
     assert observer.observe("first", has_token=False) is None
     assert observer.observe("first", has_token=True) == 2.5
     assert observer.observe("first", has_token=True) is None
+
+
+async def test_integration_includes_admission_and_records_prebuffered_output() -> None:
+    class ManualClock:
+        value = 10.0
+
+        def __call__(self) -> float:
+            return self.value
+
+    class Output:
+        def __init__(self, request_id: str, *, has_token: bool) -> None:
+            self.request_id = request_id
+            self.new_token_ids = [1] if has_token else []
+            self.new_text = "token" if has_token else ""
+
+    class Collector:
+        def __init__(self) -> None:
+            self.outputs = []
+
+        def put(self, output) -> None:
+            self.outputs.append(output)
+
+    clock = ManualClock()
+    collector = Collector()
+
+    class Engine:
+        async def add_request(self, prompt, params=None, request_id=None):
+            if prompt == "first":
+                # Simulate slow admission followed by a producer output before
+                # add_request returns to the benchmark's admission loop.
+                clock.value = 12.5
+                collector.put(Output(request_id, has_token=True))
+            else:
+                # A later slow admission must not inflate the recorded value.
+                clock.value = 50.0
+            return request_id
+
+    records = []
+    MODULE.install_observer(
+        Engine,
+        Collector,
+        clock=clock,
+        emit=lambda request_id, elapsed: records.append((request_id, elapsed)),
+    )
+
+    engine = Engine()
+    first_id = await engine.add_request("first")
+    await engine.add_request("second")
+
+    assert first_id is not None
+    assert records == [(first_id, 2.5)]
+    assert len(collector.outputs) == 1

--- a/tests/test_perf_spot_first_token.py
+++ b/tests/test_perf_spot_first_token.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "docs"
+    / "engineering"
+    / "performance"
+    / "perf_spot_first_token.py"
+)
+SPEC = importlib.util.spec_from_file_location("perf_spot_first_token", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_observer_emits_once_for_only_first_admitted_request() -> None:
+    times = iter((10.0, 12.5))
+    observer = MODULE.FirstRequestTTFT(clock=lambda: next(times))
+
+    observer.admitted("first")
+    observer.admitted("second")
+
+    assert observer.observe("second", has_token=True) is None
+    assert observer.observe("first", has_token=False) is None
+    assert observer.observe("first", has_token=True) == 2.5
+    assert observer.observe("first", has_token=True) is None


### PR DESCRIPTION
## Rationale

Record a reproducible consumer-tier comparison of the published Rapid-MLX 0.13.0 and 0.12.18 packages before the measurements are lost in private machine logs. The report keeps the exact earlier benchmark command as the comparable metric and labels the new first-token observation separately.

## Review contract

- **User-visible goal:** give users and maintainers an evidence-backed view of short-context 0.13.0 performance on an M2 Pro Mac mini.
- **Allowed scope:** one performance report, its first-token observation helper, the performance index, and a direct helper contract test.
- **Non-goals:** product or benchmark-runtime changes, release actions, claims about uncached models, long-context or concurrency claims, and unrelated documentation cleanup.
- **Constraints:** compare PyPI wheels in fresh Python 3.12 environments; use only five already-cached exact checkpoints; three fresh-process samples per version and model; preserve the exact #2245 command for the comparable metric; identify the first-token seam as new and non-#2245.
- **Acceptance:** exact environment, wheel hashes, commands, raw samples, medians, model coverage, and limitations are recorded; calculations agree with retained raw logs; the helper reproduces the measured observation without changing benchmark scheduling.
- **Diff under review:** `origin/main...7df6be4e`.

## Validation

- 30 primary benchmark processes: 5 models × 2 versions × 3 fresh processes — passed
- 30 corrected first-token observation processes: 5 models × 2 versions × 3 fresh processes — passed; exactly one record per process
- Fresh PyPI 0.13.0 install, cached model serve, and chat request — HTTP 200 with non-empty completion
- Focused first-token observer tests — 2 passed
- `ruff check` and `ruff format --check` for helper and test — passed
- `git diff --check` — passed
