### PR TITLE
feat: cached Wan checkpoints pinned by WAN_REVISIONS count as runnable (#2406 part B)

### DIFF
--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -486,6 +486,19 @@ def test_cache_entry_runnable_for_cached_kokoro(tmp_path, monkeypatch):
     assert cli._cache_entry_is_runnable(repo) is True
 
 
+def _seed_wan_hf_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> None:
+    """Seed an HF-cache-shaped Wan snapshot (blobs + snapshot symlinks)."""
+    repo_root = repo_root.resolve()
+    blobs = repo_root / "blobs"
+    blobs.mkdir(parents=True)
+    snap = repo_root / "snapshots" / pinned_sha
+    snap.mkdir(parents=True)
+    for name, payload in files.items():
+        blob = blobs / f"blob-{len(payload)}-{name}"
+        blob.write_bytes(payload)
+        (snap / name).symlink_to(blob)
+
+
 def test_runnable_recognizes_complete_pinned_wan_repo(tmp_path, monkeypatch):
     """A cached Wan checkpoint pinned by WAN_REVISIONS commit counts as runnable.
 
@@ -500,12 +513,16 @@ def test_runnable_recognizes_complete_pinned_wan_repo(tmp_path, monkeypatch):
     pinned_sha = WAN_REVISIONS[repo]
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo.replace('/', '--')}"
-    snapshot = repo_root / "snapshots" / pinned_sha
-    snapshot.mkdir(parents=True)
-    (snapshot / "config.json").write_text("{}")
-    (snapshot / "model.safetensors").write_bytes(b"w" * 1024)
-    (snapshot / "t5_encoder.safetensors").write_bytes(b"t" * 1024)
-    (snapshot / "vae.safetensors").write_bytes(b"v" * 1024)
+    _seed_wan_hf_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
     # No refs/main — pinned-by-commit download, exactly the live-serving shape.
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
@@ -557,12 +574,16 @@ def test_runnable_rejects_incomplete_pinned_wan_repo(tmp_path, monkeypatch):
     pinned_sha = WAN_REVISIONS[repo]
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo.replace('/', '--')}"
-    snapshot = repo_root / "snapshots" / pinned_sha
-    snapshot.mkdir(parents=True)
-    (snapshot / "config.json").write_text("{}")
-    (snapshot / "model.safetensors").write_bytes(b"w" * 1024)
-    (snapshot / "t5_encoder.safetensors").write_bytes(b"t" * 1024)
-    # vae.safetensors absent.
+    _seed_wan_hf_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            # vae.safetensors absent.
+        },
+    )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert cli._cache_entry_is_runnable(repo) is False

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -486,6 +486,32 @@ def test_cache_entry_runnable_for_cached_kokoro(tmp_path, monkeypatch):
     assert cli._cache_entry_is_runnable(repo) is True
 
 
+def test_runnable_recognizes_complete_pinned_wan_repo(tmp_path, monkeypatch):
+    """A cached Wan checkpoint pinned by WAN_REVISIONS commit counts as runnable.
+
+    ``snapshot_download(repo, revision=<sha>)`` caches under ``snapshots/<sha>``
+    without advancing ``refs/main`` and Wan ships no ``split_model.json``, so
+    only the Wan-specific probe sees this warm cache; ``_cache_entry_is_runnable``
+    must report it ready (not re-download on every start).
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+    pinned_sha = WAN_REVISIONS[repo]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo.replace('/', '--')}"
+    snapshot = repo_root / "snapshots" / pinned_sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"w" * 1024)
+    (snapshot / "t5_encoder.safetensors").write_bytes(b"t" * 1024)
+    (snapshot / "vae.safetensors").write_bytes(b"v" * 1024)
+    # No refs/main — pinned-by-commit download, exactly the live-serving shape.
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert cli._cache_entry_is_runnable(repo) is True
+
+
 def test_cache_entry_runnable_for_cached_whisper_turbo(tmp_path, monkeypatch):
     """A cached whisper-large-v3-turbo (``weights.safetensors``, not NPZ) is
     runnable via the audio-family branch."""
