### PR TITLE
docs: correct Nemotron 0.13.0 wording

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -26,8 +26,8 @@ responsiveness and cache correctness.
 ### Added
 
 - **More capable local models.** Supported Qwen3-Next checkpoints can stream
-  experts from disk, Nemotron Labs Diffusion 3B can generate images, and
-  verified Ornith 1.5 models are available from the Desktop catalog.
+  experts from disk, Nemotron Labs Diffusion 3B runs as a standard text model,
+  and verified Ornith 1.5 models are available from the Desktop catalog.
 - **Chat understands the current local date and time.** Questions about today
   no longer depend on the model's training cutoff or require a web search.
 - **Desktop workflows cover more of the local stack.** Attachments, dedicated
@@ -105,9 +105,9 @@ does not replace the stable updater feed.
 - **Ornith 1.5 is available end to end.** The 9B dense and 35B-A3B
   mixture-of-experts checkpoints are recognized by the engine and exposed in
   the Mac model picker with the correct runtime routes.
-- **More local generation choices.** Nemotron Labs Diffusion 3B can generate
-  images through its autoregressive path, and Qwen3-Next can stream routed
-  experts from disk on memory-constrained machines.
+- **More local generation choices.** Nemotron Labs Diffusion 3B runs as a
+  standard text model, and Qwen3-Next can stream routed experts from disk on
+  memory-constrained machines.
 - **Agent health is visible and actionable.** The CLI reports integration
   health and can re-run setup, while the Mac menu bar can copy the active API
   endpoint for connecting another client.

--- a/docs/release-notes/v0.13.0-rc1.md
+++ b/docs/release-notes/v0.13.0-rc1.md
@@ -11,9 +11,9 @@ feed.
   entries, with dense versus hybrid/MoE selection verified on real hardware.
   ([#2197](https://github.com/raullenchai/Rapid-MLX/pull/2197),
   [#2200](https://github.com/raullenchai/Rapid-MLX/pull/2200))
-- **Broader local generation.** Nemotron Labs Diffusion 3B is served through
-  its autoregressive image path, Qwen3-Next gains routed-expert disk streaming,
-  and the Mac bundle carries a compatible image-generation runtime.
+- **Broader local generation.** Nemotron Labs Diffusion 3B runs as a standard
+  text model, Qwen3-Next gains routed-expert disk streaming, and the Mac bundle
+  carries a compatible image-generation runtime.
   ([#2194](https://github.com/raullenchai/Rapid-MLX/pull/2194),
   [#2192](https://github.com/raullenchai/Rapid-MLX/pull/2192),
   [#2204](https://github.com/raullenchai/Rapid-MLX/pull/2204))


### PR DESCRIPTION
## Rationale

The published Desktop changelog incorrectly described Nemotron Labs Diffusion 3B as an image-generation model. Rapid-MLX supports its autoregressive language-model path and serves it as a standard text model. The incorrect wording is already visible in the Desktop update dialog, so this PR corrects both the consolidated stable section and the rc1 source wording.

## Review contract

- **User-visible goal:** make the shipped 0.13.0 model description technically accurate.
- **Allowed scope:** the affected stable and rc1 release-note sentences only.
- **Non-goals:** model behavior, catalog entries, product code, artifacts, tags, workflows, or unrelated release-note edits.
- **Acceptance:** no affected release text claims Nemotron Labs Diffusion 3B generates images; the wording agrees with the existing stable engine release note and #2194's text-lane contract.

## Validation

- Incorrect-claim exact-string sweep — passed
- `bash tests/release/test_build_release_notes.sh` — 63 passed
- `git diff --check` — passed
- Published `rapid-mac-v0.13.0` body synchronized; `v0.13.0` was already correct and was not changed
