### PR TITLE
release: integrate 0.13.1 train 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \
             tests/test_share_cli.py \
+            tests/test_cli_models.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -10,11 +10,19 @@ import Foundation
 /// (`src-tauri/src/server.rs`), which is the v0.1.13 cross-session
 /// orphan fix.
 ///
-/// Strategy: `lsof -ti :8000` lists every pid holding the port, we send
+/// Strategy: `netstat -anv -p tcp` lists every TCP listener without walking
+/// mounted filesystems, we select the pids holding the target port, then send
 /// each one SIGTERM, wait 1.5 s for graceful uvicorn shutdown, then
 /// SIGKILL anyone still alive. A developer running rapid-mlx in their
 /// own terminal can opt out via `RAPID_DESKTOP_NO_PORT_SWEEP=1`.
 enum PortSweep {
+    /// Filesystem-independent listener inventory. Exposed internally so the
+    /// removable-volume regression test pins the executable as well as the
+    /// output parser; replacing this with a file-descriptor scanner would
+    /// reintroduce the picker-time mount traversal fixed in #2343.
+    static let socketTableProbeExecutable = URL(fileURLWithPath: "/usr/sbin/netstat")
+    static let socketTableProbeArguments = ["-anv", "-p", "tcp"]
+
     /// The opportunistic launch-time sweep, so a spawn can wait it out
     /// instead of racing it. Detached at launch (never blocking the UI); a
     /// ``ServerManager.start`` that lands while it is still running awaits it
@@ -254,36 +262,23 @@ enum PortSweep {
         return owned
     }
 
-    /// Shells out to `lsof -nP -sTCP:LISTEN -ti :<port>` and parses the
-    /// pid list. `-sTCP:LISTEN` restricts to processes actively LISTENing
-    /// on the port — a client merely connected TO :8000 is excluded, so
-    /// a curl/browser session can't accidentally be SIGTERM'd by the
-    /// sweep. `-ti` is terse pid-only output we can parse directly;
-    /// `-nP` disables name resolution for speed.
+    /// Ask the kernel's socket table for TCP listeners, then select the exact
+    /// local port. Do not use `lsof` here: even an internet-socket-filtered
+    /// invocation walks the mount table and stats mounted filesystems. A model
+    /// switch can call this once per candidate port, so an unrelated mounted
+    /// installer or external disk was touched merely by opening the picker and
+    /// could trigger macOS removable-volume consent (#2343).
     ///
-    /// Codex round-1 finding: the previous version returned every pid
-    /// `lsof -i :8000` saw (listeners + clients) AND killed them
-    /// unconditionally. Launching Rapid while a user had any other
-    /// dev server on :8000 would SIGTERM/SIGKILL that server. We now
-    /// (a) filter to LISTEN sockets only, and (b) verify each pid's
-    /// executable matches a ``rapid-mlx`` / ``python`` profile before
-    /// signalling — anything else is left untouched and reported.
+    /// `netstat` reads the networking table directly. `-n` disables name
+    /// resolution, `-a` includes listeners, `-v` includes the owning
+    /// `process:pid` field, and `-p tcp` excludes unrelated protocols. The
+    /// ownership check below remains authoritative before any signal is sent.
     private static func pidsOnPort(port: Int) -> [Int32] {
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
-        guard let data = runCapturingStdout(task) else {
-            return pidsOnPortFallback(port: port)
-        }
-        return parsePids(data)
-    }
-
-    private static func pidsOnPortFallback(port: Int) -> [Int32] {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/lsof")
-        task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
+        task.executableURL = socketTableProbeExecutable
+        task.arguments = socketTableProbeArguments
         guard let data = runCapturingStdout(task) else { return [] }
-        return parsePids(data)
+        return parseListeningPIDs(data, port: port)
     }
 
     /// Run ``task`` to completion and return its stdout bytes, draining
@@ -352,11 +347,29 @@ enum PortSweep {
         return stdoutData
     }
 
-    private static func parsePids(_ data: Data) -> [Int32] {
+    /// Parse macOS `netstat -anv -p tcp` output. Kept as a pure seam so the
+    /// listener-only and exact-port contracts do not depend on the host's live
+    /// sockets. Field positions are defined by netstat's own header; malformed
+    /// or permission-redacted rows fail closed.
+    static func parseListeningPIDs(_ data: Data, port: Int) -> [Int32] {
         guard let text = String(data: data, encoding: .utf8) else { return [] }
-        return text
-            .split(whereSeparator: { $0.isWhitespace })
-            .compactMap { Int32($0) }
+        guard (1...65_535).contains(port) else { return [] }
+        let portSuffix = ".\(port)"
+        var result: [Int32] = []
+        var seen: Set<Int32> = []
+        for line in text.split(separator: "\n") {
+            let fields = line.split(whereSeparator: { $0.isWhitespace })
+            guard fields.count > 10,
+                  fields[0] == "tcp4" || fields[0] == "tcp6",
+                  fields[5] == "LISTEN",
+                  fields[3].hasSuffix(portSuffix),
+                  let separator = fields[10].lastIndex(of: ":"),
+                  let pid = Int32(fields[10][fields[10].index(after: separator)...]),
+                  pid > 0,
+                  seen.insert(pid).inserted else { continue }
+            result.append(pid)
+        }
+        return result
     }
 
     /// Drain a child process's pipe to EOF using the *throwing*

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -354,17 +354,57 @@ enum PortSweep {
     static func parseListeningPIDs(_ data: Data, port: Int) -> [Int32] {
         guard let text = String(data: data, encoding: .utf8) else { return [] }
         guard (1...65_535).contains(port) else { return [] }
+
+        enum OwnerColumn {
+            case processAndPID(Int)
+            case numericPID(Int)
+        }
+
         let portSuffix = ".\(port)"
         var result: [Int32] = []
         var seen: Set<Int32> = []
+        var ownerColumn: OwnerColumn?
         for line in text.split(separator: "\n") {
             let fields = line.split(whereSeparator: { $0.isWhitespace })
-            guard fields.count > 10,
+
+            // Header labels contain two two-word address columns, while each
+            // data row contains one token per address. Derive the owner column
+            // from the table's own header so both supported macOS layouts work:
+            // current releases expose `process:pid`; older releases expose
+            // separate numeric `pid` / `epid` columns.
+            if fields.first == "Proto" {
+                let addressLabelAdjustment = 2
+                if let index = fields.firstIndex(of: "process:pid"),
+                   index >= addressLabelAdjustment {
+                    ownerColumn = .processAndPID(index - addressLabelAdjustment)
+                } else if let index = fields.firstIndex(of: "pid"),
+                          fields.contains("epid"),
+                          index >= addressLabelAdjustment {
+                    ownerColumn = .numericPID(index - addressLabelAdjustment)
+                } else {
+                    ownerColumn = nil
+                }
+                continue
+            }
+
+            guard let ownerColumn,
+                  fields.count > 5,
                   fields[0] == "tcp4" || fields[0] == "tcp6",
                   fields[5] == "LISTEN",
-                  fields[3].hasSuffix(portSuffix),
-                  let separator = fields[10].lastIndex(of: ":"),
-                  let pid = Int32(fields[10][fields[10].index(after: separator)...]),
+                  fields[3].hasSuffix(portSuffix) else { continue }
+
+            let pid: Int32?
+            switch ownerColumn {
+            case let .processAndPID(index):
+                guard fields.indices.contains(index),
+                      let separator = fields[index].lastIndex(of: ":") else { continue }
+                pid = Int32(fields[index][fields[index].index(after: separator)...])
+            case let .numericPID(index):
+                guard fields.indices.contains(index) else { continue }
+                pid = Int32(fields[index])
+            }
+
+            guard let pid,
                   pid > 0,
                   seen.insert(pid).inserted else { continue }
             result.append(pid)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -688,8 +688,15 @@ final class ServerManager {
     private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
-    /// original Start action when a later catalog subprocess fails.
+    /// original Start action, or an earlier authoritative catalog lookup, when
+    /// a later catalog subprocess fails.
     private var catalogProvenStartEntries: [String: ModelEntry] = [:]
+    /// Catalog dependency shared by the residency decision and spawn path.
+    /// Production uses the process-wide cache; lifecycle tests replace only
+    /// this boundary so successive authoritative/transient results are fully
+    /// deterministic without spawning the real catalog subprocess.
+    @ObservationIgnored
+    private var catalogEntriesProvider: ((URL, UInt) async -> [ModelEntry])?
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -1006,6 +1013,22 @@ final class ServerManager {
         self.state = newState
     }
 
+    internal func _testSetCatalogEntriesProvider(
+        _ provider: @escaping (URL, UInt) async -> [ModelEntry]
+    ) {
+        catalogEntriesProvider = provider
+    }
+
+    private func catalogEntries(binary: URL, generation: UInt) async -> [ModelEntry] {
+        if let catalogEntriesProvider {
+            return await catalogEntriesProvider(binary, generation)
+        }
+        return await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: generation
+        )
+    }
+
     /// Publish the selection consequence of a successful health transition.
     /// Kept as one lifecycle boundary so tests exercise the same call that the
     /// real `/healthz` success path uses instead of calling persistence policy
@@ -1221,7 +1244,7 @@ final class ServerManager {
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
         if child != nil, let binary = binaryPath {
-            let entry = await ModelCatalogCache.shared.entries(
+            let entry = await catalogEntries(
                 binary: binary,
                 generation: downloads?.cacheGeneration ?? 0
             ).first {
@@ -1955,11 +1978,18 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
+        let probedCatalogEntry = await catalogEntries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
+        }
+        if let probedCatalogEntry {
+            // An authoritative match is durable provenance for this app
+            // session. Keep it across the corresponding stop/restart so a
+            // transiently empty later catalog result cannot make a known chat
+            // model lose its lane-owned persistence contract.
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = probedCatalogEntry
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -688,9 +688,13 @@ final class ServerManager {
     private let sessionDefaults: UserDefaults?
     /// Catalog provenance supplied by UI start paths. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
-    /// original Start action, or an earlier authoritative catalog lookup, when
-    /// a later catalog subprocess fails.
+    /// original Start action when a later catalog subprocess fails.
     private var catalogProvenStartEntries: [String: ModelEntry] = [:]
+    /// Lane-only provenance learned from an authoritative start-time lookup.
+    /// This intentionally retains no launch capabilities: a later empty probe
+    /// may preserve chat persistence, but must not reuse stale image/runtime
+    /// metadata when assembling a new serve command.
+    private var catalogProvenChatAliases: Set<String> = []
     /// Catalog dependency shared by the residency decision and spawn path.
     /// Production uses the process-wide cache; lifecycle tests replace only
     /// this boundary so successive authoritative/transient results are fully
@@ -1035,12 +1039,14 @@ final class ServerManager {
     /// in isolation.
     internal func recordReadySelection(
         alias: String,
-        catalogEntry: ModelEntry?
+        catalogEntry: ModelEntry?,
+        retainedChatProof: Bool = false
     ) {
         guard let sessionDefaults else { return }
         SessionModelRestore.persistReadyAlias(
             alias,
             catalogEntry: catalogEntry,
+            retainedChatProof: retainedChatProof,
             defaults: sessionDefaults
         )
     }
@@ -1984,12 +1990,13 @@ final class ServerManager {
         ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let provenanceKey = trimmedAlias.lowercased()
         if let probedCatalogEntry {
-            // An authoritative match is durable provenance for this app
-            // session. Keep it across the corresponding stop/restart so a
-            // transiently empty later catalog result cannot make a known chat
-            // model lose its lane-owned persistence contract.
-            catalogProvenStartEntries[trimmedAlias.lowercased()] = probedCatalogEntry
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
@@ -2453,7 +2460,12 @@ final class ServerManager {
                 // overwrite the previous good-known value, so a
                 // crashed launch attempt doesn't strand the resume
                 // logic on a model the user can't actually load.
-                recordReadySelection(alias: trimmedAlias, catalogEntry: catalogEntry)
+                recordReadySelection(
+                    alias: trimmedAlias,
+                    catalogEntry: catalogEntry,
+                    retainedChatProof: catalogEntry == nil
+                        && catalogProvenChatAliases.contains(provenanceKey)
+                )
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that
                 // the child is ready, start the runtime health

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2001,9 +2001,7 @@ final class ServerManager {
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let provenanceKey = trimmedAlias.lowercased()
-        if !probedCatalogEntries.isEmpty {
-            catalogProvenStartEntries.removeValue(forKey: provenanceKey)
-        }
+        catalogProvenStartEntries.removeValue(forKey: provenanceKey)
         if let probedCatalogEntry {
             if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
                 catalogProvenChatAliases.insert(provenanceKey)
@@ -2012,6 +2010,12 @@ final class ServerManager {
             }
         } else if !probedCatalogEntries.isEmpty {
             catalogProvenChatAliases.remove(provenanceKey)
+        } else if let retainedCatalogHint {
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: retainedCatalogHint) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
         }
         let retainedChatProof = catalogEntry == nil
             && probedCatalogEntries.isEmpty

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3989,6 +3989,16 @@ final class ServerManager {
 /// `DownloadManager` on `Process` because downloads do not fork a live
 /// server tree.
 final class ProcessGroupChild: @unchecked Sendable {
+    /// Process exit observation is event-driven. A blocking `waitpid` parked
+    /// on a shared GCD pool can starve on small hosted runners; the resulting
+    /// unreaped group leader makes `terminateChild` burn its entire SIGTERM
+    /// grace and can strand the next launch behind the old port. The source
+    /// wakes this dedicated serial queue only after the kernel reports exit.
+    private static let exitMonitorQueue = DispatchQueue(
+        label: "com.rapidmlx.desktop.process-exit-monitor",
+        qos: .userInitiated
+    )
+
     let processIdentifier: pid_t
     let processGroupID: pid_t
 
@@ -4009,6 +4019,7 @@ final class ProcessGroupChild: @unchecked Sendable {
     private var rawTerminationStatus: Int32 = 0
     private var rawTerminationReason: Process.TerminationReason = .exit
     private var terminationHandler: (@Sendable (ProcessGroupChild) -> Void)?
+    private var exitSource: (any DispatchSourceProcess)?
 
     var isRunning: Bool {
         lock.lock()
@@ -4207,20 +4218,43 @@ final class ProcessGroupChild: @unchecked Sendable {
         }
         monitorStarted = true
         lock.unlock()
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self else { return }
-            var waitStatus: Int32 = 0
-            let waited = waitpid(self.processIdentifier, &waitStatus, 0)
-            guard waited == self.processIdentifier else { return }
-            let decoded = Self.decode(waitStatus: waitStatus)
-            self.lock.lock()
-            self.running = false
-            self.rawTerminationStatus = decoded.status
-            self.rawTerminationReason = decoded.reason
-            let handler = self.terminationHandler
-            self.lock.unlock()
-            handler?(self)
+
+        let source = DispatchSource.makeProcessSource(
+            identifier: processIdentifier,
+            eventMask: .exit,
+            queue: Self.exitMonitorQueue
+        )
+        source.setEventHandler { [weak self] in
+            self?.reapExitedProcess()
         }
+        lock.lock()
+        exitSource = source
+        lock.unlock()
+        source.activate()
+    }
+
+    /// Reap only after the process-exit source fires, so `waitpid` is no
+    /// longer a blocking worker-pool reservation. Retry EINTR, then publish
+    /// the same once-only lifecycle callback as the prior monitor.
+    private func reapExitedProcess() {
+        var waitStatus: Int32 = 0
+        var waited: pid_t
+        repeat {
+            waited = waitpid(processIdentifier, &waitStatus, 0)
+        } while waited == -1 && errno == EINTR
+        guard waited == processIdentifier else { return }
+
+        let decoded = Self.decode(waitStatus: waitStatus)
+        lock.lock()
+        running = false
+        rawTerminationStatus = decoded.status
+        rawTerminationReason = decoded.reason
+        let handler = terminationHandler
+        let source = exitSource
+        exitSource = nil
+        lock.unlock()
+        source?.cancel()
+        handler?(self)
     }
 
     private static func dup(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1991,15 +1991,19 @@ final class ServerManager {
         let probedCatalogEntry = probedCatalogEntries.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
+        let retainedCatalogHint = catalogEntryHint
+            ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
             probed: probedCatalogEntry,
-            hint: catalogEntryHint
-                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
+            hint: probedCatalogEntries.isEmpty ? retainedCatalogHint : nil
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
         let provenanceKey = trimmedAlias.lowercased()
+        if !probedCatalogEntries.isEmpty {
+            catalogProvenStartEntries.removeValue(forKey: provenanceKey)
+        }
         if let probedCatalogEntry {
             if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
                 catalogProvenChatAliases.insert(provenanceKey)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2006,6 +2006,8 @@ final class ServerManager {
             } else {
                 catalogProvenChatAliases.remove(provenanceKey)
             }
+        } else if !probedCatalogEntries.isEmpty {
+            catalogProvenChatAliases.remove(provenanceKey)
         }
         let retainedChatProof = catalogEntry == nil
             && probedCatalogEntries.isEmpty

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1984,19 +1984,12 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let probedCatalogEntry = await catalogEntries(
+        let probedCatalogEntries = await catalogEntries(
             binary: binary,
             generation: downloads?.cacheGeneration ?? 0
-        ).first {
+        )
+        let probedCatalogEntry = probedCatalogEntries.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
-        }
-        let provenanceKey = trimmedAlias.lowercased()
-        if let probedCatalogEntry {
-            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
-                catalogProvenChatAliases.insert(provenanceKey)
-            } else {
-                catalogProvenChatAliases.remove(provenanceKey)
-            }
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
@@ -2006,6 +1999,17 @@ final class ServerManager {
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }
+        let provenanceKey = trimmedAlias.lowercased()
+        if let probedCatalogEntry {
+            if SessionModelRestore.shouldPersistChatAlias(catalogEntry: probedCatalogEntry) {
+                catalogProvenChatAliases.insert(provenanceKey)
+            } else {
+                catalogProvenChatAliases.remove(provenanceKey)
+            }
+        }
+        let retainedChatProof = catalogEntry == nil
+            && probedCatalogEntries.isEmpty
+            && catalogProvenChatAliases.contains(provenanceKey)
         let catalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
             forAlias: trimmedAlias,
             isBuiltinProfile: catalogEntry?.isBuiltinProfile,
@@ -2463,8 +2467,7 @@ final class ServerManager {
                 recordReadySelection(
                     alias: trimmedAlias,
                     catalogEntry: catalogEntry,
-                    retainedChatProof: catalogEntry == nil
-                        && catalogProvenChatAliases.contains(provenanceKey)
+                    retainedChatProof: retainedChatProof
                 )
                 await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that

--- a/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift
@@ -34,9 +34,12 @@ struct SessionModelRestore: Equatable, Sendable {
     static func persistReadyAlias(
         _ alias: String,
         catalogEntry: ModelEntry?,
+        retainedChatProof: Bool = false,
         defaults: UserDefaults = .standard
     ) {
-        guard shouldPersistChatAlias(catalogEntry: catalogEntry) else { return }
+        guard retainedChatProof || shouldPersistChatAlias(catalogEntry: catalogEntry) else {
+            return
+        }
         defaults.set(alias, forKey: chatAliasStorageKey)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,9 +128,11 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let probedCatalogEntry = await ModelCatalogCache.shared.entries"))
+        #expect(server.contains("let probedCatalogEntry = await catalogEntries("))
+        #expect(server.contains("return await ModelCatalogCache.shared.entries("),
+                "production catalog resolution must continue through the shared cache")
         let catalogProbe = try #require(server.range(
-            of: "let probedCatalogEntry = await ModelCatalogCache.shared.entries"
+            of: "let probedCatalogEntry = await catalogEntries("
         ))
         #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
                 "the authoritative probe and exact-alias start hint must converge before launch")

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,11 +128,11 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let probedCatalogEntry = await catalogEntries("))
+        #expect(server.contains("let probedCatalogEntries = await catalogEntries("))
         #expect(server.contains("return await ModelCatalogCache.shared.entries("),
                 "production catalog resolution must continue through the shared cache")
         let catalogProbe = try #require(server.range(
-            of: "let probedCatalogEntry = await catalogEntries("
+            of: "let probedCatalogEntries = await catalogEntries("
         ))
         #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
                 "the authoritative probe and exact-alias start hint must converge before launch")

--- a/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Suite("PortSweep process identity")
 struct PortSweepTests {
-    @Test("Socket-table parser returns only exact TCP listeners without filesystem discovery")
-    func socketTableParserIsListenerAndPortScoped() {
+    @Test("Current socket-table parser returns only exact TCP listeners without filesystem discovery")
+    func currentSocketTableParserIsListenerAndPortScoped() {
         #expect(PortSweep.socketTableProbeExecutable.path == "/usr/sbin/netstat")
         #expect(PortSweep.socketTableProbeArguments == ["-anv", "-p", "tcp"])
 
@@ -25,6 +25,31 @@ struct PortSweepTests {
         #expect(pids == [4321])
         #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9999])
         #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 0).isEmpty)
+    }
+
+    @Test("Legacy socket-table parser reads the separate numeric pid column")
+    func legacySocketTableParserReadsNumericPIDColumn() {
+        let output = """
+        Active Internet connections (including servers)
+        Proto Recv-Q Send-Q  Local Address Foreign Address (state) rhiwat shiwat pid epid state options
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 131072 131072 2468 0 00000 00000000
+        tcp6 0 0 ::1.8000 *.* LISTEN 131072 131072 2468 0 00000 00000000
+        tcp4 0 0 127.0.0.1.18000 *.* LISTEN 131072 131072 9753 0 00000 00000000
+        tcp4 0 0 127.0.0.1.8000 127.0.0.1.50000 ESTABLISHED 131072 131072 8642 0 00102 00000000
+        """
+
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000) == [2468])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9753])
+    }
+
+    @Test("Socket-table parser fails closed when the owner layout is absent or malformed")
+    func socketTableParserRejectsUnknownOwnerLayout() {
+        let output = """
+        Proto Recv-Q Send-Q Local Address Foreign Address (state) rxbytes txbytes rhiwat shiwat owner state
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 4321 00000
+        """
+
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000).isEmpty)
     }
 
     @Test("rapid-mlx serve command is considered sweep-owned")

--- a/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
@@ -5,6 +5,28 @@ import Testing
 
 @Suite("PortSweep process identity")
 struct PortSweepTests {
+    @Test("Socket-table parser returns only exact TCP listeners without filesystem discovery")
+    func socketTableParserIsListenerAndPortScoped() {
+        #expect(PortSweep.socketTableProbeExecutable.path == "/usr/sbin/netstat")
+        #expect(PortSweep.socketTableProbeArguments == ["-anv", "-p", "tcp"])
+
+        let output = """
+        Active Internet connections (including servers)
+        Proto Recv-Q Send-Q  Local Address Foreign Address (state) rxbytes txbytes rhiwat shiwat process:pid state
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 python3.12:4321 00000
+        tcp6 0 0 ::1.8000 *.* LISTEN 0 0 131072 131072 rapid-mlx:4321 00000
+        tcp4 0 0 127.0.0.1.18000 *.* LISTEN 0 0 131072 131072 foreign:9999 00000
+        tcp4 0 0 127.0.0.1.8000 127.0.0.1.50000 ESTABLISHED 0 0 131072 131072 curl:7777 00102
+        tcp4 0 0 127.0.0.1.8000 *.* LISTEN 0 0 131072 131072 unknown:* 00000
+        """
+
+        let pids = PortSweep.parseListeningPIDs(Data(output.utf8), port: 8000)
+
+        #expect(pids == [4321])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 18_000) == [9999])
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 0).isEmpty)
+    }
+
     @Test("rapid-mlx serve command is considered sweep-owned")
     func rapidMlxServeAccepted() {
         #expect(PortSweep.isRapidOwnedCommand("/opt/homebrew/bin/rapid-mlx serve qwen3.5-4b --port 8000"))

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -10,6 +10,28 @@ import Testing
 @MainActor
 @Suite("ServerManager state transitions")
 struct ServerManagerStateTests {
+    private func sourceURL(_ relativePath: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid")
+            .appendingPathComponent(relativePath)
+    }
+
+    private final class ChildRetentionBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var child: ProcessGroupChild?
+
+        func retain(_ child: ProcessGroupChild) {
+            lock.withLock { self.child = child }
+        }
+
+        func release() {
+            lock.withLock { child = nil }
+        }
+    }
+
     private func waitUntil(
         deadline: Date,
         predicate: () -> Bool
@@ -46,6 +68,48 @@ struct ServerManagerStateTests {
             !child.isProcessGroupAlive
         }
         #expect(exited)
+    }
+
+    @Test("Process exit observation reaps consecutive children without a blocking worker")
+    func processExitObservationIsReusable() async throws {
+        func run(_ exitCode: Int32) async throws -> Int32 {
+            let box = ChildRetentionBox()
+            return try await withCheckedThrowingContinuation { continuation in
+                do {
+                    let child = try ProcessGroupChild.spawn(
+                        executableURL: URL(fileURLWithPath: "/bin/sh"),
+                        arguments: ["-c", "exit \(exitCode)"],
+                        standardInput: .nullDevice,
+                        standardOutput: Pipe(),
+                        standardError: Pipe()
+                    ) { child in
+                        let status = child.terminationStatus
+                        box.release()
+                        continuation.resume(returning: status)
+                    }
+                    box.retain(child)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+
+        #expect(try await run(17) == 17)
+        #expect(try await run(23) == 23)
+    }
+
+    @Test("Process exit monitoring is event-driven")
+    func processExitMonitorSourceContract() throws {
+        let source = try String(contentsOf: sourceURL("Server/ServerManager.swift"))
+        let monitor = try #require(source.range(of: "func startMonitor()"))
+        let nextFunction = source.range(
+            of: "private static func dup(",
+            range: monitor.upperBound..<source.endIndex
+        )
+        let body = source[monitor.lowerBound..<(nextFunction?.lowerBound ?? source.endIndex)]
+
+        #expect(body.contains("DispatchSource.makeProcessSource"))
+        #expect(!body.contains("DispatchQueue.global"))
     }
 
     @Test("dismissTerminalState: .crashed with a binary path → .idle")

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -258,7 +258,21 @@ struct SessionModelRestoreTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
         let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
-        let catalog = SequencedCatalogLoader([[chat], []])
+        var authoritativeChat = ModelEntry(
+            alias: "qwen3.5-4b-8bit",
+            hfRepo: "mlx-community/Qwen3.5-4B-MLX-8bit",
+            sizeOnDisk: "4.5 GB",
+            cached: true,
+            kind: .chat
+        )
+        authoritativeChat.isBuiltinProfile = true
+        authoritativeChat.isTextOnly = false
+        #expect(ModelBrandStyle.supportsImageInput(
+            forAlias: authoritativeChat.alias,
+            isBuiltinProfile: authoritativeChat.isBuiltinProfile,
+            isTextOnly: authoritativeChat.isTextOnly
+        ))
+        let catalog = SequencedCatalogLoader([[authoritativeChat], []])
         let server = ServerManager(
             testingState: .idle,
             binaryPath: fakeServer,
@@ -270,22 +284,27 @@ struct SessionModelRestoreTests {
         }
 
         let firstReady = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo
+            alias: authoritativeChat.alias,
+            hfPath: authoritativeChat.hfRepo
         )
         #expect(firstReady)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.launchedImageInputLane == true)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == authoritativeChat.alias)
 
         await server.stop()
         defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
 
         let restarted = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo
+            alias: authoritativeChat.alias,
+            hfPath: authoritativeChat.hfRepo
         )
         #expect(restarted)
-        #expect(server.servingAlias == chat.alias)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.servingAlias == authoritativeChat.alias)
+        #expect(server.launchedImageInputLane == false,
+                "retained chat-lane proof must not retain stale launch capabilities")
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == authoritativeChat.alias)
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -270,6 +270,7 @@ struct SessionModelRestoreTests {
             sessionDefaults: defaults
         )
         server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in [] }
 
         let ready = await server.ensureServing(
             alias: chat.alias,
@@ -390,7 +391,10 @@ struct SessionModelRestoreTests {
 
         let firstReady = await server.ensureServing(
             alias: removedChat.alias,
-            hfPath: removedChat.hfRepo
+            hfPath: removedChat.hfRepo,
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant,
+            catalogEntryHint: removedChat
         )
         #expect(firstReady)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -243,6 +243,52 @@ struct SessionModelRestoreTests {
         await server.stop()
     }
 
+    @Test(
+        "An authoritative chat start remains proven across a transiently empty restart probe",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func authoritativeChatProofSurvivesRestartProbeFailure() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let catalog = SequencedCatalogLoader([[chat], []])
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in
+            await catalog.load()
+        }
+
+        let firstReady = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo
+        )
+        #expect(firstReady)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: chat.alias,
+            hfPath: chat.hfRepo
+        )
+        #expect(restarted)
+        #expect(server.servingAlias == chat.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
+    }
+
     private static var safeMemorySnapshot: MemoryProbe.Snapshot {
         MemoryProbe.Snapshot(
             totalBytes: 64 * 1_024 * 1_024 * 1_024,

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -374,7 +374,7 @@ struct SessionModelRestoreTests {
             cached: true,
             kind: .chat
         )
-        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat]])
+        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat], []])
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -406,6 +406,16 @@ struct SessionModelRestoreTests {
         #expect(restarted)
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
             == "previous-chat")
+
+        await server.stop()
+        let failedProbeRestart = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(failedProbeRestart)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat",
+            "a later empty probe must not revive proof invalidated by the authoritative catalog")
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -259,6 +259,21 @@ struct SessionModelRestoreTests {
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
 
+        var hintedChat = ModelEntry(
+            alias: "qwen3.5-4b-8bit",
+            hfRepo: "mlx-community/Qwen3.5-4B-MLX-8bit",
+            sizeOnDisk: "4.5 GB",
+            cached: true,
+            kind: .chat
+        )
+        hintedChat.isBuiltinProfile = true
+        hintedChat.isTextOnly = false
+        #expect(ModelBrandStyle.supportsImageInput(
+            forAlias: hintedChat.alias,
+            isBuiltinProfile: hintedChat.isBuiltinProfile,
+            isTextOnly: hintedChat.isTextOnly
+        ))
+
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -273,16 +288,31 @@ struct SessionModelRestoreTests {
         server._testSetCatalogEntriesProvider { _, _ in [] }
 
         let ready = await server.ensureServing(
-            alias: chat.alias,
-            hfPath: chat.hfRepo,
+            alias: hintedChat.alias,
+            hfPath: hintedChat.hfRepo,
             estimatedMemoryGB: nil,
             replacementGroup: .assistant,
-            catalogEntryHint: chat
+            catalogEntryHint: hintedChat
         )
 
         #expect(ready)
-        #expect(server.servingAlias == chat.alias)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(server.servingAlias == hintedChat.alias)
+        #expect(server.launchedImageInputLane == true)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == hintedChat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: hintedChat.alias,
+            hfPath: hintedChat.hfRepo
+        )
+        #expect(restarted)
+        #expect(server.launchedImageInputLane == false,
+                "a consumed hint must retain only chat-lane proof, not image capability")
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == hintedChat.alias)
         await server.stop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -17,6 +17,48 @@ struct SessionModelRestoreTests {
         }
     }
 
