### PR TITLE
docs: stage 0.13.1 release notes

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -30,12 +30,13 @@ can actually understand.
 - **Assistant changes are explicit, safe transactions.** API clients can choose
   whether a busy text or vision model switch should reject, wait, or abort
   active assistant work. Desktop rejects a busy switch safely, and auxiliary
-  speech models remain resident. The replacement API accepts
-  `memory_policy=keep_then_commit` or `evict_first_if_needed`; the default
-  projection-gated policy evicts the replaced model only when both cannot fit
-  and the projected replacement fits, otherwise returning a typed 507 with
-  `replacement_projection` before eviction. Use `keep_then_commit` to require
-  a rollback-safe load. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+  speech models remain resident. The `/v1/models/load` API defaults
+  `memory_policy` to `evict_first_if_needed`: it keeps the rollback-safe load
+  when old and new fit together, evicts the replaced assistant first only when
+  keeping both breaches the limit but the replacement alone fits, and otherwise
+  returns a typed 507 with `replacement_projection` before destructive mutation.
+  Set `memory_policy=keep_then_commit` to require rollback-safe loading.
+  ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 - **Large multi-variant repositories can download one serving format.** The CLI
   accepts `--bits` or `--format`, so users do not need to fetch every
   quantization in a repository. ([#2145](https://github.com/raullenchai/Rapid-MLX/issues/2145),
@@ -55,13 +56,16 @@ can actually understand.
   validation now requires image-dependent answers from two cached vision
   families before the sidecar can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
   [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
-- **Vision-capable Qwen checkpoints choose the working lane by default.** With
-  mlx-vlm 0.6.16 or newer (included in the Desktop sidecar), Qwen3.5, Qwen3.6,
-  and supported Qwen3.8 vision-capable checkpoints serve on the vision lane so
-  photos work directly in chat. The experimental Flash-Next checkpoint remains
-  text-only in this release. Use `--no-mllm` in the CLI or the per-model
-  Performance override in Desktop to force text-only serving; MTP and
-  speculative decoding automatically retain the text lane.
+- **Vision-capable Qwen checkpoints choose the working lane automatically.**
+  Vision-capable Qwen3.5, Qwen3.6, and supported Qwen3.8 checkpoints use the
+  vision lane automatically when mlx-vlm 0.6.16 or newer is installed and the
+  checkpoint meets its measured vision-memory recommendation. If automatic
+  admission cannot use that lane, serving falls back to text with a
+  machine-readable reason. The experimental Flash-Next checkpoint is explicitly
+  text-only in this release. CLI users can force text serving with `--no-mllm`,
+  and Desktop exposes the same per-model Performance choice. Requests that
+  enable MTP or another speculative decoder select the text lane, where that
+  decoder is supported.
 - **API validation fails early with actionable fields.** Requests accept scalar
   or array `stop`, reject invalid timeouts and non-boolean residency controls,
   and identify the exact invalid load field. ([#2367](https://github.com/raullenchai/Rapid-MLX/pull/2367),
@@ -112,10 +116,12 @@ can actually understand.
 - **Speech to Text arms itself after model lifecycle changes.** When speech
   input is enabled, it becomes ready without an extra manual start button.
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
-- **Structured text requests terminate normally on the vision lane.** JSON
-  schema and title-generation requests now carry their output constraints and
-  complete with a terminal stop while photo requests continue using the same
-  multimodal server. ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
+- **Structured text requests terminate normally on the vision lane.**
+  JSON-schema responses and bounded-thinking or title-generation requests now
+  terminate normally on the vision lane: their request-local output processors
+  and complete configured EOS set reach the multimodal scheduler, while photo
+  requests continue using the same server.
+  ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
 - **Serving lanes honor the requested workload.** Experimental
   Qwen3.8-Flash-Next remains on its supported text lane, MTP and other
   speculative decoding requests choose the text lane, and text-diffusion

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -22,8 +22,10 @@ can actually understand.
 ### Added
 
 - **Experimental Qwen3.8-Flash-Next text inference.** The M1 lane supports the
-  mixed 4-bit checkpoint on Macs with at least 128 GB of unified memory. MTP
-  and vision support remain planned for a later release.
+  mixed 4-bit checkpoint through the `qwen3.8-flash-next-4bit` alias on Macs
+  with at least 128 GB of unified memory. This release exposes the experimental
+  text lane through the CLI and API; Desktop, MTP, and vision support remain
+  planned for a later release.
   ([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
 - **Assistant changes are explicit, safe transactions.** API clients can choose
   whether a busy text or vision model switch should reject, wait, or abort
@@ -83,6 +85,19 @@ can actually understand.
 - **Dictation remains available across chat-model switches.** The speech model
   stays resident and is restored after switching chat models.
   ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))
+- **MTP assistants survive loading a second model.** Generation remains bound
+  to its worker, so the original assistant continues answering instead of
+  losing its GPU stream. ([#2441](https://github.com/raullenchai/Rapid-MLX/pull/2441))
+- **Model-switch memory projections credit the assistant being replaced.** The
+  estimate uses the same fit thresholds as the replacement transaction and no
+  longer warns about memory that will be freed before the new model starts.
+  ([#2443](https://github.com/raullenchai/Rapid-MLX/pull/2443),
+  [#2444](https://github.com/raullenchai/Rapid-MLX/pull/2444))
+- **Speech to Text arms itself after model lifecycle changes.** When speech
+  input is enabled, it becomes ready without an extra manual start button.
+  ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
+<!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
+the bisect identifies and validates the exact landed fix. -->
 - **Photo rejection and multimodal reloads recover cleanly.** A rejected image
   cannot poison the next text turn, and a reloaded vision model cannot reuse a
   stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -55,6 +55,12 @@ can actually understand.
   validation now requires image-dependent answers from two cached vision
   families before the sidecar can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
   [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
+- **Vision-capable Qwen checkpoints choose the working lane by default.** With
+  mlx-vlm 0.6.16 or newer (included in the Desktop sidecar), Qwen3.5, Qwen3.6,
+  and Qwen3.8 vision-capable checkpoints serve on the vision lane so photos
+  work directly in chat. Use `--no-mllm` in the CLI or the per-model
+  Performance override in Desktop to force text-only serving; MTP and
+  speculative decoding automatically retain the text lane.
 - **API validation fails early with actionable fields.** Requests accept scalar
   or array `stop`, reject invalid timeouts and non-boolean residency controls,
   and identify the exact invalid load field. ([#2367](https://github.com/raullenchai/Rapid-MLX/pull/2367),

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -38,6 +38,21 @@ can actually understand.
   prevents models from selecting general web search or claiming the advertised
   Weather tool is unavailable. ([#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
   [#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
+- **Desktop photo input uses the updated bundled vision runtime.** Release
+  validation now requires image-dependent answers from two cached vision
+  families before the sidecar can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
+  [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
+- **API validation fails early with actionable fields.** Requests accept scalar
+  or array `stop`, reject invalid timeouts and non-boolean residency controls,
+  and identify the exact invalid load field. ([#2367](https://github.com/raullenchai/Rapid-MLX/pull/2367),
+  [#2371](https://github.com/raullenchai/Rapid-MLX/pull/2371),
+  [#2372](https://github.com/raullenchai/Rapid-MLX/pull/2372))
+- **Guided setup accurately describes data preservation.** Its confirmation no
+  longer implies that onboarding reset deletes user data. ([#2239](https://github.com/raullenchai/Rapid-MLX/issues/2239),
+  [#2322](https://github.com/raullenchai/Rapid-MLX/pull/2322))
+- **Share CLI contracts use supported invocation forms and run in CI.**
+  ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
+  [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
 
 ### Documentation
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -55,6 +55,15 @@ can actually understand.
 - **Share CLI contracts use supported invocation forms and run in CI.**
   ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
+- **Environment diagnosis identifies the CLI that is actually running.**
+  `rapid-mlx doctor` reports both the active-environment executable and a
+  different installation found on `PATH`, with actionable mismatch guidance.
+  ([#2352](https://github.com/raullenchai/Rapid-MLX/issues/2352),
+  [#2402](https://github.com/raullenchai/Rapid-MLX/pull/2402))
+- **Offline serving failures are concise and actionable.** An uncached model
+  now stops after one cache and connectivity explanation instead of repeating
+  download work or recommending an unrelated serving lane.
+  ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
 - **First run chooses a hardware-fit starter and photos use the correct lane.**
   Eligible cached models remain preferred, and supported hybrid vision models
   route automatically. ([#2385](https://github.com/raullenchai/Rapid-MLX/pull/2385),
@@ -90,6 +99,10 @@ can actually understand.
   [#2350](https://github.com/raullenchai/Rapid-MLX/issues/2350),
   [#2392](https://github.com/raullenchai/Rapid-MLX/pull/2392),
   [#2349](https://github.com/raullenchai/Rapid-MLX/issues/2349))
+- **Cached speech checkpoints are recognized by their real layouts.** Complete
+  Kokoro and Whisper Turbo snapshots count as runnable when their verified
+  family-specific weights are present. ([#2406](https://github.com/raullenchai/Rapid-MLX/issues/2406),
+  [#2417](https://github.com/raullenchai/Rapid-MLX/pull/2417))
 - **System-prompt settings explain what is actually sent.** Saved and effective
   prompts are distinguished, and optional credentials are read only when
   needed. ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -36,9 +36,9 @@ can actually understand.
   as LFM2.5 2.6B 4-bit no longer fall back to a slow or unreachable upstream
   route merely because the quantization lives in a repository subfolder.
   ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/2279))
-- **Explicit weather requests stay on the Weather tool.** Evaluation coverage
-  prevents models from selecting general web search or claiming the advertised
-  Weather tool is unavailable. ([#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
+- **Explicit weather requests have dedicated regression coverage.** Evaluation
+  scenarios detect models selecting general web search or claiming the
+  advertised Weather tool is unavailable. ([#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
   [#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
 - **Desktop photo input uses the updated bundled vision runtime.** Release
   validation now requires image-dependent answers from two cached vision

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -53,6 +53,44 @@ can actually understand.
 - **Share CLI contracts use supported invocation forms and run in CI.**
   ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
+- **First run chooses a hardware-fit starter and photos use the correct lane.**
+  Eligible cached models remain preferred, and supported hybrid vision models
+  route automatically. ([#2385](https://github.com/raullenchai/Rapid-MLX/pull/2385),
+  [#2219](https://github.com/raullenchai/Rapid-MLX/issues/2219),
+  [#2388](https://github.com/raullenchai/Rapid-MLX/pull/2388))
+- **Dictation remains available across chat-model switches.** The speech model
+  stays resident and is restored after switching, while a proven chat selection
+  survives an in-session restart. ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400),
+  [#2374](https://github.com/raullenchai/Rapid-MLX/pull/2374),
+  [#2363](https://github.com/raullenchai/Rapid-MLX/issues/2363),
+  [#2364](https://github.com/raullenchai/Rapid-MLX/issues/2364))
+- **Photo rejection and multimodal reloads recover cleanly.** A rejected image
+  cannot poison the next text turn, and a reloaded vision model cannot reuse a
+  stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
+  [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),
+  [#2401](https://github.com/raullenchai/Rapid-MLX/pull/2401),
+  [#2397](https://github.com/raullenchai/Rapid-MLX/issues/2397))
+- **Live API identity and cancellation are dependable.** Readiness and connect
+  guidance use the live port and served model name, and public streaming IDs
+  are cancellable. ([#2386](https://github.com/raullenchai/Rapid-MLX/pull/2386),
+  [#2348](https://github.com/raullenchai/Rapid-MLX/issues/2348),
+  [#2395](https://github.com/raullenchai/Rapid-MLX/pull/2395),
+  [#2353](https://github.com/raullenchai/Rapid-MLX/issues/2353),
+  [#2398](https://github.com/raullenchai/Rapid-MLX/pull/2398),
+  [#2342](https://github.com/raullenchai/Rapid-MLX/issues/2342))
+- **Reload failures preserve a truthful serving state.** Registry, residency,
+  routing, readiness, and speech handoff remain consistent even when both a
+  primary reload and its restoration fail. ([#2394](https://github.com/raullenchai/Rapid-MLX/pull/2394),
+  [#2360](https://github.com/raullenchai/Rapid-MLX/issues/2360))
+- **Download status and size warnings stay truthful offline.** Catalog size is
+  retained when remote metadata is unavailable, and cached pulls report
+  verification rather than a new download. ([#2391](https://github.com/raullenchai/Rapid-MLX/pull/2391),
+  [#2350](https://github.com/raullenchai/Rapid-MLX/issues/2350),
+  [#2392](https://github.com/raullenchai/Rapid-MLX/pull/2392),
+  [#2349](https://github.com/raullenchai/Rapid-MLX/issues/2349))
+- **System-prompt settings explain what is actually sent.** Saved and effective
+  prompts are distinguished, and optional credentials are read only when
+  needed. ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
 
 ### Documentation
 
@@ -60,6 +98,8 @@ can actually understand.
   supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
 - Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
   ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
+
+<!-- Train 3 entries are added here only after that train lands. -->
 
 ## [0.13.0] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -24,8 +24,8 @@ can actually understand.
 - **Experimental Qwen3.8-Flash-Next text inference.** The M1 lane supports the
   mixed 4-bit checkpoint through the `qwen3.8-flash-next-4bit` alias on Macs
   with at least 128 GB of unified memory. This release exposes the experimental
-  text lane through the CLI and API; Desktop, MTP, and vision support remain
-  planned for a later release.
+  text lane through the CLI and API; release validation used a 256 GB Mac, and
+  Desktop, MTP, and vision support remain planned for a later release.
   ([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
 - **Assistant changes are explicit, safe transactions.** API clients can choose
   whether a busy text or vision model switch should reject, wait, or abort
@@ -57,8 +57,9 @@ can actually understand.
   [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
 - **Vision-capable Qwen checkpoints choose the working lane by default.** With
   mlx-vlm 0.6.16 or newer (included in the Desktop sidecar), Qwen3.5, Qwen3.6,
-  and Qwen3.8 vision-capable checkpoints serve on the vision lane so photos
-  work directly in chat. Use `--no-mllm` in the CLI or the per-model
+  and supported Qwen3.8 vision-capable checkpoints serve on the vision lane so
+  photos work directly in chat. The experimental Flash-Next checkpoint remains
+  text-only in this release. Use `--no-mllm` in the CLI or the per-model
   Performance override in Desktop to force text-only serving; MTP and
   speculative decoding automatically retain the text lane.
 - **API validation fails early with actionable fields.** Requests accept scalar
@@ -84,7 +85,8 @@ can actually understand.
 - **Offline serving failures are concise and actionable.** An uncached model
   now stops after one cache and connectivity explanation instead of repeating
   download work or recommending an unrelated serving lane.
-  ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
+  ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357),
+  [#2423](https://github.com/raullenchai/Rapid-MLX/pull/2423))
 - **First run chooses a hardware-fit starter and photos use the correct lane.**
   Eligible cached models remain preferred, and supported hybrid vision models
   route automatically. ([#2385](https://github.com/raullenchai/Rapid-MLX/pull/2385),
@@ -110,12 +112,26 @@ can actually understand.
 - **Speech to Text arms itself after model lifecycle changes.** When speech
   input is enabled, it becomes ready without an extra manual start button.
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
-<!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
-the bisect identifies and validates the exact landed fix. -->
-<!-- KNOWN-ISSUE CONDITIONAL: include only if the train-6c suffix-decoding fix
-does not land: "Suffix decoding with sliding-window models such as Gemma 4 and
-GPT-OSS can abort a request at a window boundary. Workaround: disable suffix
-decoding." -->
+- **Structured text requests terminate normally on the vision lane.** JSON
+  schema and title-generation requests now carry their output constraints and
+  complete with a terminal stop while photo requests continue using the same
+  multimodal server. ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
+- **Serving lanes honor the requested workload.** Experimental
+  Qwen3.8-Flash-Next remains on its supported text lane, MTP and other
+  speculative decoding requests choose the text lane, and text-diffusion
+  assistants can replace another assistant without a spurious group-conflict
+  response. ([#2472](https://github.com/raullenchai/Rapid-MLX/pull/2472))
+- **iPhone HEIC photos can be attached to chat.** Picker, drop, and paste share
+  one normalization boundary that converts supported still images to truthful
+  JPEG or PNG bytes while preserving the attachment size limit.
+  ([#2467](https://github.com/raullenchai/Rapid-MLX/pull/2467))
+- **High-resolution photos fit the model's vision budget.** Desktop downscales
+  oversized images before sending them, and a typed image rejection no longer
+  leaves a failed attachment turn that contaminates the conversation.
+- **Launch avoids full app-bundle identity revalidation.** Keychain namespace
+  selection checks the signing certificate without rehashing every sealed
+  resource, and Escape no longer silently declines the later telemetry-consent
+  invitation. ([#2470](https://github.com/raullenchai/Rapid-MLX/pull/2470))
 - **Photo rejection and multimodal reloads recover cleanly.** A rejected image
   cannot poison the next text turn, and a reloaded vision model cannot reuse a
   stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
@@ -147,11 +163,6 @@ decoding." -->
 - **System-prompt settings explain what is actually sent.** Saved and effective
   prompts are distinguished, and optional credentials are read only when
   needed. ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
-- **Generated images can be removed safely from the session gallery.** A
-  confirmation protects against accidental deletion, adjacent selection and
-  the empty state recover correctly, and files already saved to disk are left
-  untouched. Contributed by
-  [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
 - **Complete offline snapshots remain available without a branch ref.** A
   single immutable cached revision is recognized as runnable, while ambiguous
   multi-snapshot caches still fail closed. ([#2351](https://github.com/raullenchai/Rapid-MLX/issues/2351),
@@ -171,6 +182,12 @@ decoding." -->
   supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
 - Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
   ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
+
+### Known issues
+
+- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
+  abort a request at a window boundary. Disable suffix decoding for these
+  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
 
 ## [0.13.0] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -30,7 +30,12 @@ can actually understand.
 - **Assistant changes are explicit, safe transactions.** API clients can choose
   whether a busy text or vision model switch should reject, wait, or abort
   active assistant work. Desktop rejects a busy switch safely, and auxiliary
-  speech models remain resident. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+  speech models remain resident. The replacement API accepts
+  `memory_policy=keep_then_commit` or `evict_first_if_needed`; the default
+  projection-gated policy evicts the replaced model only when both cannot fit
+  and the projected replacement fits, otherwise returning a typed 507 with
+  `replacement_projection` before eviction. Use `keep_then_commit` to require
+  a rollback-safe load. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 - **Large multi-variant repositories can download one serving format.** The CLI
   accepts `--bits` or `--format`, so users do not need to fetch every
   quantization in a repository. ([#2145](https://github.com/raullenchai/Rapid-MLX/issues/2145),

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -74,11 +74,8 @@ can actually understand.
   [#2219](https://github.com/raullenchai/Rapid-MLX/issues/2219),
   [#2388](https://github.com/raullenchai/Rapid-MLX/pull/2388))
 - **Dictation remains available across chat-model switches.** The speech model
-  stays resident and is restored after switching, while a proven chat selection
-  survives an in-session restart. ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400),
-  [#2374](https://github.com/raullenchai/Rapid-MLX/pull/2374),
-  [#2363](https://github.com/raullenchai/Rapid-MLX/issues/2363),
-  [#2364](https://github.com/raullenchai/Rapid-MLX/issues/2364))
+  stays resident and is restored after switching chat models.
+  ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))
 - **Photo rejection and multimodal reloads recover cleanly.** A rejected image
   cannot poison the next text turn, and a reloaded vision model cannot reuse a
   stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -73,6 +73,9 @@ can actually understand.
   route automatically. ([#2385](https://github.com/raullenchai/Rapid-MLX/pull/2385),
   [#2219](https://github.com/raullenchai/Rapid-MLX/issues/2219),
   [#2388](https://github.com/raullenchai/Rapid-MLX/pull/2388))
+- **8 GB Macs start with a model that fits.** First run recommends
+  `lfm2.5-1b-4bit` on the lowest memory tier, avoiding the RAM warning produced
+  by the previous 2.6B starter. ([#2432](https://github.com/raullenchai/Rapid-MLX/pull/2432))
 - **Dictation remains available across chat-model switches.** The speech model
   stays resident and is restored after switching chat models.
   ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -118,8 +118,6 @@ can actually understand.
 - Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
   ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
 
-<!-- Remaining train 4 entries are added here only after that train lands. -->
-
 ## [0.13.0] — 2026-08-26
 
 Rapid-MLX 0.13.0 makes first setup clearer, expands local model support, keeps

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -98,6 +98,18 @@ can actually understand.
   the empty state recover correctly, and files already saved to disk are left
   untouched. Contributed by
   [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
+- **Complete offline snapshots remain available without a branch ref.** A
+  single immutable cached revision is recognized as runnable, while ambiguous
+  multi-snapshot caches still fail closed. ([#2351](https://github.com/raullenchai/Rapid-MLX/issues/2351),
+  [#2404](https://github.com/raullenchai/Rapid-MLX/pull/2404))
+- **Model switching no longer scans mounted filesystems to discover servers.**
+  Live socket ownership supplies the same port and process facts without
+  prompting for access to unrelated volumes. ([#2343](https://github.com/raullenchai/Rapid-MLX/issues/2343),
+  [#2408](https://github.com/raullenchai/Rapid-MLX/pull/2408))
+- **Files can be dropped directly into the chat composer.** Supported native
+  file URLs use the existing attachment importer, while unsupported drops
+  cannot leak a local path into the message. Contributed by
+  [osdodo](https://github.com/osdodo). ([#2396](https://github.com/raullenchai/Rapid-MLX/pull/2396))
 
 ### Documentation
 
@@ -106,7 +118,7 @@ can actually understand.
 - Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
   ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
 
-<!-- Remaining train 3/4 entries are added here only after those trains land. -->
+<!-- Remaining train 4 entries are added here only after that train lands. -->
 
 ## [0.13.0] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -52,6 +52,10 @@ can actually understand.
 - **Guided setup accurately describes data preservation.** Its confirmation no
   longer implies that onboarding reset deletes user data. ([#2239](https://github.com/raullenchai/Rapid-MLX/issues/2239),
   [#2322](https://github.com/raullenchai/Rapid-MLX/pull/2322))
+- **Telemetry consent appears after Rapid demonstrates value.** The one-time
+  question follows a successful chat reply, delivered dictation transcript, or
+  generated image instead of interrupting first launch. Nothing is sent before
+  explicit consent. ([#2424](https://github.com/raullenchai/Rapid-MLX/pull/2424))
 - **Share CLI contracts use supported invocation forms and run in CI.**
   ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,35 @@ can actually understand.
 
 ## [Unreleased]
 
+### Added
+
+- **Assistant changes are explicit, safe transactions.** Desktop and API
+  clients can choose whether a busy text or vision model switch should reject,
+  wait, or abort active assistant work, without evicting auxiliary speech
+  models or leaving request ownership ambiguous. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+- **Large multi-variant repositories can download one serving format.** The CLI
+  accepts `--bits` or `--format`, so users do not need to fetch every
+  quantization in a repository. ([#2145](https://github.com/raullenchai/Rapid-MLX/issues/2145),
+  [#2338](https://github.com/raullenchai/Rapid-MLX/pull/2338))
+
+### Fixed
+
+- **Mirrored subfolder quantizations download from the fast path.** Models such
+  as LFM2.5 2.6B 4-bit no longer fall back to a slow or unreachable upstream
+  route merely because the quantization lives in a repository subfolder.
+  ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/2279))
+- **Explicit weather requests stay on the Weather tool.** Evaluation coverage
+  prevents models from selecting general web search or claiming the advertised
+  Weather tool is unavailable. ([#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
+  [#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
+
+### Documentation
+
+- Corrected the 0.13.0 Nemotron Labs Diffusion description to identify its
+  supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
+- Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
+  ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
+
 ## [0.13.0] — 2026-08-26
 
 Rapid-MLX 0.13.0 makes first setup clearer, expands local model support, keeps

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,8 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.1] — 2026-08-26
+
 ### Added
 
 - **Assistant changes are explicit, safe transactions.** Desktop and API
@@ -91,6 +93,11 @@ can actually understand.
 - **System-prompt settings explain what is actually sent.** Saved and effective
   prompts are distinguished, and optional credentials are read only when
   needed. ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
+- **Generated images can be removed safely from the session gallery.** A
+  confirmation protects against accidental deletion, adjacent selection and
+  the empty state recover correctly, and files already saved to disk are left
+  untouched. Contributed by
+  [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
 
 ### Documentation
 
@@ -99,7 +106,7 @@ can actually understand.
 - Published a reproducible M2 Pro comparison of 0.13.0 and 0.12.18.
   ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
 
-<!-- Train 3 entries are added here only after that train lands. -->
+<!-- Remaining train 3/4 entries are added here only after those trains land. -->
 
 ## [0.13.0] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -21,10 +21,10 @@ can actually understand.
 
 ### Added
 
-- **Assistant changes are explicit, safe transactions.** Desktop and API
-  clients can choose whether a busy text or vision model switch should reject,
-  wait, or abort active assistant work, without evicting auxiliary speech
-  models or leaving request ownership ambiguous. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+- **Assistant changes are explicit, safe transactions.** API clients can choose
+  whether a busy text or vision model switch should reject, wait, or abort
+  active assistant work. Desktop rejects a busy switch safely, and auxiliary
+  speech models remain resident. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 - **Large multi-variant repositories can download one serving format.** The CLI
   accepts `--bits` or `--format`, so users do not need to fetch every
   quantization in a repository. ([#2145](https://github.com/raullenchai/Rapid-MLX/issues/2145),
@@ -3301,7 +3301,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.12.16...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...HEAD
+[0.13.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.0...rapid-mac-v0.13.1
 [0.5.16]: https://github.com/machinefi/rapid-desktop/compare/v0.5.15...v0.5.16
 [0.5.15]: https://github.com/machinefi/rapid-desktop/compare/v0.5.14...v0.5.15
 [0.5.14]: https://github.com/machinefi/rapid-desktop/compare/v0.5.13...v0.5.14

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -21,6 +21,10 @@ can actually understand.
 
 ### Added
 
+- **Experimental Qwen3.8-Flash-Next text inference.** The M1 lane supports the
+  mixed 4-bit checkpoint on Macs with at least 128 GB of unified memory. MTP
+  and vision support remain planned for a later release.
+  ([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
 - **Assistant changes are explicit, safe transactions.** API clients can choose
   whether a busy text or vision model switch should reject, wait, or abort
   active assistant work. Desktop rejects a busy switch safely, and auxiliary

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -94,8 +94,11 @@ can actually understand.
   to its worker, so the original assistant continues answering instead of
   losing its GPU stream. ([#2441](https://github.com/raullenchai/Rapid-MLX/pull/2441))
 - **Model-switch memory projections credit the assistant being replaced.** The
-  estimate uses the same fit thresholds as the replacement transaction and no
-  longer warns about memory that will be freed before the new model starts.
+  estimate uses the same fit thresholds as the replacement transaction.
+  Desktop's low-memory threshold moves from 85% to 100%: 95–100% shows
+  advisory guidance and above 100% requires confirmation. The previous
+  conservative threshold is superseded now that projections credit memory
+  freed by the model being replaced.
   ([#2443](https://github.com/raullenchai/Rapid-MLX/pull/2443),
   [#2444](https://github.com/raullenchai/Rapid-MLX/pull/2444))
 - **Speech to Text arms itself after model lifecycle changes.** When speech
@@ -103,6 +106,10 @@ can actually understand.
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
 <!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
 the bisect identifies and validates the exact landed fix. -->
+<!-- KNOWN-ISSUE CONDITIONAL: include only if the train-6c suffix-decoding fix
+does not land: "Suffix decoding with sliding-window models such as Gemma 4 and
+GPT-OSS can abort a request at a window boundary. Workaround: disable suffix
+decoding." -->
 - **Photo rejection and multimodal reloads recover cleanly.** A rejected image
   cannot poison the next text turn, and a reloaded vision model cannot reuse a
   stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -84,6 +84,18 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Generated images can be removed from the in-memory gallery with confirmation;
   saved copies remain untouched. Contributed by
   [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
+- A complete offline cache with one immutable snapshot remains runnable even
+  when a branch ref is unavailable; ambiguous multi-snapshot caches remain
+  unresolved rather than guessing. ([#2351](https://github.com/raullenchai/Rapid-MLX/issues/2351),
+  [#2404](https://github.com/raullenchai/Rapid-MLX/pull/2404))
+- Server discovery for model switching uses live socket ownership instead of
+  scanning mounted filesystems, avoiding unrelated volume-access prompts.
+  ([#2343](https://github.com/raullenchai/Rapid-MLX/issues/2343),
+  [#2408](https://github.com/raullenchai/Rapid-MLX/pull/2408))
+- Native file URL drops on the chat composer use the existing attachment
+  importer, and unsupported drops cannot insert a local path into the message.
+  Contributed by [osdodo](https://github.com/osdodo).
+  ([#2396](https://github.com/raullenchai/Rapid-MLX/pull/2396))
 
 ## Release evidence and corrections
 
@@ -96,5 +108,5 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 
 - This file is a living release skeleton. It will be updated with every merged
   0.13.1 train before the version bump and final release cut.
-- Remaining train 3 and train 4 changes will be curated into the sections above
-  only after they land; this placeholder does not claim unmerged work.
+- Remaining train 4 changes will be curated into the sections above only after
+  they land; this placeholder does not claim unmerged work.

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -43,6 +43,13 @@ two cached vision families produce image-dependent answers before an artifact
 can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
 
+With mlx-vlm 0.6.16 or newer—bundled in the Desktop sidecar—vision-capable
+Qwen3.5, Qwen3.6, and Qwen3.8 checkpoints use the vision lane by default, so
+photos work directly in chat. CLI users can force text-only serving with
+`--no-mllm`; Desktop users can make the same choice through the model's
+Performance override. MTP or speculative decoding automatically retains the
+text lane.
+
 **A better first model for each Mac** — First run now prefers an eligible
 cached model, then chooses a starter that fits the machine instead of applying
 one recommendation to every Mac. Supported hybrid vision checkpoints are

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -19,9 +19,9 @@ of gigabytes of formats the user did not select. ([#2145](https://github.com/rau
 [#2338](https://github.com/raullenchai/Rapid-MLX/pull/2338))
 
 **More dependable downloads and tool routing** — Subfolder-based quantizations
-can use the Rapid mirror instead of being hard-routed upstream, and explicit
-current-weather prompts are locked to the advertised Weather tool rather than a
-generic search fallback. ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/2279),
+can use the Rapid mirror instead of being hard-routed upstream. Dedicated
+evaluation scenarios now catch explicit current-weather prompts that choose a
+generic search fallback instead of the advertised Weather tool. ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/2279),
 [#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
 [#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
 

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -52,6 +52,13 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Share CLI coverage now exercises only supported invocation forms and runs in
   CI. ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
+- `rapid-mlx doctor` distinguishes the executable running inside the active
+  environment from another installation found on `PATH`, and explains how to
+  resolve a mismatch. ([#2352](https://github.com/raullenchai/Rapid-MLX/issues/2352),
+  [#2402](https://github.com/raullenchai/Rapid-MLX/pull/2402))
+- Serving an uncached model while offline stops with one actionable cache and
+  connectivity explanation instead of retrying the same download or suggesting
+  an unrelated serving lane. ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
 - Dictation stays resident and is restored after switching chat models, while
   an in-session restart preserves a proven chat selection. ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400),
   [#2374](https://github.com/raullenchai/Rapid-MLX/pull/2374),
@@ -79,6 +86,9 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   [#2350](https://github.com/raullenchai/Rapid-MLX/issues/2350),
   [#2392](https://github.com/raullenchai/Rapid-MLX/pull/2392),
   [#2349](https://github.com/raullenchai/Rapid-MLX/issues/2349))
+- Complete cached Kokoro and Whisper Turbo snapshots are recognized as runnable
+  using their verified audio weight layouts. ([#2406](https://github.com/raullenchai/Rapid-MLX/issues/2406),
+  [#2417](https://github.com/raullenchai/Rapid-MLX/pull/2417))
 - System-prompt settings distinguish the saved instruction from the effective
   prompt and avoid touching optional credentials until they are needed.
   ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -81,6 +81,9 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - System-prompt settings distinguish the saved instruction from the effective
   prompt and avoid touching optional credentials until they are needed.
   ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
+- Generated images can be removed from the in-memory gallery with confirmation;
+  saved copies remain untouched. Contributed by
+  [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
 
 ## Release evidence and corrections
 
@@ -93,5 +96,5 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 
 - This file is a living release skeleton. It will be updated with every merged
   0.13.1 train before the version bump and final release cut.
-- Train 3 changes will be curated into the sections above after that train
-  lands; this placeholder does not claim unmerged work.
+- Remaining train 3 and train 4 changes will be curated into the sections above
+  only after they land; this placeholder does not claim unmerged work.

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -6,8 +6,10 @@ on the fast download route.
 ## Highlights
 
 **Experimental Qwen3.8-Flash-Next text inference** — The M1 lane supports the
-mixed 4-bit checkpoint on Macs with at least 128 GB of unified memory. MTP and
-vision support remain planned for a later release.
+mixed 4-bit checkpoint through the `qwen3.8-flash-next-4bit` alias on Macs with
+at least 128 GB of unified memory. This release exposes the experimental text
+lane through the CLI and API; Desktop, MTP, and vision support remain planned
+for a later release.
 ([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
 
 **Switch assistants without losing track of active work** — API model
@@ -73,6 +75,19 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   by the previous 2.6B starter. ([#2432](https://github.com/raullenchai/Rapid-MLX/pull/2432))
 - Dictation stays resident and is restored after switching chat models.
   ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))
+- MTP generation remains bound to its worker when another model loads, so the
+  original assistant continues answering instead of losing its GPU stream.
+  ([#2441](https://github.com/raullenchai/Rapid-MLX/pull/2441))
+- Model-switch memory estimates credit the assistant being replaced and use
+  the same fit thresholds as the actual replacement transaction, avoiding a
+  warning for memory that will be freed before the new model starts.
+  ([#2443](https://github.com/raullenchai/Rapid-MLX/pull/2443),
+  [#2444](https://github.com/raullenchai/Rapid-MLX/pull/2444))
+- Speech to Text automatically arms after model lifecycle changes when the user
+  has enabled it; there is no extra manual start button to press.
+  ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
+<!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
+the bisect identifies and validates the exact landed fix. -->
 - A rejected photo no longer contaminates the next text turn, and multimodal
   unload/reload cannot reuse a stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
   [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -49,6 +49,10 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Guided setup now says explicitly that it preserves user data, avoiding a
   misleading destructive-action warning. ([#2239](https://github.com/raullenchai/Rapid-MLX/issues/2239),
   [#2322](https://github.com/raullenchai/Rapid-MLX/pull/2322))
+- The one-time telemetry consent question waits until Rapid has delivered a
+  successful chat reply, dictation transcript, or generated image instead of
+  interrupting first launch. Nothing is sent before explicit consent.
+  ([#2424](https://github.com/raullenchai/Rapid-MLX/pull/2424))
 - Share CLI coverage now exercises only supported invocation forms and runs in
   CI. ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -24,6 +24,26 @@ generic search fallback. ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/
 [#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
 [#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
 
+**Photo input uses the validated bundled vision runtime** — The Desktop
+sidecar carries the updated vision stack and the release gate now proves that
+two cached vision families produce image-dependent answers before an artifact
+can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
+[#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
+
+## Reliability and setup corrections
+
+- API request validation accepts either a scalar or array `stop`, rejects
+  invalid timeouts, requires real JSON booleans for resident-model controls,
+  and reports the precise invalid field path. ([#2367](https://github.com/raullenchai/Rapid-MLX/pull/2367),
+  [#2371](https://github.com/raullenchai/Rapid-MLX/pull/2371),
+  [#2372](https://github.com/raullenchai/Rapid-MLX/pull/2372))
+- Guided setup now says explicitly that it preserves user data, avoiding a
+  misleading destructive-action warning. ([#2239](https://github.com/raullenchai/Rapid-MLX/issues/2239),
+  [#2322](https://github.com/raullenchai/Rapid-MLX/pull/2322))
+- Share CLI coverage now exercises only supported invocation forms and runs in
+  CI. ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
+  [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
+
 ## Release evidence and corrections
 
 - Corrected the published Nemotron Labs Diffusion description so it accurately

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -5,11 +5,12 @@ on the fast download route.
 
 ## Highlights
 
-**Switch assistants without losing track of active work** — Model replacement
-now has explicit reject, wait, and abort policies shared by the engine and
-server. Request ownership transfers atomically, admitted work is quiesced before
-reload, and auxiliary dictation residency remains independent of the selected
-assistant. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+**Switch assistants without losing track of active work** — API model
+replacement now has explicit reject, wait, and abort policies shared by the
+engine and server; Desktop uses the safe reject policy while a request is busy.
+Request ownership transfers atomically, admitted work is quiesced before reload,
+and auxiliary dictation residency remains independent of the selected assistant.
+([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 
 **Download one usable variant instead of an entire repository** — `rapid-mlx
 pull` accepts `--bits` or `--format` for repositories that store several

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -30,6 +30,14 @@ two cached vision families produce image-dependent answers before an artifact
 can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
 
+**A better first model for each Mac** — First run now prefers an eligible
+cached model, then chooses a starter that fits the machine instead of applying
+one recommendation to every Mac. Supported hybrid vision checkpoints are
+routed to their working multimodal lane, so photos work with the recommended
+model without a manual engine choice. ([#2385](https://github.com/raullenchai/Rapid-MLX/pull/2385),
+[#2219](https://github.com/raullenchai/Rapid-MLX/issues/2219),
+[#2388](https://github.com/raullenchai/Rapid-MLX/pull/2388))
+
 ## Reliability and setup corrections
 
 - API request validation accepts either a scalar or array `stop`, rejects
@@ -43,6 +51,36 @@ can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 - Share CLI coverage now exercises only supported invocation forms and runs in
   CI. ([#2377](https://github.com/raullenchai/Rapid-MLX/issues/2377),
   [#2382](https://github.com/raullenchai/Rapid-MLX/pull/2382))
+- Dictation stays resident and is restored after switching chat models, while
+  an in-session restart preserves a proven chat selection. ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400),
+  [#2374](https://github.com/raullenchai/Rapid-MLX/pull/2374),
+  [#2363](https://github.com/raullenchai/Rapid-MLX/issues/2363),
+  [#2364](https://github.com/raullenchai/Rapid-MLX/issues/2364))
+- A rejected photo no longer contaminates the next text turn, and multimodal
+  unload/reload cannot reuse a stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
+  [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),
+  [#2401](https://github.com/raullenchai/Rapid-MLX/pull/2401),
+  [#2397](https://github.com/raullenchai/Rapid-MLX/issues/2397))
+- Readiness and connection guidance now report the live port, selected model,
+  and served name. Public streaming request IDs can be cancelled reliably.
+  ([#2386](https://github.com/raullenchai/Rapid-MLX/pull/2386),
+  [#2348](https://github.com/raullenchai/Rapid-MLX/issues/2348),
+  [#2395](https://github.com/raullenchai/Rapid-MLX/pull/2395),
+  [#2353](https://github.com/raullenchai/Rapid-MLX/issues/2353),
+  [#2398](https://github.com/raullenchai/Rapid-MLX/pull/2398),
+  [#2342](https://github.com/raullenchai/Rapid-MLX/issues/2342))
+- Failed primary reload recovery keeps registry, residency, routing, readiness,
+  and speech handoff consistent. ([#2394](https://github.com/raullenchai/Rapid-MLX/pull/2394),
+  [#2360](https://github.com/raullenchai/Rapid-MLX/issues/2360))
+- Downloads retain the catalog's size warning when remote metadata is missing,
+  and cached pulls are reported as verified rather than newly downloaded.
+  ([#2391](https://github.com/raullenchai/Rapid-MLX/pull/2391),
+  [#2350](https://github.com/raullenchai/Rapid-MLX/issues/2350),
+  [#2392](https://github.com/raullenchai/Rapid-MLX/pull/2392),
+  [#2349](https://github.com/raullenchai/Rapid-MLX/issues/2349))
+- System-prompt settings distinguish the saved instruction from the effective
+  prompt and avoid touching optional credentials until they are needed.
+  ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
 
 ## Release evidence and corrections
 
@@ -55,3 +93,5 @@ can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 
 - This file is a living release skeleton. It will be updated with every merged
   0.13.1 train before the version bump and final release cut.
+- Train 3 changes will be curated into the sections above after that train
+  lands; this placeholder does not claim unmerged work.

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -8,8 +8,8 @@ on the fast download route.
 **Experimental Qwen3.8-Flash-Next text inference** — The M1 lane supports the
 mixed 4-bit checkpoint through the `qwen3.8-flash-next-4bit` alias on Macs with
 at least 128 GB of unified memory. This release exposes the experimental text
-lane through the CLI and API; Desktop, MTP, and vision support remain planned
-for a later release.
+lane through the CLI and API; release validation used a 256 GB Mac, and Desktop,
+MTP, and vision support remain planned for a later release.
 ([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
 
 **Switch assistants without losing track of active work** — API model
@@ -44,11 +44,12 @@ can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
 
 With mlx-vlm 0.6.16 or newer—bundled in the Desktop sidecar—vision-capable
-Qwen3.5, Qwen3.6, and Qwen3.8 checkpoints use the vision lane by default, so
-photos work directly in chat. CLI users can force text-only serving with
-`--no-mllm`; Desktop users can make the same choice through the model's
-Performance override. MTP or speculative decoding automatically retains the
-text lane.
+Qwen3.5, Qwen3.6, and supported Qwen3.8 checkpoints use the vision lane by
+default, so photos work directly in chat. The experimental Flash-Next
+checkpoint remains text-only in this release. CLI users can force text-only
+serving with `--no-mllm`; Desktop users can make the same choice through the
+model's Performance override. MTP or speculative decoding automatically
+retains the text lane.
 
 **A better first model for each Mac** — First run now prefers an eligible
 cached model, then chooses a starter that fits the machine instead of applying
@@ -81,7 +82,8 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   [#2402](https://github.com/raullenchai/Rapid-MLX/pull/2402))
 - Serving an uncached model while offline stops with one actionable cache and
   connectivity explanation instead of retrying the same download or suggesting
-  an unrelated serving lane. ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
+  an unrelated serving lane. ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357),
+  [#2423](https://github.com/raullenchai/Rapid-MLX/pull/2423))
 - **8 GB Macs start with a model that fits.** First run recommends
   `lfm2.5-1b-4bit` on the lowest memory tier, avoiding the RAM warning produced
   by the previous 2.6B starter. ([#2432](https://github.com/raullenchai/Rapid-MLX/pull/2432))
@@ -102,12 +104,23 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Speech to Text automatically arms after model lifecycle changes when the user
   has enabled it; there is no extra manual start button to press.
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
-<!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
-the bisect identifies and validates the exact landed fix. -->
-<!-- KNOWN-ISSUE CONDITIONAL: include only if the train-6c suffix-decoding fix
-does not land: "Suffix decoding with sliding-window models such as Gemma 4 and
-GPT-OSS can abort a request at a window boundary. Workaround: disable suffix
-decoding." -->
+- Structured text requests on the vision lane now retain their JSON-schema or
+  title-generation constraints and emit a terminal stop, while photo requests
+  continue using the same multimodal server. ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
+- Experimental Qwen3.8-Flash-Next remains on its supported text lane; MTP and
+  other speculative decoding requests also choose the text lane; and
+  text-diffusion assistants can replace another assistant without a spurious
+  group-conflict response. ([#2472](https://github.com/raullenchai/Rapid-MLX/pull/2472))
+- iPhone HEIC photos work through picker, drop, and paste. Supported still
+  images are normalized to truthful JPEG or PNG bytes at the shared attachment
+  boundary while preserving the attachment size limit.
+  ([#2467](https://github.com/raullenchai/Rapid-MLX/pull/2467))
+- High-resolution photos are downscaled before Desktop sends them so they fit
+  the model's vision budget, and a typed image rejection no longer leaves a
+  failed attachment turn that contaminates the conversation.
+- Launch no longer rehashes every sealed app resource merely to choose the
+  Keychain namespace, and Escape cannot silently decline the post-value
+  telemetry-consent invitation. ([#2470](https://github.com/raullenchai/Rapid-MLX/pull/2470))
 - A rejected photo no longer contaminates the next text turn, and multimodal
   unload/reload cannot reuse a stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
   [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),
@@ -136,9 +149,6 @@ decoding." -->
 - System-prompt settings distinguish the saved instruction from the effective
   prompt and avoid touching optional credentials until they are needed.
   ([#2341](https://github.com/raullenchai/Rapid-MLX/pull/2341))
-- Generated images can be removed from the in-memory gallery with confirmation;
-  saved copies remain untouched. Contributed by
-  [osdodo](https://github.com/osdodo). ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387))
 - A complete offline cache with one immutable snapshot remains runnable even
   when a branch ref is unavailable; ambiguous multi-snapshot caches remain
   unresolved rather than guessing. ([#2351](https://github.com/raullenchai/Rapid-MLX/issues/2351),
@@ -158,3 +168,9 @@ decoding." -->
   describes the supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
 - Recorded a reproducible M2 Pro performance comparison between the published
   0.13.0 and 0.12.18 packages. ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
+
+## Known issues
+
+- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
+  abort a request at a window boundary. Disable suffix decoding for these
+  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -5,6 +5,11 @@ on the fast download route.
 
 ## Highlights
 
+**Experimental Qwen3.8-Flash-Next text inference** — The M1 lane supports the
+mixed 4-bit checkpoint on Macs with at least 128 GB of unified memory. MTP and
+vision support remain planned for a later release.
+([#2433](https://github.com/raullenchai/Rapid-MLX/pull/2433))
+
 **Switch assistants without losing track of active work** — API model
 replacement now has explicit reject, wait, and abort policies shared by the
 engine and server; Desktop uses the safe reject policy while a request is busy.

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -17,6 +17,11 @@ replacement now has explicit reject, wait, and abort policies shared by the
 engine and server; Desktop uses the safe reject policy while a request is busy.
 Request ownership transfers atomically, admitted work is quiesced before reload,
 and auxiliary dictation residency remains independent of the selected assistant.
+The replacement API accepts `memory_policy=keep_then_commit` or
+`evict_first_if_needed`: the default projection-gated policy evicts the model
+being replaced only when both models cannot fit and the replacement will fit,
+otherwise it returns a typed 507 with `replacement_projection` before eviction;
+use `keep_then_commit` when rollback-safe loading is required.
 ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 
 **Download one usable variant instead of an entire repository** — `rapid-mlx

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -84,8 +84,12 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   original assistant continues answering instead of losing its GPU stream.
   ([#2441](https://github.com/raullenchai/Rapid-MLX/pull/2441))
 - Model-switch memory estimates credit the assistant being replaced and use
-  the same fit thresholds as the actual replacement transaction, avoiding a
-  warning for memory that will be freed before the new model starts.
+  the same fit thresholds as the actual replacement transaction. Desktop's
+  low-memory threshold is now 100% instead of 85%: projections from 95–100%
+  are advisory, while values above 100% require confirmation. The earlier
+  conservative threshold is superseded because the projection now credits the
+  model being replaced, avoiding a warning for memory that will be freed before
+  the new model starts.
   ([#2443](https://github.com/raullenchai/Rapid-MLX/pull/2443),
   [#2444](https://github.com/raullenchai/Rapid-MLX/pull/2444))
 - Speech to Text automatically arms after model lifecycle changes when the user
@@ -93,6 +97,10 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
 <!-- TRAIN-6 PLACEHOLDER: add the Claude Code connection correction only after
 the bisect identifies and validates the exact landed fix. -->
+<!-- KNOWN-ISSUE CONDITIONAL: include only if the train-6c suffix-decoding fix
+does not land: "Suffix decoding with sliding-window models such as Gemma 4 and
+GPT-OSS can abort a request at a window boundary. Workaround: disable suffix
+decoding." -->
 - A rejected photo no longer contaminates the next text turn, and multimodal
   unload/reload cannot reuse a stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
   [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -17,11 +17,12 @@ replacement now has explicit reject, wait, and abort policies shared by the
 engine and server; Desktop uses the safe reject policy while a request is busy.
 Request ownership transfers atomically, admitted work is quiesced before reload,
 and auxiliary dictation residency remains independent of the selected assistant.
-The replacement API accepts `memory_policy=keep_then_commit` or
-`evict_first_if_needed`: the default projection-gated policy evicts the model
-being replaced only when both models cannot fit and the replacement will fit,
-otherwise it returns a typed 507 with `replacement_projection` before eviction;
-use `keep_then_commit` when rollback-safe loading is required.
+The `/v1/models/load` API defaults `memory_policy` to `evict_first_if_needed`:
+it keeps the rollback-safe load when old and new fit together, evicts the
+replaced assistant first only when keeping both breaches the limit but the
+replacement alone fits, and otherwise returns a typed 507 with
+`replacement_projection` before destructive mutation. Set
+`memory_policy=keep_then_commit` to require rollback-safe loading.
 ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
 
 **Download one usable variant instead of an entire repository** — `rapid-mlx
@@ -43,13 +44,15 @@ two cached vision families produce image-dependent answers before an artifact
 can ship. ([#2384](https://github.com/raullenchai/Rapid-MLX/pull/2384),
 [#2380](https://github.com/raullenchai/Rapid-MLX/issues/2380))
 
-With mlx-vlm 0.6.16 or newer—bundled in the Desktop sidecar—vision-capable
-Qwen3.5, Qwen3.6, and supported Qwen3.8 checkpoints use the vision lane by
-default, so photos work directly in chat. The experimental Flash-Next
-checkpoint remains text-only in this release. CLI users can force text-only
-serving with `--no-mllm`; Desktop users can make the same choice through the
-model's Performance override. MTP or speculative decoding automatically
-retains the text lane.
+Vision-capable Qwen3.5, Qwen3.6, and supported Qwen3.8 checkpoints use the
+vision lane automatically when mlx-vlm 0.6.16 or newer is installed and the
+checkpoint meets its measured vision-memory recommendation. If automatic
+admission cannot use that lane, serving falls back to text with a
+machine-readable reason. The experimental Flash-Next checkpoint is explicitly
+text-only in this release. CLI users can force text serving with `--no-mllm`,
+and Desktop exposes the same per-model Performance choice. Requests that enable
+MTP or another speculative decoder select the text lane, where that decoder is
+supported.
 
 **A better first model for each Mac** — First run now prefers an eligible
 cached model, then chooses a starter that fits the machine instead of applying
@@ -104,9 +107,10 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Speech to Text automatically arms after model lifecycle changes when the user
   has enabled it; there is no extra manual start button to press.
   ([#2448](https://github.com/raullenchai/Rapid-MLX/pull/2448))
-- Structured text requests on the vision lane now retain their JSON-schema or
-  title-generation constraints and emit a terminal stop, while photo requests
-  continue using the same multimodal server. ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
+- JSON-schema responses and bounded-thinking or title-generation requests now
+  terminate normally on the vision lane: their request-local output processors
+  and complete configured EOS set reach the multimodal scheduler, while photo
+  requests continue using the same server. ([#2471](https://github.com/raullenchai/Rapid-MLX/pull/2471))
 - Experimental Qwen3.8-Flash-Next remains on its supported text lane; MTP and
   other speculative decoding requests also choose the text lane; and
   text-diffusion assistants can replace another assistant without a spurious

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -63,11 +63,8 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Serving an uncached model while offline stops with one actionable cache and
   connectivity explanation instead of retrying the same download or suggesting
   an unrelated serving lane. ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
-- Dictation stays resident and is restored after switching chat models, while
-  an in-session restart preserves a proven chat selection. ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400),
-  [#2374](https://github.com/raullenchai/Rapid-MLX/pull/2374),
-  [#2363](https://github.com/raullenchai/Rapid-MLX/issues/2363),
-  [#2364](https://github.com/raullenchai/Rapid-MLX/issues/2364))
+- Dictation stays resident and is restored after switching chat models.
+  ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))
 - A rejected photo no longer contaminates the next text turn, and multimodal
   unload/reload cannot reuse a stale generation worker. ([#2379](https://github.com/raullenchai/Rapid-MLX/pull/2379),
   [#2378](https://github.com/raullenchai/Rapid-MLX/issues/2378),

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -103,10 +103,3 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
   describes the supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
 - Recorded a reproducible M2 Pro performance comparison between the published
   0.13.0 and 0.12.18 packages. ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
-
-## Upgrade notes
-
-- This file is a living release skeleton. It will be updated with every merged
-  0.13.1 train before the version bump and final release cut.
-- Remaining train 4 changes will be curated into the sections above only after
-  they land; this placeholder does not claim unmerged work.

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -63,6 +63,9 @@ model without a manual engine choice. ([#2385](https://github.com/raullenchai/Ra
 - Serving an uncached model while offline stops with one actionable cache and
   connectivity explanation instead of retrying the same download or suggesting
   an unrelated serving lane. ([#2357](https://github.com/raullenchai/Rapid-MLX/issues/2357))
+- **8 GB Macs start with a model that fits.** First run recommends
+  `lfm2.5-1b-4bit` on the lowest memory tier, avoiding the RAM warning produced
+  by the previous 2.6B starter. ([#2432](https://github.com/raullenchai/Rapid-MLX/pull/2432))
 - Dictation stays resident and is restored after switching chat models.
   ([#2400](https://github.com/raullenchai/Rapid-MLX/pull/2400))
 - A rejected photo no longer contaminates the next text turn, and multimodal

--- a/docs/release-notes/v0.13.1.md
+++ b/docs/release-notes/v0.13.1.md
@@ -1,0 +1,37 @@
+Rapid-MLX 0.13.1 focuses on safer model changes and smoother first-use paths:
+assistant replacement is now an explicit transaction, large multi-variant
+repositories can download only the requested format, and mirrored models stay
+on the fast download route.
+
+## Highlights
+
+**Switch assistants without losing track of active work** — Model replacement
+now has explicit reject, wait, and abort policies shared by the engine and
+server. Request ownership transfers atomically, admitted work is quiesced before
+reload, and auxiliary dictation residency remains independent of the selected
+assistant. ([#2369](https://github.com/raullenchai/Rapid-MLX/pull/2369))
+
+**Download one usable variant instead of an entire repository** — `rapid-mlx
+pull` accepts `--bits` or `--format` for repositories that store several
+quantizations side by side. This avoids turning a small-model download into tens
+of gigabytes of formats the user did not select. ([#2145](https://github.com/raullenchai/Rapid-MLX/issues/2145),
+[#2338](https://github.com/raullenchai/Rapid-MLX/pull/2338))
+
+**More dependable downloads and tool routing** — Subfolder-based quantizations
+can use the Rapid mirror instead of being hard-routed upstream, and explicit
+current-weather prompts are locked to the advertised Weather tool rather than a
+generic search fallback. ([#2279](https://github.com/raullenchai/Rapid-MLX/pull/2279),
+[#2222](https://github.com/raullenchai/Rapid-MLX/issues/2222),
+[#2327](https://github.com/raullenchai/Rapid-MLX/pull/2327))
+
+## Release evidence and corrections
+
+- Corrected the published Nemotron Labs Diffusion description so it accurately
+  describes the supported text-model path. ([#2376](https://github.com/raullenchai/Rapid-MLX/pull/2376))
+- Recorded a reproducible M2 Pro performance comparison between the published
+  0.13.0 and 0.12.18 packages. ([#2375](https://github.com/raullenchai/Rapid-MLX/pull/2375))
+
+## Upgrade notes
+
+- This file is a living release skeleton. It will be updated with every merged
+  0.13.1 train before the version bump and final release cut.


### PR DESCRIPTION
## Intention

Ship an accurate, user-facing 0.13.1 Desktop CHANGELOG and release-note page before the version bump. Every product claim maps to a change already integrated on main or to an explicitly named train-6c member.

## Inventory

- Direct/main: #2279, #2327, #2338, #2369, #2375, #2376, #2432, #2440.
- Train 1: #2367, #2371, #2372, #2382, #2322, #2384.
- Train 2: #2388, #2394, #2401, #2391, #2398, #2386, #2385, #2379, #2341, #2400.
- Train 3: #2404, #2408.
- Train 4: #2396, with contributor credit preserved.
- Train 5: #2402, #2423, #2392, #2395, #2417, #2424.
- Train 6/6b: #2441, #2443, #2444, #2448, #2433.
- Train 6c (merged as #2477): #2471, #2472, #2467, #2470.
- Train 6d: #2476 Desktop high-resolution photo downscaling and typed-rejection conversation recovery; #2478 explicit over-capacity load confirmation.

Not shipping and intentionally absent: #2374, #2387, #2469. The open suffix-decoding limitation is documented as a known issue with #2463.

Fixes #2239
Fixes #2145
Fixes #2222
Fixes #2358
Fixes #2359
Fixes #2361
Fixes #2362
Fixes #2377
Fixes #2378
Fixes #2360
Fixes #2397
Fixes #2350
Fixes #2349
Fixes #2353
Fixes #2342
Fixes #2348
Fixes #2219
Fixes #2351
Fixes #2343
Fixes #2352
Fixes #2357

## Scope

Documentation only: `apps/rapid-mac/CHANGELOG.md` and `docs/release-notes/v0.13.1.md`. No version bump, tag, publication, workflow, or product behavior change. The branch is reconciled to exact content-complete train-6d main `c730e45f`.

## Verification

- Release/version contract suite: 122 passed.
- `git diff --check`: passed.
- Explicit inventory audit against `v0.13.0..origin/main`, the landed train-6c contracts, and the staged train-6d release item.
