### PR TITLE
fix(cli): connect/readiness banner must target the live server port+model (#2348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,7 @@ jobs:
         # scripts under tests/release/.
         run: |
           pytest \
+            tests/test_cli_connect.py \
             tests/test_mcp_security.py \
             tests/test_structured_output.py \
             tests/test_reasoning_parser.py \

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -522,8 +522,8 @@ def test_parse_base_url_default_port_and_errors():
     assert connect._parse_base_url("http://server.local/v1") == ("server.local", 8000)
     # Non-http scheme (incl. https, which the http-only connect SSOT would
     # silently downgrade), malformed URL, no host, an out-of-range/zero
-    # explicit port, and an unexpected path (a proxied endpoint the SSOT does
-    # not model) are all rejected rather than retargeting the snippet.
+    # explicit port, and an unexpected path-prefix (a proxied endpoint the
+    # SSOT does not model) are all rejected rather than retargeting the snippet.
     for bad in (
         "ftp://localhost:8123",
         "https://localhost:8123/v1",
@@ -536,8 +536,11 @@ def test_parse_base_url_default_port_and_errors():
     ):
         with pytest.raises(ValueError):
             connect._parse_base_url(bad)
-    # The one non-empty path the SSOT can render losslessly is allowed.
+    # The SSOT-renderable paths — empty, bare/trailing slash, `/v1` (+ trailing
+    # slash) — are all accepted losslessly.
     assert connect._parse_base_url("http://localhost:8123/v1") == ("localhost", 8123)
+    assert connect._parse_base_url("http://localhost:8123/") == ("localhost", 8123)
+    assert connect._parse_base_url("http://localhost:8123/v1/") == ("localhost", 8123)
 
 
 def test_connect_base_url_partial_override_keeps_other_coordinate(monkeypatch):

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -517,6 +517,17 @@ def test_parse_base_url_ipv6_bracketing():
     )
 
 
+def test_parse_base_url_does_not_decode_non_zone_host_escapes():
+    # Only the zone-id `%25` is decoded back to `%`; other percent-escapes in a
+    # hostname are genuine octets and must survive, else the host would corrupt
+    # into a malformed URL (codex #2348-R2).
+    assert connect._parse_base_url("http://%2Fexample.com:8000/v1") == (
+        "%2Fexample.com",
+        8000,
+    )
+    assert connect._parse_base_url("http://%20host:8000/v1") == ("%20host", 8000)
+
+
 def test_parse_base_url_default_port_and_errors():
     # No port → the rapid-mlx default.
     assert connect._parse_base_url("http://server.local/v1") == ("server.local", 8000)
@@ -533,11 +544,13 @@ def test_parse_base_url_default_port_and_errors():
         "http://localhost:70000/v1",
         "http://server/proxy/v1",
         "http://localhost:8123/custom",
+        "http://localhost:8123//",
+        "http://localhost:8123/v1//",
     ):
         with pytest.raises(ValueError):
             connect._parse_base_url(bad)
-    # The SSOT-renderable paths — empty, bare/trailing slash, `/v1` (+ trailing
-    # slash) — are all accepted losslessly.
+    # The SSOT-renderable paths — empty, bare/trailing slash, `/v1` (+ one
+    # trailing slash) — are all accepted losslessly.
     assert connect._parse_base_url("http://localhost:8123/v1") == ("localhost", 8123)
     assert connect._parse_base_url("http://localhost:8123/") == ("localhost", 8123)
     assert connect._parse_base_url("http://localhost:8123/v1/") == ("localhost", 8123)

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -521,8 +521,9 @@ def test_parse_base_url_default_port_and_errors():
     # No port → the rapid-mlx default.
     assert connect._parse_base_url("http://server.local/v1") == ("server.local", 8000)
     # Non-http scheme (incl. https, which the http-only connect SSOT would
-    # silently downgrade), malformed URL, no host, and an out-of-range/zero
-    # explicit port are all rejected rather than retargeting the snippet.
+    # silently downgrade), malformed URL, no host, an out-of-range/zero
+    # explicit port, and an unexpected path (a proxied endpoint the SSOT does
+    # not model) are all rejected rather than retargeting the snippet.
     for bad in (
         "ftp://localhost:8123",
         "https://localhost:8123/v1",
@@ -530,9 +531,13 @@ def test_parse_base_url_default_port_and_errors():
         "http://:8123",
         "http://localhost:0/v1",
         "http://localhost:70000/v1",
+        "http://server/proxy/v1",
+        "http://localhost:8123/custom",
     ):
         with pytest.raises(ValueError):
             connect._parse_base_url(bad)