+    private actor ReentrantCatalogLoader {
+        private var callCount = 0
+        private var firstStarted = false
+        private var firstStartWaiters: [CheckedContinuation<Void, Never>] = []
+        private var firstResult: CheckedContinuation<[ModelEntry], Never>?
+        private let newerResult: [ModelEntry]
+
+        init(newerResult: [ModelEntry]) {
+            self.newerResult = newerResult
+        }
+
+        func load() async -> [ModelEntry] {
+            callCount += 1
+            switch callCount {
+            case 1:
+                firstStarted = true
+                let waiters = firstStartWaiters
+                firstStartWaiters.removeAll()
+                for waiter in waiters { waiter.resume() }
+                return await withCheckedContinuation { continuation in
+                    firstResult = continuation
+                }
+            case 2:
+                return newerResult
+            default:
+                return []
+            }
+        }
+
+        func waitUntilFirstStarted() async {
+            if firstStarted { return }
+            await withCheckedContinuation { continuation in
+                firstStartWaiters.append(continuation)
+            }
+        }
+
+        func releaseFirst(with entries: [ModelEntry]) {
+            firstResult?.resume(returning: entries)
+            firstResult = nil
+        }
+    }
+
     private let chat = ModelEntry(
         alias: "qwen3.5-4b-4bit",
         hfRepo: "mlx-community/Qwen3.5-4B-MLX-4bit",
@@ -305,6 +347,125 @@ struct SessionModelRestoreTests {
                 "retained chat-lane proof must not retain stale launch capabilities")
         #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
             == authoritativeChat.alias)
