### PR TITLE
fix(server): budget pinned speech input with assistants

### DIFF
--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -148,6 +148,7 @@ async def test_audio_load_admission_surfaces_typed_507(monkeypatch):
     from vllm_mlx.routes import audio as audio_route
     from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
     from vllm_mlx.runtime.resident_models import ResidentModelManager
+    from vllm_mlx.runtime.role_capacity import speech_input_capacity
 
     gib = 1024**3
     registry = ModelRegistry()
@@ -164,13 +165,25 @@ async def test_audio_load_admission_surfaces_typed_507(monkeypatch):
     manager = ResidentModelManager(
         registry,
         unused_loader,
-        memory_limit_bytes=4 * gib,
+        memory_limit_bytes=5 * gib,
         memory_reader=lambda: 0,
     )
     manager.register_primary(primary, estimated_bytes=4 * gib)
     monkeypatch.setattr(audio_route, "_residency_manager", lambda: manager)
 
-    admission = audio_route._admitting_speech_input("mlx-community/whisper-small-mlx")
+    old_model = "mlx-community/whisper-small-mlx"
+    old_capacity = speech_input_capacity(old_model)
+    async with manager.admit_role(
+        role="speech-input",
+        model_id=old_model,
+        requested_bytes=old_capacity.requested_bytes,
+        capacity_source=old_capacity.source,
+    ):
+        pass
+
+    admission = audio_route._admitting_speech_input(
+        "mlx-community/whisper-large-v3-mlx", replace_existing=True
+    )
     with pytest.raises(HTTPException) as raised:
         await admission.__aenter__()
 
@@ -179,12 +192,13 @@ async def test_audio_load_admission_surfaces_typed_507(monkeypatch):
     assert error["code"] == "insufficient_capacity_error"
     assert error["reason"] == "role_capacity_speech_input"
     assert error["used_bytes"] == 4 * gib
-    assert error["limit_bytes"] == 4 * gib
+    assert error["limit_bytes"] == 5 * gib
     assert error["requested_bytes"] > 0
+    assert manager.snapshot()["roles"][-1]["model"] == old_model
     unused_loader.assert_not_awaited()
 
 
-def test_audio_residency_manager_probe_fails_closed(monkeypatch):
+def test_audio_residency_manager_probe_does_not_disable_capacity(monkeypatch):
     from vllm_mlx import config
     from vllm_mlx.routes import audio as audio_route
 
@@ -192,7 +206,8 @@ def test_audio_residency_manager_probe_fails_closed(monkeypatch):
         raise RuntimeError("config unavailable")
 
     monkeypatch.setattr(config, "get_config", unavailable_config)
-    assert audio_route._residency_manager() is None
+    with pytest.raises(RuntimeError, match="config unavailable"):
+        audio_route._residency_manager()
 
 
 def _replacement_manager(server, old_worker):

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -81,6 +81,120 @@ class _ReplacementWorker:
         self.stopped = True
 
 