+    # The one non-empty path the SSOT can render losslessly is allowed.
+    assert connect._parse_base_url("http://localhost:8123/v1") == ("localhost", 8123)
 
 
 def test_connect_base_url_partial_override_keeps_other_coordinate(monkeypatch):

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -520,9 +520,38 @@ def test_parse_base_url_ipv6_bracketing():
 def test_parse_base_url_default_port_and_errors():
     # No port → the rapid-mlx default.
     assert connect._parse_base_url("http://server.local/v1") == ("server.local", 8000)
-    for bad in ("ftp://localhost:8123", "not-a-url", "http://:8123"):
+    # Non-http scheme (incl. https, which the http-only connect SSOT would
+    # silently downgrade), malformed URL, no host, and an out-of-range/zero
+    # explicit port are all rejected rather than retargeting the snippet.
+    for bad in (
+        "ftp://localhost:8123",
+        "https://localhost:8123/v1",
+        "not-a-url",
+        "http://:8123",
+        "http://localhost:0/v1",
+        "http://localhost:70000/v1",
+    ):
         with pytest.raises(ValueError):
             connect._parse_base_url(bad)
+
+
+def test_connect_base_url_partial_override_keeps_other_coordinate(monkeypatch):
+    """`--host` and `--port` are independent overrides of the base URL: giving
+    only `--host` must keep the base URL's port (not fall back to 8000)."""
+    probed = []
+
+    def fake_probe(host, port):
+        probed.append((host, port))
+        return "m"
+
+    monkeypatch.setattr(connect, "_probe_running_model", fake_probe)
+    out = _run_connect(
+        target="openai-python",
+        base_url="http://localhost:8123/v1",
+        host="127.0.0.1",
+    )
+    assert "http://127.0.0.1:8123/v1" in out
+    assert probed == [("127.0.0.1", 8123)]
 
 
 def test_connect_openai_python_uses_base_url_for_snippet(monkeypatch):

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -30,7 +30,9 @@ def _endpoints(host="localhost", port=8000, model="qwen3.6-35b-4bit"):
     return connect.ServerEndpoints(host, port, model=model)
 
 
-def _run_connect(*, target=None, json_=False, host=None, port=None, model=None):
+def _run_connect(
+    *, target=None, json_=False, host=None, port=None, model=None, base_url=None
+):
     """Invoke ``connect_command`` the way argparse drives it, capturing stdout."""
     buf = io.StringIO()
     with redirect_stdout(buf):
@@ -41,6 +43,7 @@ def _run_connect(*, target=None, json_=False, host=None, port=None, model=None):
                 host=host,
                 port=port,
                 model=model,
+                base_url=base_url,
             )
         )
     return buf.getvalue()
@@ -81,7 +84,9 @@ def test_render_banner_matches_spec():
     assert (
         "rapid-mlx agents continue --setup --base-url http://localhost:8000/v1" in out
     )
-    assert "rapid-mlx connect openai-python" in out
+    # #2348: every Connect row carries the live endpoint — including the Python
+    # snippet, which a standalone `connect` process otherwise can't know.
+    assert "rapid-mlx connect openai-python --base-url http://localhost:8000/v1" in out
 
 
 def test_listen_fd_shape():
@@ -258,7 +263,12 @@ def test_connect_unknown_target_exits(monkeypatch):
     with pytest.raises(SystemExit) as exc, redirect_stdout(buf):
         connect_command(
             argparse.Namespace(
-                target="nope", json=False, host=None, port=None, model=None
+                target="nope",
+                json=False,
+                host=None,
+                port=None,
+                model=None,
+                base_url=None,
             )
         )
     assert exc.value.code == 1
@@ -483,6 +493,92 @@ def test_banner_already_bracketed_host_not_double_bracketed():
     out = connect.render_banner(connect.ServerEndpoints("[::1]", 8000, model="m"))
     assert "Ready: http://[::1]:8000" in out
     assert "[[::1]]" not in out
