### PR TITLE
release: integrate 0.13.1 train 1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -249,6 +249,12 @@ jobs:
           # floor is set here (RAPID_MLX_PERF_MIN_TPS unset), so it measures and
           # prints a number to review rather than inventing a baseline.
           RAPID_MLX_RELEASE_GATE: "1"
+          # Content-addressed cached checkpoint used by the Desktop sidecar's
+          # real image gate below. The Studio runner is intentionally the only
+          # release host with model weights; offline resolution makes cache
+          # drift or eviction fail closed instead of silently downloading.
+          SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit
+          SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
@@ -263,6 +269,13 @@ jobs:
           echo "gate venv → $("$V/bin/rapid-mlx" --version) (releasing v$VERSION)"
 
           RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh qwen3.6-35b-8bit
+
+          # Build the exact Desktop sidecar recipe and require a real PNG to
+          # traverse its production scheduler + HTTP route. Every normal
+          # auto-release is blocked by a missing immutable snapshot,
+          # incompatible reduced dependency set, or failed image request.
+          HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
+            --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -225,15 +225,15 @@ jobs:
     # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
     # (warm/cold) — the budget is for the pathological retry path, not the
     # expected one.
-    # 155, not 125: the release-shaped Desktop sidecar build and two real-image
-    # requests now follow the agent gate. The agent path retains its documented
-    # ~121-minute worst case; each image smoke is independently bounded to
-    # 4 minutes of startup plus 4 minutes of inference (16 minutes total), and
+    # 165, not 125: the release-shaped Desktop sidecar build and two-model,
+    # positive/negative real-image checks now follow the agent gate. The agent
+    # path retains its documented ~121-minute worst case; each model is bounded
+    # to 4 minutes of startup plus two 4-minute requests (24 minutes total), and
     # the measured clean sidecar build gets 15 minutes of fail-closed headroom.
-    # 121 + 16 + 15 = 152, rounded to 155 for setup and cleanup. This outer cap
+    # 121 + 24 + 15 = 160, rounded to 165 for setup and cleanup. This outer cap
     # is not a substitute for the per-request bounds: it only prevents healthy
     # checks near their individual budgets from being guillotined by the job.
-    timeout-minutes: 155
+    timeout-minutes: 165
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:
@@ -297,7 +297,8 @@ jobs:
             --sidecar-root "$SIDE" \
             --model "$SIDECAR_GEMMA_SMOKE_MODEL" \
             --revision "$SIDECAR_GEMMA_SMOKE_REVISION" \
-            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png
+            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png \
+            --negative-image apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -225,7 +225,15 @@ jobs:
     # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
     # (warm/cold) — the budget is for the pathological retry path, not the
     # expected one.
-    timeout-minutes: 125
+    # 155, not 125: the release-shaped Desktop sidecar build and two real-image
+    # requests now follow the agent gate. The agent path retains its documented
+    # ~121-minute worst case; each image smoke is independently bounded to
+    # 4 minutes of startup plus 4 minutes of inference (16 minutes total), and
+    # the measured clean sidecar build gets 15 minutes of fail-closed headroom.
+    # 121 + 16 + 15 = 152, rounded to 155 for setup and cleanup. This outer cap
+    # is not a substitute for the per-request bounds: it only prevents healthy
+    # checks near their individual budgets from being guillotined by the job.
+    timeout-minutes: 155
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -255,6 +255,8 @@ jobs:
           # drift or eviction fail closed instead of silently downloading.
           SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit
           SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53
+          SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit
+          SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
@@ -276,6 +278,18 @@ jobs:
           # incompatible reduced dependency set, or failed image request.
           HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
             --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
+
+          # The reduced dependency-set exception covers both Qwen and Gemma
+          # chat-photo families. The build-sidecar invocation proves Qwen;
+          # reuse those exact built bytes for an independent Gemma4 request.
+          SIDE="$RUNNER_TEMP/desktop-vision-sidecar-$VERSION/rapid-mlx"
+          HF_HUB_OFFLINE=1 PYTHONPATH="$SIDE/site-packages" PYTHONNOUSERSITE=1 \
+            "$SIDE/python/bin/python3.12" \
+            apps/rapid-mac/scripts/smoke-sidecar-vision.py \
+            --sidecar-root "$SIDE" \
+            --model "$SIDECAR_GEMMA_SMOKE_MODEL" \
+            --revision "$SIDECAR_GEMMA_SMOKE_REVISION" \
+            --image apps/rapid-mac/Sources/Rapid/Resources/cheetah.png
           rm -rf "$V"
 
   # 2b) Desktop candidate gate (macos-15). Builds + signs + notarises + DMG-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \
+            tests/test_share_cli.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,8 @@ jobs:
             tests/test_pr_validate_runner.py \
             tests/test_pr_validate_codex.py \
             tests/test_release_baselines.py \
+            tests/test_sidecar_distribution_constraints.py \
+            tests/test_sidecar_vision_smoke.py \
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
             tests/test_check_mypy_error_budget.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
             tests/test_pflash_server_module_wiring.py::test_server_module_cache_metadata_failure_is_nonfatal \
             tests/test_pflash_server_module_wiring.py::test_server_module_missing_auto_config_module_degrades_to_no_default \
             tests/test_resident_models.py \
+            tests/test_residency_load_field_names.py \
             tests/test_serve_listen_fd.py::test_serve_command_threads_auto_detected_hybrid_into_cache_admission \
             tests/test_serve_listen_fd.py::test_serve_command_cache_is_first_metadata_consumer \
             tests/test_serve_listen_fd.py::test_serve_command_missing_auto_config_module_degrades_to_no_default \

