### PR TITLE
fix(mac): choose a hardware-fit first-run model

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
@@ -31,11 +31,10 @@ import Foundation
 ///
 /// ## Why lfm2.5-1b-4bit (LFM2.5 1.2B Instruct)
 ///
-/// 2026-08-05: swapped from ``bonsai-1.7b-2bit``. Kept in lock-step
-/// with ``QuickstartCoordinator.defaultChoice`` — the two are the same
-/// product decision reached by two paths (bundled vs downloaded), and
-/// letting them drift means an airgapped build ships a first-launch
-/// model the online path has already rejected.
+/// 2026-08-05: swapped from ``bonsai-1.7b-2bit``. It now stays in lock-step
+/// with ``QuickstartCoordinator.lowMemoryChoice``: the hardware-fit automatic
+/// starter is larger, while the bundle remains the explicit low-memory and
+/// airgapped escape hatch.
 ///
 /// Bonsai was chosen (#1092) on a tool-call eval: 6/6 clean
 /// ``tool_calls`` on the 1.7B. That measurement was real but did not

--- a/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
@@ -50,8 +50,7 @@ import Foundation
 /// logic without duplicating the threshold constant.
 enum DiskSpaceProbe {
 
-    /// The free-space threshold the Quickstart pre-flight uses to
-    /// decide whether to surface the low-disk banner.
+    /// Minimum free-space threshold for a small Quickstart download.
     ///
     /// Sized for the Quickstart default ``lfm2.5-1b-4bit``
     /// (~0.6 GB on disk):
@@ -79,6 +78,17 @@ enum DiskSpaceProbe {
     /// ``QuickstartCoordinator.defaultChoice``) moves again, re-derive this
     /// constant — do not assume 2 GiB still covers it.
     static let quickstartRequiredBytes: Int64 = 2 * 1024 * 1024 * 1024
+
+    /// Selected-model budget: 1.5× transient download peak plus 1 GiB for
+    /// macOS, rounded up to a whole GiB so the warning copy stays legible.
+    /// The historical 2 GiB threshold remains the floor for small models.
+    static func requiredBytes(downloadBytes: Int64) -> Int64 {
+        guard downloadBytes > 0 else { return quickstartRequiredBytes }
+        let gib = Double(1 << 30)
+        let budget = Double(downloadBytes) * 1.5 + gib
+        let rounded = Int64((budget / gib).rounded(.up)) * Int64(1 << 30)
+        return max(quickstartRequiredBytes, rounded)
+    }
 
     /// Outcome of ``decide``. Used to drive both the UI banner and a
     /// future telemetry signal (how often does the warning fire for

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -667,7 +667,8 @@ struct ModelPickerBar: View {
     /// independent notion of emptiness is exactly how the picker ended up
     /// with a branch that believed it had rows while rendering none.
     private var hasSelectableRows: Bool {
-        if quickstartEntry() != nil { return true }
+        let quickstartAlias = quickstartEntry()?.alias
+        if quickstartAlias != nil { return true }
         if !recommendedPickRows().isEmpty { return true }
         let filtered = ModelPickerVisibility.filter(
             catalog,
@@ -676,7 +677,7 @@ struct ModelPickerBar: View {
         )
         let deduped = ModelPickerBar.dedupedAllEntries(
             filtered: filtered,
-            quickstartRowRendered: quickstartEntry() != nil
+            quickstartAlias: quickstartAlias
         )
         let partition = ModelPickerBar.partitionByFit(deduped, hardware: hardware)
         return !partition.fits.isEmpty || !partition.notFit.isEmpty
@@ -791,10 +792,10 @@ struct ModelPickerBar: View {
     /// invariant directly without standing up a SwiftUI host.
     static func dedupedAllEntries(
         filtered: [ModelEntry],
-        quickstartRowRendered: Bool
+        quickstartAlias: String?
     ) -> [ModelEntry] {
-        guard quickstartRowRendered else { return filtered }
-        return filtered.filter { $0.alias != QuickstartCoordinator.defaultChoice.alias }
+        guard let quickstartAlias else { return filtered }
+        return filtered.filter { $0.alias != quickstartAlias }
     }
 
     /// Order the "All models" list: downloaded (cached) aliases first,
@@ -866,7 +867,7 @@ struct ModelPickerBar: View {
         // "select this alias" semantics.
         let deduped = ModelPickerBar.dedupedAllEntries(
             filtered: filtered,
-            quickstartRowRendered: quickstartEntry() != nil
+            quickstartAlias: quickstartEntry()?.alias
         )
         let partition = ModelPickerBar.partitionByFit(deduped, hardware: hardware)
         let sorted = ModelPickerBar.orderedAllModels(partition.fits)

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// card can still one-click install the demo model from the picker:
 ///
 ///   ┌── Quickstart ─────────────────────────────────┐
-///   │  lfm2.5-1b-4bit · Smallest model — fastest   │ ← RAM-blind, F-LWT-1
+///   │  qwen3.5-4b-4bit · Recommended first model   │ ← standard starter
 ///   │  first install                                │
 ///   ├── Recommended for your 18 GB Mac ─────────────┤
 ///   │  Recommended qwen3.5-9b-4bit   [amber row     │ ← the RAM tier's
@@ -86,7 +86,7 @@ struct ModelPickerBar: View {
 
     /// The alias the Quickstart flow is currently aimed at — the wizard's
     /// live selection (#1524) while a coordinator is attached, else the
-    /// fixed starter (lfm2.5-1b-4bit). This is the target the in-flight
+    /// standard starter when no coordinator is attached. This is the target the in-flight
     /// picker breadcrumb mirrors onto so the picker never shows a model
     /// that disagrees with what's downloading. The picker's *own*
     /// persistent "Quickstart" demo row is a separate, always-starter
@@ -644,15 +644,14 @@ struct ModelPickerBar: View {
         }
     }
 
-    /// F-LWT-1: dedicated single-row "Quickstart" section above the
-    /// RAM-aware Recommended section. RAM-blind by design — the
-    /// Quickstart alias is the same on every Mac (lfm2.5-1b-4bit is
-    /// the smallest first-impression install). Persists
+    /// Dedicated single-row "Quickstart" section above the RAM-aware
+    /// Recommended section. It exposes the standard starter after onboarding;
+    /// the first-run wizard itself applies the hardware/cache-aware policy. Persists
     /// across all Quickstart phases including ``.dismissed`` so a
     /// user who closed the Quickstart card can still come back and
     /// one-click install the demo model from the picker.
     ///
-    /// Row subtitle ("Smallest model — fastest first install") is
+    /// Row subtitle ("Recommended first model") is
     /// pinned by ``ModelPickerBar.quickstartSubtitle`` so the test
     /// suite catches accidental drift (the section's whole purpose
     /// is to be the bottom-anchored "I just want to try the app"
@@ -732,11 +731,9 @@ struct ModelPickerBar: View {
     /// Subtitle pinned to a single short phrase (~30 chars) so the
     /// "Quickstart" section copy stays anchored even if the file is
     /// later edited around it. The two candidates considered in
-    /// F-LWT-1 ("~1.5 min cold install" / "Smallest model — fastest
-    /// first impression") collapse to the second because the timing
-    /// promise depends on link speed — calling out "smallest /
-    /// fastest" is honest regardless of the user's bandwidth.
-    static let quickstartSubtitle: String = "Smallest model — fastest first install"
+    /// The row makes the product recommendation without promising a download
+    /// duration or claiming this quality-floor starter is the smallest model.
+    static let quickstartSubtitle: String = "Recommended first model"
 
     /// Resolve the safe picker default while the current user is still
     /// eligible for Quickstart. Kept pure so the retired-starter regression

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -93,7 +93,8 @@ struct ModelPickerBar: View {
     /// affordance and
     /// uses ``QuickstartCoordinator.defaultChoice`` directly.
     private var quickstartTargetAlias: String {
-        quickstart?.selection.alias ?? QuickstartCoordinator.defaultChoice.alias
+        quickstart?.selection.alias
+            ?? QuickstartCoordinator.baselineChoice(hardware: hardware).alias
     }
     /// cycle-7: hide sub-1B aliases (qwen3-0.6b-*) from the
     /// alphabetical "All models" list by default — they hallucinate
@@ -698,7 +699,8 @@ struct ModelPickerBar: View {
     /// section is dropped entirely rather than rendering a row that
     /// can't be Started.
     private func quickstartEntry() -> ModelEntry? {
-        return catalog.first(where: { $0.alias == QuickstartCoordinator.defaultChoice.alias })
+        let alias = QuickstartCoordinator.baselineChoice(hardware: hardware).alias
+        return catalog.first(where: { $0.alias == alias })
     }
 
     /// One row for the Quickstart section. Mirrors ``aliasButton``'s

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -183,8 +183,8 @@ struct QuickstartRecommendedCard: View {
                         .foregroundStyle(RapidTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                     HStack(spacing: 7) {
-                        OnboardingAttributePill(text: "Instant")
-                        OnboardingAttributePill(text: "Runs on any Mac")
+                        OnboardingAttributePill(text: "On-device")
+                        OnboardingAttributePill(text: "Fits this Mac")
                     }
                     .padding(.top, 2)
                 }
@@ -207,7 +207,7 @@ struct QuickstartRecommendedCard: View {
         if choice.isStarter { parts.append("recommended starter") }
         parts.append(choice.blurb)
         if !sizeText.isEmpty { parts.append("download \(sizeText)") }
-        parts.append("instant, runs on any Mac")
+        parts.append("on-device, fits this Mac")
         return parts.joined(separator: ". ")
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -4443,8 +4443,8 @@ struct QuickstartView: View {
     /// disk probe (FU-4) and the real kickoff:
     ///
     ///   * Probe ``freeBytesProbe`` (defaults to the HF cache volume).
-    ///   * Run ``DiskSpaceProbe.decide`` against
-    ///     ``DiskSpaceProbe.quickstartRequiredBytes``.
+    ///   * Derive the selected model's transient + OS-headroom requirement.
+    ///   * Run ``DiskSpaceProbe.decide`` against that requirement.
     ///   * ``.ok`` → fire ``kickoffDownload`` directly.
     ///   * ``.warn`` → flip the coordinator to ``.lowDiskWarning`` and
     ///     let the user choose Continue / Cancel from the rendered
@@ -4463,11 +4463,22 @@ struct QuickstartView: View {
         QuickstartView.applyPreflightDecision(
             decision: DiskSpaceProbe.decide(
                 freeBytes: freeBytesProbe(),
-                requiredBytes: DiskSpaceProbe.quickstartRequiredBytes
+                requiredBytes: Self.requiredDiskBytes(for: coordinator.selection)
             ),
             coordinator: coordinator,
             onKickoff: { kickoffDownload() }
         )
+    }
+
+    /// Translate the same selected-model size shown by onboarding into the
+    /// disk pre-flight budget. Authored byte receipts win; other choices use
+    /// the existing model-sizing estimate rather than alias-specific logic.
+    static func requiredDiskBytes(for choice: QuickstartModelChoice) -> Int64 {
+        let gib = Double(1 << 30)
+        let downloadBytes = choice.downloadBytes ?? Int64(
+            (ModelSizing.estimate(alias: choice.alias).weightsGB * gib).rounded(.up)
+        )
+        return DiskSpaceProbe.requiredBytes(downloadBytes: downloadBytes)
     }
 
     /// Cached models skip both the disk-space warning and DownloadManager.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -510,6 +510,7 @@ Open the picker any time to switch models.
     /// return rather than a reset.
     func beginBrowsingCatalog() {
         guard case .idle = phase else { return }
+        selectionUsesAutomaticPolicy = false
         stage = .chooseModel
         step2Stage = .browsing
     }
@@ -534,6 +535,7 @@ Open the picker any time to switch models.
     func beginReviewDownload(origin: ReviewOrigin) {
         guard case .idle = phase else { return }
         guard step2Stage != .reviewing else { return }
+        selectionUsesAutomaticPolicy = false
         stage = .chooseModel
         reviewOrigin = origin
         step2Stage = .reviewing

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -255,6 +255,7 @@ final class QuickstartCoordinator {
         alias: "qwen3.5-4b-4bit",
         displayName: "Qwen 3.5 · 4B",
         hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
+        downloadBytes: 3_061_121_321,
         blurb: "Strong everyday chat and tools, chosen for a reliable first conversation.",
         tier: .starter
     )
@@ -264,6 +265,7 @@ final class QuickstartCoordinator {
         alias: "lfm2.5-2.6b-4bit",
         displayName: "LFM2.5 · 2.6B",
         hfRepo: "LiquidAI/LFM2.5-2.6B-MLX",
+        downloadBytes: 1_601_103_345,
         blurb: "A lighter everyday model chosen to fit lower-memory Macs.",
         tier: .starter
     )

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1932,17 +1932,21 @@ struct QuickstartView: View {
     /// welcome screen appears; neither ordering may leave the chooser pointing
     /// at a card it does not render.
     private func advanceToModelChoice() {
-        coordinator.settleDefaultChoice(
-            hardware: hardware,
-            catalog: catalogLoaded ? cachedModels : []
-        )
+        if catalogLoaded {
+            coordinator.settleDefaultChoice(hardware: hardware, catalog: cachedModels)
+        } else {
+            // This is a provisional RAM baseline, not an authoritative empty
+            // catalog. Keep automatic policy live so the first real snapshot
+            // can still prefer an eligible cached model.
+            coordinator.applyDefaultChoice(hardware: hardware, catalog: [])
+        }
         coordinator.advanceToChooseModel()
     }
 
-    /// The one genuine onboarding dismissal. Keep the policy settlement and
+    /// The one genuine onboarding dismissal. Keep the live policy refresh and
     /// callback together so every exit preserves the same starter selection.
     private func skipForNow() {
-        coordinator.settleDefaultChoice(
+        coordinator.applyDefaultChoice(
             hardware: hardware,
             catalog: catalogLoaded ? cachedModels : []
         )

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1486,7 +1486,10 @@ struct QuickstartView: View {
             // it with an eligible cached model, but an immediate Skip can
             // never leak the static 16 GB starter onto a smaller Mac.
             .onAppear {
-                coordinator.applyDefaultChoice(hardware: hardware, catalog: [])
+                coordinator.applyDefaultChoice(
+                    hardware: hardware,
+                    catalog: catalogLoaded ? cachedModels : []
+                )
             }
             // Observe serve transitions so we can flip to ``.ready`` (and
             // seed the welcome message) as soon as the sidecar comes
@@ -1871,6 +1874,14 @@ struct QuickstartView: View {
                     // #1653; it does not any more, because a user asking to
                     // see the catalogue has not asked to leave setup.
                     Button("Skip for now") {
+                        // The catalog can become authoritative one run-loop
+                        // turn before its `.task` executes. Resolve that live
+                        // snapshot synchronously so Skip never outruns an
+                        // eligible cached-model preference.
+                        coordinator.applyDefaultChoice(
+                            hardware: hardware,
+                            catalog: catalogLoaded ? cachedModels : []
+                        )
                         onSkip()
                     }
                     .buttonStyle(.onboardingQuiet)

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -327,9 +327,7 @@ final class QuickstartCoordinator {
         hardware: MacHardware,
         catalog: [ModelEntry]
     ) -> QuickstartModelChoice {
-        let baseline = hardware.physicalRAMGB < 16
-            ? compactDefaultChoice
-            : defaultChoice
+        let baseline = baselineChoice(hardware: hardware)
         let eligibleCatalog = catalog.filter { $0.kind == .chat }
         let excluded = CacheAwareDefault.retiredAutomaticAliases
             .union([lowMemoryChoice.alias])
@@ -340,6 +338,14 @@ final class QuickstartCoordinator {
             excludedAliases: excluded
         ) else { return baseline }
         return choice(forAlias: alias)
+    }
+
+    /// RAM-only baseline shared by onboarding and the persistent picker row.
+    /// Cached preference is deliberately layered only by ``defaultChoice``.
+    static func baselineChoice(hardware: MacHardware) -> QuickstartModelChoice {
+        hardware.physicalRAMGB < 16
+            ? compactDefaultChoice
+            : defaultChoice
     }
 
     /// UserDefaults key for the persistent "Quickstart already

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1481,6 +1481,13 @@ struct QuickstartView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(RapidTheme.canvas)
+            // Establish the RAM-only baseline synchronously before welcome
+            // actions become interactive. The catalog task below may replace
+            // it with an eligible cached model, but an immediate Skip can
+            // never leak the static 16 GB starter onto a smaller Mac.
+            .onAppear {
+                coordinator.applyDefaultChoice(hardware: hardware, catalog: [])
+            }
             // Observe serve transitions so we can flip to ``.ready`` (and
             // seed the welcome message) as soon as the sidecar comes
             // online. ``.task(id:)`` re-fires on every ``server.state``

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -338,7 +338,17 @@ final class QuickstartCoordinator {
             hardware: hardware,
             bucketedDefault: baseline.alias,
             excludedAliases: excluded
-        ) else { return baseline }
+        ) else {
+            // An older sidecar may not know the new starter aliases yet. The
+            // authored 1.2B ladder entry remains a catalog-proven compatibility
+            // fallback; it is not considered while either current baseline or
+            // another eligible cached choice can be resolved.
+            if !eligibleCatalog.isEmpty,
+               eligibleCatalog.contains(where: { $0.alias == lowMemoryChoice.alias }) {
+                return lowMemoryChoice
+            }
+            return baseline
+        }
         return choice(forAlias: alias)
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -731,6 +731,14 @@ Open the picker any time to switch models.
         selection = Self.defaultChoice(hardware: hardware, catalog: catalog)
     }
 
+    /// Apply the first authoritative catalog decision exactly once. Later
+    /// cache refreshes must not retarget a starter the chooser already shows.
+    func settleDefaultChoice(hardware: MacHardware, catalog: [ModelEntry]) {
+        guard case .idle = phase, selectionUsesAutomaticPolicy else { return }
+        selection = Self.defaultChoice(hardware: hardware, catalog: catalog)
+        selectionUsesAutomaticPolicy = false
+    }
+
     /// True once ``markDone`` has been called. Read on every eligibility
     /// check so the surface never returns. Mirrors UserDefaults.
     private(set) var done: Bool
@@ -1538,7 +1546,7 @@ struct QuickstartView: View {
                     .sorted()
             )) {
                 guard catalogLoaded else { return }
-                coordinator.applyDefaultChoice(hardware: hardware, catalog: cachedModels)
+                coordinator.settleDefaultChoice(hardware: hardware, catalog: cachedModels)
             }
             // The warning asks the user to free memory, so keep observing the
             // result of that action while this exact decision is visible.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1497,6 +1497,19 @@ struct QuickstartView: View {
             .task(id: downloadJobStatusKey) {
                 handleDownloadStatusChange()
             }
+            // Selection belongs to the whole onboarding lifecycle, not Step 2:
+            // Skip is available on the welcome screen and must hand the parent
+            // the same hardware/cache-aware alias the chooser would show.
+            .task(id: StarterSelectionKey(
+                catalogLoaded: catalogLoaded,
+                physicalRAMGB: hardware.physicalRAMGB,
+                catalogSignature: cachedModels
+                    .map { "\($0.alias):\($0.kind):\($0.cached)" }
+                    .sorted()
+            )) {
+                guard catalogLoaded else { return }
+                coordinator.applyDefaultChoice(hardware: hardware, catalog: cachedModels)
+            }
             // The warning asks the user to free memory, so keep observing the
             // result of that action while this exact decision is visible.
             // The view-bound task cancels when onboarding unmounts; three
@@ -1904,16 +1917,6 @@ struct QuickstartView: View {
         // signal rather than a timer. Re-fires when the snapshot lands.
         .task(id: catalogLoaded) {
             coordinator.resolveRecommendationLoading(catalogLoaded: catalogLoaded)
-        }
-        .task(id: StarterSelectionKey(
-            catalogLoaded: catalogLoaded,
-            physicalRAMGB: hardware.physicalRAMGB,
-            catalogSignature: cachedModels
-                .map { "\($0.alias):\($0.kind):\($0.cached)" }
-                .sorted()
-        )) {
-            guard catalogLoaded else { return }
-            coordinator.applyDefaultChoice(hardware: hardware, catalog: cachedModels)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1877,7 +1877,7 @@ struct QuickstartView: View {
 
                 OnboardingActionLane {
                     Button {
-                        coordinator.advanceToChooseModel()
+                        advanceToModelChoice()
                     } label: {
                         Text(Self.welcomePrimaryTitle(resuming: coordinator.isResumingIncompleteSetup))
                     }
@@ -1902,15 +1902,7 @@ struct QuickstartView: View {
                     // #1653; it does not any more, because a user asking to
                     // see the catalogue has not asked to leave setup.
                     Button("Skip for now") {
-                        // The catalog can become authoritative one run-loop
-                        // turn before its `.task` executes. Resolve that live
-                        // snapshot synchronously so Skip never outruns an
-                        // eligible cached-model preference.
-                        coordinator.applyDefaultChoice(
-                            hardware: hardware,
-                            catalog: catalogLoaded ? cachedModels : []
-                        )
-                        onSkip()
+                        skipForNow()
                     }
                     .buttonStyle(.onboardingQuiet)
                     .keyboardShortcut(.cancelAction)
@@ -1933,6 +1925,28 @@ struct QuickstartView: View {
     /// the model chooser").
     static func welcomePrimaryTitle(resuming: Bool) -> String {
         resuming ? "Continue setup" : "Get started"
+    }
+
+    /// Resolve the latest hardware/cache policy at the user's action boundary.
+    /// SwiftUI's catalogue task can legitimately settle before or after the
+    /// welcome screen appears; neither ordering may leave the chooser pointing
+    /// at a card it does not render.
+    private func advanceToModelChoice() {
+        coordinator.settleDefaultChoice(
+            hardware: hardware,
+            catalog: catalogLoaded ? cachedModels : []
+        )
+        coordinator.advanceToChooseModel()
+    }
+
+    /// The one genuine onboarding dismissal. Keep the policy settlement and
+    /// callback together so every exit preserves the same starter selection.
+    private func skipForNow() {
+        coordinator.settleDefaultChoice(
+            hardware: hardware,
+            catalog: catalogLoaded ? cachedModels : []
+        )
+        onSkip()
     }
 
     // MARK: - Step 2 · Choose a model
@@ -3267,7 +3281,21 @@ struct QuickstartView: View {
                 ? QuickstartCoordinator.compactDefaultChoice.alias
                 : QuickstartCoordinator.defaultChoice.alias
         } ?? QuickstartCoordinator.defaultChoice.alias
-        let cachedPresentation = quickstartCachedPresentation(catalog, limit: 6)
+        var cachedPresentation = quickstartCachedPresentation(catalog, limit: 6)
+        // A catalog-preferred authored choice can sit just beyond the bounded
+        // cached row. Keep the bound, but swap that selected row into view so
+        // selection and AXSelected always have one visible owner.
+        if choices.contains(where: { $0.alias == selection }),
+           !cachedPresentation.primary.contains(where: { $0.alias == selection }),
+           let selectedEntry = quickstartCachedModels(catalog).first(where: {
+               $0.alias == selection
+           }) {
+            cachedPresentation.alternates.removeAll { $0.alias == selection }
+            if let displaced = cachedPresentation.primary.popLast() {
+                cachedPresentation.alternates.insert(displaced, at: 0)
+            }
+            cachedPresentation.primary.append(selectedEntry)
+        }
         let existing = cachedPresentation.primary
         let existingAliases = Set(existing.map(\.alias))
         // The RAM-aware recommended row: SSOT picks for this Mac, dropped if

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -17,82 +17,46 @@ import SwiftUI
 /// inert until something finishes loading. That is the worst possible
 /// first-touch shape for an inference app.
 ///
-/// Quickstart collapses the cold-start into one click. The card surfaces
+/// Quickstart collapses the cold-start into one guided choice. The card surfaces
 /// when (a) the user has no last-served alias persisted — or has one that
 /// is a ``retiredStarters`` entry, i.e. a model we stranded them on —
 /// AND (b) the quickstart flag in UserDefaults hasn't been set yet AND
-/// (c) the server isn't already busy with something else. Clicking
-/// "Get started"
-/// triggers a ``rapid-mlx pull lfm2.5-1b-4bit`` (~0.6 GB) via the
-/// existing ``DownloadManager``, then auto-spawns
-/// ``rapid-mlx serve lfm2.5-1b-4bit`` once the pull is done, then
+/// (c) the server isn't already busy with something else. The chooser picks a
+/// hardware-fit starter, preferring an eligible cached chat model, and uses the
+/// existing ``DownloadManager`` only when the chosen model is not on disk. It
+/// then auto-spawns that selection and
 /// drops the user into chat with a single seeded assistant message
 /// introducing the model.
 ///
-/// ## Why lfm2.5-1b-4bit
+/// ## Starter policy
 ///
-/// Starter = LFM2.5 1.2B Instruct (mlx 4-bit; rapid-mlx alias
-/// ``lfm2.5-1b-4bit``). This supersedes the ``bonsai-1.7b-2bit``
-/// starter, which degenerated 4/4 on a plain-chat word problem — see
-/// ``defaultChoice`` for the measurements.
-///
-/// History: the original ``qwen3.5-4b-4bit`` (~2.3 GB) cold-installed in
-/// ~11 minutes at the user's observed 4.4 MB/s — an atrocious first
-/// impression — so F-LWT-1 dropped to a tiny ~400 MB 0.6B purely for
-/// install latency. #1092 then moved to Bonsai on the strength of a
-/// tool-call eval. Both swaps optimised something other than "does the
-/// first answer come out right", which is what the user actually sees.
-///
-/// ### The selection criterion this slot actually has
-///
-/// A starter is judged on the first plain-chat reply, not on capability
-/// breadth. Concretely, in priority order:
-///
-///   1. **It must terminate and be coherent.** Non-negotiable, and the
-///      one thing neither prior pick was measured on. Note the guard
-///      cannot cover for a weak model here: the loop breaker and the
-///      streaming hard-stop are both gated on ``request.has_tools``,
-///      and onboarding is plain chat.
-///   2. **It must answer immediately.** A reasoning model is
-///      disqualified regardless of quality — hidden thinking means a
-///      blank screen on the one interaction that forms the impression.
-///      This is why the stronger ``lfm2.5-2.6b-4bit`` is not the
-///      starter even though it is the 8-15 GB tier pick.
-///   3. **Download small enough not to lose the user.** Real, but
-///      weaker than it looks: 637 MB pulled in 21 s, *faster* than
-///      Bonsai's 484 MB in 24 s. Shard parallelism dominates at this
-///      size, so a few hundred MB is not the deciding axis.
-///
-/// Tool calling is deliberately absent from that list. It is the right
-/// bar for a *recommended* model, not for the first 60 seconds.
+/// Below 16 GB, onboarding starts from LFM2.5 2.6B; at 16 GB and above,
+/// it starts from Qwen 3.5 4B. An eligible cached chat model takes priority
+/// so an existing installation does not force another download. LFM2.5 1.2B
+/// remains visible as an explicit low-memory alternative, but is never chosen
+/// automatically. The policy is pure and covered by the starter matrix tests.
 ///
 /// ### What this means for the empty state
 ///
-///   1. The starter is text-first. If ``ToolUseCapability`` does not
-///      list ``lfm2.5-`` as ``.known``, the empty-state capability chip
-///      row stays hidden by the tool-bias gate (PR #333 + FU-9) — which
-///      is the correct, honest surface for it.
+///   1. Capability affordances continue to come from catalog metadata; the
+///      starter choice does not invent capability claims.
 ///   2. The ``ChatView`` empty-state prompts stay model-agnostic pure
 ///      text by design — they must read well on ANY starter, not tease
 ///      a capability tied to one alias — so they are unchanged.
 ///   3. Users who want more depth trade up via the picker's
-///      **Recommended Default** (``RAMBucketedDefault``, RAM-aware —
-///      e.g. ``qwen3.5-9b-4bit`` on an 18 GB Mac), and the
+///      **Recommended Default** (``RAMBucketedDefault``), and the
 ///      ``UpgradeBanner`` nudges them there after a few turns.
 ///
 /// ### What we keep
 ///
-///   * One-click install + chat for the brand-new user, well under a
-///     minute of cold install.
-///   * A dedicated "Quickstart" picker section (RAM-blind, persists
-///     post-dismiss) so a user who skipped Quickstart can still
-///     one-click install the demo model from the picker.
+///   * A short install + chat path for the brand-new user.
+///   * A dedicated "Quickstart" picker section after onboarding.
 ///
 /// The alias resolves in ``vllm_mlx/aliases.json`` (rapid-mlx submodule)
 /// so the value is pinned, not derived. Bumping it is a deliberate
 /// product decision — change the constant + re-run the model
-/// recommendation tests, and keep ``BundledModel.bundledAlias`` in
-/// lock-step (the upgrade nudge keys on it).
+/// recommendation tests. Air-gapped bundled builds keep their independently
+/// versioned small fallback; production DMGs do not bundle model weights.
 ///
 /// ## Why a separate surface (not folded into ``ModelPickerBar``)
 ///
@@ -116,10 +80,10 @@ import SwiftUI
 
 /// One selectable model in the Quickstart wizard's "choose your first
 /// model" step (#1524). The wizard defaults to — and recommends — the
-/// small starter (see ``QuickstartCoordinator.defaultChoice``), but lets
+/// hardware-fit starter (see ``QuickstartCoordinator.defaultChoice(hardware:catalog:)``), but lets
 /// the user trade up to a bigger model before the first download.
 ///
-/// ``hfRepo`` is pinned only for the starter (it wires the precise
+/// ``hfRepo`` is pinned for authored starters (it wires the precise
 /// bytes-on-disk monitor for the first-impression cold install — see the
 /// ``kickoffDownload`` rationale). The bigger options pass ``nil`` and
 /// fall back to tqdm file-count progress; both drive an identical
@@ -134,14 +98,14 @@ struct QuickstartModelChoice: Equatable, Identifiable, Sendable {
     var id: String { alias }
     /// Canonical alias resolved in ``vllm_mlx/aliases.json``.
     let alias: String
-    /// Prose label for onboarding copy ("LFM2.5 · 1.2B"). Hand-picked
+    /// Prose label for onboarding copy (for example, "Qwen 3.5 · 4B"). Hand-picked
     /// rather than catalog-derived so the copy never reads a raw alias.
     let displayName: String
-    /// HF repo backing the byte monitor. Pinned for the starter; ``nil``
+    /// HF repo backing the byte monitor. Pinned for authored starters; ``nil``
     /// for bigger options (tqdm-fallback progress is acceptable there).
     let hfRepo: String?
     /// Curated download size for choices whose alias rounds away a meaningful
-    /// parameter fraction. The starter alias says `1b` for a 1.2B repository;
+    /// parameter fraction. The low-memory alias says `1b` for a 1.2B repository;
     /// using its alias estimate under-reported both the chooser and progress
     /// denominator. Other choices continue to use `ModelSizing` estimates.
     let downloadBytes: Int64?
@@ -284,77 +248,35 @@ final class QuickstartCoordinator {
         case failed(message: String, origin: FailureOrigin)
     }
 
-    /// The default + recommended starter — the first-run decision.
-    /// Pinned, not derived (F-LWT-1: ~11 min cold install of the old 4B
-    /// pick was the wrong first-impression tradeoff; a small starter
-    /// wins).
-    ///
-    /// ## History
-    ///
-    /// - 2026-07-10 (#1092): ``qwen3-0.6b-4bit`` → ``bonsai-1.7b-2bit``.
-    /// - 2026-08-05: ``bonsai-1.7b-2bit`` → ``lfm2.5-1b-4bit``, because
-    ///   the Bonsai starter does not survive an ordinary chat question.
-    ///
-    /// ## Why the Bonsai starter had to go
-    ///
-    /// A community report showed the starter collapsing on a basic
-    /// multi-step word problem. Reproduced on an M2 Pro against engine
-    /// 0.12.4, one plain-chat request (no tools), 4 attempts at two
-    /// different token budgets: it degenerated **4/4** and terminated
-    /// **0/4**. Output doubles words within the first line ("for for",
-    /// "the the the the"), then collapses into an unbounded loop
-    /// (``\text{1} \text{1} …``, ``1 + 9 = 1 + 9 = …``) that only ends
-    /// when it hits ``max_tokens``.
-    ///
-    /// Two things made this the worst possible default. It is *fast*
-    /// while being wrong, so it reads as "this app is broken" rather
-    /// than "this Mac is slow". And the runaway-generation guard cannot
-    /// save it: both the logits-level loop breaker and the streaming
-    /// hard-stop are gated on ``request.has_tools``, and onboarding is
-    /// plain chat — so nothing intervenes.
-    ///
-    /// The prior "6/6 clean ``tool_calls``" evidence is not contradicted;
-    /// it just measured the wrong thing for this slot. Emitting
-    /// well-formed tool calls says nothing about staying coherent in the
-    /// free-form chat every new user actually types first.
-    ///
-    /// ## Why the 1.2B and not the 2.6B
-    ///
-    /// Measured on the same M2 Pro, same prompt. The download worry that
-    /// motivated a ~0.5 GB pick does not survive measurement: 637 MB
-    /// pulled in 21 s, *faster* than Bonsai's 484 MB in 24 s (HF shard
-    /// parallelism dominates at this size).
-    ///
-    /// ``lfm2.5-2.6b-4bit`` is the stronger model and stays the 8-15 GB
-    /// tier recommendation — but it is the wrong *starter*. It routes
-    /// through the ``qwen3`` reasoning parser, so ~2/3 of its output is
-    /// hidden thinking: 3.6 s to a first answer, most of it a blank
-    /// screen. The 1.2B has no reasoning phase — 1.1 s, 170 tok/s, and it
-    /// answered correctly and terminated on **16/16** recorded runs
-    /// (12/12 of them in one controlled repro; quote the 16, it is the
-    /// whole sample). For a first impression, "instant and right" beats
-    /// "smarter but silent first".
-    ///
-    /// Users still trade up in the wizard or later via the picker.
+    /// Standard starter for Macs with at least 16 GB RAM. The first-run
+    /// decision itself is made by ``defaultChoice(hardware:catalog:)`` so a
+    /// lower-memory Mac and an eligible cached model can take the right path.
     static let defaultChoice = QuickstartModelChoice(
+        alias: "qwen3.5-4b-4bit",
+        displayName: "Qwen 3.5 · 4B",
+        hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
+        blurb: "Strong everyday chat and tools, chosen for a reliable first conversation.",
+        tier: .starter
+    )
+
+    /// Smaller quality-floor starter for Macs below 16 GB RAM.
+    static let compactDefaultChoice = QuickstartModelChoice(
+        alias: "lfm2.5-2.6b-4bit",
+        displayName: "LFM2.5 · 2.6B",
+        hfRepo: "LiquidAI/LFM2.5-2.6B-MLX",
+        blurb: "A lighter everyday model chosen to fit lower-memory Macs.",
+        tier: .starter
+    )
+
+    /// Deliberately weaker than the starter. Onboarding surfaces this one explicitly as
+    /// a memory-first fallback and names the trade-off instead of pretending
+    /// it is an equivalent recommendation.
+    static let lowMemoryChoice = QuickstartModelChoice(
         alias: "lfm2.5-1b-4bit",
         displayName: "LFM2.5 · 1.2B",
         hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
         downloadBytes: 663_397_140,
-        blurb: "Small download (~0.6 GB), runs on any Mac. Answers instantly and follows instructions well. Upgrade anytime for more depth.",
-        tier: .starter
-    )
-
-    /// Deliberately weaker than the starter. The normal model picker hides
-    /// sub-1B models to protect users from accidentally choosing quality
-    /// below the product floor; onboarding surfaces this one explicitly as
-    /// a memory-first fallback and names the trade-off instead of pretending
-    /// it is an equivalent recommendation.
-    static let lowMemoryChoice = QuickstartModelChoice(
-        alias: "qwen3-0.6b-4bit",
-        displayName: "Qwen 3 · 0.6B",
-        hfRepo: "mlx-community/Qwen3-0.6B-4bit",
-        blurb: "Lowest memory and fastest startup. Good for basic chat, but less accurate and not recommended for tools.",
+        blurb: "For basic chat only; less accurate and not recommended for tools.",
         tier: .lowMemory
     )
 
@@ -370,14 +292,8 @@ final class QuickstartCoordinator {
     /// ``BenchScoresCatalog`` at render.
     static let onboardingChoices: [QuickstartModelChoice] = [
         defaultChoice,
+        compactDefaultChoice,
         lowMemoryChoice,
-        QuickstartModelChoice(
-            alias: "qwen3.5-4b-4bit",
-            displayName: "Qwen 3.5 · 4B",
-            hfRepo: nil,
-            blurb: "Better everyday quality. Still light on disk.",
-            tier: .tradeUp
-        ),
         QuickstartModelChoice(
             alias: "qwen3.5-9b-4bit",
             displayName: "Qwen 3.5 · 9B",
@@ -403,6 +319,29 @@ final class QuickstartCoordinator {
         ),
     ]
 
+    /// Hardware-aware first-run policy. The existing cache-aware policy is the
+    /// eligibility SSOT for cached choices; onboarding adds only its explicit
+    /// 16 GB baseline and excludes the 1.2B manual fallback from automatic
+    /// selection.
+    static func defaultChoice(
+        hardware: MacHardware,
+        catalog: [ModelEntry]
+    ) -> QuickstartModelChoice {
+        let baseline = hardware.physicalRAMGB < 16
+            ? compactDefaultChoice
+            : defaultChoice
+        let eligibleCatalog = catalog.filter { $0.kind == .chat }
+        let excluded = CacheAwareDefault.retiredAutomaticAliases
+            .union([lowMemoryChoice.alias])
+        guard let alias = CacheAwareDefault.pick(
+            catalog: eligibleCatalog,
+            hardware: hardware,
+            bucketedDefault: baseline.alias,
+            excludedAliases: excluded
+        ) else { return baseline }
+        return choice(forAlias: alias)
+    }
+
     /// UserDefaults key for the persistent "Quickstart already
     /// completed" flag. Once set, the surface NEVER returns — not
     /// even after the user deletes every model. Versioned so a
@@ -422,11 +361,9 @@ final class QuickstartCoordinator {
     /// intro rather than an empty transcript. Interpolates the chosen
     /// model's display name.
     ///
-    /// The starter (lfm2.5-1b-4bit) is intentionally the smallest
-    /// pick, so its copy keeps the "start in about a minute, trade up
-    /// any time" framing. A bigger pick gets a plainer intro without
-    /// the "smallest model" framing (it earned the trade-up, so don't
-    /// undersell it).
+    /// An authored starter keeps the short onboarding framing. A cached or
+    /// manually selected alternative gets a plainer intro without implying it
+    /// was downloaded specifically for setup.
     var seedMessage: String {
         if selection.isStarter {
             return """
@@ -452,6 +389,9 @@ Open the picker any time to switch models.
     /// ContentView visibility gate's alias check) reads this instead of
     /// a pinned constant.
     private(set) var selection: QuickstartModelChoice = QuickstartCoordinator.defaultChoice
+    /// False after the user or persisted session chose a concrete model, so a
+    /// later catalog refresh can never replace explicit intent.
+    private var selectionUsesAutomaticPolicy = true
 
     /// Which pre-download wizard screen shows while ``phase`` is
     /// ``.idle``. Once the download kicks off, ``phase`` leaves ``.idle``
@@ -757,9 +697,18 @@ Open the picker any time to switch models.
     func select(_ choice: QuickstartModelChoice) {
         guard case .idle = phase else { return }
         selection = choice
+        selectionUsesAutomaticPolicy = false
         if let pending = pendingReadyAlias, pending != choice.alias {
             clearPendingReady()
         }
+    }
+
+    /// Apply the first-run policy once the authoritative catalog snapshot is
+    /// available. Re-applying is safe when cache state changes, but only while
+    /// the selection is still automatic.
+    func applyDefaultChoice(hardware: MacHardware, catalog: [ModelEntry]) {
+        guard case .idle = phase, selectionUsesAutomaticPolicy else { return }
+        selection = Self.defaultChoice(hardware: hardware, catalog: catalog)
     }
 
     /// True once ``markDone`` has been called. Read on every eligibility
@@ -805,7 +754,7 @@ Open the picker any time to switch models.
             // quit-mid-flow relaunch trivially matched. Now the live
             // ``selection`` drives the seed target, but ``selection`` is
             // NOT persisted — a fresh ``QuickstartCoordinator()`` re-inits
-            // it to ``defaultChoice`` (0.6B). Persisting the target alias
+            // it to the static standard choice. Persisting the target alias
             // here (and restoring ``selection`` from it in ``init``) keeps
             // the ContentView seed observers comparing the served alias
             // against the model that was actually in flight, so a
@@ -940,6 +889,7 @@ Open the picker any time to switch models.
         if self.awaitingWelcomeSeed,
            let alias = defaults.string(forKey: Self.awaitingSeedAliasKey) {
             self.selection = Self.choice(forAlias: alias)
+            self.selectionUsesAutomaticPolicy = false
         }
         // An unconfirmed Ready flow restores its model and drops the user
         // back at the chooser rather than the welcome hero — they already
@@ -951,6 +901,7 @@ Open the picker any time to switch models.
         // re-entered by the live server observer or not at all.
         if let alias = self.pendingReadyAlias {
             self.selection = Self.choice(forAlias: alias)
+            self.selectionUsesAutomaticPolicy = false
             self.stage = .chooseModel
         }
     }
@@ -1010,6 +961,7 @@ Open the picker any time to switch models.
         catalogSort = .familyThenSize
         catalogScrollID = nil
         selection = Self.defaultChoice
+        selectionUsesAutomaticPolicy = true
         hasSeededWelcome = false
         awaitingWelcomeSeed = false
         pendingReadyAlias = nil
@@ -1953,6 +1905,22 @@ struct QuickstartView: View {
         .task(id: catalogLoaded) {
             coordinator.resolveRecommendationLoading(catalogLoaded: catalogLoaded)
         }
+        .task(id: StarterSelectionKey(
+            catalogLoaded: catalogLoaded,
+            physicalRAMGB: hardware.physicalRAMGB,
+            catalogSignature: cachedModels
+                .map { "\($0.alias):\($0.kind):\($0.cached)" }
+                .sorted()
+        )) {
+            guard catalogLoaded else { return }
+            coordinator.applyDefaultChoice(hardware: hardware, catalog: cachedModels)
+        }
+    }
+
+    private struct StarterSelectionKey: Equatable {
+        let catalogLoaded: Bool
+        let physicalRAMGB: Double
+        let catalogSignature: [String]
     }
 
     /// The canvas + footer lane every Step 2 micro-stage shares.
@@ -2751,6 +2719,10 @@ struct QuickstartView: View {
     private func catalogRow(_ entry: ModelEntry) -> some View {
         let choice = Self.choice(forCatalogEntry: entry)
         let available = OnboardingModelSelection.isAvailable(alias: entry.alias, hardware: hardware)
+        let recommendedAlias = QuickstartCoordinator.defaultChoice(
+            hardware: hardware,
+            catalog: cachedModels
+        ).alias
         OnboardingCatalogRow(
             alias: entry.alias,
             subtitle: Self.catalogRowSubtitle(
@@ -2761,7 +2733,11 @@ struct QuickstartView: View {
             sizeText: Self.rowSizeText(for: entry),
             selected: coordinator.selection.alias == entry.alias,
             isAvailable: available,
-            badges: Self.catalogRowBadges(entry: entry, available: available),
+            badges: Self.catalogRowBadges(
+                entry: entry,
+                available: available,
+                recommendedAlias: recommendedAlias
+            ),
             onActivate: { activatePrimary(in: .catalogue) }
         ) {
             coordinator.select(choice)
@@ -2808,10 +2784,11 @@ struct QuickstartView: View {
     /// capability, benchmark or compatibility claim is introduced.
     static func catalogRowBadges(
         entry: ModelEntry,
-        available: Bool
+        available: Bool,
+        recommendedAlias: String
     ) -> [OnboardingCatalogRow.Badge] {
         var badges: [OnboardingCatalogRow.Badge] = []
-        if entry.alias == QuickstartCoordinator.defaultChoice.alias {
+        if entry.alias == recommendedAlias {
             badges.append(.init(text: "RECOMMENDED", tone: .amber))
         }
         if !available {
@@ -3236,6 +3213,11 @@ struct QuickstartView: View {
         physicalRAMGB: Double? = nil
     ) -> Shortlist {
         let choices = QuickstartCoordinator.onboardingChoices
+        let starterAlias = physicalRAMGB.map {
+            $0 < 16
+                ? QuickstartCoordinator.compactDefaultChoice.alias
+                : QuickstartCoordinator.defaultChoice.alias
+        } ?? QuickstartCoordinator.defaultChoice.alias
         let cachedPresentation = quickstartCachedPresentation(catalog, limit: 6)
         let existing = cachedPresentation.primary
         let existingAliases = Set(existing.map(\.alias))
@@ -3245,7 +3227,9 @@ struct QuickstartView: View {
         var recommended: [QuickstartModelChoice] = []
         if let ram = physicalRAMGB {
             var excluded = existingAliases
-            excluded.insert(QuickstartCoordinator.defaultChoice.alias)
+            excluded.formUnion(
+                choices.filter { $0.isStarter || $0.isLowMemory }.map(\.alias)
+            )
             recommended = Self.recommendedChoices(
                 from: RAMBucketedDefault.picks(forPhysicalRAMGB: ram),
                 authored: choices,
@@ -3268,7 +3252,11 @@ struct QuickstartView: View {
         return Shortlist(
             cached: existing,
             cachedAlternates: cachedPresentation.alternates,
-            starters: choices.filter { $0.isStarter && !existingAliases.contains($0.alias) },
+            starters: choices.filter {
+                $0.isStarter
+                    && $0.alias == starterAlias
+                    && !existingAliases.contains($0.alias)
+            },
             recommended: recommended,
             lowMemory: choices.filter { $0.isLowMemory && !existingAliases.contains($0.alias) },
             tradeUps: tradeUps,

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -14,7 +14,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton id="GitHub.Star.EmptyState" desc="Star on GitHub" help="Opens the Rapid-MLX repository in your browser" enabled=true
-          AXGroup desc="lfm2.5-1b-4bit isn't downloaded yet, It downloads once (~<size>), then starts in seconds." enabled=true
+          AXGroup desc="lfm2.5-2.6b-4bit isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="Readiness.Action" desc="Download" enabled=true
@@ -25,7 +25,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
-          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-1b-4bit before sending." enabled=false
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-2.6b-4bit before sending." enabled=false
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -10,13 +10,10 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
         AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. recommended starter. Small download (~<size>), runs on any Mac. Answers instantly and follows instructions well. Upgrade anytime for more depth.. download ~<size>. instant, runs on any Mac" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. recommended starter. A lighter everyday model chosen to fit lower-memory Macs.. download <size>. on-device, fits this Mac" enabled=true
         AXStaticText value=text enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="lfm2.5 · 2.6B. Not for coding. download <size> · 64%" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. Lowest memory. For basic chat only; less accurate and not recommended for tools. Download ~<size>" enabled=true
         AXStaticText value=text enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="Qwen 3 · 0.6B. Lowest memory. Lowest memory and fastest startup. Good for basic chat, but less accurate and not recommended for tools. Download ~<size>" enabled=true
-        AXStaticText value=text enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 4B. Better everyday quality. Still light on disk.. download <size>" enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 9B. Strong all-rounder if you have the RAM to spare.. download <size>" enabled=true
         AXButton id="Quickstart.BrowseAll" desc="Browse all models" enabled=true
         AXStaticText id="Quickstart.SizeLegend" value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/BundledModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BundledModelTests.swift
@@ -45,16 +45,15 @@ struct BundledModelTests {
     }
 
     @MainActor
-    @Test("Bundled alias agrees with the Quickstart wizard starter — the upgrade nudge keys on this")
-    func bundledAliasMatchesQuickstartStarter() {
+    @Test("Air-gapped bundle remains the explicit low-memory onboarding choice")
+    func bundledAliasMatchesLowMemoryChoice() {
         // The upgrade banner fires only when the active alias equals
         // ``BundledModel.bundledAlias`` (see ``UpgradeBannerCoordinator``),
-        // but the model a fresh-install user actually gets is
-        // ``QuickstartCoordinator.defaultChoice``. If these two ever
-        // drift apart the nudge silently never fires. Pin them equal so
-        // a one-sided edit fails here instead of shipping a dead banner.
-        #expect(BundledModel.bundledAlias == QuickstartCoordinator.defaultChoice.alias)
-        #expect(QuickstartCoordinator.defaultChoice.hfRepo == BundledModel.bundledRepoID)
+        // and air-gapped builds deliberately keep the smallest authored
+        // onboarding choice. Production DMGs bundle no weights, so their
+        // hardware-aware starter is independent from this fallback.
+        #expect(BundledModel.bundledAlias == QuickstartCoordinator.lowMemoryChoice.alias)
+        #expect(QuickstartCoordinator.lowMemoryChoice.hfRepo == BundledModel.bundledRepoID)
     }
 
     // MARK: - Snapshot URL resolution

--- a/apps/rapid-mac/Tests/RapidTests/DiskSpaceProbeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DiskSpaceProbeTests.swift
@@ -40,10 +40,12 @@ struct DiskSpaceProbeTests {
         ) == 4 * gib)
         #expect(QuickstartView.requiredDiskBytes(
             for: QuickstartCoordinator.defaultChoice
-        ) == 5 * gib)
+        ) == 6 * gib)
         #expect(QuickstartView.requiredDiskBytes(
             for: QuickstartCoordinator.lowMemoryChoice
         ) == 2 * gib)
+        #expect(QuickstartCoordinator.defaultChoice.downloadBytes == 3_061_121_321)
+        #expect(QuickstartCoordinator.compactDefaultChoice.downloadBytes == 1_601_103_345)
     }
 
     // MARK: - Decision truth table

--- a/apps/rapid-mac/Tests/RapidTests/DiskSpaceProbeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DiskSpaceProbeTests.swift
@@ -31,6 +31,21 @@ struct DiskSpaceProbeTests {
         #expect(DiskSpaceProbe.quickstartRequiredBytes == 2 * 1024 * 1024 * 1024)
     }
 
+    @Test("Automatic starters derive model-sized download headroom")
+    func automaticStarterRequirements() {
+        let gib: Int64 = 1024 * 1024 * 1024
+
+        #expect(QuickstartView.requiredDiskBytes(
+            for: QuickstartCoordinator.compactDefaultChoice
+        ) == 4 * gib)
+        #expect(QuickstartView.requiredDiskBytes(
+            for: QuickstartCoordinator.defaultChoice
+        ) == 5 * gib)
+        #expect(QuickstartView.requiredDiskBytes(
+            for: QuickstartCoordinator.lowMemoryChoice
+        ) == 2 * gib)
+    }
+
     // MARK: - Decision truth table
 
     @Test("decide returns .ok when free bytes exceed requirement")

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -33,7 +33,7 @@ import Testing
 /// the Quickstart section AND the All models section — otherwise
 /// the same row renders twice and the user reads it as a UI bug.
 /// The de-dup gate lives in
-/// ``ModelPickerBar.dedupedAllEntries(filtered:quickstartRowRendered:)``.
+/// ``ModelPickerBar.dedupedAllEntries(filtered:quickstartAlias:)``.
 @MainActor
 @Suite("ModelPickerBar section order — F-LWT-1 Quickstart section")
 struct ModelPickerBarSectionOrderTests {
@@ -219,7 +219,7 @@ struct ModelPickerBarSectionOrderTests {
         let filtered = makeCatalog()
         let deduped = ModelPickerBar.dedupedAllEntries(
             filtered: filtered,
-            quickstartRowRendered: true
+            quickstartAlias: QuickstartCoordinator.defaultChoice.alias
         )
         let dedupedAliases = Set(deduped.map { $0.alias })
         #expect(!dedupedAliases.contains(QuickstartCoordinator.defaultChoice.alias),
@@ -236,7 +236,7 @@ struct ModelPickerBarSectionOrderTests {
         let filtered = makeCatalog()
         let deduped = ModelPickerBar.dedupedAllEntries(
             filtered: filtered,
-            quickstartRowRendered: false
+            quickstartAlias: nil
         )
         let dedupedAliases = Set(deduped.map { $0.alias })
         #expect(dedupedAliases.contains(QuickstartCoordinator.defaultChoice.alias),
@@ -266,12 +266,50 @@ struct ModelPickerBarSectionOrderTests {
         for filtered in cases {
             let deduped = ModelPickerBar.dedupedAllEntries(
                 filtered: filtered,
-                quickstartRowRendered: true
+                quickstartAlias: qsAlias
             )
             let count = deduped.filter { $0.alias == qsAlias }.count
             #expect(count == 0,
                     "Quickstart alias appeared \(count) times in deduped output of \(filtered.count)-entry input")
         }
+    }
+
+    @Test("Dedup follows the hardware-specific Quickstart alias")
+    func dedupUsesRenderedHardwareStarter() {
+        let compact = QuickstartCoordinator.baselineChoice(
+            hardware: hardware(ramGB: 8)
+        ).alias
+        let standard = QuickstartCoordinator.baselineChoice(
+            hardware: hardware(ramGB: 16)
+        ).alias
+        let filtered = [
+            entry(compact, hfRepo: "mlx-community/LFM2.5-2.6B-MLX-4bit", cached: false),
+            entry(standard, hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit", cached: false),
+        ]
+
+        let compactAliases = Set(ModelPickerBar.dedupedAllEntries(
+            filtered: filtered,
+            quickstartAlias: compact
+        ).map(\.alias))
+        #expect(!compactAliases.contains(compact))
+        #expect(compactAliases.contains(standard))
+
+        let standardAliases = Set(ModelPickerBar.dedupedAllEntries(
+            filtered: filtered,
+            quickstartAlias: standard
+        ).map(\.alias))
+        #expect(!standardAliases.contains(standard))
+        #expect(standardAliases.contains(compact))
+    }
+
+    private func hardware(ramGB: Double) -> MacHardware {
+        MacHardware(
+            brandString: "Test Mac",
+            family: .m3,
+            tier: .base,
+            physicalRAMBytes: UInt64(ramGB * 1_073_741_824),
+            memoryBandwidthGBs: 100
+        )
     }
 
     // MARK: - Quickstart in-flight gate (the Start CTA disabled-state)

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// a pinned order:
 ///
 ///   ┌── Quickstart ──────────────────────────────────────┐
-///   │  lfm2.5-1b-4bit · Smallest model — fastest first   │ ← RAM-blind during first run
+///   │  qwen3.5-4b-4bit · Recommended first model          │ ← standard starter
 ///   ├── Recommended for your <RAM> GB Mac ───────────────┤
 ///   │  Recommended <smart pick> · Faster <light pick>     │ ← RAM-tier measured pair
 ///   ├── All models (alphabetical) ───────────────────────┤
@@ -84,7 +84,7 @@ struct ModelPickerBarSectionOrderTests {
             eligible: true
         )
 
-        #expect(pick == "lfm2.5-1b-4bit")
+        #expect(pick == QuickstartCoordinator.defaultChoice.alias)
         #expect(pick != "bonsai-1.7b-2bit")
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -787,21 +787,37 @@ struct OnboardingDirectionDTests {
             sizeOnDisk: nil,
             cached: true
         )
-        let starterBadges = QuickstartView.catalogRowBadges(entry: starter, available: true)
+        let starterBadges = QuickstartView.catalogRowBadges(
+            entry: starter,
+            available: true,
+            recommendedAlias: starter.alias
+        )
         #expect(starterBadges.map { $0.text } == ["RECOMMENDED", "ON THIS MAC"])
 
-        let plain = ModelEntry(alias: "qwen3.5-4b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: false)
-        #expect(QuickstartView.catalogRowBadges(entry: plain, available: true).isEmpty,
+        let plain = ModelEntry(alias: "qwen3.5-9b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: false)
+        #expect(QuickstartView.catalogRowBadges(
+            entry: plain,
+            available: true,
+            recommendedAlias: starter.alias
+        ).isEmpty,
                 "an ordinary uncached row makes no claim at all")
 
-        let cached = ModelEntry(alias: "qwen3.5-4b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: true)
-        #expect(QuickstartView.catalogRowBadges(entry: cached, available: true)
+        let cached = ModelEntry(alias: "qwen3.5-9b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: true)
+        #expect(QuickstartView.catalogRowBadges(
+            entry: cached,
+            available: true,
+            recommendedAlias: starter.alias
+        )
             .map { $0.text } == ["ON THIS MAC"])
 
         // WON'T FIT replaces the cached badge rather than stacking with it:
         // whether it is on disk stops being the useful fact once it cannot run.
         let tooBig = ModelEntry(alias: "llama3.1-70b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: true)
-        #expect(QuickstartView.catalogRowBadges(entry: tooBig, available: false)
+        #expect(QuickstartView.catalogRowBadges(
+            entry: tooBig,
+            available: false,
+            recommendedAlias: starter.alias
+        )
             .map { $0.text } == ["WON'T FIT"])
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -66,6 +66,21 @@ struct OnboardingDirectionDTests {
                 "the setup surface must take the window's size, not a panel's")
     }
 
+    @Test("Welcome-screen Skip receives the hardware-aware starter policy")
+    func starterPolicyIsOwnedByTheRootView() throws {
+        let source = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        let body = try #require(source.range(of: "varbody:someView{"))
+        let content = try #require(source.range(of: "privatevarcontent:someView{"))
+        let policyTask = try #require(source.range(of: ".task(id:StarterSelectionKey("))
+        let chooser = try #require(source.range(of: "privatevarchooseModelStep:someView{"))
+
+        #expect(policyTask.lowerBound > body.lowerBound)
+        #expect(policyTask.lowerBound < content.lowerBound,
+                "the policy task must mount with the root view before welcome Skip is actionable")
+        #expect(policyTask.lowerBound < chooser.lowerBound,
+                "the policy task must not be owned by Step 2")
+    }
+
     /// #2033 finding 2 — a first-time user reported two enabled "Start"
     /// controls on Step 2 at once: the wizard's own footer primary
     /// ("Start existing model") AND the shared ``ReadinessBanner``'s inline

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -71,9 +71,12 @@ struct OnboardingDirectionDTests {
         let source = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
         let body = try #require(source.range(of: "varbody:someView{"))
         let content = try #require(source.range(of: "privatevarcontent:someView{"))
-        let baseline = try #require(source.range(of: ".onAppear{coordinator.applyDefaultChoice(hardware:hardware,catalog:[])"))
+        let baseline = try #require(source.range(of: ".onAppear{coordinator.applyDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])"))
         let policyTask = try #require(source.range(of: ".task(id:StarterSelectionKey("))
         let chooser = try #require(source.range(of: "privatevarchooseModelStep:someView{"))
+        let skipRefresh = try #require(source.range(
+            of: "Button(\"Skipfornow\"){coordinator.applyDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])onSkip()"
+        ))
 
         #expect(baseline.lowerBound > body.lowerBound)
         #expect(baseline.lowerBound < content.lowerBound,
@@ -83,6 +86,8 @@ struct OnboardingDirectionDTests {
                 "the policy task must mount with the root view before welcome Skip is actionable")
         #expect(policyTask.lowerBound < chooser.lowerBound,
                 "the policy task must not be owned by Step 2")
+        #expect(skipRefresh.lowerBound < chooser.lowerBound,
+                "welcome Skip must synchronously consume the latest authoritative snapshot")
     }
 
     /// #2033 finding 2 — a first-time user reported two enabled "Start"

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -75,10 +75,10 @@ struct OnboardingDirectionDTests {
         let policyTask = try #require(source.range(of: ".task(id:StarterSelectionKey("))
         let chooser = try #require(source.range(of: "privatevarchooseModelStep:someView{"))
         let actionBoundary = try #require(source.range(
-            of: "privatefuncadvanceToModelChoice(){coordinator.settleDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])coordinator.advanceToChooseModel()}"
+            of: "privatefuncadvanceToModelChoice(){ifcatalogLoaded{coordinator.settleDefaultChoice(hardware:hardware,catalog:cachedModels)}else{coordinator.applyDefaultChoice(hardware:hardware,catalog:[])}coordinator.advanceToChooseModel()}"
         ))
         let skipRefresh = try #require(source.range(
-            of: "privatefuncskipForNow(){coordinator.settleDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])onSkip()}"
+            of: "privatefuncskipForNow(){coordinator.applyDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])onSkip()}"
         ))
 
         #expect(baseline.lowerBound > body.lowerBound)

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -74,8 +74,11 @@ struct OnboardingDirectionDTests {
         let baseline = try #require(source.range(of: ".onAppear{coordinator.applyDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])"))
         let policyTask = try #require(source.range(of: ".task(id:StarterSelectionKey("))
         let chooser = try #require(source.range(of: "privatevarchooseModelStep:someView{"))
+        let actionBoundary = try #require(source.range(
+            of: "privatefuncadvanceToModelChoice(){coordinator.settleDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])coordinator.advanceToChooseModel()}"
+        ))
         let skipRefresh = try #require(source.range(
-            of: "Button(\"Skipfornow\"){coordinator.applyDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])onSkip()"
+            of: "privatefuncskipForNow(){coordinator.settleDefaultChoice(hardware:hardware,catalog:catalogLoaded?cachedModels:[])onSkip()}"
         ))
 
         #expect(baseline.lowerBound > body.lowerBound)
@@ -86,6 +89,8 @@ struct OnboardingDirectionDTests {
                 "the policy task must mount with the root view before welcome Skip is actionable")
         #expect(policyTask.lowerBound < chooser.lowerBound,
                 "the policy task must not be owned by Step 2")
+        #expect(actionBoundary.lowerBound < chooser.lowerBound,
+                "Get Started must synchronously consume the latest authoritative snapshot")
         #expect(skipRefresh.lowerBound < chooser.lowerBound,
                 "welcome Skip must synchronously consume the latest authoritative snapshot")
     }

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -71,9 +71,13 @@ struct OnboardingDirectionDTests {
         let source = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
         let body = try #require(source.range(of: "varbody:someView{"))
         let content = try #require(source.range(of: "privatevarcontent:someView{"))
+        let baseline = try #require(source.range(of: ".onAppear{coordinator.applyDefaultChoice(hardware:hardware,catalog:[])"))
         let policyTask = try #require(source.range(of: ".task(id:StarterSelectionKey("))
         let chooser = try #require(source.range(of: "privatevarchooseModelStep:someView{"))
 
+        #expect(baseline.lowerBound > body.lowerBound)
+        #expect(baseline.lowerBound < content.lowerBound,
+                "the RAM baseline must be synchronous in the root view")
         #expect(policyTask.lowerBound > body.lowerBound)
         #expect(policyTask.lowerBound < content.lowerBound,
                 "the policy task must mount with the root view before welcome Skip is actionable")

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
@@ -583,7 +583,11 @@ struct OnboardingWontFitReviewTests {
             cached: true
         )
         // Still one badge, still replacing ON THIS MAC rather than stacking.
-        let badges = QuickstartView.catalogRowBadges(entry: entry, available: false)
+        let badges = QuickstartView.catalogRowBadges(
+            entry: entry,
+            available: false,
+            recommendedAlias: QuickstartCoordinator.defaultChoice.alias
+        )
         #expect(badges.map { $0.text } == ["WON'T FIT"])
         #expect(badges.first?.tone == .error)
 

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -254,9 +254,9 @@ struct QuickstartBrowseAllDestinationTests {
             "The one dismissal control must route through the complete Skip action."
         )
         #expect(
-            stripped.contains(#"privatefuncskipForNow(){coordinator.settleDefaultChoice("#)
+            stripped.contains(#"privatefuncskipForNow(){coordinator.applyDefaultChoice("#)
                 && stripped.contains(#"catalog:catalogLoaded?cachedModels:[])onSkip()}"#),
-            "Skip must settle the live starter policy before its one onSkip() callback."
+            "Skip must refresh the live starter policy before its one onSkip() callback."
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -248,9 +248,15 @@ struct QuickstartBrowseAllDestinationTests {
             the user gets to choose.
             """
         )
+        let stripped = Self.stripped(source)
         #expect(
-            Self.stripped(source).contains(#"Button("Skipfornow"){onSkip()}"#),
-            "The one onSkip() call must be Skip for now."
+            stripped.contains(#"Button("Skipfornow"){skipForNow()}"#),
+            "The one dismissal control must route through the complete Skip action."
+        )
+        #expect(
+            stripped.contains(#"privatefuncskipForNow(){coordinator.settleDefaultChoice("#)
+                && stripped.contains(#"catalog:catalogLoaded?cachedModels:[])onSkip()}"#),
+            "Skip must settle the live starter policy before its one onSkip() callback."
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -125,10 +125,13 @@ struct QuickstartCachedModelTests {
         ]
         let shortlist = QuickstartView.shortlist(
             catalog: rows,
-            selection: "qwen3.5-4b-4bit"
+            selection: "qwen3.5-4b-4bit",
+            physicalRAMGB: 16
         )
 
         #expect(shortlist.cached.count == 6)
+        #expect(shortlist.cached.last?.alias == "qwen3.5-4b-4bit")
+        #expect(shortlist.visibleAliases.contains("qwen3.5-4b-4bit"))
         #expect(QuickstartView.cachedModel(
             alias: "qwen3.5-4b-4bit",
             cachedModels: rows

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -136,6 +136,30 @@ struct QuickstartStarterPolicyTests {
         #expect(standard.starters.map(\.alias) == ["qwen3.5-4b-4bit"])
     }
 
+    @Test("An automatically selected sibling alternate is surfaced as Your Pick")
+    func selectedCachedAlternateRemainsVisible() {
+        let catalog = [
+            entry("qwen3.5-4b-4bit"),
+            entry("llama3-8b-2bit", cached: true),
+            entry("llama3-8b-4bit", cached: true),
+        ]
+        let pick = QuickstartCoordinator.defaultChoice(
+            hardware: hardware(32),
+            catalog: catalog
+        )
+        let shortlist = QuickstartView.shortlist(
+            catalog: catalog,
+            selection: pick.alias,
+            physicalRAMGB: 32
+        )
+
+        #expect(pick.alias == "llama3-8b-2bit")
+        #expect(shortlist.cached.map(\.alias) == ["llama3-8b-4bit"])
+        #expect(shortlist.cachedAlternates.map(\.alias) == ["llama3-8b-2bit"])
+        #expect(shortlist.yourPick?.alias == pick.alias)
+        #expect(shortlist.visibleAliases.contains(pick.alias))
+    }
+
     @Test("Cached media and the 1.2B escape never become automatic starters")
     func ineligibleCacheDoesNotWin() {
         let pick = QuickstartCoordinator.defaultChoice(

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -47,6 +47,12 @@ struct QuickstartStarterPolicyTests {
         #expect(QuickstartCoordinator.defaultChoice(
             hardware: hardware(64), catalog: catalog
         ).alias == "qwen3.5-4b-4bit")
+        #expect(QuickstartCoordinator.baselineChoice(
+            hardware: hardware(8)
+        ).alias == "lfm2.5-2.6b-4bit")
+        #expect(QuickstartCoordinator.baselineChoice(
+            hardware: hardware(16)
+        ).alias == "qwen3.5-4b-4bit")
     }
 
     @Test("The synchronous no-catalog baseline is safe before welcome Skip")

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -174,6 +174,20 @@ struct QuickstartStarterPolicyTests {
         #expect(QuickstartCoordinator.lowMemoryChoice.alias == "lfm2.5-1b-4bit")
     }
 
+    @Test("An older authoritative catalog falls back to its 1.2B ladder entry")
+    func oldCatalogCompatibilityFallback() {
+        let catalog = [entry("lfm2.5-1b-4bit")]
+
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(8),
+            catalog: catalog
+        ).alias == "lfm2.5-1b-4bit")
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(16),
+            catalog: catalog
+        ).alias == "lfm2.5-1b-4bit")
+    }
+
     @Test("A later cache refresh never overrides an explicit user choice")
     func explicitSelectionWins() {
         let coordinator = QuickstartCoordinator()

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -49,6 +49,14 @@ struct QuickstartStarterPolicyTests {
         ).alias == "qwen3.5-4b-4bit")
     }
 
+    @Test("The synchronous no-catalog baseline is safe before welcome Skip")
+    func immediateWelcomeBaseline() {
+        let coordinator = QuickstartCoordinator()
+        coordinator.applyDefaultChoice(hardware: hardware(8), catalog: [])
+
+        #expect(coordinator.selection.alias == "lfm2.5-2.6b-4bit")
+    }
+
     @Test("An eligible cached chat model wins without a download")
     func cachedEligibleWins() {
         let pick = QuickstartCoordinator.defaultChoice(

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -61,6 +61,45 @@ struct QuickstartStarterPolicyTests {
         #expect(pick.alias == "qwen3.5-9b-4bit")
     }
 
+    @Test("A cached standard starter stays visible when it wins below 16 GB")
+    func cachedStandardStarterRemainsVisible() {
+        let catalog = [
+            entry("lfm2.5-2.6b-4bit"),
+            entry("qwen3.5-4b-4bit", cached: true),
+        ]
+        let pick = QuickstartCoordinator.defaultChoice(
+            hardware: hardware(15.99),
+            catalog: catalog
+        )
+        let shortlist = QuickstartView.shortlist(
+            catalog: catalog,
+            selection: pick.alias,
+            physicalRAMGB: 15.99
+        )
+
+        #expect(pick.alias == "qwen3.5-4b-4bit")
+        #expect(shortlist.cached.map(\.alias).contains(pick.alias))
+        #expect(shortlist.visibleAliases.contains(pick.alias))
+    }
+
+    @Test("An 8 GB Mac does not promote a cached model that fails its fit contract")
+    func cachedStandardStarterMustFit() {
+        let catalog = [
+            entry("lfm2.5-2.6b-4bit"),
+            entry("qwen3.5-4b-4bit", cached: true),
+        ]
+        let machine = hardware(8)
+
+        #expect(ModelSizing.classify(
+            ModelSizing.estimate(alias: "qwen3.5-4b-4bit"),
+            on: machine
+        ) == .tooBig)
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: machine,
+            catalog: catalog
+        ).alias == "lfm2.5-2.6b-4bit")
+    }
+
     @Test("The chooser presents one hardware-fit starter, not two competing recommendations")
     func shortlistHasOneStarter() {
         let catalog = [

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -199,4 +199,23 @@ struct QuickstartStarterPolicyTests {
         )
         #expect(coordinator.selection.alias == explicit.alias)
     }
+
+    @Test("Catalog refresh cannot retarget a model being browsed or reviewed")
+    func navigationFreezesAutomaticSelection() {
+        let newCache = [entry("qwen3.5-9b-4bit", cached: true)]
+
+        let browsing = QuickstartCoordinator()
+        browsing.applyDefaultChoice(hardware: hardware(16), catalog: [])
+        let browsingAlias = browsing.selection.alias
+        browsing.beginBrowsingCatalog()
+        browsing.applyDefaultChoice(hardware: hardware(16), catalog: newCache)
+        #expect(browsing.selection.alias == browsingAlias)
+
+        let reviewing = QuickstartCoordinator()
+        reviewing.applyDefaultChoice(hardware: hardware(16), catalog: [])
+        let reviewingAlias = reviewing.selection.alias
+        reviewing.beginReviewDownload(origin: .shortlist)
+        reviewing.applyDefaultChoice(hardware: hardware(16), catalog: newCache)
+        #expect(reviewing.selection.alias == reviewingAlias)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -218,4 +218,21 @@ struct QuickstartStarterPolicyTests {
         reviewing.applyDefaultChoice(hardware: hardware(16), catalog: newCache)
         #expect(reviewing.selection.alias == reviewingAlias)
     }
+
+    @Test("The first authoritative catalog settles the shortlist selection")
+    func authoritativeCatalogSettlesSelection() {
+        let coordinator = QuickstartCoordinator()
+        coordinator.applyDefaultChoice(hardware: hardware(16), catalog: [])
+        coordinator.settleDefaultChoice(
+            hardware: hardware(16),
+            catalog: [entry("qwen3.5-4b-4bit")]
+        )
+        let settled = coordinator.selection.alias
+
+        coordinator.applyDefaultChoice(
+            hardware: hardware(16),
+            catalog: [entry("qwen3.5-9b-4bit", cached: true)]
+        )
+        #expect(coordinator.selection.alias == settled)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -235,4 +235,22 @@ struct QuickstartStarterPolicyTests {
         )
         #expect(coordinator.selection.alias == settled)
     }
+
+    @Test("Entering Step 2 before catalog load preserves cached preference")
+    func deferredAuthoritativeCatalogStillWins() {
+        let coordinator = QuickstartCoordinator()
+        coordinator.applyDefaultChoice(hardware: hardware(15.99), catalog: [])
+        coordinator.advanceToChooseModel()
+        #expect(coordinator.selection.alias == "lfm2.5-2.6b-4bit")
+
+        coordinator.settleDefaultChoice(
+            hardware: hardware(15.99),
+            catalog: [
+                entry("lfm2.5-2.6b-4bit"),
+                entry("qwen3.5-4b-4bit", cached: true),
+            ]
+        )
+
+        #expect(coordinator.selection.alias == "qwen3.5-4b-4bit")
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -1,0 +1,111 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Quickstart hardware-aware starter policy")
+struct QuickstartStarterPolicyTests {
+    private func hardware(_ ramGB: Double) -> MacHardware {
+        MacHardware(
+            brandString: "Test Mac",
+            family: .m3,
+            tier: .base,
+            physicalRAMBytes: UInt64(ramGB * 1_073_741_824),
+            memoryBandwidthGBs: 100
+        )
+    }
+
+    private func entry(
+        _ alias: String,
+        cached: Bool = false,
+        kind: ModelKind = .chat
+    ) -> ModelEntry {
+        ModelEntry(
+            alias: alias,
+            hfRepo: "fixture/\(alias)",
+            sizeOnDisk: nil,
+            cached: cached,
+            kind: kind
+        )
+    }
+
+    @Test("RAM threshold chooses 2.6B below 16 GB and Qwen 4B at 16 GB or above")
+    func ramMatrix() {
+        let catalog = [
+            entry("lfm2.5-2.6b-4bit"),
+            entry("qwen3.5-4b-4bit"),
+        ]
+
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(8), catalog: catalog
+        ).alias == "lfm2.5-2.6b-4bit")
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(15.99), catalog: catalog
+        ).alias == "lfm2.5-2.6b-4bit")
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(16), catalog: catalog
+        ).alias == "qwen3.5-4b-4bit")
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(64), catalog: catalog
+        ).alias == "qwen3.5-4b-4bit")
+    }
+
+    @Test("An eligible cached chat model wins without a download")
+    func cachedEligibleWins() {
+        let pick = QuickstartCoordinator.defaultChoice(
+            hardware: hardware(16),
+            catalog: [
+                entry("qwen3.5-4b-4bit"),
+                entry("qwen3.5-9b-4bit", cached: true),
+            ]
+        )
+        #expect(pick.alias == "qwen3.5-9b-4bit")
+    }
+
+    @Test("The chooser presents one hardware-fit starter, not two competing recommendations")
+    func shortlistHasOneStarter() {
+        let catalog = [
+            entry("lfm2.5-2.6b-4bit"),
+            entry("qwen3.5-4b-4bit"),
+        ]
+
+        let compact = QuickstartView.shortlist(
+            catalog: catalog,
+            selection: "lfm2.5-2.6b-4bit",
+            physicalRAMGB: 8
+        )
+        #expect(compact.starters.map(\.alias) == ["lfm2.5-2.6b-4bit"])
+
+        let standard = QuickstartView.shortlist(
+            catalog: catalog,
+            selection: "qwen3.5-4b-4bit",
+            physicalRAMGB: 16
+        )
+        #expect(standard.starters.map(\.alias) == ["qwen3.5-4b-4bit"])
+    }
+
+    @Test("Cached media and the 1.2B escape never become automatic starters")
+    func ineligibleCacheDoesNotWin() {
+        let pick = QuickstartCoordinator.defaultChoice(
+            hardware: hardware(16),
+            catalog: [
+                entry("qwen3.5-4b-4bit"),
+                entry("lfm2.5-1b-4bit", cached: true),
+                entry("flux-klein", cached: true, kind: .image),
+            ]
+        )
+        #expect(pick.alias == "qwen3.5-4b-4bit")
+        #expect(QuickstartCoordinator.lowMemoryChoice.alias == "lfm2.5-1b-4bit")
+    }
+
+    @Test("A later cache refresh never overrides an explicit user choice")
+    func explicitSelectionWins() {
+        let coordinator = QuickstartCoordinator()
+        let explicit = QuickstartCoordinator.choice(forAlias: "qwen3.5-9b-4bit")
+        coordinator.select(explicit)
+        coordinator.applyDefaultChoice(
+            hardware: hardware(8),
+            catalog: [entry("lfm2.5-2.6b-4bit", cached: true)]
+        )
+        #expect(coordinator.selection.alias == explicit.alias)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -57,17 +57,9 @@ struct QuickstartViewTests {
         #expect(!lowered.contains("web search"))
     }
 
-    /// F-LWT-1 belt-and-suspenders: explicitly forbid the previous
-    /// 4B pick. The principled checks above pin the new identifiers;
-    /// this guard catches an accidental "revert to 4B for capability
-    /// reasons" regression even if a future refactor accidentally
-    /// re-introduces the literal.
-    @Test("F-LWT-1: alias must NOT regress to ``qwen3.5-4b-4bit``")
-    func aliasIsNotPreviousFourB() {
-        #expect(
-            QuickstartCoordinator.defaultChoice.alias != "qwen3.5-4b-4bit",
-            "Quickstart alias must not regress to qwen3.5-4b-4bit — the starter is lfm2.5-1b-4bit, which keeps the small-download win while adding real tool calls."
-        )
+    @Test("The standard starter is the approved 16 GB choice")
+    func standardStarterIsFourB() {
+        #expect(QuickstartCoordinator.defaultChoice.alias == "qwen3.5-4b-4bit")
     }
 
     @Test("Persistent flag storage key is v1-versioned")
@@ -540,15 +532,15 @@ struct QuickstartViewTests {
 
     @Test("Low-memory recovery is offered only when it clears the live danger line")
     func lowMemoryRecoveryMustActuallyBeSafer() {
-        // On an 18 GB Mac, 12.2 GB already used makes the 3.36 GB starter
-        // unsafe (~86.4%) while the 3.03 GB 0.6B fallback stays below 85%.
+        // The warning snapshot leaves enough headroom for the 1.2B fallback,
+        // while the standard 4B choice remains unsafe.
         let recoverable = ModelSizing.MemoryWarning(
             alias: QuickstartCoordinator.defaultChoice.alias,
             hfPath: QuickstartCoordinator.defaultChoice.hfRepo,
             isAutoRespawn: false,
             severity: .unsafe,
             footprintGB: ModelSizing.estimate(alias: QuickstartCoordinator.defaultChoice.alias).totalGB,
-            freeGB: 5.8,
+            freeGB: 7.0,
             totalGB: 18
         )
         #expect(
@@ -667,43 +659,34 @@ struct QuickstartViewTests {
 /// is exactly the kind of bug the F-LWT-1 review explicitly called
 /// out.
 @MainActor
-@Suite("Quickstart source-grep tripwires — F-LWT-1 partial-swap guard")
+@Suite("Quickstart starter identity contracts")
 struct QuickstartViewSourceGrepTests {
 
-    // #1524: the old blanket source-grep for the ``qwen3.5-4b-4bit``
-    // literal is retired — 4B is now a legitimate *bigger trade-up*
-    // option in ``QuickstartCoordinator.onboardingChoices`` — so a
-    // whole-file grep would fire on an intentional line. The intent
-    // (the STARTER must stay the small lfm2.5-1b-4bit pick, never
-    // the old 4B one) is preserved as direct value assertions on
-    // ``defaultChoice``.
-
-    @Test("Starter alias stays the lfm2.5-1b-4bit pick, never regresses to the old 4B")
-    func starterAliasNotOld4B() {
-        #expect(QuickstartCoordinator.defaultChoice.alias == "lfm2.5-1b-4bit")
-        #expect(QuickstartCoordinator.defaultChoice.alias != "qwen3.5-4b-4bit")
+    @Test("Standard and compact starter aliases remain pinned")
+    func starterAliasesStayPinned() {
+        #expect(QuickstartCoordinator.defaultChoice.alias == "qwen3.5-4b-4bit")
+        #expect(QuickstartCoordinator.compactDefaultChoice.alias == "lfm2.5-2.6b-4bit")
     }
 
-    @Test("Starter hfRepo is the bonsai repo, not the old 4B repo")
-    func starterHFRepoNotOld4B() {
-        #expect(QuickstartCoordinator.defaultChoice.hfRepo == "mlx-community/LFM2.5-1.2B-Instruct-4bit")
-        #expect(QuickstartCoordinator.defaultChoice.hfRepo?.contains("4B") != true)
+    @Test("Starter repositories match their catalog contracts")
+    func starterRepositoriesStayPinned() {
+        #expect(QuickstartCoordinator.defaultChoice.hfRepo == "mlx-community/Qwen3.5-4B-MLX-4bit")
+        #expect(QuickstartCoordinator.compactDefaultChoice.hfRepo == "LiquidAI/LFM2.5-2.6B-MLX")
     }
 
-    @Test("Starter advertises and seeds its curated repository size, not the rounded 1B alias estimate (#1550)")
-    func starterUsesCuratedDownloadSize() {
-        let choice = QuickstartCoordinator.defaultChoice
+    @Test("Low-memory alternative keeps its curated repository size (#1550)")
+    func lowMemoryChoiceUsesCuratedDownloadSize() {
+        let choice = QuickstartCoordinator.lowMemoryChoice
         #expect(choice.downloadBytes == 663_397_140)
         #expect(QuickstartView.sizeText(for: choice) == "~633 MB")
         #expect(QuickstartView.sizeText(for: choice) != QuickstartView.sizeText(for: choice.alias))
     }
 
-    @Test("Onboarding keeps one explicit, honestly-labelled sub-1B escape hatch")
+    @Test("Onboarding keeps one explicit, honestly-labelled low-memory escape hatch")
     func lowMemoryChoiceIsExplicitAndHonest() {
         let choice = QuickstartCoordinator.lowMemoryChoice
-        #expect(choice.alias == "qwen3-0.6b-4bit")
+        #expect(choice.alias == "lfm2.5-1b-4bit")
         #expect(choice.tier == .lowMemory)
-        #expect(choice.blurb.localizedCaseInsensitiveContains("lowest memory"))
         #expect(choice.blurb.localizedCaseInsensitiveContains("less accurate"))
         #expect(choice.blurb.localizedCaseInsensitiveContains("not recommended for tools"))
         #expect(QuickstartCoordinator.onboardingChoices.filter(\.isLowMemory) == [choice])

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -569,17 +569,17 @@ struct Step2ModelSelectionBehaviorTests {
     @Test("A 32 GB Mac recommends only the 27B, not the 48 GB+ 35B")
     func midRAMRecommendsOnly27B() {
         let list = QuickstartView.shortlist(catalog: [], selection: "", physicalRAMGB: 32)
-        #expect(list.recommended.map(\.alias) == ["qwen3.8-27b-4bit", "qwen3.5-4b-4bit"],
-                "32 GB tier is smart 27B then fast 4B; the 35B is a 48 GB+ pick")
+        #expect(list.recommended.map(\.alias) == ["qwen3.8-27b-4bit"],
+                "32 GB shows the smart 27B; the fast 4B is already the starter")
     }
 
     @Test("The starter is never duplicated inside the recommended row")
     func starterEqualFastPickIsDroppedFromRecommended() {
-        // 8 GB's fast pick is the starter itself; it must stay in the ✓ card
-        // and not reappear in the recommended row.
+        // At 8 GB the smart pick is the starter and the fast pick is the
+        // explicit low-memory card, so neither belongs in a duplicate row.
         let list = QuickstartView.shortlist(catalog: [], selection: "", physicalRAMGB: 8)
-        #expect(list.recommended.map(\.alias) == ["lfm2.5-2.6b-4bit"],
-                "the starter-equal fast pick is deduplicated against the ✓ card")
+        #expect(list.recommended.isEmpty,
+                "starter and low-memory picks are deduplicated against their authored cards")
     }
 
     @Test("No RAM argument means no recommended row")

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -1047,7 +1047,7 @@ def _emit_catalog(subcommand, alias):
         if "--json" in sys.argv:
             aliases = []
             if _setting("FAKE_INCLUDE_STARTER") == "1":
-                aliases.append("lfm2.5-1b-4bit")
+                aliases.extend(["lfm2.5-2.6b-4bit", "lfm2.5-1b-4bit"])
             if _setting("FAKE_CACHED_CURATED_TRADEUP") == "1":
                 aliases.extend([f"a-cached-{index}" for index in range(6)])
                 aliases.append("qwen3.5-4b-4bit")
@@ -1085,10 +1085,12 @@ def _emit_catalog(subcommand, alias):
         print("Alias                  Parser           Reasoning        Preset")
         print("---------------------  ---------------  ---------------  --------")
         if _setting("FAKE_INCLUDE_STARTER") == "1":
-            # A production catalog always contains the onboarding starter.
+            # A production catalog contains both the RAM-aware compact starter
+            # and the explicit low-memory alternative.
             # Most flows deliberately keep the compact single-chat-row
             # fixture, but fresh-install must exercise the real default
             # selection contract rather than falling back to fake-alias.
+            print("lfm2.5-2.6b-4bit      hermes           none")
             print("lfm2.5-1b-4bit        hermes           none")
         if _setting("FAKE_CACHED_CURATED_TRADEUP") == "1":
             for index in range(6):

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1292,8 +1292,8 @@ flow_fresh_install() {
     press "$OUT/welcome-returned.json" Quickstart.Skip "$OUT/quickstart-skip.json"
     wait_identifier rapid.chat.compose "$OUT/steady.json"
     selected_model="$(element_field "$OUT/steady.json" ModelPickerBar.ModelMenu value)"
-    [[ "$selected_model" == *"lfm2.5-1b-4bit"* ]] \
-        || die "#1564: skipping Quickstart selected '$selected_model' instead of the small starter"
+    [[ "$selected_model" == *"lfm2.5-2.6b-4bit"* ]] \
+        || die "#2219: 8 GB onboarding selected '$selected_model' instead of the compact starter"
     for id in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
         jq -e --arg id "$id" '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/steady.json" >/dev/null \
             || die "post-onboarding shell missing $id"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1285,7 +1285,7 @@ flow_fresh_install() {
     see_main "$OUT/compact.json"
     baseline onboarding-direction-d.compact "$OUT/compact.json"
     press "$OUT/compact.json" Quickstart.GetStarted "$OUT/get-started.json"
-    wait_tree_text "~633 MB" "$OUT/chooser-settled.json"
+    wait_selected Quickstart.Choice.lfm2.5-2.6b-4bit "$OUT/chooser-settled.json"
     baseline onboarding-direction-d.compact-chooser "$OUT/chooser-settled.json"
     press "$OUT/chooser-settled.json" Quickstart.Footer.Back "$OUT/chooser-back.json"
     wait_identifier Quickstart.Skip "$OUT/welcome-returned.json"
@@ -1463,9 +1463,9 @@ flow_cached_quickstart() {
 }
 
 flow_cached_curated_tradeup() {
-    log "cached curated trade-up keeps its on-disk state past the six-row cap"
+    log "cached hardware-fit starter stays visible past the six-row cap"
     start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1 \
-        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=16 \
         RAPID_HARDWARE_BRAND="$GOLDEN_BRAND"
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -1474,23 +1474,18 @@ flow_cached_curated_tradeup() {
     fi
 
     # Six alphabetically earlier cached rows consume the bounded "Already on
-    # this Mac" presentation. Qwen remains a native curated trade-up, so this
-    # pins the exact seam where cached provenance used to be discarded.
+    # this Mac" presentation. The hardware-fit cached starter still has to own
+    # the one visible selected row; cached preference cannot produce a hidden
+    # choice with a disabled footer.
     wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
-    wait_identifier Quickstart.Choice.qwen3.5-4b-4bit "$OUT/chooser.json"
+    wait_selected Quickstart.CachedModel.qwen3.5-4b-4bit "$OUT/chooser.json"
     jq -e '.data.ui_elements[]?
-            | select(.identifier == "Quickstart.Choice.qwen3.5-4b-4bit")
+            | select(.identifier == "Quickstart.CachedModel.qwen3.5-4b-4bit")
             | select((.description // "") | contains("on disk 2.9 GB"))
-            | select(((.description // "") | contains("download")) | not)' \
+            | select(((.description // "") | contains("Download 2.9 GB")) | not)' \
         "$OUT/chooser.json" >/dev/null \
-        || die "cached curated trade-up still advertises a download"
-    press "$OUT/chooser.json" Quickstart.Choice.qwen3.5-4b-4bit "$OUT/select.json"
-    # Verify the action's semantic result, not footer copy. The cached model's
-    # provenance is pinned above; after the press the durable contract is that
-    # this exact card becomes selected. Footer wording is presentation copy and
-    # is not required for the cached trade-up behavior under test.
-    wait_selected Quickstart.Choice.qwen3.5-4b-4bit "$OUT/selected.json"
+        || die "cached hardware-fit starter is hidden or advertises a download"
     cleanup_persona
 }
 
@@ -1534,11 +1529,13 @@ flow_download_progress() {
     fi
     wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
-    # The footer exists while Step 2 is still asynchronously reading the
-    # catalogue. Waiting for that shared identifier can capture the transient
-    # "Matching models" state before the recommendation and its size land.
-    wait_tree_text "~633 MB" "$OUT/chooser.json"
-    press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/review-open.json"
+    # Cached preference is the normal first-run policy now. Select the explicit
+    # low-memory download so this journey still exercises the 633 MB overrun
+    # fixture rather than accidentally starting the cached fake model.
+    wait_identifier Quickstart.Choice.lfm2.5-1b-4bit "$OUT/chooser.json"
+    press "$OUT/chooser.json" Quickstart.Choice.lfm2.5-1b-4bit "$OUT/select-download.json"
+    wait_selected Quickstart.Choice.lfm2.5-1b-4bit "$OUT/selected-download.json"
+    press "$OUT/selected-download.json" Quickstart.Footer.Primary "$OUT/review-open.json"
     wait_identifier Quickstart.Review.Alias "$OUT/review.json"
     assert_tree_text "$OUT/review.json" "Download & start"
     # AXPress is normally immediate, but AppKit can synchronously hold the
@@ -2491,19 +2488,19 @@ flow_low_memory_choice() {
     fi
     wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
-    wait_identifier Quickstart.Choice.qwen3-0.6b-4bit "$OUT/model-choices.json"
+    wait_identifier Quickstart.Choice.lfm2.5-1b-4bit "$OUT/model-choices.json"
 
     local fallback_label
-    fallback_label="$(element_field "$OUT/model-choices.json" Quickstart.Choice.qwen3-0.6b-4bit description)"
+    fallback_label="$(element_field "$OUT/model-choices.json" Quickstart.Choice.lfm2.5-1b-4bit description)"
     [[ "$fallback_label" == *"Lowest memory"* ]] \
         || die "low-memory choice is missing its spoken category label"
     [[ "$fallback_label" == *"less accurate"* ]] \
         || die "low-memory choice hides its quality trade-off"
     [[ "$fallback_label" == *"not recommended for tools"* ]] \
         || die "low-memory choice hides its tool-use limitation"
-    press "$OUT/model-choices.json" Quickstart.Choice.qwen3-0.6b-4bit "$OUT/select-low-memory.json"
+    press "$OUT/model-choices.json" Quickstart.Choice.lfm2.5-1b-4bit "$OUT/select-low-memory.json"
     see_main "$OUT/low-memory-selected.json"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Choice.qwen3-0.6b-4bit")' \
+    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Choice.lfm2.5-1b-4bit")' \
         "$OUT/low-memory-selected.json" >/dev/null \
         || die "selecting the low-memory choice dismissed or replaced the chooser"
     jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Footer.Primary")' \
@@ -3030,10 +3027,14 @@ flow_browse_all_destination() {
     for ((i=0; i<40; i++)); do
         see_main "$OUT/ba-chooser.json"
         chosen="$(jq -r '[.data.ui_elements[]?
-                          | select((.identifier // "") | startswith("Quickstart.Choice."))]
+                          | select((.identifier // "") as $id
+                            | ($id | startswith("Quickstart.Choice."))
+                              or ($id | startswith("Quickstart.CachedModel."))
+                              or ($id | startswith("Quickstart.YourPick.")))]
                          | (map(select(.selected == true))) as $default
                          | if ($default | length) != 1 then empty
-                           else (map(select(.identifier != $default[0].identifier))[0].identifier // empty)
+                           else (map(select(.identifier != $default[0].identifier
+                                    and ((.identifier // "") | startswith("Quickstart.Choice."))))[0].identifier // empty)
                            end' \
                   "$OUT/ba-chooser.json")"
         if [[ -n "$chosen" ]]; then break; fi

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -365,21 +365,25 @@ QUICKSTART = REPO / "apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift"
 BUNDLED = REPO / "apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift"
 
 
-def _parse_quickstart_default() -> tuple[str, str]:
-    """``(alias, hfRepo)`` from ``QuickstartCoordinator.defaultChoice``."""
+def _parse_quickstart_choice(name: str) -> tuple[str, str]:
+    """``(alias, hfRepo)`` from one authored Quickstart choice."""
     text = QUICKSTART.read_text()
     block = re.search(
-        r"static let defaultChoice = QuickstartModelChoice\((.*?)\n    \)",
+        rf"static let {name} = QuickstartModelChoice\((.*?)\n    \)",
         text,
         re.DOTALL,
     )
-    assert block, "defaultChoice literal not found in QuickstartView.swift"
+    assert block, f"{name} literal not found in QuickstartView.swift"
     body = block.group(1)
     alias = re.search(r'alias:\s*"([^"]+)"', body)
     repo = re.search(r'hfRepo:\s*"([^"]+)"', body)
-    assert alias, "defaultChoice has no alias literal"
-    assert repo, "defaultChoice must pin hfRepo — it drives the byte-progress monitor"
+    assert alias, f"{name} has no alias literal"
+    assert repo, f"{name} must pin hfRepo — it drives the byte-progress monitor"
     return alias.group(1), repo.group(1)
+
+
+def _parse_quickstart_default() -> tuple[str, str]:
+    return _parse_quickstart_choice("defaultChoice")
 
 
 def _parse_bundled() -> tuple[str, str]:
@@ -414,16 +418,23 @@ def test_quickstart_pinned_repo_matches_the_registry():
     )
 
 
-def test_bundled_starter_tracks_the_quickstart_starter():
-    """``BundledModel`` is the airgapped twin of the Quickstart pick. The
-    two are one product decision reached by two paths; letting them drift
-    ships an offline build whose first launch uses the rejected model."""
+def test_bundled_model_tracks_the_explicit_low_memory_choice():
+    """Bundled weights remain a runnable offline/low-memory escape hatch.
+
+    They are deliberately no longer the automatic starter: first run chooses
+    the hardware-fit 2.6B/4B baseline, while the existing 1.2B bundle remains
+    available without stranding airgapped or memory-constrained users.
+    """
     q_alias, q_repo = _parse_quickstart_default()
+    low_alias, low_repo = _parse_quickstart_choice("lowMemoryChoice")
     b_alias, b_repo = _parse_bundled()
-    assert b_alias == q_alias, (
-        f"bundledAlias {b_alias!r} != Quickstart starter {q_alias!r}"
+    assert (b_alias, b_repo) == (low_alias, low_repo), (
+        f"bundled model {(b_alias, b_repo)!r} != low-memory choice "
+        f"{(low_alias, low_repo)!r}"
     )
-    assert b_repo == q_repo, f"bundledRepoID {b_repo!r} != Quickstart hfRepo {q_repo!r}"
+    assert (b_alias, b_repo) != (q_alias, q_repo), (
+        "the 1.2B bundle must not silently become the automatic starter again"
+    )
 
 
 def test_build_script_stages_the_bundled_repo():


### PR DESCRIPTION
## Why

The first-run flow automatically selected the 1.2B low-memory model on every Mac. That model remains useful as an explicit escape hatch, but it is not a reliable quality floor for a new user’s first conversation.

## What

- choose LFM2.5 2.6B below 16 GB RAM and Qwen 3.5 4B at 16 GB or above
- prefer an eligible cached chat model so setup does not force a download
- keep LFM2.5 1.2B as an explicit, honestly labelled low-memory alternative
- keep the chooser recommendation, accessibility copy, picker copy, and deterministic fresh-install fixture aligned

## Non-goals

No recommendation-schema role, capability-percentage, catalog, engine/server, or unrelated onboarding redesign.

## Evidence

- focused onboarding/starter contracts: 194 passed
- complete Desktop Swift suite: 2,851 passed serial and 2,851 passed parallel
- recommendation-tier script: all passed
- release-shaped local build: passed
- fresh-install onboarding AX journey: passed; 8 GB fixture selected `lfm2.5-2.6b-4bit`

Fixes #2219.