### PR TITLE
fix(#2406): cached Kokoro + whisper-large-v3-turbo count as runnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
             tests/test_chat_template_registry.py \
             tests/test_alias_subfolder.py \
             tests/test_download_gate.py \
+            tests/test_cli_models.py \
             tests/test_first_run_guide.py \
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_version_sync.py \

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -402,6 +402,65 @@ def test_cached_view_recognizes_complete_unmapped_whisper_npz(
     assert repo in out
 
 
+# --- #2406 part A: _cache_entry_is_runnable routes audio families -----------
+
+
+def test_cache_entry_runnable_for_cached_kokoro(tmp_path, monkeypatch):
+    """A cached Kokoro repo (``kokoro-v1_0.safetensors``) is runnable — the
+    audio-family branch, not the text ``model*.safetensors`` probe."""
+    repo = "mlx-community/Kokoro-82M-bf16"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--Kokoro-82M-bf16"
+    sha = "kokoro123"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "kokoro-v1_0.safetensors").write_bytes(b"k" * 4096)
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(sha)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert cli._cache_entry_is_runnable(repo) is True
+
+
+def test_cache_entry_runnable_for_cached_whisper_turbo(tmp_path, monkeypatch):
+    """A cached whisper-large-v3-turbo (``weights.safetensors``, not NPZ) is
+    runnable via the audio-family branch."""
+    repo = "mlx-community/whisper-large-v3-turbo"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--whisper-large-v3-turbo"
+    sha = "w12345"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "weights.safetensors").write_bytes(b"w" * 4096)
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(sha)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert cli._cache_entry_is_runnable(repo) is True
+
+
+def test_cache_entry_not_runnable_for_metadata_only_kokoro(tmp_path, monkeypatch):
+    """A Kokoro repo with only config.json (no weights) is NOT runnable — the
+    weightless-cache guard must hold for audio families too."""
+    repo = "mlx-community/Kokoro-82M-bf16"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--Kokoro-82M-bf16"
+    sha = "kokoro-stub"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(sha)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert cli._cache_entry_is_runnable(repo) is False
+
+
 def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, capsys):
     """Metadata-only cache directories must not advertise an alias as ready."""
     from vllm_mlx.model_aliases import list_profiles

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -623,6 +623,72 @@ def test_audio_family_rejects_weights_symlinked_outside(
     assert gate._snapshot_is_complete_audio_model(repo, family) is False
 
 
+def test_audio_family_incomplete_without_refs_main(tmp_path, monkeypatch):
+    """No pinned ``refs/main`` sha → not runnable (the sha resolution fails
+    before any weight check)."""
+    repo = "mlx-community/example-audio"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-audio"
+    sha = "norefs"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "weights.safetensors").write_bytes(b"x" * 4096)
+    # Deliberately no refs/main.
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, "whisper") is False
+
+
+def test_audio_family_incomplete_without_config(tmp_path, monkeypatch):
+    """A weight file without ``config.json`` is not a runnable snapshot."""
+    repo = "mlx-community/example-audio"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-audio"
+    sha = "noconfig"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "weights.safetensors").write_bytes(b"x" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, "whisper") is False
+
+
+@pytest.mark.parametrize(
+    "weight",
+    ["voice.safetensors", "weights.npz"],  # other-family safetensors / NPZ
+)
+def test_audio_family_generic_runnable(tmp_path, monkeypatch, weight):
+    """Any other audio family (e.g. parakeet STT) with a real weight file is
+    runnable — a safetensors shard or the NPZ layout."""
+    repo = "mlx-community/example-other"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-other"
+    sha = "other123"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / weight).write_bytes(b"x" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, "parakeet") is True
+
+
+def test_audio_family_exception_is_not_runnable(monkeypatch):
+    """A failure inside the completeness check degrades to not-runnable."""
+
+    def _boom(*a, **k):
+        raise OSError("boom")
+
+    monkeypatch.setattr(gate, "_resolved_snapshot_sha", _boom)
+    assert gate._snapshot_is_complete_audio_model("a/b", "whisper") is False
+
+
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     """Empty HF cache directory → False."""
     empty_cache = tmp_path / "hf-cache"

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -536,6 +536,93 @@ def test_whisper_cache_rejects_files_symlinked_outside_repo(
     )
 
 
