### PR TITLE
fix(mllm): bind generation streams to engine lifetimes

### DIFF
--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -247,7 +247,17 @@ class TestChatValidation:
 
 
 def _build_embed_app(patch_cfg, monkeypatch, embed_return):
+    import sys
+    from types import ModuleType
+
     from vllm_mlx.routes import embeddings as emb_route
+
+    embedding_stub = ModuleType("vllm_mlx.embedding")
+    embedding_stub.EMBEDDINGS_EXTRA_INSTALL_HINT = ""
+    embedding_stub.EmbeddingInputTooLongError = type(
+        "EmbeddingInputTooLongError", (ValueError,), {}
+    )
+    monkeypatch.setitem(sys.modules, "vllm_mlx.embedding", embedding_stub)
 
     app = FastAPI()
     app.include_router(emb_route.router)
@@ -739,9 +749,9 @@ class TestMLLMBatchGeneratorFailsLoud:
     def _source(self):
         from pathlib import Path
 
-        import vllm_mlx.mllm_batch_generator as mod
+        import vllm_mlx
 
-        return Path(mod.__file__).read_text()
+        return Path(vllm_mlx.__file__).with_name("mllm_batch_generator.py").read_text()
 
     def test_image_branch_raises_explicit_client_error(self):
         src = self._source()
@@ -773,9 +783,9 @@ class TestMLLMBatchGeneratorFailsLoud:
         C2 fix silently regresses to "client hangs"."""
         from pathlib import Path
 
-        import vllm_mlx.mllm_scheduler as sched_mod
+        import vllm_mlx
 
-        src = Path(sched_mod.__file__).read_text()
+        src = Path(vllm_mlx.__file__).with_name("mllm_scheduler.py").read_text()
         # Find the next() call and assert the surrounding catch.
         idx = src.find("self.batch_generator.next()")
         assert idx != -1, "MLLMScheduler no longer calls batch_generator.next()"

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -609,7 +609,7 @@ def test_close_swallows_synchronize_thread_error(monkeypatch):
     """`close()` must not propagate RuntimeError from mx.synchronize.
 
     mlx-lm 0.31.3+ streams are thread-local. When the engine is torn down
-    from a thread that isn't the one that owns MLLMBatchGenerator._stream,
+    from a thread that isn't the one that owns the generator's stream,
     mx.synchronize raises `There is no Stream(gpu, N) in current thread`.
     Pre-fix this propagated out of the lifespan shutdown and produced a
     scary traceback (Persona E v0.6.51 onboarding finding). The sync is

--- a/tests/test_mllm_logprobs_plumbing.py
+++ b/tests/test_mllm_logprobs_plumbing.py
@@ -145,10 +145,6 @@ def test_mllm_batch_generator_init_does_not_call_new_stream(monkeypatch):
 
     from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
 
-    # Reset the class-level singleton so this test exercises the
-    # construction-time stream assignment regardless of test ordering.
-    monkeypatch.setattr(MLLMBatchGenerator, "_stream", None)
-
     new_stream_calls: list[object] = []
 
     def _trap_new_stream(device):
@@ -168,29 +164,54 @@ def test_mllm_batch_generator_init_does_not_call_new_stream(monkeypatch):
     monkeypatch.setattr(mx, "new_stream", _trap_new_stream)
 
     # Build the generator through the real constructor.
