### PR TITLE
fix(mac): restore dictation after switching chat models

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -326,22 +326,24 @@ final class DictationController {
     func serverStateDidChange(_ newState: ServerState) {
         guard isEnabled, !modelPreparationDeferred else { return }
         switch newState {
-        case .starting(let alias) where alias != modelAlias:
+        case .starting(let alias):
+            // `prewarmModel` owns an audio-only fallback while its flight is
+            // present. A same-alias transition with no such flight is an
+            // external restart (for example ServerManager auto-respawn) and
+            // must reconcile just like a chat-process replacement.
+            guard alias != modelAlias || prewarmTask == nil else { break }
             cancelActiveSessionForModelChange()
             cancelModelPreparation()
             hotkey.stop()
             phase = .preparingModel
-        case .ready(let alias) where alias != modelAlias:
+        case .ready(let alias):
+            guard alias != modelAlias || prewarmTask == nil else { break }
             cancelActiveSessionForModelChange()
             hotkey.stop()
             phase = .preparingModel
             Task { [weak self] in
                 await self?.enable(replacingCurrentPrewarm: true)
             }
-        case .starting, .ready:
-            // This controller initiated its audio-only fallback; its in-flight
-            // preparation owns the transition and must not cancel itself.
-            break
         case .crashed, .stopped, .idle, .missing:
             cancelActiveSessionForModelChange()
             cancelModelPreparation()

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -326,19 +326,30 @@ final class DictationController {
     func serverStateDidChange(_ newState: ServerState) {
         guard isEnabled, !modelPreparationDeferred else { return }
         switch newState {
-        case .starting:
+        case .starting(let alias) where alias != modelAlias:
             cancelActiveSessionForModelChange()
+            cancelModelPreparation()
             hotkey.stop()
             phase = .preparingModel
-        case .ready:
+        case .ready(let alias) where alias != modelAlias:
             cancelActiveSessionForModelChange()
             hotkey.stop()
             phase = .preparingModel
             Task { [weak self] in
                 await self?.enable(replacingCurrentPrewarm: true)
             }
-        default:
+        case .starting, .ready:
+            // This controller initiated its audio-only fallback; its in-flight
+            // preparation owns the transition and must not cancel itself.
             break
+        case .crashed, .stopped, .idle, .missing:
+            cancelActiveSessionForModelChange()
+            cancelModelPreparation()
+            hotkey.stop()
+            // Preserve the user's Enabled intent, but publish a terminal
+            // non-ready phase. Foreground revalidation or a later server
+            // transition can retry through the existing enable path.
+            phase = .off
         }
     }
 
@@ -496,6 +507,13 @@ final class DictationController {
         hud.hide()
     }
 
+    private func cancelModelPreparation() {
+        prewarmTask?.cancel()
+        prewarmTask = nil
+        prewarmRequestID = nil
+        enableRequestID = nil
+    }
+
     /// Tear down the process-wide dictation service without changing the
     /// user's persisted Enabled preference. A normal relaunch should re-arm
     /// dictation, but no global hotkey may survive into the app's synchronous
@@ -647,14 +665,14 @@ final class DictationController {
         // authoritative snapshot before arming the global hotkey: a mounted
         // audio route alone is not proof that a process-replacing model switch
         // restored the selected speech weights.
-        await server.refreshResidency()
+        let voiceLaneResident = await server.refreshVoiceLaneResidency(
+            for: alias,
+            modelPath: facts?.repo
+        )
         guard !Task.isCancelled,
               isEnabled,
               modelAlias == alias,
-              server.isVoiceLaneResident(
-                  for: alias,
-                  modelPath: facts?.repo
-              ) else { return false }
+              voiceLaneResident else { return false }
         if warmed {
             lastWarmupWarning = nil
         } else {

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -317,6 +317,31 @@ final class DictationController {
         await enable()
     }
 
+    /// Keep the enabled speech lane attached to whichever chat process owns
+    /// the current session. A process-replacing model switch discards every
+    /// lazy audio engine, while an in-process assistant replacement preserves
+    /// it; both transitions arrive through the same ``ServerState`` boundary.
+    /// Re-running the existing preparation flight is therefore idempotent for
+    /// the latter and restores the former without inventing another lifecycle.
+    func serverStateDidChange(_ newState: ServerState) {
+        guard isEnabled, !modelPreparationDeferred else { return }
+        switch newState {
+        case .starting:
+            cancelActiveSessionForModelChange()
+            hotkey.stop()
+            phase = .preparingModel
+        case .ready:
+            cancelActiveSessionForModelChange()
+            hotkey.stop()
+            phase = .preparingModel
+            Task { [weak self] in
+                await self?.enable(replacingCurrentPrewarm: true)
+            }
+        default:
+            break
+        }
+    }
+
     func enable(
         replacingCurrentPrewarm: Bool = false,
         deferModelPreparation: Bool = false
@@ -373,6 +398,15 @@ final class DictationController {
         let prewarmSucceeded = await prewarmModel(
             replacingCurrent: replacingCurrentPrewarm
         )
+        // A test prewarm seam represents the whole preparation contract. In
+        // production, readiness comes only from the server's exact catalog
+        // model path in the latest audio-lane residency snapshot.
+        let voiceLaneReady = testingPrewarm != nil
+            ? prewarmSucceeded
+            : server.isVoiceLaneResident(
+                for: preparingAlias,
+                modelPath: catalogByAlias[preparingAlias]?.repo
+            )
         guard DictationEnablePolicy.mayRegisterHotkey(after: .init(
             prewarmSucceeded: prewarmSucceeded,
             isEnabled: isEnabled,
@@ -380,7 +414,7 @@ final class DictationController {
             selectedAlias: modelAlias,
             preparingAlias: preparingAlias,
             isPreparing: phase == .preparingModel,
-            voiceLaneReady: server.isVoiceLaneReady(for: preparingAlias)
+            voiceLaneReady: voiceLaneReady
         )) else {
             if isEnabled, enableRequestID == requestID, modelAlias == preparingAlias {
                 lastError = "\(preparingAlias) couldn't load. There may not be enough memory to start dictation."
@@ -599,7 +633,7 @@ final class DictationController {
         guard isEnabled, !modelAlias.isEmpty else { return false }
         if let testingPrewarm { return await testingPrewarm() }
         let alias = modelAlias
-        _ = await catalogFacts(for: alias)
+        let facts = await catalogFacts(for: alias)
         // Actor reentrancy: every await above and below is a window for
         // disable() or a model change to land. Re-check before each step
         // that mutates the sidecar or touches the wire.
@@ -609,10 +643,18 @@ final class DictationController {
             guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         }
         let warmed = await warmUpEngine()
+        // The silence request materializes the lazy STT engine. Refresh the
+        // authoritative snapshot before arming the global hotkey: a mounted
+        // audio route alone is not proof that a process-replacing model switch
+        // restored the selected speech weights.
+        await server.refreshResidency()
         guard !Task.isCancelled,
               isEnabled,
               modelAlias == alias,
-              server.isVoiceLaneReady(for: alias) else { return false }
+              server.isVoiceLaneResident(
+                  for: alias,
+                  modelPath: facts?.repo
+              ) else { return false }
         if warmed {
             lastWarmupWarning = nil
         } else {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -360,6 +360,16 @@ final class ServerManager {
         return residency.containsResidentAudioLane(modelPath: modelPath)
     }
 
+    /// Refresh and verify as one contract so a failed request can never make
+    /// a caller treat the previous process's audio snapshot as current.
+    func refreshVoiceLaneResidency(for alias: String, modelPath: String?) async -> Bool {
+        // An audio-only process owns this model at startup; no lazy lane or
+        // prior-process snapshot is involved.
+        if servingAlias == alias { return true }
+        guard await refreshResidency() else { return false }
+        return isVoiceLaneResident(for: alias, modelPath: modelPath)
+    }
+
     /// Bring up a server for a voice (STT/TTS) request, reusing the primary
     /// chat LLM/VLM process when one is already up so voice and text/vision
     /// run side-by-side instead of voice replacing the chat model.
@@ -395,16 +405,18 @@ final class ServerManager {
         isModelResident(alias) ? .ready(alias: alias) : state
     }
 
-    func refreshResidency() async {
+    @discardableResult
+    func refreshResidency() async -> Bool {
         guard case .ready = state else {
             residency = .empty
-            return
+            return false
         }
         guard let snapshot = await residencyClient.fetch(
             port: activePort,
             bearer: activeBearer
-        ) else { return }
+        ) else { return false }
         residency = snapshot
+        return true
     }
 
     func confirmPendingModelSwitch(_ request: PendingModelSwitch) {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -350,6 +350,16 @@ final class ServerManager {
         servingAlias == alias || voiceCoLoadsOnPrimary
     }
 
+    /// Whether the selected voice engine is actually resident, rather than
+    /// merely routable through a chat process that mounted ``/v1/audio/*``.
+    /// Exact catalog provenance keeps this capability check independent of
+    /// alias naming conventions.
+    func isVoiceLaneResident(for alias: String, modelPath: String?) -> Bool {
+        if servingAlias == alias { return true }
+        guard voiceCoLoadsOnPrimary, let modelPath else { return false }
+        return residency.containsResidentAudioLane(modelPath: modelPath)
+    }
+
     /// Bring up a server for a voice (STT/TTS) request, reusing the primary
     /// chat LLM/VLM process when one is already up so voice and text/vision
     /// run side-by-side instead of voice replacing the chat model.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -89,6 +89,20 @@ struct ResidentPerformanceStatus: Codable, Sendable, Equatable {
     }
 }
 
+/// One lazily loaded speech engine mounted beside the primary chat model.
+/// The server reports the authoritative model path and lifecycle state; the
+/// Desktop uses those fields instead of assuming that an audio-capable route
+/// means the selected speech weights are still resident.
+struct ResidentAudioLaneStatus: Codable, Sendable, Equatable {
+    let lane: String
+    let model: String?
+    let state: String
+
+    func matches(modelPath: String) -> Bool {
+        model == modelPath && state == "resident"
+    }
+}
+
 struct ModelResidencySnapshot: Codable, Sendable, Equatable {
     let memoryLimitBytes: UInt64
     let memoryUsedBytes: UInt64
@@ -97,6 +111,7 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
     let loadsTotal: Int
     let evictionsTotal: Int
     let models: [ResidentModelStatus]
+    let audioLanes: [ResidentAudioLaneStatus]
 
     enum CodingKeys: String, CodingKey {
         case memoryLimitBytes = "memory_limit_bytes"
@@ -106,6 +121,42 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
         case loadsTotal = "loads_total"
         case evictionsTotal = "evictions_total"
         case models
+        case audioLanes = "audio_lanes"
+    }
+
+    init(
+        memoryLimitBytes: UInt64,
+        memoryUsedBytes: UInt64,
+        memoryAvailableBytes: UInt64?,
+        idleTTLSeconds: Double,
+        loadsTotal: Int,
+        evictionsTotal: Int,
+        models: [ResidentModelStatus],
+        audioLanes: [ResidentAudioLaneStatus] = []
+    ) {
+        self.memoryLimitBytes = memoryLimitBytes
+        self.memoryUsedBytes = memoryUsedBytes
+        self.memoryAvailableBytes = memoryAvailableBytes
+        self.idleTTLSeconds = idleTTLSeconds
+        self.loadsTotal = loadsTotal
+        self.evictionsTotal = evictionsTotal
+        self.models = models
+        self.audioLanes = audioLanes
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        memoryLimitBytes = try values.decode(UInt64.self, forKey: .memoryLimitBytes)
+        memoryUsedBytes = try values.decode(UInt64.self, forKey: .memoryUsedBytes)
+        memoryAvailableBytes = try values.decodeIfPresent(UInt64.self, forKey: .memoryAvailableBytes)
+        idleTTLSeconds = try values.decode(Double.self, forKey: .idleTTLSeconds)
+        loadsTotal = try values.decode(Int.self, forKey: .loadsTotal)
+        evictionsTotal = try values.decode(Int.self, forKey: .evictionsTotal)
+        models = try values.decode([ResidentModelStatus].self, forKey: .models)
+        audioLanes = try values.decodeIfPresent(
+            [ResidentAudioLaneStatus].self,
+            forKey: .audioLanes
+        ) ?? []
     }
 
     static let empty = ModelResidencySnapshot(
@@ -115,11 +166,16 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
         idleTTLSeconds: 0,
         loadsTotal: 0,
         evictionsTotal: 0,
-        models: []
+        models: [],
+        audioLanes: []
     )
 
     func contains(_ alias: String) -> Bool {
         models.contains { $0.matches(alias) && $0.state != "evicting" }
+    }
+
+    func containsResidentAudioLane(modelPath: String) -> Bool {
+        audioLanes.contains { $0.matches(modelPath: modelPath) }
     }
 
     /// Pick the resident text model that can host chat-only subsystems such

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -145,6 +145,10 @@ struct ContentView: View {
             }
         }
         .onChange(of: server.state) { _, newState in
+            // A chat-model replacement can keep the process or respawn it.
+            // Dictation owns the same reconciliation entry point for both so
+            // an enabled STT lane is resident before its hotkey reads Ready.
+            dictation.serverStateDidChange(newState)
             // #223: clear the download-prompt CTA the moment the server
             // moves out of ``.idle``.
             if case .idle = newState {} else { autoStartPendingDownload = nil }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -391,6 +391,41 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("completed chat-model switch re-prepares enabled dictation before Ready")
+    func chatModelSwitchRepreparesEnabledDictation() async {
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            phase: .idle,
+            prewarm: {
+                prewarmCount += 1
+                return await withCheckedContinuation { warmupContinuation = $0 }
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        controller.serverStateDidChange(.starting(alias: "lfm2.5-1b-4bit"))
+        #expect(controller.phase == .preparingModel)
+        #expect(prewarmCount == 0)
+        #expect(hotkeyStartCount == 0)
+
+        controller.serverStateDidChange(.ready(alias: "lfm2.5-1b-4bit"))
+        while warmupContinuation == nil { await Task.yield() }
+        #expect(controller.phase == .preparingModel)
+        #expect(prewarmCount == 1)
+        #expect(hotkeyStartCount == 0)
+
+        warmupContinuation?.resume(returning: true)
+        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+    }
+
+    @MainActor
     @Test("launch bootstrap arms before deferred model preparation")
     func launchBootstrapArmsWithoutWaitingForPrimaryHealth() async {
         var prewarmCount = 0

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -460,23 +460,63 @@ struct DictationTests {
     }
 
     @MainActor
-    @Test("audio-only fallback transitions do not cancel their own preparation")
-    func audioFallbackDoesNotSelfCancel() {
+    @Test("audio-only fallback transitions do not cancel their owning preparation flight")
+    func audioFallbackDoesNotSelfCancel() async {
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
         var prewarmCount = 0
         let controller = readinessController(
-            phase: .preparingModel,
             prewarm: {
                 prewarmCount += 1
-                return true
+                return await withCheckedContinuation { warmupContinuation = $0 }
             },
             hotkeyStart: { true }
         )
 
+        let enabling = Task { await controller.enable() }
+        while warmupContinuation == nil { await Task.yield() }
         controller.serverStateDidChange(.starting(alias: "whisper-small"))
         controller.serverStateDidChange(.ready(alias: "whisper-small"))
 
         #expect(controller.phase == .preparingModel)
-        #expect(prewarmCount == 0)
+        #expect(prewarmCount == 1)
+        warmupContinuation?.resume(returning: true)
+        await enabling.value
+        #expect(controller.phase == .idle)
+    }
+
+    @MainActor
+    @Test("audio-only auto-respawn re-arms enabled dictation")
+    func audioFallbackAutoRespawnRearms() async {
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            phase: .idle,
+            prewarm: {
+                prewarmCount += 1
+                return await withCheckedContinuation { warmupContinuation = $0 }
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        controller.serverStateDidChange(.crashed(
+            alias: "whisper-small",
+            message: "fixture crash"
+        ))
+        controller.serverStateDidChange(.starting(alias: "whisper-small"))
+        #expect(controller.phase == .preparingModel)
+        controller.serverStateDidChange(.ready(alias: "whisper-small"))
+        while warmupContinuation == nil { await Task.yield() }
+        #expect(prewarmCount == 1)
+        #expect(hotkeyStartCount == 0)
+
+        warmupContinuation?.resume(returning: true)
+        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
     }
 
     @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -426,6 +426,60 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("failed chat-model switch leaves enabled dictation retryable")
+    func failedChatModelSwitchIsRetryable() async {
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            phase: .idle,
+            prewarm: {
+                await withCheckedContinuation { warmupContinuation = $0 }
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        controller.serverStateDidChange(.starting(alias: "lfm2.5-1b-4bit"))
+        controller.serverStateDidChange(.crashed(
+            alias: "lfm2.5-1b-4bit",
+            message: "fixture failure"
+        ))
+        #expect(controller.isEnabled)
+        #expect(controller.phase == .off)
+        #expect(hotkeyStartCount == 0)
+
+        controller.revalidate()
+        while warmupContinuation == nil { await Task.yield() }
+        #expect(controller.phase == .preparingModel)
+        warmupContinuation?.resume(returning: true)
+        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+    }
+
+    @MainActor
+    @Test("audio-only fallback transitions do not cancel their own preparation")
+    func audioFallbackDoesNotSelfCancel() {
+        var prewarmCount = 0
+        let controller = readinessController(
+            phase: .preparingModel,
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: { true }
+        )
+
+        controller.serverStateDidChange(.starting(alias: "whisper-small"))
+        controller.serverStateDidChange(.ready(alias: "whisper-small"))
+
+        #expect(controller.phase == .preparingModel)
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
     @Test("launch bootstrap arms before deferred model preparation")
     func launchBootstrapArmsWithoutWaitingForPrimaryHealth() async {
         var prewarmCount = 0

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -56,6 +56,59 @@ struct ModelResidencyTests {
                 cacheMemoryMB: 4096
             )
         ))
+        #expect(snapshot.audioLanes.isEmpty, "older snapshots remain compatible")
+    }
+
+    @Test("Audio-lane residency decodes and matches only the exact catalog model path")
+    func decodesAudioLaneTruth() throws {
+        let data = Data(
+            #"""
+            {
+              "memory_limit_bytes": 34359738368,
+              "memory_used_bytes": 10737418240,
+              "memory_available_bytes": 23622320128,
+              "idle_ttl_seconds": 1800,
+              "loads_total": 0,
+              "evictions_total": 0,
+              "models": [],
+              "audio_lanes": [
+                {
+                  "lane": "stt",
+                  "model": "mlx-community/whisper-small-mlx",
+                  "state": "resident",
+                  "active_requests": 0,
+                  "loaded_at": 123.0,
+                  "idle_seconds": 4.0,
+                  "last_error": null
+                },
+                {
+                  "lane": "tts",
+                  "model": null,
+                  "state": "registered",
+                  "active_requests": 0,
+                  "loaded_at": null,
+                  "idle_seconds": 0.0,
+                  "last_error": null
+                }
+              ]
+            }
+            """#.utf8
+        )
+
+        let snapshot = try JSONDecoder().decode(ModelResidencySnapshot.self, from: data)
+
+        #expect(snapshot.audioLanes == [
+            ResidentAudioLaneStatus(
+                lane: "stt",
+                model: "mlx-community/whisper-small-mlx",
+                state: "resident"
+            ),
+            ResidentAudioLaneStatus(lane: "tts", model: nil, state: "registered")
+        ])
+        #expect(snapshot.containsResidentAudioLane(
+            modelPath: "mlx-community/whisper-small-mlx"
+        ))
+        #expect(!snapshot.containsResidentAudioLane(modelPath: "whisper-small"))
     }
 
     @Test("Resident rows prefer the catalog alias over the HF path")

--- a/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
@@ -42,6 +42,43 @@ struct VoiceCoLoadTests {
         #expect(server.servingAlias == "qwen3.6-27b-4bit")
         #expect(server.voiceCoLoadsOnPrimary == true)
         #expect(server.isVoiceLaneReady(for: "whisper-small") == true)
+        #expect(server.isVoiceLaneResident(
+            for: "whisper-small",
+            modelPath: "mlx-community/whisper-small-mlx"
+        ) == false, "a mounted route is not resident speech weights")
+    }
+
+    @Test("audio residency truth survives an in-process chat-model switch")
+    func residentVoiceLaneUsesExactCatalogPath() {
+        let snapshot = ModelResidencySnapshot(
+            memoryLimitBytes: 1,
+            memoryUsedBytes: 1,
+            memoryAvailableBytes: 0,
+            idleTTLSeconds: 1,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [],
+            audioLanes: [ResidentAudioLaneStatus(
+                lane: "stt",
+                model: "mlx-community/whisper-small-mlx",
+                state: "resident"
+            )]
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: "lfm2.5-1b-4bit"),
+            residency: snapshot,
+            activeBearer: "test-bearer"
+        )
+
+        #expect(server.isVoiceLaneResident(
+            for: "whisper-small",
+            modelPath: "mlx-community/whisper-small-mlx"
+        ))
+        #expect(!server.isVoiceLaneResident(
+            for: "whisper-small",
+            modelPath: "mlx-community/other-whisper"
+        ))
+        #expect(server.servingAlias == "lfm2.5-1b-4bit")
     }
 
     @Test("mid-start is not co-loaded (no live serving alias yet)")

--- a/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VoiceCoLoadTests.swift
@@ -81,6 +81,45 @@ struct VoiceCoLoadTests {
         #expect(server.servingAlias == "lfm2.5-1b-4bit")
     }
 
+    @Test("failed refresh cannot validate a stale audio-lane snapshot")
+    func failedRefreshRejectsStaleVoiceLane() async {
+        let snapshot = ModelResidencySnapshot(
+            memoryLimitBytes: 1,
+            memoryUsedBytes: 1,
+            memoryAvailableBytes: 0,
+            idleTTLSeconds: 1,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [],
+            audioLanes: [ResidentAudioLaneStatus(
+                lane: "stt",
+                model: "mlx-community/whisper-small-mlx",
+                state: "resident"
+            )]
+        )
+        let server = await ServerManager(
+            testingState: .ready(alias: "lfm2.5-1b-4bit"),
+            residency: snapshot,
+            activeBearer: "test-bearer"
+        )
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FailedResidencyRefreshProtocol.self]
+        var client = ServerResidencyClient()
+        client.session = URLSession(configuration: configuration)
+        await server._testSetResidencyClient(client)
+
+        let verified = await server.refreshVoiceLaneResidency(
+            for: "whisper-small",
+            modelPath: "mlx-community/whisper-small-mlx"
+        )
+
+        #expect(!verified)
+        #expect(await server.isVoiceLaneResident(
+            for: "whisper-small",
+            modelPath: "mlx-community/whisper-small-mlx"
+        ), "the stale snapshot remains cached but is not accepted as current")
+    }
+
     @Test("mid-start is not co-loaded (no live serving alias yet)")
     func notCoLoadedWhileStarting() {
         let server = ServerManager(
@@ -139,4 +178,23 @@ struct VoiceCoLoadTests {
         let readyNoAuth = ServerManager(testingState: .ready(alias: "qwen3.6-27b-4bit"))
         #expect(readyNoAuth.voiceCoLoadsOnPrimary == false)
     }
+}
+
+private final class FailedResidencyRefreshProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 503,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"error":"unavailable"}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -300,6 +300,10 @@ FAKE_IMAGE_REPO = "fake-org/fake-image-repo"
 # ``/v1/models/load`` path instead of the legacy stop/start fallback when the
 # GUI asks for a second model while the sidecar is already running (#1838).
 SERVED_ALIAS = ""
+# Lazy audio engines are process-owned in production. The fixture mirrors
+# that lifecycle: a successful transcription materializes the STT lane, while
+# a sidecar replacement starts a fresh process with no resident audio lanes.
+RESIDENT_AUDIO_LANES = {}
 
 # The engine's own, actionable rejection reason. Kept out of the snapshot so a
 # stock persona never changes residency shape; a flow opts in with
@@ -600,6 +604,7 @@ class Handler(BaseHTTPRequestHandler):
                 "loads_total": 0,
                 "evictions_total": 0,
                 "models": [],
+                "audio_lanes": [],
             }
         return {
             "memory_limit_bytes": 34359738368,
@@ -621,6 +626,18 @@ class Handler(BaseHTTPRequestHandler):
                 "measured_bytes": None,
                 "idle_seconds": 0.0,
             }],
+            "audio_lanes": [
+                {
+                    "lane": lane,
+                    "model": model,
+                    "state": "resident",
+                    "active_requests": 0,
+                    "loaded_at": 1.0,
+                    "idle_seconds": 0.0,
+                    "last_error": None,
+                }
+                for lane, model in sorted(RESIDENT_AUDIO_LANES.items())
+            ],
         }
 
     def _models_load(self):
@@ -843,6 +860,7 @@ class Handler(BaseHTTPRequestHandler):
             delay_ms = int(_setting("FAKE_AUDIO_TRANSCRIPTION_DELAY_MS", "0") or "0")
             if delay_ms > 0:
                 time.sleep(delay_ms / 1000)
+            RESIDENT_AUDIO_LANES["stt"] = "fake/whisper-small"
             self._json(200, {
                 "text": "Golden transcription result.",
                 "language": "en",


### PR DESCRIPTION
## Why

Switching a chat model can replace the Desktop-managed sidecar when the model requires different process launch capabilities. That replacement drops the process-owned speech-to-text weights even though Dictation remains enabled, leaving the UI ready-looking but the voice lane absent.

Requested by the maintainer during 0.13.1 dogfood.

## What

- Reconcile enabled Dictation through the existing voice-lane preparation path after every completed chat-model transition.
- Decode the server's authoritative `audio_lanes` residency snapshot and require the selected catalog model to be resident before arming the hotkey or showing Ready.
- Keep process replacement and in-process model loads on the same idempotent lifecycle path.
- Extend the deterministic sidecar fixture and focused lifecycle/residency contracts.

## Scope

Desktop only. No engine changes, memory policy, conflict UX, retry loop, timer, model-name heuristic, or new serving mechanism.

## Evidence

- Focused Dictation/residency/co-load contracts: 58 passed.
- Full Desktop Swift suite (`swift test --no-parallel`): 2,849 passed in 32.85 s.
- Release-shaped local build: passed.
- Dictation AX golden flow: passed; setup, co-loaded warmup, persisted intent, relaunch, preserved chat.