+
+
+# --- #2348: connect must accept/use the live instance base URL ---------------
+# The serve banner advertises ``connect openai-python --base-url <url>`` so the
+# pasted command points at the *actual* running server (its port + model),
+# not the localhost:8000 default the standalone process would otherwise print.
+
+
+def test_parse_base_url_derives_host_and_port():
+    assert connect._parse_base_url("http://localhost:8123/v1") == ("localhost", 8123)
+    assert connect._parse_base_url("http://127.0.0.1:9000") == ("127.0.0.1", 9000)
+    # Trailing /v1 is the OpenAI-style form the banner prints; it's stripped.
+    assert connect._parse_base_url("http://localhost:8123/v1")[1] == 8123
+
+
+def test_parse_base_url_ipv6_bracketing():
+    # Bracket-wrapped / scoped IPv6 pasted verbatim from the banner.
+    assert connect._parse_base_url("http://[::1]:8000/v1") == ("::1", 8000)
+    assert connect._parse_base_url("http://[fe80::1%25en0]:8123/v1") == (
+        "fe80::1%en0",
+        8123,
+    )
+
+
+def test_parse_base_url_default_port_and_errors():
+    # No port → the rapid-mlx default.
+    assert connect._parse_base_url("http://server.local/v1") == ("server.local", 8000)
+    for bad in ("ftp://localhost:8123", "not-a-url", "http://:8123"):
+        with pytest.raises(ValueError):
+            connect._parse_base_url(bad)
+
+
+def test_connect_openai_python_uses_base_url_for_snippet(monkeypatch):
+    """`--base-url` (the banner's pasted command) must make the standalone
+    snippet target the live host/port and probe THAT server for the model, not
+    default to localhost:8000."""
+    probed = []
+
+    def fake_probe(host, port):
+        probed.append((host, port))
+        return "lfm2.5-1b-4bit"
+
+    monkeypatch.setattr(connect, "_probe_running_model", fake_probe)
+    out = _run_connect(target="openai-python", base_url="http://localhost:8123/v1")
+    assert "http://localhost:8123/v1" in out
+    assert "lfm2.5-1b-4bit" in out
+    assert "http://localhost:8000" not in out
+    # The probe hit the base-url's port, not the 8000 default.
+    assert probed == [("localhost", 8123)]
+
+
+def test_connect_base_url_yields_to_explicit_host_port(monkeypatch):
+    """Explicit --host/--port flags win over --base-url (flags > base-url)."""
+    probed = []
+
+    def fake_probe(host, port):
+        probed.append((host, port))
+        return "m"
+
+    monkeypatch.setattr(connect, "_probe_running_model", fake_probe)
+    out = _run_connect(
+        target="openai-python",
+        base_url="http://localhost:8123/v1",
+        host="10.0.0.5",
+        port=9999,
+    )
+    assert "http://10.0.0.5:9999/v1" in out
+    assert probed == [("10.0.0.5", 9999)]
+
+
+def test_connect_invalid_base_url_exits_cleanly(monkeypatch):
+    """A malformed --base-url must not crash; it prints a clear message."""
+    buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc, redirect_stdout(buf):
+        connect_command(
+            argparse.Namespace(
+                target="openai-python",
+                json=False,
+                host=None,
+                port=None,
+                model=None,
+                base_url="ftp://localhost:8123",
+            )
+        )
+    assert exc.value.code == 1
+    assert "invalid --base-url" in buf.getvalue()
 
 
 def test_point_command_base_url_is_shell_quoted():

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -518,14 +518,24 @@ def test_parse_base_url_ipv6_bracketing():
 
 
 def test_parse_base_url_does_not_decode_non_zone_host_escapes():
-    # Only the zone-id `%25` is decoded back to `%`; other percent-escapes in a
-    # hostname are genuine octets and must survive, else the host would corrupt
-    # into a malformed URL (codex #2348-R2).
+    # In an ordinary (non-IPv6) hostname every percent-escape is a genuine
+    # octet and must survive untouched — including `%25` — else the generated
+    # URL would be malformed (codex #2348-R2/R3).
     assert connect._parse_base_url("http://%2Fexample.com:8000/v1") == (
         "%2Fexample.com",
         8000,
     )
     assert connect._parse_base_url("http://%20host:8000/v1") == ("%20host", 8000)