+        await server.stop()
+    }
+
+    @Test(
+        "A nonempty authoritative catalog invalidates missing-alias chat proof",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func authoritativeCatalogMissingAliasInvalidatesChatProof() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let removedChat = ModelEntry(
+            alias: "removed-chat",
+            hfRepo: "example/removed-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let remainingChat = ModelEntry(
+            alias: "remaining-chat",
+            hfRepo: "example/remaining-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let catalog = SequencedCatalogLoader([[removedChat], [remainingChat]])
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in await catalog.load() }
+
+        let firstReady = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(firstReady)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == removedChat.alias)
+
+        await server.stop()
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let restarted = await server.ensureServing(
+            alias: removedChat.alias,
+            hfPath: removedChat.hfRepo
+        )
+        #expect(restarted)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
+        await server.stop()
+    }
+
+    @Test(
+        "A superseded catalog probe cannot restore stale chat provenance",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func supersededProbeCannotRewriteChatProvenance() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("previous-chat", forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let sharedAlias = "lane-reclassified-model"
+        let formerlyChat = ModelEntry(
+            alias: sharedAlias,
+            hfRepo: "example/former-chat",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .chat
+        )
+        let nowAudio = ModelEntry(
+            alias: sharedAlias,
+            hfRepo: "example/now-audio",
+            sizeOnDisk: "1 GB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let catalog = ReentrantCatalogLoader(newerResult: [nowAudio])
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+        server.memorySnapshotProvider = { Self.safeMemorySnapshot }
+        server._testSetCatalogEntriesProvider { _, _ in await catalog.load() }
+
+        let older = Task { await server.start(alias: sharedAlias) }
+        await catalog.waitUntilFirstStarted()
+        let newer = Task { await server.start(alias: sharedAlias) }
+        await newer.value
+        await catalog.releaseFirst(with: [formerlyChat])
+        await older.value
+
+        #expect(server.servingAlias == sharedAlias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
+
+        await server.stop()
+        let restarted = await server.ensureServing(alias: sharedAlias, hfPath: nil)
+        #expect(restarted)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey)
+            == "previous-chat")
         await server.stop()
     }
 

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -430,6 +430,66 @@ def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, 
     assert alias not in out
 
 
+def test_cached_view_marks_singleton_snapshot_without_refs_main_runnable(
+    tmp_path, monkeypatch, capsys
+):
+    """#2351: an unambiguous COMPLETE immutable snapshot with NO ``refs/main``
+    (a pinned ``snapshot_download``/manual pull of an exact commit) is loadable
+    by the routing & loader contract, so ``models --cached`` must report it
+    available, not ``(incomplete)`` — the inventory must agree with the serve
+    path. Ambiguous (multiple) snapshots stay unresolved."""
+    repo = "mlx-community/qwen-cached-singleton"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--qwen-cached-singleton"
+    sha = "93760be4f1f69842a46bc13dbdc0f19e291392a3"
+    snapshot = repo_root / "snapshots" / sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "tokenizer.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"weights")
+    # NO refs/ directory at all — the #2351 repro.
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 1_600_000_000, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+
+    assert repo in out
+    assert "(incomplete)" not in out, out
+
+
+def test_cached_view_marks_ambiguous_multiple_snapshots_incomplete(
+    tmp_path, monkeypatch, capsys
+):
+    """Two snapshots with no ``refs/main`` stay unresolved (can't know which a
+    fresh resolve would pick) — preserves the round-10 guarantee that an old
+    complete snapshot cannot mask a newer incomplete one."""
+    repo = "mlx-community/qwen-ambiguous"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--qwen-ambiguous"
+    for sha in ("aaa", "bbb"):
+        snap = repo_root / "snapshots" / sha
+        snap.mkdir(parents=True)
+        (snap / "config.json").write_text("{}")
+        (snap / "model.safetensors").write_bytes(b"weights")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 1_600_000_000, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+    assert "(incomplete)" in out
+
+
 def test_cached_view_renders_complete_mflux_alias(monkeypatch, capsys):
     """A complete mflux cache must map back to its image alias in ``ls``."""
     repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5655,6 +5655,13 @@ def _cache_entry_is_runnable(repo: str) -> bool:
     downloads (config/tokenizer only, no weights) look ready in ``ls`` and in
     the desktop model picker. Reuse the serve download gate's authoritative
     completeness checks for both text and component-split video layouts.
+
+    ``resolve_unreferenced_cached_snapshot`` closes the #2351 gap: a complete,
+    unambiguous SINGLE snapshot with no ``refs/main`` (a commit-pinned
+    ``snapshot_download`` / manual pull) is loadable by the routing & loader
+    contract — the inventory must report it available, not ``(incomplete)``,
+    so ``models --cached`` and the serve gate agree with the loader. Multiple
+    snapshots are ambiguous and stay unresolved there.
     """
     try:
         from vllm_mlx._download_gate import (
@@ -5664,6 +5671,7 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             is_repo_cached,
         )
         from vllm_mlx.audio.registry import resolve_audio_alias
+        from vllm_mlx.model_metadata import resolve_unreferenced_cached_snapshot
 
         audio_entry = resolve_audio_alias(repo)
         if audio_entry is not None and audio_entry.family == "whisper":
@@ -5672,6 +5680,7 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)
             or _snapshot_is_complete_mflux_model(repo)
+            or resolve_unreferenced_cached_snapshot(repo) is not None
         )
     except Exception:
         return False


### PR DESCRIPTION
## Intention

Integrate the final pre-release set of independently reviewed CLI and Desktop
fixes in one serialized train so required cross-platform and Desktop gates run
once on the exact combined head.

## Members

- #2404 `5f2c6a7204b8f3c79966deee80554eb3a4cbe7bc` (ds0732): recognize a complete single cached snapshot without `refs/main`. Fixes #2351.
- #2408 `37a1d807b4a008626f8bf3bc3da1558361857d2d` (Pixel): avoid mounted-volume access while selecting a Desktop server port. Fixes #2343.
- #2374 `462a49f5fabf69b1ec9ba26690e55947d9481464` (Pixel): preserve a proven chat selection across an in-session sidecar restart. Fixes #2363. Fixes #2364.

Base: `eb9b33526ecb80f0d7d569aef99f8c919fd364ae`.

Each frozen member was merged in the listed order with `--no-ff`. There are no
manual integration edits.

## Scope and non-goals

Allowed scope is exactly the three frozen member diffs and their direct tests.
This train does not redesign model cache discovery, CLI installation, Desktop
port ownership, model lifecycle, or release automation. It excludes #2357 and
the late ds0731 stack for Train 4. #2402 was removed after its hosted Linux
contract test failed on the prior audit head and remains with its owner.

## Local validation on the combined head

- Hosted-equivalent no-MLX list plus changed-lines coverage: PASS (exit 0; coverage threshold 100%).
- Real-MLX full unit: 19,083 passed, 97 skipped, 22 deselected, 6 xfailed,
  1 xpassed in 410.39s.
- `SessionModelRestoreTests` serial: 16/16 passed in 6.672s (55.95s cold wall).
- `VoiceCoLoadTests` serial: 10/10 passed in 0.008s (3.27s wall).
- Worktree clean; exact integration head `8167c2699db276334447974ea194b9e1cd7b6f97`.

## Landing contract

Merge only when PR validation and required full CI are green on this exact head
and the branch is zero behind `main`. If that does not happen by 14:30Z, hold
the merge until after the release.
