### PR TITLE
fix(mac): update bundled vision runtime

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -249,6 +249,12 @@ jobs:
           # floor is set here (RAPID_MLX_PERF_MIN_TPS unset), so it measures and
           # prints a number to review rather than inventing a baseline.
           RAPID_MLX_RELEASE_GATE: "1"
+          # Content-addressed cached checkpoint used by the Desktop sidecar's
+          # real image gate below. The Studio runner is intentionally the only
+          # release host with model weights; offline resolution makes cache
+          # drift or eviction fail closed instead of silently downloading.
+          SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit
+          SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
@@ -263,6 +269,13 @@ jobs:
           echo "gate venv → $("$V/bin/rapid-mlx" --version) (releasing v$VERSION)"
 
           RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh qwen3.6-35b-8bit
+
+          # Build the exact Desktop sidecar recipe and require a real PNG to
+          # traverse its production scheduler + HTTP route. Every normal
+          # auto-release is blocked by a missing immutable snapshot,
+          # incompatible reduced dependency set, or failed image request.
+          HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
+            --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -225,15 +225,15 @@ jobs:
     # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
     # (warm/cold) — the budget is for the pathological retry path, not the
     # expected one.
-    # 155, not 125: the release-shaped Desktop sidecar build and two real-image
-    # requests now follow the agent gate. The agent path retains its documented
-    # ~121-minute worst case; each image smoke is independently bounded to
-    # 4 minutes of startup plus 4 minutes of inference (16 minutes total), and
+    # 165, not 125: the release-shaped Desktop sidecar build and two-model,
+    # positive/negative real-image checks now follow the agent gate. The agent
+    # path retains its documented ~121-minute worst case; each model is bounded
+    # to 4 minutes of startup plus two 4-minute requests (24 minutes total), and
     # the measured clean sidecar build gets 15 minutes of fail-closed headroom.
-    # 121 + 16 + 15 = 152, rounded to 155 for setup and cleanup. This outer cap
+    # 121 + 24 + 15 = 160, rounded to 165 for setup and cleanup. This outer cap
     # is not a substitute for the per-request bounds: it only prevents healthy
     # checks near their individual budgets from being guillotined by the job.
-    timeout-minutes: 155
+    timeout-minutes: 165
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:
@@ -297,7 +297,8 @@ jobs:
             --sidecar-root "$SIDE" \
             --model "$SIDECAR_GEMMA_SMOKE_MODEL" \
             --revision "$SIDECAR_GEMMA_SMOKE_REVISION" \
-            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png
+            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png \
+            --negative-image apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -225,7 +225,15 @@ jobs:
     # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
     # (warm/cold) — the budget is for the pathological retry path, not the
     # expected one.
-    timeout-minutes: 125
+    # 155, not 125: the release-shaped Desktop sidecar build and two real-image
+    # requests now follow the agent gate. The agent path retains its documented
+    # ~121-minute worst case; each image smoke is independently bounded to
+    # 4 minutes of startup plus 4 minutes of inference (16 minutes total), and
+    # the measured clean sidecar build gets 15 minutes of fail-closed headroom.
+    # 121 + 16 + 15 = 152, rounded to 155 for setup and cleanup. This outer cap
+    # is not a substitute for the per-request bounds: it only prevents healthy
+    # checks near their individual budgets from being guillotined by the job.
+    timeout-minutes: 155
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -255,6 +255,8 @@ jobs:
           # drift or eviction fail closed instead of silently downloading.
           SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit
           SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53
+          SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit
+          SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
@@ -276,6 +278,18 @@ jobs:
           # incompatible reduced dependency set, or failed image request.
           HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
             --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
+
+          # The reduced dependency-set exception covers both Qwen and Gemma
+          # chat-photo families. The build-sidecar invocation proves Qwen;
+          # reuse those exact built bytes for an independent Gemma4 request.
+          SIDE="$RUNNER_TEMP/desktop-vision-sidecar-$VERSION/rapid-mlx"
+          HF_HUB_OFFLINE=1 PYTHONPATH="$SIDE/site-packages" PYTHONNOUSERSITE=1 \
+            "$SIDE/python/bin/python3.12" \
+            apps/rapid-mac/scripts/smoke-sidecar-vision.py \
+            --sidecar-root "$SIDE" \
+            --model "$SIDECAR_GEMMA_SMOKE_MODEL" \
+            --revision "$SIDECAR_GEMMA_SMOKE_REVISION" \
+            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,8 @@ jobs:
             tests/test_pr_validate_runner.py \
             tests/test_pr_validate_codex.py \
             tests/test_release_baselines.py \
+            tests/test_sidecar_distribution_constraints.py \
+            tests/test_sidecar_vision_smoke.py \
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
             tests/test_check_mypy_error_budget.py \

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -125,10 +125,9 @@ Both pinned by `PBS_VERSION` / `PBS_TAG` in `scripts/build-sidecar.sh`.
 ### Engine runtime dependencies
 
 The root `pyproject.toml` `[project].dependencies` block, installed in
-full. The ranges below are the **root manifest's**; the sidecar build
-narrows one of them, pinning `transformers>=5.5.0,<5.13` at install time
-(step 2 of `scripts/build-sidecar.sh`), so a shipped bundle never carries
-a `transformers` older than 5.5.0.
+full. The ranges below are the **root manifest's**; the sidecar build pins
+`mlx==0.32.2` and `transformers==5.12.1` at install time (step 2 of
+`scripts/build-sidecar.sh`) so the shipped vision stack is reproducible.
 
 | Component | Declared range | License | Project |
 | --- | --- | --- | --- |
@@ -159,7 +158,7 @@ path works in a text-only bundle:
 
 | Component | Pin | License | Project |
 | --- | --- | --- | --- |
-| mlx-vlm | `==0.6.3` | MIT | https://github.com/Blaizzy/mlx-vlm |
+| mlx-vlm | `==0.6.16` | MIT | https://github.com/Blaizzy/mlx-vlm |
 | Pillow | `>=10.0` | MIT-CMU | https://github.com/python-pillow/Pillow |
 
 ### Third-party source vendored into the engine

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -68,6 +68,8 @@ struct SidecarBuildScriptTests {
         #expect(script.contains("SIDECAR_VISION_SMOKE_MODEL"))
         #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-vision.py"),
                 "Configured release-candidate builds must run real image inference through the sidecar.")