+# --- #2406 part A: family-appropriate audio runnability ---------------------
+
+
+@pytest.mark.parametrize(
+    "family,weight",
+    [
+        ("whisper", "weights.npz"),  # classic mlx-community Whisper layout
+        ("whisper", "weights.safetensors"),  # whisper-large-v3-turbo layout
+        ("kokoro", "kokoro-v1_0.safetensors"),  # Kokoro canonical base weights
+    ],
+)
+def test_audio_family_runnable_with_family_weights(
+    tmp_path, monkeypatch, family, weight
+):
+    """A cached audio repo with its family-appropriate weight file is runnable
+    (the text probe would reject it because audio repos ship no
+    ``model*.safetensors``)."""
+    repo = "mlx-community/example-audio"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-audio"
+    sha = "audio123"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / weight).write_bytes(b"x" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, family) is True
+
+
+@pytest.mark.parametrize(
+    "family,weight",
+    [
+        ("whisper", "weights.safetensors"),
+        ("kokoro", "kokoro-v1_0.safetensors"),
+    ],
+)
+def test_audio_family_incomplete_when_only_config(
+    tmp_path, monkeypatch, family, weight
+):
+    """config.json without any weight file must NOT count as runnable — that is
+    a metadata-only stub, exactly like the text path's weightless-cache guard."""
+    repo = "mlx-community/example-audio"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-audio"
+    sha = "audiostub"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, family) is False
+
+
+@pytest.mark.parametrize(
+    "family,weight",
+    [
+        ("kokoro", "kokoro-v1_0.safetensors"),
+        ("whisper", "weights.safetensors"),
+    ],
+)
+def test_audio_family_rejects_weights_symlinked_outside(
+    tmp_path, monkeypatch, family, weight
+):
+    """A crafted cache symlink must not borrow proof from an unrelated file
+    (mirrors the whisper probe's escape guard)."""
+    repo = "mlx-community/example-audio"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-audio"
+    sha = "audioesc"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    outside = tmp_path / f"outside-{family}"
+    outside.write_bytes(b"x" * 4096)
+    (snap / weight).symlink_to(outside)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, family) is False
+
+
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     """Empty HF cache directory → False."""
     empty_cache = tmp_path / "hf-cache"

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -661,9 +661,11 @@ def test_audio_family_incomplete_without_config(tmp_path, monkeypatch):
     "weight",
     ["voice.safetensors", "weights.npz"],  # other-family safetensors / NPZ
 )
-def test_audio_family_generic_runnable(tmp_path, monkeypatch, weight):
-    """Any other audio family (e.g. parakeet STT) with a real weight file is
-    runnable — a safetensors shard or the NPZ layout."""
+def test_audio_family_no_generic_any_safetensors(tmp_path, monkeypatch, weight):
+    """An UNSUPPORTED audio family must NOT be marked runnable from a generic
+    ``*.safetensors`` / ``weights.npz`` — no speculative any-safetensors
+    routing. Each family is added explicitly with its verified weight filename
+    (#2406 part A is strictly Kokoro + Whisper)."""
     repo = "mlx-community/example-other"
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--example-other"
@@ -676,7 +678,26 @@ def test_audio_family_generic_runnable(tmp_path, monkeypatch, weight):
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    assert gate._snapshot_is_complete_audio_model(repo, "parakeet") is True
+    assert gate._snapshot_is_complete_audio_model(repo, "parakeet") is False
+
+
+def test_audio_family_kokoro_rejects_unrelated_safetensors(tmp_path, monkeypatch):
+    """Kokoro must require its VERIFIED ``kokoro-v1_0.safetensors``; a stray
+    sharded/aux safetensors must never false-mark the upload as runnable
+    (the codex BLOCKING the strict filename fixes)."""
+    repo = "mlx-community/example-kokoro"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--example-kokoro"
+    sha = "kokoroaux"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "kokoro-v1_0.model.safetensors").write_bytes(b"x" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_audio_model(repo, "kokoro") is False
 
 
 def test_audio_family_exception_is_not_runnable(monkeypatch):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -662,10 +662,13 @@ def test_audio_family_incomplete_without_config(tmp_path, monkeypatch):
     ["voice.safetensors", "weights.npz"],  # other-family safetensors / NPZ
 )
 def test_audio_family_no_generic_any_safetensors(tmp_path, monkeypatch, weight):
