### PR TITLE
fix(vision): auto-route supported hybrid VLMs

### DIFF
--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -112,7 +112,6 @@ vllm_mlx/spec_decode/mtp/quantized_argmax.py 2
 vllm_mlx/spec_decode/mtp/qwen3_5_inject.py 5
 vllm_mlx/speculative/ddtree/runtime.py 2
 vllm_mlx/speculative/ddtree/server.py 3
-vllm_mlx/speculative/dflash/eligibility.py 1
 vllm_mlx/speculative/dflash/server.py 5
 vllm_mlx/telemetry/transport.py 2
 vllm_mlx/tool_parsers/abstract_tool_parser.py 2

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -25,7 +25,7 @@ vllm_mlx/api/responses_adapter.py 4
 vllm_mlx/api/responses_models.py 2
 vllm_mlx/api/tool_calling.py 22
 vllm_mlx/api/tool_grammar.py 1
-vllm_mlx/api/utils.py 6
+vllm_mlx/api/utils.py 5
 vllm_mlx/audio/processor.py 4
 vllm_mlx/audio/stt.py 10
 vllm_mlx/audio/tts.py 7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,11 @@ def scheduler_config_stub(monkeypatch):
             self.enable_prefix_cache = True
             self.hybrid_cache_entries = 0
             self.non_trimmable_exact_prefix_reuse = False
+            self.enable_mtp = False
+            self.spec_decode = "none"
             self.__dict__.update(kwargs)
+            if self.enable_mtp:
+                self.spec_decode = "mtp"
 
     scheduler.SchedulerConfig = SchedulerConfig
     monkeypatch.setitem(sys.modules, "vllm_mlx.scheduler", scheduler)

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -81,6 +81,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "ddtree_speculative_tokens",
         "ddtree_tree_budget",
         "min_memory_gb",
+        "vision_min_memory_gb",
         "recommended_sampling",
         "pflash_tier",
         "pflash_keep_ratio",
@@ -591,6 +592,20 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         _coerce(
             "fake-alias",
             {"hf_path": "fake/Model", "supports_dflash": True},
+        )
+
+
+@pytest.mark.parametrize("bad_floor", [0, -1, True, "32"])
+def test_vision_memory_floor_requires_a_positive_number(bad_floor) -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="vision_min_memory_gb"):
+        _coerce(
+            "fake-vision-alias",
+            {
+                "hf_path": "fake/Vision-Model",
+                "vision_min_memory_gb": bad_floor,
+            },
         )
 
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -553,10 +553,11 @@ class TestIsMllmModelWeightsPresenceOverride:
         )
         assert is_mllm_model(str(model_dir)) is False
 
-    def test_qwen35_4b_alias_pin_still_text_only(self):
-        """The aliases.json ``is_text_only`` pin on qwen3.5-4b short-circuits
-        BEFORE weight inspection and must keep returning text (round-3 fix)."""
-        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+    def test_qwen35_4b_alias_no_longer_forces_text(self):
+        """Runtime capability, not a stale alias pin, now decides this VLM."""
+        from vllm_mlx.model_aliases import resolve_profile
+
+        assert resolve_profile("qwen3.5-4b-4bit").is_text_only is False
 
     def test_legacy_weights_probe_wrapper_delegates_to_shared_metadata(self, tmp_path):
         model_dir = self._make_model_dir(
@@ -785,13 +786,28 @@ class TestIsMllmModelCachedMetadata:
 
         assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
 
-    def test_curated_text_alias_smoke_qwen35_4b_is_text(self):
-        """End-to-end: the shipped alias registry curates the default smoke
-        model as text, so ``is_mllm_model`` returns False through the REAL
-        ``resolve_profile`` (no monkeypatch).  This is the exact routing the
-        7 previously-red CLI serve tests depend on."""
-        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
-        assert is_mllm_model("qwen3.5-4b-4bit") is False
+    def test_qwen35_4b_positive_checkpoint_evidence_routes_as_vision(self, monkeypatch):
+        """The former text pin no longer masks complete vision weights."""
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5ForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                    "text_config": {"layer_types": ["linear_attention"]},
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: True,
+        )
+
+        assert is_mllm_model("qwen3.5-4b-4bit") is True
 
     def test_inconclusive_verdict_is_not_promoted_by_file_existence(
         self, monkeypatch, tmp_path
@@ -1125,11 +1141,22 @@ class TestResolveServingLane:
     """The single lane-decision orchestrator: given the two offline probes and
     the explicit flags, decide the FINAL (is_mllm_lane, auto_text_fallback)."""
 
-    def _patch_probes(self, monkeypatch, *, is_mllm, hybrid):
+    def _patch_probes(
+        self, monkeypatch, *, is_mllm, hybrid, hybrid_runtime_supported=False
+    ):
         from vllm_mlx.api import utils as utils_mod
 
         monkeypatch.setattr(utils_mod, "is_mllm_model", lambda n: is_mllm)
-        monkeypatch.setattr(utils_mod, "mllm_backbone_is_hybrid", lambda n: hybrid)
+        monkeypatch.setattr(
+            utils_mod,
+            "mllm_backbone_cache_mode",
+            lambda n: "arrays" if hybrid else None,
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "mllm_hybrid_runtime_supported",
+            lambda: hybrid_runtime_supported,
+        )
 
     def test_hybrid_vlm_auto_downgrades_to_text(self, monkeypatch):
         from vllm_mlx.api.utils import resolve_serving_lane
@@ -1138,6 +1165,84 @@ class TestResolveServingLane:
         # as an AUTOMATIC fallback (Qwen3.6-27B shape).
         self._patch_probes(monkeypatch, is_mllm=True, hybrid=True)
         assert resolve_serving_lane("any/qwen36-27b") == (False, True)
+
+    def test_hybrid_vlm_uses_vision_when_runtime_supports_it(self, monkeypatch):
+        from vllm_mlx.api.utils import (
+            resolve_serving_lane,
+            resolve_serving_lane_decision,
+        )
+
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        assert resolve_serving_lane("any/qwen35-9b") == (True, False)
+        assert (
+            resolve_serving_lane_decision("any/qwen35-9b").reason
+            == "vision_hybrid_runtime_supported"
+        )
+
+    @pytest.mark.parametrize(
+        ("installed", "supported"),
+        [("0.6.15", False), ("0.6.16", True), ("0.7.0", True)],
+    )
+    def test_hybrid_runtime_version_contract(self, monkeypatch, installed, supported):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(utils_mod, "version", lambda _distribution: installed)
+        assert utils_mod.mllm_hybrid_runtime_supported() is supported
+
+    def test_missing_hybrid_runtime_fails_closed(self, monkeypatch):
+        from importlib.metadata import PackageNotFoundError
+
+        from vllm_mlx.api import utils as utils_mod
+
+        def missing(_distribution):
+            raise PackageNotFoundError
+
+        monkeypatch.setattr(utils_mod, "version", missing)
+        assert utils_mod.mllm_hybrid_runtime_supported() is False
+
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            ({"text_config": {"layer_types": ["mamba"]}}, "other"),
+            ({"text_config": {"model_type": "qwen3_next"}}, "arrays"),
+        ],
+    )
+    def test_hybrid_cache_mode_uses_checkpoint_metadata(
+        self, monkeypatch, config, expected
+    ):
+        from types import SimpleNamespace
+
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda _name: SimpleNamespace(config=config),
+        )
+
+        assert utils_mod.mllm_backbone_cache_mode("local/checkpoint") == expected
+
+    def test_missing_vendored_vision_module_fails_closed(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda _name: SimpleNamespace(config={"model_type": "muse_glimmer"}),
+        )
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda _name: (_ for _ in ()).throw(ImportError("vision extra missing")),
+        )
+
+        assert utils_mod.mllm_arch_unsupported_but_text_vendored("local/model") is True
 
     def test_genuine_vlm_stays_on_mllm_lane(self, monkeypatch):
         from vllm_mlx.api.utils import resolve_serving_lane
@@ -1634,6 +1739,90 @@ class TestContentToText:
 
 
 class TestValidateContentBlocksForCapabilities:
+    def test_text_lane_image_error_has_stable_machine_readable_code(self):
+        from vllm_mlx.api.utils import UnsupportedContentBlockError
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "https://x/img"}}
+                ],
+            }
+        ]
+
+        with pytest.raises(UnsupportedContentBlockError) as caught:
+            validate_content_blocks_for_capabilities(
+                messages,
+                model_name="vision-model",
+                allow_image=False,
+                allow_video=False,
+            )
+
+        assert caught.value.openai_detail(
+            serving_lane_reason="vision_hybrid_runtime_unsupported"
+        ) == {
+            "error": {
+                "message": (
+                    "Model 'vision-model' is serving text-only; image input "
+                    "is unsupported."
+                ),
+                "type": "invalid_request_error",
+                "code": "image_input_unsupported",
+                "param": "messages.content",
+                "serving_lane_reason": "vision_hybrid_runtime_unsupported",
+            }
+        }
+
+    def test_chat_route_preserves_typed_text_lane_image_error(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.routes.chat import router
+
+        class TextLaneEngine:
+            is_mllm = False
+            serving_lane_reason = "vision_hybrid_runtime_unsupported"
+            preserve_native_tool_format = False
+            supports_guided_generation = False
+            tokenizer = None
+
+        cfg = reset_config()
+        cfg.engine = TextLaneEngine()
+        cfg.model_name = "vision-model"
+        cfg.model_registry = None
+        cfg.no_thinking = True
+        cfg.tool_call_parser = None
+        cfg.reasoning_parser_name = None
+        app = FastAPI()
+        app.include_router(router)
+
+        try:
+            response = TestClient(app).post(
+                "/v1/chat/completions",
+                json={
+                    "model": "vision-model",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": "data:image/png;base64,abc"},
+                                }
+                            ],
+                        }
+                    ],
+                    "max_tokens": 8,
+                },
+            )
+        finally:
+            reset_config()
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["error"]["code"] == ("image_input_unsupported")
+
     def test_chat_text_block_rejects_missing_text(self):
         messages = [{"role": "user", "content": [{"type": "text"}]}]
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -2156,3 +2156,21 @@ class TestGptOssSpecialTokens:
         text = "<|channel|>analysis<|message|>Just thinking <|constrain|>something"
         result = clean_output_text(text)
         assert "<|constrain|>" not in result
+
+
+def test_dflash_runtime_probe_uses_symbol_level_discovery(monkeypatch):
+    """The lightweight probe checks the required drafter package itself."""
+    import importlib.util
+
+    from vllm_mlx.speculative.dflash.eligibility import have_runtime
+
+    probes: list[str] = []
+
+    def find_spec(name: str):
+        probes.append(name)
+        return object()
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+    assert have_runtime() is True
+    assert probes == ["mlx_vlm.speculative.drafters"]

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -557,7 +557,9 @@ class TestIsMllmModelWeightsPresenceOverride:
         """Runtime capability, not a stale alias pin, now decides this VLM."""
         from vllm_mlx.model_aliases import resolve_profile
 
-        assert resolve_profile("qwen3.5-4b-4bit").is_text_only is False
+        profile = resolve_profile("qwen3.5-4b-4bit")
+        assert profile.is_text_only is False
+        assert profile.vision_min_memory_gb == 32.0
 
     def test_legacy_weights_probe_wrapper_delegates_to_shared_metadata(self, tmp_path):
         model_dir = self._make_model_dir(
@@ -1157,6 +1159,7 @@ class TestResolveServingLane:
             "mllm_hybrid_runtime_supported",
             lambda: hybrid_runtime_supported,
         )
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 64.0)
 
     def test_hybrid_vlm_auto_downgrades_to_text(self, monkeypatch):
         from vllm_mlx.api.utils import resolve_serving_lane
@@ -1165,6 +1168,32 @@ class TestResolveServingLane:
         # as an AUTOMATIC fallback (Qwen3.6-27B shape).
         self._patch_probes(monkeypatch, is_mllm=True, hybrid=True)
         assert resolve_serving_lane("any/qwen36-27b") == (False, True)
+
+    @pytest.mark.parametrize(
+        ("architecture_unavailable", "cache_mode", "reason"),
+        [
+            (True, None, "vision_architecture_unavailable"),
+            (False, "other", "vision_hybrid_cache_unsupported"),
+        ],
+    )
+    def test_unsupported_vision_contracts_fail_closed(
+        self, monkeypatch, architecture_unavailable, cache_mode, reason
+    ):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(utils_mod, "is_mllm_model", lambda _name: True)
+        monkeypatch.setattr(
+            utils_mod,
+            "mllm_arch_unsupported_but_text_vendored",
+            lambda _name: architecture_unavailable,
+        )
+        monkeypatch.setattr(
+            utils_mod, "mllm_backbone_cache_mode", lambda _name: cache_mode
+        )
+
+        assert utils_mod.resolve_serving_lane_decision(
+            "local/checkpoint"
+        ) == utils_mod.ServingLaneDecision(False, reason, auto_text_fallback=True)
 
     def test_hybrid_vlm_uses_vision_when_runtime_supports_it(self, monkeypatch):
         from vllm_mlx.api.utils import (
@@ -1183,6 +1212,68 @@ class TestResolveServingLane:
             resolve_serving_lane_decision("any/qwen35-9b").reason
             == "vision_hybrid_runtime_supported"
         )
+
+    def test_hybrid_vlm_falls_back_when_measured_vision_floor_does_not_fit(
+        self, monkeypatch
+    ):
+        from vllm_mlx.api import utils as utils_mod
+
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
+
+        decision = utils_mod.resolve_serving_lane_decision(
+            "local/qwen35", vision_min_memory_gb=32.0
+        )
+
+        assert decision == utils_mod.ServingLaneDecision(
+            False, "vision_memory_insufficient", auto_text_fallback=True
+        )
+
+    def test_hybrid_vlm_uses_vision_at_measured_memory_floor(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 32.0)
+
+        assert utils_mod.resolve_serving_lane_decision(
+            "local/qwen35", vision_min_memory_gb=32.0
+        ) == utils_mod.ServingLaneDecision(True, "vision_hybrid_runtime_supported")
+
+    def test_explicit_vision_overrides_measured_memory_floor(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
+
+        assert utils_mod.resolve_serving_lane_decision(
+            "local/qwen35",
+            force_mllm=True,
+            vision_min_memory_gb=32.0,
+        ) == utils_mod.ServingLaneDecision(True, "vision_lane_forced")
+
+    def test_unknown_physical_memory_does_not_invent_a_fallback(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 0.0)
+
+        assert utils_mod.resolve_serving_lane_decision(
+            "local/qwen35", vision_min_memory_gb=32.0
+        ) == utils_mod.ServingLaneDecision(True, "vision_hybrid_runtime_supported")
 
     @pytest.mark.parametrize(
         ("installed", "supported"),
@@ -1739,6 +1830,62 @@ class TestContentToText:
 
 
 class TestValidateContentBlocksForCapabilities:
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_audio", "input_audio": "not-an-object"}
+                    ],
+                }
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_audio",
+                            "input_audio": {"data": "abc", "format": "exe"},
+                        }
+                    ],
+                }
+            ],
+        ],
+    )
+    def test_invalid_input_audio_payload_is_rejected(self, messages):
+        with pytest.raises(ValueError):
+            validate_content_blocks_for_capabilities(
+                messages,
+                model_name="audio-model",
+                allow_image=False,
+                allow_video=False,
+                allow_audio=True,
+            )
+
+    def test_enabled_image_and_video_capabilities_accept_media(self):
+        validate_content_blocks_for_capabilities(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.png"},
+                        },
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "https://example.com/video.mp4"},
+                        },
+                    ],
+                }
+            ],
+            model_name="vision-model",
+            allow_image=True,
+            allow_video=True,
+        )
+
     def test_text_lane_image_error_has_stable_machine_readable_code(self):
         from vllm_mlx.api.utils import UnsupportedContentBlockError
 
@@ -1773,6 +1920,10 @@ class TestValidateContentBlocksForCapabilities:
                 "serving_lane_reason": "vision_hybrid_runtime_unsupported",
             }
         }
+        assert (
+            "serving_lane_reason"
+            not in caught.value.openai_detail(serving_lane_reason=object())["error"]
+        )
 
     def test_chat_route_preserves_typed_text_lane_image_error(self):
         from fastapi import FastAPI

--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -486,8 +486,9 @@ class TestChatRejectsImageOnTextOnlyModel:
             },
         )
         assert r.status_code == 400
-        detail = r.json()["detail"]
-        assert "image" in detail.lower() or "video" in detail.lower()
+        error = r.json().get("detail", r.json())["error"]
+        assert error["code"] == "image_input_unsupported"
+        assert "image" in error["message"].lower()
 
     def test_video_on_text_only_engine_400(self, patched_config, monkeypatch):
         client = _build_chat_app(patched_config, monkeypatch)

--- a/tests/test_basewheel_hybrid_vlm_serve_1017.py
+++ b/tests/test_basewheel_hybrid_vlm_serve_1017.py
@@ -43,13 +43,28 @@ def _args(model: str = "some/model", *, mllm: bool = False, no_mllm: bool = Fals
 # ---------------------------------------------------------------------------
 
 
-def _patch_probes(monkeypatch, *, is_mllm: bool, hybrid: bool):
+def _patch_probes(
+    monkeypatch,
+    *,
+    is_mllm: bool,
+    hybrid: bool,
+    hybrid_runtime_supported: bool = False,
+):
     """Stub the two offline probes ``resolve_serving_lane`` consults so the
     lane decision is exercised without a materialized checkpoint config."""
     from vllm_mlx.api import utils as api_utils
 
     monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: is_mllm)
