### PR TITLE
fix(doctor): report running CLI exe separately from PATH resolution (#2352)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,7 @@ jobs:
             tests/test_alias_subfolder.py \
             tests/test_download_gate.py \
             tests/test_first_run_guide.py \
+            tests/test_doctor_env_health.py \
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -99,8 +99,16 @@ def test_low_disk_marks_fail():
     ]
 
 
-def test_huge_hf_cache_marks_warn():
-    """> 100 GB HF cache → WARN with cleanup hint."""
+def test_huge_hf_cache_marks_warn(tmp_path):
+    """> 100 GB HF cache → WARN with cleanup hint.
+
+    The cache dir is pointed at a fresh ``tmp_path`` that EXISTS so the
+    ``cache.exists()`` branch is taken deterministically on every platform
+    (a fresh Linux CI runner has no ``~/.cache/huggingface`` yet, which would
+    otherwise short-circuit to "HF cache: not present" and skip the WARN). The
+    reported size comes from the mocked ``_dir_size_gb``, not host state.
+    """
+    (tmp_path / "dummy").mkdir()
     with (
         mock.patch.object(eh.platform, "system", return_value="Darwin"),
         mock.patch.object(eh.platform, "machine", return_value="arm64"),
@@ -111,6 +119,7 @@ def test_huge_hf_cache_marks_warn():
         mock.patch.object(eh, "_detect_apple_silicon", return_value=("Apple M3", 36)),
         mock.patch.object(eh, "_disk_free_gb", return_value=200.0),
         mock.patch.object(eh, "_dir_size_gb", return_value=246.0),
+        mock.patch.object(eh, "_hf_cache_dir", return_value=tmp_path),
     ):
         section = eh.section_system()
 

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -858,6 +858,63 @@ def test_rapid_mlx_not_on_path_marks_fail(tmp_path: Path):
     assert "NOT on $PATH" in path_row.label
 
 