+        #expect(script.contains(#"PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1"#),
+                "The image gate must resolve its pinned snapshot with the bundled runtime, not host Python.")
         for architecture in [
             "diffusion_gemma", "gemma3", "gemma3n", "gemma4", "gemma4_unified",
             "qwen3_5", "qwen3_5_moe", "qwen3_vl", "qwen3_vl_moe",

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -60,12 +60,14 @@ struct SidecarBuildScriptTests {
     func visionStackIsReproducibleAndCompatible() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
 
-        #expect(script.contains("'mlx-vlm==0.6.3'"))
+        #expect(script.contains("'mlx-vlm==0.6.16'"))
         #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
                 "The no-deps sidecar install must never float within a range.")
-        #expect(script.contains("from packaging.requirements import Requirement"))
-        #expect(script.contains("actual not in req.specifier"),
-                "Post-install validation must reject incompatible installed dependency versions.")
+        #expect(script.contains("$REPO_ROOT/scripts/check-sidecar-distributions.py"),
+                "Every sidecar build must execute the tested metadata-coherence gate.")
+        #expect(script.contains("SIDECAR_VISION_SMOKE_MODEL"))
+        #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-vision.py"),
+                "Configured release-candidate builds must run real image inference through the sidecar.")
         for architecture in [
             "diffusion_gemma", "gemma3", "gemma3n", "gemma4", "gemma4_unified",
             "qwen3_5", "qwen3_5_moe", "qwen3_vl", "qwen3_vl_moe",

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -977,11 +977,18 @@ fi
 # release operator supplies the immutable local snapshot explicitly.
 if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
     SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
-    "$STAGE/python/bin/python3.12" \
-        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
-        --sidecar-root "$STAGE" \
-        --model "$SIDECAR_VISION_SMOKE_MODEL" \
+    SIDECAR_VISION_SMOKE_ARGS=(
+        --sidecar-root "$STAGE"
+        --model "$SIDECAR_VISION_SMOKE_MODEL"
         --image "$SIDECAR_VISION_SMOKE_IMAGE"
+    )
+    if [[ -n "${SIDECAR_VISION_SMOKE_REVISION:-}" ]]; then
+        SIDECAR_VISION_SMOKE_ARGS+=(--revision "$SIDECAR_VISION_SMOKE_REVISION")
+    fi
+    PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
+        "$STAGE/python/bin/python3.12" \
+        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
+        "${SIDECAR_VISION_SMOKE_ARGS[@]}"
 else
     echo "==> real image smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
 fi

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -254,7 +254,8 @@ fi
     --no-compile \
     --upgrade \
     "${RAPID_MLX_SOURCE}[audio-desktop]" \
-    'transformers>=5.5.0,<5.13'
+    'mlx==0.32.2' \
+    'transformers==5.12.1'
 
 # pip normally selects wheels for the BUILD host. A sidecar assembled on
 # macOS 26 therefore receives mlx / mlx-metal's macosx_26 wheels even though
@@ -321,7 +322,7 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    'mlx-vlm==0.6.3' \
+    'mlx-vlm==0.6.16' \
     'Pillow>=10.0'
 
 # ----- step 2.6: bundle mflux --no-deps (Images tab image-gen lane) ----
@@ -456,26 +457,10 @@ PY
 # ``--no-deps`` is intentional for bundle size, but it must not hide version
 # conflicts among distributions that ARE present. Missing optional heavy deps
 # remain allowed; every installed-to-installed edge must satisfy its metadata.
-PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 "$STAGE/python/bin/python3.12" -s - <<'PY'
-from importlib import metadata
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
-
-installed = {canonicalize_name(dist.metadata["Name"]): dist.version for dist in metadata.distributions()}
-errors = []
-for dist in metadata.distributions():
-    owner = dist.metadata["Name"]
-    for raw in dist.requires or ():
-        req = Requirement(raw)
-        if req.marker and not req.marker.evaluate():
-            continue
-        actual = installed.get(canonicalize_name(req.name))
-        if actual is not None and req.specifier and actual not in req.specifier:
-            errors.append(f"{owner} requires {req}, but bundled {req.name}=={actual}")
-if errors:
-    raise SystemExit("incompatible bundled distributions:\n  " + "\n  ".join(sorted(errors)))
-print("==> bundled distribution metadata constraints: OK")
-PY
+PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
+    "$STAGE/python/bin/python3.12" -s \
+    "$REPO_ROOT/scripts/check-sidecar-distributions.py" \
+    "$STAGE/site-packages"
 
 # ----- step 3: strip dev / unused artifacts ----------------------------
 
@@ -983,6 +968,22 @@ print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>
         echo "$METAL_OUT" >&2
         exit 3
     fi
+fi
+
+# Release-candidate builds can opt into a real image request against a cached
+# checkpoint. Once configured, this gate is fail-closed: a missing model/image,
+# failed server start, non-200 response, or implausible description aborts the
+# build. Hosted package builders do not download multi-GB model weights, so the
+# release operator supplies the immutable local snapshot explicitly.
+if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
+    SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
+    "$STAGE/python/bin/python3.12" \
+        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
+        --sidecar-root "$STAGE" \
+        --model "$SIDECAR_VISION_SMOKE_MODEL" \
+        --image "$SIDECAR_VISION_SMOKE_IMAGE"
+else
+    echo "==> real image smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
 fi
 
 # ----- step 7: package --------------------------------------------------

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -977,10 +977,12 @@ fi
 # release operator supplies the immutable local snapshot explicitly.
 if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
     SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
+    SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE="${SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png}"
     SIDECAR_VISION_SMOKE_ARGS=(
         --sidecar-root "$STAGE"
         --model "$SIDECAR_VISION_SMOKE_MODEL"
         --image "$SIDECAR_VISION_SMOKE_IMAGE"
+        --negative-image "$SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE"
     )
     if [[ -n "${SIDECAR_VISION_SMOKE_REVISION:-}" ]]; then
         SIDECAR_VISION_SMOKE_ARGS+=(--revision "$SIDECAR_VISION_SMOKE_REVISION")

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fail closed on incompatible installed distributions in the Desktop sidecar."""
+
+from __future__ import annotations
+
+import argparse
+from importlib import metadata
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+
+def is_validated_compatibility_exception(
+    *, owner: str, owner_version: str, requirement: Requirement, actual: str
+) -> bool:
+    """Return true only for the release-tested reduced vision runtime.
+
+    mlx-vlm 0.6.16 declares Transformers >=5.14 for its complete feature set.
+    Rapid's shipped Qwen/Gemma image lanes do not exercise that newer surface;
+    they are validated by real image inference with Transformers 5.12.1.  This
+    is deliberately an exact tuple rather than a package-wide metadata bypass.
+
+    Remove this exception after replacing Rapid's Transformers <5.13 cap with
+    !=5.13.0 and completing the tracked 5.15.x coherence sweep. Every other
+    owner/version, dependency, declared specifier, or actual version remains a
+    hard error.
+    """
+
+    return (
+        canonicalize_name(owner) == "mlx-vlm"
+        and owner_version == "0.6.16"
+        and canonicalize_name(requirement.name) == "transformers"
+        and str(requirement.specifier) == ">=5.14.0"
+        and actual == "5.12.1"
+    )
+
+
+def find_errors(site_packages: Path) -> list[str]:
+    distributions = list(metadata.distributions(path=[str(site_packages)]))
+    installed = {
+        canonicalize_name(dist.metadata["Name"]): dist.version for dist in distributions
+    }
+    errors: list[str] = []
+    for dist in distributions:
+        owner = dist.metadata["Name"]
+        for raw in dist.requires or ():
+            requirement = Requirement(raw)
+            if requirement.marker and not requirement.marker.evaluate():
+                continue
+            actual = installed.get(canonicalize_name(requirement.name))
+            if actual is None or not requirement.specifier:
+                continue
+            if actual in requirement.specifier:
+                continue
+            if is_validated_compatibility_exception(
+                owner=owner,
+                owner_version=dist.version,
+                requirement=requirement,
+                actual=actual,
+            ):
+                print(
+                    "==> validated compatibility exception: "
+                    "mlx-vlm 0.6.16 with transformers 5.12.1"
+                )
+                continue
+            errors.append(
+                f"{owner} requires {requirement}, but bundled "
+                f"{requirement.name}=={actual}"
+            )
+    return sorted(errors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("site_packages", type=Path)
+    args = parser.parse_args()
+    if not args.site_packages.is_dir():
+        parser.error(f"site-packages directory does not exist: {args.site_packages}")
+    errors = find_errors(args.site_packages)
+    if errors:
+        raise SystemExit(
+            "incompatible bundled distributions:\n  " + "\n  ".join(errors)
+        )
+    print("==> bundled distribution metadata constraints: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -38,6 +38,8 @@ def is_validated_compatibility_exception(
 
 def find_errors(site_packages: Path) -> list[str]:
     distributions = list(metadata.distributions(path=[str(site_packages)]))
+    if not distributions:
+        return [f"no installed distributions found in {site_packages}"]
     installed = {
         canonicalize_name(dist.metadata["Name"]): dist.version for dist in distributions
     }

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -24,32 +24,10 @@ def _bound_local_listener() -> socket.socket:
 
 
 def _completion_is_sensible(text: object) -> bool:
-    """Reject empty/error output and require recognition of the known fixture."""
+    """Accept only the deterministic answer requested for the known fixture."""
     if not isinstance(text, str):
         return False
-    tokens = [word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()]
-    words = set(tokens)
-    fixture_labels = {"cheetah", "leopard", "cat", "feline"}
-    uncertainty = {"cannot", "can't", "unable", "unclear", "unknown", "unsure"}
-    if len(words) < 3 or not words & fixture_labels or words & uncertainty:
-        return False
-    if any(
-        left == "not" and right == "sure" for left, right in zip(tokens, tokens[1:])
-    ):
-        return False
-    for index, token in enumerate(tokens):
-        if token not in fixture_labels:
-            continue
-        prior = tokens[max(0, index - 2) : index]
-        if prior and prior[-1] in {"not", "no"}:
-            return False
-        if (
-            len(prior) == 2
-            and prior[0] in {"not", "no"}
-            and prior[1] in {"a", "an", "the"}
-        ):
-            return False
-    return True
+    return text.strip().rstrip(".!?").casefold() == "spotted_cat"
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
@@ -138,32 +116,35 @@ def main() -> int:
 
     listener = _bound_local_listener()
     base_url = f"http://127.0.0.1:{listener.getsockname()[1]}"
+    process: subprocess.Popen | None = None
     with tempfile.NamedTemporaryFile(
         prefix="rapid-sidecar-vision-", suffix=".log", delete=False
     ) as log:
         log_path = Path(log.name)
-        try:
-            process = subprocess.Popen(
-                [
-                    str(executable),
-                    "serve",
-                    str(model),
-                    "--mllm",
-                    "--listen-fd",
-                    str(listener.fileno()),
-                ],
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-                pass_fds=(listener.fileno(),),
-                env={**os.environ, "PYTHONNOUSERSITE": "1"},
-            )
-        finally:
-            # Popen duplicates pass_fds into the child before it returns. Close
-            # the parent's copy only after that atomic handoff.
-            listener.close()
 
     try:
+        with log_path.open("ab") as log:
+            try:
+                process = subprocess.Popen(
+                    [
+                        str(executable),
+                        "serve",
+                        str(model),
+                        "--mllm",
+                        "--listen-fd",
+                        str(listener.fileno()),
+                    ],
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    pass_fds=(listener.fileno(),),
+                    env={**os.environ, "PYTHONNOUSERSITE": "1"},
+                )
+            finally:
+                # Popen duplicates pass_fds into the child before it returns.
+                # Close the parent's copy only after that atomic handoff.
+                listener.close()
+
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
         payload = {
@@ -174,7 +155,11 @@ def main() -> int:
                     "content": [
                         {
                             "type": "text",
-                            "text": "Describe the main animal in this image in one short sentence.",
+                            "text": (
+                                "Reply with exactly SPOTTED_CAT if the main animal "
+                                "in this image is a spotted wild cat such as a "
+                                "cheetah or leopard; otherwise reply OTHER."
+                            ),
                         },
                         {
                             "type": "image_url",
@@ -184,7 +169,7 @@ def main() -> int:
                 }
             ],
             "temperature": 0,
-            "max_tokens": 64,
+            "max_tokens": 16,
             "stream": False,
         }
         body = _request_json(
@@ -193,16 +178,18 @@ def main() -> int:
         content = body.get("choices", [{}])[0].get("message", {}).get("content")
         if not _completion_is_sensible(content):
             raise RuntimeError(
-                f"vision smoke returned an implausible description: {content!r}"
+                f"vision smoke returned an incorrect fixture verdict: {content!r}"
             )
-        print(f"vision smoke: HTTP 200; description={content!r}")
+        print("vision smoke: HTTP 200; fixture verdict=SPOTTED_CAT")
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
         print(log_path.read_text(errors="replace"))
         raise
     finally:
-        _stop_process(process)
+        listener.close()
+        if process is not None:
+            _stop_process(process)
         log_path.unlink(missing_ok=True)
 
 

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -27,19 +27,29 @@ def _completion_is_sensible(text: object) -> bool:
     """Reject empty/error output and require recognition of the known fixture."""
     if not isinstance(text, str):
         return False
-    words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
+    tokens = [word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()]
+    words = set(tokens)
     fixture_labels = {"cheetah", "leopard", "cat", "feline"}
-    uncertainty = {
-        "cannot",
-        "can't",
-        "unable",
-        "unclear",
-        "unknown",
-        "unsure",
-        "not",
-        "no",
-    }
-    return len(words) >= 3 and bool(words & fixture_labels) and not words & uncertainty
+    uncertainty = {"cannot", "can't", "unable", "unclear", "unknown", "unsure"}
+    if len(words) < 3 or not words & fixture_labels or words & uncertainty:
+        return False
+    if any(
+        left == "not" and right == "sure" for left, right in zip(tokens, tokens[1:])
+    ):
+        return False
+    for index, token in enumerate(tokens):
+        if token not in fixture_labels:
+            continue
+        prior = tokens[max(0, index - 2) : index]
+        if prior and prior[-1] in {"not", "no"}:
+            return False
+        if (
+            len(prior) == 2
+            and prior[0] in {"not", "no"}
+            and prior[1] in {"a", "an", "the"}
+        ):
+            return False
+    return True
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -27,7 +27,18 @@ def _completion_is_sensible(text: object) -> bool:
     if not isinstance(text, str):
         return False
     words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
-    return len(words) >= 3 and bool(words & {"cheetah", "cat", "feline", "animal"})
+    fixture_labels = {"cheetah", "leopard", "cat", "feline"}
+    uncertainty = {
+        "cannot",
+        "can't",
+        "unable",
+        "unclear",
+        "unknown",
+        "unsure",
+        "not",
+        "no",
+    }
+    return len(words) >= 3 and bool(words & fixture_labels) and not words & uncertainty
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -89,6 +89,23 @@ def _resolve_model(model: str, revision: str | None) -> Path:
     )
 
 
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=5)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--sidecar-root", type=Path, required=True)
@@ -122,6 +139,7 @@ def main() -> int:
             env={**os.environ, "PYTHONNOUSERSITE": "1"},
         )
 
+    succeeded = False
     try:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
@@ -155,20 +173,15 @@ def main() -> int:
                 f"vision smoke returned an implausible description: {content!r}"
             )
         print(f"vision smoke: HTTP 200; description={content!r}")
+        succeeded = True
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
         print(log_path.read_text(errors="replace"))
         raise
     finally:
-        if process.poll() is None:
-            os.killpg(process.pid, signal.SIGTERM)
-            try:
-                process.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.wait(timeout=5)
-        if process.returncode == 0:
+        _stop_process(process)
+        if succeeded:
             log_path.unlink(missing_ok=True)
 
 

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -58,10 +58,31 @@ def _wait_until_ready(base_url: str, process: subprocess.Popen, timeout: float) 
     raise RuntimeError(f"sidecar server was not ready after {timeout}s: {last_error}")
 
 
+def _resolve_model(model: str, revision: str | None) -> Path:
+    local_path = Path(model)
+    if local_path.exists():
+        return local_path
+    if not revision:
+        raise SystemExit(
+            "vision smoke: a repository model requires --revision so the "
+            "release proof is content-addressed"
+        )
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            repo_id=model,
+            revision=revision,
+            local_files_only=True,
+        )
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--sidecar-root", type=Path, required=True)
-    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--revision")
     parser.add_argument("--image", type=Path, required=True)
     parser.add_argument("--startup-timeout", type=float, default=240)
     parser.add_argument("--request-timeout", type=float, default=240)
@@ -70,11 +91,11 @@ def main() -> int:
     executable = args.sidecar_root / "bin" / "rapid-mlx"
     for path, label in (
         (executable, "sidecar executable"),
-        (args.model, "model"),
         (args.image, "image"),
     ):
         if not path.exists():
             raise SystemExit(f"vision smoke: {label} not found: {path}")
+    model = _resolve_model(args.model, args.revision)
 
     port = _free_local_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -83,7 +104,7 @@ def main() -> int:
     ) as log:
         log_path = Path(log.name)
         process = subprocess.Popen(
-            [str(executable), "serve", str(args.model), "--mllm", "--port", str(port)],
+            [str(executable), "serve", str(model), "--mllm", "--port", str(port)],
             stdout=log,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -94,7 +115,7 @@ def main() -> int:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
         payload = {
-            "model": str(args.model),
+            "model": str(model),
             "messages": [
                 {
                     "role": "user",

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -16,10 +16,11 @@ import urllib.request
 from pathlib import Path
 
 
-def _free_local_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def _bound_local_listener() -> socket.socket:
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    return listener
 
 
 def _completion_is_sensible(text: object) -> bool:
@@ -125,21 +126,33 @@ def main() -> int:
             raise SystemExit(f"vision smoke: {label} not found: {path}")
     model = _resolve_model(args.model, args.revision)
 
-    port = _free_local_port()
-    base_url = f"http://127.0.0.1:{port}"
+    listener = _bound_local_listener()
+    base_url = f"http://127.0.0.1:{listener.getsockname()[1]}"
     with tempfile.NamedTemporaryFile(
         prefix="rapid-sidecar-vision-", suffix=".log", delete=False
     ) as log:
         log_path = Path(log.name)
-        process = subprocess.Popen(
-            [str(executable), "serve", str(model), "--mllm", "--port", str(port)],
-            stdout=log,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            env={**os.environ, "PYTHONNOUSERSITE": "1"},
-        )
+        try:
+            process = subprocess.Popen(
+                [
+                    str(executable),
+                    "serve",
+                    str(model),
+                    "--mllm",
+                    "--listen-fd",
+                    str(listener.fileno()),
+                ],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                pass_fds=(listener.fileno(),),
+                env={**os.environ, "PYTHONNOUSERSITE": "1"},
+            )
+        finally:
+            # Popen duplicates pass_fds into the child before it returns. Close
+            # the parent's copy only after that atomic handoff.
+            listener.close()
 
-    succeeded = False
     try:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
@@ -173,7 +186,6 @@ def main() -> int:
                 f"vision smoke returned an implausible description: {content!r}"
             )
         print(f"vision smoke: HTTP 200; description={content!r}")
-        succeeded = True
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
@@ -181,8 +193,7 @@ def main() -> int:
         raise
     finally:
         _stop_process(process)
-        if succeeded:
-            log_path.unlink(missing_ok=True)
+        log_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -23,11 +23,11 @@ def _bound_local_listener() -> socket.socket:
     return listener
 
 
-def _completion_is_sensible(text: object) -> bool:
-    """Accept only the deterministic answer requested for the known fixture."""
+def _completion_matches(text: object, expected: str) -> bool:
+    """Accept only the deterministic class requested for a fixture."""
     if not isinstance(text, str):
         return False
-    return text.strip().rstrip(".!?").casefold() == "spotted_cat"
+    return text.strip().rstrip(".!?").casefold() == expected.casefold()
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
@@ -101,6 +101,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--revision")
     parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--negative-image", type=Path, required=True)
     parser.add_argument("--startup-timeout", type=float, default=240)
     parser.add_argument("--request-timeout", type=float, default=240)
     args = parser.parse_args()
@@ -109,6 +110,7 @@ def main() -> int:
     for path, label in (
         (executable, "sidecar executable"),
         (args.image, "image"),
+        (args.negative_image, "negative image"),
     ):
         if not path.exists():
             raise SystemExit(f"vision smoke: {label} not found: {path}")
@@ -146,41 +148,47 @@ def main() -> int:
                 listener.close()
 
         _wait_until_ready(base_url, process, args.startup_timeout)
-        image = base64.b64encode(args.image.read_bytes()).decode("ascii")
-        payload = {
-            "model": str(model),
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": (
-                                "Reply with exactly SPOTTED_CAT if the main animal "
-                                "in this image is a spotted wild cat such as a "
-                                "cheetah or leopard; otherwise reply OTHER."
-                            ),
-                        },
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "data:image/png;base64," + image},
-                        },
-                    ],
-                }
-            ],
-            "temperature": 0,
-            "max_tokens": 16,
-            "stream": False,
-        }
-        body = _request_json(
-            f"{base_url}/v1/chat/completions", payload, args.request_timeout
-        )
-        content = body.get("choices", [{}])[0].get("message", {}).get("content")
-        if not _completion_is_sensible(content):
-            raise RuntimeError(
-                f"vision smoke returned an incorrect fixture verdict: {content!r}"
+        for image_path, expected in (
+            (args.image, "SPOTTED_CAT"),
+            (args.negative_image, "OTHER"),
+        ):
+            image = base64.b64encode(image_path.read_bytes()).decode("ascii")
+            payload = {
+                "model": str(model),
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Classify the main subject in this image. Reply "
+                                    "with exactly SPOTTED_CAT for a spotted wild cat "
+                                    "such as a cheetah or leopard, or OTHER for "
+                                    "anything else."
+                                ),
+                            },
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "data:image/png;base64," + image},
+                            },
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 16,
+                "stream": False,
+            }
+            body = _request_json(
+                f"{base_url}/v1/chat/completions", payload, args.request_timeout
             )
-        print("vision smoke: HTTP 200; fixture verdict=SPOTTED_CAT")
+            content = body.get("choices", [{}])[0].get("message", {}).get("content")
+            if not _completion_matches(content, expected):
+                raise RuntimeError(
+                    f"vision smoke expected {expected} for {image_path.name}, "
+                    f"got: {content!r}"
+                )
+        print("vision smoke: HTTP 200; fixture verdicts=SPOTTED_CAT,OTHER")
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Run one real image request through a freshly built Desktop sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _free_local_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _completion_is_sensible(text: object) -> bool:
+    """Reject empty/error output and require recognition of the known fixture."""
+    if not isinstance(text, str):
+        return False
+    words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
+    return len(words) >= 3 and bool(words & {"cheetah", "cat", "feline", "animal"})
+
+
+def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data else {},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"{url} returned HTTP {response.status}")
+        return json.load(response)
+
+
+def _wait_until_ready(base_url: str, process: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"sidecar server exited early with {process.returncode}")
+        try:
+            _request_json(f"{base_url}/v1/models", None, 2)
+            return
+        except (OSError, ValueError, RuntimeError) as exc:
+            last_error = exc
+            time.sleep(0.5)
+    raise RuntimeError(f"sidecar server was not ready after {timeout}s: {last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sidecar-root", type=Path, required=True)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--startup-timeout", type=float, default=240)
+    parser.add_argument("--request-timeout", type=float, default=240)
+    args = parser.parse_args()
+
+    executable = args.sidecar_root / "bin" / "rapid-mlx"
+    for path, label in (
+        (executable, "sidecar executable"),
+        (args.model, "model"),
+        (args.image, "image"),
+    ):
+        if not path.exists():
+            raise SystemExit(f"vision smoke: {label} not found: {path}")
+
+    port = _free_local_port()
+    base_url = f"http://127.0.0.1:{port}"
+    with tempfile.NamedTemporaryFile(
+        prefix="rapid-sidecar-vision-", suffix=".log", delete=False
+    ) as log:
+        log_path = Path(log.name)
+        process = subprocess.Popen(
+            [str(executable), "serve", str(args.model), "--mllm", "--port", str(port)],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env={**os.environ, "PYTHONNOUSERSITE": "1"},
+        )
+
+    try:
+        _wait_until_ready(base_url, process, args.startup_timeout)
+        image = base64.b64encode(args.image.read_bytes()).decode("ascii")
+        payload = {
+            "model": str(args.model),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Describe the main animal in this image in one short sentence.",
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64," + image},
+                        },
+                    ],
+                }
+            ],
+            "temperature": 0,
+            "max_tokens": 64,
+            "stream": False,
+        }
+        body = _request_json(
+            f"{base_url}/v1/chat/completions", payload, args.request_timeout
+        )
+        content = body.get("choices", [{}])[0].get("message", {}).get("content")
+        if not _completion_is_sensible(content):
+            raise RuntimeError(
+                f"vision smoke returned an implausible description: {content!r}"
+            )
+        print(f"vision smoke: HTTP 200; description={content!r}")
+        return 0
+    except Exception:
+        print(f"vision smoke server log: {log_path}")
+        print(log_path.read_text(errors="replace"))
+        raise
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        if process.returncode == 0:
+            log_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -135,8 +135,8 @@ def test_desktop_sidecar_uses_validated_mlx_vlm_bound():
     # ``--no-deps`` install must not float.  That exact pin must remain inside
     # the project's coherence-gated vision range; it need not copy the range
     # text verbatim.
-    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.3").specifier
-    assert Version("0.6.3") in vision_specs[0].specifier
+    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.16").specifier
+    assert Version("0.6.16") in vision_specs[0].specifier
 
 
 def test_image_extra_tracks_mlx_032_compatible_mflux_line():

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -58,3 +58,44 @@ def test_every_nearby_mismatch_still_fails_closed(
         requirement=Requirement(requirement),
         actual=actual,
     )
+
+
+def _write_metadata(
+    root: Path, name: str, version: str, requires: tuple[str, ...] = ()
+) -> None:
+    dist_info = root / f"{name.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir()
+    lines = ["Metadata-Version: 2.1", f"Name: {name}", f"Version: {version}"]
+    lines.extend(f"Requires-Dist: {requirement}" for requirement in requires)
+    (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
+
+
+def test_find_errors_reads_real_distribution_metadata(
+    constraints, tmp_path: Path
+) -> None:
+    _write_metadata(tmp_path, "transformers", "5.12.1")
+    _write_metadata(
+        tmp_path,
+        "mlx-vlm",
+        "0.6.16",
+        ("transformers>=5.14.0; python_version >= '3'",),
+    )
+    assert constraints.find_errors(tmp_path) == []
+
+
+def test_find_errors_rejects_nonexception_conflict_from_metadata(
+    constraints, tmp_path: Path
+) -> None:
+    _write_metadata(tmp_path, "transformers", "5.12.1")
+    _write_metadata(tmp_path, "other-vision", "1.0", ("transformers>=5.14.0",))
+    assert constraints.find_errors(tmp_path) == [
+        "other-vision requires transformers>=5.14.0, but bundled transformers==5.12.1"
+    ]
+
+
+def test_find_errors_rejects_empty_distribution_directory(
+    constraints, tmp_path: Path
+) -> None:
+    assert constraints.find_errors(tmp_path) == [
+        f"no installed distributions found in {tmp_path}"
+    ]

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "apps"
+    / "rapid-mac"
+    / "scripts"
+    / "check-sidecar-distributions.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sidecar_constraints", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def constraints():
+    return _load_module()
+
+
+def test_exact_reduced_vision_runtime_is_allowed(constraints) -> None:
+    assert constraints.is_validated_compatibility_exception(
+        owner="mlx-vlm",
+        owner_version="0.6.16",
+        requirement=Requirement("transformers>=5.14.0"),
+        actual="5.12.1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "owner_version", "requirement", "actual"),
+    [
+        ("other", "0.6.16", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.15", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.17", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.13.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "other>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.12.0"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.13.1"),
+    ],
+)
+def test_every_nearby_mismatch_still_fails_closed(
+    constraints, owner: str, owner_version: str, requirement: str, actual: str
+) -> None:
+    assert not constraints.is_validated_compatibility_exception(
+        owner=owner,
+        owner_version=owner_version,
+        requirement=Requirement(requirement),
+        actual=actual,
+    )

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parents[1] / "apps/rapid-mac/scripts/smoke-sidecar-vision.py"
+_SPEC = importlib.util.spec_from_file_location("sidecar_vision_smoke", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
+    assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
+    assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
+
+
+def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
+    assert not _MODULE._completion_is_sensible(None)
+    assert not _MODULE._completion_is_sensible("")
+    assert not _MODULE._completion_is_sensible("Internal server error")
+    assert not _MODULE._completion_is_sensible("A blue square is visible.")

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _SCRIPT = Path(__file__).parents[1] / "apps/rapid-mac/scripts/smoke-sidecar-vision.py"
 _SPEC = importlib.util.spec_from_file_location("sidecar_vision_smoke", _SCRIPT)
 assert _SPEC and _SPEC.loader
@@ -20,3 +22,21 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
+
+
+def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
+    workflow = (
+        Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
+    ).read_text()
+    assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
+    assert (
+        "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
+        in workflow
+    )
+    assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+    assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+
+
+def test_repository_model_without_revision_fails_closed() -> None:
+    with pytest.raises(SystemExit, match="requires --revision"):
+        _MODULE._resolve_model("owner/model", None)

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import socket
 from pathlib import Path
 
 import pytest
@@ -52,6 +53,18 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
 def test_repository_model_without_revision_fails_closed() -> None:
     with pytest.raises(SystemExit, match="requires --revision"):
         _MODULE._resolve_model("owner/model", None)
+
+
+def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
+    listener = _MODULE._bound_local_listener()
+    host, port = listener.getsockname()
+    contender = socket.socket()
+    try:
+        with pytest.raises(OSError):
+            contender.bind((host, port))
+    finally:
+        contender.close()
+        listener.close()
 
 
 class _FakeProcess:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -52,3 +52,40 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
 def test_repository_model_without_revision_fails_closed() -> None:
     with pytest.raises(SystemExit, match="requires --revision"):
         _MODULE._resolve_model("owner/model", None)
+
+
+class _FakeProcess:
+    pid = 12345
+
+    def __init__(self, poll_result: int | None) -> None:
+        self.poll_result = poll_result
+        self.wait_calls: list[int] = []
+
+    def poll(self) -> int | None:
+        return self.poll_result
+
+    def wait(self, timeout: int) -> int:
+        self.wait_calls.append(timeout)
+        return 0
+
+
+def test_stop_process_is_noop_after_server_already_exited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(0)
+    monkeypatch.setattr(_MODULE.os, "killpg", lambda *_: pytest.fail("must not signal"))
+    _MODULE._stop_process(process)
+    assert process.wait_calls == []
+
+
+def test_stop_process_tolerates_exit_between_poll_and_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(None)
+
+    def process_gone(*_: object) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(_MODULE.os, "killpg", process_gone)
+    _MODULE._stop_process(process)
+    assert process.wait_calls == [15]

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -14,9 +14,8 @@ _SPEC.loader.exec_module(_MODULE)
 
 
 def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
-    assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
-    assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
-    assert _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
+    assert _MODULE._completion_is_sensible("SPOTTED_CAT")
+    assert _MODULE._completion_is_sensible(" spotted_cat. ")
 
 
 def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
@@ -24,13 +23,10 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
-    assert not _MODULE._completion_is_sensible("I cannot identify the animal.")
-    assert not _MODULE._completion_is_sensible("I cannot identify the cat.")
-    assert not _MODULE._completion_is_sensible(
-        "The animal might be a cat, but I am unsure."
-    )
+    assert not _MODULE._completion_is_sensible("OTHER")
     assert not _MODULE._completion_is_sensible("This is not a cheetah.")
-    assert not _MODULE._completion_is_sensible("I am not sure this is a leopard.")
+    assert not _MODULE._completion_is_sensible("A dog is chasing a cat.")
+    assert not _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
@@ -99,7 +95,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         assert content[0]["type"] == "text"
         assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
         body = json.dumps({
-            "choices": [{"message": {"content": "A spotted cheetah cub runs forward."}}]
+            "choices": [{"message": {"content": "SPOTTED_CAT"}}]
         }).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -144,6 +140,45 @@ def test_main_executes_socket_activated_http_image_journey(
         ],
     )
     assert _MODULE.main() == 0
+
+
+def test_main_cleans_log_when_process_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sidecar = tmp_path / "sidecar"
+    executable = sidecar / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    model = tmp_path / "model"
+    model.mkdir()
+    image = tmp_path / "fixture.png"
+    image.write_bytes(b"fixture")
+    original_named_temporary_file = _MODULE.tempfile.NamedTemporaryFile
+
+    def local_temporary_file(**kwargs):
+        return original_named_temporary_file(dir=tmp_path, **kwargs)
+
+    def fail_to_start(*args, **kwargs):
+        raise OSError("exec failed")
+
+    monkeypatch.setattr(_MODULE.tempfile, "NamedTemporaryFile", local_temporary_file)
+    monkeypatch.setattr(_MODULE.subprocess, "Popen", fail_to_start)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(_SCRIPT),
+            "--sidecar-root",
+            str(sidecar),
+            "--model",
+            str(model),
+            "--image",
+            str(image),
+        ],
+    )
+    with pytest.raises(OSError, match="exec failed"):
+        _MODULE.main()
+    assert list(tmp_path.glob("rapid-sidecar-vision-*.log")) == []
 
 
 class _FakeProcess:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -33,7 +33,14 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
         in workflow
     )
+    assert "SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit" in workflow
+    assert (
+        "SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2"
+        in workflow
+    )
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+    assert '"$SIDE/python/bin/python3.12"' in workflow
+    assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow
     assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
 
 

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -33,6 +33,7 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
+    assert "timeout-minutes: 155" in workflow
     assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
     assert (
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -16,6 +16,7 @@ _SPEC.loader.exec_module(_MODULE)
 def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
     assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
     assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
+    assert _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
 
 
 def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
@@ -28,6 +29,8 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible(
         "The animal might be a cat, but I am unsure."
     )
+    assert not _MODULE._completion_is_sensible("This is not a cheetah.")
+    assert not _MODULE._completion_is_sensible("I am not sure this is a leopard.")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -67,6 +67,82 @@ def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
         listener.close()
 
 
+_FAKE_SIDECAR = """#!/usr/bin/env python3
+import http.server
+import json
+import socket
+import sys
+
+fd = int(sys.argv[sys.argv.index("--listen-fd") + 1])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        assert self.path == "/v1/models"
+        body = json.dumps({"data": []}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        assert self.path == "/v1/chat/completions"
+        length = int(self.headers["Content-Length"])
+        payload = json.loads(self.rfile.read(length))
+        content = payload["messages"][0]["content"]
+        assert content[0]["type"] == "text"
+        assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+        body = json.dumps({
+            "choices": [{"message": {"content": "A spotted cheetah cub runs forward."}}]
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+listener = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler, bind_and_activate=False)
+server.socket = listener
+server.server_address = listener.getsockname()
+server.serve_forever()
+"""
+
+
+def test_main_executes_socket_activated_http_image_journey(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sidecar = tmp_path / "sidecar"
+    executable = sidecar / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True)
+    executable.write_text(_FAKE_SIDECAR)
+    executable.chmod(0o755)
+    model = tmp_path / "model"
+    model.mkdir()
+    image = tmp_path / "fixture.png"
+    image.write_bytes(b"fixture-image-bytes")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(_SCRIPT),
+            "--sidecar-root",
+            str(sidecar),
+            "--model",
+            str(model),
+            "--image",
+            str(image),
+            "--startup-timeout",
+            "5",
+            "--request-timeout",
+            "5",
+        ],
+    )
+    assert _MODULE.main() == 0
+
+
 class _FakeProcess:
     pid = 12345
 

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -22,6 +22,11 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
+    assert not _MODULE._completion_is_sensible("I cannot identify the animal.")
+    assert not _MODULE._completion_is_sensible("I cannot identify the cat.")
+    assert not _MODULE._completion_is_sensible(
+        "The animal might be a cat, but I am unsure."
+    )
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -13,27 +13,25 @@ _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 
 
-def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
-    assert _MODULE._completion_is_sensible("SPOTTED_CAT")
-    assert _MODULE._completion_is_sensible(" spotted_cat. ")
+def test_completion_matches_exact_expected_fixture_class() -> None:
+    assert _MODULE._completion_matches("SPOTTED_CAT", "SPOTTED_CAT")
+    assert _MODULE._completion_matches(" other. ", "OTHER")
 
 
-def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
-    assert not _MODULE._completion_is_sensible(None)
-    assert not _MODULE._completion_is_sensible("")
-    assert not _MODULE._completion_is_sensible("Internal server error")
-    assert not _MODULE._completion_is_sensible("A blue square is visible.")
-    assert not _MODULE._completion_is_sensible("OTHER")
-    assert not _MODULE._completion_is_sensible("This is not a cheetah.")
-    assert not _MODULE._completion_is_sensible("A dog is chasing a cat.")
-    assert not _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
+def test_completion_rejects_empty_error_wrong_or_unrelated_output() -> None:
+    assert not _MODULE._completion_matches(None, "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("Internal server error", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("A blue square is visible.", "OTHER")
+    assert not _MODULE._completion_matches("OTHER", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("SPOTTED_CAT", "OTHER")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
-    assert "timeout-minutes: 155" in workflow
+    assert "timeout-minutes: 165" in workflow
     assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
     assert (
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
@@ -47,6 +45,10 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
     assert '"$SIDE/python/bin/python3.12"' in workflow
     assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow
+    assert (
+        "--negative-image apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png"
+        in workflow
+    )
     assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
 
 
@@ -69,6 +71,7 @@ def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
 
 _FAKE_SIDECAR = """#!/usr/bin/env python3
 import http.server
+import base64
 import json
 import socket
 import sys
@@ -95,9 +98,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
         content = payload["messages"][0]["content"]
         assert content[0]["type"] == "text"
         assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
-        body = json.dumps({
-            "choices": [{"message": {"content": "SPOTTED_CAT"}}]
-        }).encode()
+        encoded = content[1]["image_url"]["url"].split(",", 1)[1]
+        image = base64.b64decode(encoded)
+        verdict = "SPOTTED_CAT" if image == b"positive-image" else "OTHER"
+        body = json.dumps({"choices": [{"message": {"content": verdict}}]}).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -123,7 +127,9 @@ def test_main_executes_socket_activated_http_image_journey(
     model = tmp_path / "model"
     model.mkdir()
     image = tmp_path / "fixture.png"
-    image.write_bytes(b"fixture-image-bytes")
+    image.write_bytes(b"positive-image")
+    negative_image = tmp_path / "negative.png"
+    negative_image.write_bytes(b"negative-image")
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -134,6 +140,8 @@ def test_main_executes_socket_activated_http_image_journey(
             str(model),
             "--image",
             str(image),
+            "--negative-image",
+            str(negative_image),
             "--startup-timeout",
             "5",
             "--request-timeout",
@@ -155,6 +163,8 @@ def test_main_cleans_log_when_process_creation_fails(
     model.mkdir()
     image = tmp_path / "fixture.png"
     image.write_bytes(b"fixture")
+    negative_image = tmp_path / "negative.png"
+    negative_image.write_bytes(b"negative")
     original_named_temporary_file = _MODULE.tempfile.NamedTemporaryFile
 
     def local_temporary_file(**kwargs):
@@ -175,6 +185,8 @@ def test_main_cleans_log_when_process_creation_fails(
             str(model),
             "--image",
             str(image),
+            "--negative-image",
+            str(negative_image),
         ],
     )
     with pytest.raises(OSError, match="exec failed"):


### PR DESCRIPTION
## Goal

Restore reliable photo input in the bundled Desktop runtime by shipping the validated vision loader version and proving it against a real image request.

## Why

The previously bundled loader mishandles image inputs for a supported vision architecture, so Desktop users can select a photo-capable model yet fail on their first real photo. Import-only checks do not exercise that path; the release gate therefore needs an actual image request through the packaged runtime.

## Scope

- pin the Desktop sidecar to MLX 0.32.2, Transformers 5.12.1, and mlx-vlm 0.6.16
- preserve fail-closed installed-distribution validation, with one exact-version compatibility exception and a tracked removal condition (#2380)
- add an opt-in, fail-closed real-image smoke for release-candidate builds
- update bundled dependency documentation and CI test inventory

## Non-goals

- no engine/server routing or public dependency-extra change
- no wheel metadata mutation or broad dependency bypass
- no full vision-extra bundle, product UI change, release tag, or publication

## Acceptance evidence

- focused Python contracts: 41 passed
- focused Swift packaging contracts: 7 passed
- clean sidecar build: 173 Mach-Os, 474 MiB raw, 161 MiB tarball
- built sidecar versions: MLX 0.32.2, Transformers 5.12.1, mlx-vlm 0.6.16, mlx-audio 0.4.3
- Qwen/Gemma/DiffusionGemma imports passed; torch, torchvision, and cv2 remain absent
- cached Qwen3.5-9B-4bit + project PNG through the bundled executable and `/v1/chat/completions`: HTTP 200 with a correct image description
- release-shaped ad-hoc app: 513 MiB (+11 MiB from the 0.13.0 baseline); strict codesign verification passed

The local DMG content build reached the Finder layout step, where the shared Studio session had multiple older read-only images mounted with the same volume identity. The isolated hosted release lane remains the authoritative DMG, signing, and notarization gate.