+def test_registered_speech_input_models_have_metadata_capacity():
+    from vllm_mlx.audio.registry import list_audio_aliases
+    from vllm_mlx.runtime.role_capacity import speech_input_capacity
+
+    entries = [entry for entry in list_audio_aliases() if entry.type == "stt"]
+    assert entries
+    for entry in entries:
+        capacity = speech_input_capacity(entry.alias)
+        assert capacity.source == "catalog", entry.alias
+        assert capacity.requested_bytes is not None
+        assert capacity.requested_bytes > 0
+
+    unknown = speech_input_capacity("private/unlisted-speech-model")
+    assert unknown.source == "unknown"
+    assert unknown.requested_bytes is None
+
+
+@pytest.mark.asyncio
+async def test_audio_load_admission_uses_shared_role_ledger(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import ResidentModelManager
+
+    gib = 1024**3
+    registry = ModelRegistry()
+    primary_engine = _ReplacementWorker("chat")
+    primary = ModelEntry(
+        engine=primary_engine,
+        model_name="chat",
+        model_path="repo/chat",
+    )
+    registry.add(primary, is_default=True)
+
+    unused_loader = AsyncMock()
+
+    manager = ResidentModelManager(
+        registry,
+        unused_loader,
+        memory_limit_bytes=8 * gib,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * gib)
+    monkeypatch.setattr(audio_route, "_residency_manager", lambda: manager)
+
+    async with audio_route._admitting_speech_input("mlx-community/whisper-small-mlx"):
+        role = manager.snapshot()["roles"][-1]
+        assert role["role"] == "speech-input"
+        assert role["state"] == "loading"
+        assert role["capacity_source"] == "catalog"
+
+    assert manager.snapshot()["roles"][-1]["state"] == "resident"
+    await audio_route._release_speech_input_role()
+    assert all(role["role"] != "speech-input" for role in manager.snapshot()["roles"])
+    unused_loader.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_audio_load_admission_surfaces_typed_507(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import ResidentModelManager
+
+    gib = 1024**3
+    registry = ModelRegistry()
+    primary_engine = _ReplacementWorker("chat")
+    primary = ModelEntry(
+        engine=primary_engine,
+        model_name="chat",
+        model_path="repo/chat",
+    )
+    registry.add(primary, is_default=True)
+
+    unused_loader = AsyncMock()
+
+    manager = ResidentModelManager(
+        registry,
+        unused_loader,
+        memory_limit_bytes=4 * gib,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * gib)
+    monkeypatch.setattr(audio_route, "_residency_manager", lambda: manager)
+
+    admission = audio_route._admitting_speech_input("mlx-community/whisper-small-mlx")
+    with pytest.raises(HTTPException) as raised:
+        await admission.__aenter__()
+
+    assert raised.value.status_code == 507
+    error = raised.value.detail["error"]
+    assert error["code"] == "insufficient_capacity_error"
+    assert error["reason"] == "role_capacity_speech_input"
+    assert error["used_bytes"] == 4 * gib
+    assert error["limit_bytes"] == 4 * gib
+    assert error["requested_bytes"] > 0
+    unused_loader.assert_not_awaited()
+
+
+def test_audio_residency_manager_probe_fails_closed(monkeypatch):
+    from vllm_mlx import config
+    from vllm_mlx.routes import audio as audio_route
+
+    def unavailable_config():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(config, "get_config", unavailable_config)
+    assert audio_route._residency_manager() is None
+
+
 def _replacement_manager(server, old_worker):
     from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
     from vllm_mlx.runtime.resident_models import ResidentModelManager
@@ -315,6 +429,7 @@ async def test_lane_snapshot_reports_resident_model_after_successful_load():
     assert dispatcher.snapshot() == [
         {
             "lane": "stt",
+            "role": "speech-input",
             "model": "whisper-small",
             "state": "resident",
             "active_requests": 0,
@@ -555,6 +670,12 @@ async def test_stt_load_and_inference_use_audio_worker(monkeypatch):
         def unload(self) -> None:
             operations.append("unload-aligner")
 
+    class _OldSTT:
+        model_name = "old-stt"
+
+        def unload(self) -> None:
+            operations.append("unload-stt")
+
     class _STT:
         def __init__(self, model_name: str) -> None:
             self.model_name = model_name
@@ -570,7 +691,7 @@ async def test_stt_load_and_inference_use_audio_worker(monkeypatch):
 
     worker = _RecordingWorker()
     monkeypatch.setattr(stt_module, "STTEngine", _STT)
-    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    monkeypatch.setattr(audio_route, "_stt_engine", _OldSTT())
     monkeypatch.setattr(audio_route, "_aligner_engine", _OldAligner())
     bind_audio_worker(worker)
     try:
@@ -586,8 +707,42 @@ async def test_stt_load_and_inference_use_audio_worker(monkeypatch):
         bind_audio_worker(None)
 
     assert response == {"text": "hello", "language": "en", "duration": 1.0}
-    assert operations == ["unload-aligner", "load-stt", "infer-stt"]
-    assert len(worker.async_calls) == 3
+    assert operations == ["unload-aligner", "unload-stt", "load-stt", "infer-stt"]
+    assert len(worker.async_calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_alignment_retires_replaced_speech_input_role(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    released = 0
+
+    async def fake_stream(_file, _tmp):
+        return None
+
+    async def fake_completion(_func, *_args):
+        return SimpleNamespace(text="aligned", language="en", duration=1.0)
+
+    async def release_role():
+        nonlocal released
+        released += 1
+
+    class _Upload:
+        filename = "speech.wav"
+
+    monkeypatch.setattr(audio_route, "_resolve_stt_model", lambda _model: "aligner")
+    monkeypatch.setattr(audio_route, "_is_aligner_model", lambda _model: True)
+    monkeypatch.setattr(audio_route, "_stream_upload_to_tempfile", fake_stream)
+    monkeypatch.setattr(audio_route, "run_to_completion", fake_completion)
+    monkeypatch.setattr(audio_route, "_release_speech_input_role", release_role)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+
+    result = await audio_route._run_alignment_request(
+        _Upload(), "aligner", "known text", "en", "json"
+    )
+
+    assert result == {"text": "aligned", "language": "en", "duration": 1.0}
+    assert released == 1
 
 
 def test_alignment_load_and_inference_use_audio_worker(monkeypatch):
@@ -726,18 +881,52 @@ async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
 
     class _Manager:
         def snapshot(self):
-            return {"models": [{"id": "chat-model"}]}
+            return {
+                "models": [{"id": "chat-model"}],
+                "roles": [
+                    {
+                        "role": "speech-input",
+                        "model": "whisper-small",
+                        "state": "resident",
+                        "active_requests": 0,
+                    }
+                ],
+            }
 
     monkeypatch.setattr(residency, "_manager", lambda: _Manager())
     monkeypatch.setattr(
         audio_worker,
         "snapshot",
-        lambda: [{"lane": "stt", "model": "whisper-small"}],
+        lambda: [
+            {
+                "lane": "stt",
+                "role": "speech-input",
+                "model": "whisper-small",
+                "state": "busy",
+                "active_requests": 1,
+            }
+        ],
     )
 
     assert await residency.model_residency() == {
         "models": [{"id": "chat-model"}],
-        "audio_lanes": [{"lane": "stt", "model": "whisper-small"}],
+        "roles": [
+            {
+                "role": "speech-input",
+                "model": "whisper-small",
+                "state": "busy",
+                "active_requests": 1,
+            }
+        ],
+        "audio_lanes": [
+            {
+                "lane": "stt",
+                "role": "speech-input",
+                "model": "whisper-small",
+                "state": "busy",
+                "active_requests": 1,
+            }
+        ],
     }
 
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -930,6 +930,16 @@ async def test_residency_snapshot_includes_audio_lane_truth(monkeypatch):
     }
 
 
+def test_alignment_lane_does_not_claim_dictation_role():
+    from vllm_mlx.runtime.audio_worker import AudioWorkerDispatcher
+
+    dispatcher = AudioWorkerDispatcher()
+    dispatcher.execute_sync("alignment", "aligner", "load", lambda: None)
+
+    assert dispatcher.snapshot()[0]["role"] == "alignment"
+    dispatcher.bind(None)
+
+
 @pytest.mark.asyncio
 async def test_primary_replacement_rebinds_after_audio_work_finishes(monkeypatch):
     import vllm_mlx.server as server

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -450,6 +450,129 @@ def manager_fixture(*, limit_gib=10, ttl=0):
     return manager, registry, loaded, clock
 
 
+@pytest.mark.asyncio
+async def test_speech_input_reservation_blocks_assistant_before_load():
+    manager, _registry, loaded, _clock = manager_fixture(limit_gib=10)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/whisper",
+        requested_bytes=2 * GIB,
+        capacity_source="catalog",
+    ):
+        loading = manager.snapshot()
+        assert loading["memory_used_bytes"] == 6 * GIB
+        assert loading["roles"][-1] == {
+            "role": "speech-input",
+            "model": "repo/whisper",
+            "state": "loading",
+            "pinned": True,
+            "active_requests": 0,
+            "reserved_bytes": 2 * GIB,
+            "capacity_source": "catalog",
+        }
+
+    with pytest.raises(ResidentModelCapacityError) as raised:
+        await manager.load("large-assistant", estimated_bytes=5 * GIB)
+
+    error = raised.value
+    assert error.reason == "role_capacity_assistant"
+    assert error.requested_bytes == 5 * GIB
+    assert error.used_bytes == 6 * GIB
+    assert error.limit_bytes == 10 * GIB
+    assert "large-assistant" not in loaded
+    assert manager.snapshot()["roles"][-1]["state"] == "resident"
+
+
+@pytest.mark.asyncio
+async def test_speech_input_admission_rejects_unknown_and_over_budget_capacity():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=8)
+
+    unknown_admission = manager.admit_role(
+        role="speech-input",
+        model_id="org/unmeasured",
+        requested_bytes=None,
+        capacity_source="unknown",
+    )
+    with pytest.raises(ResidentModelCapacityError) as unknown:
+        await unknown_admission.__aenter__()
+    assert unknown.value.reason == "role_capacity_unknown"
+    assert manager.snapshot()["roles"] == [manager.snapshot()["roles"][0]]
+
+    over_budget_admission = manager.admit_role(
+        role="speech-input",
+        model_id="repo/whisper",
+        requested_bytes=5 * GIB,
+        capacity_source="catalog",
+    )
+    with pytest.raises(ResidentModelCapacityError) as over_budget:
+        await over_budget_admission.__aenter__()
+    assert over_budget.value.reason == "role_capacity_speech_input"
+    assert over_budget.value.used_bytes == 4 * GIB
+
+
+@pytest.mark.asyncio
+async def test_role_reservation_exact_boundary_and_failed_load_rollback():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=6)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/whisper",
+        requested_bytes=2 * GIB,
+        capacity_source="catalog",
+    ):
+        assert manager.snapshot()["memory_available_bytes"] == 0
+    await manager.release_role("speech-input")
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        async with manager.admit_role(
+            role="speech-input",
+            model_id="repo/whisper",
+            requested_bytes=2 * GIB,
+            capacity_source="catalog",
+        ):
+            raise RuntimeError("load failed")
+    assert all(role["role"] != "speech-input" for role in manager.snapshot()["roles"])
+
+
+@pytest.mark.asyncio
+async def test_duplicate_role_admission_is_rejected():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=8)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/whisper",
+        requested_bytes=2 * GIB,
+        capacity_source="catalog",
+    ):
+        duplicate = manager.admit_role(
+            role="speech-input",
+            model_id="repo/other",
+            requested_bytes=1 * GIB,
+            capacity_source="catalog",
+        )
+        with pytest.raises(ResidentModelError, match="already resident"):
+            await duplicate.__aenter__()
+
+
+@pytest.mark.asyncio
+async def test_disabled_ceiling_keeps_unknown_role_truth_without_rejection():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=0)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="org/unmeasured",
+        requested_bytes=None,
+        capacity_source="unknown",
+    ):
+        pass
+
+    role = manager.snapshot()["roles"][-1]
+    assert role["role"] == "speech-input"
+    assert role["reserved_bytes"] == 0
+    assert role["capacity_source"] == "unknown"
+
+
 @pytest.fixture
 def residency_activity_contract(monkeypatch):
     """Exercise the activity SSOT from the MLX-free Linux fixed selector."""