-    MLLMBatchGenerator(
+    generator = MLLMBatchGenerator(
         model=_RecordingVLMModel(),
         processor=object(),
         mm_processor=None,
         enable_vision_cache=False,
     )
 
-    try:
-        assert new_stream_calls == [], (
-            "Construction must not allocate a new mx.stream. "
-            "Saw mx.new_stream calls: " + repr(new_stream_calls)
-        )
-        # And the stream must equal the worker's process-wide default.
-        expected = mx.default_stream(mx.default_device())
-        assert MLLMBatchGenerator._stream is not None
-        assert MLLMBatchGenerator._stream == expected, (
-            "MLLMBatchGenerator._stream must be the worker default "
-            "stream (process-wide, materialisable from any thread). "
-            f"Got: {MLLMBatchGenerator._stream!r}, expected: {expected!r}"
-        )
-    finally:
-        # Cleanup the singleton so other tests start clean.
-        MLLMBatchGenerator._stream = None
+    assert new_stream_calls == [], (
+        "Construction must not allocate a new mx.stream. "
+        "Saw mx.new_stream calls: " + repr(new_stream_calls)
+    )
+    # And the stream must equal the worker's default.
+    expected = mx.default_stream(mx.default_device())
+    assert generator._stream is not None
+    assert generator._stream == expected, (
+        "generator._stream must be the worker default stream. "
+        f"Got: {generator._stream!r}, expected: {expected!r}"
+    )
+
+
+def test_reloaded_generator_owns_the_new_worker_stream(monkeypatch):
+    """A new engine lifetime must not reuse the unloaded worker's stream."""
+    import mlx.core as mx
+
+    from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+    old_worker_stream = object()
+    new_worker_stream = object()
+    streams = iter((old_worker_stream, new_worker_stream))
+    monkeypatch.setattr(mx, "default_stream", lambda _device: next(streams))
+    monkeypatch.setattr(mx, "synchronize", lambda _stream: None)
+
+    first = MLLMBatchGenerator(
+        model=_RecordingVLMModel(),
+        processor=object(),
+        mm_processor=None,
+        enable_vision_cache=False,
+    )
+    first.close()
+    reloaded = MLLMBatchGenerator(
+        model=_RecordingVLMModel(),
+        processor=object(),
+        mm_processor=None,
+        enable_vision_cache=False,
+    )
+
+    assert first._stream is old_worker_stream
+    assert reloaded._stream is new_worker_stream
 
 
 def test_mllm_next_evals_outgoing_logprobs_before_response(monkeypatch):

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +15,106 @@ from tests._headless_mlx import install_headless_mlx_import_stubs
 install_headless_mlx_import_stubs()
 
 from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler  # noqa: E402
+
+
+def test_batch_generator_uses_worker_default_stream(monkeypatch) -> None:
+    """Construction binds each generator lifetime to its worker's stream."""
+    from vllm_mlx import mllm_batch_generator as module
+
+    stream = object()
+    monkeypatch.setattr(module.mx, "default_device", lambda: "gpu")
+    monkeypatch.setattr(module.mx, "default_stream", lambda device: stream)
+    monkeypatch.setattr(module.mx.metal, "is_available", lambda: False)
+
+    generator = module.MLLMBatchGenerator(
+        model=SimpleNamespace(language_model=object()),
+        processor=object(),
+        enable_vision_cache=False,
+    )
+
+    assert generator._stream is stream
+
+
+def test_batch_generator_close_tolerates_retired_worker_stream(
+    monkeypatch, caplog
+) -> None:
+    """A stale thread-local stream cannot prevent wired-limit cleanup."""
+    from vllm_mlx import mllm_batch_generator as module
+
+    generator = module.MLLMBatchGenerator.__new__(module.MLLMBatchGenerator)
+    generator._stream = object()
+    generator._old_wired_limit = 123
+    restored: list[int] = []
+    caplog.set_level(logging.DEBUG, logger=module.__name__)
+    monkeypatch.setattr(
+        module.mx,
+        "synchronize",
+        lambda _stream: (_ for _ in ()).throw(RuntimeError("retired stream")),
+    )
+    monkeypatch.setattr(module.mx, "set_wired_limit", restored.append)
+
+    generator.close()
+
+    assert restored == [123]
+    assert generator._old_wired_limit is None
+    assert "retired stream" in caplog.text
+
+
+def test_batch_generator_prefill_enters_owned_stream(monkeypatch) -> None:
+    """Vision prefill executes under the generator-owned stream context."""
+    from contextlib import contextmanager
+
+    from vllm_mlx import mllm_batch_generator as module
+
+    owned_stream = object()
+    entered: list[object] = []
+
+    @contextmanager
+    def stream_context(stream):
+        entered.append(stream)
+        yield
+
+    generator = module.MLLMBatchGenerator.__new__(module.MLLMBatchGenerator)
+    generator.language_model = object()
+    generator._stream = owned_stream
+    generator.vision_prefill_token_budget = 8192
+    generator.allow_arrays_cache = False
+    generator._stats = SimpleNamespace(prompt_tokens=0)
+    generator._preprocess_request = lambda _request: None
+    generator._run_vision_encoding = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        RuntimeError("prefill reached")
+    )
+    request = SimpleNamespace(input_ids=SimpleNamespace(size=1))
+    monkeypatch.setattr(module.mx, "stream", stream_context)
+    monkeypatch.setattr(module, "_prefill_cap_violation", lambda *_args: None)
+
+    with pytest.raises(RuntimeError, match="prefill reached"):
+        generator._process_prompts([request])
+
+    assert entered == [owned_stream]
+
+
+def test_batch_generator_next_uses_owned_stream(monkeypatch) -> None:
+    """Each decode step runs in the same worker-owned stream context."""
+    from contextlib import contextmanager
+
+    from vllm_mlx import mllm_batch_generator as module
+
+    owned_stream = object()
+    entered: list[object] = []
+
+    @contextmanager
+    def stream_context(stream):
+        entered.append(stream)
+        yield
+
+    generator = module.MLLMBatchGenerator.__new__(module.MLLMBatchGenerator)
+    generator._stream = owned_stream
+    generator._next = lambda: ["token"]
+    monkeypatch.setattr(module.mx, "stream", stream_context)
+
+    assert generator.next() == ["token"]
+    assert entered == [owned_stream]
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -564,9 +564,6 @@ class MLLMBatchGenerator:
         ...         print(f"Request {resp.request_id}: token={resp.token}")
     """
 
-    # Generation stream for async eval
-    _stream = None
-
     def __init__(
         self,
         model: nn.Module,
@@ -742,7 +739,7 @@ class MLLMBatchGenerator:
         # That crash path went live the moment PR #716 plumbed
         # ``MLLMBatchResponse.logprobs`` through to the route layer:
         # the per-step logprob slice was produced inside ``with
-        # mx.stream(MLLMBatchGenerator._stream):`` blocks on the
+        # mx.stream(self._stream):`` blocks on the
         # ``mllm-step`` worker, then the route handler (asyncio loop
         # thread) called ``np.array(logprobs_array)`` from
         # ``service.helpers._extract_token_logprob`` — and the loop
@@ -754,16 +751,15 @@ class MLLMBatchGenerator:
         # The text scheduler avoids this by running on a dedicated
         # ``mlx-step`` worker initialised via ``_init_mlx_step_thread``
         # (engine_core.py), which adopts
-        # ``mx.default_stream(mx.default_device())`` — the process-wide
-        # default that every thread can materialise against. Mirror
-        # that here: the MLLM worker (``mllm-step``) was already
-        # initialised by the same ``_init_mlx_step_thread`` callback
-        # at executor construction, so its default stream is the same
-        # process-wide default the model weights / KV cache were
-        # tagged with. Logprob arrays produced under this default
-        # round-trip cleanly to the route handler thread.
-        if MLLMBatchGenerator._stream is None:
-            MLLMBatchGenerator._stream = mx.default_stream(mx.default_device())
+        # ``mx.default_stream(mx.default_device())``. Mirror that here on
+        # every generator lifetime: a resident VLM reload owns a fresh worker,
+        # so retaining the prior generator's stream in class state makes the
+        # new worker fail with ``There is no Stream(gpu, N) in current
+        # thread``. Logprob arrays are evaluated on this worker before they
+        # cross to the route handler, so instance ownership preserves the
+        # existing cross-thread output contract without sharing execution
+        # state between engines.
+        self._stream = mx.default_stream(mx.default_device())
 
         # Memory management
         self._old_wired_limit = None
@@ -782,7 +778,7 @@ class MLLMBatchGenerator:
             # during process exit anyway, and the wired-limit reset still
             # needs to run to free reserved memory.
             try:
-                mx.synchronize(MLLMBatchGenerator._stream)
+                mx.synchronize(self._stream)
             except RuntimeError as e:
                 logger.debug(f"mx.synchronize skipped during close: {e}")
             mx.set_wired_limit(self._old_wired_limit)
@@ -1376,7 +1372,7 @@ class MLLMBatchGenerator:
             # Create a fresh KVCache for this request's language model prefill
             request_cache = make_prompt_cache(self.language_model)
 
-            with mx.stream(MLLMBatchGenerator._stream):
+            with mx.stream(self._stream):
                 # Run VLM forward pass — cache= flows through to language_model
                 logits = self._run_vision_encoding(req, cache=request_cache)
 
@@ -1631,7 +1627,7 @@ class MLLMBatchGenerator:
         # stream rules crashes with ``There is no Stream(...) in current
         # thread``. Pairs with the worker-default-stream adoption in
         # ``__init__`` so logprobs survive a cross-thread ``np.array(...)``
-        # even if ``MLLMBatchGenerator._stream`` is ever re-pointed.
+        # even if another generator lifetime is created.
         mx.eval(outgoing_logprobs)
 
         y = y.tolist()
@@ -1720,7 +1716,7 @@ class MLLMBatchGenerator:
         Returns:
             List of MLLMBatchResponse, one per active request
         """
