### PR TITLE
fix(pull): report already-cached model as verified, not Downloaded (#2349)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,7 @@ jobs:
             tests/test_pull_variant_selection.py \
             tests/test_share_cli.py \
             tests/test_cli_models.py \
+            tests/test_doctor_env_health.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,8 @@ jobs:
             tests/test_alias_subfolder.py \
             tests/test_download_gate.py \
             tests/test_first_run_guide.py \
+            tests/test_mirror_pull.py \
+            tests/test_pull_summary.py \
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4381,7 +4381,7 @@ def test_mirror_nonnfs_relink_is_a_pinned_documented_limitation(
     exists for — stay exact via the LFS ``blob_already_local`` probe. This test
     PINS that behavior so it is a contract, not an accident. Follow-up for full
     exactness: huggingface_hub downloader instrumentation (post-0.13.1, Vector
-    lane).
+    lane) — https://github.com/raullenchai/Rapid-MLX/issues/2427.
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     revision = "0badf00d" * 5

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4203,7 +4203,14 @@ def test_mirror_download_reports_transfer_account_via_out(
         target = snap / filename
         target.parent.mkdir(parents=True, exist_ok=True)
         expected_size = next(s for n, s in files if n == filename)
-        target.write_bytes(b"h" * expected_size)
+        # A genuine wire fetch materializes a BLOB in ``blobs/`` (HF writes
+        # the blob and links the snapshot to it); the blob diff is the
+        # network_fetch signal, so a real fetch flips it True.
+        repo_root = Path(cache_dir) / f"models--{repo_id.replace('/', '--')}"
+        blob = repo_root / "blobs" / filename.replace(".", "_")
+        blob.parent.mkdir(parents=True, exist_ok=True)
+        blob.write_bytes(b"h" * expected_size)
+        target.symlink_to(f"../../blobs/{blob.name}")
         return str(target)
 
     monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4224,3 +4224,80 @@ def test_mirror_download_reports_transfer_account_via_out(
     assert out["transferred_bytes"] == 300, (
         "R2 (config.json: 100) + HF (model.safetensors: 200) = 300"
     )
+
+
+def test_mirror_hf_relink_of_local_blob_is_not_a_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing snapshot link satisfied from HF's LOCAL blob cache is NOT a
+    network fetch (Codex #2392).
+
+    When the blob for a file already exists in the HF cache (``blobs/<sha>``)
+    but the snapshot symlink is absent, ``hf_hub_download`` only re-links it —
+    zero bytes cross the wire. The stable local-file-inventory seam records
+    that the blob was present BEFORE the call, so the file is classified
+    ``cached`` and ``out[\"network_fetch\"]`` stays False — a warm pull is not
+    mislabelled ``Downloaded``. (The old classification treated any
+    ``hf_hub_download`` success as a fetch.)
+    """
+    import hashlib
+
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "0badf00d" * 5
+    sha = hashlib.sha256(b"x" * 100).hexdigest()
+    files = [("model.safetensors", 100, sha)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # R2 misses the file — it falls back to HF.
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/model.safetensors",
+        _FakeResponse(404, b""),
+    )
+
+    repo_root = Path(tmp_path) / f"models--{repo_id.replace('/', '--')}"
+    # The blob is ALREADY in HF's local cache before the pull (warm), but the
+    # snapshot symlink is missing — the exact case a re-link must not count
+    # as a fetch.
+    blob_dir = repo_root / "blobs"
+    blob_dir.mkdir(parents=True, exist_ok=True)
+    (blob_dir / sha).write_bytes(b"x" * 100)
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        target = snap / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Only link the pre-existing blob — no bytes written (HF re-link of a
+        # local blob), mirroring hf_hub_download on a warm local cache.
+        target.write_bytes(b"x" * 100)
+        return str(target)
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    out: dict[str, object] = {}
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf) as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path, out=out)
+
+    assert ok is True
+    assert hf_mock.call_count == 1  # HF re-linked the local blob
+    assert out["network_fetch"] is False, (
+        "re-linking a locally-cached blob is NOT a fetch (Codex #2392)"
+    )
+    assert out["transferred_bytes"] == 0

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4363,3 +4363,81 @@ def test_mirror_hf_relink_of_local_blob_is_not_a_fetch(
         "re-linking a locally-cached blob is NOT a fetch (Codex #2392)"
     )
     assert out["transferred_bytes"] == 0
+
+
+def test_mirror_hf_nonnfs_relink_of_local_blob_is_not_a_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-LFS HF re-link from an ALREADY-LOCAL blob is not a fetch (Codex
+    #2392 R4 BLOCKING).
+
+    R2 misses the file; the HF fallback finds its blob already in HF's local
+    cache (no catalog sha256 exposed for non-LFS files) and only re-links the
+    snapshot symlink — zero bytes cross the wire. The old
+    ``expected_sha256``-only ``blob_already_local`` check left such files
+    always classified ``"hf"`` (over-counting ``transferred_bytes``). The
+    blob-store fingerprint before vs after the HF call catches this kind too:
+    unchanged store -> ``"cached"``.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "0badf00d" * 5
+    # No sha256 — a non-LFS metadata file. Its blob key lives only in HF's
+    # own cache, not the catalog.
+    files = [("config.json", 100)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # R2 misses the file — it falls back to HF.
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/config.json",
+        _FakeResponse(404, b""),
+    )
+
+    repo_root = Path(tmp_path) / f"models--{repo_id.replace('/', '--')}"
+    # A blob for this non-LFS file is ALREADY in HF's local cache before the
+    # pull (warm). We don't know its key from the catalog — but the store is
+    # non-empty, which is what the before/after fingerprint needs to rule out
+    # the "empty store forces a download" tautology.
+    blob_dir = repo_root / "blobs"
+    blob_dir.mkdir(parents=True, exist_ok=True)
+    (blob_dir / "already-local-blob").write_bytes(b"x" * 100)
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        target = snap / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # HF re-links the snapshot symlink to the pre-existing local blob; it
+        # writes NO new blob (warm local cache). The store is unchanged across
+        # the call, so the file classifies "cached".
+        target.symlink_to("../../blobs/already-local-blob")
+        return str(target)
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    out: dict[str, object] = {}
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf) as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path, out=out)
+
+    assert ok is True
+    assert hf_mock.call_count == 1  # HF re-linked the local non-LFS blob
+    assert out["network_fetch"] is False, (
+        "re-linking a locally-cached non-LFS blob is NOT a fetch (Codex #2392 R4)"
+    )
+    assert out["transferred_bytes"] == 0

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4233,6 +4233,58 @@ def test_mirror_download_reports_transfer_account_via_out(
     )
 
 
+def test_mirror_r2_only_non_lfs_fetch_is_a_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pure R2 fetch of a non-LFS file is still a network transfer (Codex
+    #2392 R4 BLOCKING).
+
+    R2 serves files that carry no catalog sha256 straight into
+    ``snapshots/<rev>/`` WITHOUT writing an HF ``blobs/<sha>`` blob — so the
+    blob-store diff alone would wrongly report ``network_fetch=False`` ("Already
+    cached") for an R2-only cold pull. ``network_fetch`` must also count
+    ``bool(r2_hits)`` (any R2 worker that actually fetched over the wire) to
+    catch this. HF is never invoked, so the blob store stays byte-identical.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "0badf00d" * 5
+    # No third element => no lfs sha256 => R2 lands it directly in snapshots/
+    # with no blob write (and no warm-cache blob-name shortcut).
+    files = [("config.json", 100)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # config.json is an R2 hit (200) — the ONLY transfer this pull.
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/config.json",
+        _FakeResponse(200, b"x" * 100),
+    )
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    out: dict[str, object] = {}
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download") as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path, out=out)
+
+    assert ok is True
+    assert hf_mock.call_count == 0  # pure R2 pull — HF never invoked
+    # No blob was written (non-LFS file, no catalog sha256), yet bytes DID
+    # cross the wire from R2 — the boolean must be True.
+    assert out["network_fetch"] is True, "R2-only fetch is still a transfer"
+    assert out["transferred_bytes"] == 100
+
+
 def test_mirror_hf_relink_of_local_blob_is_not_a_fetch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4365,20 +4365,23 @@ def test_mirror_hf_relink_of_local_blob_is_not_a_fetch(
     assert out["transferred_bytes"] == 0
 
 
-def test_mirror_hf_nonnfs_relink_of_local_blob_is_not_a_fetch(
+def test_mirror_nonnfs_relink_is_a_pinned_documented_limitation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-LFS HF re-link from an ALREADY-LOCAL blob is not a fetch (Codex
-    #2392 R4 BLOCKING).
+    """A non-LFS (no catalog sha) warm HF re-link counts as a fetch — the
+    ACCEPTED documented limitation (Atlas decision 2026-08-26, option A).
 
-    R2 misses the file; the HF fallback finds its blob already in HF's local
-    cache (no catalog sha256 exposed for non-LFS files) and only re-links the
-    snapshot symlink — zero bytes cross the wire. The old
-    ``expected_sha256``-only ``blob_already_local`` check left such files
-    always classified ``"hf"`` (over-counting ``transferred_bytes``). The
-    blob-store fingerprint before vs after the HF call catches this kind too:
-    unchanged store -> ``"cached"``.
+    For non-LFS files the blob key is unknowable ahead of time, so a warm
+    re-link of an already-local blob is indistinguishable from a real download
+    without huggingface_hub downloader instrumentation. Per Atlas's decision
+    the mirror classifies these ``"hf"`` (a download): a no-sha tiny non-LFS
+    file can show ``Downloaded`` only when (1) R2 misses it AND (2) its blob is
+    already in HF's local cache. The weight bytes — the actual transfer a pull
+    exists for — stay exact via the LFS ``blob_already_local`` probe. This test
+    PINS that behavior so it is a contract, not an accident. Follow-up for full
+    exactness: huggingface_hub downloader instrumentation (post-0.13.1, Vector
+    lane).
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     revision = "0badf00d" * 5
@@ -4400,9 +4403,7 @@ def test_mirror_hf_nonnfs_relink_of_local_blob_is_not_a_fetch(
 
     repo_root = Path(tmp_path) / f"models--{repo_id.replace('/', '--')}"
     # A blob for this non-LFS file is ALREADY in HF's local cache before the
-    # pull (warm). We don't know its key from the catalog — but the store is
-    # non-empty, which is what the before/after fingerprint needs to rule out
-    # the "empty store forces a download" tautology.
+    # pull (warm) — the exact corner the documented limitation covers.
     blob_dir = repo_root / "blobs"
     blob_dir.mkdir(parents=True, exist_ok=True)
     (blob_dir / "already-local-blob").write_bytes(b"x" * 100)
@@ -4418,8 +4419,7 @@ def test_mirror_hf_nonnfs_relink_of_local_blob_is_not_a_fetch(
         target = snap / filename
         target.parent.mkdir(parents=True, exist_ok=True)
         # HF re-links the snapshot symlink to the pre-existing local blob; it
-        # writes NO new blob (warm local cache). The store is unchanged across
-        # the call, so the file classifies "cached".
+        # writes NO new blob (warm local cache).
         target.symlink_to("../../blobs/already-local-blob")
         return str(target)
 
@@ -4437,7 +4437,9 @@ def test_mirror_hf_nonnfs_relink_of_local_blob_is_not_a_fetch(
 
     assert ok is True
     assert hf_mock.call_count == 1  # HF re-linked the local non-LFS blob
-    assert out["network_fetch"] is False, (
-        "re-linking a locally-cached non-LFS blob is NOT a fetch (Codex #2392 R4)"
+    # PINNED: non-LFS relink counts as a fetch (documented limitation, option A).
+    assert out["network_fetch"] is True, (
+        "non-LFS warm relink shows Downloaded — ACCEPTED documented limitation "
+        "(Atlas 2026-08-26); LFS weights stay exact"
     )
-    assert out["transferred_bytes"] == 0
+    assert out["transferred_bytes"] == 100

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -1382,6 +1382,75 @@ def test_r2_lfs_sha256_mismatch_falls_back_to_hf(
     assert leftovers == []
 
 
+def test_lfs_blob_probe_oserror_falls_through_to_hf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The per-file LFS blob-locality probe wraps ``is_file()`` in OSError
+    protection (Codex #2392): an exotic FS that raises on ``stat`` must not
+    crash the pull — it degrades to "blob not local" and lets the HF fallback
+    proceed. (pathlib normally swallows OSError in ``is_file``, so this is a
+    defensive branch exercised by making ``is_file`` raise on the probe path.)
+    """
+    import hashlib
+
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "11ee" * 10
+    payload_correct = b"x" * 200
+    correct_sha = hashlib.sha256(payload_correct).hexdigest()
+    files = [("model.safetensors", 200, correct_sha)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/model.safetensors",
+        _FakeResponse(200, b"z" * 200),
+    )
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        target = snap / filename
+        target.write_bytes(payload_correct)
+        return str(target)
+
+    blob_path_suffix = f"blobs/{correct_sha}"
+    original_is_file = Path.is_file
+
+    def _raising_is_file(self):
+        if str(self).endswith(blob_path_suffix):
+            raise OSError("simulated stat failure on blob probe")
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", _raising_is_file)
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf) as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    # The OSError on the blob probe must not abort the pull — HF still serves
+    # the file and the pull reports success.
+    assert ok
+    assert hf_mock.call_count == 1
+    snap = tmp_path / "models--mlx-community--Qwen3-0.6B-4bit" / "snapshots" / revision
+    assert (snap / "model.safetensors").read_bytes() == payload_correct
+
+
 def test_r2_lfs_sha256_match_accepts_download(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4278,9 +4278,12 @@ def test_mirror_hf_relink_of_local_blob_is_not_a_fetch(
         snap.mkdir(parents=True, exist_ok=True)
         target = snap / filename
         target.parent.mkdir(parents=True, exist_ok=True)
-        # Only link the pre-existing blob — no bytes written (HF re-link of a
-        # local blob), mirroring hf_hub_download on a warm local cache.
-        target.write_bytes(b"x" * 100)
+        # HF re-link of a local blob creates the snapshot SYMLINK to the
+        # pre-existing blob — it writes no bytes (warm local cache). Real HF
+        # snapshot links are relative ``blobs/<sha>`` symlinks; assert the
+        # blob stays byte-identical and the (unchanged) link is the only
+        # addition.
+        target.symlink_to(f"../../blobs/{sha}")  # HF-style relative symlink
         return str(target)
 
     monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -4149,3 +4149,78 @@ def test_subfolder_allow_patterns_fetches_only_that_quant(
     requested = [r["url"] for r in router.requests]
     assert not any("/8bit/" in u for u in requested)
     assert not any(u.endswith("/LICENSE") for u in requested)
+
+
+# ---------------------------------------------------------------------------
+# issue #2349 — download_with_mirror_fallback reports its transfer account
+# through ``out`` (out["transferred_bytes"] + out["network_fetch"]).
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_download_reports_transfer_account_via_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing ``out={}`` returns the authoritative transfer account: which
+    bytes crossed the wire this pull and whether anything was fetched at all.
+
+    Drives the REAL ``download_with_mirror_fallback`` R2+HF path (mocked
+    HTTP): one file (config.json) is an R2 hit, another (model.safetensors)
+    misses R2 and falls back to HF. Both arms increment
+    ``transferred_bytes`` (R2 and HF), so ``out["transferred_bytes"]`` and
+    ``out["network_fetch"]`` are fully exercised. Issue #2349: ``pull_command``
+    reads these to tell "already cached" from "download" truthfully.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "0badf00d" * 5
+    files = [("config.json", 100), ("model.safetensors", 200)]
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    # config.json is an R2 hit; model.safetensors misses R2 (404) so it
+    # falls back to HF — covering both the R2 and HF transfer arms.
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/config.json",
+        _FakeResponse(200, b"x" * 100),
+    )
+    router.add(
+        "https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/model.safetensors",
+        _FakeResponse(404, b""),
+    )
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        target = snap / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        expected_size = next(s for n, s in files if n == filename)
+        target.write_bytes(b"h" * expected_size)
+        return str(target)
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    out: dict[str, object] = {}
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf) as hf_mock,
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path, out=out)
+
+    assert ok is True
+    assert hf_mock.call_count == 1  # model.safetensors fell back to HF
+    assert out["network_fetch"] is True, "bytes fetched -> network_fetch True"
+    assert out["transferred_bytes"] == 300, (
+        "R2 (config.json: 100) + HF (model.safetensors: 200) = 300"
+    )

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -357,3 +357,59 @@ def test_format_pull_duration_units() -> None:
     assert cli._format_pull_duration(125.0) == "2m 5s"
     # Rounding rule: 119.9s reads as 2m 0s, not 1m 59s.
     assert cli._format_pull_duration(119.9) == "2m 0s"
+
+
+def test_hf_bytes_bar_tracks_transfer_and_reports_network_fetch() -> None:
+    """The network-transfer bar class (issue #2349) detects a real fetch.
+
+    ``_hf_bytes_bar_class`` returns a tqdm subclass that records ONLY the
+    network-transfer bar (``unit="B"`` + ``desc.startswith("Download")``),
+    flags ``_touched`` on any ``update()`` (even ``n=0``, for zero-byte
+    files), and ``_hf_network_fetch`` turns that into the authoritative
+    transfer verdict. These exercise the real construction path with no
+    network and no MLX.
+    """
+    # Each call to ``_hf_bytes_bar_class`` returns a fresh tqdm subclass
+    # with its own ``_bar_instances``, so the four cases below are isolated.
+
+    # No transfer bar constructed -> unknown (None), never a false cache hit.
+    empty = cli._hf_bytes_bar_class()
+    assert cli._hf_network_fetch(empty) is None
+
+    # A non-transfer file bar (unit "it") is NOT registered as a transfer →
+    # still None (the file bar counts completions, not network bytes).
+    base = cli._hf_bytes_bar_class()
+    file_bar = base(unit="it", desc="Fetching 4 files", total=10)
+    file_bar.update(n=10)
+    file_bar.close()
+    assert cli._hf_network_fetch(base) is None
+
+    # A transfer bar CONSTRUCTED but never updated -> False (clean cache hit).
+    cached_cls = cli._hf_bytes_bar_class()
+    cached_bar = cached_cls(unit="B", desc="Downloading model.safetensors", total=None)
+    cached_bar.close()
+    assert cli._hf_network_fetch(cached_cls) is False
+
+    # A transfer bar that observes an update() -> True, including an n=0
+    # (zero-byte) file, which still orchestrates a fetch.
+    fetched = cli._hf_bytes_bar_class()
+    transfer = fetched(unit="B", desc="Downloading model.safetensors", total=None)
+    transfer.update(n=0)  # zero-byte file still counts as a transfer
+    transfer.update(n=512)
+    transfer.close()
+    assert cli._hf_network_fetch(fetched) is True
+
+
+def test_print_pull_summary_was_cached_branch(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``was_cached=True`` prints the "Already cached ... verified" line
+    (issue #2349) rather than the "Downloaded" line — a proven no-transfer."""
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    (snap / "model.safetensors").write_bytes(b"\x00" * 4096)
+    cli._print_pull_summary("mlx-community/Qwen3-0.6B-4bit", snap, 1.5, was_cached=True)
+    out_str = capsys.readouterr().out
+    assert "Already cached" in out_str
+    assert "Downloaded" not in out_str
+    assert "verified (nothing to download)" in out_str

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -69,13 +69,9 @@ def test_summary_printed_on_hf_success(
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
     with (
+        # Not cached at entry (no resolved snapshot), so this pull actually
+        # transfers bytes — the summary reports a download.
         patch.object(cli, "_try_mirror_prefetch", return_value=False),
-        # Not cached at entry — this pull actually transfers bytes, so the
-        # summary reports a download (issue #2349 keeps "Downloaded" for this).
-        patch(
-            "vllm_mlx._download_gate.is_repo_cached",
-            return_value=False,
-        ),
         patch(
             "huggingface_hub.snapshot_download",
             return_value=str(snapshot_dir),
@@ -103,30 +99,30 @@ def test_summary_printed_on_mirror_success(
     """R2-mirror success path also prints the summary line.
 
     We point the HF cache root at ``tmp_path`` via the ``HF_HUB_CACHE``
-    constant so ``pull_command`` resolves the snapshot dir under our
-    fixture and our seeded file shows up in the size sum.
+    constant so ``pull_command`` resolves the snapshot dir under our fixture.
+    The mirror mock simulates an actual fetch: it creates ``refs/main`` and
+    populates the snapshot ONLY during the pull, so no snapshot exists at
+    entry (pre-pull size is unknown) and the summary reports a real download.
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     revision = "abc123" * 6  # 36 hex chars; shape doesn't matter for the test
 
     cache_root = tmp_path / "hub"
-    repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
-    refs_dir = repo_root / "refs"
-    refs_dir.mkdir(parents=True, exist_ok=True)
-    (refs_dir / "main").write_text(revision)
-    snapshot_dir = repo_root / "snapshots" / revision
-    _make_fake_snapshot(snapshot_dir, total_bytes=4096)
-
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    def _mirror_fetch(model_name: str) -> bool:
+        """Simulate the mirror downloading the snapshot during this pull."""
+        repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
+        refs_dir = repo_root / "refs"
+        refs_dir.mkdir(parents=True, exist_ok=True)
+        (refs_dir / "main").write_text(revision)
+        snapshot_dir = repo_root / "snapshots" / revision
+        _make_fake_snapshot(snapshot_dir, total_bytes=4096)
+        return True
 
     args = argparse.Namespace(model=repo_id)
 
-    with (
-        # The snapshot was NOT complete before this pull (the mirror just
-        # fetched it), so the summary reports a real download.
-        patch("vllm_mlx._download_gate.is_repo_cached", return_value=False),
-        patch.object(cli, "_try_mirror_prefetch", return_value=True),
-    ):
+    with patch.object(cli, "_try_mirror_prefetch", side_effect=_mirror_fetch):
         cli.pull_command(args)
 
     out = capsys.readouterr().out
@@ -163,16 +159,61 @@ def test_cached_pull_reports_verified_not_downloaded(
 
     args = argparse.Namespace(model=repo_id)
 
-    with (
-        patch("vllm_mlx._download_gate.is_repo_cached", return_value=True),
-        patch.object(cli, "_try_mirror_prefetch", return_value=True),
-    ):
+    # The snapshot is already complete at entry AND the mirror pulls nothing
+    # new, so pre-pull and post-pull sizes match -> "verified (nothing to
+    # download)", not "Downloaded".
+    with patch.object(cli, "_try_mirror_prefetch", return_value=True):
         cli.pull_command(args)
 
     out = capsys.readouterr().out
     assert "Already cached" in out, out
     assert "Downloaded" not in out, out
     assert "verified (nothing to download)" in out, out
+
+
+def test_moved_main_reported_as_download(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local snapshot may be complete while ``main`` advanced remote-side.
+
+    The codex BLOCKING on #2349: ``is_repo_cached`` (local presence) alone is
+    wrong for a mutable ``main`` — the subsequent mirror/HF call can transfer
+    new files while the summary falsely says "nothing to download". The
+    summary must reflect the ACTUAL transfer. Here a stale rev_A is fully
+    cached pre-pull, then the mirror populates a NEWER rev_B with real bytes:
+    the pre-pull size (measured against rev_A) and the post-pull size (against
+    the now-resolved rev_B) differ, so the pull is reported as a download.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    stale_rev = "aaaaaa" * 6
+    head_rev = "bbbbbb" * 6
+    cache_root = tmp_path / "hub"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
+    refs_dir = repo_root / "refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    # A fully-cached STALE rev exists before the pull.
+    (refs_dir / "main").write_text(stale_rev)
+    _make_fake_snapshot(repo_root / "snapshots" / stale_rev, total_bytes=4096)
+
+    def _mirror_fetch(model_name: str) -> bool:
+        # Remote main advanced mid-pull: refs/main now points at a NEWER rev
+        # whose snapshot is populated with more bytes than the stale one.
+        (refs_dir / "main").write_text(head_rev)
+        _make_fake_snapshot(repo_root / "snapshots" / head_rev, total_bytes=8192)
+        return True
+
+    args = argparse.Namespace(model=repo_id)
+
+    with patch.object(cli, "_try_mirror_prefetch", side_effect=_mirror_fetch):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Downloaded" in out, out
+    assert "Already cached" not in out, out
 
 
 def test_summary_not_printed_on_404(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -106,11 +106,13 @@ def test_hf_cached_fallback_reports_verified(
     snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
 
     def _download(*args, tqdm_class=None, **_kwargs):
-        # Byte bars exist but record zero = nothing transferred (cached).
+        # The transfer ("Download") bar exists but never updates = nothing
+        # crossed the network (cached). The reconstruction bar IS updated (HF
+        # writes the symlink/dedup metadata to disk on a warm pull) and the
+        # file bar advances per cached file, but neither is network traffic
+        # (codex round-4 #2) — so the label must stay "Already cached".
         tqdm_class(desc="Downloading bytes", total=0, unit="B")
-        tqdm_class(desc="Reconstructing", total=0, unit="B")
-        # The file bar advances per completed file (cache hits too) but is
-        # NOT counted as bytes — it must not flip the label to "Downloaded".
+        tqdm_class(desc="Reconstructing", total=4096, unit="B").update(4096)
         tqdm_class(desc="Fetching 7 files", total=7, unit="it").update(7)
         return str(snapshot_dir)
 
@@ -126,6 +128,38 @@ def test_hf_cached_fallback_reports_verified(
     assert "Already cached" in out, out
     assert "verified (nothing to download)" in out, out
     assert "Downloaded" not in out, out
+
+
+def test_hf_fetch_zero_byte_file_counts_as_download(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A fetched zero-byte file is a network fetch, not a cache hit.
+
+    codex round-4 BLOCKING #3: a transfer bar that records zero bytes could
+    be mislabelled "Already cached". HF still calls ``update()`` on the
+    transfer bar for a fetched file even when it is zero-byte; ``_touched``
+    flags that as a real network fetch, so the summary says ``Downloaded``.
+    """
+    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+
+    def _download(*args, tqdm_class=None, **_kwargs):
+        # A file was fetched but its size is 0 bytes.
+        tqdm_class(desc="Downloading bytes", total=0, unit="B").update(0)
+        tqdm_class(desc="Reconstructing", total=0, unit="B")
+        return str(snapshot_dir)
+
+    args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", side_effect=_download),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Downloaded" in out, out
+    assert "Already cached" not in out, out
 
 
 def test_hf_fallback_transfers_bytes_as_download(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -91,6 +91,69 @@ def test_summary_printed_on_hf_success(
     assert any(p.endswith("s") and p[0].isdigit() for p in parts), line
 
 
+def test_hf_cached_fallback_reports_verified(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A cached no-op on the HF-fallback path is labelled ``Already cached``.
+
+    codex round-4 BLOCKING #2/#3: even when the mirror miss forces the HF
+    fallback, a pull that transfers zero bytes must NOT print ``Downloaded``.
+    Here ``snapshot_download`` constructs the real ``unit="B"`` byte bars the
+    way huggingface_hub 1.28 does but records zero bytes (all files cached),
+    so the pull is reported as verified, not downloaded.
+    """
+    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+
+    def _download(*args, tqdm_class=None, **_kwargs):
+        # Byte bars exist but record zero = nothing transferred (cached).
+        tqdm_class(desc="Downloading bytes", total=0, unit="B")
+        tqdm_class(desc="Reconstructing", total=0, unit="B")
+        # The file bar advances per completed file (cache hits too) but is
+        # NOT counted as bytes — it must not flip the label to "Downloaded".
+        tqdm_class(desc="Fetching 7 files", total=7, unit="it").update(7)
+        return str(snapshot_dir)
+
+    args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", side_effect=_download),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Already cached" in out, out
+    assert "verified (nothing to download)" in out, out
+    assert "Downloaded" not in out, out
+
+
+def test_hf_fallback_transfers_bytes_as_download(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A real HF-fallback transfer (byte bar records bytes) is a download."""
+    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+
+    def _download(*args, tqdm_class=None, **_kwargs):
+        # The transfer byte-bar recorded 2048 bytes -> a real download.
+        tqdm_class(desc="Downloading bytes", total=2048, unit="B").update(2048)
+        tqdm_class(desc="Reconstructing", total=0, unit="B")
+        return str(snapshot_dir)
+
+    args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", side_effect=_download),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Downloaded" in out, out
+    assert "Already cached" not in out, out
+
+
 def test_summary_printed_on_mirror_success(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -119,7 +182,7 @@ def test_summary_printed_on_mirror_success(
         snapshot_dir = repo_root / "snapshots" / revision
         _make_fake_snapshot(snapshot_dir, total_bytes=4096)
         if out is not None:
-            out["transferred_bytes"] = 4096
+            out["network_fetch"] = True
         return True
 
     args = argparse.Namespace(model=repo_id)
@@ -165,7 +228,7 @@ def test_cached_pull_reports_verified_not_downloaded(
     # already cached) -> "verified (nothing to download)", not "Downloaded".
     def _mirror_already_cached(model_name: str, *, out=None) -> bool:
         if out is not None:
-            out["transferred_bytes"] = 0
+            out["network_fetch"] = False
         return True
 
     with patch.object(cli, "_try_mirror_prefetch", side_effect=_mirror_already_cached):
@@ -210,7 +273,7 @@ def test_moved_main_reported_as_download(
         (refs_dir / "main").write_text(head_rev)
         _make_fake_snapshot(repo_root / "snapshots" / head_rev, total_bytes=4096)
         if out is not None:
-            out["transferred_bytes"] = 4096
+            out["network_fetch"] = True
         return True
 
     args = argparse.Namespace(model=repo_id)

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -165,6 +165,52 @@ def test_hf_cached_fallback_reports_verified(
     assert "Downloaded" not in out, out
 
 
+
+def test_partial_mirror_fetch_combines_into_fallback_verdict(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mirror that fetched SOME bytes before failing must still report
+    ``Downloaded``, even though the snapshot_download that follows is a no-op
+    (Codex #2353).
+
+    When the mirror returns False (partial/failed) it still records
+    ``out["network_fetch"] = True`` for the blobs it DID fetch. The HF-fallback
+    baseline is captured AFTER the mirror wrote those blobs, so its own
+    before/after blob comparison is a no-op -> ""Already cached"". The mirror's
+    transfer state must therefore be OR'd in: bytes did cross the wire this
+    invocation, so the summary says ``Downloaded``.
+    """
+    revision = "abc123" * 6
+    cache_root, blob_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    def _mirror_partial(model_name: str, *, out=None) -> bool:
+        # Mirror fetched some blobs (network_fetch=True) but ultimately
+        # returned False (a file missed both R2 and HF).
+        if out is not None:
+            out["network_fetch"] = True
+        return False
+
+    def _download(*_args, **_kwargs):
+        # The fallback is a no-op: the mirror already laid down the blobs, so
+        # this invocation's before/after blob comparison is unchanged.
+        return str(blob_dir.parent / "snapshots" / revision)
+
+    args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", side_effect=_mirror_partial),
+        patch("huggingface_hub.snapshot_download", side_effect=_download),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Downloaded" in out, out
+    assert "Already cached" not in out, out
 def test_hf_fetch_zero_byte_file_counts_as_download(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -165,7 +165,6 @@ def test_hf_cached_fallback_reports_verified(
     assert "Downloaded" not in out, out
 
 
-
 def test_partial_mirror_fetch_combines_into_fallback_verdict(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -211,6 +210,8 @@ def test_partial_mirror_fetch_combines_into_fallback_verdict(
     out = capsys.readouterr().out
     assert "Downloaded" in out, out
     assert "Already cached" not in out, out
+
+
 def test_hf_fetch_zero_byte_file_counts_as_download(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -436,8 +436,12 @@ def test_blob_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
 
     # A fetched ZERO-byte file (new, empty blob) still changes the inventory
     # -> Download, never a false cache hit (carried from codex round-4 #3).
+    # Compare against the fingerprint captured immediately BEFORE this write,
+    # not the original ``before`` (the ``config`` addition above already made
+    # ``before`` unequal, so that comparison would be tautological).
+    pre_empty = cli._blob_identifier(tmp_path)
     (blobs / "empty").write_bytes(b"")
-    assert cli._blob_identifier(tmp_path) != before
+    assert cli._blob_identifier(tmp_path) != pre_empty
 
     # A REPAIR of an existing blob (mtime/size change) -> Download (the exact
     # case a snapshot-symlink fingerprint would miss). Snapshot the fingerprint

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -70,6 +70,12 @@ def test_summary_printed_on_hf_success(
 
     with (
         patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        # Not cached at entry — this pull actually transfers bytes, so the
+        # summary reports a download (issue #2349 keeps "Downloaded" for this).
+        patch(
+            "vllm_mlx._download_gate.is_repo_cached",
+            return_value=False,
+        ),
         patch(
             "huggingface_hub.snapshot_download",
             return_value=str(snapshot_dir),
@@ -115,7 +121,12 @@ def test_summary_printed_on_mirror_success(
 
     args = argparse.Namespace(model=repo_id)
 
-    with patch.object(cli, "_try_mirror_prefetch", return_value=True):
+    with (
+        # The snapshot was NOT complete before this pull (the mirror just
+        # fetched it), so the summary reports a real download.
+        patch("vllm_mlx._download_gate.is_repo_cached", return_value=False),
+        patch.object(cli, "_try_mirror_prefetch", return_value=True),
+    ):
         cli.pull_command(args)
 
     out = capsys.readouterr().out
@@ -124,6 +135,44 @@ def test_summary_printed_on_mirror_success(
     parts = line.split()
     assert any(_looks_like_size(p) for p in parts), line
     assert any(p.endswith("s") and p[0].isdigit() for p in parts), line
+
+
+def test_cached_pull_reports_verified_not_downloaded(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fully-cached pull must say the cache was verified, not ``Downloaded``.
+
+    Issue #2349: ``rapid-mlx pull <cached-model>`` printed
+    ``Downloaded ... in 3.8s`` after "[10/10] ... cached". The final outcome
+    now reserves ``Downloaded`` + transfer timing for a pull that actually
+    fetched bytes; an already-complete snapshot reports the cache was reused.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "abc123" * 6
+    cache_root = tmp_path / "hub"
+    repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
+    refs_dir = repo_root / "refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "main").write_text(revision)
+    snapshot_dir = repo_root / "snapshots" / revision
+    _make_fake_snapshot(snapshot_dir, total_bytes=4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    args = argparse.Namespace(model=repo_id)
+
+    with (
+        patch("vllm_mlx._download_gate.is_repo_cached", return_value=True),
+        patch.object(cli, "_try_mirror_prefetch", return_value=True),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    assert "Already cached" in out, out
+    assert "Downloaded" not in out, out
+    assert "verified (nothing to download)" in out, out
 
 
 def test_summary_not_printed_on_404(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -182,9 +182,10 @@ def test_moved_main_reported_as_download(
     wrong for a mutable ``main`` — the subsequent mirror/HF call can transfer
     new files while the summary falsely says "nothing to download". The
     summary must reflect the ACTUAL transfer. Here a stale rev_A is fully
-    cached pre-pull, then the mirror populates a NEWER rev_B with real bytes:
-    the pre-pull size (measured against rev_A) and the post-pull size (against
-    the now-resolved rev_B) differ, so the pull is reported as a download.
+    cached pre-pull, then the mirror populates a NEWER rev_B. To prove the
+    label keys on the resolved revision (not byte count), rev_B is the SAME
+    total size as rev_A; the pull is nonetheless reported as a download
+    because the post-pull snapshot resolves to a different directory.
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     stale_rev = "aaaaaa" * 6
@@ -200,10 +201,11 @@ def test_moved_main_reported_as_download(
     _make_fake_snapshot(repo_root / "snapshots" / stale_rev, total_bytes=4096)
 
     def _mirror_fetch(model_name: str) -> bool:
-        # Remote main advanced mid-pull: refs/main now points at a NEWER rev
-        # whose snapshot is populated with more bytes than the stale one.
+        # Remote main advanced mid-pull: refs/main now points at a NEWER rev.
+        # Same total byte count as the stale rev, so only the resolved PATH
+        # (not the size) proves a transfer happened.
         (refs_dir / "main").write_text(head_rev)
-        _make_fake_snapshot(repo_root / "snapshots" / head_rev, total_bytes=8192)
+        _make_fake_snapshot(repo_root / "snapshots" / head_rev, total_bytes=4096)
         return True
 
     args = argparse.Namespace(model=repo_id)

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -101,8 +101,8 @@ def test_summary_printed_on_mirror_success(
     We point the HF cache root at ``tmp_path`` via the ``HF_HUB_CACHE``
     constant so ``pull_command`` resolves the snapshot dir under our fixture.
     The mirror mock simulates an actual fetch: it creates ``refs/main`` and
-    populates the snapshot ONLY during the pull, so no snapshot exists at
-    entry (pre-pull size is unknown) and the summary reports a real download.
+    populates the snapshot ONLY during the pull, reporting ``out[
+    transferred_bytes] = 4096`` so the summary reports a real download.
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     revision = "abc123" * 6  # 36 hex chars; shape doesn't matter for the test
@@ -110,7 +110,7 @@ def test_summary_printed_on_mirror_success(
     cache_root = tmp_path / "hub"
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _mirror_fetch(model_name: str) -> bool:
+    def _mirror_fetch(model_name: str, *, out=None) -> bool:
         """Simulate the mirror downloading the snapshot during this pull."""
         repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
         refs_dir = repo_root / "refs"
@@ -118,6 +118,8 @@ def test_summary_printed_on_mirror_success(
         (refs_dir / "main").write_text(revision)
         snapshot_dir = repo_root / "snapshots" / revision
         _make_fake_snapshot(snapshot_dir, total_bytes=4096)
+        if out is not None:
+            out["transferred_bytes"] = 4096
         return True
 
     args = argparse.Namespace(model=repo_id)
@@ -159,10 +161,14 @@ def test_cached_pull_reports_verified_not_downloaded(
 
     args = argparse.Namespace(model=repo_id)
 
-    # The snapshot is already complete at entry AND the mirror pulls nothing
-    # new, so pre-pull and post-pull sizes match -> "verified (nothing to
-    # download)", not "Downloaded".
-    with patch.object(cli, "_try_mirror_prefetch", return_value=True):
+    # The mirror reports it fetched ZERO bytes this pull (every file was
+    # already cached) -> "verified (nothing to download)", not "Downloaded".
+    def _mirror_already_cached(model_name: str, *, out=None) -> bool:
+        if out is not None:
+            out["transferred_bytes"] = 0
+        return True
+
+    with patch.object(cli, "_try_mirror_prefetch", side_effect=_mirror_already_cached):
         cli.pull_command(args)
 
     out = capsys.readouterr().out
@@ -182,10 +188,8 @@ def test_moved_main_reported_as_download(
     wrong for a mutable ``main`` — the subsequent mirror/HF call can transfer
     new files while the summary falsely says "nothing to download". The
     summary must reflect the ACTUAL transfer. Here a stale rev_A is fully
-    cached pre-pull, then the mirror populates a NEWER rev_B. To prove the
-    label keys on the resolved revision (not byte count), rev_B is the SAME
-    total size as rev_A; the pull is nonetheless reported as a download
-    because the post-pull snapshot resolves to a different directory.
+    cached pre-pull, then the mirror reports it fetched NEWER files (rev_B) as
+    ``out["transferred_bytes"]``; the pull is reported as a download.
     """
     repo_id = "mlx-community/Qwen3-0.6B-4bit"
     stale_rev = "aaaaaa" * 6
@@ -200,12 +204,13 @@ def test_moved_main_reported_as_download(
     (refs_dir / "main").write_text(stale_rev)
     _make_fake_snapshot(repo_root / "snapshots" / stale_rev, total_bytes=4096)
 
-    def _mirror_fetch(model_name: str) -> bool:
-        # Remote main advanced mid-pull: refs/main now points at a NEWER rev.
-        # Same total byte count as the stale rev, so only the resolved PATH
-        # (not the size) proves a transfer happened.
+    def _mirror_fetch(model_name: str, *, out=None) -> bool:
+        # Remote main advanced mid-pull: refs/main now points at a NEWER rev
+        # whose snapshot bytes were actually fetched over the wire.
         (refs_dir / "main").write_text(head_rev)
         _make_fake_snapshot(repo_root / "snapshots" / head_rev, total_bytes=4096)
+        if out is not None:
+            out["transferred_bytes"] = 4096
         return True
 
     args = argparse.Namespace(model=repo_id)

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -437,8 +437,17 @@ def test_snapshot_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
     (snap / "empty.bin").write_bytes(b"")
     assert cli._snapshot_identifier(str(snap)) != before
 
-    # Empty vs populated: a fresh pull's before (()) differs from after.
-    assert before == () or after != ()
+    # The authentic fresh-pull transition: an ABSENT snapshot fingerprints
+    # empty (()) before, and the populated dir fingerprints non-empty after —
+    # a genuine download (not a tautological assertion).
+    fresh = tmp_path / "fresh-snap"
+    assert cli._snapshot_identifier(str(fresh)) == ()
+    fresh.mkdir()
+    (fresh / "model.safetensors").write_bytes(b"\x00" * 2048)
+    fresh_after = cli._snapshot_identifier(str(fresh))
+    assert fresh_after != () and fresh_after != cli._snapshot_identifier(
+        str(tmp_path / "fresh-snap-does-not-exist")
+    )
 
 
 def test_hf_snapshot_dir_for_resolves_cached_snapshot(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -43,30 +43,28 @@ def _hf_snapshot_layout(
     revision: str,
     root: Path,
     *,
-    files: dict[str, bytes] | None = None,
+    blob_name: str = "abcdef",
     already_cached: bool = False,
 ) -> tuple[Path, Path]:
     """Build a deterministic HF cache entry ``root/models--<id>/`` for the
-    HF-fallback transfer-account tests.
+    HF-fallback transfer-account tests, keyed on the BLOB store.
 
-    Returns ``(cache_root, snapshot_dir)``. Points ``refs/main`` at
-    ``revision``. When ``already_cached`` the snapshot dir already exists
-    with ``files`` (a warm, fully-cached pull leaves it untouched); when not,
-    no snapshot exists up front — the test's ``snapshot_download`` mock is
-    expected to create one during the pull so the before-inventory is empty.
-    ``repo_id`` must map to no catalog subfolder (the tests use
-    ``mlx-community/Qwen3-0.6B-4bit``), so the layout is flat.
+    Returns ``(cache_root, blob_dir)``. Points ``refs/main`` at ``revision``
+    and creates ``blobs/``. When ``already_cached`` a blob is already present
+    (a warm, fully-cached pull leaves ``blobs/`` untouched — the transfer seam
+    compares the blob inventory before/after); when not, ``blobs/`` starts
+    empty and the test's ``snapshot_download`` mock is expected to create a
+    blob during the pull (a fetch). ``repo_id`` maps to no catalog subfolder.
     """
     cache_root = root / "hub"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
     (repo_root / "refs").mkdir(parents=True, exist_ok=True)
     (repo_root / "refs" / "main").write_text(revision)
-    snapshot_dir = repo_root / "snapshots" / revision
+    blob_dir = repo_root / "blobs"
+    blob_dir.mkdir(parents=True, exist_ok=True)
     if already_cached:
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        for name, data in (files or {"model.safetensors": b"\x00" * 2048}).items():
-            (snapshot_dir / name).write_bytes(data)
-    return cache_root, snapshot_dir
+        (blob_dir / blob_name).write_bytes(b"\x00" * 2048)
+    return cache_root, blob_dir
 
 
 def _looks_like_size(token: str) -> bool:
@@ -97,18 +95,17 @@ def test_summary_printed_on_hf_success(
 ) -> None:
     """HF-fallback path prints ``Downloaded ... — <size> in <duration>``."""
     revision = "abc123" * 6
-    cache_root, snapshot_dir = _hf_snapshot_layout(
+    cache_root, blob_dir = _hf_snapshot_layout(
         "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     def _download(*_args, **_kwargs):
-        # Not cached at entry (no resolved snapshot); the pull actually
-        # transfers bytes — the before-inventory is empty and the after-side
-        # (this freshly-written snapshot) differs, so the summary is a download.
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        (snapshot_dir / "model.safetensors").write_bytes(b"\x00" * 2048)
-        return str(snapshot_dir)
+        # Not cached at entry (blobs/ empty); the pull transfers bytes — the
+        # before-inventory is empty and the after-side (this new blob) differs,
+        # so the summary is a download.
+        (blob_dir / "cafe").write_bytes(b"\x00" * 2048)
+        return str(blob_dir.parent / "snapshots" / revision)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
@@ -139,20 +136,20 @@ def test_hf_cached_fallback_reports_verified(
 
     Even when the mirror miss forces the HF fallback, a pull that transfers
     zero bytes must NOT print ``Downloaded``. The transfer account is the
-    stable on-disk snapshot inventory BEFORE vs AFTER the pull (Codex #2392,
-    no huggingface_hub tqdm-progress internals): a warm, fully-cached pull
-    leaves the snapshot untouched, so before == after and it reports verified.
+    stable BLOB-store inventory BEFORE vs AFTER the pull (Codex #2392, no
+    huggingface_hub tqdm-progress internals): a warm, fully-cached pull leaves
+    ``blobs/`` untouched, so before == after and it reports verified.
     """
     revision = "abc123" * 6
-    cache_root, snapshot_dir = _hf_snapshot_layout(
+    cache_root, blob_dir = _hf_snapshot_layout(
         "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     def _download(*_args, **_kwargs):
-        # A warm pull touches NOTHING on disk: the snapshot was already there,
-        # complete. before == after -> verified.
-        return str(snapshot_dir)
+        # A warm pull touches NOTHING in blobs/: the blobs were already there.
+        # before == after (the blob inventory) -> verified.
+        return str(blob_dir.parent / "snapshots" / revision)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
@@ -175,23 +172,21 @@ def test_hf_fetch_zero_byte_file_counts_as_download(
 ) -> None:
     """A fetched zero-byte file is a network fetch, not a cache hit.
 
-    codex round-4 BLOCKING #3 carried over to the stable seam: a fetched
-    zero-byte file adds a NEW row to the snapshot inventory (the file did not
-    exist before), so before != after and the summary says ``Downloaded`` even
-    though the file carries no bytes.
+    codex round-4 BLOCKING #3 carried over to the blob-inventory seam: a
+    fetched zero-byte file creates a NEW blob (the file did not exist before),
+    so the blob inventory changes even though the file carries no bytes, and
+    the summary says ``Downloaded``.
     """
     revision = "abc123" * 6
-    cache_root, snapshot_dir = _hf_snapshot_layout(
+    cache_root, blob_dir = _hf_snapshot_layout(
         "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     def _download(*_args, **_kwargs):
-        # The pull fetched a file that is 0 bytes: it appears in the
-        # snapshot now (a new inventory row) though it carries no bytes.
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        (snapshot_dir / "empty.bin").write_bytes(b"")
-        return str(snapshot_dir)
+        # The pull fetched a file that is 0 bytes: a NEW (empty) blob appears.
+        (blob_dir / "deadbeef").write_bytes(b"")
+        return str(blob_dir.parent / "snapshots" / revision)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
@@ -211,19 +206,18 @@ def test_hf_fallback_transfers_bytes_as_download(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A real HF-fallback transfer is a download: the snapshot inventory
-    changes across the pull (files appear), so before != after -> Downloaded."""
+    """A real HF-fallback transfer is a download: the blob inventory changes
+    across the pull (a new blob appears), so before != after -> Downloaded."""
     revision = "abc123" * 6
-    cache_root, snapshot_dir = _hf_snapshot_layout(
+    cache_root, blob_dir = _hf_snapshot_layout(
         "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     def _download(*_args, **_kwargs):
-        # A real fetch creates the snapshot with 2048 bytes of content.
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        (snapshot_dir / "model.safetensors").write_bytes(b"\x00" * 2048)
-        return str(snapshot_dir)
+        # A real fetch materializes a new 2048-byte blob.
+        (blob_dir / "cafebabe").write_bytes(b"\x00" * 2048)
+        return str(blob_dir.parent / "snapshots" / revision)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
@@ -409,71 +403,68 @@ def test_format_pull_duration_units() -> None:
     assert cli._format_pull_duration(119.9) == "2m 0s"
 
 
-def test_snapshot_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
-    """``_snapshot_identifier`` fingerprints snapshot content so a before/after
+def test_blob_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
+    """``_blob_identifier`` fingerprints the BLOB store so a before/after
     comparison classifies the pull without huggingface_hub tqdm internals
-    (Codex #2392). The cases directly mirror the old byte-bar verdicts:
-    unchanged content == cache hit; any new/changed file — INCLUDING a newly
-    fetched zero-byte file — == a network fetch.
+    (Codex #2392). A new/modified blob is the only thing meaning bytes crossed
+    the wire; re-linking snapshot symlinks to existing blobs (unchanged) is a
+    cache hit. The cases directly mirror the old byte-bar verdicts.
     """
-    # Nothing cached yet -> empty fingerprint (before-side of a fresh pull).
-    assert cli._snapshot_identifier(None) == ()
-    assert cli._snapshot_identifier(str(tmp_path / "does-not-exist")) == ()
+    # No cache entry / empty blob store -> empty fingerprint (fresh pull).
+    assert cli._blob_identifier(None) == ()
+    assert cli._blob_identifier(tmp_path / "does-not-exist") == ()
 
-    # A warm, untouched snapshot: before == after -> verified (no transfer).
-    snap = tmp_path / "snap"
-    snap.mkdir()
-    (snap / "model.safetensors").write_bytes(b"\x00" * 2048)
-    before = cli._snapshot_identifier(str(snap))
-    after = cli._snapshot_identifier(str(snap))
+    # A warm blob store left untouched: before == after -> verified (no
+    # transfer), even if snapshot symlinks were recreated (we only fingerprint
+    # blobs/).
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    (blobs / "aabbcc").write_bytes(b"\x00" * 2048)
+    before = cli._blob_identifier(tmp_path)
+    after = cli._blob_identifier(tmp_path)
     assert before == after != ()
 
-    # A real fetch adds a file -> the inventory changes -> Download.
-    (snap / "config.json").write_bytes(b"{}")
-    assert cli._snapshot_identifier(str(snap)) != before
+    # A real fetch materializes a new blob -> the inventory changes -> Download.
+    (blobs / "config").write_bytes(b"{}")
+    assert cli._blob_identifier(tmp_path) != before
 
-    # A fetched ZERO-byte file (new row, no bytes) still changes the inventory
+    # A fetched ZERO-byte file (new, empty blob) still changes the inventory
     # -> Download, never a false cache hit (carried from codex round-4 #3).
-    (snap / "empty.bin").write_bytes(b"")
-    assert cli._snapshot_identifier(str(snap)) != before
+    (blobs / "empty").write_bytes(b"")
+    assert cli._blob_identifier(tmp_path) != before
 
-    # The authentic fresh-pull transition: an ABSENT snapshot fingerprints
-    # empty (()) before, and the populated dir fingerprints non-empty after —
-    # a genuine download (not a tautological assertion).
-    fresh = tmp_path / "fresh-snap"
-    assert cli._snapshot_identifier(str(fresh)) == ()
-    fresh.mkdir()
-    (fresh / "model.safetensors").write_bytes(b"\x00" * 2048)
-    fresh_after = cli._snapshot_identifier(str(fresh))
-    assert fresh_after != () and fresh_after != cli._snapshot_identifier(
-        str(tmp_path / "fresh-snap-does-not-exist")
-    )
+    # A REPAIR of an existing blob (mtime/size change) -> Download (the exact
+    # case a snapshot-symlink fingerprint would miss).
+    (blobs / "aabbcc").write_bytes(b"\x00" * 4096)
+    repaired = cli._blob_identifier(tmp_path)
+    assert repaired != before
+
+    # .incomplete* scratch churn must NOT change the transfer verdict.
+    (blobs / ".incomplete-somehash").write_bytes(b"")
+    assert cli._blob_identifier(tmp_path) == repaired
+
+    # Authentic fresh-pull transition: absent blobs (()) before, populated
+    # after — a genuine download (not tautological).
+    fresh = tmp_path / "fresh"
+    assert cli._blob_identifier(fresh) == ()
+    (fresh / "blobs").mkdir(parents=True)
+    (fresh / "blobs" / "cafe").write_bytes(b"\x00" * 512)
+    assert cli._blob_identifier(fresh) != ()
 
 
-def test_hf_snapshot_dir_for_resolves_cached_snapshot(
+def test_hf_cache_root_resolves_owner_and_single_component(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_hf_snapshot_dir_for`` locates the current on-disk snapshot (the
-    before-side target) purely from the hub cache, with no network — and
-    returns None when nothing is cached yet (Codex #2392 before-side)."""
-    revision = "abc123" * 6
-    cache_root, snapshot_dir = _hf_snapshot_layout(
-        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
+    """``_hf_cache_root`` resolves the HF cache ``models--<id>`` dir from the
+    hub cache with no network, for BOTH ``owner/repo`` and single-component
+    repo ids (Codex #2392), and returns None when HF_HUB_CACHE is unavailable.
+    """
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    assert cli._hf_cache_root("mlx-community/Qwen3-0.6B-4bit") == Path(
+        tmp_path / "models--mlx-community--Qwen3-0.6B-4bit"
     )
-    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
-    assert cli._hf_snapshot_dir_for("mlx-community/Qwen3-0.6B-4bit") == Path(
-        snapshot_dir
-    )
-
-    # Nothing cached yet -> no before-side dir to fingerprint.
-    cache_root2, _ = _hf_snapshot_layout(
-        "mlx-community/Qwen3-0.6B-4bit",
-        revision,
-        tmp_path / "fresh",
-        already_cached=False,
-    )
-    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root2))
-    assert cli._hf_snapshot_dir_for("mlx-community/Qwen3-0.6B-4bit") is None
+    # Single-component (no '/') must map to models--<repo>, not a broken path.
+    assert cli._hf_cache_root("Qwen3-0.6B") == Path(tmp_path / "models--Qwen3-0.6B")
 
 
 def test_print_pull_summary_was_cached_branch(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -38,6 +38,37 @@ def _make_fake_snapshot(root: Path, total_bytes: int) -> Path:
     return root
 
 
+def _hf_snapshot_layout(
+    repo_id: str,
+    revision: str,
+    root: Path,
+    *,
+    files: dict[str, bytes] | None = None,
+    already_cached: bool = False,
+) -> tuple[Path, Path]:
+    """Build a deterministic HF cache entry ``root/models--<id>/`` for the
+    HF-fallback transfer-account tests.
+
+    Returns ``(cache_root, snapshot_dir)``. Points ``refs/main`` at
+    ``revision``. When ``already_cached`` the snapshot dir already exists
+    with ``files`` (a warm, fully-cached pull leaves it untouched); when not,
+    no snapshot exists up front — the test's ``snapshot_download`` mock is
+    expected to create one during the pull so the before-inventory is empty.
+    ``repo_id`` must map to no catalog subfolder (the tests use
+    ``mlx-community/Qwen3-0.6B-4bit``), so the layout is flat.
+    """
+    cache_root = root / "hub"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    (repo_root / "refs").mkdir(parents=True, exist_ok=True)
+    (repo_root / "refs" / "main").write_text(revision)
+    snapshot_dir = repo_root / "snapshots" / revision
+    if already_cached:
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        for name, data in (files or {"model.safetensors": b"\x00" * 2048}).items():
+            (snapshot_dir / name).write_bytes(data)
+    return cache_root, snapshot_dir
+
+
 def _looks_like_size(token: str) -> bool:
     """Loose acceptance of either SI (``GB``) or IEC (``GiB``) suffixes.
 
@@ -62,20 +93,28 @@ def _summary_line(captured: str) -> str:
 def test_summary_printed_on_hf_success(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """HF-fallback path prints ``Downloaded ... — <size> in <duration>``."""
-    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+    revision = "abc123" * 6
+    cache_root, snapshot_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    def _download(*_args, **_kwargs):
+        # Not cached at entry (no resolved snapshot); the pull actually
+        # transfers bytes — the before-inventory is empty and the after-side
+        # (this freshly-written snapshot) differs, so the summary is a download.
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / "model.safetensors").write_bytes(b"\x00" * 2048)
+        return str(snapshot_dir)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
 
     with (
-        # Not cached at entry (no resolved snapshot), so this pull actually
-        # transfers bytes — the summary reports a download.
         patch.object(cli, "_try_mirror_prefetch", return_value=False),
-        patch(
-            "huggingface_hub.snapshot_download",
-            return_value=str(snapshot_dir),
-        ),
+        patch("huggingface_hub.snapshot_download", side_effect=_download),
     ):
         cli.pull_command(args)
 
@@ -94,26 +133,25 @@ def test_summary_printed_on_hf_success(
 def test_hf_cached_fallback_reports_verified(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A cached no-op on the HF-fallback path is labelled ``Already cached``.
 
-    codex round-4 BLOCKING #2/#3: even when the mirror miss forces the HF
-    fallback, a pull that transfers zero bytes must NOT print ``Downloaded``.
-    Here ``snapshot_download`` constructs the real ``unit="B"`` byte bars the
-    way huggingface_hub 1.28 does but records zero bytes (all files cached),
-    so the pull is reported as verified, not downloaded.
+    Even when the mirror miss forces the HF fallback, a pull that transfers
+    zero bytes must NOT print ``Downloaded``. The transfer account is the
+    stable on-disk snapshot inventory BEFORE vs AFTER the pull (Codex #2392,
+    no huggingface_hub tqdm-progress internals): a warm, fully-cached pull
+    leaves the snapshot untouched, so before == after and it reports verified.
     """
-    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+    revision = "abc123" * 6
+    cache_root, snapshot_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _download(*args, tqdm_class=None, **_kwargs):
-        # The transfer ("Download") bar exists but never updates = nothing
-        # crossed the network (cached). The reconstruction bar IS updated (HF
-        # writes the symlink/dedup metadata to disk on a warm pull) and the
-        # file bar advances per cached file, but neither is network traffic
-        # (codex round-4 #2) — so the label must stay "Already cached".
-        tqdm_class(desc="Downloading bytes", total=0, unit="B")
-        tqdm_class(desc="Reconstructing", total=4096, unit="B").update(4096)
-        tqdm_class(desc="Fetching 7 files", total=7, unit="it").update(7)
+    def _download(*_args, **_kwargs):
+        # A warm pull touches NOTHING on disk: the snapshot was already there,
+        # complete. before == after -> verified.
         return str(snapshot_dir)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
@@ -133,20 +171,26 @@ def test_hf_cached_fallback_reports_verified(
 def test_hf_fetch_zero_byte_file_counts_as_download(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A fetched zero-byte file is a network fetch, not a cache hit.
 
-    codex round-4 BLOCKING #3: a transfer bar that records zero bytes could
-    be mislabelled "Already cached". HF still calls ``update()`` on the
-    transfer bar for a fetched file even when it is zero-byte; ``_touched``
-    flags that as a real network fetch, so the summary says ``Downloaded``.
+    codex round-4 BLOCKING #3 carried over to the stable seam: a fetched
+    zero-byte file adds a NEW row to the snapshot inventory (the file did not
+    exist before), so before != after and the summary says ``Downloaded`` even
+    though the file carries no bytes.
     """
-    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+    revision = "abc123" * 6
+    cache_root, snapshot_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _download(*args, tqdm_class=None, **_kwargs):
-        # A file was fetched but its size is 0 bytes.
-        tqdm_class(desc="Downloading bytes", total=0, unit="B").update(0)
-        tqdm_class(desc="Reconstructing", total=0, unit="B")
+    def _download(*_args, **_kwargs):
+        # The pull fetched a file that is 0 bytes: it appears in the
+        # snapshot now (a new inventory row) though it carries no bytes.
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / "empty.bin").write_bytes(b"")
         return str(snapshot_dir)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
@@ -165,14 +209,20 @@ def test_hf_fetch_zero_byte_file_counts_as_download(
 def test_hf_fallback_transfers_bytes_as_download(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A real HF-fallback transfer (byte bar records bytes) is a download."""
-    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+    """A real HF-fallback transfer is a download: the snapshot inventory
+    changes across the pull (files appear), so before != after -> Downloaded."""
+    revision = "abc123" * 6
+    cache_root, snapshot_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _download(*args, tqdm_class=None, **_kwargs):
-        # The transfer byte-bar recorded 2048 bytes -> a real download.
-        tqdm_class(desc="Downloading bytes", total=2048, unit="B").update(2048)
-        tqdm_class(desc="Reconstructing", total=0, unit="B")
+    def _download(*_args, **_kwargs):
+        # A real fetch creates the snapshot with 2048 bytes of content.
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / "model.safetensors").write_bytes(b"\x00" * 2048)
         return str(snapshot_dir)
 
     args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
@@ -359,45 +409,62 @@ def test_format_pull_duration_units() -> None:
     assert cli._format_pull_duration(119.9) == "2m 0s"
 
 
-def test_hf_bytes_bar_tracks_transfer_and_reports_network_fetch() -> None:
-    """The network-transfer bar class (issue #2349) detects a real fetch.
-
-    ``_hf_bytes_bar_class`` returns a tqdm subclass that records ONLY the
-    network-transfer bar (``unit="B"`` + ``desc.startswith("Download")``),
-    flags ``_touched`` on any ``update()`` (even ``n=0``, for zero-byte
-    files), and ``_hf_network_fetch`` turns that into the authoritative
-    transfer verdict. These exercise the real construction path with no
-    network and no MLX.
+def test_snapshot_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
+    """``_snapshot_identifier`` fingerprints snapshot content so a before/after
+    comparison classifies the pull without huggingface_hub tqdm internals
+    (Codex #2392). The cases directly mirror the old byte-bar verdicts:
+    unchanged content == cache hit; any new/changed file — INCLUDING a newly
+    fetched zero-byte file — == a network fetch.
     """
-    # Each call to ``_hf_bytes_bar_class`` returns a fresh tqdm subclass
-    # with its own ``_bar_instances``, so the four cases below are isolated.
+    # Nothing cached yet -> empty fingerprint (before-side of a fresh pull).
+    assert cli._snapshot_identifier(None) == ()
+    assert cli._snapshot_identifier(str(tmp_path / "does-not-exist")) == ()
 
-    # No transfer bar constructed -> unknown (None), never a false cache hit.
-    empty = cli._hf_bytes_bar_class()
-    assert cli._hf_network_fetch(empty) is None
+    # A warm, untouched snapshot: before == after -> verified (no transfer).
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    (snap / "model.safetensors").write_bytes(b"\x00" * 2048)
+    before = cli._snapshot_identifier(str(snap))
+    after = cli._snapshot_identifier(str(snap))
+    assert before == after != ()
 
-    # A non-transfer file bar (unit "it") is NOT registered as a transfer →
-    # still None (the file bar counts completions, not network bytes).
-    base = cli._hf_bytes_bar_class()
-    file_bar = base(unit="it", desc="Fetching 4 files", total=10)
-    file_bar.update(n=10)
-    file_bar.close()
-    assert cli._hf_network_fetch(base) is None
+    # A real fetch adds a file -> the inventory changes -> Download.
+    (snap / "config.json").write_bytes(b"{}")
+    assert cli._snapshot_identifier(str(snap)) != before
 
-    # A transfer bar CONSTRUCTED but never updated -> False (clean cache hit).
-    cached_cls = cli._hf_bytes_bar_class()
-    cached_bar = cached_cls(unit="B", desc="Downloading model.safetensors", total=None)
-    cached_bar.close()
-    assert cli._hf_network_fetch(cached_cls) is False
+    # A fetched ZERO-byte file (new row, no bytes) still changes the inventory
+    # -> Download, never a false cache hit (carried from codex round-4 #3).
+    (snap / "empty.bin").write_bytes(b"")
+    assert cli._snapshot_identifier(str(snap)) != before
 
-    # A transfer bar that observes an update() -> True, including an n=0
-    # (zero-byte) file, which still orchestrates a fetch.
-    fetched = cli._hf_bytes_bar_class()
-    transfer = fetched(unit="B", desc="Downloading model.safetensors", total=None)
-    transfer.update(n=0)  # zero-byte file still counts as a transfer
-    transfer.update(n=512)
-    transfer.close()
-    assert cli._hf_network_fetch(fetched) is True
+    # Empty vs populated: a fresh pull's before (()) differs from after.
+    assert before == () or after != ()
+
+
+def test_hf_snapshot_dir_for_resolves_cached_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_hf_snapshot_dir_for`` locates the current on-disk snapshot (the
+    before-side target) purely from the hub cache, with no network — and
+    returns None when nothing is cached yet (Codex #2392 before-side)."""
+    revision = "abc123" * 6
+    cache_root, snapshot_dir = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    assert cli._hf_snapshot_dir_for("mlx-community/Qwen3-0.6B-4bit") == Path(
+        snapshot_dir
+    )
+
+    # Nothing cached yet -> no before-side dir to fingerprint.
+    cache_root2, _ = _hf_snapshot_layout(
+        "mlx-community/Qwen3-0.6B-4bit",
+        revision,
+        tmp_path / "fresh",
+        already_cached=False,
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root2))
+    assert cli._hf_snapshot_dir_for("mlx-community/Qwen3-0.6B-4bit") is None
 
 
 def test_print_pull_summary_was_cached_branch(

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -176,15 +176,21 @@ def test_hf_fetch_zero_byte_file_counts_as_download(
     fetched zero-byte file creates a NEW blob (the file did not exist before),
     so the blob inventory changes even though the file carries no bytes, and
     the summary says ``Downloaded``.
+
+    The cache is seeded with ONE pre-existing blob so ``_before != ()`` —
+    otherwise an empty pre-pull fingerprint already forces ``_was_cached = False``
+    and the test would pass without ever exercising the blob transition.
     """
     revision = "abc123" * 6
     cache_root, blob_dir = _hf_snapshot_layout(
-        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=False
+        "mlx-community/Qwen3-0.6B-4bit", revision, tmp_path, already_cached=True
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     def _download(*_args, **_kwargs):
-        # The pull fetched a file that is 0 bytes: a NEW (empty) blob appears.
+        # The pull fetched a NEW file that is 0 bytes: a distinct empty blob
+        # appears (the store starts non-empty via the seeded blob). The
+        # transition is what must drive the "Downloaded" verdict.
         (blob_dir / "deadbeef").write_bytes(b"")
         return str(blob_dir.parent / "snapshots" / revision)
 
@@ -434,10 +440,15 @@ def test_blob_identifier_is_a_stable_transfer_seam(tmp_path: Path) -> None:
     assert cli._blob_identifier(tmp_path) != before
 
     # A REPAIR of an existing blob (mtime/size change) -> Download (the exact
-    # case a snapshot-symlink fingerprint would miss).
+    # case a snapshot-symlink fingerprint would miss). Snapshot the fingerprint
+    # immediately BEFORE the rewrite and compare against THAT, not the original
+    # ``before`` — the intervening ``config``/``empty`` additions already make
+    # ``before`` unequal, so comparing to ``before`` would not prove the
+    # modification itself is detected.
+    pre_repair = cli._blob_identifier(tmp_path)
     (blobs / "aabbcc").write_bytes(b"\x00" * 4096)
     repaired = cli._blob_identifier(tmp_path)
-    assert repaired != before
+    assert repaired != pre_repair
 
     # .incomplete* scratch churn must NOT change the transfer verdict.
     (blobs / ".incomplete-somehash").write_bytes(b"")

--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -529,6 +529,108 @@ def test_hf_cache_root_resolves_owner_and_single_component(
     assert cli._hf_cache_root("Qwen3-0.6B") == Path(tmp_path / "models--Qwen3-0.6B")
 
 
+def test_hf_cache_root_prefers_repo_name_to_id_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_hf_cache_root`` uses HF's ``repo_name_to_id`` when the installed
+    version exposes it (Codex #2392 success branch). The concurrent no-MLX
+    matrix's huggingface_hub usually lacks this symbol, so the fallback
+    (``repo_id.replace``) is what the other tests exercise; this pins the
+    preferred branch so diff-cover sees it and a future HF upgrade that adds
+    the symbol can't regress the path silently.
+    """
+    import huggingface_hub.utils as _hf_utils
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    # The current huggingface_hub lacks ``repo_name_to_id`` (that's exactly
+    # why the fallback branch is what other tests exercise). Inject it on the
+    # real module so ``_hf_cache_root``'s ``from huggingface_hub.utils import
+    # repo_name_to_id`` resolves and runs the success branch.
+    monkeypatch.setattr(
+        _hf_utils,
+        "repo_name_to_id",
+        lambda repo_id: repo_id.replace("/", "--").upper(),
+        raising=False,
+    )
+    # ``owner/repo`` is normalized by the monkeypatched repo_name_to_id.
+    assert cli._hf_cache_root("mlx-community/Qwen3-0.6B-4bit") == Path(
+        tmp_path / "models--MLX-COMMUNITY--QWEN3-0.6B-4BIT"
+    )
+
+
+def test_hf_cache_root_returns_none_when_hf_constants_unimportable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_hf_cache_root`` returns None when ``HF_HUB_CACHE`` cannot be
+    imported (Codex #2392 OSError/import-failure branch) — the caller treats
+    this as "no cache configured" rather than crashing.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _guard(name, *args, **kwargs):
+        if name == "huggingface_hub.constants":
+            raise ImportError("simulated missing HF_HUB_CACHE")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _guard)
+    assert cli._hf_cache_root("mlx-community/Qwen3-0.6B-4bit") is None
+
+
+def test_blob_identifier_listdir_oserror_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_blob_identifier`` returns ``()`` when listing ``blobs/`` raises
+    OSError (EACCES / a permissive mount) instead of propagating — an empty
+    inventory is a safe no-transfer baseline (Codex #2392).
+    """
+    import os
+
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    (blobs / "cafe").write_bytes(b"\x00" * 512)
+
+    original_listdir = os.listdir
+
+    def _raising_listdir(path):
+        if str(path) == str(blobs):
+            raise OSError("simulated listdir failure")
+        return original_listdir(path)
+
+    monkeypatch.setattr(os, "listdir", _raising_listdir)
+    assert cli._blob_identifier(tmp_path) == ()
+
+
+def test_blob_identifier_stat_oserror_skips_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_blob_identifier`` skips (does not crash on) a blob whose ``stat()``
+    raises OSError (e.g. a vanished/transiently-locked file) and still returns
+    the rest of the inventory (Codex #2392).
+    """
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    good = blobs / "good"
+    good.write_bytes(b"\x00" * 64)
+    bad = blobs / "bad"
+    bad.write_bytes(b"\x00" * 32)
+
+    original_stat = Path.stat
+    bad_s = f"{bad}"
+
+    def _raising_stat(self, *args, **kwargs):
+        if str(self) == bad_s:
+            raise OSError("simulated stat failure")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _raising_stat)
+    ident = cli._blob_identifier(tmp_path)
+    # "bad" is skipped; "good" still fingerprints.
+    assert ("good", 64, ident[0][2]) in ident
+    assert all(row[0] != "bad" for row in ident)
+
+
 def test_print_pull_summary_was_cached_branch(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1425,40 +1425,34 @@ def _safe_display_name(fname: str, max_len: int = 80) -> str:
     return cleaned
 
 
-def _blob_fingerprint(repo_root) -> tuple[tuple[str, int, int], ...]:
-    """Sorted ``(name, size, mtime_ns)`` of every real blob under ``blobs/``.
+def _hf_landed_blob_predated_pull(
+    hf_path: str | None,
+    predicted: Path,
+    pull_start_wall: float,
+) -> bool:
+    """True when the HF-fallback file's byte-backed blob already existed before
+    this pull started (a warm re-link, zero bytes transferred).
 
-    The mirror's stable transfer signal (Codex #2392): a NEW/MODIFIED blob is
-    the only thing meaning bytes crossed the wire. ``network_fetch`` compares
-    this before vs after the per-file pool, so a warm fallback that merely
-    re-links snapshot symlinks to ALREADY-LOCAL blobs is not counted as a
-    fetch — regardless of whether the catalog exposed a sha256 (the
-    ``expected_sha256``-only check missed non-LFS files, whose blobs HF stores
-    under their own blob id). ``.incomplete*`` scratch is excluded (HF churn).
+    ``hf_hub_download`` returns the snapshot path, normally a relative symlink
+    to ``blobs/<sha>``. We resolve it to the real blob and compare its mtime
+    against ``pull_start_wall``: a blob written before the pull began was
+    already on disk, so HF only re-linked it -> "cached". A fresh blob (mtime
+    >= pull start, including a freshly-written zero-byte blob) means HF wrote
+    bytes this pull -> "hf".
+
+    This is per-file and O(1): it stats only THIS file's resolved blob, never
+    the whole ``blobs/`` store — so it carries no shared-cache race and no
+    O(N×B) scan (Codex #2392 R5). On any failure to resolve/stat we fall back
+    to assuming a real download ("not predated"), which only risks a display-
+    level over-count, never an under-count.
     """
-    import os as _os
-
-    if not repo_root:
-        return ()
-    blob_dir = repo_root / "blobs"
-    if not blob_dir.is_dir():
-        return ()
-    rows: list[tuple[str, int, int]] = []
     try:
-        names = _os.listdir(blob_dir)
+        src = Path(hf_path) if hf_path else predicted
+        resolved = src.resolve(strict=True)
+        mtime_ns = resolved.stat().st_mtime_ns
     except OSError:
-        return ()
-    for name in names:
-        if name.startswith(".incomplete"):
-            continue
-        p = blob_dir / name
-        try:
-            if p.is_file():
-                st = p.stat()
-                rows.append((name, st.st_size, st.st_mtime_ns))
-        except OSError:
-            continue
-    return tuple(sorted(rows))
+        return False
+    return mtime_ns < int(pull_start_wall * 1e9)
 
 
 def download_with_mirror_fallback(
@@ -1624,10 +1618,6 @@ def download_with_mirror_fallback(
     cache_root = cache_dir if cache_dir else _hf_cache_root()
     owner, _, repo = repo_id.partition("/")
     repo_root = cache_root / f"models--{owner}--{repo}"
-    # Stable transfer account (Codex #2392): fingerprint the BLOB store before
-    # the per-file pool so we can tell a warm re-link from a real fetch, even
-    # for non-LFS files with no catalog sha256.
-    blobs_before = _blob_fingerprint(repo_root)
     snap_dir = repo_root / "snapshots" / revision
     refs_dir = repo_root / "refs"
     # Codex round-14 BLOCKING #1+#2: keep ``.part`` and ``.lock``
@@ -1972,22 +1962,26 @@ def download_with_mirror_fallback(
         # collide with our aggregate UI; keep it for weight/unknown-size
         # files (see ``_should_suppress_hf_bar``).
         #
-        # Stable transfer-account seam (Codex #2392, R4 BLOCKING): before the
-        # HF call, fingerprint the local BLOB store (sorted name/size/mtime of
-        # every real blob under ``blobs/``). If ``hf_hub_download`` only
-        # re-links a blob that was ALREADY in HF's local cache, the store is
-        # unchanged — zero bytes cross the wire — so the outcome is a "cached"
-        # no-transfer, not a fetch. If it materializes or repairs a blob
-        # (bytes crossed the wire), the store changes -> "hf". Unlike the
-        # earlier ``blob_already_local`` check (which needed ``expected_sha256``
-        # and left non-LFS files always classified "hf"), this also classifies
-        # files whose blob key the catalog does not expose (config.json etc.).
-        # A worker that really downloads always writes its own blob, so a real
-        # fetch is never misread as cached; a relink racing an unrelated
-        # concurrent write can only over-count, never under-count. Keyed on the
-        # local file inventory (public size/mtime), never on huggingface_hub's
-        # tqdm progress internals.
-        blobs_before_file = _blob_fingerprint(repo_root)
+        # Stable transfer-account seam (Codex #2392 R5): detect a warm HF
+        # re-link per-file, WITHOUT a shared-cache blob diff — a repository-
+        # wide diff is racy under concurrent workers / foreign processes and
+        # costs O(N×B) scandir to compute per file (Codex #2392 R5 #1/#2/#3).
+        #   * LFS files (catalog exposes ``expected_sha256``): the blob key is
+        #     known, so probe ``blobs/<sha>`` directly — O(1), deterministic,
+        #     immune to other workers. If it is present BEFORE the call,
+        #     ``hf_hub_download`` only re-links it (zero bytes) -> "cached".
+        #   * Non-LFS files (no catalog sha): the blob key is unknowable ahead
+        #     of time, so after the call we resolve the SPECIFIC blob this file
+        #     landed on and compare its mtime to this pull's start. A blob that
+        #     predates the pull was already on disk -> "cached"; a fresh blob
+        #     (mtime >= pull start) means HF wrote bytes -> "hf". This is
+        #     per-file (O(1)), not a whole-store scan.
+        blob_already_local = False
+        if expected_sha256 is not None:
+            try:
+                blob_already_local = (repo_root / "blobs" / expected_sha256).is_file()
+            except OSError:
+                blob_already_local = False
         ok, hf_path = _hf_fallback_one(
             repo_id,
             fname,
@@ -2009,11 +2003,15 @@ def download_with_mirror_fallback(
                     size = (snap_dir / fname).stat().st_size
             except OSError:
                 size = 0
-            # If the blob store was unchanged across this HF call, the file was
-            # satisfied from HF's LOCAL blob cache (a warm re-link) — no bytes
-            # transferred (Codex #2392 R4). Classify as "cached", not "hf", so
-            # `network_fetch`/`transferred_bytes` don't mislabel a warm pull.
-            was_hf_fetch = blobs_before_file != _blob_fingerprint(repo_root)
+            # A warm re-link of an already-local blob (either kind) transfers
+            # no bytes -> "cached", so `network_fetch`/`transferred_bytes`
+            # never mislabel a warm pull as a download (Codex #2392 R5).
+            if blob_already_local:
+                was_hf_fetch = False
+            else:
+                was_hf_fetch = not _hf_landed_blob_predated_pull(
+                    hf_path, snap_dir / fname, pull_start_wall
+                )
             return fname, ("hf" if was_hf_fetch else "cached"), size
 
         return fname, "miss", 0
@@ -2034,6 +2032,13 @@ def download_with_mirror_fallback(
     # Issue #651 follow-up: track elapsed wall-time for the final
     # summary so users see throughput, not just total bytes.
     pull_started = time.monotonic()
+    # Wall-clock twin used by the HF-fallback transfer probe (Codex #2392
+    # R5): a blob whose mtime predates the pull start was already on disk, so
+    # a re-link that merely points at it is "cached", not a fetch. Captured
+    # once here (worker closure) so every ``_do_file`` compares against the
+    # same pull boundary. NS-precision ``st_mtime_ns`` vs this float is fine
+    # on a single host.
+    pull_start_wall = time.time()
     completed = 0
     # Issue #689: wrap the pool block in try/finally so the final
     # ``progress_tracker.flush()`` always fires — even when a worker
@@ -2139,6 +2144,24 @@ def download_with_mirror_fallback(
         # 100% before the failure banner.
         progress_tracker.flush()
 
+    # Transfer account — populated on EVERY exit path (success AND partial
+    # miss), so ``pull_command`` combines a failed/partial mirror attempt
+    # with its HF-fallback baseline instead of discarding the bytes the
+    # mirror DID fetch (Codex #2392 R5 + #2353). ``network_fetch`` is the
+    # authoritative "did THIS invocation fetch anything over the wire?" —
+    # aggregated from the per-file classifications, never a shared-cache blob
+    # diff, so concurrent processes cannot pollute it (Codex #2392 R5 #1/#2).
+    # ``r2_hits``/``hf_hits`` are bumped only for files this worker actually
+    # fetched: R2 workers return "cached" before fetching when the target
+    # already exists, and an HF worker re-linking an already-local blob
+    # classifies "cached" (LFS via the pre-call blob probe; non-LFS via the
+    # resolved blob's pre-pull mtime). A fetched zero-byte file still counts
+    # (its freshly-written blob classifies hf). ``bool(r2_hits) or
+    # bool(hf_hits)`` is therefore foreign-process-immune and O(1).
+    if out is not None:
+        out["transferred_bytes"] = transferred_bytes
+        out["network_fetch"] = bool(r2_hits) or bool(hf_hits)
+
     if misses:
         # At least one file we couldn't get from either source. Caller
         # should fall back to ``snapshot_download`` — it has more retry
@@ -2201,29 +2224,9 @@ def download_with_mirror_fallback(
             f"{DIM}(HF: {hf_hits}){RESET}{suffix}"
         )
     else:
-        # All files were already cached — quiet success.
+        # All files were already cached — quiet success. NB ``out`` was
+        # already populated before the ``if misses`` branch above, so the
+        # "Already cached" label here is consistent with what the caller
+        # reads from ``out["network_fetch"]``.
         _print_dim(f"  {BOLD}Already cached{RESET} ({len(files)} files, {mb:.0f} MB)")
-    if out is not None:
-        out["transferred_bytes"] = transferred_bytes
-        # Authoritative "did we fetch anything over the wire this pull?" —
-        # distinct from the byte count so a fetched zero-byte file still
-        # counts as a transfer (codex round-4 BLOCKING #4).
-        #
-        # Two independent signals, OR'd (Codex #2392 + R4 BLOCKING):
-        #   1. ``bool(r2_hits)`` — any R2 worker actually fetched a file
-        #      over the wire. R2 serves non-LFS / no-catalog-sha256 files
-        #      straight into ``snapshots/<rev>/`` WITHOUT touching HF's
-        #      ``blobs/`` store, so those transfers are invisible to the
-        #      blob diff yet are genuine fetches. ``_do_file`` returns
-        #      "cached" before ever calling R2 when the target already
-        #      exists, so a warm R2 pull does not bump ``r2_hits``.
-        #   2. ``blobs_before != _blob_fingerprint(repo_root)`` — an HF
-        #      fallback materialized a new/modified blob (bytes crossed the
-        #      wire). A warm re-link of an already-local blob does NOT
-        #      change the blob store, so it is not counted as a fetch
-        #      (matching the ``blob_already_local`` "cached" classification
-        #      in ``_do_file``).
-        out["network_fetch"] = bool(r2_hits) or (
-            blobs_before != _blob_fingerprint(repo_root)
-        )
     return True

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1432,8 +1432,14 @@ def download_with_mirror_fallback(
     revision: str | None = None,
     on_pull_start: Callable[[], None] | None = None,
     allow_patterns: list[str] | None = None,
+    out: dict | None = None,
 ) -> bool:
     """Download ``repo_id`` to the HF cache via R2-first / HF-fallback.
+
+    ``out`` (optional) receives ``out["transferred_bytes"]`` = the count of
+    bytes actually fetched over the wire this pull (R2 + HF-fallback only;
+    warm ``cached`` hits are excluded). ``pull_command`` uses it to say
+    "already cached … (nothing to download)" truthfully (issue #2349).
 
     Returns True if every file landed in the snapshot dir (mix of R2 +
     HF is fine). Returns False if the caller should fall back to the
@@ -1718,6 +1724,12 @@ def download_with_mirror_fallback(
     hf_hits = 0
     misses: list[str] = []
     total_bytes = 0
+    # Bytes actually transferred over the wire this pull (R2 + HF-fallback
+    # files). ``total_bytes`` also counts warm ``cached`` hits, which helps
+    # the progress bar but must NOT be reported as a download — the pull
+    # summary needs the fresh-only count so a warm pull says "already
+    # cached / nothing to download" truthfully (issue #2349).
+    transferred_bytes = 0
 
     def _do_file(
         item: tuple[str, int | None, str | None],
@@ -1988,9 +2000,11 @@ def download_with_mirror_fallback(
                 if kind == "r2":
                     r2_hits += 1
                     total_bytes += size
+                    transferred_bytes += size
                 elif kind == "hf":
                     hf_hits += 1
                     total_bytes += size
+                    transferred_bytes += size
                     # HF fallback's tqdm doesn't feed into the R2 chunk loop,
                     # so the aggregate tracker would miss these bytes
                     # entirely. Bump it at completion so the heartbeat
@@ -2122,4 +2136,6 @@ def download_with_mirror_fallback(
     else:
         # All files were already cached — quiet success.
         _print_dim(f"  {BOLD}Already cached{RESET} ({len(files)} files, {mb:.0f} MB)")
+    if out is not None:
+        out["transferred_bytes"] = transferred_bytes
     return True

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1926,6 +1926,21 @@ def download_with_mirror_fallback(
         # Mute HF's tqdm for confirmed-small metadata files so it doesn't
         # collide with our aggregate UI; keep it for weight/unknown-size
         # files (see ``_should_suppress_hf_bar``).
+        #
+        # Stable transfer-account seam (Codex #2392): before the HF call,
+        # record whether this file's blob ALREADY exists in HF's local cache
+        # (``blobs/<sha>``). When it does, ``hf_hub_download`` only
+        # materializes the missing snapshot link from the local blob — zero
+        # bytes cross the wire — so the outcome is a "cached" no-transfer, not
+        # a fetch. When the blob is absent, a success IS a real network fetch.
+        # This keyed on the local file inventory (public, size/hash), never on
+        # huggingface_hub's tqdm progress internals.
+        blob_already_local = False
+        if expected_sha256 is not None:
+            try:
+                blob_already_local = (repo_root / "blobs" / expected_sha256).is_file()
+            except OSError:
+                blob_already_local = False
         ok, hf_path = _hf_fallback_one(
             repo_id,
             fname,
@@ -1947,7 +1962,11 @@ def download_with_mirror_fallback(
                     size = (snap_dir / fname).stat().st_size
             except OSError:
                 size = 0
-            return fname, "hf", size
+            # If the blob was already in HF's local cache, hf_hub_download only
+            # linked it into the snapshot — no bytes were transferred. Classify
+            # as "cached", not "hf", so `network_fetch` doesn't mislabel a warm
+            # pull as a download (Codex #2392; stable local-file-inventory seam).
+            return fname, ("cached" if blob_already_local else "hf"), size
 
         return fname, "miss", 0
 

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1425,36 +1425,6 @@ def _safe_display_name(fname: str, max_len: int = 80) -> str:
     return cleaned
 
 
-def _hf_landed_blob_predated_pull(
-    hf_path: str | None,
-    predicted: Path,
-    pull_start_wall: float,
-) -> bool:
-    """True when the HF-fallback file's byte-backed blob already existed before
-    this pull started (a warm re-link, zero bytes transferred).
-
-    ``hf_hub_download`` returns the snapshot path, normally a relative symlink
-    to ``blobs/<sha>``. We resolve it to the real blob and compare its mtime
-    against ``pull_start_wall``: a blob written before the pull began was
-    already on disk, so HF only re-linked it -> "cached". A fresh blob (mtime
-    >= pull start, including a freshly-written zero-byte blob) means HF wrote
-    bytes this pull -> "hf".
-
-    This is per-file and O(1): it stats only THIS file's resolved blob, never
-    the whole ``blobs/`` store — so it carries no shared-cache race and no
-    O(N×B) scan (Codex #2392 R5). On any failure to resolve/stat we fall back
-    to assuming a real download ("not predated"), which only risks a display-
-    level over-count, never an under-count.
-    """
-    try:
-        src = Path(hf_path) if hf_path else predicted
-        resolved = src.resolve(strict=True)
-        mtime_ns = resolved.stat().st_mtime_ns
-    except OSError:
-        return False
-    return mtime_ns < int(pull_start_wall * 1e9)
-
-
 def download_with_mirror_fallback(
     repo_id: str,
     cache_dir: Path | None = None,
@@ -1475,6 +1445,10 @@ def download_with_mirror_fallback(
     "did we fetch at all" (see ``network_fetch``) and for the approximate
     download size, not for per-byte metering. ``pull_command`` uses it to say
     "already cached … (nothing to download)" truthfully (issue #2349).
+    Known, accepted limitation (Atlas 2026-08-26): a non-LFS file with no
+    catalog sha256 that warm re-links a locally-cached blob counts as a fetch
+    (classifies ``"hf"``), because the relink is indistinguishable without
+    downloader instrumentation; LFS weight bytes are exact.
 
     Returns True if every file landed in the snapshot dir (mix of R2 +
     HF is fine). Returns False if the caller should fall back to the
@@ -1962,20 +1936,24 @@ def download_with_mirror_fallback(
         # collide with our aggregate UI; keep it for weight/unknown-size
         # files (see ``_should_suppress_hf_bar``).
         #
-        # Stable transfer-account seam (Codex #2392 R5): detect a warm HF
-        # re-link per-file, WITHOUT a shared-cache blob diff — a repository-
-        # wide diff is racy under concurrent workers / foreign processes and
-        # costs O(N×B) scandir to compute per file (Codex #2392 R5 #1/#2/#3).
+        # Stable transfer-account seam (Codex #2392): detect a warm HF re-link
+        # per-file, deterministically and WITHOUT a shared-cache diff (a
+        # repository-wide blob diff is racy under concurrent workers / foreign
+        # processes, and per-file mtime heuristics are fragile on coarse
+        # timestamps — both rejected by Codex).
         #   * LFS files (catalog exposes ``expected_sha256``): the blob key is
         #     known, so probe ``blobs/<sha>`` directly — O(1), deterministic,
         #     immune to other workers. If it is present BEFORE the call,
         #     ``hf_hub_download`` only re-links it (zero bytes) -> "cached".
         #   * Non-LFS files (no catalog sha): the blob key is unknowable ahead
-        #     of time, so after the call we resolve the SPECIFIC blob this file
-        #     landed on and compare its mtime to this pull's start. A blob that
-        #     predates the pull was already on disk -> "cached"; a fresh blob
-        #     (mtime >= pull start) means HF wrote bytes -> "hf". This is
-        #     per-file (O(1)), not a whole-store scan.
+        #     of time, so a warm relink is indistinguishable from a real fetch
+        #     without downloader instrumentation. Per Atlas decision 2026-08-26
+        #     ((A) documented limitation), these classify "hf" — a no-sha tiny
+        #     non-LFS file showing "Downloaded" only when R2 misses AND its
+        #     blob is already local is an ACCEPTED, bounded edge (the weight
+        #     bytes — the actual transfer a pull exists for — are exact via the
+        #     LFS probe above). Follow-up for full exactness: huggingface_hub
+        #     downloader instrumentation, post-0.13.1 Vector lane.
         blob_already_local = False
         if expected_sha256 is not None:
             try:
@@ -2003,16 +1981,11 @@ def download_with_mirror_fallback(
                     size = (snap_dir / fname).stat().st_size
             except OSError:
                 size = 0
-            # A warm re-link of an already-local blob (either kind) transfers
-            # no bytes -> "cached", so `network_fetch`/`transferred_bytes`
-            # never mislabel a warm pull as a download (Codex #2392 R5).
-            if blob_already_local:
-                was_hf_fetch = False
-            else:
-                was_hf_fetch = not _hf_landed_blob_predated_pull(
-                    hf_path, snap_dir / fname, pull_start_wall
-                )
-            return fname, ("hf" if was_hf_fetch else "cached"), size
+            # A warm re-link of an already-local LFS blob transfers no bytes ->
+            # "cached", so `network_fetch`/`transferred_bytes` never mislabel a
+            # warm pull as a download (Codex #2392). Non-LFS re-links (no sha)
+            # are the accepted documented limitation above: they classify "hf".
+            return fname, ("cached" if blob_already_local else "hf"), size
 
         return fname, "miss", 0
 
@@ -2032,13 +2005,6 @@ def download_with_mirror_fallback(
     # Issue #651 follow-up: track elapsed wall-time for the final
     # summary so users see throughput, not just total bytes.
     pull_started = time.monotonic()
-    # Wall-clock twin used by the HF-fallback transfer probe (Codex #2392
-    # R5): a blob whose mtime predates the pull start was already on disk, so
-    # a re-link that merely points at it is "cached", not a fetch. Captured
-    # once here (worker closure) so every ``_do_file`` compares against the
-    # same pull boundary. NS-precision ``st_mtime_ns`` vs this float is fine
-    # on a single host.
-    pull_start_wall = time.time()
     completed = 0
     # Issue #689: wrap the pool block in try/finally so the final
     # ``progress_tracker.flush()`` always fires — even when a worker

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1972,20 +1972,22 @@ def download_with_mirror_fallback(
         # collide with our aggregate UI; keep it for weight/unknown-size
         # files (see ``_should_suppress_hf_bar``).
         #
-        # Stable transfer-account seam (Codex #2392): before the HF call,
-        # record whether this file's blob ALREADY exists in HF's local cache
-        # (``blobs/<sha>``). When it does, ``hf_hub_download`` only
-        # materializes the missing snapshot link from the local blob — zero
-        # bytes cross the wire — so the outcome is a "cached" no-transfer, not
-        # a fetch. When the blob is absent, a success IS a real network fetch.
-        # This keyed on the local file inventory (public, size/hash), never on
-        # huggingface_hub's tqdm progress internals.
-        blob_already_local = False
-        if expected_sha256 is not None:
-            try:
-                blob_already_local = (repo_root / "blobs" / expected_sha256).is_file()
-            except OSError:
-                blob_already_local = False
+        # Stable transfer-account seam (Codex #2392, R4 BLOCKING): before the
+        # HF call, fingerprint the local BLOB store (sorted name/size/mtime of
+        # every real blob under ``blobs/``). If ``hf_hub_download`` only
+        # re-links a blob that was ALREADY in HF's local cache, the store is
+        # unchanged — zero bytes cross the wire — so the outcome is a "cached"
+        # no-transfer, not a fetch. If it materializes or repairs a blob
+        # (bytes crossed the wire), the store changes -> "hf". Unlike the
+        # earlier ``blob_already_local`` check (which needed ``expected_sha256``
+        # and left non-LFS files always classified "hf"), this also classifies
+        # files whose blob key the catalog does not expose (config.json etc.).
+        # A worker that really downloads always writes its own blob, so a real
+        # fetch is never misread as cached; a relink racing an unrelated
+        # concurrent write can only over-count, never under-count. Keyed on the
+        # local file inventory (public size/mtime), never on huggingface_hub's
+        # tqdm progress internals.
+        blobs_before_file = _blob_fingerprint(repo_root)
         ok, hf_path = _hf_fallback_one(
             repo_id,
             fname,
@@ -2007,11 +2009,12 @@ def download_with_mirror_fallback(
                     size = (snap_dir / fname).stat().st_size
             except OSError:
                 size = 0
-            # If the blob was already in HF's local cache, hf_hub_download only
-            # linked it into the snapshot — no bytes were transferred. Classify
-            # as "cached", not "hf", so `network_fetch` doesn't mislabel a warm
-            # pull as a download (Codex #2392; stable local-file-inventory seam).
-            return fname, ("cached" if blob_already_local else "hf"), size
+            # If the blob store was unchanged across this HF call, the file was
+            # satisfied from HF's LOCAL blob cache (a warm re-link) — no bytes
+            # transferred (Codex #2392 R4). Classify as "cached", not "hf", so
+            # `network_fetch`/`transferred_bytes` don't mislabel a warm pull.
+            was_hf_fetch = blobs_before_file != _blob_fingerprint(repo_root)
+            return fname, ("hf" if was_hf_fetch else "cached"), size
 
         return fname, "miss", 0
 

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1425,6 +1425,42 @@ def _safe_display_name(fname: str, max_len: int = 80) -> str:
     return cleaned
 
 
+def _blob_fingerprint(repo_root) -> tuple[tuple[str, int, int], ...]:
+    """Sorted ``(name, size, mtime_ns)`` of every real blob under ``blobs/``.
+
+    The mirror's stable transfer signal (Codex #2392): a NEW/MODIFIED blob is
+    the only thing meaning bytes crossed the wire. ``network_fetch`` compares
+    this before vs after the per-file pool, so a warm fallback that merely
+    re-links snapshot symlinks to ALREADY-LOCAL blobs is not counted as a
+    fetch — regardless of whether the catalog exposed a sha256 (the
+    ``expected_sha256``-only check missed non-LFS files, whose blobs HF stores
+    under their own blob id). ``.incomplete*`` scratch is excluded (HF churn).
+    """
+    import os as _os
+
+    if not repo_root:
+        return ()
+    blob_dir = repo_root / "blobs"
+    if not blob_dir.is_dir():
+        return ()
+    rows: list[tuple[str, int, int]] = []
+    try:
+        names = _os.listdir(blob_dir)
+    except OSError:
+        return ()
+    for name in names:
+        if name.startswith(".incomplete"):
+            continue
+        p = blob_dir / name
+        try:
+            if p.is_file():
+                st = p.stat()
+                rows.append((name, st.st_size, st.st_mtime_ns))
+        except OSError:
+            continue
+    return tuple(sorted(rows))
+
+
 def download_with_mirror_fallback(
     repo_id: str,
     cache_dir: Path | None = None,
@@ -1583,6 +1619,10 @@ def download_with_mirror_fallback(
     cache_root = cache_dir if cache_dir else _hf_cache_root()
     owner, _, repo = repo_id.partition("/")
     repo_root = cache_root / f"models--{owner}--{repo}"
+    # Stable transfer account (Codex #2392): fingerprint the BLOB store before
+    # the per-file pool so we can tell a warm re-link from a real fetch, even
+    # for non-LFS files with no catalog sha256.
+    blobs_before = _blob_fingerprint(repo_root)
     snap_dir = repo_root / "snapshots" / revision
     refs_dir = repo_root / "refs"
     # Codex round-14 BLOCKING #1+#2: keep ``.part`` and ``.lock``
@@ -2159,6 +2199,10 @@ def download_with_mirror_fallback(
         out["transferred_bytes"] = transferred_bytes
         # Authoritative "did we fetch anything over the wire this pull?" —
         # distinct from the byte count so a fetched zero-byte file still
-        # counts as a transfer (codex round-4 BLOCKING #4).
-        out["network_fetch"] = bool(r2_hits or hf_hits)
+        # counts as a transfer (codex round-4 BLOCKING #4). The verdict is the
+        # BLOB-store diff (Codex #2392): a new/modified blob means bytes
+        # crossed the wire; a warm re-link of already-local blobs does NOT
+        # (including non-LFS files with no catalog sha256, which the old
+        # ``bool(r2_hits or hf_hits)`` / sha256-only checks miscounted).
+        out["network_fetch"] = blobs_before != _blob_fingerprint(repo_root)
     return True

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -2138,4 +2138,8 @@ def download_with_mirror_fallback(
         _print_dim(f"  {BOLD}Already cached{RESET} ({len(files)} files, {mb:.0f} MB)")
     if out is not None:
         out["transferred_bytes"] = transferred_bytes
+        # Authoritative "did we fetch anything over the wire this pull?" —
+        # distinct from the byte count so a fetched zero-byte file still
+        # counts as a transfer (codex round-4 BLOCKING #4).
+        out["network_fetch"] = bool(r2_hits or hf_hits)
     return True

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1472,9 +1472,14 @@ def download_with_mirror_fallback(
 ) -> bool:
     """Download ``repo_id`` to the HF cache via R2-first / HF-fallback.
 
-    ``out`` (optional) receives ``out["transferred_bytes"]`` = the count of
-    bytes actually fetched over the wire this pull (R2 + HF-fallback only;
-    warm ``cached`` hits are excluded). ``pull_command`` uses it to say
+    ``out`` (optional) receives ``out["transferred_bytes"]`` = the total
+    completed-file bytes of every file actually fetched over the wire this
+    pull (R2 + HF-fallback only; warm ``cached`` hits are excluded). This is
+    the files' on-disk size after download, NOT a byte-exact wire delta: a
+    resumed partial reuses bytes already written by the prior attempt, so the
+    count can over-state the fresh bytes in a resume. It is authoritative for
+    "did we fetch at all" (see ``network_fetch``) and for the approximate
+    download size, not for per-byte metering. ``pull_command`` uses it to say
     "already cached … (nothing to download)" truthfully (issue #2349).
 
     Returns True if every file landed in the snapshot dir (mix of R2 +
@@ -2199,10 +2204,23 @@ def download_with_mirror_fallback(
         out["transferred_bytes"] = transferred_bytes
         # Authoritative "did we fetch anything over the wire this pull?" —
         # distinct from the byte count so a fetched zero-byte file still
-        # counts as a transfer (codex round-4 BLOCKING #4). The verdict is the
-        # BLOB-store diff (Codex #2392): a new/modified blob means bytes
-        # crossed the wire; a warm re-link of already-local blobs does NOT
-        # (including non-LFS files with no catalog sha256, which the old
-        # ``bool(r2_hits or hf_hits)`` / sha256-only checks miscounted).
-        out["network_fetch"] = blobs_before != _blob_fingerprint(repo_root)
+        # counts as a transfer (codex round-4 BLOCKING #4).
+        #
+        # Two independent signals, OR'd (Codex #2392 + R4 BLOCKING):
+        #   1. ``bool(r2_hits)`` — any R2 worker actually fetched a file
+        #      over the wire. R2 serves non-LFS / no-catalog-sha256 files
+        #      straight into ``snapshots/<rev>/`` WITHOUT touching HF's
+        #      ``blobs/`` store, so those transfers are invisible to the
+        #      blob diff yet are genuine fetches. ``_do_file`` returns
+        #      "cached" before ever calling R2 when the target already
+        #      exists, so a warm R2 pull does not bump ``r2_hits``.
+        #   2. ``blobs_before != _blob_fingerprint(repo_root)`` — an HF
+        #      fallback materialized a new/modified blob (bytes crossed the
+        #      wire). A warm re-link of an already-local blob does NOT
+        #      change the blob store, so it is not counted as a fetch
+        #      (matching the ``blob_already_local`` "cached" classification
+        #      in ``_do_file``).
+        out["network_fetch"] = bool(r2_hits) or (
+            blobs_before != _blob_fingerprint(repo_root)
+        )
     return True

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6370,6 +6370,40 @@ def _format_pull_duration(seconds: float) -> str:
     return f"{minutes}m {secs}s"
 
 
+def _resolve_pull_snapshot_dir(repo_id: str):
+    """Resolve the HF-cache snapshot dir a ``pull`` would populate, or ``None``.
+
+    Mirrors how ``pull_command`` derives ``repo_root/snapshots/<rev>`` after a
+    mirror/HF transfer (including the catalog subfolder narrowing applied in
+    :func:`_print_pull_summary`). Used to capture the snapshot's pre-pull size
+    so the summary can tell "nothing transferred" from a real download without
+    relying on bare local presence (a moved ``main`` can advance the snapshot
+    even when some local rev is already complete — issue #2349, codex round:
+    derive the label from the actual transfer, not pre-pull cache presence).
+    Returns ``None`` when the cache has no resolved snapshot yet (a fresh pull).
+    """
+    from pathlib import Path
+
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    from vllm_mlx.model_aliases import resolve_subfolder
+
+    owner, _, repo = repo_id.partition("/")
+    repo_root = Path(HF_HUB_CACHE) / f"models--{owner}--{repo}"
+    refs_main = repo_root / "refs" / "main"
+    try:
+        rev = refs_main.read_text().strip()
+    except OSError:
+        return None
+    snap = repo_root / "snapshots" / rev
+    sub = resolve_subfolder(repo_id)
+    if sub:
+        cand = snap / sub
+        if cand.is_dir():
+            snap = cand
+    return snap
+
+
 def _snapshot_size_bytes(path) -> int:
     """Sum file sizes under ``path`` (recursively, following symlinks).
 
@@ -6423,13 +6457,18 @@ def _print_pull_summary(
     snapshot_dir,
     elapsed: float,
     *,
-    was_cached: bool = False,
+    pre_size: int | None = None,
 ) -> None:
     """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary.
 
-    When ``was_cached`` is true the pull reused an already-complete snapshot
-    (nothing was transferred), so the summary says the cache was verified
-    rather than claiming a download + transfer time (issue #2349).
+    ``pre_size`` is the snapshot's on-disk size before this pull began
+    (:func:`_resolve_pull_snapshot_dir` + :func:`_snapshot_size_bytes`), or
+    ``None`` for a fresh pull with no pre-existing snapshot. The summary is
+    labelled "Already cached ... verified (nothing to download)" only when the
+    pull transferred no new bytes — i.e. the resolved snapshot is byte-for-byte
+    the same size as before. A mutable ``main`` that advanced remote-side makes
+    post-pull size grow, so it is reported as a real download instead of a lie
+    (issue #2349; see codex: label from actual transfer, not pre-pull presence).
     """
     import os as _os
 
@@ -6444,6 +6483,9 @@ def _print_pull_summary(
         if _os.path.isdir(_candidate):
             snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
+    # Nothing was transferred iff the post-pull snapshot is byte-for-byte the
+    # same size as before the pull began; ``pre_size=None`` means a fresh pull.
+    was_cached = pre_size is not None and size == pre_size
     if was_cached:
         print(
             f"  Already cached {repo_id} — {_format_bytes(size)} verified "
@@ -6584,15 +6626,16 @@ def pull_command(args):
         )
         sys.exit(1)
 
-    # Was the snapshot already complete before this pull? If so, nothing
-    # will be transferred — the final summary must say the cache was verified
-    # rather than claiming a download + transfer time (issue #2349).
+    # Capture the resolved snapshot's size BEFORE the transfer. The post-pull
+    # summary is labelled "verified (nothing to download)" only when no new
+    # bytes were transferred (size unchanged), not merely because some local
+    # rev was already complete — a moved ``main`` can fetch new files even when
+    # a stale local snapshot exists (issue #2349).
     try:
-        from vllm_mlx._download_gate import is_repo_cached
-
-        was_cached = is_repo_cached(repo_id)
+        _pre_dir = _resolve_pull_snapshot_dir(repo_id)
+        _pre_size = _snapshot_size_bytes(_pre_dir) if _pre_dir else None
     except Exception:
-        was_cached = False
+        _pre_size = None
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
     # before adding more. huggingface_hub gives each attempt a uniquely-named
@@ -6645,7 +6688,7 @@ def pull_command(args):
             snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
         _print_pull_summary(
-            repo_id, snapshot_dir, time.monotonic() - t0, was_cached=was_cached
+            repo_id, snapshot_dir, time.monotonic() - t0, pre_size=_pre_size
         )
         return
     # Mirror returned False — fall through to plain snapshot_download.
@@ -6741,7 +6784,7 @@ def pull_command(args):
             sys.exit(1)
         raise
     print(f"  Cached at: {path}")
-    _print_pull_summary(repo_id, path, time.monotonic() - t0, was_cached=was_cached)
+    _print_pull_summary(repo_id, path, time.monotonic() - t0, pre_size=_pre_size)
 
 
 def rm_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6461,8 +6461,18 @@ def _hf_snapshot_dir_for(repo_id: str):
     except Exception:
         return None
     cache_root = Path(HF_HUB_CACHE)
-    owner, _, repo = repo_id.partition("/")
-    repo_root = cache_root / f"models--{owner}--{repo}"
+    # Stable cache-path construction that handles BOTH ``owner/repo`` and
+    # single-component repo ids (Codex #2392 #2): ``owner/repo`` maps to the
+    # ``models--owner--repo`` dir, while a bare ``repo`` (no ``/``) maps to
+    # ``models--repo`` — HF's real layout. Prefer HF's own constant when the
+    # installed version exposes it, else reconstruct it locally.
+    try:
+        from huggingface_hub.utils import repo_name_to_id  # type: ignore[attr-defined]
+
+        _cache_id = repo_name_to_id(repo_id)
+    except Exception:
+        _cache_id = repo_id.replace("/", "--")
+    repo_root = cache_root / f"models--{_cache_id}"
     try:
         rev = (repo_root / "refs" / "main").read_text().strip()
     except OSError:
@@ -6482,9 +6492,15 @@ def _snapshot_identifier(directory) -> tuple[tuple[str, int, int], ...]:
     wire (cache hit); any new/changed file means bytes were fetched this pull
     (including a fetched zero-byte file, which still adds a new inventory row).
     ``directory`` may be None (nothing cached yet) -> empty fingerprint.
-    Symlinks are fingerprinted via ``lstat`` (their own metadata, not the
-    blob target), so a warm pull that leaves the snapshot untouched is
-    identical while a fetch adds/rewrites entries.
+
+    Entries are fingerprinted with ``stat`` (FOLLOWING symlinks to their blob
+    targets), NOT ``lstat``: HF stores snapshot files as symlinks into
+    ``blobs/<sha>``, and restoring a missing/corrupt BLOCK changes only the
+    blob (its size/mtime) while leaving the snapshot symlink itself
+    unchanged. Fingerprinting the resolved target is what makes that repair
+    visible as a transfer rather than a false "Already cached". A warm pull
+    that re-links an existing, unchanged blob leaves both the link and the
+    blob untouched, so its fingerprint is identical.
     """
     import os as _os
 
@@ -6495,7 +6511,10 @@ def _snapshot_identifier(directory) -> tuple[tuple[str, int, int], ...]:
         for name in files:
             p = _os.path.join(dirpath, name)
             try:
-                st = _os.lstat(p)
+                # Follow symlinks: capture the blob target's size/mtime so a
+                # blob repair (which the lstat of the symlink would hide) is
+                # still detected as a transfer (Codex #2392).
+                st = _os.stat(p)
             except OSError:
                 continue
             rows.append((_os.path.relpath(p, directory), st.st_size, st.st_mtime_ns))

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6427,17 +6427,23 @@ def _hf_bytes_bar_class():
     """Return a ``tqdm_class`` for ``snapshot_download`` that records bytes.
 
     huggingface_hub builds its ``snapshot_download`` progress from several
-    bars via ``tqdm_class``: two byte-oriented bars (``unit="B"`` —
-    "Download complete", "Reconstruction complete") and a FILE bar
-    (``unit="it"`` — "Fetching N files") that advances once per completed
-    file, cache hits included. Only the ``unit="B"`` bars measure actual
-    bytes transferred, so we record only those and exclude the file bar
-    (codex round-3/4 BLOCKING #2). A fully-cached online pull records zero
-    bytes on the byte bars -> "nothing to download" truthfully; a real
-    transfer records >0 -> "Downloaded". Returns a real ``tqdm`` subclass
-    (not a callable) because HF hands it to code that expects class methods
-    (e.g. ``get_lock``). Defined lazily to avoid a module-scope ``tqdm``
-    import (the mirror path never needs it).
+    bars via ``tqdm_class``: a network-transfer bar (``unit="B"``, desc
+    "Download complete"/"Downloading bytes"), a local-reconstruction bar
+    (``unit="B"``, desc "Reconstruction…"),
+    and a file bar (``unit="it"``, desc "Fetching N files") that advances once
+    per completed file, cache hits included.
+
+    Only the NETWORK-TRANSFER bar measures actual bytes fetched; the
+    reconstruction and file bars count local disk writes / file completions,
+    so they must NOT count as network traffic (codex round-4 BLOCKING #2).
+    We therefore track instances only for the transfer bar (desc starts with
+    "Download"), and additionally set ``_touched`` on ANY ``update()`` call —
+    including ``n=0`` — so a fetched zero-byte file is still recognized as a
+    network fetch even though it records no bytes (codex round-4 BLOCKING #3).
+
+    Returns a real ``tqdm`` subclass (not a callable) because HF hands it to
+    code that expects class methods (e.g. ``get_lock``). Defined lazily to
+    avoid a module-scope ``tqdm`` import (the mirror path never needs it).
     """
     from tqdm import tqdm
 
@@ -6446,11 +6452,16 @@ def _hf_bytes_bar_class():
 
         def __init__(self, *args, **kwargs):
             self._recorded: list[int] = []
+            self._touched = False
             super().__init__(*args, **kwargs)
-            if getattr(self, "unit", None) == "B":
+            desc = str(getattr(self, "desc", "") or "")
+            if getattr(self, "unit", None) == "B" and desc.startswith("Download"):
                 self._bar_instances.append(self)
 
         def update(self, n=1):
+            # Flag any update() call — even n=0 — as evidence a network fetch
+            # was orchestrated for this file (covers zero-byte files).
+            self._touched = True
             if n:
                 self._recorded.append(int(n))
             super().update(n)
@@ -6459,19 +6470,20 @@ def _hf_bytes_bar_class():
 
 
 def _hf_network_fetch(bar_cls) -> bool | None:
-    """Did the HF pull fetch bytes? True/False from byte bars, None if unknown.
+    """Did the HF pull fetch bytes over the network? True/False/None.
 
-    True if any ``unit="B"`` byte-bar recorded a positive update (a real
-    transfer, including a fetched zero-byte file); False if byte bars were
-    constructed but recorded zero (a clean no-op cache hit); None if no byte
-    bar was constructed at all (offline/anomalous downloader) — the caller
-    treats that as unknown and reports a download rather than over-claiming a
-    cache hit.
+    Considers only the network-transfer bar (see :func:`_hf_bytes_bar_class`).
+    True if that bar observed any ``update()`` — i.e. a file was fetched,
+    whether it carried bytes or was zero-byte (codex round-4 #3); False if the
+    transfer bar was constructed but never updated (a clean no-op cache hit);
+    None if no transfer bar was constructed at all (offline/anomalous
+    downloader) — the caller treats None as unknown and reports a download
+    rather than over-claiming a cache hit.
     """
-    byte_bars = bar_cls._bar_instances
-    if not byte_bars:
+    bars = bar_cls._bar_instances
+    if not bars:
         return None
-    return any(b._recorded for b in byte_bars)
+    return any(b._touched for b in bars)
 
 
 def _print_pull_summary(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6457,18 +6457,20 @@ def _print_pull_summary(
     snapshot_dir,
     elapsed: float,
     *,
+    pre_dir=None,
     pre_size: int | None = None,
 ) -> None:
     """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary.
 
-    ``pre_size`` is the snapshot's on-disk size before this pull began
-    (:func:`_resolve_pull_snapshot_dir` + :func:`_snapshot_size_bytes`), or
-    ``None`` for a fresh pull with no pre-existing snapshot. The summary is
-    labelled "Already cached ... verified (nothing to download)" only when the
-    pull transferred no new bytes — i.e. the resolved snapshot is byte-for-byte
-    the same size as before. A mutable ``main`` that advanced remote-side makes
-    post-pull size grow, so it is reported as a real download instead of a lie
-    (issue #2349; see codex: label from actual transfer, not pre-pull presence).
+    ``pre_dir``/``pre_size`` describe the resolved snapshot before this pull
+    began (:func:`_resolve_pull_snapshot_dir` + :func:`_snapshot_size_bytes`);
+    both are ``None`` for a fresh pull with no pre-existing snapshot. The
+    summary is labelled "Already cached ... verified (nothing to download)"
+    only when the pull transferred no new bytes — i.e. the post-pull snapshot
+    resolves to the SAME directory AND is byte-for-byte the same size as
+    before. Comparing path+size (not bare presence, and not size alone) is what
+    distinguishes a true no-op from a ``main`` that advanced to another rev of
+    equal or different size (issue #2349; see codex: label from actual transfer).
     """
     import os as _os
 
@@ -6483,9 +6485,16 @@ def _print_pull_summary(
         if _os.path.isdir(_candidate):
             snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
-    # Nothing was transferred iff the post-pull snapshot is byte-for-byte the
-    # same size as before the pull began; ``pre_size=None`` means a fresh pull.
-    was_cached = pre_size is not None and size == pre_size
+    # Nothing was transferred iff the post-pull snapshot is the SAME resolved
+    # directory as before AND byte-for-byte the same size. ``pre_dir=None``
+    # marks a fresh pull (no prior snapshot). Path equality catches a ``main``
+    # that advanced to a different revision even when the byte count happens to
+    # match; size equality guards against in-place growth of the same rev.
+    _post_dir = _os.path.normpath(_os.path.abspath(str(snapshot_dir)))
+    _same_dir = pre_dir is not None and _post_dir == _os.path.normpath(
+        _os.path.abspath(str(pre_dir))
+    )
+    was_cached = _same_dir and pre_size is not None and size == pre_size
     if was_cached:
         print(
             f"  Already cached {repo_id} — {_format_bytes(size)} verified "
@@ -6626,15 +6635,16 @@ def pull_command(args):
         )
         sys.exit(1)
 
-    # Capture the resolved snapshot's size BEFORE the transfer. The post-pull
-    # summary is labelled "verified (nothing to download)" only when no new
-    # bytes were transferred (size unchanged), not merely because some local
-    # rev was already complete — a moved ``main`` can fetch new files even when
-    # a stale local snapshot exists (issue #2349).
+    # Capture the resolved snapshot's dir + size BEFORE the transfer. The
+    # post-pull summary is labelled "verified (nothing to download)" only when
+    # the pull transferred no new bytes — same resolved dir AND same size —
+    # not merely because some stale local rev was already complete (issue
+    # #2349; a moved ``main`` can fetch new files despite a pre-existing rev).
     try:
         _pre_dir = _resolve_pull_snapshot_dir(repo_id)
         _pre_size = _snapshot_size_bytes(_pre_dir) if _pre_dir else None
     except Exception:
+        _pre_dir = None
         _pre_size = None
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
@@ -6688,7 +6698,11 @@ def pull_command(args):
             snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
         _print_pull_summary(
-            repo_id, snapshot_dir, time.monotonic() - t0, pre_size=_pre_size
+            repo_id,
+            snapshot_dir,
+            time.monotonic() - t0,
+            pre_dir=_pre_dir,
+            pre_size=_pre_size,
         )
         return
     # Mirror returned False — fall through to plain snapshot_download.
@@ -6784,7 +6798,9 @@ def pull_command(args):
             sys.exit(1)
         raise
     print(f"  Cached at: {path}")
-    _print_pull_summary(repo_id, path, time.monotonic() - t0, pre_size=_pre_size)
+    _print_pull_summary(
+        repo_id, path, time.monotonic() - t0, pre_dir=_pre_dir, pre_size=_pre_size
+    )
 
 
 def rm_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6418,8 +6418,19 @@ def _external_tree_size_bytes(path: str) -> int:
     return total
 
 
-def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
-    """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary."""
+def _print_pull_summary(
+    repo_id: str,
+    snapshot_dir,
+    elapsed: float,
+    *,
+    was_cached: bool = False,
+) -> None:
+    """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary.
+
+    When ``was_cached`` is true the pull reused an already-complete snapshot
+    (nothing was transferred), so the summary says the cache was verified
+    rather than claiming a download + transfer time (issue #2349).
+    """
     import os as _os
 
     from vllm_mlx.model_aliases import resolve_subfolder
@@ -6433,10 +6444,16 @@ def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
         if _os.path.isdir(_candidate):
             snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
-    print(
-        f"  Downloaded {repo_id} — {_format_bytes(size)} in "
-        f"{_format_pull_duration(elapsed)}"
-    )
+    if was_cached:
+        print(
+            f"  Already cached {repo_id} — {_format_bytes(size)} verified "
+            f"(nothing to download)"
+        )
+    else:
+        print(
+            f"  Downloaded {repo_id} — {_format_bytes(size)} in "
+            f"{_format_pull_duration(elapsed)}"
+        )
 
     # Activation funnel (docs/telemetry-activation.md): a successful pull is
     # the ``model_pull`` milestone (an activation, NOT inference-engaged).
@@ -6567,6 +6584,16 @@ def pull_command(args):
         )
         sys.exit(1)
 
+    # Was the snapshot already complete before this pull? If so, nothing
+    # will be transferred — the final summary must say the cache was verified
+    # rather than claiming a download + transfer time (issue #2349).
+    try:
+        from vllm_mlx._download_gate import is_repo_cached
+
+        was_cached = is_repo_cached(repo_id)
+    except Exception:
+        was_cached = False
+
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
     # before adding more. huggingface_hub gives each attempt a uniquely-named
     # ``.incomplete`` blob and removes it while unwinding, which a killed
@@ -6617,7 +6644,9 @@ def pull_command(args):
         except OSError:
             snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
-        _print_pull_summary(repo_id, snapshot_dir, time.monotonic() - t0)
+        _print_pull_summary(
+            repo_id, snapshot_dir, time.monotonic() - t0, was_cached=was_cached
+        )
         return
     # Mirror returned False — fall through to plain snapshot_download.
     # Either the catalog was unreachable, the alias isn't catalog-listed,
@@ -6712,7 +6741,7 @@ def pull_command(args):
             sys.exit(1)
         raise
     print(f"  Cached at: {path}")
-    _print_pull_summary(repo_id, path, time.monotonic() - t0)
+    _print_pull_summary(repo_id, path, time.monotonic() - t0, was_cached=was_cached)
 
 
 def rm_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6423,23 +6423,76 @@ def _external_tree_size_bytes(path: str) -> int:
     return total
 
 
+def _hf_bytes_bar_class():
+    """Return a ``tqdm_class`` for ``snapshot_download`` that records bytes.
+
+    huggingface_hub builds its ``snapshot_download`` progress from several
+    bars via ``tqdm_class``: two byte-oriented bars (``unit="B"`` —
+    "Download complete", "Reconstruction complete") and a FILE bar
+    (``unit="it"`` — "Fetching N files") that advances once per completed
+    file, cache hits included. Only the ``unit="B"`` bars measure actual
+    bytes transferred, so we record only those and exclude the file bar
+    (codex round-3/4 BLOCKING #2). A fully-cached online pull records zero
+    bytes on the byte bars -> "nothing to download" truthfully; a real
+    transfer records >0 -> "Downloaded". Returns a real ``tqdm`` subclass
+    (not a callable) because HF hands it to code that expects class methods
+    (e.g. ``get_lock``). Defined lazily to avoid a module-scope ``tqdm``
+    import (the mirror path never needs it).
+    """
+    from tqdm import tqdm
+
+    class _HFBytesBar(tqdm):
+        _bar_instances: list["_HFBytesBar"] = []
+
+        def __init__(self, *args, **kwargs):
+            self._recorded: list[int] = []
+            super().__init__(*args, **kwargs)
+            if getattr(self, "unit", None) == "B":
+                self._bar_instances.append(self)
+
+        def update(self, n=1):
+            if n:
+                self._recorded.append(int(n))
+            super().update(n)
+
+    return _HFBytesBar
+
+
+def _hf_network_fetch(bar_cls) -> bool | None:
+    """Did the HF pull fetch bytes? True/False from byte bars, None if unknown.
+
+    True if any ``unit="B"`` byte-bar recorded a positive update (a real
+    transfer, including a fetched zero-byte file); False if byte bars were
+    constructed but recorded zero (a clean no-op cache hit); None if no byte
+    bar was constructed at all (offline/anomalous downloader) — the caller
+    treats that as unknown and reports a download rather than over-claiming a
+    cache hit.
+    """
+    byte_bars = bar_cls._bar_instances
+    if not byte_bars:
+        return None
+    return any(b._recorded for b in byte_bars)
+
+
 def _print_pull_summary(
     repo_id: str,
     snapshot_dir,
     elapsed: float,
     *,
-    transferred_bytes: int | None = None,
+    was_cached: bool | None = None,
 ) -> None:
     """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary.
 
-    ``transferred_bytes`` is the authoritative count of bytes the downloader
-    (R2 mirror or HuggingFace) actually fetched over the wire this pull, or
-    ``None`` when unknown. The summary is labelled "Already cached ... verified
-    (nothing to download)" only when the transfer account says zero bytes were
-    fetched. This is derived from the downloader's own transfer result, never
-    inferred from pre/post filesystem state — a moved ``main`` that fetches
-    new blobs reports a real download (issue #2349; see codex: label from
-    actual transfer).
+    ``was_cached`` is the downloader's authoritative "nothing was transferred
+    this pull" verdict (issue #2349):
+    * ``True``  — the mirror/HF transfer account proves zero bytes were
+      fetched -> "Already cached ... verified (nothing to download)".
+    * ``False`` — the downloader reports it fetched bytes -> "Downloaded".
+    * ``None``  — unknown (e.g. the HF-fallback's downloader could not prove
+      either way) -> "Downloaded", never a false cache claim.
+    This is derived from the downloader's own transfer result, never inferred
+    from pre/post filesystem state — a moved ``main`` that fetches new blobs
+    reports a real download.
     """
     import os as _os
 
@@ -6454,12 +6507,10 @@ def _print_pull_summary(
         if _os.path.isdir(_candidate):
             snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
-    # Nothing was transferred iff the downloader reports it fetched zero bytes
-    # this pull. ``transferred_bytes`` comes from the mirror/HF transfer
-    # account; ``None`` (unknown, e.g. an unfiltered fallback) defaults to a
-    # download rather than over-claiming a cache hit.
-    was_cached = transferred_bytes is not None and transferred_bytes == 0
-    if was_cached:
+    # "Already cached" only on a proven no-transfer (``was_cached is True``);
+    # ``None`` (unknown) falls through to "Downloaded" rather than a false
+    # cache claim.
+    if was_cached is True:
         print(
             f"  Already cached {repo_id} — {_format_bytes(size)} verified "
             f"(nothing to download)"
@@ -6601,8 +6652,8 @@ def pull_command(args):
 
     # The pull summary says "already cached / nothing to download" only from
     # the DOWNLOADER's own transfer account (mirror/HF bytes fetched), never
-    # from a filesystem guess. ``transferred`` is threaded to the summary.
-    transferred: int | None = None
+    # from a filesystem guess. ``_was_cached`` is threaded to the summary.
+    _was_cached: bool | None = None
     _mirror_out: dict = {}
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
@@ -6655,12 +6706,14 @@ def pull_command(args):
         except OSError:
             snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
-        transferred = _mirror_out.get("transferred_bytes")
+        # ``network_fetch`` is the mirror's authoritative "any bytes fetched
+        # this pull" verdict (covers a fetched zero-byte file, codex #4).
+        _was_cached = not _mirror_out.get("network_fetch", True)
         _print_pull_summary(
             repo_id,
             snapshot_dir,
             time.monotonic() - t0,
-            transferred_bytes=transferred,
+            was_cached=_was_cached,
         )
         return
     # Mirror returned False — fall through to plain snapshot_download.
@@ -6725,18 +6778,17 @@ def pull_command(args):
                     f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
                 )
             _allow = [f"{_subfolder}/*"] if _subfolder else None
-        # HF-fallback runs only after a mirror miss (``_try_mirror_prefetch``
-        # returned False) — i.e. this is a fetch path and the transfer account
-        # is not authoritative here (a cached no-op is a rare fallback edge).
-        # So we intentionally do NOT pass a ``tqdm_class`` to count bytes, and
-        # the summary reports a download (``transferred`` stays ``None``). The
-        # truthful "already cached / nothing to download" label is produced by
-        # the mirror path's authoritative transfer account (issue #2349).
+        # HF-fallback runs only after a mirror miss — but a cached HF no-op is
+        # still possible and must be labelled "Already cached", so instrument
+        # the byte bars (codex round-3/4 BLOCKING #2/#3). A fully-cached pull
+        # records zero bytes on the ``unit="B"`` bars -> verified.
+        _bar_cls = _hf_bytes_bar_class()
         path = (
-            snapshot_download(repo_id, allow_patterns=_allow)
+            snapshot_download(repo_id, allow_patterns=_allow, tqdm_class=_bar_cls)
             if _allow
-            else snapshot_download(repo_id)
+            else snapshot_download(repo_id, tqdm_class=_bar_cls)
         )
+        _was_cached = _hf_network_fetch(_bar_cls) is False
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a
@@ -6767,7 +6819,7 @@ def pull_command(args):
         repo_id,
         path,
         time.monotonic() - t0,
-        transferred_bytes=transferred,
+        was_cached=_was_cached,
     )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6464,7 +6464,7 @@ def _hf_bytes_bar_class():
             self._touched = True
             if n:
                 self._recorded.append(int(n))
-            super().update(n)
+            return super().update(n)
 
     return _HFBytesBar
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6445,14 +6445,14 @@ def _narrow_to_subfolder(repo_id: str, snapshot_dir):
     return snapshot_dir
 
 
-def _hf_snapshot_dir_for(repo_id: str):
-    """Locate the CURRENT on-disk HF snapshot content dir for ``repo_id``.
+def _hf_cache_root(repo_id: str):
+    """HF cache ``models--<id>`` dir for ``repo_id``, or None.
 
-    Pure path computation from the hub cache (no network): resolves
-    ``refs/main`` and narrows to the catalog subfolder, mirroring how
-    ``snapshot_download``'s return path is narrowed. Returns None when
-    nothing is cached yet. This is the stable 'before' side of the pull
-    transfer account (Codex #2392).
+    Pure path computation from the hub cache (no network). Handles BOTH
+    ``owner/repo`` and single-component repo ids (Codex #2392 #2): ``owner/repo``
+    maps to ``models--owner--repo``; a bare ``repo`` (no ``/``) maps to
+    ``models--repo`` — HF's real layout. Prefers HF's own ``repo_name_to_id``
+    when the installed version exposes it, else reconstructs locally.
     """
     from pathlib import Path
 
@@ -6460,64 +6460,54 @@ def _hf_snapshot_dir_for(repo_id: str):
         from huggingface_hub.constants import HF_HUB_CACHE
     except Exception:
         return None
-    cache_root = Path(HF_HUB_CACHE)
-    # Stable cache-path construction that handles BOTH ``owner/repo`` and
-    # single-component repo ids (Codex #2392 #2): ``owner/repo`` maps to the
-    # ``models--owner--repo`` dir, while a bare ``repo`` (no ``/``) maps to
-    # ``models--repo`` — HF's real layout. Prefer HF's own constant when the
-    # installed version exposes it, else reconstruct it locally.
     try:
         from huggingface_hub.utils import repo_name_to_id  # type: ignore[attr-defined]
 
         _cache_id = repo_name_to_id(repo_id)
     except Exception:
         _cache_id = repo_id.replace("/", "--")
-    repo_root = cache_root / f"models--{_cache_id}"
-    try:
-        rev = (repo_root / "refs" / "main").read_text().strip()
-    except OSError:
-        return None
-    snap = repo_root / "snapshots" / rev
-    return _narrow_to_subfolder(repo_id, snap) if snap.is_dir() else None
+    return Path(HF_HUB_CACHE) / f"models--{_cache_id}"
 
 
-def _snapshot_identifier(directory) -> tuple[tuple[str, int, int], ...]:
-    """Sorted ``(relpath, size, mtime_ns)`` per file under ``directory``.
+def _blob_identifier(repo_root) -> tuple[tuple[str, int, int], ...]:
+    """Sorted ``(name, size, mtime_ns)`` for every real blob under ``blobs/``.
 
-    Stable snapshot fingerprint for the pull transfer account (Codex #2392) —
-    independent of huggingface_hub's tqdm progress internals (bar ``desc``/
-    ``unit``/``update()`` are an undocumented presentation detail that changes
-    between hub versions). The snapshot CONTENT is the source of truth: an
-    identical inventory before and after the pull means nothing crossed the
-    wire (cache hit); any new/changed file means bytes were fetched this pull
-    (including a fetched zero-byte file, which still adds a new inventory row).
-    ``directory`` may be None (nothing cached yet) -> empty fingerprint.
+    The stable transfer signal for the pull account (Codex #2392): a NEW or
+    MODIFIED blob is the only thing that means bytes crossed the wire. A warm
+    pull that merely re-links snapshot symlinks to already-present blobs
+    leaves ``blobs/`` untouched (identical fingerprint => cached); a genuine
+    fetch creates a new blob (changed); a repair of a corrupt/truncated blob
+    changes its size/mtime (changed). This is robust to ``main`` moving to a
+    snapshot assembled entirely from blobs already present locally — which
+    transfers NOTHING and must be reported cached, whereas comparing the
+    snapshot TREE (changed paths) would falsely report a download (Codex #2392).
 
-    Entries are fingerprinted with ``stat`` (FOLLOWING symlinks to their blob
-    targets), NOT ``lstat``: HF stores snapshot files as symlinks into
-    ``blobs/<sha>``, and restoring a missing/corrupt BLOCK changes only the
-    blob (its size/mtime) while leaving the snapshot symlink itself
-    unchanged. Fingerprinting the resolved target is what makes that repair
-    visible as a transfer rather than a false "Already cached". A warm pull
-    that re-links an existing, unchanged blob leaves both the link and the
-    blob untouched, so its fingerprint is identical.
+    ``.incomplete*`` scratch files are excluded — HF prunes/creates them as
+    churn that has nothing to do with this pull's outcome. ``repo_root`` may
+    be None (no cache entry yet) -> empty fingerprint.
     """
     import os as _os
 
-    if not directory:
+    if not repo_root:
+        return ()
+    blob_dir = repo_root / "blobs"
+    if not blob_dir.is_dir():
         return ()
     rows: list[tuple[str, int, int]] = []
-    for dirpath, _dirnames, files in _os.walk(directory, followlinks=False):
-        for name in files:
-            p = _os.path.join(dirpath, name)
-            try:
-                # Follow symlinks: capture the blob target's size/mtime so a
-                # blob repair (which the lstat of the symlink would hide) is
-                # still detected as a transfer (Codex #2392).
-                st = _os.stat(p)
-            except OSError:
-                continue
-            rows.append((_os.path.relpath(p, directory), st.st_size, st.st_mtime_ns))
+    try:
+        names = _os.listdir(blob_dir)
+    except OSError:
+        return ()
+    for name in names:
+        if name.startswith(".incomplete"):
+            continue
+        p = blob_dir / name
+        try:
+            if p.is_file():
+                st = p.stat()
+                rows.append((name, st.st_size, st.st_mtime_ns))
+        except OSError:
+            continue
     return tuple(sorted(rows))
 
 
@@ -6820,21 +6810,23 @@ def pull_command(args):
             _allow = [f"{_subfolder}/*"] if _subfolder else None
         # HF-fallback runs only after a mirror miss — but a cached HF no-op is
         # still possible and must be labelled "Already cached", so account the
-        # TRANSFER from stable on-disk state (Codex #2392), never
-        # huggingface_hub's tqdm progress internals: capture the snapshot
-        # content inventory BEFORE the pull, then AFTER. Identical => zero
-        # bytes crossed the wire this pull (cache hit); any new/changed file
-        # (including a fetched zero-byte file, which adds an inventory row)
-        # => a real download. ``_hf_snapshot_dir_for`` resolves the CURRENT
-        # on-disk snapshot (no network); the returned ``path`` is the
-        # authoritative after-side, narrowed to the same subfolder.
-        _before = _snapshot_identifier(_hf_snapshot_dir_for(repo_id))
+        # TRANSFER from the BLOB store (Codex #2392), never huggingface_hub's
+        # tqdm progress internals and never the snapshot tree: a NEW/MODIFIED
+        # blob is the only thing meaning bytes crossed the wire. Capture the
+        # repo's ``blobs/`` inventory BEFORE the pull then AFTER. Identical =>
+        # zero bytes crossed this pull (cache hit) — even if ``main`` moved to
+        # a snapshot assembled from blobs already present locally, or a warm
+        # re-link recreated snapshot symlinks; any changed blob (new file, or
+        # a repaired corrupt/truncated blob whose size/mtime changed) => a real
+        # download. ``_hf_cache_root`` resolves the cache entry (no network).
+        _cache_root = _hf_cache_root(repo_id)
+        _before = _blob_identifier(_cache_root)
         path = (
             snapshot_download(repo_id, allow_patterns=_allow)
             if _allow
             else snapshot_download(repo_id)
         )
-        _after = _snapshot_identifier(_narrow_to_subfolder(repo_id, path))
+        _after = _blob_identifier(_cache_root)
         _was_cached = _before == _after and _before != ()
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6423,38 +6423,6 @@ def _external_tree_size_bytes(path: str) -> int:
     return total
 
 
-def _hf_bytes_bar_class():
-    """Return a ``tqdm_class`` for ``snapshot_download`` that records bytes.
-
-    huggingface_hub accepts ``snapshot_download(..., tqdm_class=...)`` and
-    instantiates it exactly like ``tqdm``, calling ``update(n)`` per chunk and
-    setting ``total`` when the size is known. Subclassing the real bar keeps
-    the progress UX identical while we expose the aggregate bytes actually
-    fetched (issue #2349 — label the pull from the downloader's own transfer
-    result, not a filesystem guess). A fully-cached pull performs no file
-    transfer, so it records zero bytes and the summary says "nothing to
-    download" truthfully. Defined lazily to avoid a module-scope ``tqdm``
-    import (the mirror path never needs it).
-    """
-    from tqdm import tqdm
-
-    class _HFBytesBar(tqdm):
-        def __init__(self, *args, **kwargs):
-            self._recorded: list[int] = []
-            super().__init__(*args, **kwargs)
-
-        def update(self, n=1):
-            if n:
-                self._recorded.append(int(n))
-            super().update(n)
-
-        @property
-        def transferred_bytes(self) -> int:
-            return sum(self._recorded)
-
-    return _HFBytesBar
-
-
 def _print_pull_summary(
     repo_id: str,
     snapshot_dir,
@@ -6757,26 +6725,18 @@ def pull_command(args):
                     f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
                 )
             _allow = [f"{_subfolder}/*"] if _subfolder else None
-        _bar_cls = _hf_bytes_bar_class()
-        _bars: list = []
-
-        def _make_bar(*a, **k):
-            b = _bar_cls(*a, **k)
-            _bars.append(b)
-            return b
-
+        # HF-fallback runs only after a mirror miss (``_try_mirror_prefetch``
+        # returned False) — i.e. this is a fetch path and the transfer account
+        # is not authoritative here (a cached no-op is a rare fallback edge).
+        # So we intentionally do NOT pass a ``tqdm_class`` to count bytes, and
+        # the summary reports a download (``transferred`` stays ``None``). The
+        # truthful "already cached / nothing to download" label is produced by
+        # the mirror path's authoritative transfer account (issue #2349).
         path = (
-            snapshot_download(repo_id, allow_patterns=_allow, tqdm_class=_make_bar)
+            snapshot_download(repo_id, allow_patterns=_allow)
             if _allow
-            else snapshot_download(repo_id, tqdm_class=_make_bar)
+            else snapshot_download(repo_id)
         )
-        # ``_bars`` is populated only if the downloader actually constructed a
-        # progress bar. When it did, its byte count is the authoritative
-        # "bytes transferred this pull" truth; when it did NOT (a mocked or
-        # anomalous downloader), we cannot prove zero transfer, so leave
-        # ``transferred`` unknown and report a download rather than a lie.
-        if _bars:
-            transferred = sum(b.transferred_bytes for b in _bars)
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6423,67 +6423,83 @@ def _external_tree_size_bytes(path: str) -> int:
     return total
 
 
-def _hf_bytes_bar_class():
-    """Return a ``tqdm_class`` for ``snapshot_download`` that records bytes.
+def _narrow_to_subfolder(repo_id: str, snapshot_dir):
+    """Narrow a snapshot root to the catalog subfolder a filtered pull serves.
 
-    huggingface_hub builds its ``snapshot_download`` progress from several
-    bars via ``tqdm_class``: a network-transfer bar (``unit="B"``, desc
-    "Download complete"/"Downloading bytes"), a local-reconstruction bar
-    (``unit="B"``, desc "Reconstruction…"),
-    and a file bar (``unit="it"``, desc "Fetching N files") that advances once
-    per completed file, cache hits included.
-
-    Only the NETWORK-TRANSFER bar measures actual bytes fetched; the
-    reconstruction and file bars count local disk writes / file completions,
-    so they must NOT count as network traffic (codex round-4 BLOCKING #2).
-    We therefore track instances only for the transfer bar (desc starts with
-    "Download"), and additionally set ``_touched`` on ANY ``update()`` call —
-    including ``n=0`` — so a fetched zero-byte file is still recognized as a
-    network fetch even though it records no bytes (codex round-4 BLOCKING #3).
-
-    Returns a real ``tqdm`` subclass (not a callable) because HF hands it to
-    code that expects class methods (e.g. ``get_lock``). Defined lazily to
-    avoid a module-scope ``tqdm`` import (the mirror path never needs it).
+    A repo that ships one folder per quantization holds far more on disk than
+    any single alias needs; sizing or fingerprinting the ROOT would include
+    sibling quant folders left by earlier pulls. Returns the subfolder path
+    when ``repo_id`` is a catalog alias with one, else the root unchanged.
+    Shared by the transfer account and the pull summary so both key on the
+    same directory.
     """
-    from tqdm import tqdm
+    import os as _os
 
-    class _HFBytesBar(tqdm):
-        _bar_instances: list["_HFBytesBar"] = []
+    from vllm_mlx.model_aliases import resolve_subfolder
 
-        def __init__(self, *args, **kwargs):
-            self._recorded: list[int] = []
-            self._touched = False
-            super().__init__(*args, **kwargs)
-            desc = str(getattr(self, "desc", "") or "")
-            if getattr(self, "unit", None) == "B" and desc.startswith("Download"):
-                self._bar_instances.append(self)
-
-        def update(self, n=1):
-            # Flag any update() call — even n=0 — as evidence a network fetch
-            # was orchestrated for this file (covers zero-byte files).
-            self._touched = True
-            if n:
-                self._recorded.append(int(n))
-            return super().update(n)
-
-    return _HFBytesBar
+    _sub = resolve_subfolder(repo_id)
+    if _sub:
+        _candidate = _os.path.join(str(snapshot_dir), _sub)
+        if _os.path.isdir(_candidate):
+            return _candidate
+    return snapshot_dir
 
 
-def _hf_network_fetch(bar_cls) -> bool | None:
-    """Did the HF pull fetch bytes over the network? True/False/None.
+def _hf_snapshot_dir_for(repo_id: str):
+    """Locate the CURRENT on-disk HF snapshot content dir for ``repo_id``.
 
-    Considers only the network-transfer bar (see :func:`_hf_bytes_bar_class`).
-    True if that bar observed any ``update()`` — i.e. a file was fetched,
-    whether it carried bytes or was zero-byte (codex round-4 #3); False if the
-    transfer bar was constructed but never updated (a clean no-op cache hit);
-    None if no transfer bar was constructed at all (offline/anomalous
-    downloader) — the caller treats None as unknown and reports a download
-    rather than over-claiming a cache hit.
+    Pure path computation from the hub cache (no network): resolves
+    ``refs/main`` and narrows to the catalog subfolder, mirroring how
+    ``snapshot_download``'s return path is narrowed. Returns None when
+    nothing is cached yet. This is the stable 'before' side of the pull
+    transfer account (Codex #2392).
     """
-    bars = bar_cls._bar_instances
-    if not bars:
+    from pathlib import Path
+
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+    except Exception:
         return None
-    return any(b._touched for b in bars)
+    cache_root = Path(HF_HUB_CACHE)
+    owner, _, repo = repo_id.partition("/")
+    repo_root = cache_root / f"models--{owner}--{repo}"
+    try:
+        rev = (repo_root / "refs" / "main").read_text().strip()
+    except OSError:
+        return None
+    snap = repo_root / "snapshots" / rev
+    return _narrow_to_subfolder(repo_id, snap) if snap.is_dir() else None
+
+
+def _snapshot_identifier(directory) -> tuple[tuple[str, int, int], ...]:
+    """Sorted ``(relpath, size, mtime_ns)`` per file under ``directory``.
+
+    Stable snapshot fingerprint for the pull transfer account (Codex #2392) —
+    independent of huggingface_hub's tqdm progress internals (bar ``desc``/
+    ``unit``/``update()`` are an undocumented presentation detail that changes
+    between hub versions). The snapshot CONTENT is the source of truth: an
+    identical inventory before and after the pull means nothing crossed the
+    wire (cache hit); any new/changed file means bytes were fetched this pull
+    (including a fetched zero-byte file, which still adds a new inventory row).
+    ``directory`` may be None (nothing cached yet) -> empty fingerprint.
+    Symlinks are fingerprinted via ``lstat`` (their own metadata, not the
+    blob target), so a warm pull that leaves the snapshot untouched is
+    identical while a fetch adds/rewrites entries.
+    """
+    import os as _os
+
+    if not directory:
+        return ()
+    rows: list[tuple[str, int, int]] = []
+    for dirpath, _dirnames, files in _os.walk(directory, followlinks=False):
+        for name in files:
+            p = _os.path.join(dirpath, name)
+            try:
+                st = _os.lstat(p)
+            except OSError:
+                continue
+            rows.append((_os.path.relpath(p, directory), st.st_size, st.st_mtime_ns))
+    return tuple(sorted(rows))
 
 
 def _print_pull_summary(
@@ -6502,22 +6518,15 @@ def _print_pull_summary(
     * ``False`` — the downloader reports it fetched bytes -> "Downloaded".
     * ``None``  — unknown (e.g. the HF-fallback's downloader could not prove
       either way) -> "Downloaded", never a false cache claim.
-    This is derived from the downloader's own transfer result, never inferred
-    from pre/post filesystem state — a moved ``main`` that fetches new blobs
-    reports a real download.
+    For the HF-fallback path the account is the on-disk snapshot file
+    inventory before vs after the pull (a stable seam, Codex #2392) — never
+    huggingface_hub's tqdm progress internals. A moved ``main`` that fetches
+    new blobs changes the inventory and reports a real download.
     """
-    import os as _os
-
-    from vllm_mlx.model_aliases import resolve_subfolder
-
     # A filtered pull fetched one folder, but the snapshot root may also
     # hold quant folders left by earlier pulls of a sibling alias. Sizing
     # the root would report those as part of THIS download.
-    _sub = resolve_subfolder(repo_id)
-    if _sub:
-        _candidate = _os.path.join(str(snapshot_dir), _sub)
-        if _os.path.isdir(_candidate):
-            snapshot_dir = _candidate
+    snapshot_dir = _narrow_to_subfolder(repo_id, snapshot_dir)
     size = _snapshot_size_bytes(snapshot_dir)
     # "Already cached" only on a proven no-transfer (``was_cached is True``);
     # ``None`` (unknown) falls through to "Downloaded" rather than a false
@@ -6791,16 +6800,23 @@ def pull_command(args):
                 )
             _allow = [f"{_subfolder}/*"] if _subfolder else None
         # HF-fallback runs only after a mirror miss — but a cached HF no-op is
-        # still possible and must be labelled "Already cached", so instrument
-        # the byte bars (codex round-3/4 BLOCKING #2/#3). A fully-cached pull
-        # records zero bytes on the ``unit="B"`` bars -> verified.
-        _bar_cls = _hf_bytes_bar_class()
+        # still possible and must be labelled "Already cached", so account the
+        # TRANSFER from stable on-disk state (Codex #2392), never
+        # huggingface_hub's tqdm progress internals: capture the snapshot
+        # content inventory BEFORE the pull, then AFTER. Identical => zero
+        # bytes crossed the wire this pull (cache hit); any new/changed file
+        # (including a fetched zero-byte file, which adds an inventory row)
+        # => a real download. ``_hf_snapshot_dir_for`` resolves the CURRENT
+        # on-disk snapshot (no network); the returned ``path`` is the
+        # authoritative after-side, narrowed to the same subfolder.
+        _before = _snapshot_identifier(_hf_snapshot_dir_for(repo_id))
         path = (
-            snapshot_download(repo_id, allow_patterns=_allow, tqdm_class=_bar_cls)
+            snapshot_download(repo_id, allow_patterns=_allow)
             if _allow
-            else snapshot_download(repo_id, tqdm_class=_bar_cls)
+            else snapshot_download(repo_id)
         )
-        _was_cached = _hf_network_fetch(_bar_cls) is False
+        _after = _snapshot_identifier(_narrow_to_subfolder(repo_id, path))
+        _was_cached = _before == _after and _before != ()
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1598,6 +1598,8 @@ class _StatusSpinner:
 def _try_mirror_prefetch(
     model_name: str,
     on_pull_start: Callable[[], None] | None = None,
+    *,
+    out: dict | None = None,
 ) -> bool:
     """Pre-fetch a HuggingFace repo via R2-first / HF-fallback (per file).
 
@@ -1640,7 +1642,10 @@ def _try_mirror_prefetch(
         # deliberately removed). Use the legacy HF path.
         return False
     return download_with_mirror_fallback(
-        model_name, on_pull_start=on_pull_start, allow_patterns=allow_patterns
+        model_name,
+        on_pull_start=on_pull_start,
+        allow_patterns=allow_patterns,
+        out=out,
     )
 
 
@@ -6370,40 +6375,6 @@ def _format_pull_duration(seconds: float) -> str:
     return f"{minutes}m {secs}s"
 
 
-def _resolve_pull_snapshot_dir(repo_id: str):
-    """Resolve the HF-cache snapshot dir a ``pull`` would populate, or ``None``.
-
-    Mirrors how ``pull_command`` derives ``repo_root/snapshots/<rev>`` after a
-    mirror/HF transfer (including the catalog subfolder narrowing applied in
-    :func:`_print_pull_summary`). Used to capture the snapshot's pre-pull size
-    so the summary can tell "nothing transferred" from a real download without
-    relying on bare local presence (a moved ``main`` can advance the snapshot
-    even when some local rev is already complete — issue #2349, codex round:
-    derive the label from the actual transfer, not pre-pull cache presence).
-    Returns ``None`` when the cache has no resolved snapshot yet (a fresh pull).
-    """
-    from pathlib import Path
-
-    from huggingface_hub.constants import HF_HUB_CACHE
-
-    from vllm_mlx.model_aliases import resolve_subfolder
-
-    owner, _, repo = repo_id.partition("/")
-    repo_root = Path(HF_HUB_CACHE) / f"models--{owner}--{repo}"
-    refs_main = repo_root / "refs" / "main"
-    try:
-        rev = refs_main.read_text().strip()
-    except OSError:
-        return None
-    snap = repo_root / "snapshots" / rev
-    sub = resolve_subfolder(repo_id)
-    if sub:
-        cand = snap / sub
-        if cand.is_dir():
-            snap = cand
-    return snap
-
-
 def _snapshot_size_bytes(path) -> int:
     """Sum file sizes under ``path`` (recursively, following symlinks).
 
@@ -6452,25 +6423,55 @@ def _external_tree_size_bytes(path: str) -> int:
     return total
 
 
+def _hf_bytes_bar_class():
+    """Return a ``tqdm_class`` for ``snapshot_download`` that records bytes.
+
+    huggingface_hub accepts ``snapshot_download(..., tqdm_class=...)`` and
+    instantiates it exactly like ``tqdm``, calling ``update(n)`` per chunk and
+    setting ``total`` when the size is known. Subclassing the real bar keeps
+    the progress UX identical while we expose the aggregate bytes actually
+    fetched (issue #2349 — label the pull from the downloader's own transfer
+    result, not a filesystem guess). A fully-cached pull performs no file
+    transfer, so it records zero bytes and the summary says "nothing to
+    download" truthfully. Defined lazily to avoid a module-scope ``tqdm``
+    import (the mirror path never needs it).
+    """
+    from tqdm import tqdm
+
+    class _HFBytesBar(tqdm):
+        def __init__(self, *args, **kwargs):
+            self._recorded: list[int] = []
+            super().__init__(*args, **kwargs)
+
+        def update(self, n=1):
+            if n:
+                self._recorded.append(int(n))
+            super().update(n)
+
+        @property
+        def transferred_bytes(self) -> int:
+            return sum(self._recorded)
+
+    return _HFBytesBar
+
+
 def _print_pull_summary(
     repo_id: str,
     snapshot_dir,
     elapsed: float,
     *,
-    pre_dir=None,
-    pre_size: int | None = None,
+    transferred_bytes: int | None = None,
 ) -> None:
     """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary.
 
-    ``pre_dir``/``pre_size`` describe the resolved snapshot before this pull
-    began (:func:`_resolve_pull_snapshot_dir` + :func:`_snapshot_size_bytes`);
-    both are ``None`` for a fresh pull with no pre-existing snapshot. The
-    summary is labelled "Already cached ... verified (nothing to download)"
-    only when the pull transferred no new bytes — i.e. the post-pull snapshot
-    resolves to the SAME directory AND is byte-for-byte the same size as
-    before. Comparing path+size (not bare presence, and not size alone) is what
-    distinguishes a true no-op from a ``main`` that advanced to another rev of
-    equal or different size (issue #2349; see codex: label from actual transfer).
+    ``transferred_bytes`` is the authoritative count of bytes the downloader
+    (R2 mirror or HuggingFace) actually fetched over the wire this pull, or
+    ``None`` when unknown. The summary is labelled "Already cached ... verified
+    (nothing to download)" only when the transfer account says zero bytes were
+    fetched. This is derived from the downloader's own transfer result, never
+    inferred from pre/post filesystem state — a moved ``main`` that fetches
+    new blobs reports a real download (issue #2349; see codex: label from
+    actual transfer).
     """
     import os as _os
 
@@ -6485,16 +6486,11 @@ def _print_pull_summary(
         if _os.path.isdir(_candidate):
             snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
-    # Nothing was transferred iff the post-pull snapshot is the SAME resolved
-    # directory as before AND byte-for-byte the same size. ``pre_dir=None``
-    # marks a fresh pull (no prior snapshot). Path equality catches a ``main``
-    # that advanced to a different revision even when the byte count happens to
-    # match; size equality guards against in-place growth of the same rev.
-    _post_dir = _os.path.normpath(_os.path.abspath(str(snapshot_dir)))
-    _same_dir = pre_dir is not None and _post_dir == _os.path.normpath(
-        _os.path.abspath(str(pre_dir))
-    )
-    was_cached = _same_dir and pre_size is not None and size == pre_size
+    # Nothing was transferred iff the downloader reports it fetched zero bytes
+    # this pull. ``transferred_bytes`` comes from the mirror/HF transfer
+    # account; ``None`` (unknown, e.g. an unfiltered fallback) defaults to a
+    # download rather than over-claiming a cache hit.
+    was_cached = transferred_bytes is not None and transferred_bytes == 0
     if was_cached:
         print(
             f"  Already cached {repo_id} — {_format_bytes(size)} verified "
@@ -6635,17 +6631,11 @@ def pull_command(args):
         )
         sys.exit(1)
 
-    # Capture the resolved snapshot's dir + size BEFORE the transfer. The
-    # post-pull summary is labelled "verified (nothing to download)" only when
-    # the pull transferred no new bytes — same resolved dir AND same size —
-    # not merely because some stale local rev was already complete (issue
-    # #2349; a moved ``main`` can fetch new files despite a pre-existing rev).
-    try:
-        _pre_dir = _resolve_pull_snapshot_dir(repo_id)
-        _pre_size = _snapshot_size_bytes(_pre_dir) if _pre_dir else None
-    except Exception:
-        _pre_dir = None
-        _pre_size = None
+    # The pull summary says "already cached / nothing to download" only from
+    # the DOWNLOADER's own transfer account (mirror/HF bytes fetched), never
+    # from a filesystem guess. ``transferred`` is threaded to the summary.
+    transferred: int | None = None
+    _mirror_out: dict = {}
 
     # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
     # before adding more. huggingface_hub gives each attempt a uniquely-named
@@ -6679,7 +6669,7 @@ def pull_command(args):
             "  R2 mirror skipped: a --bits/--format variant was requested "
             "(the mirror cannot narrow to one variant yet)."
         )
-    if variant_allow is None and _try_mirror_prefetch(repo_id):
+    if variant_allow is None and _try_mirror_prefetch(repo_id, out=_mirror_out):
         from pathlib import Path
 
         try:
@@ -6697,12 +6687,12 @@ def pull_command(args):
         except OSError:
             snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
+        transferred = _mirror_out.get("transferred_bytes")
         _print_pull_summary(
             repo_id,
             snapshot_dir,
             time.monotonic() - t0,
-            pre_dir=_pre_dir,
-            pre_size=_pre_size,
+            transferred_bytes=transferred,
         )
         return
     # Mirror returned False — fall through to plain snapshot_download.
@@ -6767,11 +6757,26 @@ def pull_command(args):
                     f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
                 )
             _allow = [f"{_subfolder}/*"] if _subfolder else None
+        _bar_cls = _hf_bytes_bar_class()
+        _bars: list = []
+
+        def _make_bar(*a, **k):
+            b = _bar_cls(*a, **k)
+            _bars.append(b)
+            return b
+
         path = (
-            snapshot_download(repo_id, allow_patterns=_allow)
+            snapshot_download(repo_id, allow_patterns=_allow, tqdm_class=_make_bar)
             if _allow
-            else snapshot_download(repo_id)
+            else snapshot_download(repo_id, tqdm_class=_make_bar)
         )
+        # ``_bars`` is populated only if the downloader actually constructed a
+        # progress bar. When it did, its byte count is the authoritative
+        # "bytes transferred this pull" truth; when it did NOT (a mocked or
+        # anomalous downloader), we cannot prove zero transfer, so leave
+        # ``transferred`` unknown and report a download rather than a lie.
+        if _bars:
+            transferred = sum(b.transferred_bytes for b in _bars)
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a
@@ -6799,7 +6804,10 @@ def pull_command(args):
         raise
     print(f"  Cached at: {path}")
     _print_pull_summary(
-        repo_id, path, time.monotonic() - t0, pre_dir=_pre_dir, pre_size=_pre_size
+        repo_id,
+        path,
+        time.monotonic() - t0,
+        transferred_bytes=transferred,
     )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6819,6 +6819,14 @@ def pull_command(args):
         # re-link recreated snapshot symlinks; any changed blob (new file, or
         # a repaired corrupt/truncated blob whose size/mtime changed) => a real
         # download. ``_hf_cache_root`` resolves the cache entry (no network).
+        # The mirror may have ALREADY fetched some blobs before it returned
+        # False (a partial/failed attempt). Those bytes must still count: honor
+        # whatever the mirror reported on ANY exit path (Codex #2353). The R5
+        # per-file aggregation sets ``_mirror_out["network_fetch"]`` on the
+        # mirror's success AND partial-miss returns, so a partial mirror
+        # transfer forces "Downloaded" even when the snapshot_download that
+        # follows is a no-op.
+        _mirror_fetched = _mirror_out.get("network_fetch", False)
         _cache_root = _hf_cache_root(repo_id)
         _before = _blob_identifier(_cache_root)
         path = (
@@ -6827,7 +6835,7 @@ def pull_command(args):
             else snapshot_download(repo_id)
         )
         _after = _blob_identifier(_cache_root)
-        _was_cached = _before == _after and _before != ()
+        _was_cached = (_before == _after and _before != ()) and not _mirror_fetched
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a


### PR DESCRIPTION
Fixes #2349.

## Problem
`rapid-mlx pull <cached-model>` printed `[10/10] ... cached` then `Downloaded <repo> — 632.7 MiB in 3.8s` even when nothing was transferred. That made a cache reuse look like download performance and obscured whether offline reuse worked.

## Fix
- Capture `was_cached = is_repo_cached(repo_id)` at the top of `pull_command` (before any transfer).
- `_print_pull_summary` takes `was_cached` and emits `Already cached <repo> — <size> verified (nothing to download)` when the snapshot was already complete, reserving `Downloaded <repo> — <size> in <duration>` for a pull that actually transferred bytes.
- Both success paths (R2 mirror + HF fallback) pass the flag.

## Tests
- New `test_cached_pull_reports_verified_not_downloaded`: a fully-cached pull says `Already cached` + `verified (nothing to download)` and never `Downloaded`.
- Existing HF/mirror success tests now pin `is_repo_cached → False` so the "Downloaded" path is deterministic regardless of whether the test model happens to be in the real local cache.

Ran: pull_summary / mirror_pull / alias_subfolder / pull_variant_selection / pull_audio_alias_resolution suites (187 passed); ruff clean; mypy budget 725 no growth.