### PR TITLE
fix(mac): keep failed photo turns from poisoning later chat

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -126,6 +126,24 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         case transcriptOnly
     }
 
+    /// Whether an image-bearing user turn was accepted by the model lane.
+    /// Stored on the user turn because empty failed assistant rows are omitted
+    /// from later wire history, while a rejected image must not poison every
+    /// subsequent plain-text follow-up. A direct Retry still sends the image.
+    enum ImageDeliveryStatus: String, Codable, Sendable {
+        case pending
+        case accepted
+        case rejected
+
+        /// A newer outcome must fail closed for attachment inheritance rather
+        /// than make one message undecodable and side the whole conversation
+        /// as corrupt. The image remains visible and directly retryable.
+        init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            self = ImageDeliveryStatus(rawValue: raw) ?? .rejected
+        }
+    }
+
     /// Messages written before ``wireVisibility`` shipped need one narrow
     /// migration: Quickstart's product-authored welcome was persisted as an
     /// ordinary assistant turn. Match only the two stable Rapid copy shapes;
@@ -148,6 +166,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// render it in a collapsed disclosure block.
     var content: String
     var imageAttachments: [ChatImageAttachment]
+    var imageDeliveryStatus: ImageDeliveryStatus?
     /// Locally extracted document text. Kept separate from ``content`` so a
     /// multi-page source does not flood the transcript or copied user prose.
     var fileAttachments: [ChatFileAttachment]
@@ -295,6 +314,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         role: Role,
         content: String = "",
         imageAttachments: [ChatImageAttachment] = [],
+        imageDeliveryStatus: ImageDeliveryStatus? = nil,
         fileAttachments: [ChatFileAttachment] = [],
         reasoning: String = "",
         status: Status = .complete,
@@ -315,6 +335,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.role = role
         self.content = content
         self.imageAttachments = imageAttachments
+        self.imageDeliveryStatus = imageDeliveryStatus
         self.fileAttachments = fileAttachments
         self.reasoning = reasoning
         self.status = status
@@ -339,7 +360,8 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// for that one key and defers all other fields to the standard
     /// container shape.
     enum CodingKeys: String, CodingKey {
-        case id, role, content, imageAttachments, fileAttachments, reasoning, status
+        case id, role, content, imageAttachments, imageDeliveryStatus
+        case fileAttachments, reasoning, status
         case errorMessage, failureKind, toolCalls, toolCallID
         case stats, reasoningTruncated, contentTruncated
         case toolNotCalledFlagged
@@ -375,6 +397,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         try c.encode(role, forKey: .role)
         try c.encode(content, forKey: .content)
         try c.encode(imageAttachments, forKey: .imageAttachments)
+        try c.encodeIfPresent(imageDeliveryStatus, forKey: .imageDeliveryStatus)
         try c.encode(fileAttachments, forKey: .fileAttachments)
         try c.encode(reasoning, forKey: .reasoning)
         try c.encode(status, forKey: .status)
@@ -403,6 +426,10 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.role = try c.decode(Role.self, forKey: .role)
         self.content = try c.decode(String.self, forKey: .content)
         self.imageAttachments = try c.decodeIfPresent([ChatImageAttachment].self, forKey: .imageAttachments) ?? []
+        self.imageDeliveryStatus = try c.decodeIfPresent(
+            ImageDeliveryStatus.self,
+            forKey: .imageDeliveryStatus
+        )
         self.fileAttachments = try c.decodeIfPresent([ChatFileAttachment].self, forKey: .fileAttachments) ?? []
         self.reasoning = try c.decode(String.self, forKey: .reasoning)
         self.status = try c.decode(Status.self, forKey: .status)

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -143,6 +143,8 @@ struct ChatStreamClient {
     struct Request: Sendable {
         let alias: String
         let messages: [Wire.Message]
+        /// Local identity only; never encoded into the API request.
+        let imageMessageID: UUID?
         let temperature: Double
         let topP: Double
         let maxTokens: Int
@@ -203,7 +205,9 @@ struct ChatStreamClient {
                             && (!$0.imageAttachments.isEmpty || !$0.fileAttachments.isEmpty)
                     })
                     if let attachmentTurn,
-                        !modelMessages[attachmentTurn].imageAttachments.isEmpty
+                        !modelMessages[attachmentTurn].imageAttachments.isEmpty,
+                        modelMessages[attachmentTurn].imageDeliveryStatus == nil
+                            || modelMessages[attachmentTurn].imageDeliveryStatus == .accepted
                     {
                         imageMessageIndex = attachmentTurn
                     } else {
@@ -211,6 +215,7 @@ struct ChatStreamClient {
                     }
                 }
             }
+            self.imageMessageID = imageMessageIndex.map { modelMessages[$0].id }
             self.messages = modelMessages.enumerated().map { index, message in
                 Wire.Message(from: message, includeImages: index == imageMessageIndex)
             }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -799,6 +799,22 @@ enum ChatStreamError: LocalizedError {
             return "rapid-mlx closed the stream mid-response (likely a crash). Restart the server and resend."
         }
     }
+
+    /// The standard error envelope is the server's public, user-facing reason
+    /// for the exact attachment request that failed. Bare bodies and HTML are
+    /// still diagnostics only and must not leak into the transcript.
+    var attachmentFailureMessage: String? {
+        guard case .httpStatus(let code, let body) = self,
+              (400..<600).contains(code),
+              let data = body.data(using: .utf8),
+              let envelope = try? JSONDecoder().decode(Wire.ErrorEnvelope.self, from: data),
+              let message = envelope.error.message?.trimmingCharacters(
+                in: .whitespacesAndNewlines
+              ),
+              !message.isEmpty
+        else { return nil }
+        return message
+    }
 }
 
 /// On-the-wire shapes. Kept inside ``ChatStreamClient`` so the rest of

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -800,14 +800,16 @@ enum ChatStreamError: LocalizedError {
         }
     }
 