+    assert connect._parse_base_url("http://%25example.com:8000/v1") == (
+        "%25example.com",
+        8000,
+    )
+    # Only in a scoped IPv6 literal is `%25` a zone-id separator, decoded back
+    # to `%`.
+    assert connect._parse_base_url("http://[fe80::1%25en0]:8123/v1") == (
+        "fe80::1%en0",
+        8123,
+    )
 
 
 def test_parse_base_url_default_port_and_errors():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9012,9 +9012,30 @@ def connect_command(args):
     lifespan banner uses — so ``ready``/``openai``/``anthropic`` and the
     machine form can never drift from what a running server prints.
     """
-    from vllm_mlx.connect import probe_server_alive, render_banner, resolve_endpoints
+    from vllm_mlx.connect import (
+        _parse_base_url,
+        probe_server_alive,
+        render_banner,
+        resolve_endpoints,
+    )
 
-    eps = resolve_endpoints(host=args.host, port=args.port, model=args.model)
+    # ``--base-url`` is the explicit way to pass the *live* server instance
+    # context across process boundaries (#2348): the serve banner advertises
+    # ``connect openai-python --base-url <url>`` pointing at the real server,
+    # and a standalone ``connect`` derives host/port from it instead of falling
+    # back to the localhost:8000 default. It fills host/port only when neither
+    # explicit ``--host``/``--port`` flag was given (flags > base-url > config).
+    host = args.host
+    port = args.port
+    base_url = getattr(args, "base_url", None)
+    if base_url is not None and host is None and port is None:
+        try:
+            host, port = _parse_base_url(base_url)
+        except ValueError:
+            print(f"  connect: invalid --base-url: {base_url}")
+            sys.exit(1)
+
+    eps = resolve_endpoints(host=host, port=port, model=args.model)
 
     # Per-target "how to connect" cheat sheet.
     if args.target:
@@ -11171,6 +11192,17 @@ Examples:
         default=None,
         help="Model name to advertise (default: auto-detect from server)",
     ).completer = alias_completer
+    connect_parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        help=(
+            "Explicit OpenAI-style base URL of the running server "
+            "(e.g. http://localhost:8123/v1) — the banner's pasted commands "
+            "carry this so the snippet targets the live host/port, not the "
+            "default. Overrides --host/--port only when those are unset."
+        ),
+    )
 
     # Doctor command — pure env-health probe (≤5 s, no model load, no server).
     # Model-validation tiers (smoke/check/full/benchmark) moved to

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9023,17 +9023,22 @@ def connect_command(args):
     # context across process boundaries (#2348): the serve banner advertises
     # ``connect openai-python --base-url <url>`` pointing at the real server,
     # and a standalone ``connect`` derives host/port from it instead of falling
-    # back to the localhost:8000 default. It fills host/port only when neither
-    # explicit ``--host``/``--port`` flag was given (flags > base-url > config).
+    # back to the localhost:8000 default. Parse the base URL first, then let an
+    # explicit ``--host``/``--port`` override its respective coordinate only
+    # when that flag is actually supplied (independent overrides, codex #2348).
     host = args.host
     port = args.port
     base_url = getattr(args, "base_url", None)
-    if base_url is not None and host is None and port is None:
+    if base_url is not None:
         try:
-            host, port = _parse_base_url(base_url)
+            base_host, base_port = _parse_base_url(base_url)
         except ValueError:
             print(f"  connect: invalid --base-url: {base_url}")
             sys.exit(1)
+        if args.host is None:
+            host = base_host
+        if args.port is None:
+            port = base_port
 
     eps = resolve_endpoints(host=host, port=port, model=args.model)
 

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -265,14 +265,21 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     user can paste the banner URL verbatim. A missing port falls back to the
     rapid-mlx default (8000).
 
-    Raises ``ValueError`` on a non-http(s) scheme or a URL with no host.
+    ``connect`` targets a local ``http://`` server (the SSOT endpoints are all
+    ``http``), so any non-``http`` scheme is rejected rather than silently
+    downgraded (codex #2348-R1). An explicit port is validated against the CLI
+    ``_port_arg`` 1-65535 invariant, so ``:0`` or out-of-range values fail
+    loudly instead of retargeting the snippet elsewhere.
+
+    Raises ``ValueError`` on a non-http scheme, a URL with no host, or an
+    explicit out-of-range port.
     """
     from urllib.parse import unquote, urlsplit
 
     split = urlsplit(base_url, scheme="http")
     scheme = split.scheme or "http"