-    monkeypatch.setattr(api_utils, "mllm_backbone_is_hybrid", lambda name: hybrid)
+    monkeypatch.setattr(
+        api_utils,
+        "mllm_backbone_cache_mode",
+        lambda name: "arrays" if hybrid else None,
+    )
+    monkeypatch.setattr(
+        api_utils,
+        "mllm_hybrid_runtime_supported",
+        lambda: hybrid_runtime_supported,
+    )
 
 
 def test_helper_hybrid_vlm_does_not_run_on_mllm_lane(monkeypatch):
@@ -68,6 +83,18 @@ def test_helper_genuine_vlm_runs_on_mllm_lane(monkeypatch):
     from vllm_mlx import cli
 
     _patch_probes(monkeypatch, is_mllm=True, hybrid=False)
+    assert cli._serve_will_run_on_mllm_lane(_args()) is True
+
+
+def test_helper_supported_hybrid_vlm_runs_on_mllm_lane(monkeypatch):
+    from vllm_mlx import cli
+
+    _patch_probes(
+        monkeypatch,
+        is_mllm=True,
+        hybrid=True,
+        hybrid_runtime_supported=True,
+    )
     assert cli._serve_will_run_on_mllm_lane(_args()) is True
 
 

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -103,6 +103,11 @@ class _StubMLLMEngine:
         )
 
 
+class _StubTextFallbackEngine(_StubMLLMEngine):
+    is_mllm = False
+    serving_lane_reason = "vision_hybrid_runtime_unsupported"
+
+
 def _make_client(engine: _StubMLLMEngine) -> TestClient:
     cfg = reset_config()
     cfg.engine = engine
@@ -135,6 +140,33 @@ def _multipart_user_message(text: str) -> dict:
             {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URL}},
         ],
     }
+
+
+def test_chat_route_rejects_image_on_text_lane_with_typed_reason():
+    engine = _StubTextFallbackEngine()
+    client = _make_client(engine)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-vl-8b-4bit",
+            "messages": [_multipart_user_message("Describe this")],
+            "max_tokens": 8,
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    error = response.json()["detail"]["error"]
+    assert error == {
+        "message": (
+            "Model 'qwen3-vl-8b-4bit' is serving text-only; image input is unsupported."
+        ),
+        "type": "invalid_request_error",
+        "code": "image_input_unsupported",
+        "param": "messages.content",
+        "serving_lane_reason": "vision_hybrid_runtime_unsupported",
+    }
+    assert engine.chat_calls == []
 
 
 def test_chat_route_forwards_image_url_content_to_mllm_engine():

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -20,6 +20,37 @@ from vllm_mlx.output_collector import RequestOutputCollector  # noqa: E402
 from vllm_mlx.scheduler import BackpressureError, Scheduler  # noqa: E402
 
 
+@pytest.mark.asyncio
+async def test_missing_vision_weights_update_live_lane_reason(monkeypatch):
+    from vllm_mlx.models import mllm as mllm_mod
+
+    class FakeTextOnlyMLLM:
+        def __init__(self, model_name, trust_remote_code=True):
+            self.model_name = model_name
+
+        def load(self):
+            raise mllm_mod.TextOnlyCheckpointError(
+                "checkpoint has no vision tower", missing_count=1
+            )
+
+    monkeypatch.setattr(mllm_mod, "MLXMultimodalLM", FakeTextOnlyMLLM)
+    engine = BatchedEngine(
+        "fake/text-only-vision-checkpoint",
+        serving_lane_reason="vision_supported",
+    )
+    engine._is_mllm = True
+
+    async def start_llm():
+        return None
+
+    monkeypatch.setattr(engine, "_start_llm", start_llm)
+
+    await engine._start_mllm()
+
+    assert engine.serving_lane == "text"
+    assert engine.serving_lane_reason == "vision_weights_unavailable"
+
+
 def _engine(*, reservations: int = 0, running: dict | None = None):
     engine = BatchedEngine.__new__(BatchedEngine)
     engine._is_mllm = False

--- a/tests/test_image_block_requires_vision_model.py
+++ b/tests/test_image_block_requires_vision_model.py
@@ -306,7 +306,9 @@ def test_openai_text_only_model_rejects_image_url_block():
         },
     )
     assert resp.status_code == 400, resp.text
-    assert "does not support" in resp.json()["detail"]
+    assert resp.json().get("detail", resp.json())["error"]["code"] == (
+        "image_input_unsupported"
+    )
 
 
 def test_openai_text_only_model_accepts_text_only_content():

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -488,14 +488,11 @@ def test_models_lane_fields_use_matching_live_engine(monkeypatch):
         lambda model_id: engine if model_id == "served-alias" else None,
     )
 
-    assert models_route._served_lane_fields("served-alias") == {
-        "serving_lane": "text",
-        "serving_lane_reason": "vision_hybrid_runtime_unsupported",
-    }
-    assert models_route._served_lane_fields("unknown") == {
-        "serving_lane": None,
-        "serving_lane_reason": None,
-    }
+    assert models_route._served_lane_fields("served-alias") == (
+        "text",
+        "vision_hybrid_runtime_unsupported",
+    )
+    assert models_route._served_lane_fields("unknown") == (None, None)
 
 
 @pytest.fixture

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -450,6 +450,54 @@ def manager_fixture(*, limit_gib=10, ttl=0):
     return manager, registry, loaded, clock
 
 
+def test_residency_snapshot_exposes_live_serving_lane_truth():
+    manager, registry, _, _ = manager_fixture()
+    engine = registry.get_entry("chat").engine
+    engine.serving_lane = "text"
+    engine.serving_lane_reason = "vision_hybrid_runtime_unsupported"
+
+    payload = manager.snapshot()["models"][0]
+
+    assert payload["serving_lane"] == "text"
+    assert payload["serving_lane_reason"] == "vision_hybrid_runtime_unsupported"
+
+
+def test_live_engine_exposes_serving_lane_decision():
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._is_mllm = True
+    engine._serving_lane_reason = "vision_hybrid_runtime_supported"
+
+    assert engine.serving_lane == "vision"
+    assert engine.serving_lane_reason == "vision_hybrid_runtime_supported"
+
+
+def test_models_lane_fields_use_matching_live_engine(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes import models as models_route
+
+    engine = SimpleNamespace(
+        serving_lane="text",
+        serving_lane_reason="vision_hybrid_runtime_unsupported",
+    )
+    monkeypatch.setattr(
+        models_route,
+        "_engine_for",
+        lambda model_id: engine if model_id == "served-alias" else None,
+    )
+
+    assert models_route._served_lane_fields("served-alias") == {
+        "serving_lane": "text",
+        "serving_lane_reason": "vision_hybrid_runtime_unsupported",
+    }
+    assert models_route._served_lane_fields("unknown") == {
+        "serving_lane": None,
+        "serving_lane_reason": None,
+    }
+
+
 @pytest.fixture
 def residency_activity_contract(monkeypatch):
     """Exercise the activity SSOT from the MLX-free Linux fixed selector."""

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -350,6 +350,40 @@ class TestResponsesNonStream:
         assert body["output"][0]["content"][0]["text"] == document
         assert all(item["type"] != "reasoning" for item in body["output"])
 
+        # This fixed-list protocol test also guards the typed multimodal
+        # rejection envelope before either path can enter generation.
+        engine.serving_lane_reason = "vision_hybrid_runtime_unsupported"
+        image_response = responses_client.client.post(
+            "/v1/responses",
+            json=_payload(
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_image",
+                                "image_url": "data:image/png;base64,abc",
+                            }
+                        ],
+                    }
+                ]
+            ),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+
+        assert image_response.status_code == 400
+        image_body = image_response.json()
+        assert image_body.get("detail", image_body)["error"] == {
+            "message": (
+                "Model 'test-model' is serving text-only; image input is unsupported."
+            ),
+            "type": "invalid_request_error",
+            "code": "image_input_unsupported",
+            "param": "messages.content",
+            "serving_lane_reason": "vision_hybrid_runtime_unsupported",
+        }
+
     def test_response_carries_loaded_model_not_request_alias(self, responses_client):
         """The response.model field must be the loaded engine's model
         name, not whatever the client typed — same convention as #557."""
@@ -737,8 +771,9 @@ class TestResponsesNonStream:
 
         assert response.status_code == 400, response.text
         body = response.json()
-        msg = body.get("detail") or body.get("error", {}).get("message", "")
-        assert "image inputs" in msg
+        error = body.get("detail", body)["error"]
+        assert error["code"] == "image_input_unsupported"
+        assert "serving text-only" in error["message"]
         assert engine.calls == []
 
     @pytest.mark.parametrize(

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -305,7 +305,9 @@ class TestResponsesNonStream:
         assert body["usage"]["output_tokens"] == 2
         assert body["usage"]["total_tokens"] == 5
 
-    def test_structured_output_keeps_bare_json_out_of_reasoning(self, responses_client):
+    def test_structured_output_keeps_bare_json_out_of_reasoning(
+        self, responses_client, monkeypatch
+    ):
         from vllm_mlx.reasoning.cohere_command_parser import (
             CohereCommand4ReasoningParser,
         )
@@ -383,6 +385,32 @@ class TestResponsesNonStream:
             "param": "messages.content",
             "serving_lane_reason": "vision_hybrid_runtime_unsupported",
         }