@@ -518,6 +544,25 @@ def test_cache_entry_not_runnable_for_metadata_only_kokoro(tmp_path, monkeypatch
     refs = repo_root / "refs"
     refs.mkdir()
     (refs / "main").write_text(sha)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert cli._cache_entry_is_runnable(repo) is False
+
+
+def test_runnable_rejects_incomplete_pinned_wan_repo(tmp_path, monkeypatch):
+    """A cached Wan repo missing a verified weight is NOT runnable."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+    pinned_sha = WAN_REVISIONS[repo]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo.replace('/', '--')}"
+    snapshot = repo_root / "snapshots" / pinned_sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"w" * 1024)
+    (snapshot / "t5_encoder.safetensors").write_bytes(b"t" * 1024)
+    # vae.safetensors absent.
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert cli._cache_entry_is_runnable(repo) is False

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -721,11 +721,23 @@ def _wan_pinned_pair() -> tuple[str, str]:
 
 
 def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> None:
-    """Write ``snapshots/<pinned_sha>`` under an HF-cache-shaped repo root."""
+    """Seed an HF-cache-shaped Wan snapshot: real blobs + snapshot symlinks.
+
+    Hugging Face stores every LFS blob under ``blobs/<etag>`` and materialises
+    each snapshot file as a **symlink** from ``snapshots/<sha>/<name>`` into the
+    repo's ``blobs/``. The completeness probe requires files to resolve strictly
+    inside ``blobs``, so the fixture mirrors that layout rather than dropping
+    plain files straight into the snapshot.
+    """
+    repo_root = repo_root.resolve()
+    blobs = repo_root / "blobs"
+    blobs.mkdir(parents=True)
     snap = repo_root / "snapshots" / pinned_sha
     snap.mkdir(parents=True)
     for name, payload in files.items():
-        (snap / name).write_bytes(payload)
+        blob = blobs / f"blob-{len(payload)}-{name}"
+        blob.write_bytes(payload)
+        (snap / name).symlink_to(blob)
 
 
 def test_wan_cache_accepts_5b_single_transformer_layout(tmp_path, monkeypatch):
@@ -776,6 +788,35 @@ def test_wan_cache_accepts_a14b_dual_noise_layout(tmp_path, monkeypatch):
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate._snapshot_is_complete_wan_model(repo_id) is True
+
+
+def test_wan_cache_rejects_a14b_with_stray_single_model_file(tmp_path, monkeypatch):
+    """Family-exact: an A14B repo needs BOTH noise models, never a lone model.safetensors.
+
+    Regression for codex BLOCKING #1 — the transformer layout is keyed to the
+    repo's A14B family, so an incomplete A14B snapshot carrying a stray single
+    ``model.safetensors`` (with no high/low noise files) must NOT be accepted.
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "rickylin20260522/Wan2.2-T2V-A14B-mlx"
+    pinned_sha = WAN_REVISIONS[repo_id]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            # A14B family requires high+low_noise; a lone model.safetensors is WRONG.
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
 
 
 @pytest.mark.parametrize(
@@ -849,6 +890,34 @@ def test_wan_cache_rejects_stray_unrelated_safetensors(tmp_path, monkeypatch):
     assert gate._snapshot_is_complete_wan_model(repo_id) is False
 
 
+def test_wan_cache_rejects_unclassifiable_family_repo(tmp_path, monkeypatch):
+    """A WAN_REVISIONS-pinned repo whose family can't be classed fails closed.
+
+    The transformer layout is keyed to a known family (5B single / A14B dual).
+    A pinned repo whose id carries neither marker is unclassifiable and must be
+    rejected (fail closed) rather than guessing which files to require.
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--some-org--mystery-wan"
+    # Any plausible layout must still be rejected because the family is unknown.
+    _seed_wan_snapshot(
+        repo_root,
+        "0123456789abcdef",
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setitem(WAN_REVISIONS, "some-org/mystery-wan", "0123456789abcdef")
+
+    assert gate._snapshot_is_complete_wan_model("some-org/mystery-wan") is False
+
+
 def test_wan_cache_rejects_unpinned_repo(tmp_path, monkeypatch):
     """A repo not in WAN_REVISIONS is not our lane — the helper falls through."""
     repo_id = "some-other/wan2-not-pinned"
@@ -875,26 +944,63 @@ def test_wan_cache_rejects_unpinned_repo(tmp_path, monkeypatch):
 def test_wan_cache_rejects_files_symlinked_outside_repo(
     tmp_path, monkeypatch, escaped_name
 ):
-    """A crafted cache symlink must not borrow proof from an unrelated file."""
+    """A crafted cache symlink must not borrow proof from a non-blob file.
+
+    Only files that resolve strictly inside the repo's own ``blobs`` count. A
+    symlink escaping to anywhere else (a file outside the repo) is rejected
+    even though every other verified file is present.
+    """
     repo_id, pinned_sha = _wan_pinned_pair()
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
-    snap = repo_root / "snapshots" / pinned_sha
-    snap.mkdir(parents=True)
     files = {
         "config.json": b"{}",
         "model.safetensors": b"w" * 1024,
         "t5_encoder.safetensors": b"t" * 1024,
         "vae.safetensors": b"v" * 1024,
     }
+    # Seed the OTHER verified files as proper blobs+symlinks, then rebind the
+    # escaped file to a symlink pointing outside the repo root entirely (its
+    # blobs->snapshot symlink is re-pointed away to a non-blob target).
+    _seed_wan_snapshot(repo_root, pinned_sha, files)
     outside = tmp_path / f"outside-{escaped_name}"
     outside.write_bytes(files[escaped_name])
-    for name, payload in files.items():
-        path = snap / name
-        if name == escaped_name:
-            path.symlink_to(outside)
-        else:
-            path.write_bytes(payload)
+    escaped_path = repo_root / "snapshots" / pinned_sha / escaped_name
+    escaped_path.unlink()
+    escaped_path.symlink_to(outside)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize("escaped_name", ["config.json", "vae.safetensors"])
+def test_wan_cache_rejects_symlink_borrowing_from_sibling_snapshot(
+    tmp_path, monkeypatch, escaped_name
+):
+    """A symlink into ANOTHER snapshot under the same repo must be rejected.
+
+    The blobs contract requires files to resolve under the repo's ``blobs``,
+    not merely anywhere under the repo root — so a snapshot cannot borrow proof
+    from a sibling snapshot whose plain files live outside ``blobs``.
+    """
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    # Seed a "complete" sibling snapshot with plain files (NOT under blobs).
+    sibling = repo_root / "snapshots" / "otherrev123"
+    sibling.mkdir(parents=True)
+    for name, payload in {
+        "config.json": b"{}",
+        "model.safetensors": b"w" * 1024,
+        "t5_encoder.safetensors": b"t" * 1024,
+        "vae.safetensors": b"v" * 1024,
+    }.items():
+        (sibling / name).write_bytes(payload)
+    # Our pinned snapshot symlinks one file to the sibling's plain file (which
+    # is under repo_root but NOT under blobs) — must be rejected.
+    snap = repo_root / "snapshots" / pinned_sha
+    snap.mkdir(parents=True)
+    (snap / escaped_name).symlink_to(sibling / escaped_name)
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate._snapshot_is_complete_wan_model(repo_id) is False
@@ -914,12 +1020,10 @@ def test_wan_cache_rejects_when_pinned_snapshot_dir_missing(tmp_path, monkeypatc
 
 @pytest.mark.parametrize("empty_name", ["config.json", "vae.safetensors"])
 def test_wan_cache_rejects_empty_verified_file(tmp_path, monkeypatch, empty_name):
-    """A zero-byte verified file must not count as a present weight."""
+    """A zero-byte verified file (empty blob) must not count as a present weight."""
     repo_id, pinned_sha = _wan_pinned_pair()
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
-    snapshot = repo_root / "snapshots" / pinned_sha
-    snapshot.mkdir(parents=True)
     files = {
         "config.json": b"{}",
         "model.safetensors": b"w" * 1024,
@@ -927,8 +1031,7 @@ def test_wan_cache_rejects_empty_verified_file(tmp_path, monkeypatch, empty_name
         "vae.safetensors": b"v" * 1024,
     }
     files[empty_name] = b""
-    for name, payload in files.items():
-        (snapshot / name).write_bytes(payload)
+    _seed_wan_snapshot(repo_root, pinned_sha, files)
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate._snapshot_is_complete_wan_model(repo_id) is False

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -712,6 +712,7 @@ def test_audio_family_exception_is_not_runnable(monkeypatch):
     monkeypatch.setattr(gate, "_resolved_snapshot_sha", _boom)
     assert gate._snapshot_is_complete_audio_model("a/b", "whisper") is False
 
+
 def _wan_pinned_pair() -> tuple[str, str]:
     """A real WAN_REVISIONS-pinned checkpoint (repo_id, pinned commit sha)."""
     from vllm_mlx.video.wan import WAN_REVISIONS
@@ -981,26 +982,35 @@ def test_wan_cache_rejects_symlink_borrowing_from_sibling_snapshot(
 
     The blobs contract requires files to resolve under the repo's ``blobs``,
     not merely anywhere under the repo root — so a snapshot cannot borrow proof
-    from a sibling snapshot whose plain files live outside ``blobs``.
+    from a sibling snapshot whose plain files live outside ``blobs``. The pinned
+    snapshot is seeded COMPLETE (every file present under blobs) and then only
+    ``escaped_name`` is re-bound to the sibling's plain file, so a broken
+    containment check would otherwise let it pass.
     """
     repo_id, pinned_sha = _wan_pinned_pair()
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
-    # Seed a "complete" sibling snapshot with plain files (NOT under blobs).
-    sibling = repo_root / "snapshots" / "otherrev123"
-    sibling.mkdir(parents=True)
-    for name, payload in {
+    files = {
         "config.json": b"{}",
         "model.safetensors": b"w" * 1024,
         "t5_encoder.safetensors": b"t" * 1024,
         "vae.safetensors": b"v" * 1024,
-    }.items():
+    }
+    # Seed a sibling snapshot whose plain files live under repo_root but NOT
+    # under ``blobs`` (a non-HF layout that must not satisfy the probe).
+    repo_root.resolve().mkdir(parents=True)
+    sibling = repo_root / "snapshots" / "otherrev123"
+    sibling.mkdir(parents=True)
+    for name, payload in files.items():
         (sibling / name).write_bytes(payload)
-    # Our pinned snapshot symlinks one file to the sibling's plain file (which
-    # is under repo_root but NOT under blobs) — must be rejected.
-    snap = repo_root / "snapshots" / pinned_sha
-    snap.mkdir(parents=True)
-    (snap / escaped_name).symlink_to(sibling / escaped_name)
+    # Seed our pinned snapshot as fully complete (blobs + symlinks)…
+    _seed_wan_snapshot(repo_root, pinned_sha, files)
+    # …then re-bind ONLY escaped_name to the sibling's plain (non-blob) file.
+    escaped_path = repo_root / "snapshots" / pinned_sha / escaped_name
+    escaped_path.unlink()
+    (repo_root / "snapshots" / pinned_sha / escaped_name).symlink_to(
+        sibling / escaped_name
+    )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate._snapshot_is_complete_wan_model(repo_id) is False

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -712,6 +712,249 @@ def test_audio_family_exception_is_not_runnable(monkeypatch):
     monkeypatch.setattr(gate, "_resolved_snapshot_sha", _boom)
     assert gate._snapshot_is_complete_audio_model("a/b", "whisper") is False
 
+def _wan_pinned_pair() -> tuple[str, str]:
+    """A real WAN_REVISIONS-pinned checkpoint (repo_id, pinned commit sha)."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+    return repo_id, WAN_REVISIONS[repo_id]
+
+
+def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> None:
+    """Write ``snapshots/<pinned_sha>`` under an HF-cache-shaped repo root."""
+    snap = repo_root / "snapshots" / pinned_sha
+    snap.mkdir(parents=True)
+    for name, payload in files.items():
+        (snap / name).write_bytes(payload)
+
+
+def test_wan_cache_accepts_5b_single_transformer_layout(tmp_path, monkeypatch):
+    """A pinned Wan 5B checkpoint (config + model + t5_encoder + vae) is runnable.
+
+    The generic probes miss Wan's pinned-by-commit layout: it ships no
+    ``split_model.json`` and no ``refs/main`` for the commit download, so only
+    the Wan-specific helper sees it as complete.
+    """
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is True
+
+
+def test_wan_cache_accepts_a14b_dual_noise_layout(tmp_path, monkeypatch):
+    """A pinned Wan A14B checkpoint (high+low_noise + t5_encoder + vae) is runnable."""
+    # A real pinned A14B repo exercises the dual-noise transformer contract.
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "rickylin20260522/Wan2.2-T2V-A14B-mlx"
+    pinned_sha = WAN_REVISIONS[repo_id]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "high_noise_model.safetensors": b"h" * 1024,
+            "low_noise_model.safetensors": b"l" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is True
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["config.json", "model.safetensors", "t5_encoder.safetensors", "vae.safetensors"],
+)
+def test_wan_cache_rejects_incomplete_5b_layout(tmp_path, monkeypatch, missing):
+    """A pinned Wan checkpoint with ANY verified file missing is NOT runnable."""
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    files = {
+        "config.json": b"{}",
+        "model.safetensors": b"w" * 1024,
+        "t5_encoder.safetensors": b"t" * 1024,
+        "vae.safetensors": b"v" * 1024,
+    }
+    files.pop(missing)
+    _seed_wan_snapshot(repo_root, pinned_sha, files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_dual_layout_missing_one_noise_model(tmp_path, monkeypatch):
+    """Dual-noise A14B needs BOTH high and low noise models (no partial credit)."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "rickylin20260522/Wan2.2-T2V-A14B-mlx"
+    pinned_sha = WAN_REVISIONS[repo_id]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "high_noise_model.safetensors": b"h" * 1024,
+            # low_noise_model.safetensors absent; no model.safetensors either.
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_stray_unrelated_safetensors(tmp_path, monkeypatch):
+    """Verified-filename-only: a stray *.safetensors must not imply runnable.
+
+    The 5B contract requires model.safetensors + t5_encoder + vae together; a
+    repo with only an unrelated weight file (and no VAE) is NOT runnable.
+    """
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(
+        repo_root,
+        pinned_sha,
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            # vae.safetensors missing; a stray unrelated file is NOT a substitute.
+            "unrelated.safetensors": b"x" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_unpinned_repo(tmp_path, monkeypatch):
+    """A repo not in WAN_REVISIONS is not our lane — the helper falls through."""
+    repo_id = "some-other/wan2-not-pinned"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--some-other--wan2-not-pinned"
+    # Even a perfectly-shaped snapshot must NOT be admitted via the Wan helper
+    # if the repo is not a registered pinned Wan checkpoint.
+    _seed_wan_snapshot(
+        repo_root,
+        "0123456789abcdef",
+        {
+            "config.json": b"{}",
+            "model.safetensors": b"w" * 1024,
+            "t5_encoder.safetensors": b"t" * 1024,
+            "vae.safetensors": b"v" * 1024,
+        },
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize("escaped_name", ["config.json", "vae.safetensors"])
+def test_wan_cache_rejects_files_symlinked_outside_repo(
+    tmp_path, monkeypatch, escaped_name
+):
+    """A crafted cache symlink must not borrow proof from an unrelated file."""
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    snap = repo_root / "snapshots" / pinned_sha
+    snap.mkdir(parents=True)
+    files = {
+        "config.json": b"{}",
+        "model.safetensors": b"w" * 1024,
+        "t5_encoder.safetensors": b"t" * 1024,
+        "vae.safetensors": b"v" * 1024,
+    }
+    outside = tmp_path / f"outside-{escaped_name}"
+    outside.write_bytes(files[escaped_name])
+    for name, payload in files.items():
+        path = snap / name
+        if name == escaped_name:
+            path.symlink_to(outside)
+        else:
+            path.write_bytes(payload)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_when_pinned_snapshot_dir_missing(tmp_path, monkeypatch):
+    """No cached snapshot under the pinned revision -> not runnable."""
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    # No snapshots/ dir at all — repo only reached the metadata stage.
+    repo_root.mkdir(parents=True)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize("empty_name", ["config.json", "vae.safetensors"])
+def test_wan_cache_rejects_empty_verified_file(tmp_path, monkeypatch, empty_name):
+    """A zero-byte verified file must not count as a present weight."""
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    snapshot = repo_root / "snapshots" / pinned_sha
+    snapshot.mkdir(parents=True)
+    files = {
+        "config.json": b"{}",
+        "model.safetensors": b"w" * 1024,
+        "t5_encoder.safetensors": b"t" * 1024,
+        "vae.safetensors": b"v" * 1024,
+    }
+    files[empty_name] = b""
+    for name, payload in files.items():
+        (snapshot / name).write_bytes(payload)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_returns_false_on_internal_error(tmp_path, monkeypatch):
+    """Any internal probe error fails closed (False), never crash / assume runnable."""
+    repo_id, pinned_sha = _wan_pinned_pair()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    snapshot = repo_root / "snapshots" / pinned_sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"w" * 1024)
+    (snapshot / "t5_encoder.safetensors").write_bytes(b"t" * 1024)
+    (snapshot / "vae.safetensors").write_bytes(b"v" * 1024)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    # Induce an OSError inside the probe (e.g. a permission fault on stat).
+    def boom(path, *a):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(gate.os.path, "isfile", boom)
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
 
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     """Empty HF cache directory → False."""

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -980,18 +980,27 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
     *weightless* / non-runnable and would re-download on every start.
 
     Deterministic, verified-filename-only completeness mirroring what
-    ``mlx_video.models.wan_2.generate`` loads from ``model_dir`` (all four
-    pinned checkpoints share the set): ``config.json`` at the snapshot root;
-    the mlx-video T5 encoder ``t5_encoder.safetensors``; the VAE
-    ``vae.safetensors``; and the diffusion transformer — ``model.safetensors``
-    (5B single-file) OR both ``high_noise_model.safetensors`` and
-    ``low_noise_model.safetensors`` (A14B dual). No speculative generic
-    ``*.safetensors``: an unrelated stray weight must not make the snapshot
-    look runnable. Every file must be present, non-empty, and resolve inside
-    the repo's own ``blobs`` directory (symlink guard).
+    ``mlx_video.models.wan_2.generate`` loads from ``model_dir``. The pinned
+    checkpoints share the common encoder + VAE files (``config.json``,
+    ``t5_encoder.safetensors``, ``vae.safetensors``); the diffusion transformer
+    layout is **family-exact**, not inferred from whichever files happen to be
+    present: the 5B checkpoints ship a single ``model.safetensors``, the A14B
+    checkpoints ship ``high_noise_model.safetensors`` AND
+    ``low_noise_model.safetensors``. A repo whose id does not indicate a known
+    family (5B / A14B) fails closed rather than guessing, so an incomplete A14B
+    snapshot with a stray ``model.safetensors`` is never accepted. No
+    speculative generic ``*.safetensors``: an unrelated stray weight must not
+    make the snapshot look runnable.
 
-    Returns ``False`` for an unpinned / non-``WAN_REVISIONS`` repo or on any
-    internal error, so the caller falls through to the generic probes.
+    Every file must be present, non-empty, and resolve **strictly inside the
+    repo's own ``blobs`` directory** (HF snapshot leaves symlink into
+    ``blobs/<etag>``). Requiring under ``blobs`` — not merely under the repo
+    root — stops a snapshot from borrowing files from a sibling snapshot via a
+    crafted symlink.
+
+    Returns ``False`` for an unpinned / non-``WAN_REVISIONS`` repo, an
+    unclassifiable family, or on any internal error, so the caller falls
+    through to the generic probes.
     """
     try:
         from vllm_mlx.video.wan import WAN_REVISIONS
@@ -1000,6 +1009,21 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
         if pinned_revision is None or not isinstance(pinned_revision, str):
             # Not a registered pinned Wan checkpoint — not our lane.
             return False
+
+        # Family-exact transformer layout, keyed off the repo id (matches the
+        # four pinned checkpoints: 5B -> single, A14B -> dual). Fail closed on
+        # an unclassifiable repo rather than inferring from file presence.
+        repo_lower = repo_id.casefold()
+        if "a14b" in repo_lower:
+            transformer_names: tuple[str, ...] = (
+                "high_noise_model.safetensors",
+                "low_noise_model.safetensors",
+            )
+        elif "5b" in repo_lower:
+            transformer_names = ("model.safetensors",)
+        else:
+            return False
+
         from huggingface_hub.constants import HF_HUB_CACHE
 
         repo_root = os.path.join(
@@ -1011,6 +1035,8 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             return False
 
         repo_root_real = os.path.realpath(repo_root)
+        # HF snapshot leaves symlink into this repo's own ``blobs`` dir.
+        blobs_prefix = repo_root_real + os.sep + "blobs" + os.sep
 
         def _on_repo(name: str) -> bool:
             path = os.path.join(snap_dir, name)
@@ -1019,18 +1045,13 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             if os.path.getsize(path) <= 0:
                 return False
             real = os.path.realpath(path)
-            # HF snapshot files normally symlink into this repo's own ``blobs``
-            # directory. Reject a fabricated snapshot whose weight or config
-            # links escape the repository cache root.
-            return real == repo_root_real or real.startswith(repo_root_real + os.sep)
+            # Must resolve strictly inside this repo's ``blobs`` — a symlink
+            # escaping to blobs (or a file) elsewhere in the cache is rejected,
+            # and so is borrowing from a sibling snapshot whose files live under
+            # the same repo root but not under ``blobs``.
+            return real.startswith(blobs_prefix)
 
-        # The diffusion transformer: single-file (5B) or dual noise (A14B).
-        if _on_repo("model.safetensors"):
-            transformer_ok = True
-        else:
-            transformer_ok = _on_repo("high_noise_model.safetensors") and _on_repo(
-                "low_noise_model.safetensors"
-            )
+        transformer_ok = all(_on_repo(n) for n in transformer_names)
         return (
             transformer_ok
             and _on_repo("config.json")

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -966,6 +966,81 @@ def split_model_local_snapshot(repo_id: str) -> str | None:
     return snap_dir if os.path.isdir(snap_dir) else None
 
 
+def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
+    """True when a ``WAN_REVISIONS``-pinned Wan checkpoint is cached & loadable.
+
+    Wan video repos (``video/wan.py``'s ``WAN_REVISIONS``) are pinned to an
+    exact commit sha, so ``snapshot_download(repo, revision=<sha>)`` caches
+    under ``snapshots/<sha>`` WITHOUT advancing ``refs/main`` (exactly the
+    ``IMAGE_MODEL_REVISIONS`` mflux case). The generic probes miss this warm
+    cache: ``is_repo_cached`` resolves via ``refs/main``;
+    :func:`_snapshot_is_complete_split_model` requires a ``split_model.json``
+    manifest (Wan checkpoints ship none); :func:`_snapshot_is_complete_mflux_model`
+    is image-gen-only. Without this, a warm-cached Wan snapshot reads as
+    *weightless* / non-runnable and would re-download on every start.
+
+    Deterministic, verified-filename-only completeness mirroring what
+    ``mlx_video.models.wan_2.generate`` loads from ``model_dir`` (all four
+    pinned checkpoints share the set): ``config.json`` at the snapshot root;
+    the mlx-video T5 encoder ``t5_encoder.safetensors``; the VAE
+    ``vae.safetensors``; and the diffusion transformer — ``model.safetensors``
+    (5B single-file) OR both ``high_noise_model.safetensors`` and
+    ``low_noise_model.safetensors`` (A14B dual). No speculative generic
+    ``*.safetensors``: an unrelated stray weight must not make the snapshot
+    look runnable. Every file must be present, non-empty, and resolve inside
+    the repo's own ``blobs`` directory (symlink guard).
+
+    Returns ``False`` for an unpinned / non-``WAN_REVISIONS`` repo or on any
+    internal error, so the caller falls through to the generic probes.
+    """
+    try:
+        from vllm_mlx.video.wan import WAN_REVISIONS
+
+        pinned_revision = WAN_REVISIONS.get(repo_id)
+        if pinned_revision is None or not isinstance(pinned_revision, str):
+            # Not a registered pinned Wan checkpoint — not our lane.
+            return False
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        snap_dir = os.path.join(repo_root, "snapshots", pinned_revision)
+        if not os.path.isdir(snap_dir):
+            return False
+
+        repo_root_real = os.path.realpath(repo_root)
+
+        def _on_repo(name: str) -> bool:
+            path = os.path.join(snap_dir, name)
+            if not os.path.isfile(path):
+                return False
+            if os.path.getsize(path) <= 0:
+                return False
+            real = os.path.realpath(path)
+            # HF snapshot files normally symlink into this repo's own ``blobs``
+            # directory. Reject a fabricated snapshot whose weight or config
+            # links escape the repository cache root.
+            return real == repo_root_real or real.startswith(repo_root_real + os.sep)
+
+        # The diffusion transformer: single-file (5B) or dual noise (A14B).
+        if _on_repo("model.safetensors"):
+            transformer_ok = True
+        else:
+            transformer_ok = _on_repo("high_noise_model.safetensors") and _on_repo(
+                "low_noise_model.safetensors"
+            )
+        return (
+            transformer_ok
+            and _on_repo("config.json")
+            and _on_repo("t5_encoder.safetensors")
+            and _on_repo("vae.safetensors")
+        )
+    except Exception:
+        return False
+
+
 #: Repos whose weights must resolve to an exact, previously-verified commit,
 #: mirroring ``video/wan.py``'s ``WAN_REVISIONS``. Without this, an alias
 #: only ever resolves whatever ``refs/main`` currently points to (see

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5757,10 +5757,12 @@ def _cache_runnability(repo: str) -> bool | None:
             _snapshot_is_complete_audio_model,
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
+            _snapshot_is_complete_wan_model,
             is_repo_cached,
         )
         from vllm_mlx.audio.registry import resolve_audio_alias
         from vllm_mlx.model_metadata import resolve_unreferenced_cached_snapshot
+        from vllm_mlx.video.wan import WAN_REVISIONS
 
         audio_entry = resolve_audio_alias(repo)
         if audio_entry is not None and audio_entry.family in ("whisper", "kokoro"):
@@ -5771,10 +5773,18 @@ def _cache_runnability(repo: str) -> bool | None:
             # families fall through to the generic cache probes below — their
             # layout is not pinned here, so never claim them non-runnable.
             return _snapshot_is_complete_audio_model(repo, audio_entry.family)
+        if repo in WAN_REVISIONS:
+            # Wan snapshots are authoritative: they are pinned to an exact
+            # commit with a strict verified-filename contract (config +
+            # t5_encoder + vae + transformer), so the generic text probe (which
+            # matches a lone ``model.safetensors``) must NOT mark an incomplete
+            # Wan snapshot runnable. Complete -> runnable; incomplete -> not.
+            return _snapshot_is_complete_wan_model(repo)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)
             or _snapshot_is_complete_mflux_model(repo)
+            or _snapshot_is_complete_wan_model(repo)
             or resolve_unreferenced_cached_snapshot(repo) is not None
         )
     except (OSError, KeyError, ValueError) as exc:


### PR DESCRIPTION
Closes #2406

## Why

Wan video checkpoints resolve to an exact pinned commit (`video/wan.py`
`WAN_REVISIONS`), so `snapshot_download(repo, revision=<sha>)` caches under
`snapshots/<sha>` **without advancing `refs/main`**. The generic cache
runnability probes all miss this warm cache:

- `is_repo_cached` resolves the revision via `refs/main` → sees nothing.
- `_snapshot_is_complete_split_model` requires a `split_model.json` manifest —
  Wan checkpoints ship none.
- the mflux probe is image-gen-only.

So a fully-downloaded Wan snapshot was read as *weightless* / non-runnable and
would re-download on every start. This makes a cached Wan video snapshot pinned
by sha count as **runnable** exactly like the audio families (part A), so
`models --cached` and the serve gate agree with the loader.

## Scope

- **`_download_gate.py`** — new `_snapshot_is_complete_wan_model(repo_id)`:
  deterministic, verified-filename-only completeness matching what
  `mlx_video.models.wan_2.generate` actually loads from `model_dir`:
  `config.json` + `t5_encoder.safetensors` + `vae.safetensors` + the diffusion
  transformer (`model.safetensors` for 5B, or `high_noise_model.safetensors` +
  `low_noise_model.safetensors` for A14B). Every file must be present,
  non-empty, and resolve inside the repo's own `blobs` (symlink guard). No
  speculative generic `*.safetensors` (verified-filename-only).
- **`cli.py`** — `_cache_entry_is_runnable` routes `WAN_REVISIONS`-pinned repos
  authoritatively through the Wan helper (complete → runnable; incomplete →
  not), so the generic text probe cannot mark an incomplete Wan snapshot
  runnable.
- **tests** — hermetic no-MLX: helper branches (5B/A14B layouts, incomplete,
  stray-file rejection, unpinned fallthrough, empty-file, missing snapshot dir,
  symlink-escape, internal-error fail-closed) + `_cache_entry_is_runnable`
  routing (complete → True, incomplete → False).

## Non-goals (per Atlas)

No downloader or mirror changes; no CLI output-format changes; **no `ci.yml`
change** — `tests/test_download_gate.py` and `tests/test_cli_models.py` are
already in the changed-lines coverage list.

## Validation

- diff-cover on changed lines vs base 32288e32: **100%** (29/29)
- mypy budget (pinned 2.3.1): 719 / no growth (shrink-only)
- ruff clean; focused suites: download_gate + cli_models (206 pass), test_wan_video (28 pass); no-MLX lane clean
