### PR TITLE
fix(models --cached): a complete singleton snapshot w/o refs/main is runnable (#2351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \
             tests/test_share_cli.py \
+            tests/test_cli_models.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -430,6 +430,66 @@ def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, 
     assert alias not in out
 
 
+def test_cached_view_marks_singleton_snapshot_without_refs_main_runnable(
+    tmp_path, monkeypatch, capsys
+):
+    """#2351: an unambiguous COMPLETE immutable snapshot with NO ``refs/main``
+    (a pinned ``snapshot_download``/manual pull of an exact commit) is loadable
+    by the routing & loader contract, so ``models --cached`` must report it
+    available, not ``(incomplete)`` — the inventory must agree with the serve
+    path. Ambiguous (multiple) snapshots stay unresolved."""
+    repo = "mlx-community/qwen-cached-singleton"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--qwen-cached-singleton"
+    sha = "93760be4f1f69842a46bc13dbdc0f19e291392a3"
+    snapshot = repo_root / "snapshots" / sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "tokenizer.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"weights")
+    # NO refs/ directory at all — the #2351 repro.
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 1_600_000_000, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+
+    assert repo in out
+    assert "(incomplete)" not in out, out
+
+
+def test_cached_view_marks_ambiguous_multiple_snapshots_incomplete(
+    tmp_path, monkeypatch, capsys
+):
+    """Two snapshots with no ``refs/main`` stay unresolved (can't know which a
+    fresh resolve would pick) — preserves the round-10 guarantee that an old
+    complete snapshot cannot mask a newer incomplete one."""
+    repo = "mlx-community/qwen-ambiguous"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--qwen-ambiguous"
+    for sha in ("aaa", "bbb"):
+        snap = repo_root / "snapshots" / sha
+        snap.mkdir(parents=True)
+        (snap / "config.json").write_text("{}")
+        (snap / "model.safetensors").write_bytes(b"weights")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 1_600_000_000, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+    assert "(incomplete)" in out
+
+
 def test_cached_view_renders_complete_mflux_alias(monkeypatch, capsys):
     """A complete mflux cache must map back to its image alias in ``ls``."""
     repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5655,6 +5655,13 @@ def _cache_entry_is_runnable(repo: str) -> bool:
     downloads (config/tokenizer only, no weights) look ready in ``ls`` and in
     the desktop model picker. Reuse the serve download gate's authoritative
     completeness checks for both text and component-split video layouts.
+
+    ``resolve_unreferenced_cached_snapshot`` closes the #2351 gap: a complete,
+    unambiguous SINGLE snapshot with no ``refs/main`` (a commit-pinned
+    ``snapshot_download`` / manual pull) is loadable by the routing & loader
+    contract — the inventory must report it available, not ``(incomplete)``,
+    so ``models --cached`` and the serve gate agree with the loader. Multiple
+    snapshots are ambiguous and stay unresolved there.
     """
     try:
         from vllm_mlx._download_gate import (
@@ -5664,6 +5671,7 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             is_repo_cached,
         )
         from vllm_mlx.audio.registry import resolve_audio_alias
+        from vllm_mlx.model_metadata import resolve_unreferenced_cached_snapshot
 
         audio_entry = resolve_audio_alias(repo)
         if audio_entry is not None and audio_entry.family == "whisper":
@@ -5672,6 +5680,7 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)
             or _snapshot_is_complete_mflux_model(repo)
+            or resolve_unreferenced_cached_snapshot(repo) is not None
         )
     except Exception:
         return False


### PR DESCRIPTION
Closes #2351 — inventory and loader disagree on a complete immutable singleton snapshot.

A commit-pinned `snapshot_download(..., revision=<sha>)` materializes `snapshots/<sha>` WITHOUT `refs/main`. `_cache_entry_is_runnable` (via `is_repo_cached`) read that complete, unambiguous, loadable snapshot as `(incomplete)` in `models --cached` — making a user redownload or remove a valid model.

## Change
- `_cache_entry_is_runnable` (cli.py) now also accepts a complete singleton snapshot via the loader's own `resolve_unreferenced_cached_snapshot` (#2329) — the exact 'exactly one snapshot, no refs/main' shape.
- Multiple snapshots stay ambiguous/unresolved → round-10 guarantee (an old complete snapshot cannot mask a newer incomplete one) preserved.
- `is_repo_cached` / `_resolved_snapshot_sha` intentionally unchanged (serve download-gate's stricter re-prompt policy; `_local_snapshot_if_cached` already routes singletons through `resolve_unreferenced_cached_snapshot`).

## Validation
- diff-cover 100%; ruff clean.
- New tests: singleton-complete-without-refs/main is runnable in models --cached; two snapshots without refs/main stay (incomplete).
- 295 affected tests pass (models, download-gate, alias-subfolder, qwen-image, first-run-guide).