+
+        from vllm_mlx.api.utils import UnsupportedContentBlockError
+        from vllm_mlx.routes import responses as responses_route
+
+        def reject_at_route(*_args, **_kwargs):
+            raise UnsupportedContentBlockError(
+                "forced route-boundary rejection",
+                code="image_input_unsupported",
+                param="messages.content",
+            )
+
+        monkeypatch.setattr(
+            responses_route,
+            "validate_content_blocks_for_capabilities",
+            reject_at_route,
+        )
+        route_response = responses_client.client.post(
+            "/v1/responses",
+            json=_payload(input="hello"),
+            headers={"Authorization": "Bearer test-secret"},
+        )
+        assert route_response.status_code == 400
+        route_body = route_response.json()
+        assert route_body.get("detail", route_body)["error"]["code"] == (
+            "image_input_unsupported"
+        )
 
     def test_response_carries_loaded_model_not_request_alias(self, responses_client):
         """The response.model field must be the loaded engine's model

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -307,6 +307,25 @@ def test_engine_is_mllm_or_none_is_defensive():
     assert models_route._engine_is_mllm_or_none(_StubEngine(False)) is False
 
 
+def test_model_info_exposes_live_serving_lane_reason(monkeypatch):
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import models as models_route
+
+    model_id = "fake/qwen3.5-9b-4bit"
+    restore = _stub_single_serve(monkeypatch, model_id=model_id, engine_is_mllm=False)
+    engine = get_config().engine
+    engine.serving_lane = "text"
+    engine.serving_lane_reason = "vision_hybrid_runtime_unsupported"
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
+    try:
+        info = models_route._build_model_info(model_id)
+    finally:
+        restore()
+
+    assert info.serving_lane == "text"
+    assert info.serving_lane_reason == "vision_hybrid_runtime_unsupported"
+
+
 def test_build_model_info_prefers_live_hybrid_probe(monkeypatch):
     """The wire reports the scheduler's loaded profile, not stale alias data."""
     from vllm_mlx.routes import models as models_route

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -223,7 +223,11 @@ def test_materialized_checkpoint_keeps_catalog_vision_memory_floor(monkeypatch):
     ],
 )
 async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
-    monkeypatch, auto_text_fallback, lane_reason, expected_force_text
+    monkeypatch,
+    scheduler_config_stub,
+    auto_text_fallback,
+    lane_reason,
+    expected_force_text,
 ):
     """Startup and residency must hand the same resolved path/lane to engine."""
     from vllm_mlx import server
@@ -456,7 +460,9 @@ def test_load_model_infers_programmatic_max_tokens_explicit(monkeypatch):
     assert cfg.default_max_tokens_is_explicit is False
 
 
-def test_load_model_mtp_kwarg_translates_to_scheduler_config(monkeypatch):
+def test_load_model_mtp_kwarg_translates_to_scheduler_config(
+    monkeypatch, scheduler_config_stub
+):
     from vllm_mlx import server
 
     monkeypatch.setattr(server, "BatchedEngine", _StubEngine)
@@ -479,11 +485,10 @@ def test_load_model_mtp_kwarg_translates_to_scheduler_config(monkeypatch):
     assert cfg.enable_mtp is True
 
 
-def test_load_model_mtp_kwarg_rejects_conflicting_spec_decode():
+def test_load_model_mtp_kwarg_rejects_conflicting_spec_decode(scheduler_config_stub):
     from vllm_mlx import server
-    from vllm_mlx.scheduler import SchedulerConfig
 
-    cfg = SchedulerConfig()
+    cfg = scheduler_config_stub()
     cfg.spec_decode = "suffix"
 
     with pytest.raises(ValueError, match="mtp=True.*spec_decode='suffix'"):
@@ -494,26 +499,28 @@ def test_load_model_mtp_kwarg_rejects_conflicting_spec_decode():
         )
 
 
-def test_load_model_mtp_kwarg_rejects_conflicting_suffix_config():
+def test_load_model_mtp_kwarg_rejects_conflicting_suffix_config(
+    scheduler_config_stub,
+):
     from vllm_mlx import server
-    from vllm_mlx.scheduler import SchedulerConfig
 
     with pytest.raises(ValueError, match="enable_suffix_decoding=True"):
         server.load_model(
             "mlx-community/Qwen3.5-9B-4bit",
-            scheduler_config=SchedulerConfig(enable_suffix_decoding=True),
+            scheduler_config=scheduler_config_stub(enable_suffix_decoding=True),
             mtp=True,
         )
 
 
-def test_load_model_mtp_kwarg_rejects_conflicting_dflash_config():
+def test_load_model_mtp_kwarg_rejects_conflicting_dflash_config(
+    scheduler_config_stub,
+):
     from vllm_mlx import server
-    from vllm_mlx.scheduler import SchedulerConfig
 
     with pytest.raises(ValueError, match="dflash_drafter_path"):
         server.load_model(
             "mlx-community/Qwen3.5-9B-4bit",
-            scheduler_config=SchedulerConfig(dflash_drafter_path="local/draft"),
+            scheduler_config=scheduler_config_stub(dflash_drafter_path="local/draft"),
             mtp=True,
         )
 
@@ -583,18 +590,19 @@ def test_load_model_response_cache_reconfigure_failure_forces_disabled(monkeypat
     rc.reset_response_cache_for_tests()
 
 
-def test_load_model_mtp_kwarg_rejects_legacy_optimistic_config():
+def test_load_model_mtp_kwarg_rejects_legacy_optimistic_config(
+    scheduler_config_stub,
+):
     """PR #1050 hard-reject: server.load_model(mtp=True) with a
     scheduler_config carrying ``mtp_optimistic=True`` must fail because
     the direct mutation of ``spec_decode='mtp'`` below would bypass
     ``__post_init__`` and silently drop the flag under the vendored path."""
     from vllm_mlx import server
-    from vllm_mlx.scheduler import SchedulerConfig
 
     # SchedulerConfig(mtp_optimistic=True) alone (spec_decode="none") is
     # legal — the reject is triggered only once mtp=True elevates the
     # config into the unified spec-decode interface path.
-    cfg = SchedulerConfig(mtp_optimistic=True)
+    cfg = scheduler_config_stub(mtp_optimistic=True)
 
     with pytest.raises(
         ValueError, match="mtp_optimistic.*not supported under the unified"

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -180,6 +180,40 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     assert server._engine.kwargs.get("force_text") is False
 
 
+def test_materialized_checkpoint_keeps_catalog_vision_memory_floor(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import model_aliases, model_metadata, server
+    from vllm_mlx.api import utils as api_utils
+    from vllm_mlx.model_profile import ModelProfile
+
+    monkeypatch.setattr(model_aliases, "resolve_model", lambda _name: "publisher/model")
+    monkeypatch.setattr(
+        model_aliases,
+        "resolve_profile",
+        lambda _name: ModelProfile(vision_min_memory_gb=32.0),
+    )
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(
+        model_metadata,
+        "read_model_metadata",
+        lambda _name: SimpleNamespace(snapshot_dir="/cache/snapshots/revision"),
+    )
+    monkeypatch.setattr(api_utils, "is_mllm_model", lambda _name: True)
+    monkeypatch.setattr(
+        api_utils, "mllm_arch_unsupported_but_text_vendored", lambda _name: False
+    )
+    monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda _name: "arrays")
+    monkeypatch.setattr(api_utils, "mllm_hybrid_runtime_supported", lambda: True)
+    monkeypatch.setattr(api_utils, "physical_ram_gb", lambda: 16.0)
+
+    resolved = server._resolve_serving_checkpoint("qwen3.5-4b-4bit")
+
+    assert resolved.load_path == "/cache/snapshots/revision"
+    assert resolved.auto_text_fallback is True
+    assert resolved.lane_reason == "vision_memory_insufficient"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("auto_text_fallback", "lane_reason", "expected_force_text"),

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -138,8 +138,11 @@ def test_load_model_materializes_config_before_hybrid_routing_probe(
     # its config has been materialized (i.e. after the download).
     monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: True)
     monkeypatch.setattr(
-        api_utils, "mllm_backbone_is_hybrid", lambda name: state["materialized"]
+        api_utils,
+        "mllm_backbone_cache_mode",
+        lambda name: "arrays" if state["materialized"] else None,
     )
+    monkeypatch.setattr(api_utils, "mllm_hybrid_runtime_supported", lambda: False)
 
     with caplog.at_level(logging.INFO, logger="vllm_mlx.server"):
         server.load_model("some/uncached-hybrid-vlm-4bit")
@@ -167,7 +170,7 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     _stub_routing_globals(monkeypatch, server)
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
     monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: True)
-    monkeypatch.setattr(api_utils, "mllm_backbone_is_hybrid", lambda name: False)
+    monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda name: None)
 
     server.load_model("some/genuine-vlm-4bit")
 
