### PR TITLE
fix(mac): allow deleting generated images

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -263,6 +263,35 @@ final class ImageGenViewModel {
         }
     }
 
+    /// Remove an image from the in-memory session gallery. Saved copies are
+    /// independent files and are deliberately untouched.
+    func delete(_ image: GeneratedImage) {
+        let wasActive = activeImage?.id == image.id
+        let wasEditSource = editSource?.id == image.id
+        let removedIndex = results.firstIndex { $0.id == image.id }
+
+        guard removedIndex != nil || wasEditSource else { return }
+        if let removedIndex {
+            results.remove(at: removedIndex)
+        }
+        if wasEditSource {
+            cancelEdit()
+        }
+        guard wasActive else { return }
+
+        let replacement: GeneratedImage?
+        if let removedIndex, results.indices.contains(removedIndex) {
+            // Prefer the next older image, which now occupies the same slot.
+            replacement = results[removedIndex]
+        } else if removedIndex != nil {
+            replacement = results.last
+        } else {
+            // Imported edit sources are not gallery entries.
+            replacement = results.first
+        }
+        activeID = replacement?.id
+    }
+
     /// Load the image-gen alias catalog (safe to call repeatedly).
     func refreshCatalog() async {
         catalogRefreshGeneration &+= 1

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -55,9 +55,15 @@ struct ImagesView: View {
                 pendingDeletion = nil
             }
             .accessibilityIdentifier("Images.Result.Delete.Confirm")
-            Button("Keep", role: .cancel) {
+            // SwiftUI re-hosts confirmation actions in an AppKit alert. On a
+            // headless Mac the cancel-role proxy can publish an enabled
+            // AXButton while rejecting AXPress. Keep this as an ordinary
+            // button and assign the safe default explicitly so Return keeps
+            // the image and automation receives a real press action.
+            Button("Keep") {
                 pendingDeletion = nil
             }
+            .keyboardShortcut(.defaultAction)
             .accessibilityIdentifier("Images.Result.Delete.Keep")
         } message: { _ in
             Text("This removes it from this session. Copies you've saved stay on disk.")

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -24,6 +24,7 @@ struct ImagesView: View {
 
     @State private var composeFocusToken = 0
     @State private var pickerHovering = false
+    @State private var pendingDeletion: GeneratedImage?
     /// Bumped when the user tries to submit while gated, so the readiness
     /// banner flashes for attention (same signal ChatView uses).
     @State private var blockedSendAttempts = 0
@@ -39,6 +40,27 @@ struct ImagesView: View {
         // Download button becomes Start without requiring an app restart.
         .task(id: ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)) {
             await viewModel.refreshCatalog()
+        }
+        .confirmationDialog(
+            "Delete this image?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingDeletion
+        ) { image in
+            Button("Delete Image", role: .destructive) {
+                viewModel.delete(image)
+                pendingDeletion = nil
+            }
+            .accessibilityIdentifier("Images.Result.Delete.Confirm")
+            Button("Keep", role: .cancel) {
+                pendingDeletion = nil
+            }
+            .accessibilityIdentifier("Images.Result.Delete.Keep")
+        } message: { _ in
+            Text("This removes it from this session. Copies you've saved stay on disk.")
         }
     }
 
@@ -121,6 +143,20 @@ struct ImagesView: View {
                 .help("Save image")
                 .accessibilityHint("Save image")
                 .accessibilityIdentifier("Images.Result.Save")
+
+                Button(role: .destructive) {
+                    pendingDeletion = image
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .frame(width: 28, height: 28)
+                        .background(.ultraThinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Delete image")
+                .accessibilityLabel("Delete image")
+                .accessibilityIdentifier("Images.Result.Delete")
             }
             .padding(10)
         }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -19,6 +19,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Images.Result.Edit" desc="Edit" help="Edit image" enabled=true
           AXButton id="Images.Result.Save" desc="Download" help="Save image" enabled=true
+          AXButton id="Images.Result.Delete" desc="Delete image" help="Delete image" enabled=true
           AXImage id="Images.Stage" enabled=true
           AXScrollArea id="Images.Gallery"
             AXButton id="Images.Gallery.Thumb.1" desc="Image 1, replace the couch with a blue armchair, selected" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -525,6 +525,9 @@ struct CoreWorkspaceVisualFoundationTests {
                 "Images.Gallery",
                 "Images.Result.Edit",
                 "Images.Result.Save",
+                "Images.Result.Delete",
+                "Images.Result.Delete.Confirm",
+                "Images.Result.Delete.Keep",
             ],
             "Sources/Rapid/UI/ReadinessBanner.swift": [
                 "Readiness.Action",

--- a/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Image result deletion")
+struct ImageResultDeletionTests {
+    @Test("Deleting the active result selects the adjacent older image")
+    @MainActor
+    func deletingActiveResultSelectsAdjacentImage() {
+        let viewModel = ImageGenViewModel(server: ServerManager())
+        let newest = image("newest")
+        let selected = image("selected")
+        let oldest = image("oldest")
+        viewModel.results = [newest, selected, oldest]
+        viewModel.activeID = selected.id
+
+        viewModel.delete(selected)
+
+        #expect(viewModel.results == [newest, oldest])
+        #expect(viewModel.activeImage?.id == oldest.id)
+    }
+
+    @Test("Deleting the last gallery image restores the empty stage")
+    @MainActor
+    func deletingOnlyResultClearsSelection() {
+        let viewModel = ImageGenViewModel(server: ServerManager())
+        let only = image("only")
+        viewModel.results = [only]
+        viewModel.activeID = only.id
+
+        viewModel.delete(only)
+
+        #expect(viewModel.results.isEmpty)
+        #expect(viewModel.activeID == nil)
+        #expect(viewModel.activeImage == nil)
+    }
+
+    @Test("Deleting an edit source exits editing without leaving stale state")
+    @MainActor
+    func deletingEditSourceExitsEditing() {
+        let viewModel = ImageGenViewModel(server: ServerManager())
+        viewModel.imageModels = [
+            ModelEntry(
+                alias: "image-model", hfRepo: "example/image", sizeOnDisk: nil,
+                cached: true, kind: .image, imageCapability: .generationAndEditing
+            ),
+        ]
+        viewModel.selectedAlias = "image-model"
+        let source = image("source")
+        let remaining = image("remaining")
+        viewModel.results = [source, remaining]
+        viewModel.beginEdit(source)
+
+        viewModel.delete(source)
+
+        #expect(!viewModel.isEditing)
+        #expect(viewModel.results == [remaining])
+        #expect(viewModel.activeImage?.id == remaining.id)
+        #expect(viewModel.selectedAlias == "image-model")
+    }
+
+    @Test("Deleting an imported edit source preserves gallery results")
+    @MainActor
+    func deletingImportedSourcePreservesGallery() {
+        let viewModel = ImageGenViewModel(server: ServerManager())
+        let galleryImage = image("gallery")
+        let imported = image("imported")
+        viewModel.results = [galleryImage]
+        viewModel.beginEdit(imported)
+
+        viewModel.delete(imported)
+
+        #expect(!viewModel.isEditing)
+        #expect(viewModel.results == [galleryImage])
+        #expect(viewModel.activeImage?.id == galleryImage.id)
+    }
+
+    private func image(_ prompt: String) -> GeneratedImage {
+        GeneratedImage(pngData: Data(prompt.utf8), prompt: prompt, isEdit: false)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
@@ -4,6 +4,19 @@ import Testing
 
 @Suite("Image result deletion")
 struct ImageResultDeletionTests {
+    @Test("The native Keep action remains pressable through AppKit re-hosting")
+    func keepActionUsesAnOrdinaryDefaultButton() throws {
+        let source = try String(
+            contentsOf: packageRoot.appendingPathComponent("Sources/Rapid/UI/ImagesView.swift"),
+            encoding: .utf8
+        )
+
+        #expect(source.contains("Button(\"Keep\")"))
+        #expect(source.contains(".keyboardShortcut(.defaultAction)"))
+        #expect(source.contains(".accessibilityIdentifier(\"Images.Result.Delete.Keep\")"))
+        #expect(!source.contains("Button(\"Keep\", role: .cancel)"))
+    }
+
     @Test("Deleting the active result selects the adjacent older image")
     @MainActor
     func deletingActiveResultSelectsAdjacentImage() {
@@ -77,5 +90,12 @@ struct ImageResultDeletionTests {
 
     private func image(_ prompt: String) -> GeneratedImage {
         GeneratedImage(pngData: Data(prompt.utf8), prompt: prompt, isEdit: false)
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
     }
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4373,6 +4373,63 @@ flow_image_generation() {
         ".event == \"image_response\" and .cancelled == true and .index == 6" \
         "the restarted ETA fixture did not settle as cancelled"
 
+    # 10. Deletion is destructive and session-local, so exercise both doors
+    #     through the native confirmation dialog before proving the last
+    #     result restores the real empty state.  A source-only contract cannot
+    #     tell whether SwiftUI actually hosts either dialog action in AX.
+    see_main "$OUT/ig-delete-before.json"
+    local gallery_before
+    gallery_before="$(jq '[.data.ui_elements[]?
+                           | select((.identifier // "")
+                                    | startswith("Images.Gallery.Thumb."))]
+                          | length' "$OUT/ig-delete-before.json")"
+    [[ "$gallery_before" -gt 0 ]] \
+        || die "the deletion journey has no generated results to remove"
+
+    press "$OUT/ig-delete-before.json" Images.Result.Delete "$OUT/ig-delete-open.json" \
+        || die "the active image has no pressable Delete action"
+    wait_identifier Images.Result.Delete.Keep "$OUT/ig-delete-dialog-cancel.json"
+    press "$OUT/ig-delete-dialog-cancel.json" Images.Result.Delete.Keep \
+        "$OUT/ig-delete-keep.json" \
+        || die "the native deletion dialog has no pressable Keep action"
+    wait_identifier Images.Result.Delete "$OUT/ig-delete-kept.json"
+    local gallery_after_keep
+    gallery_after_keep="$(jq '[.data.ui_elements[]?
+                              | select((.identifier // "")
+                                       | startswith("Images.Gallery.Thumb."))]
+                             | length' "$OUT/ig-delete-kept.json")"
+    [[ "$gallery_after_keep" == "$gallery_before" ]] \
+        || die "Keep removed a generated result ($gallery_before -> $gallery_after_keep)"
+
+    # Remove every result through the same user-visible contract.  The button
+    # always targets the active result; ImageGenViewModel chooses the adjacent
+    # remaining image until the final confirmation restores Images.EmptyState.
+    local remaining="$gallery_after_keep"
+    while [[ "$remaining" -gt 0 ]]; do
+        see_main "$OUT/ig-delete-${remaining}-before.json"
+        press "$OUT/ig-delete-${remaining}-before.json" Images.Result.Delete \
+            "$OUT/ig-delete-${remaining}-open.json" \
+            || die "Delete stopped being pressable with $remaining result(s) left"
+        wait_identifier Images.Result.Delete.Confirm \
+            "$OUT/ig-delete-${remaining}-dialog.json"
+        press "$OUT/ig-delete-${remaining}-dialog.json" Images.Result.Delete.Confirm \
+            "$OUT/ig-delete-${remaining}-confirm.json" \
+            || die "the native deletion dialog has no pressable Delete Image action"
+        remaining=$((remaining - 1))
+        if [[ "$remaining" -gt 0 ]]; then
+            wait_identifier Images.Result.Delete "$OUT/ig-delete-${remaining}-settled.json"
+        else
+            wait_identifier Images.EmptyState "$OUT/ig-delete-empty.json"
+        fi
+    done
+    jq -e '.success == true and .data.walk.complete == true
+           and any(.data.ui_elements[]?; .identifier == "Images.EmptyState")
+           and ([.data.ui_elements[]?
+                 | select((.identifier // "")
+                          | startswith("Images.Gallery.Thumb."))]
+                | length == 0)' "$OUT/ig-delete-empty.json" >/dev/null \
+        || die "deleting the final image did not restore a gallery-free empty state"
+
     log "  image-generation OK"
 }
 flow_resident_load_rejected() {


### PR DESCRIPTION
## Why

Generated images currently cannot be removed from the Images tab. Users can only keep generating new images, leaving unwanted results in the session gallery and consuming memory until the session limit rolls them off.

This restores a basic gallery-management workflow while preventing accidental deletion and preserving files the user explicitly saved.

## What

Adds a delete action to the Images tab with a native confirmation dialog.

Deleting an image removes it from the in-memory session gallery without affecting copies saved to disk. The view selects an adjacent result after deletion, restores the empty state when the last result is removed, and exits edit mode when the edit source is deleted.

Regression coverage exercises gallery selection, empty-state restoration, edit-source cleanup, imported images, accessibility identifiers, and the native Keep/Delete journey.

## Scope / Non-goals

The change is limited to in-memory gallery state, the destructive confirmation surface, and focused Desktop coverage. It does not delete saved files, add persistent gallery storage, alter image generation or editing behavior, or change the engine/server.

## Design precedent

The interaction follows the app's established native destructive-confirmation pattern: a clearly labeled trigger, a safe default that preserves data, an explicit destructive action, stable accessibility identifiers, and state mutation owned by the gallery view model. Session-owned results are removed independently from user-owned files on disk.

## Verification

- `swift test --no-parallel --filter 'ImageResultDeletionTests|CoreWorkspaceVisualFoundationTests'`: 34 passed on `a31da5d1`.
- `pr_validate 2387`: MERGE-SAFE on `a31da5d1` (19,081 passed; 97 skipped; 22 deselected; 6 xfailed; 1 xpassed).
- Native generated-image journey covers Keep, confirmed deletion, repeated deletion, and final empty-state restoration.


Fixes #2564