+def test_running_exe_mismatch_with_path_warns(tmp_path: Path):
+    """Issue #2352: PATH resolves a different rapid-mlx than the one actually
+    running this doctor (e.g. a venv/bin that precedes a global install) →
+    WARN with BOTH paths and an actionable fix, rather than a silently-green
+    PATH row that points troubleshooting at the wrong install."""
+    section = eh.section_shell_integration(
+        which=lambda name: (
+            "/Users/x/.local/bin/rapid-mlx" if name == "rapid-mlx" else None
+        ),
+        rcs=[tmp_path / "missing.zshrc"],
+        running_exe="/private/tmp/env/bin/rapid-mlx",
+    )
+    mismatch = next(c for c in section.checks if "differs from the $PATH" in c.label)
+    assert mismatch.status is eh.CheckStatus.WARN
+    assert "/private/tmp/env/bin/rapid-mlx" in mismatch.label
+    assert "/Users/x/.local/bin/rapid-mlx" in mismatch.label
+    assert "activate this environment" in mismatch.label
+    # The PATH row itself is still OK (it IS on PATH); only the divergence warns.
+    path_row = next(c for c in section.checks if "in $PATH" in c.label)
+    assert path_row.status is eh.CheckStatus.OK
+
+
+def test_running_exe_matching_path_has_no_mismatch_warn(tmp_path: Path):
+    """When the running CLI and the PATH-resolved CLI agree, no mismatch warn."""
+    section = eh.section_shell_integration(
+        which=lambda name: (
+            "/private/tmp/env/bin/rapid-mlx" if name == "rapid-mlx" else None
+        ),
+        rcs=[tmp_path / "missing.zshrc"],
+        running_exe="/private/tmp/env/bin/rapid-mlx",
+    )
+    assert not any("differs from the $PATH" in c.label for c in section.checks)
+
+
+def test_running_cli_exe_prefers_argv0(monkeypatch):
+    """``_running_cli_exe`` uses sys.argv[0] (the console-script path) when it
+    resolves to a `rapid-mlx` entry point."""
+    monkeypatch.setattr(eh.sys, "argv", ["/opt/venv/bin/rapid-mlx", "doctor"])
+    assert eh._running_cli_exe() == "/opt/venv/bin/rapid-mlx"
+
+
+def test_running_cli_exe_falls_back_to_executable_sibling(monkeypatch):
+    """When sys.argv[0] isn't a `rapid-mlx` script (e.g. python -m), fall back
+    to the `rapid-mlx` console script beside sys.executable."""
+    monkeypatch.setattr(eh.sys, "argv", ["-m", "rapid_mlx.doctor"])
+    monkeypatch.setattr(eh.sys, "executable", "/opt/venv/bin/python")
+    monkeypatch.setattr(eh.os.path, "exists", lambda p: p == "/opt/venv/bin/rapid-mlx")
+    assert eh._running_cli_exe() == "/opt/venv/bin/rapid-mlx"
+
+
+def test_running_cli_exe_uses_executable_when_named_rapid_mlx(monkeypatch):
+    """If sys.executable itself is `rapid-mlx` (rare direct exec), return it."""
+    monkeypatch.setattr(eh.sys, "argv", ["-m", "rapid_mlx.doctor"])
+    monkeypatch.setattr(eh.sys, "executable", "/opt/venv/bin/rapid-mlx")
+    assert eh._running_cli_exe() == "/opt/venv/bin/rapid-mlx"
+
+
 # ---------------------------------------------------------------------------
 # Exit-code aggregation
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1199,8 +1199,14 @@ def section_shell_integration(
         # from the one actually running this doctor (e.g. inside a venv whose
         # bin/ precedes a global ~/.local/bin install). Surface the divergence
         # with both paths and an actionable fix instead of a silently-green
-        # "PATH OK" that points troubleshooting at the wrong install.
-        if running_exe and os.path.abspath(running_exe) != os.path.abspath(cli_path):
+        # "PATH OK" that points troubleshooting at the wrong install. Compare
+        # with realpath + normcase so a console-script symlink (Homebrew/PyPI)
+        # that resolves to the same binary is NOT a false mismatch — the
+        # running-CLI detector already realpaths sys.argv[0].
+        if running_exe and (
+            os.path.normcase(os.path.realpath(running_exe))
+            != os.path.normcase(os.path.realpath(cli_path))
+        ):
             s.add(
                 f"running rapid-mlx ({running_exe}) differs from the $PATH "
                 f"rapid-mlx ({cli_path}) — activate this environment or reorder "

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -1149,18 +1149,44 @@ def _rapid_mlx_on_path(path_env: str | None = None) -> list[str]:
     return out
 
 
+def _running_cli_exe() -> str | None:
+    """Resolve the ``rapid-mlx`` executable that launched this process.
+
+    When invoked as a console script, ``sys.argv[0]`` is the path to the
+    ``rapid-mlx`` entry point (``<venv>/bin/rapid-mlx``). Fall back to the
+    interpreter's sibling of the same name (a console script installed in the
+    same bin dir as ``sys.executable``) so ``doctor`` still reports
+    something sensible under unusual launchers (e.g. ``python -m …``).
+    Returns ``None`` only if neither yields a plausible path (not expected).
+    """
+    argv0 = os.path.realpath(sys.argv[0]) if sys.argv and sys.argv[0] else ""
+    if argv0 and os.path.basename(argv0) == "rapid-mlx":
+        return argv0
+    sibling = os.path.join(os.path.dirname(sys.executable), "rapid-mlx")
+    if os.path.basename(sys.executable) == "rapid-mlx":
+        return os.path.realpath(sys.executable)
+    return sibling if os.path.exists(sibling) else None
+
+
 def section_shell_integration(
     *,
     which: Callable[[str], str | None] | None = None,
     rcs: list[Path] | None = None,
     find_all: Callable[[], list[str]] | None = None,
+    running_exe: str | None = None,
 ) -> Section:
     """Verify the CLI is on PATH and argcomplete is wired up.
 
-    ``which``, ``rcs`` and ``find_all`` are dependency-injected for tests.
+    ``which``, ``rcs``, ``find_all`` and ``running_exe`` are dependency-injected
+    for tests. ``running_exe`` is the executable that actually launched this
+    doctor; it defaults to the real running CLI so a venv/bin that precedes a
+    global install is surfaced (issue #2352).
     """
     s = Section("Shell Integration")
     which_fn = which or shutil.which
+
+    if running_exe is None:
+        running_exe = _running_cli_exe()
 
     cli_path = which_fn("rapid-mlx")
     if cli_path:
@@ -1169,6 +1195,19 @@ def section_shell_integration(
             CheckStatus.OK,
             detail=f"path={cli_path}",
         )
+        # Issue #2352: the PATH-checked executable can be a different install
+        # from the one actually running this doctor (e.g. inside a venv whose
+        # bin/ precedes a global ~/.local/bin install). Surface the divergence
+        # with both paths and an actionable fix instead of a silently-green
+        # "PATH OK" that points troubleshooting at the wrong install.
+        if running_exe and os.path.abspath(running_exe) != os.path.abspath(cli_path):
+            s.add(
+                f"running rapid-mlx ({running_exe}) differs from the $PATH "
+                f"rapid-mlx ({cli_path}) — activate this environment or reorder "
+                f"$PATH",
+                CheckStatus.WARN,
+                detail=f"running={running_exe} path={cli_path}",
+            )
         installs = (find_all or _rapid_mlx_on_path)()
         if len(installs) > 1:
             active, shadowed = installs[0], installs[1:]


### PR DESCRIPTION
Closes #2352 — doctor validates a different rapid-mlx executable than the active venv.

Doctor's Shell Integration section reported only `shutil.which('rapid-mlx')`, which can resolve a different (global ~/.local/bin) install than the one actually running doctor inside a venv. That hid a PATH/version mismatch and sent troubleshooting to the wrong installation.

## Change
- `_running_cli_exe()` resolves the executable that launched this doctor (sys.argv[0] when it is a rapid-mlx entry point, else the rapid-mlx console script beside sys.executable).
- `section_shell_integration()` now reports the running CLI and WARNs with BOTH paths + actionable guidance ('activate this environment or reorder $PATH') when it differs from the PATH-resolved executable. `running_exe` is dependency-injected for tests, defaults to the real running CLI.
- ci.yml enrolls `tests/test_doctor_env_health.py` in the changed-lines coverage list.

## Validation
- diff-cover 100% (12 lines); ruff clean; mypy clean on my code (only pre-existing numpy-stub env noise).
- 72 doctor env-health tests pass (4 new: mismatch-warns, match-no-warn, argv0/sibling/executable fallbacks).