### PR TITLE
fix(residency): clear failed primary reload state

### DIFF
--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -967,9 +967,9 @@ async def test_primary_reload_restores_old_config_after_publication_failure(
             model_path=path or f"repo/{name}",
         )
 
-    def publish(entry: ModelEntry) -> None:
+    def publish(entry: ModelEntry | None) -> None:
         server._set_resident_primary(entry)
-        if entry.engine is loaded[0]:
+        if entry is not None and entry.engine is loaded[0]:
             raise RuntimeError("primary publication failed")
 
     manager = ResidentModelManager(
@@ -1133,9 +1133,10 @@ async def test_primary_reload_releases_handoff_when_cleanup_and_restore_fail(
             model_path=path or f"repo/{name}",
         )
 
-    def reject_publication(entry: ModelEntry) -> None:
+    def reject_publication(entry: ModelEntry | None) -> None:
         server._set_resident_primary(entry)
-        raise RuntimeError("primary publication failed")
+        if entry is not None:
+            raise RuntimeError("primary publication failed")
 
     manager = ResidentModelManager(
         registry,

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1564,6 +1564,54 @@ async def test_restore_publication_failure_clears_partially_published_primary():
     assert manager.snapshot()["models"] == []
 
 
+@pytest.mark.asyncio
+async def test_restore_publication_failure_tolerates_cleanup_failures(caplog):
+    """Cleanup failures cannot mask the original replacement error."""
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+
+    class FailingStopEngine(FakeEngine):
+        async def stop(self):
+            raise RuntimeError("cleanup stop failed")
+
+    async def loader(name: str, path: str | None, performance=None):
+        del path
+        if performance is not None:
+            raise RuntimeError("replacement failed")
+        return entry(name, FailingStopEngine())
+
+    publications: list[ModelEntry | None] = []
+
+    def publish(value: ModelEntry | None) -> None:
+        publications.append(value)
+        if len(publications) == 1 and value is None:
+            return
+        if value is not None:
+            raise RuntimeError("restore publication failed")
+        raise RuntimeError("clear publication failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=publish,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="replacement failed"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+
+    assert registry.list_entries() == []
+    assert registry.default_name is None
+    assert "Failed to stop partially restored resident model" in caplog.text
+    assert "Failed to clear serving-layer primary" in caplog.text
+
+
 def test_clearing_resident_primary_disables_legacy_routing_and_readiness(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1521,6 +1521,49 @@ async def test_primary_reload_clear_callback_failure_restores_old_owner():
     assert manager.snapshot()["models"][0]["primary"] is True
 
 
+@pytest.mark.asyncio
+async def test_restore_publication_failure_clears_partially_published_primary():
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    published: list[ModelEntry | None] = [primary]
+    restored_engines: list[FakeEngine] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        del path
+        if performance is not None:
+            raise RuntimeError("replacement failed")
+        restored = FakeEngine()
+        restored_engines.append(restored)
+        return entry(name, restored)
+
+    def publish(value: ModelEntry | None) -> None:
+        published[0] = value
+        if value is not None and value is not primary:
+            raise RuntimeError("restore publication failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=publish,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="replacement failed"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+
+    assert published == [None]
+    assert restored_engines[0].stopped is True
+    assert registry.list_entries() == []
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+
+
 def test_clearing_resident_primary_disables_legacy_routing_and_readiness(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1388,6 +1388,72 @@ async def test_failed_performance_reload_restores_the_last_known_good_engine():
 
 
 @pytest.mark.asyncio
+async def test_double_failed_primary_reload_clears_every_serving_owner():
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    primary_changes: list[ModelEntry | None] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        del path, performance
+        if name == "secondary":
+            return entry(name)
+        raise RuntimeError("loader unavailable")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=primary_changes.append,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    await manager.load("secondary", estimated_bytes=1 * GIB)
+
+    with pytest.raises(RuntimeError, match="loader unavailable"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+
+    assert [item.model_name for item in registry.list_entries()] == ["secondary"]
+    assert registry.default_name is None
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["secondary"]
+    assert registry.get_engine("secondary") is not None
+    with pytest.raises(KeyError, match="No default model set"):
+        registry.get_engine(None)
+    assert primary_changes == [None]
+
+
+def test_clearing_resident_primary_disables_legacy_routing_and_readiness(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    cfg = SimpleNamespace()
+    monkeypatch.setattr(server, "get_config", lambda: cfg)
+    monkeypatch.setattr(server, "_engine", object())
+    monkeypatch.setattr(server, "_model_name", "chat")
+
+    server._set_resident_primary(None)
+
+    assert server._engine is None
+    assert server._model_name is None
+    assert server._model_alias is None
+    assert server._model_path is None
+    assert server._enable_auto_tool_choice is False
+    assert server._tool_call_parser is None
+    assert server._tool_parser_instance is None
+    assert server._reasoning_parser is None
+    assert server._reasoning_parser_name is None
+    assert cfg.engine is None
+    assert cfg.model_name is None
+    assert cfg.model_alias is None
+    assert cfg.model_path is None
+    assert cfg.ready is False
+
+
+@pytest.mark.asyncio
 async def test_failed_stop_rebuilds_the_existing_engine_before_rerouting():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     old_engine = registry.get_engine("chat")

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1425,6 +1425,102 @@ async def test_double_failed_primary_reload_clears_every_serving_owner():
     assert primary_changes == [None]
 
 
+@pytest.mark.asyncio
+async def test_primary_reload_clears_default_before_awaiting_replacement():
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    replacement_started = asyncio.Event()
+    finish_replacement = asyncio.Event()
+    primary_changes: list[ModelEntry | None] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        del path, performance
+        if name == "secondary":
+            return entry(name)
+        replacement_started.set()
+        await finish_replacement.wait()
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_changed=primary_changes.append,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    await manager.load("secondary", estimated_bytes=1 * GIB)
+
+    reload_task = asyncio.create_task(
+        manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+    )
+    await replacement_started.wait()
+
+    assert registry.default_name is None
+    assert registry.get_engine("secondary") is not None
+    with pytest.raises(KeyError, match="No default model set"):
+        registry.get_engine(None)
+    assert primary_changes == [None]
+
+    finish_replacement.set()
+    replacement = await reload_task
+    assert registry.default_name == "chat"
+    assert primary_changes == [None, replacement.entry]
+
+
+@pytest.mark.asyncio
+async def test_primary_reload_clear_callback_failure_restores_old_owner():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat", old_engine)
+    registry.add(primary, is_default=True)
+    changes: list[ModelEntry | None] = []
+    handoff_events: list[str] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        del path, performance
+        return entry(name)
+
+    def publish(value: ModelEntry | None) -> None:
+        changes.append(value)
+        if value is None:
+            raise RuntimeError("clear failed")
+
+    class Handoff:
+        def commit(self, committed):
+            handoff_events.append(f"commit:{committed}")
+
+        def rollback(self):
+            handoff_events.append("rollback")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: Handoff(),
+        on_primary_changed=publish,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="clear failed"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+
+    assert changes == [None, primary]
+    assert handoff_events == ["rollback"]
+    assert registry.default_name == "chat"
+    assert registry.get_engine(None) is old_engine
+    assert old_engine.stopped is False
+    assert manager.snapshot()["models"][0]["primary"] is True
+
+
 def test_clearing_resident_primary_disables_legacy_routing_and_readiness(monkeypatch):
     from types import SimpleNamespace
 
@@ -1451,6 +1547,11 @@ def test_clearing_resident_primary_disables_legacy_routing_and_readiness(monkeyp
     assert cfg.model_alias is None
     assert cfg.model_path is None
     assert cfg.ready is False
+
+    replacement = entry("replacement")
+    server._set_resident_primary(replacement)
+    assert cfg.engine is replacement.engine
+    assert cfg.ready is True
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/runtime/model_registry.py
+++ b/vllm_mlx/runtime/model_registry.py
@@ -206,6 +206,12 @@ class ModelRegistry:
         logger.info("Promoted model %r to registry default", canonical)
         return self._entries[canonical]
 
+    def clear_default(self) -> None:
+        """Remove request-default ownership without unloading named entries."""
+
+        self._default = None
+        logger.info("Cleared registry default model")
+
     def __len__(self) -> int:
         return len(self._entries)
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -176,7 +176,7 @@ class ResidencyRecord:
 
 
 Loader = Callable[..., Awaitable[ModelEntry]]
-PrimaryChanged = Callable[[ModelEntry], None]
+PrimaryChanged = Callable[[ModelEntry | None], None]
 
 
 class PrimaryHandoffLease(Protocol):
@@ -825,6 +825,34 @@ class ResidentModelManager:
                 "Failed to restore resident model %r after reload failure",
                 record.model_id,
             )
+            # A failed rebuild cannot remain partially published.  Remove any
+            # entry that made it through the registry before a later publisher
+            # failed, then clear every default/legacy owner for a lost primary.
+            if restored_entry is not None:
+                self.registry.remove(restored_entry.model_name)
+                self._drop_record(restored_entry.model_name)
+                try:
+                    stop = getattr(restored_entry.engine, "stop", None)
+                    if callable(stop):
+                        result = stop()
+                        if asyncio.iscoroutine(result):
+                            await result
+                except BaseException:
+                    logger.exception(
+                        "Failed to stop partially restored resident model %r",
+                        record.model_id,
+                    )
+                _release_allocator_cache()
+                restored_entry = None
+            if record.primary:
+                self.registry.clear_default()
+                if self._on_primary_changed is not None:
+                    try:
+                        self._on_primary_changed(None)
+                    except BaseException:
+                        logger.exception(
+                            "Failed to clear serving-layer primary after reload failure"
+                        )
         finally:
             if handoff is not None:
                 handoff.commit(restored_entry)

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -719,8 +719,27 @@ class ResidentModelManager:
             else None
         )
 
+        if primary and self._on_primary_changed is not None:
+            try:
+                self._on_primary_changed(None)
+            except BaseException:
+                # The old engine is still intact and registered at this point.
+                # Restore its serving-layer publication before releasing the
+                # handoff so a callback failure cannot strand the transaction.
+                try:
+                    self._on_primary_changed(record.entry)
+                finally:
+                    if handoff is not None:
+                        handoff.rollback()
+                raise
         self.registry.remove(model_name)
         self._drop_record(model_name)
+        if primary:
+            # Removing the registry default otherwise promotes an unrelated
+            # secondary while the replacement loader is still in flight.  Make
+            # primary unavailability visible through both routing surfaces
+            # before the first await; publication below restores them together.
+            self.registry.clear_default()
         try:
             stop = getattr(record.entry.engine, "stop", None)
             if callable(stop):
@@ -846,13 +865,6 @@ class ResidentModelManager:
                 restored_entry = None
             if record.primary:
                 self.registry.clear_default()
-                if self._on_primary_changed is not None:
-                    try:
-                        self._on_primary_changed(None)
-                    except BaseException:
-                        logger.exception(
-                            "Failed to clear serving-layer primary after reload failure"
-                        )
         finally:
             if handoff is not None:
                 handoff.commit(restored_entry)

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -862,6 +862,14 @@ class ResidentModelManager:
                         record.model_id,
                     )
                 _release_allocator_cache()
+                if record.primary and self._on_primary_changed is not None:
+                    try:
+                        self._on_primary_changed(None)
+                    except BaseException:
+                        logger.exception(
+                            "Failed to clear serving-layer primary after "
+                            "restore publication failure"
+                        )
                 restored_entry = None
             if record.primary:
                 self.registry.clear_default()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2500,12 +2500,36 @@ def _handoff_resident_primary_audio_worker(
         ) from exc
 
 
-def _set_resident_primary(entry: ModelEntry) -> None:
+def _set_resident_primary(entry: ModelEntry | None) -> None:
     """Publish a replacement assistant as the legacy/default engine."""
 
     global _engine, _model_name, _model_alias, _model_path
     global _enable_auto_tool_choice, _tool_call_parser, _tool_parser_instance
     global _reasoning_parser, _reasoning_parser_name
+
+    if entry is None:
+        _engine = None
+        _model_name = None
+        _model_alias = None
+        _model_path = None
+        _enable_auto_tool_choice = False
+        _tool_call_parser = None
+        _tool_parser_instance = None
+        _reasoning_parser = None
+        _reasoning_parser_name = None
+
+        cfg = get_config()
+        cfg.engine = None
+        cfg.model_name = None
+        cfg.model_alias = None
+        cfg.model_path = None
+        cfg.enable_auto_tool_choice = False
+        cfg.tool_call_parser = None
+        cfg.tool_parser_instance = None
+        cfg.reasoning_parser = None
+        cfg.reasoning_parser_name = None
+        cfg.ready = False
+        return
 
     _engine = entry.engine
     _model_name = entry.model_name

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2556,6 +2556,7 @@ def _set_resident_primary(entry: ModelEntry | None) -> None:
     cfg.tool_parser_instance = None
     cfg.reasoning_parser = _reasoning_parser
     cfg.reasoning_parser_name = entry.reasoning_parser
+    cfg.ready = True
 
 
 def _sync_config() -> None:


### PR DESCRIPTION
## Intention

Keep residency, health, and request routing consistent when both a requested primary performance reload and restoration of the previous configuration fail.

Closes #2360.

## Scope

- Publish an explicit primary-unavailable state before awaiting a reload.
- Clear default-model ownership rather than implicitly promoting a secondary.
- Clear legacy/config engine identity and readiness when the primary cannot be rebuilt.
- Preserve explicitly named secondary residents.
- Cover in-flight reload, double-loader failure, callback rollback, and partial-publication failure.

## Non-goals

- Scheduler or cache redesign.
- Capacity or eviction policy changes.
- Desktop/UI changes.
- New recovery or automatic promotion policy.

## Contract

During reload, requests without a valid explicit secondary receive model-unavailable behavior rather than reaching a stopped primary or an unrelated secondary. Successful replacement/restoration republishes registry default, legacy routing, readiness, and audio handoff together. If restoration or its publication fails, all primary owners converge on unavailable while named secondary residents remain explicitly routable.

## Evidence

- Pre-fix deterministic reproduction: residency removed the primary but the serving-layer primary callback was never cleared after both loaders failed.
- Blocking-loader regression proves no unrelated secondary becomes default during the await window.
- Partial-publication regression proves a newly built engine that is published then rejected is stopped and removed, with the legacy owner reset to unavailable.
- Focused resident/audio lifecycle suites: 85 passed.
- Ruff check and format check passed.
- Diff check passed.
- Codex review round 3: LGTM.
- Exact-head hosted PR validation: MERGE-SAFE.