-    """An UNSUPPORTED audio family must NOT be marked runnable from a generic
-    ``*.safetensors`` / ``weights.npz`` — no speculative any-safetensors
-    routing. Each family is added explicitly with its verified weight filename
-    (#2406 part A is strictly Kokoro + Whisper)."""
+    """The AUDIO helper does no speculative generic any-safetensors routing:
+    an unsupported family is NOT established runnable by a stray
+    ``*.safetensors`` / ``weights.npz``. Each supported family is added
+    explicitly with its verified weight filename (#2406 part A = Kokoro +
+    Whisper). Callers (``_cache_entry_is_runnable``) decide which families
+    reach this helper and may fall through to the generic text probe for
+    unsupported ones — that routing is covered in test_cli_models."""
     repo = "mlx-community/example-other"
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--example-other"

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -781,8 +781,8 @@ def _snapshot_is_complete_audio_model(repo_id: str, family: str) -> bool:
       * Whisper (STT) historically ships ``weights.npz`` + ``config.json``
         with no safetensors; the ``whisper-large-v3-turbo`` upload ships
         ``weights.safetensors`` instead. Both count as runnable.
-      * Kokoro (TTS) ships ``kokoro-v1_0.safetensors`` (index-sharded or a
-        single shard).
+      * Kokoro (TTS) ships a single ``kokoro-v1_0.safetensors`` (the canonical
+        base weights; sharded Kokoro layouts are out of #2406 scope).
 
     Mirror ``_snapshot_is_complete_whisper_model``: resolve the pinned sha,
     require ``config.json`` present + on-this-repo (no crafted symlink

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -771,6 +771,73 @@ def _snapshot_is_complete_whisper_model(repo_id: str) -> bool:
         return False
 
 
+def _snapshot_is_complete_audio_model(repo_id: str, family: str) -> bool:
+    """True when a pinned audio snapshot carries its family-appropriate weights.
+
+    Audio repos do not share the text ``model*.safetensors`` layout, so the
+    text probe would reject a fully-downloaded audio model. The weight file a
+    given audio family expects varies:
+
+      * Whisper (STT) historically ships ``weights.npz`` + ``config.json``
+        with no safetensors; the ``whisper-large-v3-turbo`` upload ships
+        ``weights.safetensors`` instead. Both count as runnable.
+      * Kokoro (TTS) ships ``kokoro-v1_0.safetensors`` (index-sharded or a
+        single shard).
+
+    Mirror ``_snapshot_is_complete_whisper_model``: resolve the pinned sha,
+    require ``config.json`` present + on-this-repo (no crafted symlink
+    pointing outside), and require a non-empty weight file for the family.
+    Families without a verified layout (other TTS/STT) accept any non-empty
+    ``*.safetensors`` (or ``weights.npz``) so a genuinely-cached upload is
+    never falsely marked incomplete — a real weights file is never a
+    metadata-only stub.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is None:
+            return False
+        snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+        repo_root_real = os.path.realpath(repo_root)
+
+        def _present(name: str) -> bool:
+            path = os.path.join(snap_dir, name)
+            if not os.path.isfile(path):
+                return False
+            # HF snapshot files normally point into this repo's own ``blobs``
+            # directory. Do not let an unrelated local file satisfy the cache
+            # gate through a crafted symlink.
+            real = os.path.realpath(path)
+            if real != repo_root_real and not real.startswith(repo_root_real + os.sep):
+                return False
+            return os.path.getsize(path) > 0
+
+        if not _present("config.json"):
+            return False
+        if family == "whisper":
+            return _present("weights.npz") or _present("weights.safetensors")
+        if family == "kokoro":
+            return _present("kokoro-v1_0.safetensors") or any(
+                _present(name)
+                for name in os.listdir(snap_dir)
+                if name.endswith(".safetensors")
+            )
+        # Any other audio family: a real weights file (single or sharded
+        # safetensors, or the NPZ layout some STT models use).
+        return any(
+            _present(name)
+            for name in os.listdir(snap_dir)
+            if name.endswith(".safetensors")
+        ) or _present("weights.npz")
+    except Exception:
+        return False
+
+
 def _snapshot_is_complete_split_model(repo_id: str) -> bool:
     """True if the resolved snapshot is a mlx-video component-split model whose
     EVERY declared component weight is cached — the non-text analogue of

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -786,11 +786,11 @@ def _snapshot_is_complete_audio_model(repo_id: str, family: str) -> bool:
 
     Mirror ``_snapshot_is_complete_whisper_model``: resolve the pinned sha,
     require ``config.json`` present + on-this-repo (no crafted symlink
-    pointing outside), and require a non-empty weight file for the family.
-    Families without a verified layout (other TTS/STT) accept any non-empty
-    ``*.safetensors`` (or ``weights.npz``) so a genuinely-cached upload is
-    never falsely marked incomplete — a real weights file is never a
-    metadata-only stub.
+    pointing outside), and require a non-empty, VERIFIED weight file for the
+    family. Strict verified-filename-only matching: no speculative generic
+    ``any(*.safetensors)`` acceptance, so an unrelated sharded/aux safetensors
+    can never false-mark an upload as runnable. Unsupported families return
+    False (out of scope; not over-routed).
     """
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
@@ -822,18 +822,11 @@ def _snapshot_is_complete_audio_model(repo_id: str, family: str) -> bool:
         if family == "whisper":
             return _present("weights.npz") or _present("weights.safetensors")
         if family == "kokoro":
-            return _present("kokoro-v1_0.safetensors") or any(
-                _present(name)
-                for name in os.listdir(snap_dir)
-                if name.endswith(".safetensors")
-            )
-        # Any other audio family: a real weights file (single or sharded
-        # safetensors, or the NPZ layout some STT models use).
-        return any(
-            _present(name)
-            for name in os.listdir(snap_dir)
-            if name.endswith(".safetensors")
-        ) or _present("weights.npz")
+            return _present("kokoro-v1_0.safetensors")
+        # Unsupported audio family with no verified weight layout: not
+        # established runnable. Each family must be added explicitly with its
+        # verified filename — no generic any-safetensors routing.
+        return False
     except Exception:
         return False
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5658,16 +5658,20 @@ def _cache_entry_is_runnable(repo: str) -> bool:
     """
     try:
         from vllm_mlx._download_gate import (
+            _snapshot_is_complete_audio_model,
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
-            _snapshot_is_complete_whisper_model,
             is_repo_cached,
         )
         from vllm_mlx.audio.registry import resolve_audio_alias
 
         audio_entry = resolve_audio_alias(repo)
-        if audio_entry is not None and audio_entry.family == "whisper":
-            return _snapshot_is_complete_whisper_model(repo)
+        if audio_entry is not None:
+            # Audio repos don't share the text ``model*.safetensors`` layout;
+            # judge them by their family-appropriate weight file (Whisper
+            # ``weights.npz``/``weights.safetensors``, Kokoro
+            # ``kokoro-v1_0.safetensors``, etc.) just like a text cache.
+            return _snapshot_is_complete_audio_model(repo, audio_entry.family)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5666,11 +5666,13 @@ def _cache_entry_is_runnable(repo: str) -> bool:
         from vllm_mlx.audio.registry import resolve_audio_alias
 
         audio_entry = resolve_audio_alias(repo)
-        if audio_entry is not None:
+        if audio_entry is not None and audio_entry.family in ("whisper", "kokoro"):
             # Audio repos don't share the text ``model*.safetensors`` layout;
-            # judge them by their family-appropriate weight file (Whisper
-            # ``weights.npz``/``weights.safetensors``, Kokoro
-            # ``kokoro-v1_0.safetensors``, etc.) just like a text cache.
+            # judge whisper/kokoro by their family-appropriate VERIFIED weight
+            # file (Whisper ``weights.npz``/``weights.safetensors``, Kokoro
+            # ``kokoro-v1_0.safetensors``) just like a text cache. Other audio
+            # families fall through to the generic cache probes below — their
+            # layout is not pinned here, so never claim them non-runnable.
             return _snapshot_is_complete_audio_model(repo, audio_entry.family)
         return (
             is_repo_cached(repo)


### PR DESCRIPTION
Part A of #2406. Closes #2406.

## Why

A cached Kokoro (`kokoro-v1_0.safetensors`) and whisper-large-v3-turbo
(`weights.safetensors`) must count as runnable exactly like Whisper does
today (#2357's offline-serve gap). Previously only the `whisper` family was
routed, and only to the `weights.npz`-based probe, so both were shown
incomplete/not-runnable.

Because audio repos do not share the text `model*.safetensors` layout, the
text probe would reject a fully-downloaded audio model.

## Change

- `_snapshot_is_complete_audio_model(repo_id, family)` in `_download_gate.py`:
  resolve pinned sha; require `config.json` present + on-repo (symlink guard);
  require a non-empty, family-appropriate VERIFIED weight file —
  Whisper `weights.npz` OR `weights.safetensors`; Kokoro `kokoro-v1_0.safetensors`.
  Strict verified-filename-only: no speculative generic `any(*.safetensors)`
  routing for unsupported families.
- `_cache_entry_is_runnable` routes `whisper`/`kokoro` through the audio
  helper; all other audio families keep falling through to the generic cache
  probes (not made permanently non-runnable).
- Focused no-MLX tests with hermetic cache trees (download-gate + alias-level),
  all branches covered (diff-cover 100%).
- Part B (Wan pinned-snapshot) left alone per scope.

## Validation

- 203 tests (download_gate + cli_models) pass; diff-cover 100%; mypy budget
  719/no growth; ruff clean.