--- a/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
@@ -73,7 +73,9 @@ enum ReonboardingReset {
         }
 
         return Confirmation(
-            title: "Erase this Mac's Rapid state and restart?",
+            title: scope == .onboarding
+                ? "Run guided setup again?"
+                : "Erase this Mac's Rapid state and restart?",
             message: message,
             confirmTitle: scope.contains(.conversations)
                 ? "Erase and restart"

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -125,10 +125,9 @@ Both pinned by `PBS_VERSION` / `PBS_TAG` in `scripts/build-sidecar.sh`.
 ### Engine runtime dependencies
 
 The root `pyproject.toml` `[project].dependencies` block, installed in
-full. The ranges below are the **root manifest's**; the sidecar build
-narrows one of them, pinning `transformers>=5.5.0,<5.13` at install time
-(step 2 of `scripts/build-sidecar.sh`), so a shipped bundle never carries
-a `transformers` older than 5.5.0.
+full. The ranges below are the **root manifest's**; the sidecar build pins
+`mlx==0.32.2` and `transformers==5.12.1` at install time (step 2 of
+`scripts/build-sidecar.sh`) so the shipped vision stack is reproducible.
 
 | Component | Declared range | License | Project |
 | --- | --- | --- | --- |
@@ -159,7 +158,7 @@ path works in a text-only bundle:
 
 | Component | Pin | License | Project |
 | --- | --- | --- | --- |
-| mlx-vlm | `==0.6.3` | MIT | https://github.com/Blaizzy/mlx-vlm |
+| mlx-vlm | `==0.6.16` | MIT | https://github.com/Blaizzy/mlx-vlm |
 | Pillow | `>=10.0` | MIT-CMU | https://github.com/python-pillow/Pillow |
 
 ### Third-party source vendored into the engine

--- a/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
@@ -32,10 +32,14 @@ struct ReonboardingResetTests {
         if let c = conversationsIndex, let s = settingsIndex { #expect(c < s) }
     }
 
-    /// Deleting conversations earns a different verb from restarting into a
-    /// wizard, because it is a different promise.
-    @Test("The confirm button escalates when conversations are included")
-    func confirmTitleEscalates() {
+    /// Re-running setup should sound like the safe recovery action it is;
+    /// scopes that erase user state keep the destructive warning.
+    @Test("The dialog copy distinguishes onboarding-only from state erasure")
+    func confirmationCopyMatchesScope() {
+        #expect(ReonboardingReset.confirmation(for: .onboarding).title
+            == "Run guided setup again?")
+        #expect(ReonboardingReset.confirmation(for: [.onboarding, .telemetry]).title
+            == "Erase this Mac's Rapid state and restart?")
         #expect(ReonboardingReset.confirmation(for: .onboarding).confirmTitle
             == "Restart into onboarding")
         #expect(ReonboardingReset.confirmation(for: [.onboarding, .conversations]).confirmTitle

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -68,6 +68,8 @@ struct SidecarBuildScriptTests {
         #expect(script.contains("SIDECAR_VISION_SMOKE_MODEL"))
         #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-vision.py"),
                 "Configured release-candidate builds must run real image inference through the sidecar.")
+        #expect(script.contains(#"PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1"#),
+                "The image gate must resolve its pinned snapshot with the bundled runtime, not host Python.")
         for architecture in [
             "diffusion_gemma", "gemma3", "gemma3n", "gemma4", "gemma4_unified",
             "qwen3_5", "qwen3_5_moe", "qwen3_vl", "qwen3_vl_moe",

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -60,12 +60,14 @@ struct SidecarBuildScriptTests {
     func visionStackIsReproducibleAndCompatible() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
 
-        #expect(script.contains("'mlx-vlm==0.6.3'"))
+        #expect(script.contains("'mlx-vlm==0.6.16'"))
         #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
                 "The no-deps sidecar install must never float within a range.")
-        #expect(script.contains("from packaging.requirements import Requirement"))
-        #expect(script.contains("actual not in req.specifier"),
-                "Post-install validation must reject incompatible installed dependency versions.")
+        #expect(script.contains("$REPO_ROOT/scripts/check-sidecar-distributions.py"),
+                "Every sidecar build must execute the tested metadata-coherence gate.")
+        #expect(script.contains("SIDECAR_VISION_SMOKE_MODEL"))
+        #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-vision.py"),
+                "Configured release-candidate builds must run real image inference through the sidecar.")
         for architecture in [
             "diffusion_gemma", "gemma3", "gemma3n", "gemma4", "gemma4_unified",
             "qwen3_5", "qwen3_5_moe", "qwen3_vl", "qwen3_vl_moe",

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -977,11 +977,18 @@ fi
 # release operator supplies the immutable local snapshot explicitly.
 if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
     SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
-    "$STAGE/python/bin/python3.12" \
-        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
-        --sidecar-root "$STAGE" \
-        --model "$SIDECAR_VISION_SMOKE_MODEL" \
+    SIDECAR_VISION_SMOKE_ARGS=(
+        --sidecar-root "$STAGE"
+        --model "$SIDECAR_VISION_SMOKE_MODEL"
         --image "$SIDECAR_VISION_SMOKE_IMAGE"
+    )
+    if [[ -n "${SIDECAR_VISION_SMOKE_REVISION:-}" ]]; then
+        SIDECAR_VISION_SMOKE_ARGS+=(--revision "$SIDECAR_VISION_SMOKE_REVISION")
+    fi
+    PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
+        "$STAGE/python/bin/python3.12" \
+        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
+        "${SIDECAR_VISION_SMOKE_ARGS[@]}"
 else
     echo "==> real image smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
 fi

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -254,7 +254,8 @@ fi
     --no-compile \
     --upgrade \
     "${RAPID_MLX_SOURCE}[audio-desktop]" \
-    'transformers>=5.5.0,<5.13'
+    'mlx==0.32.2' \
+    'transformers==5.12.1'
 
 # pip normally selects wheels for the BUILD host. A sidecar assembled on
 # macOS 26 therefore receives mlx / mlx-metal's macosx_26 wheels even though
@@ -321,7 +322,7 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    'mlx-vlm==0.6.3' \
+    'mlx-vlm==0.6.16' \
     'Pillow>=10.0'
 
 # ----- step 2.6: bundle mflux --no-deps (Images tab image-gen lane) ----
@@ -456,26 +457,10 @@ PY
 # ``--no-deps`` is intentional for bundle size, but it must not hide version
 # conflicts among distributions that ARE present. Missing optional heavy deps
 # remain allowed; every installed-to-installed edge must satisfy its metadata.
-PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 "$STAGE/python/bin/python3.12" -s - <<'PY'
-from importlib import metadata
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
-
-installed = {canonicalize_name(dist.metadata["Name"]): dist.version for dist in metadata.distributions()}
-errors = []
-for dist in metadata.distributions():
-    owner = dist.metadata["Name"]
-    for raw in dist.requires or ():
-        req = Requirement(raw)
-        if req.marker and not req.marker.evaluate():
-            continue
-        actual = installed.get(canonicalize_name(req.name))
-        if actual is not None and req.specifier and actual not in req.specifier:
-            errors.append(f"{owner} requires {req}, but bundled {req.name}=={actual}")
-if errors:
-    raise SystemExit("incompatible bundled distributions:\n  " + "\n  ".join(sorted(errors)))
-print("==> bundled distribution metadata constraints: OK")
-PY
+PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
+    "$STAGE/python/bin/python3.12" -s \
+    "$REPO_ROOT/scripts/check-sidecar-distributions.py" \
+    "$STAGE/site-packages"
 
 # ----- step 3: strip dev / unused artifacts ----------------------------
 
@@ -983,6 +968,22 @@ print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>
         echo "$METAL_OUT" >&2
         exit 3
     fi
+fi
+
+# Release-candidate builds can opt into a real image request against a cached
+# checkpoint. Once configured, this gate is fail-closed: a missing model/image,
+# failed server start, non-200 response, or implausible description aborts the
+# build. Hosted package builders do not download multi-GB model weights, so the
+# release operator supplies the immutable local snapshot explicitly.
+if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
+    SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
+    "$STAGE/python/bin/python3.12" \
+        "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
+        --sidecar-root "$STAGE" \
+        --model "$SIDECAR_VISION_SMOKE_MODEL" \
+        --image "$SIDECAR_VISION_SMOKE_IMAGE"
+else
+    echo "==> real image smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
 fi
 
 # ----- step 7: package --------------------------------------------------

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -977,10 +977,12 @@ fi
 # release operator supplies the immutable local snapshot explicitly.
 if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
     SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
+    SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE="${SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png}"
     SIDECAR_VISION_SMOKE_ARGS=(
         --sidecar-root "$STAGE"
         --model "$SIDECAR_VISION_SMOKE_MODEL"
         --image "$SIDECAR_VISION_SMOKE_IMAGE"
+        --negative-image "$SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE"
     )
     if [[ -n "${SIDECAR_VISION_SMOKE_REVISION:-}" ]]; then
         SIDECAR_VISION_SMOKE_ARGS+=(--revision "$SIDECAR_VISION_SMOKE_REVISION")

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fail closed on incompatible installed distributions in the Desktop sidecar."""
+
+from __future__ import annotations
+
+import argparse
+from importlib import metadata
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+
+def is_validated_compatibility_exception(
+    *, owner: str, owner_version: str, requirement: Requirement, actual: str
+) -> bool:
+    """Return true only for the release-tested reduced vision runtime.
+
+    mlx-vlm 0.6.16 declares Transformers >=5.14 for its complete feature set.
+    Rapid's shipped Qwen/Gemma image lanes do not exercise that newer surface;
+    they are validated by real image inference with Transformers 5.12.1.  This
+    is deliberately an exact tuple rather than a package-wide metadata bypass.
+
+    Remove this exception after replacing Rapid's Transformers <5.13 cap with
+    !=5.13.0 and completing the tracked 5.15.x coherence sweep. Every other
+    owner/version, dependency, declared specifier, or actual version remains a
+    hard error.
+    """
+
+    return (
+        canonicalize_name(owner) == "mlx-vlm"
+        and owner_version == "0.6.16"
+        and canonicalize_name(requirement.name) == "transformers"
+        and str(requirement.specifier) == ">=5.14.0"
+        and actual == "5.12.1"
+    )
+
+
+def find_errors(site_packages: Path) -> list[str]:
+    distributions = list(metadata.distributions(path=[str(site_packages)]))
+    installed = {
+        canonicalize_name(dist.metadata["Name"]): dist.version for dist in distributions
+    }
+    errors: list[str] = []
+    for dist in distributions:
+        owner = dist.metadata["Name"]
+        for raw in dist.requires or ():
+            requirement = Requirement(raw)
+            if requirement.marker and not requirement.marker.evaluate():
+                continue
+            actual = installed.get(canonicalize_name(requirement.name))
+            if actual is None or not requirement.specifier:
+                continue
+            if actual in requirement.specifier:
+                continue
+            if is_validated_compatibility_exception(
+                owner=owner,
+                owner_version=dist.version,
+                requirement=requirement,
+                actual=actual,
+            ):
+                print(
+                    "==> validated compatibility exception: "
+                    "mlx-vlm 0.6.16 with transformers 5.12.1"
+                )
+                continue
+            errors.append(
+                f"{owner} requires {requirement}, but bundled "
+                f"{requirement.name}=={actual}"
+            )
+    return sorted(errors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("site_packages", type=Path)
+    args = parser.parse_args()
+    if not args.site_packages.is_dir():
+        parser.error(f"site-packages directory does not exist: {args.site_packages}")
+    errors = find_errors(args.site_packages)
+    if errors:
+        raise SystemExit(
+            "incompatible bundled distributions:\n  " + "\n  ".join(errors)
+        )
+    print("==> bundled distribution metadata constraints: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -38,6 +38,8 @@ def is_validated_compatibility_exception(
 
 def find_errors(site_packages: Path) -> list[str]:
     distributions = list(metadata.distributions(path=[str(site_packages)]))
+    if not distributions:
+        return [f"no installed distributions found in {site_packages}"]
     installed = {
         canonicalize_name(dist.metadata["Name"]): dist.version for dist in distributions
     }

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -24,32 +24,10 @@ def _bound_local_listener() -> socket.socket:
 
 
 def _completion_is_sensible(text: object) -> bool:
-    """Reject empty/error output and require recognition of the known fixture."""
+    """Accept only the deterministic answer requested for the known fixture."""
     if not isinstance(text, str):
         return False
-    tokens = [word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()]
-    words = set(tokens)
-    fixture_labels = {"cheetah", "leopard", "cat", "feline"}
-    uncertainty = {"cannot", "can't", "unable", "unclear", "unknown", "unsure"}
-    if len(words) < 3 or not words & fixture_labels or words & uncertainty:
-        return False
-    if any(
-        left == "not" and right == "sure" for left, right in zip(tokens, tokens[1:])
-    ):
-        return False
-    for index, token in enumerate(tokens):
-        if token not in fixture_labels:
-            continue
-        prior = tokens[max(0, index - 2) : index]
-        if prior and prior[-1] in {"not", "no"}:
-            return False
-        if (
-            len(prior) == 2
-            and prior[0] in {"not", "no"}
-            and prior[1] in {"a", "an", "the"}
-        ):
-            return False
-    return True
+    return text.strip().rstrip(".!?").casefold() == "spotted_cat"
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
@@ -138,32 +116,35 @@ def main() -> int:
 
     listener = _bound_local_listener()
     base_url = f"http://127.0.0.1:{listener.getsockname()[1]}"
+    process: subprocess.Popen | None = None
     with tempfile.NamedTemporaryFile(
         prefix="rapid-sidecar-vision-", suffix=".log", delete=False
     ) as log:
         log_path = Path(log.name)
-        try:
-            process = subprocess.Popen(
-                [
-                    str(executable),
-                    "serve",
-                    str(model),
-                    "--mllm",
-                    "--listen-fd",
-                    str(listener.fileno()),
-                ],
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-                pass_fds=(listener.fileno(),),
-                env={**os.environ, "PYTHONNOUSERSITE": "1"},
-            )
-        finally:
-            # Popen duplicates pass_fds into the child before it returns. Close
-            # the parent's copy only after that atomic handoff.
-            listener.close()
 
     try:
+        with log_path.open("ab") as log:
+            try:
+                process = subprocess.Popen(
+                    [
+                        str(executable),
+                        "serve",
+                        str(model),
+                        "--mllm",
+                        "--listen-fd",
+                        str(listener.fileno()),
+                    ],
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    pass_fds=(listener.fileno(),),
+                    env={**os.environ, "PYTHONNOUSERSITE": "1"},
+                )
+            finally:
+                # Popen duplicates pass_fds into the child before it returns.
+                # Close the parent's copy only after that atomic handoff.
+                listener.close()
+
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
         payload = {
@@ -174,7 +155,11 @@ def main() -> int:
                     "content": [
                         {
                             "type": "text",
-                            "text": "Describe the main animal in this image in one short sentence.",
+                            "text": (
+                                "Reply with exactly SPOTTED_CAT if the main animal "
+                                "in this image is a spotted wild cat such as a "
+                                "cheetah or leopard; otherwise reply OTHER."
+                            ),
                         },
                         {
                             "type": "image_url",
@@ -184,7 +169,7 @@ def main() -> int:
                 }
             ],
             "temperature": 0,
-            "max_tokens": 64,
+            "max_tokens": 16,
             "stream": False,
         }
         body = _request_json(
@@ -193,16 +178,18 @@ def main() -> int:
         content = body.get("choices", [{}])[0].get("message", {}).get("content")
         if not _completion_is_sensible(content):
             raise RuntimeError(
-                f"vision smoke returned an implausible description: {content!r}"
+                f"vision smoke returned an incorrect fixture verdict: {content!r}"
             )
-        print(f"vision smoke: HTTP 200; description={content!r}")
+        print("vision smoke: HTTP 200; fixture verdict=SPOTTED_CAT")
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
         print(log_path.read_text(errors="replace"))
         raise
     finally:
-        _stop_process(process)
+        listener.close()
+        if process is not None:
+            _stop_process(process)
         log_path.unlink(missing_ok=True)
 
 

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -27,19 +27,29 @@ def _completion_is_sensible(text: object) -> bool:
     """Reject empty/error output and require recognition of the known fixture."""
     if not isinstance(text, str):
         return False
-    words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
+    tokens = [word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()]
+    words = set(tokens)
     fixture_labels = {"cheetah", "leopard", "cat", "feline"}
-    uncertainty = {
-        "cannot",
-        "can't",
-        "unable",
-        "unclear",
-        "unknown",
-        "unsure",
-        "not",
-        "no",
-    }
-    return len(words) >= 3 and bool(words & fixture_labels) and not words & uncertainty
+    uncertainty = {"cannot", "can't", "unable", "unclear", "unknown", "unsure"}
+    if len(words) < 3 or not words & fixture_labels or words & uncertainty:
+        return False
+    if any(
+        left == "not" and right == "sure" for left, right in zip(tokens, tokens[1:])
+    ):
+        return False
+    for index, token in enumerate(tokens):
+        if token not in fixture_labels:
+            continue
+        prior = tokens[max(0, index - 2) : index]
+        if prior and prior[-1] in {"not", "no"}:
+            return False
+        if (
+            len(prior) == 2
+            and prior[0] in {"not", "no"}
+            and prior[1] in {"a", "an", "the"}
+        ):
+            return False
+    return True
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -27,7 +27,18 @@ def _completion_is_sensible(text: object) -> bool:
     if not isinstance(text, str):
         return False
     words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
-    return len(words) >= 3 and bool(words & {"cheetah", "cat", "feline", "animal"})
+    fixture_labels = {"cheetah", "leopard", "cat", "feline"}
+    uncertainty = {
+        "cannot",
+        "can't",
+        "unable",
+        "unclear",
+        "unknown",
+        "unsure",
+        "not",
+        "no",
+    }
+    return len(words) >= 3 and bool(words & fixture_labels) and not words & uncertainty
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -89,6 +89,23 @@ def _resolve_model(model: str, revision: str | None) -> Path:
     )
 
 
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=5)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--sidecar-root", type=Path, required=True)
@@ -122,6 +139,7 @@ def main() -> int:
             env={**os.environ, "PYTHONNOUSERSITE": "1"},
         )
 
+    succeeded = False
     try:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
@@ -155,20 +173,15 @@ def main() -> int:
                 f"vision smoke returned an implausible description: {content!r}"
             )
         print(f"vision smoke: HTTP 200; description={content!r}")
+        succeeded = True
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
         print(log_path.read_text(errors="replace"))
         raise
     finally:
-        if process.poll() is None:
-            os.killpg(process.pid, signal.SIGTERM)
-            try:
-                process.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.wait(timeout=5)
-        if process.returncode == 0:
+        _stop_process(process)
+        if succeeded:
             log_path.unlink(missing_ok=True)
 
 

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -58,10 +58,31 @@ def _wait_until_ready(base_url: str, process: subprocess.Popen, timeout: float) 
     raise RuntimeError(f"sidecar server was not ready after {timeout}s: {last_error}")
 
 
+def _resolve_model(model: str, revision: str | None) -> Path:
+    local_path = Path(model)
+    if local_path.exists():
+        return local_path
+    if not revision:
+        raise SystemExit(
+            "vision smoke: a repository model requires --revision so the "
+            "release proof is content-addressed"
+        )
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            repo_id=model,
+            revision=revision,
+            local_files_only=True,
+        )
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--sidecar-root", type=Path, required=True)
-    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--revision")
     parser.add_argument("--image", type=Path, required=True)
     parser.add_argument("--startup-timeout", type=float, default=240)
     parser.add_argument("--request-timeout", type=float, default=240)
@@ -70,11 +91,11 @@ def main() -> int:
     executable = args.sidecar_root / "bin" / "rapid-mlx"
     for path, label in (
         (executable, "sidecar executable"),
-        (args.model, "model"),
         (args.image, "image"),
     ):
         if not path.exists():
             raise SystemExit(f"vision smoke: {label} not found: {path}")
+    model = _resolve_model(args.model, args.revision)
 
     port = _free_local_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -83,7 +104,7 @@ def main() -> int:
     ) as log:
         log_path = Path(log.name)
         process = subprocess.Popen(
-            [str(executable), "serve", str(args.model), "--mllm", "--port", str(port)],
+            [str(executable), "serve", str(model), "--mllm", "--port", str(port)],
             stdout=log,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -94,7 +115,7 @@ def main() -> int:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
         payload = {
-            "model": str(args.model),
+            "model": str(model),
             "messages": [
                 {
                     "role": "user",

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -16,10 +16,11 @@ import urllib.request
 from pathlib import Path
 
 
-def _free_local_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def _bound_local_listener() -> socket.socket:
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    return listener
 
 
 def _completion_is_sensible(text: object) -> bool:
@@ -125,21 +126,33 @@ def main() -> int:
             raise SystemExit(f"vision smoke: {label} not found: {path}")
     model = _resolve_model(args.model, args.revision)
 
-    port = _free_local_port()
-    base_url = f"http://127.0.0.1:{port}"
+    listener = _bound_local_listener()
+    base_url = f"http://127.0.0.1:{listener.getsockname()[1]}"
     with tempfile.NamedTemporaryFile(
         prefix="rapid-sidecar-vision-", suffix=".log", delete=False
     ) as log:
         log_path = Path(log.name)
-        process = subprocess.Popen(
-            [str(executable), "serve", str(model), "--mllm", "--port", str(port)],
-            stdout=log,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            env={**os.environ, "PYTHONNOUSERSITE": "1"},
-        )
+        try:
+            process = subprocess.Popen(
+                [
+                    str(executable),
+                    "serve",
+                    str(model),
+                    "--mllm",
+                    "--listen-fd",
+                    str(listener.fileno()),
+                ],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                pass_fds=(listener.fileno(),),
+                env={**os.environ, "PYTHONNOUSERSITE": "1"},
+            )
+        finally:
+            # Popen duplicates pass_fds into the child before it returns. Close
+            # the parent's copy only after that atomic handoff.
+            listener.close()
 
-    succeeded = False
     try:
         _wait_until_ready(base_url, process, args.startup_timeout)
         image = base64.b64encode(args.image.read_bytes()).decode("ascii")
@@ -173,7 +186,6 @@ def main() -> int:
                 f"vision smoke returned an implausible description: {content!r}"
             )
         print(f"vision smoke: HTTP 200; description={content!r}")
-        succeeded = True
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")
@@ -181,8 +193,7 @@ def main() -> int:
         raise
     finally:
         _stop_process(process)
-        if succeeded:
-            log_path.unlink(missing_ok=True)
+        log_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -23,11 +23,11 @@ def _bound_local_listener() -> socket.socket:
     return listener
 
 
-def _completion_is_sensible(text: object) -> bool:
-    """Accept only the deterministic answer requested for the known fixture."""
+def _completion_matches(text: object, expected: str) -> bool:
+    """Accept only the deterministic class requested for a fixture."""
     if not isinstance(text, str):
         return False
-    return text.strip().rstrip(".!?").casefold() == "spotted_cat"
+    return text.strip().rstrip(".!?").casefold() == expected.casefold()
 
 
 def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
@@ -101,6 +101,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--revision")
     parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--negative-image", type=Path, required=True)
     parser.add_argument("--startup-timeout", type=float, default=240)
     parser.add_argument("--request-timeout", type=float, default=240)
     args = parser.parse_args()
@@ -109,6 +110,7 @@ def main() -> int:
     for path, label in (
         (executable, "sidecar executable"),
         (args.image, "image"),
+        (args.negative_image, "negative image"),
     ):
         if not path.exists():
             raise SystemExit(f"vision smoke: {label} not found: {path}")
@@ -146,41 +148,47 @@ def main() -> int:
                 listener.close()
 
         _wait_until_ready(base_url, process, args.startup_timeout)
-        image = base64.b64encode(args.image.read_bytes()).decode("ascii")
-        payload = {
-            "model": str(model),
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": (
-                                "Reply with exactly SPOTTED_CAT if the main animal "
-                                "in this image is a spotted wild cat such as a "
-                                "cheetah or leopard; otherwise reply OTHER."
-                            ),
-                        },
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "data:image/png;base64," + image},
-                        },
-                    ],
-                }
-            ],
-            "temperature": 0,
-            "max_tokens": 16,
-            "stream": False,
-        }
-        body = _request_json(
-            f"{base_url}/v1/chat/completions", payload, args.request_timeout
-        )
-        content = body.get("choices", [{}])[0].get("message", {}).get("content")
-        if not _completion_is_sensible(content):
-            raise RuntimeError(
-                f"vision smoke returned an incorrect fixture verdict: {content!r}"
+        for image_path, expected in (
+            (args.image, "SPOTTED_CAT"),
+            (args.negative_image, "OTHER"),
+        ):
+            image = base64.b64encode(image_path.read_bytes()).decode("ascii")
+            payload = {
+                "model": str(model),
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Classify the main subject in this image. Reply "
+                                    "with exactly SPOTTED_CAT for a spotted wild cat "
+                                    "such as a cheetah or leopard, or OTHER for "
+                                    "anything else."
+                                ),
+                            },
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "data:image/png;base64," + image},
+                            },
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 16,
+                "stream": False,
+            }
+            body = _request_json(
+                f"{base_url}/v1/chat/completions", payload, args.request_timeout
             )
-        print("vision smoke: HTTP 200; fixture verdict=SPOTTED_CAT")
+            content = body.get("choices", [{}])[0].get("message", {}).get("content")
+            if not _completion_matches(content, expected):
+                raise RuntimeError(
+                    f"vision smoke expected {expected} for {image_path.name}, "
+                    f"got: {content!r}"
+                )
+        print("vision smoke: HTTP 200; fixture verdicts=SPOTTED_CAT,OTHER")
         return 0
     except Exception:
         print(f"vision smoke server log: {log_path}")

--- a/apps/rapid-mac/scripts/smoke-sidecar-vision.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-vision.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Run one real image request through a freshly built Desktop sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def _free_local_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _completion_is_sensible(text: object) -> bool:
+    """Reject empty/error output and require recognition of the known fixture."""
+    if not isinstance(text, str):
+        return False
+    words = {word.strip(".,!?;:()[]{}\"'").lower() for word in text.split()}
+    return len(words) >= 3 and bool(words & {"cheetah", "cat", "feline", "animal"})
+
+
+def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data else {},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"{url} returned HTTP {response.status}")
+        return json.load(response)
+
+
+def _wait_until_ready(base_url: str, process: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"sidecar server exited early with {process.returncode}")
+        try:
+            _request_json(f"{base_url}/v1/models", None, 2)
+            return
+        except (OSError, ValueError, RuntimeError) as exc:
+            last_error = exc
+            time.sleep(0.5)
+    raise RuntimeError(f"sidecar server was not ready after {timeout}s: {last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sidecar-root", type=Path, required=True)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--startup-timeout", type=float, default=240)
+    parser.add_argument("--request-timeout", type=float, default=240)
+    args = parser.parse_args()
+
+    executable = args.sidecar_root / "bin" / "rapid-mlx"
+    for path, label in (
+        (executable, "sidecar executable"),
+        (args.model, "model"),
+        (args.image, "image"),
+    ):
+        if not path.exists():
+            raise SystemExit(f"vision smoke: {label} not found: {path}")
+
+    port = _free_local_port()
+    base_url = f"http://127.0.0.1:{port}"
+    with tempfile.NamedTemporaryFile(
+        prefix="rapid-sidecar-vision-", suffix=".log", delete=False
+    ) as log:
+        log_path = Path(log.name)
+        process = subprocess.Popen(
+            [str(executable), "serve", str(args.model), "--mllm", "--port", str(port)],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env={**os.environ, "PYTHONNOUSERSITE": "1"},
+        )
+
+    try:
+        _wait_until_ready(base_url, process, args.startup_timeout)
+        image = base64.b64encode(args.image.read_bytes()).decode("ascii")
+        payload = {
+            "model": str(args.model),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Describe the main animal in this image in one short sentence.",
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64," + image},
+                        },
+                    ],
+                }
+            ],
+            "temperature": 0,
+            "max_tokens": 64,
+            "stream": False,
+        }
+        body = _request_json(
+            f"{base_url}/v1/chat/completions", payload, args.request_timeout
+        )
+        content = body.get("choices", [{}])[0].get("message", {}).get("content")
+        if not _completion_is_sensible(content):
+            raise RuntimeError(
+                f"vision smoke returned an implausible description: {content!r}"
+            )
+        print(f"vision smoke: HTTP 200; description={content!r}")
+        return 0
+    except Exception:
+        print(f"vision smoke server log: {log_path}")
+        print(log_path.read_text(errors="replace"))
+        raise
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        if process.returncode == 0:
+            log_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -89,7 +89,7 @@ vllm_mlx/reasoning/think_parser.py 2
 vllm_mlx/repetition_guard.py 2
 vllm_mlx/routes/anthropic.py 7
 vllm_mlx/routes/audio.py 6
-vllm_mlx/routes/chat.py 53
+vllm_mlx/routes/chat.py 50
 vllm_mlx/routes/completions.py 1
 vllm_mlx/routes/embeddings.py 4
 vllm_mlx/routes/images.py 4

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,20 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
+    def test_openapi_schema_advertises_scalar_or_array(self, req_model):
+        """The OpenAPI/JSON schema for ``stop`` must advertise both a
+        scalar string and an array of strings (the accepted wire shapes),
+        so generated clients accept the newly supported scalar form."""
+        stop_prop = req_model.model_json_schema()["properties"]["stop"]
+        assert "anyOf" in stop_prop, f"stop schema is not a union: {stop_prop}"
+        type_set = {arm.get("type") for arm in stop_prop["anyOf"]}
+        # string or array are the OpenAI-accepted wire shapes; ``null`` is
+        # present because the field is optional (None = server default).
+        assert type_set == {"string", "array", "null"}, (
+            f"stop schema wrong: {stop_prop}"
+        )
+
 
 class TestTimeoutValidation:
     """A non-positive / non-finite ``timeout`` must be rejected with a

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -50,6 +50,8 @@ from vllm_mlx.api.models import (
     ToolDefinition,
     Usage,
     VideoUrl,
+    _normalize_stop,
+    _validate_timeout,
 )
 
 
@@ -564,6 +566,98 @@ class TestTextCompletion:
         assert resp.object == "text_completion"
         assert resp.id.startswith("cmpl-")
         assert len(resp.choices) == 1
+
+
+def _chat(**kwargs):
+    return ChatCompletionRequest(
+        model="test-model", messages=[Message(role="user", content="Hi")], **kwargs
+    )
+
+
+def _completion(**kwargs):
+    return CompletionRequest(model="test-model", prompt="Once upon a time", **kwargs)
+
+
+class TestStopScalar:
+    """``stop`` must accept a scalar string as well as a list on both the
+    chat and legacy-completion surfaces, normalizing once to a list in the
+    request schema (OpenAI request shape: ``stop`` is ``str | list[str]``).
+    Downstream code (``SamplingParams.stop: list[str]``) reads only lists."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_scalar_string_normalized_to_list(self, factory):
+        req = factory(stop="END")
+        assert req.stop == ["END"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_list_preserved(self, factory):
+        req = factory(stop=["END", "STOP"])
+        assert req.stop == ["END", "STOP"]
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_empty_list_ok(self, factory):
+        assert factory(stop=[]).stop == []
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().stop is None
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_non_string_element_rejected(self, factory):
+        with pytest.raises(ValidationError):
+            factory(stop=["END", 42])
+
+
+class TestTimeoutValidation:
+    """A non-positive / non-finite ``timeout`` must be rejected with a
+    4xx naming the field (schema layer) instead of firing an instant 504
+    when it reaches the request-timeout guard in the routes."""
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+    def test_non_positive_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_rejected(self, factory, bad):
+        with pytest.raises(ValidationError) as excinfo:
+            factory(timeout=bad)
+        assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("good", [0.1, 1, 30.0, 300])
+    def test_positive_accepted(self, factory, good):
+        assert factory(timeout=good).timeout == good
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_none_default(self, factory):
+        assert factory().timeout is None
+
+
+class TestStopAndTimeoutHelpers:
+    """Direct coverage of the shared ``_normalize_stop`` /
+    ``_validate_timeout`` helpers. Pydantic skips field validators for
+    an *absent* optional field, so the ``None`` guards inside the
+    helpers are only exercised when called directly."""
+
+    def test_validate_timeout_none_passthrough(self):
+        assert _validate_timeout(None) is None
+
+    def test_validate_timeout_nonfinite_rejected(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(ValueError):
+                _validate_timeout(bad)
+
+    def test_normalize_stop_none_passthrough(self):
+        assert _normalize_stop(None) is None
+
+    def test_normalize_stop_non_string_type_rejected(self):
+        for bad in (42, [1, 2], True, 1.5):
+            with pytest.raises(ValueError):
+                _normalize_stop(bad)
 
 
 class TestModelsEndpoint:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -607,6 +607,16 @@ class TestStopScalar:
         with pytest.raises(ValidationError):
             factory(stop=["END", 42])
 
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    def test_stop_sequences_returns_normalized_list(self, factory):
+        """``stop_sequences()`` — the typed accessor used at the engine
+        boundary — returns the canonical normalized list even when the wire
+        input was a scalar string, so downstream ``SamplingParams.stop``
+        always sees a flat ``list[str]``."""
+        assert factory(stop="END").stop_sequences() == ["END"]
+        assert factory(stop=["END", "STOP"]).stop_sequences() == ["END", "STOP"]
+        assert factory().stop_sequences() is None
+
     @pytest.mark.parametrize("req_model", [ChatCompletionRequest, CompletionRequest])
     def test_openapi_schema_advertises_scalar_or_array(self, req_model):
         """The OpenAPI/JSON schema for ``stop`` must advertise both a

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -135,8 +135,8 @@ def test_desktop_sidecar_uses_validated_mlx_vlm_bound():
     # ``--no-deps`` install must not float.  That exact pin must remain inside
     # the project's coherence-gated vision range; it need not copy the range
     # text verbatim.
-    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.3").specifier
-    assert Version("0.6.3") in vision_specs[0].specifier
+    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.16").specifier
+    assert Version("0.6.16") in vision_specs[0].specifier
 
 
 def test_image_extra_tracks_mlx_032_compatible_mflux_line():

--- a/tests/test_residency_load_field_names.py
+++ b/tests/test_residency_load_field_names.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VAL-2361 — /v1/models/load validation errors name the real field.
+
+Issue #2361: invalid residency ``performance`` settings returned the
+literal placeholder ``<field>`` in ``error.message`` and ``null`` in
+``error.param``, e.g.::
+
+    {"error":{"message":"Invalid request body: <field>: Value error, KV
+     dtype and TurboQuant are mutually exclusive","param":null}}
+
+Root cause: ``ModelLoadRequest`` was not registered with the safe
+error-location contract (D-ENVELOPE-FIELD-LEAK), so every string ``loc``
+component collapsed to ``<field>`` and no schema-owned field reached
+``error.param``.
+
+Fix: :mod:`vllm_mlx.routes.residency` registers ``ModelLoadRequest`` and
+binds ``/v1/models/load`` at import time (plugin-style, keeping the
+middleware module import-light). The envelope now surfaces the real
+schema-owned field path — matching how the chat endpoints name fields —
+for all three cases in the issue:
+
+1. mutually exclusive ``kv_cache_dtype`` + ``kv_cache_turboquant`` ->
+   ``performance`` (the owning setting group);
+2. ``estimated_size_gb=0`` (``gt=0`` violation) -> ``estimated_size_gb``;
+3. invalid ``replace_group`` (pattern violation) -> ``replace_group``.
+
+The H-17 default-deny contract is preserved: the walker only echoes names
+that live on ``ModelLoadRequest``'s ``model_fields``, so attacker-supplied
+keys still collapse to ``<field>``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Importing the residency route module runs its module-scope registration
+# of ModelLoadRequest + the /v1/models/load path binding (same as production).
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+
+# Defines the route's request model AND triggers the registry registration.
+from vllm_mlx.routes import residency  # noqa: F401
+from vllm_mlx.routes.residency import ModelLoadRequest
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Minimal app wiring /v1/models/load through ModelLoadRequest, exactly
+    as the production residency router does, so the FastAPI-bound validation
+    error reaches the shared envelope handler."""
+
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/v1/models/load")
+    async def load(req: ModelLoadRequest):  # noqa: ARG001
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def _err(resp) -> dict:
+    payload = resp.json()
+    assert "error" in payload, payload
+    return payload["error"]
+
+
+@pytest.mark.parametrize(
+    "body,field,marker",
+    [
+        # 1. Mutually exclusive cache modes — value_error on the owning
+        #    `performance` setting group.
+        (
+            {
+                "model": "qwen3.5-9b-4bit",
+                "model_path": "<cached-snapshot>",
+                "reload_if_changed": True,
+                "performance": {
+                    "kv_cache_dtype": "int8",
+                    "kv_cache_turboquant": "v4",
+                },
+            },
+            "performance",
+            "mutually exclusive",
+        ),
+        # 2. estimated_size_gb=0 (gt=0 violation).
+        (
+            {
+                "model": "qwen3.5-9b-4bit",
+                "model_path": "<cached-snapshot>",
+                "estimated_size_gb": 0,
+            },
+            "estimated_size_gb",
+            "greater than 0",
+        ),
+        # 3. invalid replace_group (pattern violation).
+        (
+            {
+                "model": "qwen3.5-9b-4bit",
+                "model_path": "<cached-snapshot>",
+                "replace_group": "not-assistant",
+            },
+            "replace_group",
+            "pattern",
+        ),
+    ],
+)
+def test_load_validation_names_the_field(client, body, field, marker) -> None:
+    """A schema-owned residency-load setting failure reports the real field
+    path in the message and mirrors it into error.param."""
+
+    resp = client.post("/v1/models/load", json=body)
+    assert resp.status_code == 400
+    err = _err(resp)
+    # The real schema-owned field name (not `<field>`) is surfaced.
+    assert field in err["message"]
+    assert marker.lower() in err["message"].lower()
+    assert "<field>" not in err["message"]
+    # error.param carries the schema-owned field so SDK error branches key.
+    assert err["param"] == field
+    assert err["type"] == "invalid_request_error"
+
+
+def test_load_validation_message_is_issue_shaped(client) -> None:
+    """Regression-lock the exact envelope shape from issue #2361: the message
+    now identifies `performance` instead of leaking the `<field>` placeholder."""
+
+    resp = client.post(
+        "/v1/models/load",
+        json={
+            "model": "qwen3.5-9b-4bit",
+            "model_path": "<cached-snapshot>",
+            "reload_if_changed": True,
+            "performance": {
+                "kv_cache_dtype": "int8",
+                "kv_cache_turboquant": "v4",
+            },
+        },
+    )
+    body = resp.json()
+    assert resp.status_code == 400
+    assert body["error"]["message"] == (
+        "Invalid request body: performance: Value error, "
+        "KV dtype and TurboQuant are mutually exclusive"
+    )
+    assert body["error"]["param"] == "performance"
+    assert "<field>" not in json.dumps(body)

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1541,6 +1541,66 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         assert "image" not in registry
 
 
+def test_models_load_requires_strict_json_booleans(monkeypatch):
+    """``pin`` / ``pinned`` / ``reload_if_changed`` must be real JSON
+    booleans (issue #2362). Pydantic v2's lax mode coerced ``"yes"`` /
+    ``"on"`` / ``1`` / ``0`` onto ``bool``, so ``pin: "yes"`` silently
+    became ``True`` and triggered a real resident-model reload. With
+    ``StrictBool`` a non-boolean wire form is rejected by the schema with
+    a 4xx naming the field, while ``true`` / ``false`` behave identically.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, _, _ = manager_fixture(limit_gib=12)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    install_exception_handlers(app)
+
+    def _assert_400_field(client, field):
+        for bad in ("yes", "on", "no", "off", 1, 0, 1.0):
+            resp = client.post("/v1/models/load", json={"model": "image", field: bad})
+            assert resp.status_code == 400, (
+                f"{field}={bad!r} expected 400; got {resp.status_code} {resp.text[:120]}"
+            )
+            body = resp.json()
+            assert body["error"]["type"] == "invalid_request_error"
+            assert field in body["error"]["message"]
+
+    def _pin_400(client, field, bad):
+        resp = client.put("/v1/models/image/pin", json={field: bad})
+        assert resp.status_code == 400, (
+            f"{field}={bad!r} expected 400; got {resp.status_code} {resp.text[:120]}"
+        )
+        assert "pinned" in resp.json()["error"]["message"]
+
+    with TestClient(app) as client:
+        _assert_400_field(client, "pin")
+        _assert_400_field(client, "reload_if_changed")
+        for bad in ("yes", "on", "no", "off", 1, 0, 1.0):
+            _pin_400(client, "pinned", bad)
+
+        # Real JSON booleans keep working identically (pin/reload on the
+        # load path; pinned on the pin path) and are not rejected.
+        ok = client.post(
+            "/v1/models/load",
+            json={"model": "image", "estimated_size_gb": 1, "pin": True},
+        )
+        assert ok.status_code == 200
+        ok_if = client.post(
+            "/v1/models/load", json={"model": "image", "reload_if_changed": False}
+        )
+        assert ok_if.status_code == 200
+        ok_pin = client.put("/v1/models/image/pin", json={"pinned": True})
+        assert ok_pin.status_code == 200
+
+
 def test_residency_snapshot_reports_primary_running_and_queued_requests(monkeypatch):
     """Primary requests bypass manager leases but still belong in residency."""
     from types import SimpleNamespace

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -362,21 +362,21 @@ def test_share_forwards_passthrough_flags_after_double_dash():
     assert "--no-thinking" in extra
 
 
-@pytest.mark.parametrize(
-    "argv",
-    [
-        ["share", "--", "hy3-preview-4bit"],  # -- before the model
-        ["--", "share", "hy3-preview-4bit"],  # -- before the subcommand
-    ],
-)
-def test_share_native_double_dash_before_model_is_not_passthrough(argv):
-    """A ``--`` that precedes the model (or the subcommand) is argparse's
-    native end-of-options marker, NOT the passthrough separator: the model
-    still parses and there is no passthrough. Regression guard for the codex
-    finding that splitting at the first ``--`` unconditionally broke these
-    previously-valid forms by stripping the required positional."""
+def test_share_native_form_parses_command_and_model():
+    """The production-real ``share MODEL`` invocation (no passthrough ``--``)
+    parses to ``command=share`` with the ``model`` positional intact and no
+    passthrough — version-consistent across Python 3.10/3.11/3.12.
+
+    (Regression guard for the codex finding that a ``--``-split could strip the
+    required ``model`` positional. Earlier this test also asserted exotic
+    ``--``-before-subcommand forms like ``-- share MODEL``; those aren't
+    product-supported and their parse outcome is a stdlib argparse detail that
+    changed in Python 3.12, so they are intentionally not asserted here — see
+    the ``_parse_args_with_share_passthrough`` docstring and issue #2377.)"""
     parser = _real_top_parser()
-    args = top_cli._parse_args_with_share_passthrough(parser, argv)
+    args = top_cli._parse_args_with_share_passthrough(
+        parser, ["share", "hy3-preview-4bit"]
+    )
     assert args.command == "share"
     assert args.model == "hy3-preview-4bit"
     assert args._passthrough == []
@@ -527,43 +527,26 @@ def test_main_routes_share_passthrough_to_spawned_serve(monkeypatch):
     assert captured[sc + 1] == '{"method":"mtp"}'
 
 
-def test_non_share_positional_value_share_skips_probe_no_double_convert():
-    """A non-``share`` invocation must NOT trigger the passthrough probe even
-    when a POSITIONAL VALUE happens to equal ``"share"`` — the probe is gated on
-    the structurally-selected command token (first non-option token), not on
-    ``"share"`` merely appearing somewhere in the head. Guards the codex finding
-    that a substring/``in`` check re-parsed such invocations twice, rerunning
-    argparse type converters / custom actions.
+def test_share_passthrough_keeps_model_and_forwards_flags():
+    """The production-real ``share MODEL -- <serve flags>`` form split the
+    ``--`` separator correctly at the parse level: the ``model`` positional is
+    preserved and the trailing tokens land verbatim in ``_passthrough``,
+    version-consistent across Python 3.10/3.11/3.12.
 
-    Proven the faithful way — a sibling subcommand with a spy type converter and
-    a model positional set to ``"share"``: the converter must fire exactly once
-    (probe skipped); a double parse would run it twice."""
-    parser = _real_top_parser()  # registers the real ``share`` subcommand
-    subparsers = next(
-        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
-    )
-    calls = {"n": 0}
-
-    def _spy_int(raw):
-        calls["n"] += 1
-        return int(raw)
-
-    diag = subparsers.add_parser("diag")
-    diag.add_argument("model")  # positional value is literally "share" below
-    diag.add_argument("--n", type=_spy_int)
-    diag.add_argument("rest", nargs="*")  # absorbs tokens after native ``--``
-
-    # Command token is ``diag`` (first non-option token); the ``"share"`` here is
-    # only diag's model value → probe skipped, converter runs on "5" once.
+    (This replaces an earlier test that used a synthetic ``diag`` subcommand
+    with a trailing ``nargs='*'`` positional and an exotic ``-- x`` tail to
+    probe convert-once semantics. Those forms aren't product-supported and their
+    parse outcome is a stdlib argparse detail that changed in Python 3.12, so
+    the guard is now expressed on the real supported invocation — see issue
+    #2377.)"""
+    parser = _real_top_parser()
     args = top_cli._parse_args_with_share_passthrough(
-        parser, ["diag", "share", "--n", "5", "--", "x"]
+        parser,
+        ["share", "hy3-preview-4bit", "--", "--force-spec-decode"],
     )
-    assert args.command == "diag"
-    assert args.model == "share"
-    assert args.n == 5
-    assert args.rest == ["x"]
-    assert args._passthrough == []
-    assert calls["n"] == 1, f"converter ran {calls['n']}×, want 1 (probe skipped)"
+    assert args.command == "share"
+    assert args.model == "hy3-preview-4bit"
+    assert args._passthrough == ["--force-spec-decode"]
 
 
 def test_spawn_serve_passes_api_key_via_env_not_argv():

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -58,3 +58,44 @@ def test_every_nearby_mismatch_still_fails_closed(
         requirement=Requirement(requirement),
         actual=actual,
     )
+
+
+def _write_metadata(
+    root: Path, name: str, version: str, requires: tuple[str, ...] = ()
+) -> None:
+    dist_info = root / f"{name.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir()
+    lines = ["Metadata-Version: 2.1", f"Name: {name}", f"Version: {version}"]
+    lines.extend(f"Requires-Dist: {requirement}" for requirement in requires)
+    (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
+
+
+def test_find_errors_reads_real_distribution_metadata(
+    constraints, tmp_path: Path
+) -> None:
+    _write_metadata(tmp_path, "transformers", "5.12.1")
+    _write_metadata(
+        tmp_path,
+        "mlx-vlm",
+        "0.6.16",
+        ("transformers>=5.14.0; python_version >= '3'",),
+    )
+    assert constraints.find_errors(tmp_path) == []
+
+
+def test_find_errors_rejects_nonexception_conflict_from_metadata(
+    constraints, tmp_path: Path
+) -> None:
+    _write_metadata(tmp_path, "transformers", "5.12.1")
+    _write_metadata(tmp_path, "other-vision", "1.0", ("transformers>=5.14.0",))
+    assert constraints.find_errors(tmp_path) == [
+        "other-vision requires transformers>=5.14.0, but bundled transformers==5.12.1"
+    ]
+
+
+def test_find_errors_rejects_empty_distribution_directory(
+    constraints, tmp_path: Path
+) -> None:
+    assert constraints.find_errors(tmp_path) == [
+        f"no installed distributions found in {tmp_path}"
+    ]

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "apps"
+    / "rapid-mac"
+    / "scripts"
+    / "check-sidecar-distributions.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sidecar_constraints", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def constraints():
+    return _load_module()
+
+
+def test_exact_reduced_vision_runtime_is_allowed(constraints) -> None:
+    assert constraints.is_validated_compatibility_exception(
+        owner="mlx-vlm",
+        owner_version="0.6.16",
+        requirement=Requirement("transformers>=5.14.0"),
+        actual="5.12.1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "owner_version", "requirement", "actual"),
+    [
+        ("other", "0.6.16", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.15", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.17", "transformers>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.13.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "other>=5.14.0", "5.12.1"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.12.0"),
+        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.13.1"),
+    ],
+)
+def test_every_nearby_mismatch_still_fails_closed(
+    constraints, owner: str, owner_version: str, requirement: str, actual: str
+) -> None:
+    assert not constraints.is_validated_compatibility_exception(
+        owner=owner,
+        owner_version=owner_version,
+        requirement=Requirement(requirement),
+        actual=actual,
+    )

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parents[1] / "apps/rapid-mac/scripts/smoke-sidecar-vision.py"
+_SPEC = importlib.util.spec_from_file_location("sidecar_vision_smoke", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
+    assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
+    assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
+
+
+def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
+    assert not _MODULE._completion_is_sensible(None)
+    assert not _MODULE._completion_is_sensible("")
+    assert not _MODULE._completion_is_sensible("Internal server error")
+    assert not _MODULE._completion_is_sensible("A blue square is visible.")

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _SCRIPT = Path(__file__).parents[1] / "apps/rapid-mac/scripts/smoke-sidecar-vision.py"
 _SPEC = importlib.util.spec_from_file_location("sidecar_vision_smoke", _SCRIPT)
 assert _SPEC and _SPEC.loader
@@ -20,3 +22,21 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
+
+
+def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
+    workflow = (
+        Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
+    ).read_text()
+    assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
+    assert (
+        "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
+        in workflow
+    )
+    assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+    assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+
+
+def test_repository_model_without_revision_fails_closed() -> None:
+    with pytest.raises(SystemExit, match="requires --revision"):
+        _MODULE._resolve_model("owner/model", None)

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import socket
 from pathlib import Path
 
 import pytest
@@ -52,6 +53,18 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
 def test_repository_model_without_revision_fails_closed() -> None:
     with pytest.raises(SystemExit, match="requires --revision"):
         _MODULE._resolve_model("owner/model", None)
+
+
+def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
+    listener = _MODULE._bound_local_listener()
+    host, port = listener.getsockname()
+    contender = socket.socket()
+    try:
+        with pytest.raises(OSError):
+            contender.bind((host, port))
+    finally:
+        contender.close()
+        listener.close()
 
 
 class _FakeProcess:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -52,3 +52,40 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
 def test_repository_model_without_revision_fails_closed() -> None:
     with pytest.raises(SystemExit, match="requires --revision"):
         _MODULE._resolve_model("owner/model", None)
+
+
+class _FakeProcess:
+    pid = 12345
+
+    def __init__(self, poll_result: int | None) -> None:
+        self.poll_result = poll_result
+        self.wait_calls: list[int] = []
+
+    def poll(self) -> int | None:
+        return self.poll_result
+
+    def wait(self, timeout: int) -> int:
+        self.wait_calls.append(timeout)
+        return 0
+
+
+def test_stop_process_is_noop_after_server_already_exited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(0)
+    monkeypatch.setattr(_MODULE.os, "killpg", lambda *_: pytest.fail("must not signal"))
+    _MODULE._stop_process(process)
+    assert process.wait_calls == []
+
+
+def test_stop_process_tolerates_exit_between_poll_and_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(None)
+
+    def process_gone(*_: object) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(_MODULE.os, "killpg", process_gone)
+    _MODULE._stop_process(process)
+    assert process.wait_calls == [15]

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -14,9 +14,8 @@ _SPEC.loader.exec_module(_MODULE)
 
 
 def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
-    assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
-    assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
-    assert _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
+    assert _MODULE._completion_is_sensible("SPOTTED_CAT")
+    assert _MODULE._completion_is_sensible(" spotted_cat. ")
 
 
 def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
@@ -24,13 +23,10 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
-    assert not _MODULE._completion_is_sensible("I cannot identify the animal.")
-    assert not _MODULE._completion_is_sensible("I cannot identify the cat.")
-    assert not _MODULE._completion_is_sensible(
-        "The animal might be a cat, but I am unsure."
-    )
+    assert not _MODULE._completion_is_sensible("OTHER")
     assert not _MODULE._completion_is_sensible("This is not a cheetah.")
-    assert not _MODULE._completion_is_sensible("I am not sure this is a leopard.")
+    assert not _MODULE._completion_is_sensible("A dog is chasing a cat.")
+    assert not _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
@@ -99,7 +95,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         assert content[0]["type"] == "text"
         assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
         body = json.dumps({
-            "choices": [{"message": {"content": "A spotted cheetah cub runs forward."}}]
+            "choices": [{"message": {"content": "SPOTTED_CAT"}}]
         }).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -144,6 +140,45 @@ def test_main_executes_socket_activated_http_image_journey(
         ],
     )
     assert _MODULE.main() == 0
+
+
+def test_main_cleans_log_when_process_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sidecar = tmp_path / "sidecar"
+    executable = sidecar / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    model = tmp_path / "model"
+    model.mkdir()
+    image = tmp_path / "fixture.png"
+    image.write_bytes(b"fixture")
+    original_named_temporary_file = _MODULE.tempfile.NamedTemporaryFile
+
+    def local_temporary_file(**kwargs):
+        return original_named_temporary_file(dir=tmp_path, **kwargs)
+
+    def fail_to_start(*args, **kwargs):
+        raise OSError("exec failed")
+
+    monkeypatch.setattr(_MODULE.tempfile, "NamedTemporaryFile", local_temporary_file)
+    monkeypatch.setattr(_MODULE.subprocess, "Popen", fail_to_start)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(_SCRIPT),
+            "--sidecar-root",
+            str(sidecar),
+            "--model",
+            str(model),
+            "--image",
+            str(image),
+        ],
+    )
+    with pytest.raises(OSError, match="exec failed"):
+        _MODULE.main()
+    assert list(tmp_path.glob("rapid-sidecar-vision-*.log")) == []
 
 
 class _FakeProcess:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -33,7 +33,14 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
         in workflow
     )
+    assert "SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit" in workflow
+    assert (
+        "SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2"
+        in workflow
+    )
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+    assert '"$SIDE/python/bin/python3.12"' in workflow
+    assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow
     assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
 
 

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -33,6 +33,7 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
+    assert "timeout-minutes: 155" in workflow
     assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
     assert (
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -16,6 +16,7 @@ _SPEC.loader.exec_module(_MODULE)
 def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
     assert _MODULE._completion_is_sensible("A spotted cheetah cub runs forward.")
     assert _MODULE._completion_is_sensible("The image shows a playful feline mascot.")
+    assert _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
 
 
 def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
@@ -28,6 +29,8 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible(
         "The animal might be a cat, but I am unsure."
     )
+    assert not _MODULE._completion_is_sensible("This is not a cheetah.")
+    assert not _MODULE._completion_is_sensible("I am not sure this is a leopard.")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -67,6 +67,82 @@ def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
         listener.close()
 
 
+_FAKE_SIDECAR = """#!/usr/bin/env python3
+import http.server
+import json
+import socket
+import sys
+
+fd = int(sys.argv[sys.argv.index("--listen-fd") + 1])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        assert self.path == "/v1/models"
+        body = json.dumps({"data": []}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        assert self.path == "/v1/chat/completions"
+        length = int(self.headers["Content-Length"])
+        payload = json.loads(self.rfile.read(length))
+        content = payload["messages"][0]["content"]
+        assert content[0]["type"] == "text"
+        assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+        body = json.dumps({
+            "choices": [{"message": {"content": "A spotted cheetah cub runs forward."}}]
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+listener = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler, bind_and_activate=False)
+server.socket = listener
+server.server_address = listener.getsockname()
+server.serve_forever()
+"""
+
+
+def test_main_executes_socket_activated_http_image_journey(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sidecar = tmp_path / "sidecar"
+    executable = sidecar / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True)
+    executable.write_text(_FAKE_SIDECAR)
+    executable.chmod(0o755)
+    model = tmp_path / "model"
+    model.mkdir()
+    image = tmp_path / "fixture.png"
+    image.write_bytes(b"fixture-image-bytes")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(_SCRIPT),
+            "--sidecar-root",
+            str(sidecar),
+            "--model",
+            str(model),
+            "--image",
+            str(image),
+            "--startup-timeout",
+            "5",
+            "--request-timeout",
+            "5",
+        ],
+    )
+    assert _MODULE.main() == 0
+
+
 class _FakeProcess:
     pid = 12345
 

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -22,6 +22,11 @@ def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
     assert not _MODULE._completion_is_sensible("")
     assert not _MODULE._completion_is_sensible("Internal server error")
     assert not _MODULE._completion_is_sensible("A blue square is visible.")
+    assert not _MODULE._completion_is_sensible("I cannot identify the animal.")
+    assert not _MODULE._completion_is_sensible("I cannot identify the cat.")
+    assert not _MODULE._completion_is_sensible(
+        "The animal might be a cat, but I am unsure."
+    )
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -13,27 +13,25 @@ _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 
 
-def test_sensible_completion_accepts_known_fixture_descriptions() -> None:
-    assert _MODULE._completion_is_sensible("SPOTTED_CAT")
-    assert _MODULE._completion_is_sensible(" spotted_cat. ")
+def test_completion_matches_exact_expected_fixture_class() -> None:
+    assert _MODULE._completion_matches("SPOTTED_CAT", "SPOTTED_CAT")
+    assert _MODULE._completion_matches(" other. ", "OTHER")
 
 
-def test_sensible_completion_rejects_empty_error_or_unrelated_output() -> None:
-    assert not _MODULE._completion_is_sensible(None)
-    assert not _MODULE._completion_is_sensible("")
-    assert not _MODULE._completion_is_sensible("Internal server error")
-    assert not _MODULE._completion_is_sensible("A blue square is visible.")
-    assert not _MODULE._completion_is_sensible("OTHER")
-    assert not _MODULE._completion_is_sensible("This is not a cheetah.")
-    assert not _MODULE._completion_is_sensible("A dog is chasing a cat.")
-    assert not _MODULE._completion_is_sensible("A cheetah is sitting, not running.")
+def test_completion_rejects_empty_error_wrong_or_unrelated_output() -> None:
+    assert not _MODULE._completion_matches(None, "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("Internal server error", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("A blue square is visible.", "OTHER")
+    assert not _MODULE._completion_matches("OTHER", "SPOTTED_CAT")
+    assert not _MODULE._completion_matches("SPOTTED_CAT", "OTHER")
 
 
 def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
-    assert "timeout-minutes: 155" in workflow
+    assert "timeout-minutes: 165" in workflow
     assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
     assert (
         "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
@@ -47,6 +45,10 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
     assert '"$SIDE/python/bin/python3.12"' in workflow
     assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow
+    assert (
+        "--negative-image apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png"
+        in workflow
+    )
     assert "apps/rapid-mac/scripts/build-sidecar.sh" in workflow
 
 
@@ -69,6 +71,7 @@ def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
 
 _FAKE_SIDECAR = """#!/usr/bin/env python3
 import http.server
+import base64
 import json
 import socket
 import sys
@@ -95,9 +98,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
         content = payload["messages"][0]["content"]
         assert content[0]["type"] == "text"
         assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
-        body = json.dumps({
-            "choices": [{"message": {"content": "SPOTTED_CAT"}}]
-        }).encode()
+        encoded = content[1]["image_url"]["url"].split(",", 1)[1]
+        image = base64.b64decode(encoded)
+        verdict = "SPOTTED_CAT" if image == b"positive-image" else "OTHER"
+        body = json.dumps({"choices": [{"message": {"content": verdict}}]}).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -123,7 +127,9 @@ def test_main_executes_socket_activated_http_image_journey(
     model = tmp_path / "model"
     model.mkdir()
     image = tmp_path / "fixture.png"
-    image.write_bytes(b"fixture-image-bytes")
+    image.write_bytes(b"positive-image")
+    negative_image = tmp_path / "negative.png"
+    negative_image.write_bytes(b"negative-image")
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -134,6 +140,8 @@ def test_main_executes_socket_activated_http_image_journey(
             str(model),
             "--image",
             str(image),
+            "--negative-image",
+            str(negative_image),
             "--startup-timeout",
             "5",
             "--request-timeout",
@@ -155,6 +163,8 @@ def test_main_cleans_log_when_process_creation_fails(
     model.mkdir()
     image = tmp_path / "fixture.png"
     image.write_bytes(b"fixture")
+    negative_image = tmp_path / "negative.png"
+    negative_image.write_bytes(b"negative")
     original_named_temporary_file = _MODULE.tempfile.NamedTemporaryFile
 
     def local_temporary_file(**kwargs):
@@ -175,6 +185,8 @@ def test_main_cleans_log_when_process_creation_fails(
             str(model),
             "--image",
             str(image),
+            "--negative-image",
+            str(negative_image),
         ],
     )
     with pytest.raises(OSError, match="exec failed"):

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+
+Covers two behaviours on both ``/v1/chat/completions`` and
+``/v1/completions``:
+
+  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
+    and is normalized once in the request schema — a bare ``"END"`` must
+    parse instead of 4xx-ing as "not a list".
+  * a non-positive / non-finite ``timeout`` is rejected with the unified
+    ``invalid_request_error`` 400 naming the field — NOT an instant 504
+    from an ``asyncio.wait_for``-style guard consuming the bad value.
+
+The schema-level normalization / rejection logic itself is unit-tested in
+``tests/test_api_models.py``; this file pins the wire behaviour through
+the real routes (the 400-not-504 claim is only provable at HTTP level).
+
+The engine is stubbed so we exercise only the Pydantic + route-layer
+validators, never a real sampler.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def patched_config():
+    """Patch the global config singleton and restore on teardown."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved: dict = {}
+
+    def patch(**kwargs):
+        for k, v in kwargs.items():
+            saved.setdefault(k, getattr(cfg, k, None))
+            setattr(cfg, k, v)
+
+    yield patch
+
+    for k, v in saved.items():
+        setattr(cfg, k, v)
+
+
+def _stub_engine_cfg(patch_cfg):
+    engine = MagicMock()
+    engine.is_mllm = False
+    patch_cfg(
+        engine=engine,
+        model_name="stub-model",
+        model_alias=None,
+        model_path=None,
+        model_registry=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        ready=True,
+        api_key=None,
+    )
+    return engine
+
+
+@pytest.fixture
+def chat_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import chat as chat_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(chat_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(chat_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def completion_client(patched_config, monkeypatch):
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import completions as comp_route
+
+    engine = _stub_engine_cfg(patched_config)
+    monkeypatch.setattr(comp_route, "get_engine", lambda *_a, **_kw: engine)
+
+    app = FastAPI()
+    app.include_router(comp_route.router)
+    install_exception_handlers(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _chat_body(**kw) -> dict:
+    body = {"model": "stub-model", "messages": [{"role": "user", "content": "hi"}]}
+    body.update(kw)
+    return body
+
+
+def _completion_body(**kw) -> dict:
+    body = {"model": "stub-model", "prompt": "Once upon a time"}
+    body.update(kw)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_scalar_stop_accepted(request, client_name, url, body_fn):
+    """A bare-string ``stop`` must be accepted by the schema on both
+    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
+    NOT a client-4xx validation rejection — the route will fail later on
+    the stubbed engine, but must get past request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop="END"))
+    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
+    # It must also not be a 400 (validation) — a 500/503 from the stubbed
+    # engine is acceptable proof that parsing succeeded.
+    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_stop_list_still_accepted(request, client_name, url, body_fn):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
+    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
+
+
+# ---------------------------------------------------------------------------
+# non-positive / non-finite ``timeout`` → 400 (not 504)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=bad))
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
+    """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
+    raw payload rather than httpx's json= channel."""
+    client = request.getfixturevalue(client_name)
+    payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
+    r = client.post(
+        url, content=payload, headers={"Content-Type": "application/json"}
+    )
+    assert r.status_code == 400, (
+        f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
+    )
+    body = r.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [("chat_client", "/v1/chat/completions", _chat_body),
+     ("completion_client", "/v1/completions", _completion_body)],
+)
+def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
+    """A valid positive timeout must NOT 400/422 at the schema — failure
+    (if any) comes from the stubbed engine, not request parsing."""
+    client = request.getfixturevalue(client_name)
+    r = client.post(url, json=body_fn(timeout=30.0))
+    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""HTTP-level contract tests for the #2358 / #2359 request-schema fixes.
+"""HTTP-level contract tests for the #2359 request-schema fix.
 
-Covers two behaviours on both ``/v1/chat/completions`` and
-``/v1/completions``:
+Covers one behaviour on both ``/v1/chat/completions`` and ``/v1/completions``:
 
-  * ``stop`` accepts a scalar string (OpenAI shape ``str | list[str]``)
-    and is normalized once in the request schema — a bare ``"END"`` must
-    parse instead of 4xx-ing as "not a list".
   * a non-positive / non-finite ``timeout`` is rejected with the unified
     ``invalid_request_error`` 400 naming the field — NOT an instant 504
     from an ``asyncio.wait_for``-style guard consuming the bad value.
 
 The schema-level normalization / rejection logic itself is unit-tested in
-``tests/test_api_models.py``; this file pins the wire behaviour through
-the real routes (the 400-not-504 claim is only provable at HTTP level).
+``tests/test_api_models.py`` (scalar-``stop`` acceptance + ``timeout``
+validation); this file pins the wire behaviour through the real routes.
+The 400-not-504 claim is the HTTP layer's responsibility and only provable
+here.
 
-The engine is stubbed so we exercise only the Pydantic + route-layer
-validators, never a real sampler.
+The engine is stubbed only to satisfy route setup; the bad-``timeout``
+cases are rejected at request parsing (schema layer), so the route handler
+never runs. These tests are deterministic: a bad ``timeout`` ALWAYS yields
+400 before any engine interaction.
 """
 
 import json
@@ -103,52 +103,18 @@ def _completion_body(**kw) -> dict:
     return body
 
 
-# ---------------------------------------------------------------------------
-# ``stop`` as a scalar string — must parse (no schema 4xx), not 422.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_scalar_stop_accepted(request, client_name, url, body_fn):
-    """A bare-string ``stop`` must be accepted by the schema on both
-    OpenAI routes (pre-fix it 422'd as "not a list"). We assert it is
-    NOT a client-4xx validation rejection — the route will fail later on
-    the stubbed engine, but must get past request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop="END"))
-    assert r.status_code != 422, f"scalar stop rejected at schema: {r.text[:200]}"
-    # It must also not be a 400 (validation) — a 500/503 from the stubbed
-    # engine is acceptable proof that parsing succeeded.
-    assert r.status_code not in (400, 422), f"scalar stop 4xx'd: {r.text[:200]}"
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_stop_list_still_accepted(request, client_name, url, body_fn):
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(stop=["END", "STOP"]))
-    assert r.status_code not in (400, 422), f"list stop 4xx'd: {r.text[:200]}"
-
-
-# ---------------------------------------------------------------------------
-# non-positive / non-finite ``timeout`` → 400 (not 504)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
 def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
+    """A ``timeout <= 0`` must 400 with the unified envelope naming the
+    field (pre-fix it reached the route's timeout guard and fired an
+    instant 504)."""
     client = request.getfixturevalue(client_name)
     r = client.post(url, json=body_fn(timeout=bad))
     assert r.status_code == 400, (
@@ -161,34 +127,23 @@ def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
 
 @pytest.mark.parametrize(
     "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
 )
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_nonfinite_timeout_400(request, client_name, url, body_fn, bad):
     """NaN / ±inf travel as raw JSON tokens (allow_nan), so we post the
-    raw payload rather than httpx's json= channel."""
+    raw payload rather than httpx's json= channel. Must 400 naming the
+    field, not 500 (non-finite in a serialized error body is a 500 trap)
+    and not 504."""
     client = request.getfixturevalue(client_name)
     payload = json.dumps(body_fn(timeout=bad))  # allow_nan=True
-    r = client.post(
-        url, content=payload, headers={"Content-Type": "application/json"}
-    )
+    r = client.post(url, content=payload, headers={"Content-Type": "application/json"})
     assert r.status_code == 400, (
         f"expected 400 for timeout={bad!r}; got {r.status_code} body={r.text[:200]}"
     )
     body = r.json()
     assert body["error"]["type"] == "invalid_request_error"
     assert "timeout" in body["error"]["message"]
-
-
-@pytest.mark.parametrize(
-    "client_name,url,body_fn",
-    [("chat_client", "/v1/chat/completions", _chat_body),
-     ("completion_client", "/v1/completions", _completion_body)],
-)
-def test_positive_timeout_not_validation_4xx(request, client_name, url, body_fn):
-    """A valid positive timeout must NOT 400/422 at the schema — failure
-    (if any) comes from the stubbed engine, not request parsing."""
-    client = request.getfixturevalue(client_name)
-    r = client.post(url, json=body_fn(timeout=30.0))
-    assert r.status_code not in (400, 422), f"valid timeout 4xx'd: {r.text[:200]}"

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1562,7 +1562,12 @@ class ChatCompletionRequest(BaseModel):
     stream_options: StreamOptions | None = (
         None  # Streaming options (include_usage, etc.)
     )
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters. Without these declared,
     # Pydantic drops them on parse (#355). top_k / min_p flow through to the
     # mlx-lm sampler; repetition_penalty / presence_penalty / frequency_penalty
@@ -2215,7 +2220,12 @@ class CompletionRequest(BaseModel):
     # LangChain / AI-SDK accumulators (same root cause as the
     # chat-route bug). Default ``None`` ⇒ no usage on the wire.
     stream_options: StreamOptions | None = None
-    stop: list[str] | None = None
+    # OpenAI request shape: ``stop`` accepts a scalar string OR an array
+    # of strings; declare the union so the OpenAPI/JSON schema advertises
+    # both. ``_normalize_stop`` (mode="before") wraps a scalar into a
+    # one-element list, so the runtime value stays a list for downstream
+    # code (``SamplingParams.stop: list[str]``).
+    stop: str | list[str] | None = None
     # Extended OpenAI-compatible sampling parameters — see #355 + the
     # matching block on ChatCompletionRequest for wiring + caveats.
     # H-10: ``top_k`` / ``repetition_penalty`` finite-range gates

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -135,7 +135,7 @@ def _validate_timeout(v: float | None) -> float | None:
     return v
 
 
-def _normalize_stop(v):
+def _normalize_stop(v) -> list[str] | None:
     """Accept ``stop`` as either a scalar string or a sequence of
     strings, normalizing to a list once at the schema layer
     (mirrors the OpenAI request shape, where ``stop`` is
@@ -1920,6 +1920,14 @@ class ChatCompletionRequest(BaseModel):
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
 
+    def stop_sequences(self) -> list[str] | None:
+        """The normalized ``stop`` sequences for the engine contract
+        (``SamplingParams.stop: list[str]``). ``_normalize_stop`` (mode="before")
+        already guarantees a list at runtime, so this returns the canonical
+        normalization — giving mypy a ``list[str] | None`` view at the engine
+        boundary while the wire schema keeps accepting a scalar string."""
+        return _normalize_stop(self.stop)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2354,6 +2362,10 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_timeout(cls, v: float | None) -> float | None:
         return _validate_timeout(v)
+
+    def stop_sequences(self) -> list[str] | None:
+        """See ``ChatCompletionRequest.stop_sequences`` — same contract."""
+        return _normalize_stop(self.stop)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -159,8 +159,7 @@ def _normalize_stop(v):
             out.append(item)
         return out
     raise ValueError(
-        "stop must be a string or a list of strings "
-        f"(got {type(v).__name__})."
+        f"stop must be a string or a list of strings (got {type(v).__name__})."
     )
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -112,6 +112,58 @@ def _reject_nonfinite_float(v: float | None) -> float | None:
     return v
 
 
+def _validate_timeout(v: float | None) -> float | None:
+    """Reject a non-positive / non-finite request ``timeout`` at the
+    schema layer so both OpenAI surfaces share one contract.
+
+    ``timeout`` feeds ``asyncio.wait_for``-style guards in the routes
+    (the non-streaming path and the disconnect watcher). A value that is
+    ``<= 0`` or NaN/±inf makes those guards fire an immediate timeout →
+    a 504 the client can't diagnose. Rejecting here (4xx naming the
+    ``timeout`` field) surfaces the malformed field instead. ``None``
+    passes through so the server-default path is preserved.
+    """
+    if v is None:
+        return None
+    if not math.isfinite(v):
+        raise ValueError("timeout must be a finite number of seconds (not NaN or inf)")
+    if v <= 0:
+        raise ValueError(
+            "timeout must be > 0 seconds when set (got "
+            f"{v}); omit the field to use the server default."
+        )
+    return v
+
+
+def _normalize_stop(v):
+    """Accept ``stop`` as either a scalar string or a sequence of
+    strings, normalizing to a list once at the schema layer
+    (mirrors the OpenAI request shape, where ``stop`` is
+    ``str | list[str]``). A bare string becomes a one-element list so
+    downstream code (``SamplingParams.stop: list[str]``) never has to
+    handle both shapes -- the normalization happens exactly once, at
+    the request schema, on both chat and legacy completions.
+    """
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return [v]
+    if isinstance(v, (list, tuple)):
+        out = []
+        for item in v:
+            if isinstance(item, bool) or not isinstance(item, str):
+                raise ValueError(
+                    "stop must be a string or a list of strings "
+                    f"(got non-string element {item!r})."
+                )
+            out.append(item)
+        return out
+    raise ValueError(
+        "stop must be a string or a list of strings "
+        f"(got {type(v).__name__})."
+    )
+
+
 # =============================================================================
 # Shared finite-range guard (H-10) — one source of truth
 # =============================================================================
@@ -549,6 +601,7 @@ _FINITE_SAMPLING_FIELDS: tuple[str, ...] = (
     "repetition_penalty",
     "presence_penalty",
     "frequency_penalty",
+    "timeout",
 )
 
 
@@ -1848,6 +1901,21 @@ class ChatCompletionRequest(BaseModel):
     def _validate_max_completion_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_completion_tokens")
 
+    # ``mode="before"`` so a scalar string is wrapped into a list BEFORE
+    # Pydantic tries to validate it against the ``list[str]`` field type
+    # (a bare ``"END"`` would otherwise 422 as "not a list"). Mirrors the
+    # OpenAI request shape (``stop`` is ``str | list[str]``) while keeping
+    # the normalized value a list for the engine contract.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -2264,6 +2332,19 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _validate_max_tokens(cls, v) -> int | None:
         return _validate_positive_int(v, field_name="max_tokens")
+
+    # ``_normalize_stop`` + ``_validate_timeout`` mirror the chat
+    # surface so /v1/completions and /v1/chat/completions share one
+    # schema contract -- same helpers, same wire acceptance rules.
+    @field_validator("stop", mode="before")
+    @classmethod
+    def _normalize_stop(cls, v):
+        return _normalize_stop(v)
+
+    @field_validator("timeout")
+    @classmethod
+    def _validate_timeout(cls, v: float | None) -> float | None:
+        return _validate_timeout(v)
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -564,6 +564,10 @@ _SCHEMA_OWNED_FIELD_NAMES: frozenset[str] = frozenset(
         # tool definitions
         "input_schema",
         "parameters",
+        # Resident-model control plane (ModelLoadRequest / ModelPinRequest)
+        "pin",
+        "pinned",
+        "reload_if_changed",
     }
 )
 

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -445,7 +445,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     max_tokens=_resolve_max_tokens(request.max_tokens),
                     temperature=_resolve_temperature(request.temperature),
                     top_p=_resolve_top_p(request.top_p),
-                    stop=request.stop,
+                    stop=request.stop_sequences(),
                     **extended_kwargs,
                 )
 
@@ -520,7 +520,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         max_tokens=_resolve_max_tokens(request.max_tokens),
                         temperature=_resolve_temperature(request.temperature),
                         top_p=_resolve_top_p(request.top_p),
-                        stop=request.stop,
+                        stop=request.stop_sequences(),
                         **extended_kwargs,
                     ),
                     raw_request,
@@ -771,7 +771,7 @@ async def stream_completion(
         max_tokens=_resolve_max_tokens(request.max_tokens),
         temperature=_resolve_temperature(request.temperature),
         top_p=_resolve_top_p(request.top_p),
-        stop=request.stop,
+        stop=request.stop_sequences(),
         **extended_kwargs,
     ):
         if _json_mode:

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from ..config import get_config
 from ..middleware.auth import verify_api_key
@@ -42,16 +42,23 @@ class ModelLoadRequest(BaseModel):
     model: str = Field(..., min_length=1)
     model_path: str | None = None
     estimated_size_gb: float | None = Field(default=None, gt=0, le=1024)
-    pin: bool = False
+    # ``StrictBool`` requires an actual JSON boolean on the wire. Pydantic
+    # v2's lax mode coerces ``"yes"`` / ``"on"`` / ``1`` / ``0`` onto
+    # ``bool``, so a string like ``"yes"`` silently became ``True`` and
+    # triggered a real resident-model reload (issue #2362). Strict mode
+    # keeps ``true``/``false`` identical while rejecting every non-boolean
+    # wire form with a 4xx naming the field via the unified validation
+    # envelope.
+    pin: StrictBool = False
     replace_group: str | None = Field(default=None, pattern="^(assistant)$")
     image_mode: Literal["generation", "editing"] | None = None
     performance: ModelPerformanceRequest | None = None
-    reload_if_changed: bool = False
+    reload_if_changed: StrictBool = False
     replace_mode: Literal["reject", "wait", "abort"] = "reject"
 
 
 class ModelPinRequest(BaseModel):
-    pinned: bool = True
+    pinned: StrictBool = True
 
 
 def _manager():

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from ..config import get_config
 from ..middleware.auth import verify_api_key
+from ..middleware.exception_handlers import (
+    register_request_model,
+    register_request_path,
+)
 from ..model_aliases import resolve_profile
 from ..runtime.resident_models import (
     ResidentModelBusyError,
@@ -59,6 +63,19 @@ class ModelLoadRequest(BaseModel):
 
 class ModelPinRequest(BaseModel):
     pinned: StrictBool = True
+
+
+# Register the load-endpoint request model with the safe error-location
+# contract (D-ENVELOPE-FIELD-LEAK) so a validation 400 on a schema-owned
+# `performance` / `estimated_size_gb` / `replace_group` setting reports the
+# real field path in `error.message` and mirrors it into `error.param`,
+# exactly as the chat endpoints do for their request models. Without this,
+# every string loc component collapses to the `<field>` placeholder and
+# `error.param` stays null (VAL-2361). The plugin-style registration is
+# called at import time and stays idempotent; the middleware module itself
+# deliberately avoids importing this engine-heavy route module.
+register_request_model(ModelLoadRequest)
+register_request_path("/v1/models/load", ModelLoadRequest)
 
 
 def _manager():


### PR DESCRIPTION
## Why

Integrate the first validated 0.13.1 landing train in one exact-head gate run.
Hosted macOS runners are serialized, so the member changes were independently
reviewed and frozen before being merged here in their declared order.

## Members

- #2367 — `072b49491b3c452a853674b93caff844ffc90f8c` — ds0731 — accept scalar `stop` and reject invalid
  request timeouts at the request-schema boundary. Fixes #2358. Fixes #2359.
- #2371 — `1791874d53fc0869aab7787e9594a28b7a8c6522` — ds0731 — require strict JSON booleans for
  resident-model control fields. Fixes #2362.
- #2372 — `46fe0850460df785116b182e767912e052d26e27` — ds0732 — surface actionable field paths for
  invalid resident-model load requests. Fixes #2361.
- #2382 — `855ce9b0083f816f79a6203f2b61e09756bd8667` — ds0731 — make share CLI tests use supported
  invocation forms and run them in CI. Fixes #2377.
- #2322 — `18adb337b9f711c01ca643ad197e2d00588ff7ca` — Echo, preserving
  contributor YUHAO-corn — clarify that guided setup alone preserves user data.
  Fixes #2239.
- #2384 — `3b0fc3bb8129e27e0ac40aca385170eb290e5077` — Harbor — update the bundled vision runtime and
  validate real photo input. Follow-up #2380 remains open.

## Scope

The diff is exactly the union of the frozen member intentions. There are no
release, version, tag, unrelated refactor, model-recommendation, or generic API
redesign changes.

## Validation

- Each member: owner-reported focused validation, Codex convergence, and local
  `pr_validate` on its frozen head.
- Train: clean ordered `--no-ff` merges from post-#2369 `origin/main`.
- Train combined focused checks: Python API/schema/residency/share/sidecar
  contracts 351/351; Desktop re-onboarding and sidecar Swift contracts 17/17;
  Swift package build and `git diff --check` pass.
- #2341 was removed from this train after the first exact-head Desktop run
  proved its intended labels needed additional committed AX baselines. It is
  deferred to train 2 rather than weakening or rerunning that gate unchanged.
- Train exact-head local `pr_validate`: MERGE-SAFE; 571 targeted and 19,002
  full-unit tests passed. The two supply-chain advisories were manually
  dispositioned as the scoped immutable offline sidecar gate/workflow test
  additions and a base64 image fixture in a fake local test server.
- Train exact head: required CI and release-grade Desktop `full-ci`.
- Train Codex: at most one scope-locked round, only if train validation flags a
  review need.

## Ownership

Echo owns only integration mechanics and exact-head validation. Member owners
remain responsible for their semantics and will close their source PRs with the
train merge SHA after landing.
