### PR TITLE
fix(mac): keep model switching off mounted volumes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -10,11 +10,19 @@ import Foundation
 /// (`src-tauri/src/server.rs`), which is the v0.1.13 cross-session
 /// orphan fix.
 ///
-/// Strategy: `lsof -ti :8000` lists every pid holding the port, we send
+/// Strategy: `netstat -anv -p tcp` lists every TCP listener without walking
+/// mounted filesystems, we select the pids holding the target port, then send
 /// each one SIGTERM, wait 1.5 s for graceful uvicorn shutdown, then
 /// SIGKILL anyone still alive. A developer running rapid-mlx in their
 /// own terminal can opt out via `RAPID_DESKTOP_NO_PORT_SWEEP=1`.
 enum PortSweep {
+    /// Filesystem-independent listener inventory. Exposed internally so the
+    /// removable-volume regression test pins the executable as well as the
+    /// output parser; replacing this with a file-descriptor scanner would
+    /// reintroduce the picker-time mount traversal fixed in #2343.
+    static let socketTableProbeExecutable = URL(fileURLWithPath: "/usr/sbin/netstat")
+    static let socketTableProbeArguments = ["-anv", "-p", "tcp"]
+
     /// The opportunistic launch-time sweep, so a spawn can wait it out
     /// instead of racing it. Detached at launch (never blocking the UI); a
     /// ``ServerManager.start`` that lands while it is still running awaits it
@@ -254,36 +262,23 @@ enum PortSweep {
         return owned
     }
 
-    /// Shells out to `lsof -nP -sTCP:LISTEN -ti :<port>` and parses the
-    /// pid list. `-sTCP:LISTEN` restricts to processes actively LISTENing
-    /// on the port — a client merely connected TO :8000 is excluded, so
-    /// a curl/browser session can't accidentally be SIGTERM'd by the
-    /// sweep. `-ti` is terse pid-only output we can parse directly;
-    /// `-nP` disables name resolution for speed.
+    /// Ask the kernel's socket table for TCP listeners, then select the exact
+    /// local port. Do not use `lsof` here: even an internet-socket-filtered
+    /// invocation walks the mount table and stats mounted filesystems. A model
+    /// switch can call this once per candidate port, so an unrelated mounted
+    /// installer or external disk was touched merely by opening the picker and
+    /// could trigger macOS removable-volume consent (#2343).
     ///
-    /// Codex round-1 finding: the previous version returned every pid
-    /// `lsof -i :8000` saw (listeners + clients) AND killed them
-    /// unconditionally. Launching Rapid while a user had any other
-    /// dev server on :8000 would SIGTERM/SIGKILL that server. We now
-    /// (a) filter to LISTEN sockets only, and (b) verify each pid's
-    /// executable matches a ``rapid-mlx`` / ``python`` profile before
-    /// signalling — anything else is left untouched and reported.
+    /// `netstat` reads the networking table directly. `-n` disables name
+    /// resolution, `-a` includes listeners, `-v` includes the owning
+    /// `process:pid` field, and `-p tcp` excludes unrelated protocols. The
+    /// ownership check below remains authoritative before any signal is sent.
     private static func pidsOnPort(port: Int) -> [Int32] {
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
-        guard let data = runCapturingStdout(task) else {
-            return pidsOnPortFallback(port: port)
-        }
-        return parsePids(data)
-    }
-
-    private static func pidsOnPortFallback(port: Int) -> [Int32] {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/lsof")
-        task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
+        task.executableURL = socketTableProbeExecutable
+        task.arguments = socketTableProbeArguments
         guard let data = runCapturingStdout(task) else { return [] }
-        return parsePids(data)
+        return parseListeningPIDs(data, port: port)
     }
 
     /// Run ``task`` to completion and return its stdout bytes, draining
@@ -352,11 +347,29 @@ enum PortSweep {
         return stdoutData
     }
 
-    private static func parsePids(_ data: Data) -> [Int32] {
+    /// Parse macOS `netstat -anv -p tcp` output. Kept as a pure seam so the
+    /// listener-only and exact-port contracts do not depend on the host's live
+    /// sockets. Field positions are defined by netstat's own header; malformed
+    /// or permission-redacted rows fail closed.
+    static func parseListeningPIDs(_ data: Data, port: Int) -> [Int32] {
         guard let text = String(data: data, encoding: .utf8) else { return [] }
-        return text
-            .split(whereSeparator: { $0.isWhitespace })
-            .compactMap { Int32($0) }
+        guard (1...65_535).contains(port) else { return [] }
+        let portSuffix = ".\(port)"
+        var result: [Int32] = []
+        var seen: Set<Int32> = []
+        for line in text.split(separator: "\n") {
+            let fields = line.split(whereSeparator: { $0.isWhitespace })
+            guard fields.count > 10,
+                  fields[0] == "tcp4" || fields[0] == "tcp6",
+                  fields[5] == "LISTEN",
+                  fields[3].hasSuffix(portSuffix),
+                  let separator = fields[10].lastIndex(of: ":"),
+                  let pid = Int32(fields[10][fields[10].index(after: separator)...]),
+                  pid > 0,
+                  seen.insert(pid).inserted else { continue }
+            result.append(pid)
+        }
+        return result
     }
 
     /// Drain a child process's pipe to EOF using the *throwing*

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -354,17 +354,57 @@ enum PortSweep {
     static func parseListeningPIDs(_ data: Data, port: Int) -> [Int32] {
         guard let text = String(data: data, encoding: .utf8) else { return [] }
         guard (1...65_535).contains(port) else { return [] }
+
+        enum OwnerColumn {
+            case processAndPID(Int)
+            case numericPID(Int)
+        }
+
         let portSuffix = ".\(port)"
         var result: [Int32] = []
         var seen: Set<Int32> = []
+        var ownerColumn: OwnerColumn?
         for line in text.split(separator: "\n") {
             let fields = line.split(whereSeparator: { $0.isWhitespace })
-            guard fields.count > 10,
+
+            // Header labels contain two two-word address columns, while each
+            // data row contains one token per address. Derive the owner column
+            // from the table's own header so both supported macOS layouts work:
+            // current releases expose `process:pid`; older releases expose
+            // separate numeric `pid` / `epid` columns.
+            if fields.first == "Proto" {
+                let addressLabelAdjustment = 2
+                if let index = fields.firstIndex(of: "process:pid"),
+                   index >= addressLabelAdjustment {
+                    ownerColumn = .processAndPID(index - addressLabelAdjustment)
+                } else if let index = fields.firstIndex(of: "pid"),
+                          fields.contains("epid"),
+                          index >= addressLabelAdjustment {
+                    ownerColumn = .numericPID(index - addressLabelAdjustment)
+                } else {
+                    ownerColumn = nil
+                }
+                continue
+            }
+
+            guard let ownerColumn,
+                  fields.count > 5,
                   fields[0] == "tcp4" || fields[0] == "tcp6",
                   fields[5] == "LISTEN",
-                  fields[3].hasSuffix(portSuffix),
-                  let separator = fields[10].lastIndex(of: ":"),
-                  let pid = Int32(fields[10][fields[10].index(after: separator)...]),
+                  fields[3].hasSuffix(portSuffix) else { continue }
+
+            let pid: Int32?
+            switch ownerColumn {
+            case let .processAndPID(index):
+                guard fields.indices.contains(index),
+                      let separator = fields[index].lastIndex(of: ":") else { continue }
+                pid = Int32(fields[index][fields[index].index(after: separator)...])
+            case let .numericPID(index):
+                guard fields.indices.contains(index) else { continue }
+                pid = Int32(fields[index])
+            }
+
+            guard let pid,
                   pid > 0,
                   seen.insert(pid).inserted else { continue }
             result.append(pid)

--- a/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Suite("PortSweep process identity")
 struct PortSweepTests {
-    @Test("Socket-table parser returns only exact TCP listeners without filesystem discovery")
-    func socketTableParserIsListenerAndPortScoped() {
+    @Test("Current socket-table parser returns only exact TCP listeners without filesystem discovery")
+    func currentSocketTableParserIsListenerAndPortScoped() {
         #expect(PortSweep.socketTableProbeExecutable.path == "/usr/sbin/netstat")
         #expect(PortSweep.socketTableProbeArguments == ["-anv", "-p", "tcp"])
 
@@ -25,6 +25,31 @@ struct PortSweepTests {
         #expect(pids == [4321])
         #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9999])
         #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 0).isEmpty)
+    }
+
+    @Test("Legacy socket-table parser reads the separate numeric pid column")
+    func legacySocketTableParserReadsNumericPIDColumn() {
+        let output = """
+        Active Internet connections (including servers)
+        Proto Recv-Q Send-Q  Local Address Foreign Address (state) rhiwat shiwat pid epid state options
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 131072 131072 2468 0 00000 00000000
+        tcp6 0 0 ::1.8000 *.* LISTEN 131072 131072 2468 0 00000 00000000
+        tcp4 0 0 127.0.0.1.18000 *.* LISTEN 131072 131072 9753 0 00000 00000000
+        tcp4 0 0 127.0.0.1.8000 127.0.0.1.50000 ESTABLISHED 131072 131072 8642 0 00102 00000000
+        """
+
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000) == [2468])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9753])
+    }
+
+    @Test("Socket-table parser fails closed when the owner layout is absent or malformed")
+    func socketTableParserRejectsUnknownOwnerLayout() {
+        let output = """
+        Proto Recv-Q Send-Q Local Address Foreign Address (state) rxbytes txbytes rhiwat shiwat owner state
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 4321 00000
+        """
+
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000).isEmpty)
     }
 
     @Test("rapid-mlx serve command is considered sweep-owned")

--- a/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
@@ -5,6 +5,28 @@ import Testing
 
 @Suite("PortSweep process identity")
 struct PortSweepTests {
+    @Test("Socket-table parser returns only exact TCP listeners without filesystem discovery")
+    func socketTableParserIsListenerAndPortScoped() {
+        #expect(PortSweep.socketTableProbeExecutable.path == "/usr/sbin/netstat")
+        #expect(PortSweep.socketTableProbeArguments == ["-anv", "-p", "tcp"])
+
+        let output = """
+        Active Internet connections (including servers)
+        Proto Recv-Q Send-Q  Local Address Foreign Address (state) rxbytes txbytes rhiwat shiwat process:pid state
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 python3.12:4321 00000
+        tcp6 0 0 ::1.8000 *.* LISTEN 0 0 131072 131072 rapid-mlx:4321 00000
+        tcp4 0 0 127.0.0.1.18000 *.* LISTEN 0 0 131072 131072 foreign:9999 00000
+        tcp4 0 0 127.0.0.1.8000 127.0.0.1.50000 ESTABLISHED 0 0 131072 131072 curl:7777 00102
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 unknown:* 00000
+        """
+
+        let pids = PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000)
+
+        #expect(pids == [4321])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9999])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 0).isEmpty)
+    }
+
     @Test("rapid-mlx serve command is considered sweep-owned")
     func rapidMlxServeAccepted() {
         #expect(PortSweep.isRapidOwnedCommand("/opt/homebrew/bin/rapid-mlx serve qwen3.5-4b --port 8000"))


### PR DESCRIPTION
## Why

Selecting a model can respawn the Desktop sidecar. Port allocation used a file-descriptor inventory command that walks mounted filesystems even when filtered to TCP listeners, so an unrelated mounted installer could trigger macOS removable-volume consent.

Fixes #2343.

## What

- Read TCP listener ownership from the macOS socket table instead of a filesystem-scanning utility.
- Preserve exact-port, LISTEN-only, deduplication, persisted ownership, command identity, and final bind-probe contracts.
- Add a deterministic parser/probe regression contract for IPv4/IPv6, exact ports, connected sockets, redacted owners, and duplicate PIDs.

## Non-goals

- No TCC prompt suppression or `/Volumes` special case.
- No change to explicit external model-folder support.
- No change to model lifecycle, orphan ownership, or signaling policy.

## Validation

- `swift test --filter PortSweepTests` — 17/17 passed.
- `swift test --filter "Port(Sweep|Allocator)"` — 29/29 passed.
- Release build and mounted-DMG model-switch verification in progress.