@@ -1539,6 +1662,58 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         )
         assert client.delete("/v1/models/image").status_code == 204
         assert "image" not in registry
+
+
+def test_residency_load_returns_typed_role_capacity_507(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.residency import router
+
+    manager, _registry, loaded, _clock = manager_fixture(limit_gib=10)
+
+    async def reserve_speech_input() -> None:
+        async with manager.admit_role(
+            role="speech-input",
+            model_id="repo/whisper",
+            requested_bytes=2 * GIB,
+            capacity_source="catalog",
+        ):
+            pass
+
+    asyncio.run(reserve_speech_input())
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={"model": "large-assistant", "estimated_size_gb": 5},
+        )
+
+    assert response.status_code == 507
+    assert response.json() == {
+        "error": {
+            "message": (
+                "insufficient capacity for assistant: requested=5.00 GiB, "
+                "used=6.00 GiB, limit=10.00 GiB; no idle unpinned model "
+                "is eligible for eviction"
+            ),
+            "type": "insufficient_capacity_error",
+            "code": "insufficient_capacity_error",
+            "reason": "role_capacity_assistant",
+            "param": "model",
+            "requested_bytes": 5 * GIB,
+            "limit_bytes": 10 * GIB,
+            "used_bytes": 6 * GIB,
+        }
+    }
+    assert "large-assistant" not in loaded
 
 
 def test_models_load_requires_strict_json_booleans(monkeypatch):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -574,6 +574,70 @@ async def test_duplicate_role_admission_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_rejected_role_replacement_preserves_existing_reservation():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=6)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/working-stt",