-    if scheme not in ("http", "https"):
-        raise ValueError(f"base-url must be an http(s) URL, got {base_url!r}")
+    if scheme != "http":
+        raise ValueError(f"base-url must be an http URL, got {base_url!r}")
     host = split.hostname
     if not host:
         raise ValueError(f"base-url has no host, got {base_url!r}")
@@ -280,7 +287,9 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     # raw form (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then
     # re-encodes it consistently when rendering, so the round-trip is stable.
     host = unquote(host)
-    port = split.port or 8000
+    port = split.port if split.port is not None else 8000
+    if not (1 <= port <= 65535):
+        raise ValueError(f"base-url port must be between 1 and 65535, got {port}")
     return host, port
 
 

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -297,13 +297,15 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
         path = raw[:-1] if raw.endswith("/") else raw
     if path not in ("", "/v1"):
         raise ValueError(f"base-url path must be empty or /v1, got {base_url!r}")
-    # Decode ONLY the ``%25`` that represents a scoped IPv6 zone-id separator
-    # (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then re-encodes
-    # it consistently when rendering, so the round-trip is stable. Other
-    # percent-escapes inside a hostname (``%2F``, ``%20``, …) are genuine octets
-    # and must NOT be blanket-unquoted or the host would be corrupted into a
-    # malformed URL (codex #2348-R2).
-    host = host.replace("%25", "%")
+    # A scoped IPv6 literal is the only host that carries a ``%25`` zone-id
+    # separator (``fe80::1%25en0`` -> raw ``fe80::1%en0``); :func:`_authority`
+    # then re-encodes it consistently when rendering, so the round-trip is
+    # stable. Detect IPv6 the same way ``_authority`` does (a ``:`` in the
+    # host) and decode ``%25`` ONLY there — in an ordinary hostname ``%25`` is
+    # a genuine encoded octet that must be left untouched, or the generated
+    # URL would be malformed (codex #2348-R2/R3).
+    if ":" in host:
+        host = host.replace("%25", "%")
     port = split.port if split.port is not None else 8000
     if not (1 <= port <= 65535):
         raise ValueError(f"base-url port must be between 1 and 65535, got {port}")

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -134,16 +134,17 @@ class ServerEndpoints:
 
 
 # The ``--setup`` verbs printed in the human banner's "Connect:" section.
-# Each row is ``(app label, command prefix, OpenAI endpoint?)``. Rows that
-# point a first-class agent at the server (`claude-code`, `continue`) take an
-# OpenAI-style ``/v1`` base URL and get ``--base-url <url>`` appended so the
-# copied command targets the *actual* running server, not the localhost
-# default the agent would otherwise assume. ``openai-python`` writes no config
-# and just prints a snippet, so it carries no ``--base-url``.
+# Each row is ``(app label, command prefix, OpenAI endpoint?)``. Every row —
+# including ``openai-python`` — takes an OpenAI-style ``/v1`` base URL and
+# gets ``--base-url <url>`` appended so the copied command targets the
+# *actual* running server, not the localhost:8000 default the standalone
+# process would otherwise assume (#2348). ``connect`` accepts ``--base-url``
+# as the explicit way to receive that instance context, so the pasted command
+# resolves the real host/port/model instead of printing placeholders.
 _CONNECT_ROWS: list[tuple[str, str, bool]] = [
     ("Claude Code", "rapid-mlx agents claude-code --setup", True),
     ("Continue", "rapid-mlx agents continue --setup", True),
-    ("Python", "rapid-mlx connect openai-python", False),
+    ("Python", "rapid-mlx connect openai-python", True),
 ]
 
 