@@ -178,7 +181,16 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(monkeypatch):
+@pytest.mark.parametrize(
+    ("auto_text_fallback", "lane_reason", "expected_force_text"),
+    [
+        (True, "vision_hybrid_runtime_unsupported", True),
+        (False, "vision_hybrid_runtime_supported", False),
+    ],
+)
+async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
+    monkeypatch, auto_text_fallback, lane_reason, expected_force_text
+):
     """Startup and residency must hand the same resolved path/lane to engine."""
     from vllm_mlx import server
     from vllm_mlx.model_profile import ModelProfile
@@ -188,7 +200,8 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(monkey
     resolved = server._ServingCheckpoint(
         model_path="publisher/model",
         load_path="/cache/snapshots/revision",
-        auto_text_fallback=True,
+        auto_text_fallback=auto_text_fallback,
+        lane_reason=lane_reason,
     )
 
     def resolve_once(model_name, **kwargs):
@@ -220,7 +233,16 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(monkey
         ),
     ]
     assert startup_kwargs["model_name"] == runtime.engine.kwargs["model_name"]
-    assert startup_kwargs["force_text"] == runtime.engine.kwargs["force_text"] is True
+    assert (
+        startup_kwargs["force_text"]
+        == runtime.engine.kwargs["force_text"]
+        is expected_force_text
+    )
+    assert (
+        startup_kwargs["serving_lane_reason"]
+        == runtime.engine.kwargs["serving_lane_reason"]
+        == lane_reason
+    )
 
 
 def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeypatch):

--- a/tests/test_text_only_media_gate.py
+++ b/tests/test_text_only_media_gate.py
@@ -89,7 +89,9 @@ class TestTextOnlyMediaRejection:
                 ),
             )
             assert resp.status_code == 400
-            assert "does not support" in resp.json()["detail"]
+            assert resp.json().get("detail", resp.json())["error"]["code"] == (
+                "image_input_unsupported"
+            )
         finally:
             reset_config()
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -15,7 +15,6 @@
   },
   "qwen3.5-4b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-4B-MLX-4bit",
-    "is_text_only": true,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -15,6 +15,7 @@
   },
   "qwen3.5-4b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-4B-MLX-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -52,6 +53,7 @@
   },
   "qwen3.5-9b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2417,6 +2417,12 @@ class ModelInfo(BaseModel):
     # dispatches on this — populating from the server lets us drop
     # the desktop-side hard-coded modality map in a future release.
     modality: str | None = None
+    # Live serving lane and its machine-readable resolution reason. These are
+    # populated for a resident text/vision engine so clients can distinguish
+    # a genuinely text-only checkpoint from a multimodal checkpoint currently
+    # served through a text fallback. Discovery-only entries keep ``None``.
+    serving_lane: str | None = None
+    serving_lane_reason: str | None = None
     # Max prompt-token context window the loaded engine advertises
     # for this id. Populated only when the entry maps to an actively
     # loaded engine (single-model serve, or the matching ModelEntry

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -19,6 +19,7 @@ from ..model_metadata import (
     read_local_model_metadata,
     read_model_metadata,
 )
+from ..recommendations import physical_ram_gb
 from .models import Message
 
 logger = logging.getLogger(__name__)
@@ -1372,7 +1373,11 @@ class ServingLaneDecision:
 
 
 def resolve_serving_lane_decision(
-    model_name: str, *, force_mllm: bool = False, force_text: bool = False
+    model_name: str,
+    *,
+    force_mllm: bool = False,
+    force_text: bool = False,
+    vision_min_memory_gb: float | None = None,
 ) -> ServingLaneDecision:
     """Resolve one lane contract for startup, residency, and diagnostics."""
     if force_text:
@@ -1393,6 +1398,20 @@ def resolve_serving_lane_decision(
         )
     if cache_mode == "arrays":
         if mllm_hybrid_runtime_supported():
+            if vision_min_memory_gb is None:
+                profile = resolve_profile(model_name)
+                vision_min_memory_gb = (
+                    profile.vision_min_memory_gb if profile is not None else None
+                )
+            available_gb = physical_ram_gb()
+            if (
+                vision_min_memory_gb is not None
+                and available_gb > 0
+                and available_gb < vision_min_memory_gb
+            ):
+                return ServingLaneDecision(
+                    False, "vision_memory_insufficient", auto_text_fallback=True
+                )
             return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
         return ServingLaneDecision(
             False, "vision_hybrid_runtime_unsupported", auto_text_fallback=True
@@ -1590,7 +1609,7 @@ class UnsupportedContentBlockError(ValueError):
             "code": self.code,
             "param": self.param,
         }
-        if serving_lane_reason is not None:
+        if isinstance(serving_lane_reason, str):
             error["serving_lane_reason"] = serving_lane_reason
         return {"error": error}
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1333,7 +1333,7 @@ def mllm_hybrid_runtime_supported() -> bool:
         installed = Version(version("mlx-vlm"))
     except (PackageNotFoundError, InvalidVersion):
         return False
-    return installed >= _HYBRID_VISION_RUNTIME_MIN_VERSION
+    return bool(installed >= _HYBRID_VISION_RUNTIME_MIN_VERSION)
 
 
 def mllm_backbone_is_hybrid(model_name: str) -> bool:
@@ -1846,7 +1846,10 @@ def extract_multimodal_content(
 
                     tool_calls_list.append(tc_copy)
 
-                msg_dict = {"role": role, "content": _content_to_text(content)}
+                msg_dict: dict[str, object] = {
+                    "role": role,
+                    "content": _content_to_text(content),
+                }
                 if tool_calls_list:
                     msg_dict["tool_calls"] = tool_calls_list
                 processed_messages.append(msg_dict)

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -6,6 +6,10 @@ Utility functions for text processing and model detection.
 import json
 import logging
 import re
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+
+from packaging.version import InvalidVersion, Version
 
 from ..model_aliases import resolve_profile
 from ..model_metadata import (
@@ -18,6 +22,8 @@ from ..model_metadata import (
 from .models import Message
 
 logger = logging.getLogger(__name__)
+
+_HYBRID_VISION_RUNTIME_MIN_VERSION = Version("0.6.16")
 
 # =============================================================================
 # Special Token Patterns
@@ -1276,6 +1282,59 @@ def mllm_arch_unsupported_but_text_vendored(model_name: str) -> bool:
     return spec is None
 
 
+def mllm_backbone_cache_mode(model_name: str) -> str | None:
+    """Return the MLLM cache mode implied by checkpoint architecture metadata.
+
+    ``"arrays"`` is the GatedDeltaNet/linear-attention layout supported by
+    Rapid's existing correctness-first serialized MLLM scheduler.  ``"other"``
+    covers recurrent layouts whose concrete cache is not admitted there.
+    ``None`` means the language backbone uses ordinary attention caches.
+
+    This is deliberately architecture-driven.  Repository names and aliases
+    are not a cache contract and must never decide whether image inference is
+    safe.
+    """
+    metadata = read_model_metadata(model_name)
+    config = metadata.config if metadata is not None else None
+    if not isinstance(config, dict):
+        return None
+    text_cfg = config.get("text_config")
+    if not isinstance(text_cfg, dict):
+        text_cfg = config
+
+    layer_types = text_cfg.get("layer_types")
+    if isinstance(layer_types, list):
+        normalized = [lt.lower() for lt in layer_types if isinstance(lt, str)]
+        if any("linear" in lt or "gated_delta" in lt for lt in normalized):
+            return "arrays"
+        if any("mamba" in lt or "recurrent" in lt for lt in normalized):
+            return "other"
+
+    for model_type in (text_cfg.get("model_type"), config.get("model_type")):
+        if not isinstance(model_type, str):
+            continue
+        normalized_type = model_type.lower()
+        if "qwen3_next" in normalized_type:
+            return "arrays"
+        if "mamba" in normalized_type or "recurrent" in normalized_type:
+            return "other"
+    return None
+
+
+def mllm_hybrid_runtime_supported() -> bool:
+    """Whether the installed vision runtime can serve hybrid backbones.
+
+    Version 0.6.16 is the first release with the upstream Qwen3.5 vision fix.
+    Missing or malformed distribution metadata fails closed to the established
+    text fallback; an explicit vision-lane request still bypasses this guard.
+    """
+    try:
+        installed = Version(version("mlx-vlm"))
+    except (PackageNotFoundError, InvalidVersion):
+        return False
+    return installed >= _HYBRID_VISION_RUNTIME_MIN_VERSION
+
+
 def mllm_backbone_is_hybrid(model_name: str) -> bool:
     """True when a checkpoint's *language* backbone is hybrid/linear-attention.
 
@@ -1300,34 +1359,45 @@ def mllm_backbone_is_hybrid(model_name: str) -> bool:
     Returns:
         True if the language backbone uses linear-attention / recurrent layers.
     """
-    metadata = read_model_metadata(model_name)
-    config = metadata.config if metadata is not None else None
-    if not isinstance(config, dict):
-        return False
-    text_cfg = config.get("text_config")
-    if not isinstance(text_cfg, dict):
-        text_cfg = config
+    return mllm_backbone_cache_mode(model_name) is not None
 
-    # Per-layer attention markers: GatedDeltaNet declares ``linear_attention``
-    # entries interleaved with ``full_attention``; Mamba/recurrent blocks label
-    # their own layers. Sliding-window attention (``sliding_attention``) is NOT
-    # hybrid — it still uses a RotatingKVCache the MLLM engine handles.
-    layer_types = text_cfg.get("layer_types")
-    if isinstance(layer_types, list) and any(
-        isinstance(lt, str)
-        and any(tok in lt.lower() for tok in ("linear", "mamba", "recurrent"))
-        for lt in layer_types
-    ):
-        return True
 
-    # Whole-model recurrent / state-space architectures that don't enumerate
-    # per-layer types (pure Mamba, RecurrentGemma, Qwen3-Next linear stack).
-    for mt in (text_cfg.get("model_type"), config.get("model_type")):
-        if isinstance(mt, str) and any(
-            tok in mt.lower() for tok in ("mamba", "recurrent", "qwen3_next")
-        ):
-            return True
-    return False
+@dataclass(frozen=True)
+class ServingLaneDecision:
+    """Metadata-derived serving lane and stable machine-readable reason."""
+
+    is_mllm: bool
+    reason: str
+    auto_text_fallback: bool = False
+
+
+def resolve_serving_lane_decision(
+    model_name: str, *, force_mllm: bool = False, force_text: bool = False
+) -> ServingLaneDecision:
+    """Resolve one lane contract for startup, residency, and diagnostics."""
+    if force_text:
+        return ServingLaneDecision(False, "text_lane_forced")
+    if force_mllm:
+        return ServingLaneDecision(True, "vision_lane_forced")
+    if not is_mllm_model(model_name):
+        return ServingLaneDecision(False, "text_checkpoint")
+    if mllm_arch_unsupported_but_text_vendored(model_name):
+        return ServingLaneDecision(
+            False, "vision_architecture_unavailable", auto_text_fallback=True
+        )
+
+    cache_mode = mllm_backbone_cache_mode(model_name)
+    if cache_mode == "other":
+        return ServingLaneDecision(
+            False, "vision_hybrid_cache_unsupported", auto_text_fallback=True
+        )
+    if cache_mode == "arrays":
+        if mllm_hybrid_runtime_supported():
+            return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
+        return ServingLaneDecision(
+            False, "vision_hybrid_runtime_unsupported", auto_text_fallback=True
+        )
+    return ServingLaneDecision(True, "vision_supported")
 
 
 def resolve_serving_lane(
@@ -1347,16 +1417,15 @@ def resolve_serving_lane(
       text lane is treated as text (PFlash-capable) everywhere, exactly as an
       explicit ``--text-only`` run would be.
     * ``auto_text_fallback`` — True iff a multimodal checkpoint was
-      *automatically* routed to the text-only lane because its language
-      backbone is hybrid/linear-attention (ArraysCache, incompatible with MLLM
-      continuous batching — GitHub #352). Kept DISTINCT from an explicit
-      ``--no-mllm``/``force_text`` so diagnostics can say "auto-downgraded"
-      rather than falsely claim the user passed ``--no-mllm``.
+      *automatically* routed to the text-only lane because its architecture or
+      installed vision runtime cannot safely serve the checkpoint. Kept
+      DISTINCT from an explicit ``--no-mllm``/``force_text`` so diagnostics
+      can say "auto-downgraded" rather than falsely claim the user passed
+      ``--no-mllm``.
 
     Explicit flags win: ``force_text`` → text lane (no auto-fallback marker),
-    ``force_mllm`` → MLLM lane (the engine may still reject a hybrid backbone
-    with its own #352 error — the operator asked for it, so they get the flag
-    they set named in the message).
+    ``force_mllm`` → MLLM lane (the engine may still reject an unsupported
+    architecture or cache — the operator asked for it, so failures stay loud).
 
     The two probes are offline and read the checkpoint config from the local
     cache. Callers MUST materialize that config first (the model download must
@@ -1365,25 +1434,10 @@ def resolve_serving_lane(
     hybrid VLM would probe "not hybrid" and be routed into the crashing MLLM
     engine (#352 dogfood P1-②).
     """
-    if force_text:
-        return (False, False)
-    if force_mllm:
-        return (True, False)
-    if not is_mllm_model(model_name):
-        return (False, False)
-    # Auto-routed to the MLLM lane by its vision weights — but the lane
-    # cannot serve every backbone. Two auto-downgrade causes, both marked
-    # with the same ``auto_text_fallback`` flag:
-    #  * the installed mlx-vlm has no model package for the arch and we
-    #    vendor a text backbone for it (Muse Glimmer until
-    #    Blaizzy/mlx-vlm#1838 ships in a release we pin);
-    #  * a hybrid/linear-attention backbone produces ArraysCache layers the
-    #    MLLM continuous-batching engine cannot assemble (GitHub #352).
-    if mllm_arch_unsupported_but_text_vendored(model_name):
-        return (False, True)
-    if mllm_backbone_is_hybrid(model_name):
-        return (False, True)
-    return (True, False)
+    decision = resolve_serving_lane_decision(
+        model_name, force_mllm=force_mllm, force_text=force_text
+    )
+    return decision.is_mllm, decision.auto_text_fallback
 
 
 def decode_inline_tool_call_arguments(messages: list[dict]) -> None:
@@ -1521,6 +1575,26 @@ def _validate_content_part_payload(item: dict) -> None:
             )
 
 
+class UnsupportedContentBlockError(ValueError):
+    """Typed request-boundary error for unsupported media content."""
+
+    def __init__(self, message: str, *, code: str, param: str):
+        super().__init__(message)
+        self.code = code
+        self.param = param
+
+    def openai_detail(self, *, serving_lane_reason: str | None = None) -> dict:
+        error = {
+            "message": str(self),
+            "type": "invalid_request_error",
+            "code": self.code,
+            "param": self.param,
+        }
+        if serving_lane_reason is not None:
+            error["serving_lane_reason"] = serving_lane_reason
+        return {"error": error}
+
+
 def validate_content_blocks_for_capabilities(
     messages: list,
     *,
@@ -1562,6 +1636,13 @@ def validate_content_blocks_for_capabilities(
                 detail = "video inputs"
             else:
                 detail = f"{item_type!r} content blocks"
+            if item_type in IMAGE_CONTENT_TYPES and not allow_image:
+                raise UnsupportedContentBlockError(
+                    f"Model '{model_name}' is serving text-only; image input "
+                    "is unsupported.",
+                    code="image_input_unsupported",
+                    param="messages.content",
+                )
             raise ValueError(f"Model '{model_name}' does not support {detail}.")
 
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -797,6 +797,7 @@ class BatchedEngine(BaseEngine):
         enable_disk_stream: bool = False,
         disk_stream_cache_gb: float = 1.0,
         chat_template_id: str | None = None,
+        serving_lane_reason: str | None = None,
     ):
         """
         Initialize the batched engine.
@@ -833,6 +834,9 @@ class BatchedEngine(BaseEngine):
             chat_template_id: Keyword-only model-profile prompt contract.
                 Control-plane callers pass this when ``model_name`` is a local
                 snapshot path whose originating profile is already known.
+            serving_lane_reason: Machine-readable reason from the shared
+                serving-lane decision. Kept on the live engine so model and
+                residency APIs report the decision that was actually loaded.
         """
         self._model_name = model_name
         if chat_template_id is None:
@@ -866,6 +870,7 @@ class BatchedEngine(BaseEngine):
         # demand for the vision lane, so a missing vision tower must hard-fail
         # for that operator rather than silently degrade behind their back.
         self._force_mllm = force_mllm
+        self._serving_lane_reason = serving_lane_reason
         if force_text:
             # User explicitly opted out of MLLM routing. Skip the probe
             # entirely so a False from auto-detection can't be overridden
@@ -911,6 +916,16 @@ class BatchedEngine(BaseEngine):
     def model_name(self) -> str:
         """Get the model name."""
         return self._model_name
+
+    @property
+    def serving_lane(self) -> str:
+        """The live request lane exposed to capability consumers."""
+        return "vision" if self._is_mllm else "text"
+
+    @property
+    def serving_lane_reason(self) -> str | None:
+        """Stable reason supplied by the shared serving-lane contract."""
+        return self._serving_lane_reason
 
     @property
     def is_mllm(self) -> bool:
@@ -1414,6 +1429,7 @@ class BatchedEngine(BaseEngine):
             )
             gc.collect()
             self._is_mllm = False
+            self._serving_lane_reason = "vision_weights_unavailable"
             await self._start_llm()
             return
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -192,6 +192,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "ddtree_speculative_tokens",
             "ddtree_tree_budget",
             "min_memory_gb",
+            "vision_min_memory_gb",
             "recommended_sampling",
             "pflash_tier",
             "pflash_keep_ratio",
@@ -397,22 +398,19 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     # rejected on non-numeric / zero / negative so a typo fails at load
     # time instead of silently disabling the guard for an Ultra-only
     # alias.
-    raw_min_mem = value.get("min_memory_gb")
-    min_memory_gb: float | None
-    if raw_min_mem is None:
-        min_memory_gb = None
-    elif isinstance(raw_min_mem, bool) or not isinstance(raw_min_mem, (int, float)):
-        raise ValueError(
-            f"alias {alias!r}: min_memory_gb must be a positive number, "
-            f"got {type(raw_min_mem).__name__}={raw_min_mem!r}"
-        )
-    elif raw_min_mem <= 0:
-        raise ValueError(
-            f"alias {alias!r}: min_memory_gb must be a positive number, "
-            f"got {raw_min_mem}"
-        )
-    else:
-        min_memory_gb = float(raw_min_mem)
+    def _optional_positive_number(key: str) -> float | None:
+        raw = value.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)) or raw <= 0:
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a positive number, "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        return float(raw)
+
+    min_memory_gb = _optional_positive_number("min_memory_gb")
+    vision_min_memory_gb = _optional_positive_number("vision_min_memory_gb")
     raw_sampling = value.get("recommended_sampling")
     recommended_sampling: tuple[tuple[str, float], ...] | None
     if raw_sampling is None:
@@ -580,6 +578,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         pflash_keep_ratio=pflash_keep_ratio,
         turboquant_tier=turboquant_tier,
         min_memory_gb=min_memory_gb,
+        vision_min_memory_gb=vision_min_memory_gb,
     )
 
 

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -244,6 +244,12 @@ class ModelProfile:
     # GB peak RSS — needs 192 GB+ M3 Ultra). Enforced as a boot-time
     # WARNING (not a hard block) in ``vllm_mlx/cli.py``.
     min_memory_gb: float | None = None
+    # Measured unified-memory floor for automatic vision-lane admission.
+    # This is separate from ``min_memory_gb`` because the same checkpoint can
+    # remain safe through its text lane on a smaller Mac.  ``None`` preserves
+    # automatic vision admission when no catalog measurement is available;
+    # explicit ``--mllm`` always remains the operator override.
+    vision_min_memory_gb: float | None = None
     # ``is_text_only`` = this checkpoint is served through the
     # auto-regressive text (mlx-lm) lane even though its ``config.json``
     # declares a ``vision_config`` (and may ship ``vision_tower`` weights)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -54,6 +54,7 @@ from ..api.tool_calling import (
     validate_output_against_schema,
 )
 from ..api.utils import (
+    UnsupportedContentBlockError,
     clean_output_text,
     decode_inline_tool_call_arguments,
     extract_json_from_response,
@@ -4014,6 +4015,13 @@ async def _create_chat_completion_impl(
             allow_video=engine.is_mllm,
             allow_audio=False,
         )
+    except UnsupportedContentBlockError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=e.openai_detail(
+                serving_lane_reason=getattr(engine, "serving_lane_reason", None)
+            ),
+        ) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -208,6 +208,19 @@ def _engine_is_mllm_or_none(engine: object | None) -> bool | None:
     return is_mllm if isinstance(is_mllm, bool) else None
 
 
+def _served_lane_fields(model_id: str) -> dict[str, str | None]:
+    """Return lane truth from the matching live engine, never static guesses."""
+    engine = _engine_for(model_id)
+    if engine is None:
+        return {"serving_lane": None, "serving_lane_reason": None}
+    lane = getattr(engine, "serving_lane", None)
+    reason = getattr(engine, "serving_lane_reason", None)
+    return {
+        "serving_lane": lane if isinstance(lane, str) else None,
+        "serving_lane_reason": reason if isinstance(reason, str) else None,
+    }
+
+
 def _served_engine_is_mllm(model_id: str) -> bool | None:
     """Return the LIVE engine's actual modality for the served model.
 
@@ -887,6 +900,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # SERVER-WIDE backend health, not per-model audio capability
     # (which would require a separate dry-run per audio alias).
     audio_lanes = _audio_lane_snapshot()
+    lane_fields = _served_lane_fields(model_id)
 
     # R11-B-F4 (Bo 0.8.12 dogfood): audio aliases get an audio-shaped
     # ModelInfo regardless of whether the registry has a text profile
@@ -993,6 +1007,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                     context_window=context_window,
                     max_model_len=max_model_len,
                     audio_lanes=audio_lanes,
+                    **lane_fields,
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -1005,6 +1020,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             context_window=context_window,
             max_model_len=max_model_len,
             audio_lanes=audio_lanes,
+            **lane_fields,
         )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
@@ -1046,6 +1062,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         context_window=context_window,
         max_model_len=max_model_len,
         audio_lanes=audio_lanes,
+        **lane_fields,
     )
 
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -208,17 +208,17 @@ def _engine_is_mllm_or_none(engine: object | None) -> bool | None:
     return is_mllm if isinstance(is_mllm, bool) else None
 
 
-def _served_lane_fields(model_id: str) -> dict[str, str | None]:
+def _served_lane_fields(model_id: str) -> tuple[str | None, str | None]:
     """Return lane truth from the matching live engine, never static guesses."""
     engine = _engine_for(model_id)
     if engine is None:
-        return {"serving_lane": None, "serving_lane_reason": None}
+        return None, None
     lane = getattr(engine, "serving_lane", None)
     reason = getattr(engine, "serving_lane_reason", None)
-    return {
-        "serving_lane": lane if isinstance(lane, str) else None,
-        "serving_lane_reason": reason if isinstance(reason, str) else None,
-    }
+    return (
+        lane if isinstance(lane, str) else None,
+        reason if isinstance(reason, str) else None,
+    )
 
 
 def _served_engine_is_mllm(model_id: str) -> bool | None:
@@ -900,7 +900,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # SERVER-WIDE backend health, not per-model audio capability
     # (which would require a separate dry-run per audio alias).
     audio_lanes = _audio_lane_snapshot()
-    lane_fields = _served_lane_fields(model_id)
+    serving_lane, serving_lane_reason = _served_lane_fields(model_id)
 
     # R11-B-F4 (Bo 0.8.12 dogfood): audio aliases get an audio-shaped
     # ModelInfo regardless of whether the registry has a text profile
@@ -1007,7 +1007,8 @@ def _build_model_info(model_id: str) -> ModelInfo:
                     context_window=context_window,
                     max_model_len=max_model_len,
                     audio_lanes=audio_lanes,
-                    **lane_fields,
+                    serving_lane=serving_lane,
+                    serving_lane_reason=serving_lane_reason,
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -1020,7 +1021,8 @@ def _build_model_info(model_id: str) -> ModelInfo:
             context_window=context_window,
             max_model_len=max_model_len,
             audio_lanes=audio_lanes,
-            **lane_fields,
+            serving_lane=serving_lane,
+            serving_lane_reason=serving_lane_reason,
         )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
@@ -1062,7 +1064,8 @@ def _build_model_info(model_id: str) -> ModelInfo:
         context_window=context_window,
         max_model_len=max_model_len,
         audio_lanes=audio_lanes,
-        **lane_fields,
+        serving_lane=serving_lane,
+        serving_lane_reason=serving_lane_reason,
     )
 
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -69,6 +69,7 @@ from ..api.utils import (
     StreamingReasoningSanitizer,
     StreamingThinkRouter,
     StreamingToolCallFilter,
+    UnsupportedContentBlockError,
     clean_output_text,
     decode_inline_tool_call_arguments,
     extract_json_from_response,
@@ -1311,6 +1312,13 @@ async def create_response(request: Request):
                 allow_video=getattr(engine, "is_mllm", False),
                 allow_audio=False,
             )
+        except UnsupportedContentBlockError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=e.openai_detail(
+                    serving_lane_reason=getattr(engine, "serving_lane_reason", None)
+                ),
+            ) from e
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -1154,6 +1154,8 @@ class ResidentModelManager:
                     "model_path": record.entry.model_path,
                     "aliases": sorted(record.entry.aliases),
                     "modality": (_modality(record.entry)),
+                    "serving_lane": getattr(engine, "serving_lane", None),
+                    "serving_lane_reason": getattr(engine, "serving_lane_reason", None),
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1727,7 +1727,7 @@ def _resolve_serving_checkpoint(
     but no ``refs/main``; metadata resolution can identify that snapshot, and
     the engine must receive that local path rather than retrying the repo id.
     """
-    from .model_aliases import resolve_model
+    from .model_aliases import resolve_model, resolve_profile
 
     model_path = resolve_model(model_name)
     if not force_mllm and not force_text:
@@ -1740,10 +1740,14 @@ def _resolve_serving_checkpoint(
         if metadata is not None and metadata.snapshot_dir is not None
         else model_path
     )
+    profile = resolve_profile(model_path)
     decision = resolve_serving_lane_decision(
         load_path,
         force_mllm=force_mllm,
         force_text=force_text,
+        vision_min_memory_gb=(
+            profile.vision_min_memory_gb if profile is not None else None
+        ),
     )
     return _ServingCheckpoint(
         model_path=model_path,
@@ -2063,6 +2067,9 @@ def load_model(
             ),
             "vision_architecture_unavailable": (
                 "the installed vision runtime does not provide its architecture"
+            ),
+            "vision_memory_insufficient": (
+                "its measured vision footprint exceeds this Mac's physical memory"
             ),
         }.get(
             _serving_lane_reason,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -119,6 +119,7 @@ from .api.utils import (
     extract_multimodal_content,  # noqa: F401
     is_mllm_model,  # noqa: F401
     resolve_serving_lane,  # noqa: F401
+    resolve_serving_lane_decision,
     sanitize_output,  # noqa: F401
     strip_special_tokens,  # noqa: F401
     strip_thinking_tags,  # noqa: F401
@@ -1710,6 +1711,7 @@ class _ServingCheckpoint:
     model_path: str
     load_path: str
     auto_text_fallback: bool
+    lane_reason: str
 
 
 def _resolve_serving_checkpoint(
@@ -1738,7 +1740,7 @@ def _resolve_serving_checkpoint(
         if metadata is not None and metadata.snapshot_dir is not None
         else model_path
     )
-    _, auto_text_fallback = resolve_serving_lane(
+    decision = resolve_serving_lane_decision(
         load_path,
         force_mllm=force_mllm,
         force_text=force_text,
@@ -1746,7 +1748,8 @@ def _resolve_serving_checkpoint(
     return _ServingCheckpoint(
         model_path=model_path,
         load_path=load_path,
-        auto_text_fallback=auto_text_fallback,
+        auto_text_fallback=decision.auto_text_fallback,
+        lane_reason=decision.reason,
     )
 
 
@@ -2042,6 +2045,7 @@ def load_model(
     )
     _engine_model_path = model_name
     _auto_text_fallback = False
+    _serving_lane_reason = "not_applicable"
     if not _is_generative_media:
         _serving_checkpoint = _resolve_serving_checkpoint(
             model_name,
@@ -2050,19 +2054,26 @@ def load_model(
         )
         _engine_model_path = _serving_checkpoint.load_path
         _auto_text_fallback = _serving_checkpoint.auto_text_fallback
+        _serving_lane_reason = _serving_checkpoint.lane_reason
     if _auto_text_fallback:
+        fallback_detail = {
+            "vision_hybrid_runtime_unsupported": (
+                "the installed vision runtime does not support its hybrid "
+                "language backbone"
+            ),
+            "vision_architecture_unavailable": (
+                "the installed vision runtime does not provide its architecture"
+            ),
+        }.get(
+            _serving_lane_reason,
+            "its vision cache contract is not supported",
+        )
         logger.info(
-            "Model %r auto-downgraded to the text-only mlx-lm lane for "
-            "full batched throughput: it is a multimodal checkpoint whose "
-            "language backbone the MLLM continuous-batching engine cannot "
-            "batch — either hybrid/linear-attention (GatedDeltaNet: "
-            "Qwen3.5/3.6/3.8) or a vision architecture the installed "
-            "mlx-vlm cannot drive yet (e.g. muse_glimmer, served via the "
-            "vendored text backbone). Pass --mllm to serve vision: a "
-            "hybrid backbone runs a serialized one-request-at-a-time lane "
-            "(#1798); an unsupported arch errors instead. Pass --no-mllm "
-            "to silence this notice.",
+            "Model %r auto-downgraded to the text-only lane because %s. "
+            "Pass --mllm to request the vision lane explicitly, or --no-mllm "
+            "to select text-only serving explicitly.",
             model_name,
+            fallback_detail,
         )
 
     try:
@@ -2190,6 +2201,7 @@ def load_model(
             stream_interval=stream_interval,
             force_mllm=force_mllm,
             force_text=_effective_force_text,
+            serving_lane_reason=_serving_lane_reason,
             gpu_memory_utilization=gpu_memory_utilization,
             force_hybrid=force_hybrid,
             no_hybrid=no_hybrid,
@@ -2347,6 +2359,7 @@ async def _load_dynamic_resident_model(
     profile_force_text = bool(profile is not None and profile.is_text_only)
     load_path = resolved_path
     effective_force_text = profile_force_text
+    serving_lane_reason = "not_applicable"
     if modality == "text":
         serving_checkpoint = _resolve_serving_checkpoint(
             resolved_path,
@@ -2357,6 +2370,7 @@ async def _load_dynamic_resident_model(
         effective_force_text = (
             profile_force_text or serving_checkpoint.auto_text_fallback
         )
+        serving_lane_reason = serving_checkpoint.lane_reason
     model_config = profile
     if model_config is None:
         from .model_auto_config import detect_model_config
@@ -2418,6 +2432,7 @@ async def _load_dynamic_resident_model(
                 profile.chat_template_id if profile is not None else None
             ),
             force_text=effective_force_text,
+            serving_lane_reason=serving_lane_reason,
             gpu_memory_utilization=_resident_gpu_memory_utilization,
             scheduler_config=SchedulerConfig(**scheduler_kwargs),
         )

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -184,9 +184,9 @@ def have_runtime() -> bool:
         # Probe the specific symbol DFlash needs — a partial install
         # (pre-0.5.0 mlx-vlm in our deps) would have `mlx_vlm` but no
         # `speculative.drafters.load_drafter`.
-        import importlib
+        from importlib.util import find_spec
 
-        spec = importlib.util.find_spec("mlx_vlm.speculative.drafters")
+        spec = find_spec("mlx_vlm.speculative.drafters")
         return spec is not None
     except (ImportError, AttributeError):
         return False


### PR DESCRIPTION
## Why

The recommended Qwen3.5 checkpoints are natively multimodal, but automatic serving kept them on the text lane even when the installed runtime can now execute their hybrid vision backbone. Desktop photo attachments therefore failed despite complete cached vision weights. The lane also needs a measured memory floor because real image inference peaks above a safe 16 GB budget.

## Intention

Make photos work by default for vision-capable hybrid checkpoints when the installed vision runtime and measured machine budget support them, while preserving an explicit and diagnosable text fallback when either does not.

## Scope

- Centralize the metadata-derived startup/runtime serving-lane decision.
- Admit serialized hybrid vision serving only when the installed runtime is at least 0.6.16 and a cataloged measured vision floor fits physical memory.
- Expose the live serving lane and stable reason through model and residency responses.
- Return a typed HTTP 400 when image input targets a text-served model.
- Remove the obsolete text-only pin from the complete Qwen3.5 4B vision checkpoint.

## Non-goals

- No dependency-pin, sidecar, installer, GUI, scheduler/cache, audio/video, or release-workflow changes.
- No model-name heuristic.
- No change to explicit text/vision operator overrides.
- No inferred memory floor for an unmeasured third-party checkpoint.

## Acceptance

- Supported hybrid vision checkpoints loaded at startup or dynamically resolve to the same vision lane and local checkpoint path.
- Missing/older runtime, unsupported cache layouts, and insufficient measured physical memory fail closed to text with a machine-readable reason.
- Explicit vision remains the operator override.
- Model discovery and residency report live lane truth.
- Image requests on a text lane receive a stable typed 400.
- Existing dense vision, pure-text, curated text-only, and explicit override behavior remains unchanged.

## Evidence

- Focused engine/server regression before the memory follow-up: 3,385 passed, 2 skipped.
- Linux fixed-list lane: 5,255 passed, 1 skipped; lifecycle append: 75 passed.
- Changed-line coverage against main: 100% on the contracted focused surface.
- Ruff, format check, JSON validation, and diff check pass.
- Installed-wheel, offline, real-image inference without an explicit vision flag on a 256 GB Mac:
  - cached Qwen3.5 9B: vision lane, HTTP 200, peak footprint 24 GB.
  - cached Qwen3.5 4B: vision lane, HTTP 200, peak footprint 20 GB.
- Memory contract for these measured catalog entries: 16 GB selects text with `vision_memory_insufficient`; 32 GB selects vision. Pixel can consume the same reason from `/v1/models` and `/v1/models/residency`.
- Both successful model and residency responses report `vision_hybrid_runtime_supported`.


## Desktop contract

- Successful automatic hybrid vision: `serving_lane=vision`, `serving_lane_reason=vision_hybrid_runtime_supported`.
- Measured floor does not fit: `serving_lane=text`, `serving_lane_reason=vision_memory_insufficient`.
- Older/missing supported runtime: `serving_lane=text`, `serving_lane_reason=vision_hybrid_runtime_unsupported`.
- Image submitted to any text-served model: HTTP 400 with `error.code=image_input_unsupported`, `error.param=messages.content`, and the live `error.serving_lane_reason` when available.