+        requested_bytes=1 * GIB,
+        capacity_source="catalog",
+    ):
+        pass
+
+    replacement = manager.admit_role(
+        role="speech-input",
+        model_id="repo/too-large-stt",
+        requested_bytes=3 * GIB,
+        capacity_source="catalog",
+        replace_existing=True,
+    )
+    with pytest.raises(ResidentModelCapacityError) as raised:
+        await replacement.__aenter__()
+
+    assert raised.value.reason == "role_capacity_speech_input"
+    role = manager.snapshot()["roles"][-1]
+    assert role["model"] == "repo/working-stt"
+    assert role["state"] == "resident"
+
+
+@pytest.mark.asyncio
+async def test_role_replacement_rollback_tracks_previous_retirement():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=8)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/working-stt",
+        requested_bytes=1 * GIB,
+        capacity_source="catalog",
+    ):
+        pass
+
+    with pytest.raises(RuntimeError, match="unload failed"):
+        async with manager.admit_role(
+            role="speech-input",
+            model_id="repo/replacement",
+            requested_bytes=2 * GIB,
+            capacity_source="catalog",
+            replace_existing=True,
+        ):
+            raise RuntimeError("unload failed")
+    assert manager.snapshot()["roles"][-1]["model"] == "repo/working-stt"
+
+    with pytest.raises(RuntimeError, match="replacement load failed"):
+        async with manager.admit_role(
+            role="speech-input",
+            model_id="repo/replacement",
+            requested_bytes=2 * GIB,
+            capacity_source="catalog",
+            replace_existing=True,
+        ) as admission:
+            admission.retire_previous()
+            raise RuntimeError("replacement load failed")
+    assert all(role["role"] != "speech-input" for role in manager.snapshot()["roles"])
+
+
+@pytest.mark.asyncio
 async def test_disabled_ceiling_keeps_unknown_role_truth_without_rejection():
     manager, _registry, _loaded, _clock = manager_fixture(limit_gib=0)
 
@@ -589,6 +653,16 @@ async def test_disabled_ceiling_keeps_unknown_role_truth_without_rejection():
     assert role["role"] == "speech-input"
     assert role["reserved_bytes"] == 0
     assert role["capacity_source"] == "unknown"
+
+
+def test_role_accounting_keeps_memory_probe_failure_nonfatal():
+    manager, _registry, _loaded, _clock = manager_fixture(limit_gib=8)
+
+    def failed_probe():
+        raise RuntimeError("memory probe unavailable")
+
+    manager._memory_reader = failed_probe
+    assert manager.snapshot()["memory_used_bytes"] == 4 * GIB
 
 
 @pytest.fixture

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -512,6 +512,24 @@ async def test_speech_input_admission_rejects_unknown_and_over_budget_capacity()
 
 
 @pytest.mark.asyncio
+async def test_speech_input_admission_reuses_eligible_secondary_eviction():
+    manager, registry, loaded, _clock = manager_fixture(limit_gib=10)
+    secondary = await manager.load("secondary", estimated_bytes=3 * GIB)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="repo/whisper",
+        requested_bytes=4 * GIB,
+        capacity_source="catalog",
+    ):
+        assert "secondary" not in registry
+        assert secondary.entry.engine.stopped is True
+        assert manager.snapshot()["memory_used_bytes"] == 8 * GIB
+
+    assert "secondary" in loaded
+
+
+@pytest.mark.asyncio
 async def test_role_reservation_exact_boundary_and_failed_load_rollback():
     manager, _registry, _loaded, _clock = manager_fixture(limit_gib=6)
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import wave
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
@@ -157,6 +158,49 @@ _AUDIO_READ_CHUNK_SIZE = 1024 * 1024  # 1 MB chunks
 _stt_engine = None
 _tts_engine = None
 _music_engine: Any = None
+
+
+def _residency_manager():
+    """Return the shared residency manager when this server configured one."""
+
+    try:
+        from ..config import get_config
+
+        return get_config().residency_manager
+    except Exception:
+        return None
+
+
+@asynccontextmanager
+async def _admitting_speech_input(model_name: str):
+    """Reserve the speech-input role before constructing its engine weights."""
+
+    manager = _residency_manager()
+    if manager is None:
+        yield
+        return
+
+    from ..runtime.resident_models import ResidentModelCapacityError
+    from ..runtime.role_capacity import speech_input_capacity
+
+    capacity = speech_input_capacity(model_name)
+    try:
+        async with manager.admit_role(
+            role="speech-input",
+            model_id=model_name,
+            requested_bytes=capacity.requested_bytes,
+            capacity_source=capacity.source,
+        ):
+            yield
+    except ResidentModelCapacityError as exc:
+        raise HTTPException(status_code=507, detail=exc.envelope()) from exc
+
+
+async def _release_speech_input_role() -> None:
+    manager = _residency_manager()
+    if manager is not None:
+        await manager.release_role("speech-input")
+
 
 # OpenAI-style STT model alias → MLX repo. Promoted to module scope so
 # the route can validate the model BEFORE streaming the upload (F-165):