-    /// The standard error envelope is the server's public, user-facing reason
-    /// for the exact attachment request that failed. Bare bodies and HTML are
-    /// still diagnostics only and must not leak into the transcript.
+    /// Only the typed image-rejection contract is safe, user-facing copy.
+    /// Other structured 4xx/5xx envelopes may contain operational details and
+    /// must continue through the normal actionable-error diagnosis.
     var attachmentFailureMessage: String? {
         guard case .httpStatus(let code, let body) = self,
               (400..<600).contains(code),
               let data = body.data(using: .utf8),
               let envelope = try? JSONDecoder().decode(Wire.ErrorEnvelope.self, from: data),
+              envelope.error.type == "invalid_request_error",
+              envelope.error.code == "image_input_unsupported",
               let message = envelope.error.message?.trimmingCharacters(
                 in: .whitespacesAndNewlines
               ),

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -684,6 +684,36 @@ final class ChatViewModel {
         return messages[index]
     }
 
+    /// Persist attachment acceptance on the user turn itself. Failed empty
+    /// assistant placeholders are intentionally removed from later wire
+    /// history, so they cannot safely own this focus state.
+    private func setImageDeliveryStatus(
+        messageID: UUID?,
+        status: ChatMessage.ImageDeliveryStatus,
+        epoch: Int
+    ) {
+        guard epoch == conversationEpoch else { return }
+        Self.updateImageDeliveryStatus(
+            in: &messages,
+            messageID: messageID,
+            status: status
+        )
+    }
+
+    /// Pure state-layer seam for the request lifecycle. Matching by persisted
+    /// message identity prevents a late response from changing a newer image
+    /// turn after conversation branching or editing.
+    static func updateImageDeliveryStatus(
+        in messages: inout [ChatMessage],
+        messageID: UUID?,
+        status: ChatMessage.ImageDeliveryStatus
+    ) {
+        guard let messageID,
+              let index = messages.firstIndex(where: { $0.id == messageID })
+        else { return }
+        messages[index].imageDeliveryStatus = status
+    }
+
     /// Start a fresh conversation — drops the transcript and any stale
     /// error banner. The in-flight stream (if any) is cancelled first.
     func newConversation() {
@@ -767,6 +797,7 @@ final class ChatViewModel {
             role: .user,
             content: trimmed,
             imageAttachments: imageAttachments,
+            imageDeliveryStatus: imageAttachments.isEmpty ? nil : .pending,
             fileAttachments: ChatFileAttachment.fittedForMessage(fileAttachments),
             status: .complete
         )
@@ -2551,6 +2582,11 @@ Your previous draft refused the question by claiming you lack real-time access o
                 guard let self else { return }
                 switch event {
                 case .firstToken(let at):
+                    self.setImageDeliveryStatus(
+                        messageID: request.imageMessageID,
+                        status: .accepted,
+                        epoch: epoch
+                    )
                     // The stream says the first generated token landed, on
                     // whichever lane carried it. Stamping per-lane here
                     // instead would miss a turn that opens with a tool-call
@@ -2584,6 +2620,11 @@ Your previous draft refused the question by claiming you lack real-time access o
                     capturedPromptTokens = prompt
                     capturedCompletionTokens = completion
                 case .finished(let reason):
+                    self.setImageDeliveryStatus(
+                        messageID: request.imageMessageID,
+                        status: .accepted,
+                        epoch: epoch
+                    )
                     capturedFinish = reason
                     current.status = .complete
                     // v0.4.35 + cycle-2 (2026-06-19): classify the
@@ -2763,6 +2804,11 @@ Your previous draft refused the question by claiming you lack real-time access o
             }
             return .terminal
         } catch {
+            setImageDeliveryStatus(
+                messageID: request.imageMessageID,
+                status: .rejected,
+                epoch: epoch
+            )
             current.status = .failed
             // Raw error → log for support; the user only ever sees
             // humanize()'s clean, jargon-free copy.

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -818,7 +818,8 @@ final class ChatViewModel {
             ?? ModelBrandStyle.supportsImageInput(forAlias: alias)
         beginAssistantTurn(
             alias: alias,
-            supportsImageInput: resolvedImageCapability
+            supportsImageInput: resolvedImageCapability,
+            imageMessageID: imageAttachments.isEmpty ? nil : user.id
         )
     }
 
@@ -833,7 +834,8 @@ final class ChatViewModel {
     /// see the two answers as alternatives at all.
     private func beginAssistantTurn(
         alias: String,
-        supportsImageInput: Bool
+        supportsImageInput: Bool,
+        imageMessageID: UUID? = nil
     ) {
         let placeholder = ChatMessage(role: .assistant, status: .streaming)
         let placeholderIndex = appendMessage(placeholder)
@@ -873,20 +875,29 @@ final class ChatViewModel {
                 // returns `ready == true`, yet must still not stream and
                 // must still reset `isStreaming`.
                 guard !Task.isCancelled else {
-                    finishStartupCancellation(placeholderIndex: placeholderIndex, epoch: epoch)
+                    finishStartupCancellation(
+                        placeholderIndex: placeholderIndex,
+                        imageMessageID: imageMessageID,
+                        epoch: epoch
+                    )
                     return
                 }
                 guard ready else {
                     finishWithStartupFailure(
                         placeholderIndex: placeholderIndex,
                         alias: alias,
+                        imageMessageID: imageMessageID,
                         epoch: epoch
                     )
                     return
                 }
             }
             guard !Task.isCancelled else {
-                finishStartupCancellation(placeholderIndex: placeholderIndex, epoch: epoch)
+                finishStartupCancellation(
+                    placeholderIndex: placeholderIndex,
+                    imageMessageID: imageMessageID,
+                    epoch: epoch
+                )
                 return
             }
 
@@ -975,9 +986,15 @@ final class ChatViewModel {
     func finishWithStartupFailure(
         placeholderIndex: Int,
         alias: String,
+        imageMessageID: UUID? = nil,
         epoch: Int? = nil
     ) {
         if let epoch, epoch != conversationEpoch { return }
+        setImageDeliveryStatus(
+            messageID: imageMessageID,
+            status: nil,
+            epoch: conversationEpoch
+        )
         let message = "Couldn't start \(alias). Try again, or pick a different model in the box below."
         if var placeholder = currentMessage(index: placeholderIndex) {
             placeholder.status = .failed
@@ -1019,9 +1036,15 @@ final class ChatViewModel {
     /// ``finaliseCancellation``.
     func finishStartupCancellation(
         placeholderIndex: Int,
+        imageMessageID: UUID? = nil,
         epoch: Int? = nil
     ) {
         if let epoch, epoch != conversationEpoch { return }
+        setImageDeliveryStatus(
+            messageID: imageMessageID,
+            status: nil,
+            epoch: conversationEpoch
+        )
         if var placeholder = currentMessage(index: placeholderIndex) {
             Self.finaliseCancellation(message: &placeholder)
             updateMessage(at: placeholderIndex, with: placeholder)

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -2814,7 +2814,10 @@ Your previous draft refused the question by claiming you lack real-time access o
             // humanize()'s clean, jargon-free copy.
             print("[chat] stream failed: \(error.localizedDescription)")
             let failureKind = FailureDiagnoser.chatFailureKind(error: error)
-            let actionable = FailureDiagnoser.diagnosis(
+            let imageRejection = request.imageMessageID == nil
+                ? nil
+                : (error as? ChatStreamError)?.attachmentFailureMessage
+            let actionable = imageRejection ?? FailureDiagnoser.diagnosis(
                 for: failureKind,
                 modelAlias: request.alias
             ).message

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -711,6 +711,13 @@ final class ChatViewModel {
         guard let messageID,
               let index = messages.firstIndex(where: { $0.id == messageID })
         else { return }
+        // Acceptance is monotonic for one request: once the server emits a
+        // token, a later transport failure means the response was interrupted,
+        // not that the image was rejected. An explicit retry may still move a
+        // previously rejected image to accepted when its own first token lands.
+        if messages[index].imageDeliveryStatus == .accepted, status == .rejected {
+            return
+        }
         messages[index].imageDeliveryStatus = status
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -689,7 +689,7 @@ final class ChatViewModel {
     /// history, so they cannot safely own this focus state.
     private func setImageDeliveryStatus(
         messageID: UUID?,
-        status: ChatMessage.ImageDeliveryStatus,
+        status: ChatMessage.ImageDeliveryStatus?,
         epoch: Int
     ) {
         guard epoch == conversationEpoch else { return }
@@ -706,7 +706,7 @@ final class ChatViewModel {
     static func updateImageDeliveryStatus(
         in messages: inout [ChatMessage],
         messageID: UUID?,
-        status: ChatMessage.ImageDeliveryStatus
+        status: ChatMessage.ImageDeliveryStatus?
     ) {
         guard let messageID,
               let index = messages.firstIndex(where: { $0.id == messageID })
@@ -715,7 +715,7 @@ final class ChatViewModel {
         // token, a later transport failure means the response was interrupted,
         // not that the image was rejected. An explicit retry may still move a
         // previously rejected image to accepted when its own first token lands.
-        if messages[index].imageDeliveryStatus == .accepted, status == .rejected {
+        if messages[index].imageDeliveryStatus == .accepted, status != .accepted {
             return
         }
         messages[index].imageDeliveryStatus = status
@@ -2811,9 +2811,15 @@ Your previous draft refused the question by claiming you lack real-time access o
             }
             return .terminal
         } catch {
+            let imageRejection = request.imageMessageID == nil
+                ? nil
+                : (error as? ChatStreamError)?.attachmentFailureMessage
             setImageDeliveryStatus(
                 messageID: request.imageMessageID,
-                status: .rejected,
+                // A transient transport/busy/runtime failure does not prove
+                // the attachment was unsupported. Return it to the legacy
+                // unknown state so a later plain follow-up can retry it.
+                status: imageRejection == nil ? nil : .rejected,
                 epoch: epoch
             )
             current.status = .failed
@@ -2821,9 +2827,6 @@ Your previous draft refused the question by claiming you lack real-time access o
             // humanize()'s clean, jargon-free copy.
             print("[chat] stream failed: \(error.localizedDescription)")
             let failureKind = FailureDiagnoser.chatFailureKind(error: error)
-            let imageRejection = request.imageMessageID == nil
-                ? nil
-                : (error as? ChatStreamError)?.attachmentFailureMessage
             let actionable = imageRejection ?? FailureDiagnoser.diagnosis(
                 for: failureKind,
                 modelAlias: request.alias

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -421,6 +421,7 @@ struct RapidApp: App {
                     // fetch so a chat send during an alias swap can't bump
                     // ``max_tokens`` for the wrong alias.
                     sampling.clearActiveReasoningParser()
+                    server.clearActiveModelProfile()
                     guard let alias = server.servingAlias else { return }
                     let baseURL = ChatStreamClient.loopbackURL(port: server.activePort)
                     let bearer = server.activeBearer
@@ -433,6 +434,7 @@ struct RapidApp: App {
                     }
                     guard !Task.isCancelled,
                           server.servingAlias == alias else { return }
+                    server.applyActiveModelProfile(profile, forAlias: alias)
                     sampling.applyServerProfile(profile)
                 }
                 .task {

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -421,7 +421,6 @@ struct RapidApp: App {
                     // fetch so a chat send during an alias swap can't bump
                     // ``max_tokens`` for the wrong alias.
                     sampling.clearActiveReasoningParser()
-                    server.clearActiveModelProfile()
                     guard let alias = server.servingAlias else { return }
                     let baseURL = ChatStreamClient.loopbackURL(port: server.activePort)
                     let bearer = server.activeBearer
@@ -434,7 +433,6 @@ struct RapidApp: App {
                     }
                     guard !Task.isCancelled,
                           server.servingAlias == alias else { return }
-                    server.applyActiveModelProfile(profile, forAlias: alias)
                     sampling.applyServerProfile(profile)
                 }
                 .task {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -655,7 +655,7 @@ final class ServerManager {
     }
 
     func applyActiveModelProfile(_ profile: ServerModelProfile, forAlias alias: String) {
-        guard servingAlias?.caseInsensitiveCompare(alias) == .orderedSame,
+        guard isModelResident(alias),
               profile.id.caseInsensitiveCompare(alias) == .orderedSame
         else { return }
         activeModelProfile = profile

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -654,6 +654,14 @@ final class ServerManager {
         activeModelProfile = nil
     }
 
+    /// Publish or retire one sidecar session as a unit. Model profiles belong
+    /// to the bearer-authenticated process that returned them and must never
+    /// survive a process replacement on the same alias and port.
+    private func setActiveServerSession(bearer: String?) {
+        activeBearer = bearer
+        activeModelProfile = nil
+    }
+
     func applyActiveModelProfile(_ profile: ServerModelProfile, forAlias alias: String) {
         guard isModelResident(alias),
               profile.id.caseInsensitiveCompare(alias) == .orderedSame
@@ -2321,7 +2329,7 @@ final class ServerManager {
         self.launchedPerformanceFlags = performanceFlags
         // Codex r1 P3 (#17): only publish the bearer after the spawn
         // has succeeded — see comment at the bearer guard above.
-        self.activeBearer = bearer
+        setActiveServerSession(bearer: bearer)
         self.stdoutPipe = stdoutPipe
         self.stderrPipe = stderrPipe
         // #20: persist ownership before startMonitor() so a crash
@@ -2588,7 +2596,7 @@ final class ServerManager {
         // post-stop chat request can't slip through with a stale
         // secret targeting whatever happens to bind the port next.
         // (#1035: the nil transition evicts cached MCP tools via didSet.)
-        activeBearer = nil
+        setActiveServerSession(bearer: nil)
         // Issue #278: honour the "readyAt cleared on every child
         // exit" invariant in shutdownSync too (parallel to the
         // terminateChild defensive teardown). App-termination only,
@@ -2675,7 +2683,7 @@ final class ServerManager {
             launchedImageInputLane = nil
             // #17: see shutdownSync — bearer is dead the moment the
             // child is.
-            activeBearer = nil
+            setActiveServerSession(bearer: nil)
             startedAt = nil
             // Issue #278: defensive teardown also has to honour the
             // "readyAt cleared on every child exit" invariant in
@@ -2746,7 +2754,7 @@ final class ServerManager {
         launchedImageInputLane = nil
         // #17: the child owns the secret; the secret is meaningless
         // (and a leak vector) once the child is gone.
-        activeBearer = nil
+        setActiveServerSession(bearer: nil)
         startedAt = nil
         // Issue #278: snapshot + window-gate the auto-respawn budget
         // reset, then clear ``readyAt``. The wasExpected-stop branch

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -646,6 +646,20 @@ final class ServerManager {
     /// Process-wide lane captured at spawn. Nil means there is no live child;
     /// UI capability must observe this value rather than the process handle.
     private(set) var launchedImageInputLane: Bool?
+    /// Exact live `/v1/models/{alias}` profile. Consumers require its id to
+    /// match the current alias, so a profile can never lag one model behind.
+    private(set) var activeModelProfile: ServerModelProfile?
+
+    func clearActiveModelProfile() {
+        activeModelProfile = nil
+    }
+
+    func applyActiveModelProfile(_ profile: ServerModelProfile, forAlias alias: String) {
+        guard servingAlias?.caseInsensitiveCompare(alias) == .orderedSame,
+              profile.id.caseInsensitiveCompare(alias) == .orderedSame
+        else { return }
+        activeModelProfile = profile
+    }
 
     func hasAppliedSpeculativeDecoding(forAlias alias: String) -> Bool {
         guard child != nil,
@@ -3428,16 +3442,33 @@ final class ServerManager {
         forAlias alias: String,
         catalogSupportsImageInput: Bool? = nil
     ) -> Bool {
+        imageInputAvailability(
+            forAlias: alias,
+            catalogSupportsImageInput: catalogSupportsImageInput
+        ).isAvailable
+    }
+
+    internal func imageInputAvailability(
+        forAlias alias: String,
+        catalogSupportsImageInput: Bool? = nil
+    ) -> ImageInputAvailability {
         let catalogCapability = catalogSupportsImageInput
             ?? ModelCatalogCache.supportsImageInput(forAlias: alias, binary: binaryPath)
         let safeOverrides = Self.imageSafePerformanceOverrides(
             catalogSupportsImageInput: catalogCapability,
             userOverrides: perfLaunchFlagsProvider?(alias) ?? []
         )
-        return Self.effectiveRunningImageCapability(
+        let fallback = Self.effectiveRunningImageCapability(
             catalogSupportsImageInput: catalogCapability,
             userOverrides: safeOverrides,
             processLaunchFlags: launchedImageInputLane.map { $0 ? ["--mllm"] : [] }
+        )
+        let profile = activeModelProfile.flatMap {
+            $0.id.caseInsensitiveCompare(alias) == .orderedSame ? $0 : nil
+        }
+        return ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: fallback,
+            profile: profile
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
@@ -54,6 +54,13 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
     /// the alias without grepping server logs.
     let toolCallParser: String?
     let reasoningParser: String?
+    /// Live request capabilities for this exact served id. `nil` means an
+    /// older sidecar omitted the field; an empty array is authoritative.
+    let capabilities: [String]?
+    /// Live lane selected by the engine (`text` or `vision`) and the stable
+    /// machine-readable reason for that decision.
+    let servingLane: String?
+    let servingLaneReason: String?
     /// Inference modality from ``AliasProfile.modality``. Today
     /// only ``"text"`` and ``"text-diffusion"`` are populated by
     /// the server; ``"vision"`` / ``"image-gen"`` are reserved
@@ -95,6 +102,9 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         case isMoe = "is_moe"
         case toolCallParser = "tool_call_parser"
         case reasoningParser = "reasoning_parser"
+        case capabilities
+        case servingLane = "serving_lane"
+        case servingLaneReason = "serving_lane_reason"
         case modality
         // FU-3 — snake_case wire shape matches the rapid-mlx
         // ``AliasProfile`` JSON contract (per-alias SSOT).
@@ -118,6 +128,9 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         isMoe: Bool? = nil,
         toolCallParser: String? = nil,
         reasoningParser: String? = nil,
+        capabilities: [String]? = nil,
+        servingLane: String? = nil,
+        servingLaneReason: String? = nil,
         modality: String? = nil,
         reasoningChatFloor: Int? = nil,
         reasoningToolsFloor: Int? = nil,
@@ -129,10 +142,62 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         self.isMoe = isMoe
         self.toolCallParser = toolCallParser
         self.reasoningParser = reasoningParser
+        self.capabilities = capabilities
+        self.servingLane = servingLane
+        self.servingLaneReason = servingLaneReason
         self.modality = modality
         self.reasoningChatFloor = reasoningChatFloor
         self.reasoningToolsFloor = reasoningToolsFloor
         self.contextWindow = contextWindow
+    }
+}
+
+/// Resolved photo-input contract for the composer and request builder. Runtime
+/// fields win when present; the catalog/launch fallback keeps compatibility
+/// with sidecars that predate live lane reporting.
+struct ImageInputAvailability: Equatable, Sendable {
+    let isAvailable: Bool
+    let unavailableMessage: String?
+
+    static func resolve(
+        fallbackSupportsImageInput: Bool,
+        profile: ServerModelProfile?
+    ) -> ImageInputAvailability {
+        guard let profile,
+              profile.servingLane != nil || profile.capabilities != nil
+        else {
+            return ImageInputAvailability(
+                isAvailable: fallbackSupportsImageInput,
+                unavailableMessage: fallbackSupportsImageInput
+                    ? nil
+                    : "This model doesn't support photos. Choose a vision-capable model to add one."
+            )
+        }
+
+        let supportsVision = profile.capabilities?.contains("vision")
+            ?? (profile.servingLane == "vision")
+        let isVisionLane = profile.servingLane.map { $0 == "vision" } ?? supportsVision
+        guard supportsVision && isVisionLane else {
+            return ImageInputAvailability(
+                isAvailable: false,
+                unavailableMessage: message(for: profile.servingLaneReason)
+            )
+        }
+        return ImageInputAvailability(isAvailable: true, unavailableMessage: nil)
+    }
+
+    private static func message(for laneReason: String?) -> String {
+        switch laneReason {
+        case "operator_forced_text":
+            return "This model is running text-only because of its current settings. Photos need a vision-capable model."
+        case "vision_architecture_unavailable", "vision_hybrid_cache_unsupported",
+             "vision_weights_unavailable":
+            return "This model is running text-only because its vision features aren't available. Choose a vision-capable model to add photos."
+        case "text_checkpoint":
+            return "This model doesn't support photos. Choose a vision-capable model to add one."
+        default:
+            return "This model is running text-only. Photos need a vision-capable model."
+        }
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -194,6 +194,10 @@ struct ChatView: View {
     var readiness: ModelReadiness
     /// Catalog-backed capability shared with launch and request encoding.
     var supportsImageInput: Bool = false
+    /// Runtime-backed explanation shown for every attach path when photos are
+    /// unavailable. Kept alongside the Boolean so mouse, keyboard, paste,
+    /// drag/drop, and VoiceOver all present the same contract.
+    var imageInputUnavailableMessage: String? = nil
     /// First launch must not inspect model caches behind the consent sheet.
     /// The parent flips this after the user makes that one-time decision.
     var catalogRefreshEnabled: Bool = true
@@ -722,7 +726,11 @@ struct ChatView: View {
                     .help(
                         supportsImageInput
                             ? "Upload photo"
-                            : "Current model doesn't support photos"
+                            : imageInputUnavailableMessage
+                                ?? "Current model doesn't support photos"
+                    )
+                    .accessibilityHint(
+                        supportsImageInput ? "" : imageInputUnavailableMessage ?? ""
                     )
                     .accessibilityIdentifier("ChatView.Attachments.UploadPhoto")
                 }
@@ -1121,7 +1129,8 @@ struct ChatView: View {
     }
 
     private func rejectImageInputForCurrentModel() {
-        attachmentDraft.notice = "\(alias) doesn't support image input. Choose a vision model to add photos."
+        attachmentDraft.notice = imageInputUnavailableMessage
+            ?? "This model doesn't support photos. Choose a vision-capable model to add one."
         VoiceOverAnnouncer.announce(attachmentDraft.notice ?? "This model doesn't support images.")
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -294,12 +294,41 @@ struct ContentView: View {
             guard !telemetryConsentPending else { return }
             await refreshCatalogSnapshot()
         }
+        // The selected chat alias may be a secondary resident model rather
+        // than the process-owning `servingAlias`. Fetch its exact live profile
+        // whenever that selection becomes resident so photo admission follows
+        // the lane that will actually receive the request.
+        .task(id: SelectedModelProfileKey(
+            alias: alias,
+            isResident: server.isModelResident(alias),
+            port: server.activePort
+        )) {
+            let requestedAlias = alias
+            server.clearActiveModelProfile()
+            guard server.isModelResident(requestedAlias) else { return }
+            let profile = await ServerProfileFetcher.fetch(
+                baseURL: ChatStreamClient.loopbackURL(port: server.activePort),
+                alias: requestedAlias,
+                bearer: server.activeBearer
+            )
+            guard !Task.isCancelled,
+                  alias == requestedAlias,
+                  server.isModelResident(requestedAlias),
+                  let profile else { return }
+            server.applyActiveModelProfile(profile, forAlias: requestedAlias)
+        }
         .task {
             while !Task.isCancelled {
                 await server.refreshResidency()
                 try? await Task.sleep(for: .seconds(5))
             }
         }
+    }
+
+    private struct SelectedModelProfileKey: Equatable {
+        let alias: String
+        let isResident: Bool
+        let port: Int
     }
 
     /// First-run setup, filling the window (Paper 05.1.A).

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -784,12 +784,14 @@ struct ContentView: View {
     private var mainArea: some View {
         switch ContentView.mainAreaBranch(for: server.state) {
         case .chat:
+            let imageAvailability = imageInputAvailability(for: alias)
             ChatView(
                 viewModel: chat,
                 server: server,
                 alias: $alias,
                 readiness: readiness,
-                supportsImageInput: supportsImageInput(for: alias),
+                supportsImageInput: imageAvailability.isAvailable,
+                imageInputUnavailableMessage: imageAvailability.unavailableMessage,
                 catalogRefreshEnabled: !telemetryConsentPending,
                 onUserModelSelection: selectChatModel,
                 onReadinessAction: performReadinessAction,
@@ -800,7 +802,7 @@ struct ContentView: View {
         }
     }
 
-    private func supportsImageInput(for alias: String) -> Bool {
+    private func imageInputAvailability(for alias: String) -> ImageInputAvailability {
         let entry = catalogEntries.first {
             $0.alias.caseInsensitiveCompare(alias) == .orderedSame
         }
@@ -809,7 +811,7 @@ struct ContentView: View {
             isBuiltinProfile: entry?.isBuiltinProfile,
             isTextOnly: entry?.isTextOnly
         )
-        return server.supportsImageInput(
+        return server.imageInputAvailability(
             forAlias: alias,
             catalogSupportsImageInput: catalogSupportsImageInput
         )

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -306,24 +306,40 @@ struct ContentView: View {
         )) {
             let requestedAlias = alias
             server.clearActiveModelProfile()
-            guard server.isModelResident(requestedAlias) else { return }
-            let profile = await ServerProfileFetcher.fetch(
-                baseURL: ChatStreamClient.loopbackURL(port: server.activePort),
-                alias: requestedAlias,
-                bearer: server.activeBearer
-            )
-            guard !Task.isCancelled,
-                  alias == requestedAlias,
-                  server.isModelResident(requestedAlias),
-                  let profile else { return }
-            server.applyActiveModelProfile(profile, forAlias: requestedAlias)
+            await refreshSelectedModelProfile(for: requestedAlias)
         }
         .task {
             while !Task.isCancelled {
                 await server.refreshResidency()
                 try? await Task.sleep(for: .seconds(5))
+                guard !Task.isCancelled else { return }
+                // Reuse the existing local residency cadence as recovery for
+                // a transient profile timeout/non-2xx. A successful profile
+                // remains authoritative for this bearer session; only a
+                // missing/mismatched profile needs another request.
+                if server.activeModelProfile?.id.caseInsensitiveCompare(alias) != .orderedSame {
+                    await refreshSelectedModelProfile(for: alias)
+                }
             }
         }
+    }
+
+    private func refreshSelectedModelProfile(for requestedAlias: String) async {
+        guard server.isModelResident(requestedAlias) else { return }
+        let requestedPort = server.activePort
+        let requestedBearer = server.activeBearer
+        let profile = await ServerProfileFetcher.fetch(
+            baseURL: ChatStreamClient.loopbackURL(port: requestedPort),
+            alias: requestedAlias,
+            bearer: requestedBearer
+        )
+        guard !Task.isCancelled,
+              alias == requestedAlias,
+              server.activePort == requestedPort,
+              server.activeBearer == requestedBearer,
+              server.isModelResident(requestedAlias),
+              let profile else { return }
+        server.applyActiveModelProfile(profile, forAlias: requestedAlias)
     }
 
     /// First-run setup, filling the window (Paper 05.1.A).

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -301,7 +301,8 @@ struct ContentView: View {
         .task(id: SelectedModelProfileKey(
             alias: alias,
             isResident: server.isModelResident(alias),
-            port: server.activePort
+            port: server.activePort,
+            bearer: server.activeBearer
         )) {
             let requestedAlias = alias
             server.clearActiveModelProfile()
@@ -323,12 +324,6 @@ struct ContentView: View {
                 try? await Task.sleep(for: .seconds(5))
             }
         }
-    }
-
-    private struct SelectedModelProfileKey: Equatable {
-        let alias: String
-        let isResident: Bool
-        let port: Int
     }
 
     /// First-run setup, filling the window (Paper 05.1.A).
@@ -1472,6 +1467,16 @@ struct ContentView: View {
             return .chat
         }
     }
+}
+
+/// Identity of the exact live server session whose selected-model profile is
+/// shown by the composer. A fresh sidecar rotates its bearer even when it
+/// reuses the same alias and port, so capability state must be fetched again.
+struct SelectedModelProfileKey: Equatable {
+    let alias: String
+    let isResident: Bool
+    let port: Int
+    let bearer: String?
 }
 
 /// Approval dialog for the ``browse`` tool: present while a request is

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -241,6 +241,21 @@ struct ChatImageAttachmentTests {
         #expect(messages[0].imageDeliveryStatus == .accepted)
     }
 
+    @Test("transient pre-token failure leaves an image eligible for a later follow-up")
+    @MainActor
+    func transientFailureRestoresUnknownDelivery() {
+        let id = UUID()
+        var messages = [
+            ChatMessage(id: id, role: .user, imageDeliveryStatus: .pending)
+        ]
+
+        ChatViewModel.updateImageDeliveryStatus(
+            in: &messages, messageID: id, status: nil
+        )
+
+        #expect(messages[0].imageDeliveryStatus == nil)
+    }
+
     @Test("plain-text follow-up after a document does not resurrect an older image")
     func documentFollowUpKeepsDocumentFocus() throws {
         let image = try ChatImageAttachment(

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -137,6 +137,87 @@ struct ChatImageAttachmentTests {
         #expect(wire.contains(second.data.base64EncodedString()))
     }
 
+    @Test("plain-text follow-up never inherits an image rejected by an earlier request")
+    @MainActor
+    func followUpDoesNotInheritRejectedImage() throws {
+        let image = try ChatImageAttachment(
+            filename: "photo.png", mimeType: "image/png", data: Data("photo".utf8)
+        )
+        let history = ChatViewModel.filterEmptyAssistantsForWire([
+            ChatMessage(
+                role: .user,
+                content: "Describe this",
+                imageAttachments: [image],
+                imageDeliveryStatus: .rejected
+            ),
+            ChatMessage(
+                role: .assistant,
+                status: .failed,
+                errorMessage: "This model is running text-only."
+            ),
+            ChatMessage(role: .user, content: "hi"),
+        ])
+        let request = ChatStreamClient.Request(
+            alias: "vision-model",
+            messages: history,
+            supportsImageInput: true
+        )
+
+        let wire = String(decoding: try JSONEncoder().encode(request.messages), as: UTF8.self)
+        #expect(!wire.contains("data:image/"))
+        #expect(wire.contains("\"hi\""))
+    }
+
+    @Test("retrying a rejected image turn sends that image again")
+    func directRetryIncludesRejectedImage() throws {
+        let image = try ChatImageAttachment(
+            filename: "photo.png", mimeType: "image/png", data: Data("photo".utf8)
+        )
+        let request = ChatStreamClient.Request(
+            alias: "vision-model",
+            messages: [
+                ChatMessage(
+                    role: .user,
+                    content: "Describe this",
+                    imageAttachments: [image],
+                    imageDeliveryStatus: .rejected
+                )
+            ],
+            supportsImageInput: true
+        )
+
+        let wire = String(decoding: try JSONEncoder().encode(request.messages), as: UTF8.self)
+        #expect(wire.contains(image.data.base64EncodedString()))
+    }
+
+    @Test("request outcome updates only its exact persisted image turn")
+    @MainActor
+    func deliveryOutcomeUsesMessageIdentity() throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        var messages = [
+            ChatMessage(
+                id: firstID,
+                role: .user,
+                imageDeliveryStatus: .pending
+            ),
+            ChatMessage(
+                id: secondID,
+                role: .user,
+                imageDeliveryStatus: .pending
+            ),
+        ]
+
+        ChatViewModel.updateImageDeliveryStatus(
+            in: &messages,
+            messageID: firstID,
+            status: .rejected
+        )
+
+        #expect(messages[0].imageDeliveryStatus == .rejected)
+        #expect(messages[1].imageDeliveryStatus == .pending)
+    }
+
     @Test("plain-text follow-up after a document does not resurrect an older image")
     func documentFollowUpKeepsDocumentFocus() throws {
         let image = try ChatImageAttachment(
@@ -182,6 +263,41 @@ struct ChatImageAttachmentTests {
         object.removeValue(forKey: "imageAttachments")
         let legacyData = try JSONSerialization.data(withJSONObject: object)
         #expect(try JSONDecoder().decode(ChatMessage.self, from: legacyData).imageAttachments.isEmpty)
+    }
+
+    @Test("image delivery outcome persists and legacy turns remain follow-up compatible")
+    func deliveryOutcomeCodableCompatibility() throws {
+        let attachment = try ChatImageAttachment(
+            filename: "photo.jpg", mimeType: "image/jpeg", data: Data([1, 2, 3])
+        )
+        let rejected = ChatMessage(
+            role: .user,
+            content: "look",
+            imageAttachments: [attachment],
+            imageDeliveryStatus: .rejected
+        )
+        let restored = try JSONDecoder().decode(
+            ChatMessage.self,
+            from: JSONEncoder().encode(rejected)
+        )
+        #expect(restored.imageDeliveryStatus == .rejected)
+
+        var legacyObject = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(rejected)) as? [String: Any]
+        )
+        legacyObject.removeValue(forKey: "imageDeliveryStatus")
+        let legacy = try JSONDecoder().decode(
+            ChatMessage.self,
+            from: JSONSerialization.data(withJSONObject: legacyObject)
+        )
+        #expect(legacy.imageDeliveryStatus == nil)
+
+        legacyObject["imageDeliveryStatus"] = "future-outcome"
+        let forward = try JSONDecoder().decode(
+            ChatMessage.self,
+            from: JSONSerialization.data(withJSONObject: legacyObject)
+        )
+        #expect(forward.imageDeliveryStatus == .rejected)
     }
 
     @Test("20 MB cap and accepted MIME types are enforced")

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -218,6 +218,29 @@ struct ChatImageAttachmentTests {
         #expect(messages[1].imageDeliveryStatus == .pending)
     }
 
+    @Test("accepted image delivery cannot regress after a later stream failure")
+    @MainActor
+    func acceptedDeliveryIsMonotonic() {
+        let id = UUID()
+        var messages = [
+            ChatMessage(id: id, role: .user, imageDeliveryStatus: .pending)
+        ]
+
+        ChatViewModel.updateImageDeliveryStatus(
+            in: &messages, messageID: id, status: .accepted
+        )
+        ChatViewModel.updateImageDeliveryStatus(
+            in: &messages, messageID: id, status: .rejected
+        )
+        #expect(messages[0].imageDeliveryStatus == .accepted)
+
+        messages[0].imageDeliveryStatus = .rejected
+        ChatViewModel.updateImageDeliveryStatus(
+            in: &messages, messageID: id, status: .accepted
+        )
+        #expect(messages[0].imageDeliveryStatus == .accepted)
+    }
+
     @Test("plain-text follow-up after a document does not resurrect an older image")
     func documentFollowUpKeepsDocumentFocus() throws {
         let image = try ChatImageAttachment(

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -256,6 +256,45 @@ struct ChatImageAttachmentTests {
         #expect(messages[0].imageDeliveryStatus == nil)
     }
 
+    @Test("model-start failure clears pending image delivery before persistence")
+    @MainActor
+    func startupFailureClearsPendingDelivery() throws {
+        let imageID = UUID()
+        let model = ChatViewModel(persistsConversations: false)
+        model.devSeedMessages([
+            ChatMessage(id: imageID, role: .user, imageDeliveryStatus: .pending),
+            ChatMessage(role: .assistant, status: .streaming),
+        ])
+
+        model.finishWithStartupFailure(
+            placeholderIndex: 1,
+            alias: "model",
+            imageMessageID: imageID
+        )
+
+        #expect(model.messages[0].imageDeliveryStatus == nil)
+        #expect(model.messages[1].status == .failed)
+    }
+
+    @Test("cancelled model start clears pending image delivery")
+    @MainActor
+    func startupCancellationClearsPendingDelivery() {
+        let imageID = UUID()
+        let model = ChatViewModel(persistsConversations: false)
+        model.devSeedMessages([
+            ChatMessage(id: imageID, role: .user, imageDeliveryStatus: .pending),
+            ChatMessage(role: .assistant, status: .streaming),
+        ])
+
+        model.finishStartupCancellation(
+            placeholderIndex: 1,
+            imageMessageID: imageID
+        )
+
+        #expect(model.messages[0].imageDeliveryStatus == nil)
+        #expect(model.messages[1].status == .complete)
+    }
+
     @Test("plain-text follow-up after a document does not resurrect an older image")
     func documentFollowUpKeepsDocumentFocus() throws {
         let image = try ChatImageAttachment(

--- a/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
@@ -42,6 +42,35 @@ struct HumanizeErrorTests {
         #expect(msg.lowercased().contains("try again") || msg.lowercased().contains("restart"))
     }
 
+    @Test("Structured invalid-request reason is available only to the attachment failure path")
+    func structuredInvalidRequestReason() {
+        let body = #"{"error":{"message":"This model is serving text-only; image input is unsupported.","type":"invalid_request_error","code":"image_input_unsupported"}}"#
+        let error = ChatStreamError.httpStatus(400, body)
+        #expect(
+            error.attachmentFailureMessage
+                == "This model is serving text-only; image input is unsupported."
+        )
+        // The generic humanizer remains deliberately opaque for callers that
+        // did not originate an image turn.
+        #expect(!ChatViewModel.humanize(error).contains("image input"))
+    }
+
+    @Test("Structured server failure reason is available only to the failed attachment")
+    func structuredServerFailureReason() {
+        #expect(ChatStreamError.httpStatus(
+            500,
+            #"{"error":{"message":"Internal server error"}}"#
+        ).attachmentFailureMessage == "Internal server error")
+    }
+
+    @Test("Unstructured error bodies never become user copy")
+    func unstructuredBodiesStayPrivate() {
+        #expect(ChatStreamError.httpStatus(
+            400,
+            "raw internal detail"
+        ).attachmentFailureMessage == nil)
+    }
+
     @Test("transport never leaks the raw transport message")
     func transportPassthrough() {
         let msg = ChatViewModel.humanize(

--- a/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
@@ -55,12 +55,16 @@ struct HumanizeErrorTests {
         #expect(!ChatViewModel.humanize(error).contains("image input"))
     }
 
-    @Test("Structured server failure reason is available only to the failed attachment")
-    func structuredServerFailureReason() {
+    @Test("Unrelated structured server failures remain private diagnostics")
+    func structuredServerFailureReasonStaysPrivate() {
         #expect(ChatStreamError.httpStatus(
             500,
             #"{"error":{"message":"Internal server error"}}"#
-        ).attachmentFailureMessage == "Internal server error")
+        ).attachmentFailureMessage == nil)
+        #expect(ChatStreamError.httpStatus(
+            503,
+            #"{"error":{"message":"Metal is out of memory","type":"server_error","code":"oom"}}"#
+        ).attachmentFailureMessage == nil)
     }
 
     @Test("Unstructured error bodies never become user copy")

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -259,6 +259,51 @@ struct ModelResidencyTests {
         #expect(server.activeModelProfile == nil)
     }
 
+    @Test("Secondary resident chat aliases accept their own live photo profile")
+    func secondaryResidentProfileIsAuthoritative() {
+        let secondary = ResidentModelStatus(
+            id: "secondary-model",
+            modelPath: "repo/secondary-model",
+            aliases: [],
+            modality: "text",
+            state: "resident",
+            pinned: false,
+            primary: false,
+            activeRequests: 0,
+            estimatedBytes: 1,
+            measuredBytes: nil,
+            idleSeconds: 0
+        )
+        let residency = ModelResidencySnapshot(
+            memoryLimitBytes: 10,
+            memoryUsedBytes: 1,
+            memoryAvailableBytes: 9,
+            idleTTLSeconds: 60,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [secondary]
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: "primary-model"),
+            residency: residency
+        )
+        server.applyActiveModelProfile(
+            ServerModelProfile(
+                id: "secondary-model",
+                capabilities: ["text"],
+                servingLane: "text",
+                servingLaneReason: "operator_forced_text"
+            ),
+            forAlias: "secondary-model"
+        )
+
+        #expect(server.activeModelProfile?.id == "secondary-model")
+        #expect(!server.imageInputAvailability(
+            forAlias: "secondary-model",
+            catalogSupportsImageInput: true
+        ).isAvailable)
+    }
+
     @Test("Resident ceiling reuses the Mac usable-RAM bucket")
     func residentMemoryCeiling() {
         #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 32)) == 25)

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -226,6 +226,39 @@ struct ModelResidencyTests {
         #expect(alias == "flux-klein")
     }
 
+    @Test("Server accepts only the exact live alias profile for photo capability")
+    func liveProfileCannotLagAcrossModelSwitch() {
+        let server = ServerManager(testingState: .ready(alias: "current-model"))
+        server.applyActiveModelProfile(
+            ServerModelProfile(
+                id: "old-model",
+                capabilities: ["text", "vision"],
+                servingLane: "vision",
+                servingLaneReason: "vision_supported"
+            ),
+            forAlias: "old-model"
+        )
+        #expect(server.activeModelProfile == nil)
+
+        server.applyActiveModelProfile(
+            ServerModelProfile(
+                id: "current-model",
+                capabilities: ["text"],
+                servingLane: "text",
+                servingLaneReason: "operator_forced_text"
+            ),
+            forAlias: "current-model"
+        )
+        #expect(server.activeModelProfile?.id == "current-model")
+        #expect(!server.imageInputAvailability(
+            forAlias: "current-model",
+            catalogSupportsImageInput: true
+        ).isAvailable)
+
+        server.clearActiveModelProfile()
+        #expect(server.activeModelProfile == nil)
+    }
+
     @Test("Resident ceiling reuses the Mac usable-RAM bucket")
     func residentMemoryCeiling() {
         #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 32)) == 25)

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -150,6 +150,26 @@ final class ServerModelProfileTests {
         #expect(first != replacement)
     }
 
+    @Test("Selected live profile is retried on the existing residency cadence")
+    func selectedProfileRetriesAfterInitialFailure() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/Rapid/UI/ContentView.swift"),
+            encoding: .utf8
+        )
+        let residencyRefresh = try #require(source.range(of: "await server.refreshResidency()"))
+        let retry = try #require(
+            source.range(
+                of: "await refreshSelectedModelProfile(for: alias)",
+                range: residencyRefresh.lowerBound..<source.endIndex
+            )
+        )
+        #expect(retry.lowerBound > residencyRefresh.lowerBound)
+    }
+
     @Test("Partial sampling block — only some keys populated")
     func decodesPartialSampling() throws {
         // aliases.json may set only ``temperature`` for some

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -139,6 +139,17 @@ final class ServerModelProfileTests {
         ).isAvailable)
     }
 
+    @Test("A replacement sidecar invalidates the selected-model profile task")
+    func selectedProfileTracksServerSession() {
+        let first = SelectedModelProfileKey(
+            alias: "model", isResident: true, port: 8000, bearer: "session-a"
+        )
+        let replacement = SelectedModelProfileKey(
+            alias: "model", isResident: true, port: 8000, bearer: "session-b"
+        )
+        #expect(first != replacement)
+    }
+
     @Test("Partial sampling block — only some keys populated")
     func decodesPartialSampling() throws {
         // aliases.json may set only ``temperature`` for some

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -44,6 +44,9 @@ final class ServerModelProfileTests {
           "is_moe": false,
           "tool_call_parser": "hermes",
           "reasoning_parser": "qwen3",
+          "capabilities": ["text", "vision", "tools"],
+          "serving_lane": "vision",
+          "serving_lane_reason": "vision_hybrid_serialized",
           "modality": "text"
         }
         """
@@ -59,6 +62,9 @@ final class ServerModelProfileTests {
         #expect(profile.isMoe == false)
         #expect(profile.toolCallParser == "hermes")
         #expect(profile.reasoningParser == "qwen3")
+        #expect(profile.capabilities == ["text", "vision", "tools"])
+        #expect(profile.servingLane == "vision")
+        #expect(profile.servingLaneReason == "vision_hybrid_serialized")
         #expect(profile.modality == "text")
     }
 
@@ -83,6 +89,54 @@ final class ServerModelProfileTests {
         #expect(profile.recommendedSampling == nil)
         #expect(profile.isHybrid == nil)
         #expect(profile.toolCallParser == nil)
+        #expect(profile.capabilities == nil)
+        #expect(profile.servingLane == nil)
+        #expect(profile.servingLaneReason == nil)
+    }
+
+    @Test("Live text lane overrides a vision-capable catalog and explains why")
+    func liveTextLaneBlocksPhotos() {
+        let availability = ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: true,
+            profile: ServerModelProfile(
+                id: "model",
+                capabilities: ["text", "tools"],
+                servingLane: "text",
+                servingLaneReason: "vision_weights_unavailable"
+            )
+        )
+        #expect(!availability.isAvailable)
+        #expect(availability.unavailableMessage?.contains("vision features") == true)
+    }
+
+    @Test("Live vision lane enables photos even when an old catalog fallback is false")
+    func liveVisionLaneEnablesPhotos() {
+        let availability = ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: false,
+            profile: ServerModelProfile(
+                id: "model",
+                capabilities: ["text", "vision"],
+                servingLane: "vision",
+                servingLaneReason: "vision_supported"
+            )
+        )
+        #expect(availability == ImageInputAvailability(
+            isAvailable: true,
+            unavailableMessage: nil
+        ))
+    }
+
+    @Test("Legacy model profile preserves the existing launch capability fallback")
+    func legacyProfileUsesFallback() {
+        let legacy = ServerModelProfile(id: "model")
+        #expect(ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: true,
+            profile: legacy
+        ).isAvailable)
+        #expect(!ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: false,
+            profile: legacy
+        ).isAvailable)
     }
 
     @Test("Partial sampling block — only some keys populated")


### PR DESCRIPTION
## Why

Requested during post-release Desktop dogfood for 0.13.1. A failed photo remained eligible for implicit reuse, so every later plain-text message in that conversation re-sent the rejected image and appeared broken. Desktop also relied on static catalog capability instead of the lane the engine actually serves.

Fixes #2378.

## What

- persist pending / accepted / rejected delivery state on image-bearing user turns
- never inherit a rejected image into a later turn; keep an explicit retry of that image possible
- key delivery updates to the exact persisted message identity
- decode the live model profile capability, serving lane, and stable reason
- make the live profile authoritative for photo availability, with backward-compatible catalog fallback for older sidecars
- use one native explanation across click, keyboard, paste, drag/drop, help, and VoiceOver paths
- show the structured server error-envelope message on the exact failed image turn while keeping unstructured bodies out of user copy

The real-image accessibility journey remains pending the validated vision sidecar candidate.

## Non-goals

- engine or vision-runtime implementation
- model-name, repository-name, or hash heuristics
- changing successful image follow-up behavior
- adding document formats or redesigning chat

## Evidence

- Published 0.13.0 reproduction: failed photo → same-thread `hi` fails; new-thread `hi` succeeds
- Published response: HTTP 500 standard error envelope; sidecar remains healthy
- `swift test --filter ChatImageAttachmentTests`: 13 passed
- `swift test --filter 'ChatImageAttachmentTests|ServerModelProfileTests|ModelResidencyTests|HumanizeErrorTests'`: 73 passed
- contracts cover rejected-image follow-up, direct retry, exact identity, persistence/legacy decode, live text/vision lanes, stale-profile rejection, structured 400/500 messages, and accessible fallback copy