-        with mx.stream(MLLMBatchGenerator._stream):
+        with mx.stream(self._stream):
             return self._next()
 
     def stats(self) -> MLLMBatchStats:


### PR DESCRIPTION
Fixes #2397

## Intention
Keep vision inference usable when a resident multimodal model is unloaded and the same model is loaded again in the same server process.

## Scope
- Bind each MLLM batch generator to the default stream of its owning engine worker.
- Add a deterministic lifecycle regression proving a replacement generator does not reuse the stopped worker stream.
- Preserve the existing cross-thread output synchronization contract.

## Non-goals
- No scheduler, residency, cache, or stream API redesign.
- No thread-local compatibility workaround.
- No model-specific routing or memory-policy changes.
- No Desktop changes.

## Acceptance
- Image inference succeeds before and after unload/reload of the same resident VLM.
- The replacement generator owns a newly acquired worker stream.
- Existing MLLM batching, cross-thread stream, and residency tests remain green.

## Evidence
Before the edit, an installed wheel reproduced: secondary VLM load 200, image chat 200, unload 204, same VLM reload 200, identical image chat 500. The stale stream belonged to the prior stopped worker.

After the edit, a freshly built and non-editably installed wheel produced 200 / 200 / 204 / 200 / 200 for the same sequence, and shutdown completed cleanly. Logs show the replacement worker acquired its own default stream.

## Verification
- `pytest -q tests/test_mllm_logprobs_plumbing.py tests/test_mllm_cross_thread_stream_contract.py tests/test_mllm_batch_generator.py` — 56 passed
- `pytest -q tests/test_mllm_continuous_batching.py tests/test_resident_models.py tests/test_mllm_stats.py` — 106 passed, 3 deselected
- Ruff check and format check
- `git diff --check`
- Local wheel build and installed-wheel cached-model unload/reload/image regression