@@ -1311,12 +1355,21 @@ async def _run_stt_request(
             if _stt_engine is None or _stt_engine.model_name != model_name:
                 # Symmetric with the alignment path: one STT model resident.
                 await _evict_other_lane("asr")
-                _stt_engine = None
+                if _stt_engine is not None:
+                    old_stt = _stt_engine
+                    unload = getattr(old_stt, "unload", None)
+                    if callable(unload):
+                        from ..runtime.audio_worker import run_audio_mlx
+
+                        await run_audio_mlx("stt", old_stt.model_name, "unload", unload)
+                    _stt_engine = None
+                    await _release_speech_input_role()
                 stt_engine = STTEngine(model_name)
                 from ..runtime.audio_worker import run_audio_mlx
 
-                await run_audio_mlx("stt", model_name, "load", stt_engine.load)
-                _stt_engine = stt_engine
+                async with _admitting_speech_input(model_name):
+                    await run_audio_mlx("stt", model_name, "load", stt_engine.load)
+                    _stt_engine = stt_engine
 
             # Forward ``timestamp_granularities`` only when requested.
             # Keeping the default call shape unchanged preserves compatibility
@@ -1555,6 +1608,7 @@ async def shutdown_audio_lanes() -> None:
         finally:
             _stt_engine = None
             _aligner_engine = None
+            await _release_speech_input_role()
 
     async with _get_tts_lane_lock():
         try:
@@ -1810,9 +1864,16 @@ async def _run_alignment_request(
         # for exactly as long as the worker runs, even if the client
         # disconnects and cancels us mid-align.
         async with _get_stt_lane_lock():
-            result = await run_to_completion(
-                _align_blocking, model_name, tmp_path, text, language
-            )
+            try:
+                result = await run_to_completion(
+                    _align_blocking, model_name, tmp_path, text, language
+                )
+            finally:
+                # The blocking aligner path releases any cached ASR engine
+                # before loading its own weights. Retire the matching budget
+                # only after that worker operation reaches a terminal state.
+                if _stt_engine is None:
+                    await _release_speech_input_role()
 
         return _format_stt_response(result, response_format, task="transcribe")
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -160,24 +160,26 @@ _tts_engine = None
 _music_engine: Any = None
 
 
+class _NoopRoleAdmission:
+    def retire_previous(self) -> None:
+        pass
+
+
 def _residency_manager():
     """Return the shared residency manager when this server configured one."""
 
-    try:
-        from ..config import get_config
+    from ..config import get_config
 
-        return get_config().residency_manager
-    except Exception:
-        return None
+    return get_config().residency_manager
 
 
 @asynccontextmanager
-async def _admitting_speech_input(model_name: str):
+async def _admitting_speech_input(model_name: str, *, replace_existing: bool = False):
     """Reserve the speech-input role before constructing its engine weights."""
 
     manager = _residency_manager()
     if manager is None:
-        yield
+        yield _NoopRoleAdmission()
         return
 
     from ..runtime.resident_models import ResidentModelCapacityError
@@ -190,8 +192,9 @@ async def _admitting_speech_input(model_name: str):
             model_id=model_name,
             requested_bytes=capacity.requested_bytes,
             capacity_source=capacity.source,
-        ):
-            yield
+            replace_existing=replace_existing,
+        ) as admission:
+            yield admission
     except ResidentModelCapacityError as exc:
         raise HTTPException(status_code=507, detail=exc.envelope()) from exc
 
