### PR TITLE
fix(serve): refuse serve of an uncached model under offline mode with one actionable message (#2357)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,7 @@ jobs:
         run: |
           pytest \
             tests/test_cli_connect.py \
+            tests/test_cli_offline_serve.py \
             tests/test_mcp_security.py \
             tests/test_structured_output.py \
             tests/test_reasoning_parser.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,7 @@ jobs:
           pytest \
             tests/test_cli_connect.py \
             tests/test_cli_offline_serve.py \
+            tests/test_cli_chat.py \
             tests/test_mcp_security.py \
             tests/test_structured_output.py \
             tests/test_reasoning_parser.py \

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1940,6 +1940,144 @@ def test_chat_command_switch_model_rollback_on_wait_failure(monkeypatch, capsys)
     )
 
 
+def test_chat_switch_download_abort_reports_reason_above(monkeypatch, capsys):
+    """When ``/model``'s pre-download aborts via ``sys.exit(1)`` (offline +
+    uncached refusal, disk gate, or resolve timeout), the summary must say
+    "(reason above)" — NOT re-attribute it as "(disk gate)" — and keep the
+    previous server running untouched (#2357)."""
+    spawned: list[object] = []
+
+    class _FakeProc:
+        def __init__(self, name):
+            self.name = name
+            self._rapid_mlx_log = None
+            self._rapid_mlx_log_path = None
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    def _fake_spawn(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
+        proc = _FakeProc(model)
+        spawned.append(proc)
+        if register_in is not None:
+            register_in.append(proc)
+        if log_handle is not None:
+            log_handle.release()
+        return proc, f"http://127.0.0.1:{port}"
+
+    download_calls = {"n": 0}
+
+    def _ensure_aborts_on_switch(*_a, **_kw):
+        # Initial spawn's pre-download succeeds; the /model switch's
+        # pre-download aborts with the offline/disk SystemExit.
+        download_calls["n"] += 1
+        if download_calls["n"] >= 2:
+            raise SystemExit(1)
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _ensure_aborts_on_switch)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda alias: f"mlx-community/{alias}-resolved",
+    )
+
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (fake_port, payloads):
+        port = fake_port
+        inputs = iter(["first turn", "/model bogus", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(fake_port, model="qwen3.5-4b-4bit")
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    out = capsys.readouterr().out
+    assert "Model switch aborted" in out
+    assert "reason above" in out, "must not mis-attribute the abort to the disk gate"
+    assert "disk gate" not in out
+    assert "previous server still running" in out
+
+
+def test_chat_switch_confirm_cancel_keeps_old_server(monkeypatch, capsys):
+    """When the /model switch's confirm prompt is declined (``confirm_or_abort``
+    raises SystemExit, i.e. the user said no), chat_command prints "Model
+    switch cancelled" and keeps the previous server untouched."""
+    spawned: list[object] = []
+
+    class _FakeProc:
+        def __init__(self, name):
+            self.name = name
+            self._rapid_mlx_log = None
+            self._rapid_mlx_log_path = None
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    def _fake_spawn(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
+        proc = _FakeProc(model)
+        spawned.append(proc)
+        if register_in is not None:
+            register_in.append(proc)
+        if log_handle is not None:
+            log_handle.release()
+        return proc, f"http://127.0.0.1:{port}"
+
+    from vllm_mlx import _download_gate as gate
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: True)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(gate, "is_repo_cached", lambda _repo: False)
+    # The switch's uncached-model confirm is declined -> SystemExit.
+    monkeypatch.setattr(
+        gate, "confirm_or_abort", lambda *_a, **_kw: (_ for _ in ()).throw(SystemExit(0))
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda alias: f"mlx-community/{alias}-resolved",
+    )
+
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (fake_port, payloads):
+        port = fake_port
+        inputs = iter(["first turn", "/model bogus", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(fake_port, model="qwen3.5-4b-4bit")
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    out = capsys.readouterr().out
+    assert "Model switch cancelled" in out
+    assert "previous server still running" in out
+    # Only the initial server ever spawned; the cancelled switch spawned nothing.
+    assert len(spawned) == 1
+
+
 def test_chat_command_slash_command_dispatch_uses_exact_match(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2054,7 +2054,9 @@ def test_chat_switch_confirm_cancel_keeps_old_server(monkeypatch, capsys):
     monkeypatch.setattr(gate, "is_repo_cached", lambda _repo: False)
     # The switch's uncached-model confirm is declined -> SystemExit.
     monkeypatch.setattr(
-        gate, "confirm_or_abort", lambda *_a, **_kw: (_ for _ in ()).throw(SystemExit(0))
+        gate,
+        "confirm_or_abort",
+        lambda *_a, **_kw: (_ for _ in ()).throw(SystemExit(0)),
     )
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_model",

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2078,6 +2078,81 @@ def test_chat_switch_confirm_cancel_keeps_old_server(monkeypatch, capsys):
     assert len(spawned) == 1
 
 
+def test_chat_switch_refuses_offline_uncached_before_confirm(monkeypatch, capsys):
+    """An interactive offline /model to an uncached repo must refuse with the
+    one-shot action message BEFORE the confirm/size-estimate gate prints an
+    'About to download' notice (codex #2357-P2)."""
+    spawned: list[object] = []
+
+    class _FakeProc:
+        def __init__(self, name):
+            self.name = name
+            self._rapid_mlx_log = None
+            self._rapid_mlx_log_path = None
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    def _fake_spawn(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
+        proc = _FakeProc(model)
+        spawned.append(proc)
+        if register_in is not None:
+            register_in.append(proc)
+        if log_handle is not None:
+            log_handle.release()
+        return proc, f"http://127.0.0.1:{port}"
+
+    from vllm_mlx import _download_gate as gate
+
+    monkeypatch.setattr(cli, "_spawn_chat_server", _fake_spawn)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_wait_for_chat_server", lambda *_a, **_kw: True)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(gate, "is_repo_cached", lambda _repo: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    confirm_calls = []
+
+    def _confirm_never(*_a, **_k):
+        confirm_calls.append(_a)
+        raise AssertionError("confirm must not run for offline+uncached")
+
+    monkeypatch.setattr(gate, "confirm_or_abort", _confirm_never)
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda alias: f"mlx-community/{alias}-resolved",
+    )
+
+    canned = [_delta("ack")]
+    with _fake_server(canned) as (fake_port, payloads):
+        port = fake_port
+        inputs = iter(["first turn", "/model bogus", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        ns = _ns_for_chat(fake_port, model="qwen3.5-4b-4bit")
+        ns.base_url = None
+        ns.port = None
+        cli.chat_command(ns)
+
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "not cached and the network is unavailable" in out
+    assert confirm_calls == []  # refused before the confirm gate
+    # Only the initial server spawned; the offline /model spawned nothing.
+    assert len(spawned) == 1
+
+
 def test_chat_command_slash_command_dispatch_uses_exact_match(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -50,6 +50,7 @@ def _make_serve_args(model: str) -> Namespace:
         watchdog_ppid=None,
     )
 
+
 def _uncached_probe(monkeypatch):
     """Force the runnability predicate to report "not cached runnable",
     so the model falls through to the offline refusal / download path."""
@@ -202,7 +203,9 @@ def test_gate_refuses_offline_uncached_before_notices(monkeypatch, capsys):
     # (nor is the spinner'd size estimate / confirm path, which live below the
     # offline short-circuit in main()). Guard both to catch a regression.
     with (
-        patch.object(sys, "argv", ["rapid-mlx", "serve", "badorg/offline-missing-model"]),
+        patch.object(
+            sys, "argv", ["rapid-mlx", "serve", "badorg/offline-missing-model"]
+        ),
         patch.object(
             cli, "serve_command", side_effect=AssertionError("must not dispatch")
         ),
@@ -279,9 +282,7 @@ def test_gate_does_not_refuse_when_wan_local_dir_set(monkeypatch, capsys, tmp_pa
     # NOT fire; serve_command must still not be reached (gate self-skips or
     # confirm handles it), so we patch it to a sentinel just in case.
     monkeypatch.setattr(gate, "estimate_repo_size_bytes", lambda name: 1)
-    monkeypatch.setattr(
-        gate, "confirm_or_abort", lambda *a, **k: confirmed.append(a)
-    )
+    monkeypatch.setattr(gate, "confirm_or_abort", lambda *a, **k: confirmed.append(a))
     dispatched = []
     with (
         patch.object(

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -126,9 +126,10 @@ def test_offline_local_path_is_noop_not_refused(monkeypatch, capsys):
 
 def test_offline_cached_repo_is_noop_not_refused(monkeypatch, capsys):
     """A fully-cached repo (any modality, judged by the single runnability
-    predicate) never hits the offline refusal."""
+    probe core) never hits the offline refusal."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: True)
+    monkeypatch.setattr(cli, "_cache_runnability", lambda name: True)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **k: True)
     cli._ensure_model_downloaded("acme/already-cached")
     assert "is not cached" not in capsys.readouterr().err
 
@@ -136,9 +137,10 @@ def test_offline_cached_repo_is_noop_not_refused(monkeypatch, capsys):
 def test_offline_cached_mflux_is_noop_not_refused(monkeypatch, capsys):
     """A fully-cached mflux checkpoint (no root ``model*.safetensors``, so a
     text-only ``is_repo_cached`` read misses it) must NOT be refused — the
-    shared runnability predicate accepts it (codex #2357-P1)."""
+    shared runnability probe core accepts it (codex #2357-P1)."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: True)
+    monkeypatch.setattr(cli, "_cache_runnability", lambda name: True)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **k: True)
     cli._ensure_model_downloaded("acme/qwen-image-cached")
     assert "is not cached" not in capsys.readouterr().err
 
@@ -449,3 +451,33 @@ def test_cache_probe_fault_fails_open_for_offline(monkeypatch):
     )
     assert cli._cache_runnability("any/repo") is None
     assert cli._cache_runnability("any/repo") is not False
+
+
+def test_ensure_model_downloaded_does_not_refuse_offline_on_probe_fault(
+    monkeypatch, capsys
+) -> None:
+    """The real ``_ensure_model_downloaded`` refusal path must NOT fire when a
+    cachedness probe faults (inconclusive), even offline.
+
+    Codex R2: the boolean wrapper collapses ``None`` -> ``False``; the refusal
+    must therefore key on ``is False`` in the production path, not on the
+    boolean result, or a permission/malformed-cache fault would be reported as
+    definitively uncached and refuse the serve. Setting offline + inducing the
+    probe exception, the offline refusal (a ``SystemExit`` with the
+    "not cached and the network is unavailable" message) must NOT occur; the
+    function falls through to the normal online path.
+    """
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    # Induce a probe fault: _cache_runnability -> resolve_audio_alias raises.
+    monkeypatch.setattr(
+        "vllm_mlx.audio.registry.resolve_audio_alias",
+        lambda repo: (_ for _ in ()).throw(OSError("denied")),
+    )
+    # The refusal must not fire, so the function proceeds to the download path;
+    # stub the post-refusal network steps so we only exercise the gate itself.
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **k: True)
+    # No SystemExit (offline refusal) should be raised on the probe fault.
+    cli._ensure_model_downloaded("some/repo")
+    err = capsys.readouterr().err
+    assert "is not cached and the network is unavailable" not in err

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -411,19 +411,41 @@ def test_offline_hub_mode_flags_parsed_independently(monkeypatch):
 
 
 def test_cache_probe_fault_fails_open_for_offline(monkeypatch):
-    """A typed cachedness-probe fault (permission / malformed) must NOT
-    conclude 'uncached': _cache_entry_is_runnable returns True (fail open) so
-    the offline gate refuses only when uncachedness is established."""
+    """A typed cachedness-probe fault (permission / malformed) is INCONCLUSIVE.
+
+    It must NOT conclude "runnable" (would skip a needed download / show a
+    broken checkmark), and it must NOT conclude "uncached" (would make the
+    offline refusal fire on a model that may well be cached). The tri-state
+    core returns ``None``; the boolean wrapper collapses ``None`` -> ``False``
+    for skip-download/inventory callers; the offline-refusal caller (which
+    compares ``is False``) must NOT refuse on ``None``.
+    """
     # Induce an expected probe fault in resolve_audio_alias.
     monkeypatch.setattr(
         "vllm_mlx.audio.registry.resolve_audio_alias",
         lambda repo: (_ for _ in ()).throw(OSError("denied")),
     )
-    assert cli._cache_entry_is_runnable("any/repo") is True
+    # Tri-state core: inconclusive, not a baked True (regression) nor False.
+    assert cli._cache_runnability("any/repo") is None
+    # Boolean wrapper collapses None -> False so downloaders/inventory treat a
+    # probe fault as NOT runnable (never skip a needed download / never list a
+    # broken entry as runnable).
+    assert cli._cache_entry_is_runnable("any/repo") is False
 
     # Same for a malformed-cache KeyError / structural ValueError.
     monkeypatch.setattr(
         "vllm_mlx.audio.registry.resolve_audio_alias",
         lambda repo: (_ for _ in ()).throw(KeyError("hdr")),
     )
-    assert cli._cache_entry_is_runnable("any/repo") is True
+    assert cli._cache_runnability("any/repo") is None
+    assert cli._cache_entry_is_runnable("any/repo") is False
+
+    # The offline-refusal caller equates a verdict with established-uncached
+    # ONLY via ``is False``; on ``None`` it must NOT refuse. Simulate the B2
+    # serve gate's condition for an offline + probe-faulting model.
+    monkeypatch.setattr(
+        "vllm_mlx.audio.registry.resolve_audio_alias",
+        lambda repo: (_ for _ in ()).throw(ValueError("bad index")),
+    )
+    assert cli._cache_runnability("any/repo") is None
+    assert cli._cache_runnability("any/repo") is not False

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -7,11 +7,13 @@ printing "First-time download" / "Pre-download skipped; server will retry"),
 let the serve subprocess start, and end in misleading ``--mllm``/``--no-mllm``
 lane advice even though neither flag can supply the missing checkpoint.
 
-The fix (in ``_ensure_model_downloaded``) detects the offline + uncached
-condition ONCE, states which repository is missing, points to ``rapid-mlx
-pull`` and the expected cache location, and exits(1) before server
-initialization — mirroring the TimeoutError / disk-space exits. A lane override
-is never recommended when the checkpoint is simply absent.
+The fix (in ``_ensure_model_downloaded`` and ``main()``'s B2 gate) detects the
+offline + uncached condition ONCE, states which repository is missing, points
+to ``rapid-mlx pull`` and the expected cache location, and exits(1) before
+server initialization — mirroring the TimeoutError / disk-space exits. A lane
+override is never recommended when the checkpoint is simply absent. Cachedness
+is judged by the single shared ``_cache_entry_is_runnable`` predicate, so a
+fully-cached mflux / split-video / Whisper model is never refused.
 """
 
 from __future__ import annotations
@@ -25,13 +27,9 @@ from vllm_mlx import cli
 
 
 def _uncached_probe(monkeypatch):
-    """Force the cache probes to report "not cached" (weights absent)."""
-    import vllm_mlx._download_gate as gate
-
-    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
-    monkeypatch.setattr(
-        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
-    )
+    """Force the runnability predicate to report "not cached runnable",
+    so the model falls through to the offline refusal / download path."""
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
 
 
 def test_offline_hub_mode_detects_env_switches(monkeypatch):
@@ -102,45 +100,39 @@ def test_offline_local_path_is_noop_not_refused(monkeypatch, capsys):
 
 
 def test_offline_cached_repo_is_noop_not_refused(monkeypatch, capsys):
-    """A fully-cached repo never hits the offline refusal."""
-    import vllm_mlx._download_gate as gate
-
+    """A fully-cached repo (any modality, judged by the single runnability
+    predicate) never hits the offline refusal."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setattr(gate, "is_repo_cached", lambda name: True)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: True)
     cli._ensure_model_downloaded("acme/already-cached")
     assert "is not cached" not in capsys.readouterr().err
 
 
-def test_offline_cached_split_video_is_noop_not_refused(monkeypatch, capsys):
-    """A fully-cached component-split video (CogVideoX/LTX) that
-    ``is_repo_cached`` cannot see (no root ``model*.safetensors``) must NOT be
-    refused — the split-model probe marks it complete (codex #2357-R1 P1)."""
-    import vllm_mlx._download_gate as gate
-
+def test_offline_cached_mflux_is_noop_not_refused(monkeypatch, capsys):
+    """A fully-cached mflux checkpoint (no root ``model*.safetensors``, so a
+    text-only ``is_repo_cached`` read misses it) must NOT be refused — the
+    shared runnability predicate accepts it (codex #2357-P1)."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
-    monkeypatch.setattr(
-        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
-    )
-    monkeypatch.setattr(gate, "_snapshot_is_complete_split_model", lambda name: True)
-    cli._ensure_model_downloaded("acme/cogvideox-cached")
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: True)
+    cli._ensure_model_downloaded("acme/qwen-image-cached")
     assert "is not cached" not in capsys.readouterr().err
 
 
-def test_offline_cached_whisper_is_noop_not_refused(monkeypatch, capsys):
-    """A fully-cached Whisper snapshot is runnable offline — not refused."""
-    import vllm_mlx._download_gate as gate
-
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+def test_disk_gate_systemexit_still_propagates(monkeypatch, capsys):
+    """Below the offline refusal, a disk-space-gate ``SystemExit`` must still
+    clear the spinner and propagate (not be swallowed by the runnability /
+    cache refactor this file tests). Guards the re-raise boundary directly
+    under ``_cache_entry_is_runnable``."""
+    _uncached_probe(monkeypatch)  # not runnable, not offline -> reaches disk gate
+    monkeypatch.setenv("HF_HUB_OFFLINE", "")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "")
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
     monkeypatch.setattr(
-        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
+        cli, "_check_disk_space", lambda *a, **k: (_ for _ in ()).throw(SystemExit(3))
     )
-    monkeypatch.setattr(
-        gate, "_snapshot_is_complete_whisper_model", lambda name: True
-    )
-    cli._ensure_model_downloaded("openai/whisper-cached")
-    assert "is not cached" not in capsys.readouterr().err
+    with pytest.raises(SystemExit) as exc:
+        cli._ensure_model_downloaded("badorg/offline-missing-model")
+    assert exc.value.code == 3
 
 
 def test_online_uncached_still_attempts_download(monkeypatch, capsys):
@@ -170,7 +162,11 @@ def test_gate_refuses_offline_uncached_before_notices(monkeypatch, capsys):
     """
     import vllm_mlx._download_gate as gate
 
+    # Outer gate condition: text-only probe reports uncached (no root
+    # ``model*.safetensors``). Offline refusal scope: the shared runnability
+    # predicate also reports False, so the refusal must fire.
     monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
     monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     # Interactive so the gate's confirmation branch is active.

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -16,6 +16,9 @@ is never recommended when the checkpoint is simply absent.
 
 from __future__ import annotations
 
+import sys
+from unittest.mock import patch
+
 import pytest
 
 from vllm_mlx import cli
@@ -98,6 +101,48 @@ def test_offline_local_path_is_noop_not_refused(monkeypatch, capsys):
     assert "is not cached" not in capsys.readouterr().err
 
 
+def test_offline_cached_repo_is_noop_not_refused(monkeypatch, capsys):
+    """A fully-cached repo never hits the offline refusal."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: True)
+    cli._ensure_model_downloaded("acme/already-cached")
+    assert "is not cached" not in capsys.readouterr().err
+
+
+def test_offline_cached_split_video_is_noop_not_refused(monkeypatch, capsys):
+    """A fully-cached component-split video (CogVideoX/LTX) that
+    ``is_repo_cached`` cannot see (no root ``model*.safetensors``) must NOT be
+    refused — the split-model probe marks it complete (codex #2357-R1 P1)."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(
+        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
+    )
+    monkeypatch.setattr(gate, "_snapshot_is_complete_split_model", lambda name: True)
+    cli._ensure_model_downloaded("acme/cogvideox-cached")
+    assert "is not cached" not in capsys.readouterr().err
+
+
+def test_offline_cached_whisper_is_noop_not_refused(monkeypatch, capsys):
+    """A fully-cached Whisper snapshot is runnable offline — not refused."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(
+        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
+    )
+    monkeypatch.setattr(
+        gate, "_snapshot_is_complete_whisper_model", lambda name: True
+    )
+    cli._ensure_model_downloaded("openai/whisper-cached")
+    assert "is not cached" not in capsys.readouterr().err
+
+
 def test_online_uncached_still_attempts_download(monkeypatch, capsys):
     """Without offline switches, an uncached model still proceeds to the
     download path (no refusal) — connectivity may be available."""
@@ -114,3 +159,41 @@ def test_online_uncached_still_attempts_download(monkeypatch, capsys):
     with pytest.raises(StopIteration):
         cli._ensure_model_downloaded("badorg/offline-missing-model")
     assert "is not cached and the network is unavailable" not in capsys.readouterr().err
+
+
+def test_gate_refuses_offline_uncached_before_notices(monkeypatch, capsys):
+    """``main()``'s B2 confirmation gate must refuse an offline + uncached
+    serve BEFORE printing any "Resolving"/"About to download"/"Proceeding"
+    notice. ``main()`` drives the gate with a patched isatty()==True and an
+    uncached repo id; the offline refusal fires first (SystemExit 1), and the
+    size-estimate + ``confirm_or_abort`` path is never reached (#2357-P2).
+    """
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    # Interactive so the gate's confirmation branch is active.
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    # Auto-pull off by default; explicit in case a vendor sets it.
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+
+    # The gate refuses first and exits(1), so serve_command is never reached
+    # (nor is the spinner'd size estimate / confirm path, which live below the
+    # offline short-circuit in main()). Guard both to catch a regression.
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "badorg/offline-missing-model"]),
+        patch.object(
+            cli, "serve_command", side_effect=AssertionError("must not dispatch")
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 1
+
+    out = capsys.readouterr()
+    assert "badorg/offline-missing-model is not cached" in out.err
+    assert "network is unavailable (offline mode is enabled)" in out.err
+    # No contradictory download notice precedes the single refusal.
+    assert "About to download" not in out.out
+    assert "Proceeding" not in out.out

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -160,6 +160,14 @@ def test_disk_gate_systemexit_still_propagates(monkeypatch, capsys):
     assert exc.value.code == 3
 
 
+class _DiskSpaceProbeError(Exception):
+    """Raised from ``_check_disk_space`` to prove the download path was
+    entered (not refused for offline). A real exception subclass, NOT
+    ``StopIteration`` — under PEP 479 a StopIteration sentinel thrown through a
+    generator becomes RuntimeError, so the assertion would fail on
+    interpreter/configs where that wraps the throw."""
+
+
 def test_online_uncached_still_attempts_download(monkeypatch, capsys):
     """Without offline switches, an uncached model still proceeds to the
     download path (no refusal) — connectivity may be available."""
@@ -170,10 +178,11 @@ def test_online_uncached_still_attempts_download(monkeypatch, capsys):
 
     # The download path reaches _check_disk_space first; swallow it so the
     # only assertion is that we did NOT hard-refuse for offline.
-    monkeypatch.setattr(
-        cli, "_check_disk_space", lambda *a, **k: (_ for _ in ()).throw(StopIteration())
-    )
-    with pytest.raises(StopIteration):
+    def _disk_gate_reached(*a, **k):
+        raise _DiskSpaceProbeError("entered disk-space gate")
+
+    monkeypatch.setattr(cli, "_check_disk_space", _disk_gate_reached)
+    with pytest.raises(_DiskSpaceProbeError):
         cli._ensure_model_downloaded("badorg/offline-missing-model")
     assert "is not cached and the network is unavailable" not in capsys.readouterr().err
 
@@ -227,7 +236,16 @@ def test_serve_audio_alias_refuses_offline_uncached(monkeypatch, capsys):
     main()'s B2 gate, and ``_serve_audio_mode`` loads weights lazily — so the
     audio fork itself must refuse an offline + uncached model BEFORE booting
     the audio server (codex #2357-P1-a)."""
+    from vllm_mlx.audio import probe
     from vllm_mlx.audio.registry import AudioAliasEntry
+
+    # ``serve_command`` gates audio aliases on ``require_audio_or_exit`` at the
+    # top, which exits(2) when ``mlx_audio`` is absent (base install / the
+    # no-MLX CI lane). Stub that availability seam so the test still reaches
+    # the offline-refusal fork below even with no ``mlx-audio`` installed —
+    # same technique neighbouring audio tests use (``_spy`` / probe stubs).
+    monkeypatch.setattr(probe, "is_audio_model_alias", lambda _name: True)
+    monkeypatch.setattr(probe, "require_audio_or_exit", lambda _name: None)
 
     # The resolved audio entry drives runnability + the refusal message.
     entry = AudioAliasEntry(

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -384,3 +384,46 @@ def test_gate_skips_offline_refusal_for_attached_client(monkeypatch, capsys):
     out = capsys.readouterr()
     assert "is not cached and the network is unavailable" not in out.err
     assert dispatched != []  # attached client proceeded to chat_command
+
+
+def test_offline_hub_mode_flags_parsed_independently(monkeypatch):
+    """HF_HUB_OFFLINE and TRANSFORMERS_OFFLINE are parsed independently and
+    OR-ed: one switch being disabled must NOT mask the other being enabled.
+
+    Regression for the parser folding both into a single string
+    (``_is_true(get(A) or get(B))``) which turned ``HF_HUB_OFFLINE=0`` +
+    ``TRANSFORMERS_OFFLINE=1`` into offline-INACTIVE.
+    """
+    # HF=0 would short-circuit the fold to "0"; TRANSFORMERS=1 must still win.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert cli._offline_hub_mode_active() is True
+
+    # And the mirror: TRANSFORMERS=0 must not mask HF=1.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "yes")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "0")
+    assert cli._offline_hub_mode_active() is True
+
+    # Only when BOTH are disabled is offline truly inactive (no masking).
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "false")
+    assert cli._offline_hub_mode_active() is False
+
+
+def test_cache_probe_fault_fails_open_for_offline(monkeypatch):
+    """A typed cachedness-probe fault (permission / malformed) must NOT
+    conclude 'uncached': _cache_entry_is_runnable returns True (fail open) so
+    the offline gate refuses only when uncachedness is established."""
+    # Induce an expected probe fault in resolve_audio_alias.
+    monkeypatch.setattr(
+        "vllm_mlx.audio.registry.resolve_audio_alias",
+        lambda repo: (_ for _ in ()).throw(OSError("denied")),
+    )
+    assert cli._cache_entry_is_runnable("any/repo") is True
+
+    # Same for a malformed-cache KeyError / structural ValueError.
+    monkeypatch.setattr(
+        "vllm_mlx.audio.registry.resolve_audio_alias",
+        lambda repo: (_ for _ in ()).throw(KeyError("hdr")),
+    )
+    assert cli._cache_entry_is_runnable("any/repo") is True

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -19,12 +19,36 @@ fully-cached mflux / split-video / Whisper model is never refused.
 from __future__ import annotations
 
 import sys
+from argparse import Namespace
 from unittest.mock import patch
 
 import pytest
 
 from vllm_mlx import cli
 
+
+def _make_serve_args(model: str) -> Namespace:
+    """Minimal serve ``Namespace`` mirroring test_audio_alias_registry's helper
+    so the audio-serve fork in ``serve_command`` is reachable under test."""
+    return Namespace(
+        model=model,
+        _original_alias=model,
+        embedding_model=None,
+        served_model_name=None,
+        no_mllm=True,
+        mllm=False,
+        max_tokens=None,
+        api_key=None,
+        timeout=60,
+        max_request_bytes=None,
+        cors_origins=None,
+        rate_limit=0,
+        log_level="INFO",
+        host="127.0.0.1",
+        port=8000,
+        listen_fd=None,
+        watchdog_ppid=None,
+    )
 
 def _uncached_probe(monkeypatch):
     """Force the runnability predicate to report "not cached runnable",
@@ -193,3 +217,83 @@ def test_gate_refuses_offline_uncached_before_notices(monkeypatch, capsys):
     # No contradictory download notice precedes the single refusal.
     assert "About to download" not in out.out
     assert "Proceeding" not in out.out
+
+
+def test_serve_audio_alias_refuses_offline_uncached(monkeypatch, capsys):
+    """``serve whisper`` (a short audio alias with no '/') never reaches
+    main()'s B2 gate, and ``_serve_audio_mode`` loads weights lazily — so the
+    audio fork itself must refuse an offline + uncached model BEFORE booting
+    the audio server (codex #2357-P1-a)."""
+    from vllm_mlx.audio.registry import AudioAliasEntry
+
+    # The resolved audio entry drives runnability + the refusal message.
+    entry = AudioAliasEntry(
+        alias="whisper",
+        type="stt",
+        hf_id="mlx-community/whisper-tiny-mlx",
+        family="whisper",
+    )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+    reached_audio_boot = []
+
+    def _cannot_boot(*a, **k):
+        reached_audio_boot.append(a)
+        raise AssertionError("audio server must not boot for offline+uncached")
+
+    with (
+        patch.object(cli, "_resolve_audio_model_for_serve", return_value=entry),
+        patch.object(cli, "_serve_audio_mode", side_effect=_cannot_boot),
+    ):
+        args = _make_serve_args("whisper")
+        with pytest.raises(SystemExit) as exc:
+            cli.serve_command(args)
+    assert exc.value.code == 1
+    out = capsys.readouterr()
+    assert "mlx-community/whisper-tiny-mlx is not cached" in out.err
+    assert "network is unavailable (offline mode is enabled)" in out.err
+    assert reached_audio_boot == []
+
+
+def test_gate_does_not_refuse_when_wan_local_dir_set(monkeypatch, capsys, tmp_path):
+    """An offline user serving a Wan video alias with a valid
+    ``RAPID_MLX_WAN_MODEL_DIR`` local checkpoint must NOT be refused — Wan's
+    own lane loads from the local dir and never goes through
+    ``_ensure_model_downloaded`` (codex #2357-P1-b)."""
+    import vllm_mlx._download_gate as gate
+
+    (tmp_path / "checkpoint").mkdir()
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("RAPID_MLX_WAN_MODEL_DIR", str(tmp_path))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+
+    confirmed = []
+
+    # Below the (skipped) offline refusal, the gate lands in the size-estimate
+    # + confirm path. Stub both so the only assertion is that the refusal did
+    # NOT fire; serve_command must still not be reached (gate self-skips or
+    # confirm handles it), so we patch it to a sentinel just in case.
+    monkeypatch.setattr(gate, "estimate_repo_size_bytes", lambda name: 1)
+    monkeypatch.setattr(
+        gate, "confirm_or_abort", lambda *a, **k: confirmed.append(a)
+    )
+    dispatched = []
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["rapid-mlx", "serve", "Anes1032/Wan2.2-TI2V-5B-mlx-q8"],
+        ),
+        patch.object(cli, "serve_command", side_effect=dispatched.append),
+    ):
+        cli.main()
+
+    out = capsys.readouterr()
+    assert "is not cached and the network is unavailable" not in out.err
+    assert confirmed != []  # the refusal was skipped; the confirm path ran
+    assert dispatched != []  # … and serve still dispatched the Wan model

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -297,3 +297,35 @@ def test_gate_does_not_refuse_when_wan_local_dir_set(monkeypatch, capsys, tmp_pa
     assert "is not cached and the network is unavailable" not in out.err
     assert confirmed != []  # the refusal was skipped; the confirm path ran
     assert dispatched != []  # … and serve still dispatched the Wan model
+
+
+def test_gate_wan_dir_set_does_not_exempt_text_model(monkeypatch, capsys, tmp_path):
+    """A stray ``RAPID_MLX_WAN_MODEL_DIR`` must NOT exempt an unrelated text
+    model from the offline refusal — the exemption is scoped to the video-gen
+    lane (codex #2357-P2)."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("RAPID_MLX_WAN_MODEL_DIR", str(tmp_path))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["rapid-mlx", "serve", "mlx-community/Qwen3.5-4B-4bit"],
+        ),
+        patch.object(
+            cli, "serve_command", side_effect=AssertionError("must not dispatch")
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 1
+    out = capsys.readouterr()
+    assert "mlx-community/Qwen3.5-4B-4bit is not cached" in out.err
+    assert "network is unavailable (offline mode is enabled)" in out.err

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -329,3 +329,39 @@ def test_gate_wan_dir_set_does_not_exempt_text_model(monkeypatch, capsys, tmp_pa
     out = capsys.readouterr()
     assert "mlx-community/Qwen3.5-4B-4bit is not cached" in out.err
     assert "network is unavailable (offline mode is enabled)" in out.err
+
+
+def test_gate_skips_offline_refusal_for_attached_client(monkeypatch, capsys):
+    """A chat/bench attached client (--base-url/--port pointing at an existing
+    server) must NOT be refused for a model absent from the local cache — the
+    named model lives remotely and is never meant to be downloaded locally
+    (codex #2357-P1)."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda name: False)
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    dispatched = []
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "rapid-mlx",
+                "chat",
+                "mlx-community/Qwen3.5-4B-4bit",
+                "--base-url",
+                "http://127.0.0.1:9999",
+            ],
+        ),
+        patch.object(cli, "chat_command", side_effect=dispatched.append),
+    ):
+        cli.main()
+
+    out = capsys.readouterr()
+    assert "is not cached and the network is unavailable" not in out.err
+    assert dispatched != []  # attached client proceeded to chat_command

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for offline-serve refusal when a model is uncached (#2357).
+
+``rapid-mlx serve <uncached-model>`` under ``HF_HUB_OFFLINE=1`` /
+``TRANSFORMERS_OFFLINE=1`` used to fall through every download attempt (each
+printing "First-time download" / "Pre-download skipped; server will retry"),
+let the serve subprocess start, and end in misleading ``--mllm``/``--no-mllm``
+lane advice even though neither flag can supply the missing checkpoint.
+
+The fix (in ``_ensure_model_downloaded``) detects the offline + uncached
+condition ONCE, states which repository is missing, points to ``rapid-mlx
+pull`` and the expected cache location, and exits(1) before server
+initialization — mirroring the TimeoutError / disk-space exits. A lane override
+is never recommended when the checkpoint is simply absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx import cli
+
+
+def _uncached_probe(monkeypatch):
+    """Force the cache probes to report "not cached" (weights absent)."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda name: False)
+    monkeypatch.setattr(
+        gate, "mflux_missing_weights", lambda name: ["model.safetensors"]
+    )
+
+
+def test_offline_hub_mode_detects_env_switches(monkeypatch):
+    """Both offline switches flip the helper on; any truthy value counts."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    assert cli._offline_hub_mode_active() is True
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "true")
+    assert cli._offline_hub_mode_active() is True
+
+    # Both absent -> online.
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    assert cli._offline_hub_mode_active() is False
+
+
+def test_offline_uncached_serve_refuses_before_download(monkeypatch, capsys):
+    """Offline + uncached must exit(1) with one actionable message and NOT
+    attempt the download/mirror path (no repeated "First-time download")."""
+    _uncached_probe(monkeypatch)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+
+    sentinel = []
+
+    def _fail(*a, **k):
+        sentinel.append(a)
+        raise AssertionError("download/mirror path must not be reached offline")
+
+    for name in ("_check_disk_space", "_try_mirror_prefetch"):
+        monkeypatch.setattr(cli, name, _fail)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._ensure_model_downloaded("badorg/offline-missing-model")
+    assert exc.value.code == 1
+
+    out = capsys.readouterr()
+    assert "badorg/offline-missing-model is not cached" in out.err
+    assert "network is unavailable (offline mode is enabled)" in out.err
+    assert "rapid-mlx pull badorg/offline-missing-model" in out.err
+    assert "cache location" in out.err
+    # No repeated download phase, no "server will retry".
+    assert "server will retry" not in out.err
+    assert "First-time download" not in out.err
+    assert sentinel == []  # neither disk-space nor mirror was attempted
+
+
+def test_offline_refusal_counts_transformer_offline_too(monkeypatch, capsys):
+    _uncached_probe(monkeypatch)
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._ensure_model_downloaded("badorg/offline-missing-model")
+    assert exc.value.code == 1
+    assert "not cached and the network is unavailable" in capsys.readouterr().err
+
+
+def test_offline_local_path_is_noop_not_refused(monkeypatch, capsys):
+    """A local path is a no-op even under offline mode — never refused."""
+    import tempfile
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    with tempfile.TemporaryDirectory() as d:
+        cli._ensure_model_downloaded(d)  # os.path.exists -> early return
+    assert "is not cached" not in capsys.readouterr().err
+
+
+def test_online_uncached_still_attempts_download(monkeypatch, capsys):
+    """Without offline switches, an uncached model still proceeds to the
+    download path (no refusal) — connectivity may be available."""
+    _uncached_probe(monkeypatch)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "")
+    monkeypatch.setattr(cli.os.path, "exists", lambda p: False)
+
+    # The download path reaches _check_disk_space first; swallow it so the
+    # only assertion is that we did NOT hard-refuse for offline.
+    monkeypatch.setattr(
+        cli, "_check_disk_space", lambda *a, **k: (_ for _ in ()).throw(StopIteration())
+    )
+    with pytest.raises(StopIteration):
+        cli._ensure_model_downloaded("badorg/offline-missing-model")
+    assert "is not cached and the network is unavailable" not in capsys.readouterr().err

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3075,10 +3075,12 @@ def serve_command(args):
         # short audio alias (``serve whisper``) never reaches it — and
         # ``_serve_audio_mode`` loads weights lazily on first request, so
         # without this the server would boot and only fail mid-request.
-        # Judge runnability with the SAME ``_cache_entry_is_runnable``
-        # predicate (which family-scopes the Whisper ``weights.npz`` probe).
-        if _offline_hub_mode_active() and not _cache_entry_is_runnable(
-            audio_entry.hf_id
+        # Judge runnability with the SAME probe core (which family-scopes the
+        # Whisper ``weights.npz`` probe). The offline-refusal decision uses the
+        # tri-state ``is False`` so a probe fault (``None``) does not refuse.
+        if (
+            _offline_hub_mode_active()
+            and _cache_runnability(audio_entry.hf_id) is False
         ):
             _refuse_offline_uncached(audio_entry.hf_id)
         _serve_audio_mode(args, audio_entry)
@@ -5706,21 +5708,24 @@ def _scan_external_model_dirs(
     return out
 
 
-def _cache_entry_is_runnable(repo: str) -> bool:
-    """Whether a cache directory contains a complete runnable snapshot.
+def _cache_runnability(repo: str) -> bool | None:
+    """Tri-state cache runnability: ``True`` runnable, ``False`` definitively
+    not, ``None`` = inconclusive (a probe fault masked a real verdict).
 
-    A Hugging Face repo directory appears as soon as metadata starts
-    downloading.  Treating directory presence as "cached" made interrupted
-    downloads (config/tokenizer only, no weights) look ready in ``ls`` and in
-    the desktop model picker. Reuse the serve download gate's authoritative
-    completeness checks for both text and component-split video layouts.
+    This is the probe-level core. A probe fault — cache-dir permission,
+    malformed index/header — does NOT tell us whether the checkpoint is
+    cached (it may well be). Callers must decide what ``None`` means:
 
-    ``resolve_unreferenced_cached_snapshot`` closes the #2351 gap: a complete,
-    unambiguous SINGLE snapshot with no ``refs/main`` (a commit-pinned
-    ``snapshot_download`` / manual pull) is loadable by the routing & loader
-    contract — the inventory must report it available, not ``(incomplete)``,
-    so ``models --cached`` and the serve gate agree with the loader. Multiple
-    snapshots are ambiguous and stay unresolved there.
+      * Skip-download / inventory callers (``_ensure_model_downloaded``,
+        ``models --cached``) treat ``None`` as **not runnable** (via
+        :func:`_cache_entry_is_runnable`, which collapses ``None`` to
+        ``False``) — they must never skip a download or show a checkmark on
+        a checkpoint whose cachedness could not be verified.
+      * Offline-refusal callers treat ``None`` as **do not refuse** (they
+        compare ``is False`` directly) — offline refuses only when
+        uncachedness is actually established, never on a probe fault.
+
+    Unexpected exceptions are genuine bugs and still propagate.
     """
     try:
         from vllm_mlx._download_gate import (
@@ -5742,18 +5747,37 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             or resolve_unreferenced_cached_snapshot(repo) is not None
         )
     except (OSError, KeyError, ValueError) as exc:
-        # A probe fault (cache-dir permission, malformed index/header) is not
-        # evidence the model is absent: we could not establish cachedness at
-        # all. Refuse offline only when uncachedness is established, so treat
-        # probe faults as runnable (fail open) here and let the caller's
-        # offline gate NOT refuse. Unexpected exceptions are genuine bugs and
-        # still propagate.
         import logging
 
         logging.getLogger(__name__).warning(
             "Could not probe cachedness of %r: %s", repo, exc
         )
-        return True
+        return None
+
+
+def _cache_entry_is_runnable(repo: str) -> bool:
+    """Whether a cache directory contains a complete runnable snapshot.
+
+    A Hugging Face repo directory appears as soon as metadata starts
+    downloading.  Treating directory presence as "cached" made interrupted
+    downloads (config/tokenizer only, no weights) look ready in ``ls`` and in
+    the desktop model picker. Reuse the serve download gate's authoritative
+    completeness checks for both text and component-split video layouts.
+
+    ``resolve_unreferenced_cached_snapshot`` closes the #2351 gap: a complete,
+    unambiguous SINGLE snapshot with no ``refs/main`` (a commit-pinned
+    ``snapshot_download`` / manual pull) is loadable by the routing & loader
+    contract — the inventory must report it available, not ``(incomplete)``,
+    so ``models --cached`` and the serve gate agree with the loader. Multiple
+    snapshots are ambiguous and stay unresolved there.
+
+    A probe fault (see :func:`_cache_runnability`) collapses to ``False``
+    here: skip-download and inventory callers must not treat a checkpoint
+    whose cachedness could not be established as runnable. The offline-refusal
+    callers use the tri-state core directly (``is False``) so that a probe
+    fault does not make them refuse.
+    """
+    return _cache_runnability(repo) is True
 
 
 def _print_cached_models() -> None:
@@ -8286,8 +8310,9 @@ def chat_command(args):
                     # override exemption is likewise scoped to video-gen.
                     # Only print + return (stay in the REPL), not sys.exit —
                     # a failed /model must never kill the chat session.
-                    if _offline_hub_mode_active() and not _cache_entry_is_runnable(
-                        resolved
+                    if (
+                        _offline_hub_mode_active()
+                        and _cache_runnability(resolved) is False
                     ):
                         print(_offline_uncached_error(resolved), file=sys.stderr)
                         return
@@ -11856,7 +11881,7 @@ def main():
                     )
                 if (
                     _offline_hub_mode_active()
-                    and not _cache_entry_is_runnable(args.model)
+                    and _cache_runnability(args.model) is False
                     and not _is_wane_exempt
                 ):
                     _refuse_offline_uncached(args.model)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1675,7 +1675,8 @@ def _offline_uncached_error(model_name: str) -> str:
     return (
         f"\n  Error: {model_name} is not cached and the network is "
         "unavailable (offline mode is enabled).\n"
-        f"  After connectivity is restored, download it with "
+        f"  After connectivity is restored, disable offline mode "
+        f"(unset HF_HUB_OFFLINE and TRANSFORMERS_OFFLINE) and run "
         f"`rapid-mlx pull {model_name}`, then serve again.\n"
         f"  Expected cache location: {HF_HUB_CACHE}\n"
     )
@@ -11771,6 +11772,16 @@ def main():
     _chat_spawn_child = os.environ.pop("RAPID_MLX_CHAT_SPAWN", "") == "1"
 
     _GATED_COMMANDS = {"chat", "run", "serve", "pull", "bench"}
+    # Attached client (chat/bench pointed at an existing server via
+    # --base-url/--port): the named model lives remotely and is NOT meant to
+    # be downloaded into the local HF cache, so neither the confirm gate nor
+    # the offline+uncached refusal applies (codex #2357-P1). --port on a
+    # top-level serve means "bind here", not "attach", so only the
+    # client-capable commands are exempted.
+    _attached_remote = (
+        getattr(args, "command", None) in {"chat", "run", "bench"}
+        and (getattr(args, "base_url", None) or getattr(args, "port", None) is not None)
+    )
     if (
         getattr(args, "command", None) in _GATED_COMMANDS
         and hasattr(args, "model")
@@ -11778,6 +11789,7 @@ def main():
         and "/" in args.model  # only HF-style repo ids; local paths skip
         and not os.path.exists(args.model)
         and not _chat_spawn_child
+        and not _attached_remote
     ):
         # Cheap checks first: env override and non-TTY both short-circuit
         # without touching the HF API. ``confirm_or_abort`` re-checks

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1644,24 +1644,29 @@ def _try_mirror_prefetch(
     )
 
 
+def _env_flag_active(raw: str | None) -> bool:
+    """True when an HF/transformers offline-style env flag is enabled.
+
+    Bounded local truth-value predicate reproducing huggingface_hub's
+    ``_is_true`` semantics exactly (only ``1``/``ON``/``YES``/``TRUE`` count;
+    ``0``/``false``/empty leave it off) without depending on the library's
+    private ``constants._is_true`` helper, whose return type is untyped.
+    """
+    return raw is not None and str(raw).lower() in {"1", "on", "yes", "true"}
+
+
 def _offline_hub_mode_active() -> bool:
     """True when the HF/transformers offline switches pin hub access local-only.
 
-    Reproduces huggingface_hub's ``constants`` computation exactly (same
-    ``_is_true`` truthiness — ``1``/``ON``/``YES``/``TRUE`` only, so ``0``/
-    ``false`` leave offline disabled) and folds ``TRANSFORMERS_OFFLINE`` in the
-    same way the download layer does. Unlike ``constants.HF_HUB_OFFLINE`` (a
-    value baked once at import), this reads the environment live so it stays
-    truthful when tests monkeypatch the switches.
+    Reads both offline switches live (so tests monkeypatching them stay
+    truthful) and treats each **independently** before OR-ing: folding them
+    with ``os.environ.get(...) or os.environ.get(...)`` into one string lets a
+    ``HF_HUB_OFFLINE=0`` mask ``TRANSFORMERS_OFFLINE=1`` (or vice-versa), which
+    the download layer does not do.
     """
-    from huggingface_hub.constants import _is_true
-
-    # huggingface_hub's `_is_true` is untyped (returns Any); narrow to bool so
-    # this helper stays on the shrink-only mypy budget (no-any-return).
-    offline: bool = _is_true(
-        os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")
+    return _env_flag_active(os.environ.get("HF_HUB_OFFLINE")) or _env_flag_active(
+        os.environ.get("TRANSFORMERS_OFFLINE")
     )
-    return offline
 
 
 def _offline_uncached_error(model_name: str) -> str:
@@ -5736,8 +5741,19 @@ def _cache_entry_is_runnable(repo: str) -> bool:
             or _snapshot_is_complete_mflux_model(repo)
             or resolve_unreferenced_cached_snapshot(repo) is not None
         )
-    except Exception:
-        return False
+    except (OSError, KeyError, ValueError) as exc:
+        # A probe fault (cache-dir permission, malformed index/header) is not
+        # evidence the model is absent: we could not establish cachedness at
+        # all. Refuse offline only when uncachedness is established, so treat
+        # probe faults as runnable (fail open) here and let the caller's
+        # offline gate NOT refuse. Unexpected exceptions are genuine bugs and
+        # still propagate.
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Could not probe cachedness of %r: %s", repo, exc
+        )
+        return True
 
 
 def _print_cached_models() -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3061,6 +3061,15 @@ def serve_command(args):
         # routes still accept both forms because the registry's
         # reverse HF-id index covers full ids too.
         args.model = audio_entry.hf_id
+        # Offline + uncached audio (#2357): refuse BEFORE the audio-mode
+        # fork. The main() B2 gate only fires for ids containing '/', so a
+        # short audio alias (``serve whisper``) never reaches it — and
+        # ``_serve_audio_mode`` loads weights lazily on first request, so
+        # without this the server would boot and only fail mid-request.
+        # Judge runnability with the SAME ``_cache_entry_is_runnable``
+        # predicate (which family-scopes the Whisper ``weights.npz`` probe).
+        if _offline_hub_mode_active() and not _cache_entry_is_runnable(audio_entry.hf_id):
+            _refuse_offline_uncached(audio_entry.hf_id)
         _serve_audio_mode(args, audio_entry)
         return
 
@@ -11784,9 +11793,15 @@ def main():
                 # rather than ``is_repo_cached`` alone: a fully-cached mflux or
                 # split-video checkpoint has no root ``model*.safetensors``, so a
                 # text-only check would wrongly refuse a model that IS cached
-                # (codex #2357-P1).
-                if _offline_hub_mode_active() and not _cache_entry_is_runnable(
-                    args.model
+                # (codex #2357-P1). Also skip when a lane-local source makes the
+                # model available offline even with an empty HF cache — Wan's
+                # ``RAPID_MLX_WAN_MODEL_DIR`` override (its own download path
+                # never goes through ``_ensure_model_downloaded``) (codex #2357-P1).
+                _wan_dir = os.environ.get("RAPID_MLX_WAN_MODEL_DIR")
+                if (
+                    _offline_hub_mode_active()
+                    and not _cache_entry_is_runnable(args.model)
+                    and not (_wan_dir and os.path.isdir(_wan_dir))
                 ):
                     _refuse_offline_uncached(args.model)
                 # The size estimate is a silent HF ``model_info`` round-trip

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1645,15 +1645,46 @@ def _try_mirror_prefetch(
 
 
 def _offline_hub_mode_active() -> bool:
-    """True when the HF/transformers offline switches force local-only hub
-    access, making a download impossible regardless of connectivity.
+    """True when the HF/transformers offline switches pin hub access local-only.
 
-    Mirrors huggingface_hub's own semantics: ``HF_HUB_OFFLINE`` /
-    ``TRANSFORMERS_OFFLINE`` are truthy when set to any non-empty value.
+    Reproduces huggingface_hub's ``constants`` computation exactly (same
+    ``_is_true`` truthiness — ``1``/``ON``/``YES``/``TRUE`` only, so ``0``/
+    ``false`` leave offline disabled) and folds ``TRANSFORMERS_OFFLINE`` in the
+    same way the download layer does. Unlike ``constants.HF_HUB_OFFLINE`` (a
+    value baked once at import), this reads the environment live so it stays
+    truthful when tests monkeypatch the switches.
     """
-    hf_offline: str | None = os.environ.get("HF_HUB_OFFLINE")
-    transformers_offline: str | None = os.environ.get("TRANSFORMERS_OFFLINE")
-    return bool(hf_offline) or bool(transformers_offline)
+    from huggingface_hub.constants import _is_true
+
+    return _is_true(
+        os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")
+    )
+
+
+def _offline_uncached_error(model_name: str) -> str:
+    """Render the offline + uncached refusal body (one actionable message).
+
+    Reused verbatim by the ``main()`` confirmation gate (so the refusal fires
+    BEFORE any "About to download" notice) and by ``_ensure_model_downloaded``
+    (the belt-and-suspenders defense). A lane override is never recommended:
+    no ``--mllm``/``--no-mllm`` flag can supply a checkpoint that is simply
+    absent from the cache.
+    """
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    return (
+        f"\n  Error: {model_name} is not cached and the network is "
+        "unavailable (offline mode is enabled).\n"
+        f"  After connectivity is restored, download it with "
+        f"`rapid-mlx pull {model_name}`, then serve again.\n"
+        f"  Expected cache location: {HF_HUB_CACHE}\n"
+    )
+
+
+def _refuse_offline_uncached(model_name: str) -> None:
+    """Print the offline + uncached refusal and exit(1)."""
+    print(_offline_uncached_error(model_name), file=sys.stderr)
+    sys.exit(1)
 
 
 def _ensure_model_downloaded(
@@ -1680,7 +1711,12 @@ def _ensure_model_downloaded(
     # shards still in flight), letting the spawned ``serve`` quietly
     # finish the download inside its logfile. Codex round-3 BLOCKING #2.
     try:
-        from vllm_mlx._download_gate import is_repo_cached, mflux_missing_weights
+        from vllm_mlx._download_gate import (
+            _snapshot_is_complete_split_model,
+            _snapshot_is_complete_whisper_model,
+            is_repo_cached,
+            mflux_missing_weights,
+        )
 
         if is_repo_cached(model_name):
             return
@@ -1694,6 +1730,14 @@ def _ensure_model_downloaded(
         # while the UI shows "Starting" forever. Verified-complete component
         # weights are just as cached as a verified-complete root checkpoint.
         if mflux_missing_weights(model_name) == []:
+            return
+        # Non-text layouts ``is_repo_cached`` cannot see are just as runnable
+        # offline: a fully-cached component-split video (CogVideoX / LTX) or a
+        # Whisper snapshot. Without these, the offline refusal below would
+        # wrongly block a model that IS cached (codex #2357-R1 split-video P1).
+        if _snapshot_is_complete_split_model(model_name) or (
+            _snapshot_is_complete_whisper_model(model_name)
+        ):
             return
     except Exception:
         # Probe failed (filesystem permission error, unexpected layout) —
@@ -1712,17 +1756,7 @@ def _ensure_model_downloaded(
     # lane advice when the checkpoint is simply absent. This mirrors the
     # TimeoutError / disk-space exits: refuse before server initialization.
     if _offline_hub_mode_active():
-        from huggingface_hub.constants import HF_HUB_CACHE
-
-        print(
-            f"\n  Error: {model_name} is not cached and the network is "
-            "unavailable (offline mode is enabled).\n"
-            f"  After connectivity is restored, download it with "
-            f"`rapid-mlx pull {model_name}`, then serve again.\n"
-            f"  Expected cache location: {HF_HUB_CACHE}\n",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        _refuse_offline_uncached(model_name)
 
     # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)
     # and the mirror's own metadata + ``/api/models`` catalog round-trips run
@@ -8255,16 +8289,21 @@ def chat_command(args):
                         )
                         return
 
-        # 1. Pre-download the new model (this also runs the disk-space
-        #    gate). The current server keeps running while we do this so
-        #    a download failure leaves the user where they were.
+        # 1. Pre-download the new model (this also runs the disk-space gate
+        #    and the offline+uncached refusal). The current server keeps
+        #    running while we do this so a download failure leaves the user
+        #    where they were.
         try:
             _ensure_model_downloaded(resolved)
         except SystemExit:
-            # Disk gate aborted via sys.exit(1); old server is untouched.
+            # A fatal pre-download condition aborted via sys.exit(1) — disk
+            # gate, offline+uncached, or resolve timeout. Each path printed
+            # its own specific reason to stderr, so this summary deliberately
+            # does NOT re-attribute it as the disk gate (#2357). Old server
+            # is untouched.
             print(
                 f"  {RED}Model switch aborted{RESET} "
-                f"{DIM}(disk gate); previous server still running.{RESET}\n"
+                f"{DIM}(reason above); previous server still running.{RESET}\n"
             )
             return
         except RuntimeError as exc:
@@ -11762,6 +11801,16 @@ def main():
             )
 
             if not is_repo_cached(args.model):
+                # Offline + uncached (#2357): short-circuit BEFORE the size
+                # estimate + ``confirm_or_abort``. ``estimate_repo_size_bytes``
+                # makes a silent HF ``model_info`` round-trip that returns None
+                # under offline mode, which ``confirm_or_abort`` treats as
+                # "about to download … proceed" — so without this, the user
+                # would see a contradictory "About to download / Proceeding
+                # anyway" pair right before the refusal below. Refuse once here,
+                # identically to ``_ensure_model_downloaded``.
+                if _offline_hub_mode_active():
+                    _refuse_offline_uncached(args.model)
                 # The size estimate is a silent HF ``model_info`` round-trip
                 # (up to 5s). Cover it with a "Resolving…" spinner so the
                 # first-run cold start doesn't read as a hang here — the same

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1644,6 +1644,18 @@ def _try_mirror_prefetch(
     )
 
 
+def _offline_hub_mode_active() -> bool:
+    """True when the HF/transformers offline switches force local-only hub
+    access, making a download impossible regardless of connectivity.
+
+    Mirrors huggingface_hub's own semantics: ``HF_HUB_OFFLINE`` /
+    ``TRANSFORMERS_OFFLINE`` are truthy when set to any non-empty value.
+    """
+    hf_offline: str | None = os.environ.get("HF_HUB_OFFLINE")
+    transformers_offline: str | None = os.environ.get("TRANSFORMERS_OFFLINE")
+    return bool(hf_offline) or bool(transformers_offline)
+
+
 def _ensure_model_downloaded(
     model_name: str, *, force_disk_check: bool = False
 ) -> None:
@@ -1689,6 +1701,28 @@ def _ensure_model_downloaded(
         # short-circuit on its own cache check if the repo really is
         # fully present.
         pass
+
+    # Offline + uncached refusal (#2357): reaching this point means the model is
+    # NOT cached (the probes above returned on every cached/complete shape) and
+    # it is not a local path. If the hub is pinned to offline mode, a download
+    # is impossible, so refuse NOW with one actionable message instead of
+    # falling through to the network attempts that each fail and let the serve
+    # subprocess re-download — which duplicates "First-time download" /
+    # "Pre-download skipped" and eventually ends in misleading --mllm/--no-mllm
+    # lane advice when the checkpoint is simply absent. This mirrors the
+    # TimeoutError / disk-space exits: refuse before server initialization.
+    if _offline_hub_mode_active():
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        print(
+            f"\n  Error: {model_name} is not cached and the network is "
+            "unavailable (offline mode is enabled).\n"
+            f"  After connectivity is restored, download it with "
+            f"`rapid-mlx pull {model_name}`, then serve again.\n"
+            f"  Expected cache location: {HF_HUB_CACHE}\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)
     # and the mirror's own metadata + ``/api/models`` catalog round-trips run

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3069,7 +3069,9 @@ def serve_command(args):
         # without this the server would boot and only fail mid-request.
         # Judge runnability with the SAME ``_cache_entry_is_runnable``
         # predicate (which family-scopes the Whisper ``weights.npz`` probe).
-        if _offline_hub_mode_active() and not _cache_entry_is_runnable(audio_entry.hf_id):
+        if _offline_hub_mode_active() and not _cache_entry_is_runnable(
+            audio_entry.hf_id
+        ):
             _refuse_offline_uncached(audio_entry.hf_id)
         _serve_audio_mode(args, audio_entry)
         return
@@ -11778,9 +11780,8 @@ def main():
     # the offline+uncached refusal applies (codex #2357-P1). --port on a
     # top-level serve means "bind here", not "attach", so only the
     # client-capable commands are exempted.
-    _attached_remote = (
-        getattr(args, "command", None) in {"chat", "run", "bench"}
-        and (getattr(args, "base_url", None) or getattr(args, "port", None) is not None)
+    _attached_remote = getattr(args, "command", None) in {"chat", "run", "bench"} and (
+        getattr(args, "base_url", None) or getattr(args, "port", None) is not None
     )
     if (
         getattr(args, "command", None) in _GATED_COMMANDS
@@ -11832,9 +11833,7 @@ def main():
                     _is_wane_exempt = (
                         _rp_entry is not None
                         and _rp_entry.modality == "video-gen"
-                        and os.path.isdir(
-                            os.environ.get("RAPID_MLX_WAN_MODEL_DIR", "")
-                        )
+                        and os.path.isdir(os.environ.get("RAPID_MLX_WAN_MODEL_DIR", ""))
                     )
                 if (
                     _offline_hub_mode_active()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1656,9 +1656,12 @@ def _offline_hub_mode_active() -> bool:
     """
     from huggingface_hub.constants import _is_true
 
-    return _is_true(
+    # huggingface_hub's `_is_true` is untyped (returns Any); narrow to bool so
+    # this helper stays on the shrink-only mypy budget (no-any-return).
+    offline: bool = _is_true(
         os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")
     )
+    return offline
 
 
 def _offline_uncached_error(model_name: str) -> str:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8256,6 +8256,19 @@ def chat_command(args):
                 )
 
                 if not is_repo_cached(resolved):
+                    # Offline + uncached (/model swap): refuse BEFORE the size
+                    # estimate + confirm, so the user sees the one actionable
+                    # offline reason instead of an "About to download" notice
+                    # or a confirm they can cancel without learning why
+                    # (#2357). Mirrors the main() serve gate; the Wan dir
+                    # override exemption is likewise scoped to video-gen.
+                    # Only print + return (stay in the REPL), not sys.exit —
+                    # a failed /model must never kill the chat session.
+                    if _offline_hub_mode_active() and not _cache_entry_is_runnable(
+                        resolved
+                    ):
+                        print(_offline_uncached_error(resolved), file=sys.stderr)
+                        return
                     try:
                         confirm_or_abort(
                             resolved,
@@ -11797,11 +11810,24 @@ def main():
                 # model available offline even with an empty HF cache — Wan's
                 # ``RAPID_MLX_WAN_MODEL_DIR`` override (its own download path
                 # never goes through ``_ensure_model_downloaded``) (codex #2357-P1).
-                _wan_dir = os.environ.get("RAPID_MLX_WAN_MODEL_DIR")
+                # The exemption is scoped to the video-gen lane so a stray env
+                # var can't exempt an unrelated text model from the refusal.
+                _is_wane_exempt = False
+                if os.environ.get("RAPID_MLX_WAN_MODEL_DIR"):
+                    from vllm_mlx.model_aliases import resolve_profile as _rp
+
+                    _rp_entry = _rp(args.model)
+                    _is_wane_exempt = (
+                        _rp_entry is not None
+                        and _rp_entry.modality == "video-gen"
+                        and os.path.isdir(
+                            os.environ.get("RAPID_MLX_WAN_MODEL_DIR", "")
+                        )
+                    )
                 if (
                     _offline_hub_mode_active()
                     and not _cache_entry_is_runnable(args.model)
-                    and not (_wan_dir and os.path.isdir(_wan_dir))
+                    and not _is_wane_exempt
                 ):
                     _refuse_offline_uncached(args.model)
                 # The size estimate is a silent HF ``model_info`` round-trip

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1714,28 +1714,38 @@ def _ensure_model_downloaded(
     """
     if os.path.exists(model_name):
         return
-    # Reuse the cache inventory's single runnability predicate
-    # (``_cache_entry_is_runnable``, the same source ``models --cached`` uses)
-    # so what counts as "already cached" is identical everywhere and spans
-    # every modality: text ``model*.safetensors`` (``is_repo_cached``), mflux
+    # Reuse the cache inventory's single runnability probe core
+    # (``_cache_runnability``, the same source ``models --cached`` uses) so
+    # what counts as "already cached" is identical everywhere and spans every
+    # modality: text ``model*.safetensors`` (``is_repo_cached``), mflux
     # component weights, component-split video, and family-scoped Whisper
     # ``weights.npz``. A text-only ``is_repo_cached`` check would wrongly read
     # a fully-downloaded mflux / split-video model as uncached and re-download
     # on every start — a slow start at best, a hung one (SYN_SENT against a
     # poisoned address) on a hostile DNS path (codex round-3 BLOCKING #2).
-    if _cache_entry_is_runnable(model_name):
+    #
+    # Keep the tri-state result here, not the boolean wrapper: only a
+    # definitively-runnable result short-circuits the download, and only a
+    # definitively-not-runnable result triggers the offline refusal. A probe
+    # fault (``None``) must neither skip the download (never assume usable
+    # weights we couldn't verify) nor refuse offline (never assert uncached we
+    # couldn't establish) — it falls through to the normal online path.
+    cachedness = _cache_runnability(model_name)
+    if cachedness is True:
         return
 
     # Offline + uncached refusal (#2357): reaching this point means the model is
     # NOT cached (the probes above returned on every cached/complete shape) and
-    # it is not a local path. If the hub is pinned to offline mode, a download
-    # is impossible, so refuse NOW with one actionable message instead of
-    # falling through to the network attempts that each fail and let the serve
+    # it is not a local path. Refuse ONLY when uncachedness is actually
+    # established (``is False``) — a probe fault is inconclusive and must not
+    # be refused. If the hub is pinned to offline mode, a download is
+    # impossible, so refuse NOW with one actionable message instead of falling
+    # through to the network attempts that each fail and let the serve
     # subprocess re-download — which duplicates "First-time download" /
     # "Pre-download skipped" and eventually ends in misleading --mllm/--no-mllm
     # lane advice when the checkpoint is simply absent. This mirrors the
     # TimeoutError / disk-space exits: refuse before server initialization.
-    if _offline_hub_mode_active():
+    if _offline_hub_mode_active() and cachedness is False:
         _refuse_offline_uncached(model_name)
 
     # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1705,46 +1705,17 @@ def _ensure_model_downloaded(
     """
     if os.path.exists(model_name):
         return
-    # Reuse the same weight-file-presence probe as ``is_repo_cached``:
-    # the older ``try_to_load_from_cache('config.json')`` check
-    # short-circuits on a partial cache (metadata downloaded, weight
-    # shards still in flight), letting the spawned ``serve`` quietly
-    # finish the download inside its logfile. Codex round-3 BLOCKING #2.
-    try:
-        from vllm_mlx._download_gate import (
-            _snapshot_is_complete_split_model,
-            _snapshot_is_complete_whisper_model,
-            is_repo_cached,
-            mflux_missing_weights,
-        )
-
-        if is_repo_cached(model_name):
-            return
-        # ``is_repo_cached`` probes for root ``model*.safetensors``, which an
-        # mflux checkpoint never has — its weights live under ``transformer/``,
-        # ``text_encoder/`` and ``vae/``. So a fully-downloaded image model
-        # always failed that probe and fell through to the disk-space gate and
-        # the mirror below, i.e. every single start of an image model needed
-        # the network. On a hostile DNS path that is not a slow start but a
-        # hung one: the socket sits in SYN_SENT against a poisoned address
-        # while the UI shows "Starting" forever. Verified-complete component
-        # weights are just as cached as a verified-complete root checkpoint.
-        if mflux_missing_weights(model_name) == []:
-            return
-        # Non-text layouts ``is_repo_cached`` cannot see are just as runnable
-        # offline: a fully-cached component-split video (CogVideoX / LTX) or a
-        # Whisper snapshot. Without these, the offline refusal below would
-        # wrongly block a model that IS cached (codex #2357-R1 split-video P1).
-        if _snapshot_is_complete_split_model(model_name) or (
-            _snapshot_is_complete_whisper_model(model_name)
-        ):
-            return
-    except Exception:
-        # Probe failed (filesystem permission error, unexpected layout) —
-        # fall through to the heavy snapshot_download path; HF will
-        # short-circuit on its own cache check if the repo really is
-        # fully present.
-        pass
+    # Reuse the cache inventory's single runnability predicate
+    # (``_cache_entry_is_runnable``, the same source ``models --cached`` uses)
+    # so what counts as "already cached" is identical everywhere and spans
+    # every modality: text ``model*.safetensors`` (``is_repo_cached``), mflux
+    # component weights, component-split video, and family-scoped Whisper
+    # ``weights.npz``. A text-only ``is_repo_cached`` check would wrongly read
+    # a fully-downloaded mflux / split-video model as uncached and re-download
+    # on every start — a slow start at best, a hung one (SYN_SENT against a
+    # poisoned address) on a hostile DNS path (codex round-3 BLOCKING #2).
+    if _cache_entry_is_runnable(model_name):
+        return
 
     # Offline + uncached refusal (#2357): reaching this point means the model is
     # NOT cached (the probes above returned on every cached/complete shape) and
@@ -11808,8 +11779,15 @@ def main():
                 # "about to download … proceed" — so without this, the user
                 # would see a contradictory "About to download / Proceeding
                 # anyway" pair right before the refusal below. Refuse once here,
-                # identically to ``_ensure_model_downloaded``.
-                if _offline_hub_mode_active():
+                # identically to ``_ensure_model_downloaded``. Scope the refusal
+                # on the SAME runnability predicate (``_cache_entry_is_runnable``)
+                # rather than ``is_repo_cached`` alone: a fully-cached mflux or
+                # split-video checkpoint has no root ``model*.safetensors``, so a
+                # text-only check would wrongly refuse a model that IS cached
+                # (codex #2357-P1).
+                if _offline_hub_mode_active() and not _cache_entry_is_runnable(
+                    args.model
+                ):
                     _refuse_offline_uncached(args.model)
                 # The size estimate is a silent HF ``model_info`` round-trip
                 # (up to 5s). Cover it with a "Resolving…" spinner so the


### PR DESCRIPTION
Closes #2357

## Why

Serving an uncached model while the hub is offline fell through every
download/mirror attempt ("First-time download" / "Pre-download skipped; server
will retry"), let the subprocess re-download, and ended in misleading
`--mllm`/`--no-mllm` lane advice when the checkpoint is simply absent. This PR
makes `serve <uncached>` under `HF_HUB_OFFLINE=1` refuse **once**, before the
"About to download"/"Proceeding" notices, with a single actionable message
pointing at `rapid-mlx pull <model>` and the expected cache location.

## What changed

- **One-shot refusal at the serve gate** (B2), scoped on the shared
  `_cache_entry_is_runnable` predicate (the SSOT from `models --cached`), not
  text-only `is_repo_cached` — a cached mflux/split-video model is not refused.
- **Lane-aware**: audio and Wan-local-dir forks get the same centralized
  offline+uncached refusal pushed into their own serve path, before loading
  their engine (covers short aliases that bypassed the main gate).
- **Scoped exemptions**: Wan exemption is limited to video-gen (not blanket);
  attached-client / model-swap-before-confirm cases are handled explicitly.
- **codex R1 defects fixed** (both genuine, in-scope):
  1. `_offline_hub_mode_active()` now parses `HF_HUB_OFFLINE` and
     `TRANSFORMERS_OFFLINE` **independently** then ORs — `HF=0` no longer masks
     `TRANSFORMERS=1` (or vice-versa).
  2. `_cache_entry_is_runnable()` restores a typed expected-probe boundary
     (`except (OSError, KeyError, ValueError)`), failing **open** so a
     permission/malformed-cache probe fault does not crash serve before the
     intended online fallback; offline refuses only when uncachedness is
     actually established.
- **NIT + mypy regression**: the private `huggingface_hub._is_true` dependency
  is replaced by a bounded local truth predicate `_env_flag_active()`, which
  resolves the `/vllm_mlx/cli.py:1664 Returning Any from function declared to
  return bool [no-any-return]` mypy error (budget 27→28 fix).

## Validation

- tests/test_cli_offline_serve.py: 15/15 PASS (incl. new mask-independence and
  cache-probe-fault-fails-open cases)
- mypy budget (pinned mypy 2.3.1, Python 3.11): 719 / no growth (shrink-only vs
  base 32288e32)
- diff-cover on changed lines: 100%
- ruff clean; no-MLX lane clean (no module-top `mlx` import in changed tests)
- Rebased onto origin/main 32288e32 (train-3); PR diff is scoped to the 4 files
  above with no train-3 pollution.

Intended disposition: member of the 0.13.1 train-5 integration (before the
release bump). Not merged individually.