@@ -247,6 +248,40 @@ def endpoints_from_bind(
     if listen_fd is not None and (host is None or port is None):
         return ServerEndpoints(host="", port=0, model=model, listen_fd=listen_fd)
     return ServerEndpoints(host or "localhost", port or 8000, model=model)
+
+
+def _parse_base_url(base_url: str) -> tuple[str, int]:
+    """Split an OpenAI-style base URL into ``(host, port)``.
+
+    ``rapid-mlx connect`` accepts ``--base-url`` as the explicit way to carry
+    the *live* server context across process boundaries (#2348). Without it a
+    standalone ``connect`` process cannot know the port/model a ``serve``
+    picked, so it would print the localhost:8000 default instead of the real
+    endpoint. A trailing ``/v1`` (OpenAI-style, what the banner prints) is
+    accepted and ignored for host/port derivation.
+
+    Accepts and normalizes the same host shapes as :func:`_authority` —
+    bare IPv4/hostnames and bracket-wrapped or scoped IPv6 literals — so a
+    user can paste the banner URL verbatim. A missing port falls back to the
+    rapid-mlx default (8000).
+
+    Raises ``ValueError`` on a non-http(s) scheme or a URL with no host.
+    """
+    from urllib.parse import unquote, urlsplit
+
+    split = urlsplit(base_url, scheme="http")
+    scheme = split.scheme or "http"
+    if scheme not in ("http", "https"):
+        raise ValueError(f"base-url must be an http(s) URL, got {base_url!r}")
+    host = split.hostname
+    if not host:
+        raise ValueError(f"base-url has no host, got {base_url!r}")
+    # unquote canonicalizes a percent-encoded scoped IPv6 zone-id back to the
+    # raw form (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then
+    # re-encodes it consistently when rendering, so the round-trip is stable.
+    host = unquote(host)
+    port = split.port or 8000
+    return host, port
 
 
 def resolve_endpoints(

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -276,7 +276,7 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     Raises ``ValueError`` on a non-http scheme, a URL with no host, an
     unexpected path, or an explicit out-of-range port.
     """
-    from urllib.parse import unquote, urlsplit
+    from urllib.parse import urlsplit
 
     split = urlsplit(base_url, scheme="http")
     scheme = split.scheme or "http"
@@ -286,17 +286,24 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     if not host:
         raise ValueError(f"base-url has no host, got {base_url!r}")
     # Empty path (``http://host:port``), a bare trailing slash (``/``), and
-    # ``/v1`` (+ trailing slash) are the only paths the SSOT renders losslessly;
-    # a trailing slash is a common, semantics-free spelling from SDK/config
-    # tooling, so it is normalized away before comparing. Anything else is a
-    # proxied endpoint whose path-prefix this local-server tool does not model.
-    path = (split.path or "").rstrip("/")
+    # ``/v1`` (+ a single trailing slash) are the only paths the SSOT renders
+    # losslessly; one trailing slash is a semantics-free spelling from SDK/config
+    # tooling and is normalized away before comparing. Repeated slashes
+    # (``//``, ``/v1//``) and real path-prefixes are rejected since they are
+    # path-significant and this local-server tool does not model them.
+    path = ""
+    raw = split.path or ""
+    if raw:
+        path = raw[:-1] if raw.endswith("/") else raw
     if path not in ("", "/v1"):
         raise ValueError(f"base-url path must be empty or /v1, got {base_url!r}")
-    # unquote canonicalizes a percent-encoded scoped IPv6 zone-id back to the
-    # raw form (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then
-    # re-encodes it consistently when rendering, so the round-trip is stable.
-    host = unquote(host)
+    # Decode ONLY the ``%25`` that represents a scoped IPv6 zone-id separator
+    # (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then re-encodes
+    # it consistently when rendering, so the round-trip is stable. Other
+    # percent-escapes inside a hostname (``%2F``, ``%20``, …) are genuine octets
+    # and must NOT be blanket-unquoted or the host would be corrupted into a
+    # malformed URL (codex #2348-R2).
+    host = host.replace("%25", "%")
     port = split.port if split.port is not None else 8000
     if not (1 <= port <= 65535):
         raise ValueError(f"base-url port must be between 1 and 65535, got {port}")

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -285,10 +285,12 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     host = split.hostname
     if not host:
         raise ValueError(f"base-url has no host, got {base_url!r}")
-    # Empty path (``http://host:port``) and ``/v1`` (OpenAI form) are the only
-    # ones the SSOT can render losslessly; anything else is a proxied endpoint
-    # whose path this local-server tool does not model.
-    path = split.path or ""
+    # Empty path (``http://host:port``), a bare trailing slash (``/``), and
+    # ``/v1`` (+ trailing slash) are the only paths the SSOT renders losslessly;
+    # a trailing slash is a common, semantics-free spelling from SDK/config
+    # tooling, so it is normalized away before comparing. Anything else is a
+    # proxied endpoint whose path-prefix this local-server tool does not model.
+    path = (split.path or "").rstrip("/")
     if path not in ("", "/v1"):
         raise ValueError(f"base-url path must be empty or /v1, got {base_url!r}")
     # unquote canonicalizes a percent-encoded scoped IPv6 zone-id back to the

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -265,14 +265,16 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     user can paste the banner URL verbatim. A missing port falls back to the
     rapid-mlx default (8000).
 
-    ``connect`` targets a local ``http://`` server (the SSOT endpoints are all
-    ``http``), so any non-``http`` scheme is rejected rather than silently
-    downgraded (codex #2348-R1). An explicit port is validated against the CLI
-    ``_port_arg`` 1-65535 invariant, so ``:0`` or out-of-range values fail
-    loudly instead of retargeting the snippet elsewhere.
+    ``connect`` targets a local ``http://`` server whose endpoints the SSOT
+    models as ``http://host:port`` (+ a literal ``/v1`` for OpenAI) — it has no
+    notion of a URL path prefix. So, mirroring the scheme check, any path other
+    than empty or ``/v1`` is rejected with a clear error rather than silently
+    rewriting a proxied base URL to the wrong API (codex #2348-R2). An explicit
+    port is validated against the CLI ``_port_arg`` 1-65535 invariant, so ``:0``
+    or out-of-range values fail loudly instead of retargeting the snippet.
 
-    Raises ``ValueError`` on a non-http scheme, a URL with no host, or an
-    explicit out-of-range port.
+    Raises ``ValueError`` on a non-http scheme, a URL with no host, an
+    unexpected path, or an explicit out-of-range port.
     """
     from urllib.parse import unquote, urlsplit
 
@@ -283,6 +285,12 @@ def _parse_base_url(base_url: str) -> tuple[str, int]:
     host = split.hostname
     if not host:
         raise ValueError(f"base-url has no host, got {base_url!r}")
+    # Empty path (``http://host:port``) and ``/v1`` (OpenAI form) are the only
+    # ones the SSOT can render losslessly; anything else is a proxied endpoint
+    # whose path this local-server tool does not model.
+    path = split.path or ""
+    if path not in ("", "/v1"):
+        raise ValueError(f"base-url path must be empty or /v1, got {base_url!r}")
     # unquote canonicalizes a percent-encoded scoped IPv6 zone-id back to the
     # raw form (``fe80::1%25en0`` -> ``fe80::1%en0``); :func:`_authority` then
     # re-encodes it consistently when rendering, so the round-trip is stable.


### PR DESCRIPTION
## Summary

Fixes #2348 — the serve readiness banner advertised a bare `rapid-mlx connect
openai-python`, but that command runs in a *separate* process with no shared
knowledge of the serve instance, so it printed the `localhost:8000` default and
a `<detected-model>` placeholder instead of the live host/port and served model.
`connect openai-python --base-url …` was also rejected as an unrecognized arg.

Fix (all rendered from the single connect SSOT `vllm_mlx/connect.py`, so they
cannot drift):

- The banner's Python connect row now carries `--base-url <openai-url>` like
  the Claude Code / Continue rows, targeting the *actual* running server.
- `connect` accepts `--base-url` as the explicit way to receive instance
  context across process boundaries: host/port are derived from it
  (`--host`/`--port` override only their own coordinate), and the served model
  is probed on that port.
- New `_parse_base_url` helper: derives host/port from an OpenAI-style base
  URL (trailing `/v1` ignored; IPv6 / scoped-zone `%25` normalized; http-only
  so an https URL is rejected rather than silently downgraded; explicit port
  validated against the 1-65535 invariant).
- `test_cli_connect.py` enrolled in the Linux changed-lines coverage list.

## Test plan

- [x] `pytest tests/test_cli_connect.py` — 41 passed
- [x] `pytest tests/test_ready_banner_timing.py` — 4 passed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `mypy` clean on `vllm_mlx/connect.py`
- [x] diff-cover vs origin/main: 30 lines, 0 missing, 100%
- [x] Reproduced the issue end-to-end pre-fix; post-fix the banner emits the
      `--base-url` form and the pasted command prints the live port + model