@@ -1355,19 +1358,21 @@ async def _run_stt_request(
             if _stt_engine is None or _stt_engine.model_name != model_name:
                 # Symmetric with the alignment path: one STT model resident.
                 await _evict_other_lane("asr")
-                if _stt_engine is not None:
-                    old_stt = _stt_engine
-                    unload = getattr(old_stt, "unload", None)
-                    if callable(unload):
-                        from ..runtime.audio_worker import run_audio_mlx
-
-                        await run_audio_mlx("stt", old_stt.model_name, "unload", unload)
-                    _stt_engine = None
-                    await _release_speech_input_role()
+                old_stt = _stt_engine
                 stt_engine = STTEngine(model_name)
                 from ..runtime.audio_worker import run_audio_mlx
 
-                async with _admitting_speech_input(model_name):
+                async with _admitting_speech_input(
+                    model_name, replace_existing=old_stt is not None
+                ) as admission:
+                    if old_stt is not None:
+                        unload = getattr(old_stt, "unload", None)
+                        if callable(unload):
+                            await run_audio_mlx(
+                                "stt", old_stt.model_name, "unload", unload
+                            )
+                        _stt_engine = None
+                        admission.retire_previous()
                     await run_audio_mlx("stt", model_name, "load", stt_engine.load)
                     _stt_engine = stt_engine
 

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -103,7 +103,18 @@ async def model_residency():
     from ..runtime.audio_worker import audio_worker
 
     snapshot = _manager().snapshot()
-    snapshot["audio_lanes"] = audio_worker.snapshot()
+    audio_lanes = audio_worker.snapshot()
+    snapshot["audio_lanes"] = audio_lanes
+    role_activity = {
+        lane["role"]: lane
+        for lane in audio_lanes
+        if lane.get("role") is not None and lane.get("model") is not None
+    }
+    for role in snapshot.get("roles", []):
+        lane = role_activity.get(role["role"])
+        if lane is not None:
+            role["state"] = lane["state"]
+            role["active_requests"] = lane["active_requests"]
     return snapshot
 
 
@@ -158,7 +169,7 @@ async def load_resident_model(request: ModelLoadRequest):
     except HTTPException:
         raise
     except ResidentModelCapacityError as exc:
-        raise HTTPException(status_code=507, detail=str(exc)) from exc
+        raise HTTPException(status_code=507, detail=exc.envelope()) from exc
     except ResidentModelError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except Exception as exc:

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -14,7 +14,7 @@ _T = TypeVar("_T")
 
 LANE_ROLES = {
     "stt": "speech-input",
-    "alignment": "speech-input",
+    "alignment": "alignment",
     "tts": "speech-output",
 }
 

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -12,6 +12,12 @@ from typing import Any, Protocol, TypeVar
 
 _T = TypeVar("_T")
 
+LANE_ROLES = {
+    "stt": "speech-input",
+    "alignment": "speech-input",
+    "tts": "speech-output",
+}
+
 
 class ModelWorker(Protocol):
     """Minimal execution surface exported by an inference engine."""
@@ -192,6 +198,7 @@ class AudioWorkerDispatcher:
             return [
                 {
                     "lane": lane,
+                    "role": LANE_ROLES.get(lane),
                     "model": state.model,
                     "state": state.state,
                     "active_requests": state.active_requests,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -565,7 +565,13 @@ class ResidentModelManager:
                 await self._evict_locked(record, reason="idle_ttl")
             return evicted
 
-    async def _evict_for_locked(self, incoming_bytes: int, exclude: set[str]) -> None:
+    async def _evict_for_locked(
+        self,
+        incoming_bytes: int,
+        exclude: set[str],
+        *,
+        requested_role: str = "assistant",
+    ) -> None:
         if self.memory_limit_bytes <= 0:
             return
         while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
@@ -585,11 +591,11 @@ class ResidentModelManager:
             if not candidates:
                 usage = self._accounted_usage()
                 raise ResidentModelCapacityError(
-                    reason="role_capacity_assistant",
+                    reason=f"role_capacity_{requested_role.replace('-', '_')}",
                     requested_bytes=incoming_bytes,
                     limit_bytes=self.memory_limit_bytes,
                     used_bytes=usage,
-                    requested_role="assistant",
+                    requested_role=requested_role,
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
 
@@ -617,17 +623,11 @@ class ResidentModelManager:
                     requested_role=role,
                 )
             reserved_bytes = max(0, int(requested_bytes or 0))
-            if (
-                self.memory_limit_bytes > 0
-                and used + reserved_bytes > self.memory_limit_bytes
-            ):
-                raise ResidentModelCapacityError(
-                    reason=f"role_capacity_{role.replace('-', '_')}",
-                    requested_bytes=reserved_bytes,
-                    limit_bytes=self.memory_limit_bytes,
-                    used_bytes=used,
-                    requested_role=role,
-                )
+            await self._evict_for_locked(
+                reserved_bytes,
+                exclude=set(),
+                requested_role=role,
+            )
             record = ResidentRoleReservation(
                 role=role,
                 model_id=model_id,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -27,7 +27,49 @@ class ResidentModelError(RuntimeError):
 
 
 class ResidentModelCapacityError(ResidentModelError):
-    """The configured ceiling cannot admit a model after eligible eviction."""
+    """The configured ceiling cannot admit a role after eligible eviction."""
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        requested_bytes: int | None,
+        limit_bytes: int,
+        used_bytes: int,
+        requested_role: str,
+    ) -> None:
+        self.reason = reason
+        self.requested_bytes = requested_bytes
+        self.limit_bytes = limit_bytes
+        self.used_bytes = used_bytes
+        self.requested_role = requested_role
+        requested = (
+            "unknown"
+            if requested_bytes is None
+            else f"{requested_bytes / _GIB:.2f} GiB"
+        )
+        super().__init__(
+            f"insufficient capacity for {requested_role}: requested={requested}, "
+            f"used={used_bytes / _GIB:.2f} GiB, "
+            f"limit={limit_bytes / _GIB:.2f} GiB; "
+            "no idle unpinned model is eligible for eviction"
+        )
+
+    def envelope(self) -> dict[str, object]:
+        """Return the stable machine-readable 507 response contract."""
+
+        return {
+            "error": {
+                "message": str(self),
+                "type": "insufficient_capacity_error",
+                "code": "insufficient_capacity_error",
+                "reason": self.reason,
+                "param": "model",
+                "requested_bytes": self.requested_bytes,
+                "limit_bytes": self.limit_bytes,
+                "used_bytes": self.used_bytes,
+            }
+        }
 
 
 class ResidentModelBusyError(ResidentModelError):
@@ -173,6 +215,18 @@ class ResidencyRecord:
     @property
     def model_id(self) -> str:
         return self.entry.model_name
+
+
+@dataclass
+class ResidentRoleReservation:
+    """A non-registry role charged to the process residency ceiling."""
+
+    role: str
+    model_id: str
+    reserved_bytes: int
+    capacity_source: str
+    state: str
+    loaded_at: float
 
 
 Loader = Callable[..., Awaitable[ModelEntry]]
@@ -376,6 +430,7 @@ class ResidentModelManager:
         self._on_primary_changed = on_primary_changed
         self._records: dict[str, ResidencyRecord] = {}
         self._index: dict[str, str] = {}
+        self._roles: dict[str, ResidentRoleReservation] = {}
         self._lock = asyncio.Lock()
         self._ttl_task: asyncio.Task | None = None
         self.evictions_total = 0
@@ -438,6 +493,11 @@ class ResidentModelManager:
             max(record.estimated_bytes, record.measured_bytes)
             for record in self._records.values()
             if record.state == "resident"
+        )
+        reserved += sum(
+            record.reserved_bytes
+            for record in self._roles.values()
+            if record.state in {"loading", "resident"}
         )
         # Some engines (notably mflux) construct lazy MLX arrays without
         # faulting all weight pages into the process. The footprint delta at
@@ -525,13 +585,76 @@ class ResidentModelManager:
             if not candidates:
                 usage = self._accounted_usage()
                 raise ResidentModelCapacityError(
-                    "resident model memory ceiling exceeded: "
-                    f"usage={usage / _GIB:.2f} GiB, "
-                    f"incoming={incoming_bytes / _GIB:.2f} GiB, "
-                    f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
-                    "no idle unpinned model is eligible for eviction"
+                    reason="role_capacity_assistant",
+                    requested_bytes=incoming_bytes,
+                    limit_bytes=self.memory_limit_bytes,
+                    used_bytes=usage,
+                    requested_role="assistant",
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
+
+    @asynccontextmanager
+    async def admit_role(
+        self,
+        *,
+        role: str,
+        model_id: str,
+        requested_bytes: int | None,
+        capacity_source: str,
+    ):
+        """Reserve a protected auxiliary role before its weights load."""
+
+        async with self._lock:
+            if role in self._roles:
+                raise ResidentModelError(f"role {role!r} is already resident")
+            used = self._accounted_usage()
+            if self.memory_limit_bytes > 0 and requested_bytes is None:
+                raise ResidentModelCapacityError(
+                    reason="role_capacity_unknown",
+                    requested_bytes=None,
+                    limit_bytes=self.memory_limit_bytes,
+                    used_bytes=used,
+                    requested_role=role,
+                )
+            reserved_bytes = max(0, int(requested_bytes or 0))
+            if (
+                self.memory_limit_bytes > 0
+                and used + reserved_bytes > self.memory_limit_bytes
+            ):
+                raise ResidentModelCapacityError(
+                    reason=f"role_capacity_{role.replace('-', '_')}",
+                    requested_bytes=reserved_bytes,
+                    limit_bytes=self.memory_limit_bytes,
+                    used_bytes=used,
+                    requested_role=role,
+                )
+            record = ResidentRoleReservation(
+                role=role,
+                model_id=model_id,
+                reserved_bytes=reserved_bytes,
+                capacity_source=capacity_source,
+                state="loading",
+                loaded_at=self._clock(),
+            )
+            self._roles[role] = record
+        try:
+            yield record
+        except BaseException:
+            async with self._lock:
+                if self._roles.get(role) is record:
+                    self._roles.pop(role, None)
+            raise
+        else:
+            async with self._lock:
+                if self._roles.get(role) is record:
+                    record.state = "resident"
+                    record.loaded_at = self._clock()
+
+    async def release_role(self, role: str) -> None:
+        """Stop charging a role after its owning lane released the engine."""
+
+        async with self._lock:
+            self._roles.pop(role, None)
 
     async def load(
         self,
@@ -1154,6 +1277,7 @@ class ResidentModelManager:
                     "model_path": record.entry.model_path,
                     "aliases": sorted(record.entry.aliases),
                     "modality": (_modality(record.entry)),
+                    "role": _replacement_group(record.entry),
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,
@@ -1171,6 +1295,32 @@ class ResidentModelManager:
                     ),
                 }
             )
+        roles = [
+            {
+                "role": model["role"],
+                "model": model["id"],
+                "state": model["state"],
+                "pinned": model["pinned"],
+                "active_requests": model["active_requests"],
+                "reserved_bytes": max(
+                    model["estimated_bytes"], model["measured_bytes"] or 0
+                ),
+                "capacity_source": "model",
+            }
+            for model in models
+        ]
+        roles.extend(
+            {
+                "role": record.role,
+                "model": record.model_id,
+                "state": record.state,
+                "pinned": True,
+                "active_requests": 0,
+                "reserved_bytes": record.reserved_bytes,
+                "capacity_source": record.capacity_source,
+            }
+            for record in sorted(self._roles.values(), key=lambda item: item.role)
+        )
         usage = self._accounted_usage()
         return {
             "memory_limit_bytes": self.memory_limit_bytes,
@@ -1184,4 +1334,5 @@ class ResidentModelManager:
             "loads_total": self.loads_total,
             "evictions_total": self.evictions_total,
             "models": models,
+            "roles": roles,
         }

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -229,6 +229,18 @@ class ResidentRoleReservation:
     loaded_at: float
 
 
+@dataclass
+class ResidentRoleAdmission:
+    """Transaction handle for replacing one auxiliary role reservation."""
+
+    record: ResidentRoleReservation
+    previous: ResidentRoleReservation | None = None
+    previous_retired: bool = False
+
+    def retire_previous(self) -> None:
+        self.previous_retired = True
+
+
 Loader = Callable[..., Awaitable[ModelEntry]]
 PrimaryChanged = Callable[[ModelEntry], None]
 
@@ -571,10 +583,14 @@ class ResidentModelManager:
         exclude: set[str],
         *,
         requested_role: str = "assistant",
+        usage_credit_bytes: int = 0,
     ) -> None:
         if self.memory_limit_bytes <= 0:
             return
-        while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
+        while (
+            max(0, self._accounted_usage() - usage_credit_bytes) + incoming_bytes
+            > self.memory_limit_bytes
+        ):
             candidates = sorted(
                 (
                     record
@@ -589,7 +605,7 @@ class ResidentModelManager:
                 key=lambda record: record.last_used_at,
             )
             if not candidates:
-                usage = self._accounted_usage()
+                usage = max(0, self._accounted_usage() - usage_credit_bytes)
                 raise ResidentModelCapacityError(
                     reason=f"role_capacity_{requested_role.replace('-', '_')}",
                     requested_bytes=incoming_bytes,
@@ -607,13 +623,16 @@ class ResidentModelManager:
         model_id: str,
         requested_bytes: int | None,
         capacity_source: str,
+        replace_existing: bool = False,
     ):
         """Reserve a protected auxiliary role before its weights load."""
 
         async with self._lock:
-            if role in self._roles:
+            previous = self._roles.get(role)
+            if previous is not None and not replace_existing:
                 raise ResidentModelError(f"role {role!r} is already resident")
-            used = self._accounted_usage()
+            usage_credit = previous.reserved_bytes if previous is not None else 0
+            used = max(0, self._accounted_usage() - usage_credit)
             if self.memory_limit_bytes > 0 and requested_bytes is None:
                 raise ResidentModelCapacityError(
                     reason="role_capacity_unknown",
@@ -627,6 +646,7 @@ class ResidentModelManager:
                 reserved_bytes,
                 exclude=set(),
                 requested_role=role,
+                usage_credit_bytes=usage_credit,
             )
             record = ResidentRoleReservation(
                 role=role,
@@ -637,12 +657,16 @@ class ResidentModelManager:
                 loaded_at=self._clock(),
             )
             self._roles[role] = record
+            admission = ResidentRoleAdmission(record=record, previous=previous)
         try:
-            yield record
+            yield admission
         except BaseException:
             async with self._lock:
                 if self._roles.get(role) is record:
-                    self._roles.pop(role, None)
+                    if previous is not None and not admission.previous_retired:
+                        self._roles[role] = previous
+                    else:
+                        self._roles.pop(role, None)
             raise
         else:
             async with self._lock:

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -1,0 +1,26 @@
+"""Metadata-backed capacity charges for shared residency roles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoleCapacity:
+    requested_bytes: int | None
+    source: str
+
+
+def speech_input_capacity(model_id: str) -> RoleCapacity:
+    """Resolve a speech-input charge without model-name inference or I/O."""
+
+    from ..audio.registry import resolve_audio_alias
+    from ..model_sizes import size_bytes
+
+    entry = resolve_audio_alias(model_id)
+    hf_id = entry.hf_id if entry is not None else model_id
+    requested_bytes = size_bytes(hf_id)
+    return RoleCapacity(
+        requested_bytes=requested_bytes,
+        source="catalog" if requested_bytes is not None else "unknown",
+    )


### PR DESCRIPTION
Addresses the admission-time slice of #2305 and supersedes the corresponding scope in #2320.

## Intention
When dictation is enabled, its resident speech-input model remains protected while an assistant is loaded, replaced, or reloaded. If the configured process residency ceiling cannot hold both roles, reject the new admission before weight loading instead of silently evicting dictation.

## Scope
- Charge the resident speech-input role and registry-backed assistant models through the existing process residency manager.
- Resolve bundled STT capacity from the generated model-size catalog; unknown capacity fails closed only when a residency ceiling is enabled.
- Return a typed HTTP 507 envelope with `code=insufficient_capacity_error`, a stable `role_capacity_*` reason, and exact requested/limit/used byte fields.
- Expose role, state, activity, pinning, capacity source, and reserved bytes in the residency snapshot while retaining audio-lane activity as its lifecycle source of truth.
- Keep STT reservation load/rollback/release coupled to the existing audio worker lifecycle.

## Non-goals
- No UI, automatic downgrade, or conflict-choice presentation.
- No TTS or request-buffer accounting, idle TTL, scheduler/cache redesign, or eviction-policy expansion.
- No model-name, hash, or regular-expression capacity inference.
- No release or CI workflow changes.
- This is a clean implementation and does not transplant the broad contributor delta.

## API contract
Capacity conflicts return HTTP 507 with an OpenAI-shaped error object containing:
- `type` and `code`: `insufficient_capacity_error`
- `reason`: `role_capacity_assistant`, `role_capacity_speech_input`, or `role_capacity_unknown`
- `requested_bytes`, `limit_bytes`, and `used_bytes`

`GET /v1/models/residency` retains `models` and `audio_lanes`, adds role identity to those records, and adds a stable `roles` list for the shared budget.

## Preserved reproduction
Before this change, the residency snapshot had no role ledger, the manager had no speech-input reservation API, and an over-budget assistant admission returned only a prose 507. The manager and audio dispatcher each held half of the required truth.

## Verification
- Focused engine/audio/API suite: 157 passed.
- Additional registration, upload-bound, routing, and audio-probe suite: 60 passed.
- Changed-line coverage: 286/286, 100%.
- Ruff check/format and `git diff --check`: clean.
- Tests prove speech-first and assistant-first rejection, exact-boundary admission, unknown-capacity fail-closed behavior, disabled-ceiling compatibility, failed-load rollback, STT replacement/release, typed 507 fields, and merged residency role/activity truth.

## Compatibility
Servers without a configured residency ceiling preserve existing admission behavior. Bundled STT checkpoints all have catalog capacity metadata. Existing assistant eviction remains limited to eligible registry-backed models; the speech-input role is protected.