### PR TITLE
fix(installer): recommend a fast first-chat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Both install the same `rapid-mlx` CLI. Prefer `uv` or `pip`, or want to verify
 the installer before running it? See [alternative install methods](#alternative-install-methods)
 and [install security](SECURITY.md).
 
-The guided installer prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `bonsai-27b-2bit`; 32 GB+ → `qwen3.8-27b-4bit`).
+The guided installer prefers a runnable model already cached on this Mac when
+it fits the RAM tier. Otherwise its quick first-chat download is
+`lfm2.5-2.6b-4bit` below 16 GB and `qwen3.5-4b-4bit` at 16 GB or above; larger
+quality picks remain available through `rapid-mlx recipe` and the model picker.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ and [install security](SECURITY.md).
 
 The guided installer prefers a runnable model already cached on this Mac when
 it fits the RAM tier. Otherwise its quick first-chat download is
-`lfm2.5-2.6b-4bit` below 16 GB and `qwen3.5-4b-4bit` at 16 GB or above; larger
+`lfm2.5-1b-4bit` below 16 GB and `qwen3.5-4b-4bit` at 16 GB or above; larger
 quality picks remain available through `rapid-mlx recipe` and the model picker.
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,58 @@ dispatch_venv() {
     esac
 }
 
+# First-chat policy shared with Desktop onboarding (#2385): start with a small,
+# reliable baseline, but reuse a known RAM-safe cached model when one is already
+# runnable. The candidate order is the curated RAM-tier order walked downward;
+# aliases above the current tier never enter the list.
+starter_baseline_for_ram() {
+    if [ "$1" -ge 16 ]; then
+        printf '%s\n' "qwen3.5-4b-4bit"
+    else
+        printf '%s\n' "lfm2.5-2.6b-4bit"
+    fi
+}
+
+starter_cached_order_for_ram() {
+    local ram="$1"
+    if [ "$ram" -ge 48 ]; then printf '%s\n' qwen3.8-27b-4bit qwen3.6-35b-4bit qwen3.5-4b-4bit bonsai-27b-2bit qwen3.5-9b-4bit lfm2.5-2.6b-4bit
+    elif [ "$ram" -ge 32 ]; then printf '%s\n' qwen3.8-27b-4bit qwen3.5-4b-4bit bonsai-27b-2bit qwen3.5-9b-4bit lfm2.5-2.6b-4bit
+    elif [ "$ram" -ge 24 ]; then printf '%s\n' bonsai-27b-2bit qwen3.5-4b-4bit qwen3.5-9b-4bit lfm2.5-2.6b-4bit
+    elif [ "$ram" -ge 18 ]; then printf '%s\n' qwen3.5-9b-4bit qwen3.5-4b-4bit lfm2.5-2.6b-4bit
+    elif [ "$ram" -ge 16 ]; then printf '%s\n' qwen3.5-4b-4bit lfm2.5-2.6b-4bit
+    else printf '%s\n' lfm2.5-2.6b-4bit
+    fi
+}
+
+starter_alias_is_cached() {
+    local wanted="$1" cached="$2" alias
+    while IFS= read -r alias; do
+        [ "$alias" = "$wanted" ] && return 0
+    done <<EOF
+$cached
+EOF
+    return 1
+}
+
+select_starter_model() {
+    local ram="$1" cached="${2:-}" order candidate
+    order="$(starter_cached_order_for_ram "$ram")"
+    while IFS= read -r candidate; do
+        if starter_alias_is_cached "$candidate" "$cached"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done <<EOF
+$order
+EOF
+    starter_baseline_for_ram "$ram"
+}
+
+installed_cached_aliases() {
+    "$INSTALL_DIR/bin/rapid-mlx" models --cached --json 2>/dev/null |
+        "$INSTALL_DIR/bin/python" -c 'import json,sys; p=json.load(sys.stdin); print("\\n".join(m["alias"] for m in p.get("cached", []) if m.get("state") == "ok" and isinstance(m.get("alias"), str)))' 2>/dev/null
+}
+
 # When sourced by the test harness we only want the definitions above, not the
 # installer itself. `return` succeeds only in a sourced context; the `|| exit 0`
 # keeps an accidental `RAPID_INSTALL_LIB=1 bash install.sh` from erroring out.
@@ -199,38 +251,15 @@ fi
 
 # ── 2. Detect RAM → recommend model ──────────────────────────────────────────
 
-# These tiers MIRROR ``RAMBucketedDefault.tiers`` in the desktop app
-# (apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift), which is
-# the curated table with measured footprints, a capability column and a
-# monotonic-by-RAM invariant guarded by
-# apps/rapid-mac/scripts/verify-recommendation-tiers.swift.
-#
-# They used to disagree — six tiers, one match. Somebody who ran
-# ``curl … | bash`` and then opened the app was told to run two different
-# models on the same Mac, and curl is the canonical entry point in the
-# README. One table, two front doors.
-#
-# The app also surfaces a "fast alternative" per tier; this banner shows a
-# single command, so it takes the app's PRIMARY (smart) pick only.
-#
-# RECOMMENDED_FLAGS carries the tier's launch flags. Every current pick
-# ships with empty flags, but the plumbing stays: a future pick that needs
-# launch flags to fit its tier must have them printed with its serve line.
+# This is the Desktop Quickstart starter policy, not the larger "smart pick"
+# shown in the model browser. A fresh install optimizes time-to-first-chat:
+# <16 GB uses the compact 2.6B starter; every larger Mac uses the 4B starter.
+# After installation, a structured cache query may promote this to a known
+# runnable model that fits the same RAM tier.
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
 RECOMMENDED_FLAGS=""
-# 32 GB and up all get the same pick (AA-Index policy, 2026-08-18):
-# qwen3.8-27b-4bit is the highest-scoring open-weights model we serve
-# (AA Intelligence Index 52 — GPT-5.6-class), and its measured 8K-prefill
-# peak of 20 GB clears every one of these tiers' 75 % budgets. The
-# branches stay split so the banner names the user's actual tier.
-if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="96+ GB"
-elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="64-95 GB"
-elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="32-63 GB"
-elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="bonsai-27b-2bit";     RAM_TIER="24-31 GB"
-elif [ "$RAM_GB" -ge 18 ]; then RECOMMENDED_MODEL="qwen3.5-9b-4bit";     RAM_TIER="18-23 GB"
-elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="qwen3.5-4b-4bit";     RAM_TIER="16-17 GB"
-else                            RECOMMENDED_MODEL="lfm2.5-2.6b-4bit";    RAM_TIER="8-15 GB"
-fi
+RECOMMENDED_MODEL="$(select_starter_model "$RAM_GB" "")"
+if [ "$RAM_GB" -ge 16 ]; then RAM_TIER="16+ GB"; else RAM_TIER="under 16 GB"; fi
 
 dim "macOS $(sw_vers -productVersion) · Apple Silicon · ${RAM_GB} GB RAM"
 
@@ -360,6 +389,11 @@ case "$TARGET" in
             || { dim "Version ${TARGET} not on PyPI, trying GitHub tag..."; "${INSTALLER[@]}" "$PYPI_PACKAGE @ git+${GITHUB_REPO}@v${TARGET}" ; }
         ;;
 esac
+
+# Query the just-installed CLI's stable JSON surface. Failure is harmless and
+# falls back to the RAM baseline; never scrape the human table or cache paths.
+CACHED_ALIASES="$(installed_cached_aliases || true)"
+RECOMMENDED_MODEL="$(select_starter_model "$RAM_GB" "$CACHED_ALIASES")"
 
 # ── 6. Create symlinks ──────────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -152,13 +152,16 @@ dispatch_venv() {
 
 # First-chat policy shared with Desktop onboarding (#2385): start with a small,
 # reliable baseline, but reuse a known RAM-safe cached model when one is already
-# runnable. The candidate order is the curated RAM-tier order walked downward;
-# aliases above the current tier never enter the list.
+# runnable. The baseline mirrors ``QuickstartCoordinator.baselineChoice``:
+# <16 GB uses the safe 1.2B starter (Desktop's ``lowMemoryChoice``), >=16 GB the
+# 4B starter. The candidate order is the curated RAM-tier order walked downward,
+# aliases above the current tier never enter the list; the sub-16 GB order is
+# just the 1.2B baseline, because Desktop auto-selects nothing else there.
 starter_baseline_for_ram() {
     if [ "$1" -ge 16 ]; then
         printf '%s\n' "qwen3.5-4b-4bit"
     else
-        printf '%s\n' "lfm2.5-2.6b-4bit"
+        printf '%s\n' "lfm2.5-1b-4bit"
     fi
 }
 
@@ -169,7 +172,7 @@ starter_cached_order_for_ram() {
     elif [ "$ram" -ge 24 ]; then printf '%s\n' bonsai-27b-2bit qwen3.5-4b-4bit qwen3.5-9b-4bit lfm2.5-2.6b-4bit
     elif [ "$ram" -ge 18 ]; then printf '%s\n' qwen3.5-9b-4bit qwen3.5-4b-4bit lfm2.5-2.6b-4bit
     elif [ "$ram" -ge 16 ]; then printf '%s\n' qwen3.5-4b-4bit lfm2.5-2.6b-4bit
-    else printf '%s\n' lfm2.5-2.6b-4bit
+    else printf '%s\n' lfm2.5-1b-4bit
     fi
 }
 
@@ -274,7 +277,7 @@ fi
 
 # This is the Desktop Quickstart starter policy, not the larger "smart pick"
 # shown in the model browser. A fresh install optimizes time-to-first-chat:
-# <16 GB uses the compact 2.6B starter; every larger Mac uses the 4B starter.
+# <16 GB uses the safe 1.2B starter; every larger Mac uses the 4B starter.
 # After installation, a structured cache query may promote this to a known
 # runnable model that fits the same RAM tier.
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,9 @@ installed_cached_aliases() {
 
 refresh_starter_from_installed_cache() {
     local cached_aliases
-    cached_aliases="$(installed_cached_aliases || true)"
+    if ! cached_aliases="$(installed_cached_aliases)"; then
+        cached_aliases=""
+    fi
     RECOMMENDED_MODEL="$(select_starter_model "$RAM_GB" "$cached_aliases")"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,7 @@ EOF
 
 installed_cached_aliases() {
     "$INSTALL_DIR/bin/rapid-mlx" models --cached --json 2>/dev/null |
-        "$INSTALL_DIR/bin/python" -c 'import json,sys; p=json.load(sys.stdin); print("\\n".join(m["alias"] for m in p.get("cached", []) if m.get("state") == "ok" and isinstance(m.get("alias"), str)))' 2>/dev/null
+        "$INSTALL_DIR/bin/python" -c 'import json,sys; p=json.load(sys.stdin); print("\n".join(m["alias"] for m in p.get("cached", []) if m.get("state") == "ok" and isinstance(m.get("alias"), str)))' 2>/dev/null
 }
 
 # When sourced by the test harness we only want the definitions above, not the

--- a/install.sh
+++ b/install.sh
@@ -202,6 +202,25 @@ installed_cached_aliases() {
         "$INSTALL_DIR/bin/python" -c 'import json,sys; p=json.load(sys.stdin); print("\n".join(m["alias"] for m in p.get("cached", []) if m.get("state") == "ok" and isinstance(m.get("alias"), str)))' 2>/dev/null
 }
 
+refresh_starter_from_installed_cache() {
+    local cached_aliases
+    cached_aliases="$(installed_cached_aliases || true)"
+    RECOMMENDED_MODEL="$(select_starter_model "$RAM_GB" "$cached_aliases")"
+}
+
+print_quick_start_commands() {
+    info "Quick start:"
+    echo ""
+    echo "    rapid-mlx serve ${RECOMMENDED_MODEL}${RECOMMENDED_FLAGS}"
+    echo ""
+    dim "Then open a second terminal:"
+    echo ""
+    echo "    rapid-mlx chat ${RECOMMENDED_MODEL} --port 8000    # built-in chat (terminal)"
+    echo "    rapid-mlx-chat                                    # web chat UI (first: ${INSTALL_DIR}/bin/pip install 'rapid-mlx[chat]')"
+    echo "    ANTHROPIC_BASE_URL=http://localhost:8000 claude    # Claude Code (or: rapid-mlx launch claude-code)"
+    echo "    OPENAI_API_BASE=http://localhost:8000/v1 aider     # Aider"
+}
+
 # When sourced by the test harness we only want the definitions above, not the
 # installer itself. `return` succeeds only in a sourced context; the `|| exit 0`
 # keeps an accidental `RAPID_INSTALL_LIB=1 bash install.sh` from erroring out.
@@ -392,8 +411,7 @@ esac
 
 # Query the just-installed CLI's stable JSON surface. Failure is harmless and
 # falls back to the RAM baseline; never scrape the human table or cache paths.
-CACHED_ALIASES="$(installed_cached_aliases || true)"
-RECOMMENDED_MODEL="$(select_starter_model "$RAM_GB" "$CACHED_ALIASES")"
+refresh_starter_from_installed_cache
 
 # ── 6. Create symlinks ──────────────────────────────────────────────────────
 
@@ -443,16 +461,7 @@ printf "  │  Version: %-25s│\n" "$VERSION"
 printf "  │  RAM: %-29s│\n" "${RAM_GB} GB ($RAM_TIER)"
 echo "  ╰─────────────────────────────────────╯"
 echo ""
-info "Quick start:"
-echo ""
-echo "    rapid-mlx serve ${RECOMMENDED_MODEL}${RECOMMENDED_FLAGS}"
-echo ""
-dim "Then open a second terminal:"
-echo ""
-echo "    rapid-mlx chat ${RECOMMENDED_MODEL} --port 8000    # built-in chat (terminal)"
-echo "    rapid-mlx-chat                                    # web chat UI (first: ${INSTALL_DIR}/bin/pip install 'rapid-mlx[chat]')"
-echo "    ANTHROPIC_BASE_URL=http://localhost:8000 claude    # Claude Code (or: rapid-mlx launch claude-code)"
-echo "    OPENAI_API_BASE=http://localhost:8000/v1 aider     # Aider"
+print_quick_start_commands
 echo ""
 dim "Upgrade:    curl -fsSL https://rapidmlx.com/install.sh | bash"
 dim "Uninstall:  rm -rf ~/.rapid-mlx ~/.rapid-mlx-python ~/.local/bin/rapid-mlx* ~/.local/bin/vllm-mlx*"

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -236,6 +236,19 @@ case "$BANNER" in
         bad "post-install structured cache choice reaches both quick-start commands"
         printf '        banner: %s\n' "$BANNER" ;;
 esac
+
+# A subprocess can print a syntactically valid partial result and still fail.
+# install.sh's top-level pipefail must make that entire cache query fail so the
+# banner uses the RAM baseline rather than trusting output from a failed scan.
+cat > "$CACHE_FIXTURE/bin/rapid-mlx" <<'EOF'
+#!/bin/bash
+printf '%s\n' '{"cached":[{"alias":"qwen3.8-27b-4bit","state":"ok"}]}'
+exit 7
+EOF
+RECOMMENDED_MODEL="stale"
+refresh_starter_from_installed_cache
+check "failed cache scan with valid partial JSON falls back to RAM baseline" \
+    "$RECOMMENDED_MODEL" "qwen3.5-4b-4bit"
 INSTALL_DIR="$OLD_INSTALL_DIR"
 
 echo

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -213,7 +213,7 @@ check "cache matching is exact, not a substring" \
 CACHE_FIXTURE="$WORK/cache_fixture"; mkdir -p "$CACHE_FIXTURE/bin"
 cat > "$CACHE_FIXTURE/bin/rapid-mlx" <<'EOF'
 #!/bin/bash
-printf '%s\n' '{"cached":[{"alias":"qwen3.5-9b-4bit","state":"ok"},{"alias":"partial","state":"incomplete"},{"alias":null,"state":"unmapped"}]}'
+printf '%s\n' '{"cached":[{"alias":"qwen3.5-9b-4bit","state":"ok"},{"alias":"qwen3.8-27b-4bit","state":"ok"},{"alias":"partial","state":"incomplete"},{"alias":null,"state":"unmapped"}]}'
 EOF
 cat > "$CACHE_FIXTURE/bin/python" <<'EOF'
 #!/bin/bash
@@ -222,7 +222,10 @@ EOF
 chmod +x "$CACHE_FIXTURE/bin/rapid-mlx" "$CACHE_FIXTURE/bin/python"
 OLD_INSTALL_DIR="$INSTALL_DIR"; INSTALL_DIR="$CACHE_FIXTURE"
 check "structured cache reader returns only runnable mapped aliases" \
-    "$(installed_cached_aliases)" "qwen3.5-9b-4bit"
+    "$(installed_cached_aliases)" $'qwen3.5-9b-4bit\nqwen3.8-27b-4bit'
+check "multiple structured cached aliases feed the selector independently" \
+    "$(select_starter_model 32 "$(installed_cached_aliases)")" \
+    "qwen3.8-27b-4bit"
 INSTALL_DIR="$OLD_INSTALL_DIR"
 
 if grep -Fq 'CACHED_ALIASES="$(installed_cached_aliases || true)"' "$INSTALL_SH"; then

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -194,8 +194,8 @@ CALLS=""; dispatch_venv rebuild
 check "dispatch rebuild -> reset then create" "$CALLS" " reset create"
 
 # ── 13. first-chat starter mirrors Desktop Quickstart (#2385) ────────────────
-check "15 GB fresh install uses the compact starter" \
-    "$(select_starter_model 15 '')" "lfm2.5-2.6b-4bit"
+check "15 GB fresh install uses the safe 1.2B starter" \
+    "$(select_starter_model 15 '')" "lfm2.5-1b-4bit"
 check "16 GB fresh install uses the standard starter" \
     "$(select_starter_model 16 '')" "qwen3.5-4b-4bit"
 check "32 GB fresh install does not suggest an uncached 27B model" \

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -226,13 +226,17 @@ check "structured cache reader returns only runnable mapped aliases" \
 check "multiple structured cached aliases feed the selector independently" \
     "$(select_starter_model 32 "$(installed_cached_aliases)")" \
     "qwen3.8-27b-4bit"
+RAM_GB=32 RECOMMENDED_MODEL="qwen3.5-4b-4bit" RECOMMENDED_FLAGS=""
+refresh_starter_from_installed_cache
+BANNER="$(print_quick_start_commands)"
+case "$BANNER" in
+    *"rapid-mlx serve qwen3.8-27b-4bit"*"rapid-mlx chat qwen3.8-27b-4bit --port 8000"*)
+        ok "post-install structured cache choice reaches both quick-start commands" ;;
+    *)
+        bad "post-install structured cache choice reaches both quick-start commands"
+        printf '        banner: %s\n' "$BANNER" ;;
+esac
 INSTALL_DIR="$OLD_INSTALL_DIR"
-
-if grep -Fq 'CACHED_ALIASES="$(installed_cached_aliases || true)"' "$INSTALL_SH"; then
-    ok "post-install banner selection consumes the structured cache query"
-else
-    bad "post-install banner selection consumes the structured cache query"
-fi
 
 echo
 printf 'passed %d, failed %d\n' "$PASS" "$FAIL"

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -193,6 +193,44 @@ check "dispatch create -> only venv create" "$CALLS" " create"
 CALLS=""; dispatch_venv rebuild
 check "dispatch rebuild -> reset then create" "$CALLS" " reset create"
 
+# ── 13. first-chat starter mirrors Desktop Quickstart (#2385) ────────────────
+check "15 GB fresh install uses the compact starter" \
+    "$(select_starter_model 15 '')" "lfm2.5-2.6b-4bit"
+check "16 GB fresh install uses the standard starter" \
+    "$(select_starter_model 16 '')" "qwen3.5-4b-4bit"
+check "32 GB fresh install does not suggest an uncached 27B model" \
+    "$(select_starter_model 32 '')" "qwen3.5-4b-4bit"
+check "eligible cached model is preferred" \
+    "$(select_starter_model 32 $'qwen3.5-4b-4bit\nqwen3.8-27b-4bit')" \
+    "qwen3.8-27b-4bit"
+check "cached model above the RAM tier is never selected" \
+    "$(select_starter_model 16 $'qwen3.8-27b-4bit\nlfm2.5-2.6b-4bit')" \
+    "lfm2.5-2.6b-4bit"
+check "cache matching is exact, not a substring" \
+    "$(select_starter_model 32 'prefix-qwen3.8-27b-4bit-suffix')" \
+    "qwen3.5-4b-4bit"
+
+CACHE_FIXTURE="$WORK/cache_fixture"; mkdir -p "$CACHE_FIXTURE/bin"
+cat > "$CACHE_FIXTURE/bin/rapid-mlx" <<'EOF'
+#!/bin/bash
+printf '%s\n' '{"cached":[{"alias":"qwen3.5-9b-4bit","state":"ok"},{"alias":"partial","state":"incomplete"},{"alias":null,"state":"unmapped"}]}'
+EOF
+cat > "$CACHE_FIXTURE/bin/python" <<'EOF'
+#!/bin/bash
+exec python3 "$@"
+EOF
+chmod +x "$CACHE_FIXTURE/bin/rapid-mlx" "$CACHE_FIXTURE/bin/python"
+OLD_INSTALL_DIR="$INSTALL_DIR"; INSTALL_DIR="$CACHE_FIXTURE"
+check "structured cache reader returns only runnable mapped aliases" \
+    "$(installed_cached_aliases)" "qwen3.5-9b-4bit"
+INSTALL_DIR="$OLD_INSTALL_DIR"
+
+if grep -Fq 'CACHED_ALIASES="$(installed_cached_aliases || true)"' "$INSTALL_SH"; then
+    ok "post-install banner selection consumes the structured cache query"
+else
+    bad "post-install banner selection consumes the structured cache query"
+fi
+
 echo
 printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -46,6 +46,24 @@ def _select_installer_starter(ram_gb: int, cached: tuple[str, ...] = ()) -> str:
     return result.stdout.strip()
 
 
+def _installer_cached_order(ram_gb: int) -> list[str]:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'RAPID_INSTALL_LIB=1 source "$1"; starter_cached_order_for_ram "$2"',
+            "order",
+            str(INSTALL_SH),
+            str(ram_gb),
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.splitlines()
+
+
 def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
     """``[(floor_gb, primary_alias, flags)]`` from the shared SSOT."""
     payload = json.loads(RECOMMENDATIONS.read_text())
@@ -94,12 +112,14 @@ def test_every_recommended_alias_exists():
 
     known = list_aliases()
     installer_aliases = set()
-    cached_candidates = {alias for _, alias, _ in _parse_app_tiers()}
     for ram in (8, 16, 18, 24, 32, 48, 64, 96):
         installer_aliases.add(_select_installer_starter(ram))
-        for cached in cached_candidates:
+        for cached in _installer_cached_order(ram):
             selected = _select_installer_starter(ram, (cached,))
             installer_aliases.add(selected)
+            assert cached in known, (
+                f"install.sh cached order for {ram} GB contains unknown alias {cached!r}"
+            )
     for alias in installer_aliases:
         assert alias in known, f"install.sh recommends unknown alias {alias!r}"
     for _, alias, _ in _parse_app_tiers():

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -75,18 +75,22 @@ def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
 
 def test_both_tables_parse():
     """Both the first-chat selector and model-browser SSOT are reachable."""
-    assert _select_installer_starter(8) == "lfm2.5-2.6b-4bit"
+    assert _select_installer_starter(8) == "lfm2.5-1b-4bit"
     assert _select_installer_starter(16) == "qwen3.5-4b-4bit"
     assert len(_parse_app_tiers()) >= 6
 
 
 def test_fresh_installer_uses_quickstart_baseline_at_every_ram_size():
     """First chat optimizes time-to-value, not the browser's largest pick."""
-    compact_alias, _ = _parse_quickstart_choice("compactDefaultChoice")
+    # Desktop's sub-16 GB baseline is the safe 1.2B lowMemoryChoice (#2432);
+    # at 16 GB and up it is the standard 4B defaultChoice.
+    sub16_alias, _ = _parse_quickstart_choice("lowMemoryChoice")
     standard_alias, _ = _parse_quickstart_choice("defaultChoice")
-    assert "hardware.physicalRAMGB < 16" in QUICKSTART.read_text()
+    assert (
+        "physicalRAMGB < 16 ? lowMemoryChoice : defaultChoice" in QUICKSTART.read_text()
+    )
     for ram in (4, 8, 15):
-        assert _select_installer_starter(ram) == compact_alias
+        assert _select_installer_starter(ram) == sub16_alias
     for ram in (16, 18, 24, 32, 48, 64, 96, 256):
         assert _select_installer_starter(ram) == standard_alias
 
@@ -129,7 +133,7 @@ def test_every_recommended_alias_exists():
 @pytest.mark.parametrize(
     "ram,expected",
     [
-        (8, "lfm2.5-2.6b-4bit"),
+        (8, "lfm2.5-1b-4bit"),
         (16, "qwen3.5-4b-4bit"),
         (18, "qwen3.5-4b-4bit"),
     ],
@@ -183,9 +187,9 @@ def _readme_prose_tiers() -> list[tuple[int, str]]:
     """The quick-start prose pins the two first-chat baselines."""
     text = README.read_text()
     assert "prefers a runnable model already cached" in text
-    assert "`lfm2.5-2.6b-4bit` below 16 GB" in text
+    assert "`lfm2.5-1b-4bit` below 16 GB" in text
     assert "`qwen3.5-4b-4bit` at 16 GB or above" in text
-    return [(8, "lfm2.5-2.6b-4bit"), (16, "qwen3.5-4b-4bit")]
+    return [(8, "lfm2.5-1b-4bit"), (16, "qwen3.5-4b-4bit")]
 
 
 def test_readme_table_matches_the_app_tier_for_tier():
@@ -213,7 +217,7 @@ def test_readme_table_matches_the_app_tier_for_tier():
 def test_readme_prose_matches_the_readme_table():
     """Installer starters are deliberately smaller than browser smart picks."""
     assert _readme_prose_tiers() == [
-        (8, "lfm2.5-2.6b-4bit"),
+        (8, "lfm2.5-1b-4bit"),
         (16, "qwen3.5-4b-4bit"),
     ]
 

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -1,17 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""``install.sh`` and the desktop app must recommend the same model.
+"""Installer first-chat and Desktop recommendation source contracts.
 
-We ship two front doors that answer "what should this Mac run": the
-``curl … | bash`` banner and the app's picker. They drifted to six tiers
-with a single match — a user who installed via curl and then opened the
-app was told to run two different models on the same machine, and curl is
-the canonical entry point in the README.
-
-This test is the thing that would have caught it. It parses both tables
-out of their source files and compares them: same floors, same aliases,
-same launch flags. Neither file imports the other (one is shell, one is
-Swift), so a text comparison is the only mechanism available — which is
-precisely why the drift went unnoticed for so long.
+The model browser answers "what is the smartest model this Mac can run";
+the installer and Desktop Quickstart answer "what gets a new user to a good
+first chat quickly". Those are deliberately different policies. This suite
+keeps the browser table aligned with its JSON SSOT while executing the
+installer's library-mode selector to pin the Quickstart baseline and the
+RAM ceiling on cached promotions.
 
 mlx-free: pure parsing, no engine import, runs on the Linux CI leg.
 """
@@ -31,39 +26,24 @@ RECOMMENDATIONS = REPO / "vllm_mlx/model_recommendations.json"
 README = REPO / "README.md"
 
 
-def _parse_install_sh() -> list[tuple[int, str, list[str]]]:
-    """``[(floor_gb, alias, flags)]`` from the RECOMMENDED_MODEL block."""
-    text = INSTALL_SH.read_text()
-    block = re.search(r"RECOMMENDED_FLAGS=\"\"\n(.*?)\nfi\n", text, re.DOTALL)
-    assert block, "RECOMMENDED_MODEL branch block not found in install.sh"
-    body = block.group(1)
-
-    tiers: list[tuple[int, str, list[str]]] = []
-    pending_floor: int | None = None
-    pending_alias: str | None = None
-    for line in body.splitlines():
-        branch = re.search(r'-ge (\d+) \]; then RECOMMENDED_MODEL="([^"]+)"', line)
-        if branch:
-            if pending_alias is not None:
-                tiers.append((pending_floor, pending_alias, []))
-            pending_floor = int(branch.group(1))
-            pending_alias = branch.group(2)
-            continue
-        fallback = re.search(r'^else\s+RECOMMENDED_MODEL="([^"]+)"', line)
-        if fallback:
-            if pending_alias is not None:
-                tiers.append((pending_floor, pending_alias, []))
-            # The else arm is the lowest tier; its floor is the app's
-            # smallest floor, which the caller checks separately.
-            pending_floor, pending_alias = -1, fallback.group(1)
-            continue
-        flags = re.search(r'RECOMMENDED_FLAGS="\s*([^"]*)"', line)
-        if flags and pending_alias is not None:
-            tiers.append((pending_floor, pending_alias, flags.group(1).split()))
-            pending_floor = pending_alias = None
-    if pending_alias is not None:
-        tiers.append((pending_floor, pending_alias, []))
-    return tiers
+def _select_installer_starter(ram_gb: int, cached: tuple[str, ...] = ()) -> str:
+    """Execute only install.sh's library-mode pure starter selector."""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'RAPID_INSTALL_LIB=1 source "$1"; select_starter_model "$2" "$3"',
+            "selector",
+            str(INSTALL_SH),
+            str(ram_gb),
+            "\n".join(cached),
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
 
 
 def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
@@ -76,112 +56,36 @@ def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
 
 
 def test_both_tables_parse():
-    """A parser that silently matches nothing would make every assertion
-    below vacuously true."""
-    assert len(_parse_install_sh()) >= 5
+    """Both the first-chat selector and model-browser SSOT are reachable."""
+    assert _select_installer_starter(8) == "lfm2.5-2.6b-4bit"
+    assert _select_installer_starter(16) == "qwen3.5-4b-4bit"
     assert len(_parse_app_tiers()) >= 6
 
 
-def test_same_alias_at_every_ram_size():
-    """The comparison that matters: for a real Mac's RAM, both front doors
-    name the same model. Compared by RAM size rather than by row so the
-    app's explicit laptop tiers are checked at both sides of each boundary."""
-    sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
-    app = sorted(_parse_app_tiers(), key=lambda t: t[0], reverse=True)
-
-    def pick(tiers, ram):
-        """Both tables clamp below their lowest floor and must agree there
-        too — ``RAMBucketedDefault.tier`` starts at ``tiers[0]`` and only
-        moves up, install.sh's ``else`` arm catches everything. A 4 GB
-        reading (a probe failure reports 0) must not fall off the end."""
-        for floor, alias, flags in tiers:
-            if ram >= floor:
-                return alias, flags
-        return tiers[-1][1], tiers[-1][2]
-
-    # Every boundary in EITHER table, plus the value on each side of it.
-    # A fixed sample list misses the failure this test exists to catch: move
-    # the shell's 24 GB floor to 23 and a list that never probes 23 stays
-    # green while a real 23 GB Mac gets the wrong model.
-    floors = {f for f, _, _ in sh if f > 0} | {f for f, _, _ in app if f > 0}
-    probes = set()
-    for f in floors:
-        probes.update({f - 1, f, f + 1})
-    probes.update({4, 8, 256})  # below the floor, the floor, and a real Ultra
-    probes = sorted(r for r in probes if r > 0)
-
-    mismatches = []
-    for ram in probes:
-        sh_alias, sh_flags = pick(sh, ram)
-        app_alias, app_flags = pick(app, ram)
-        if (sh_alias, sh_flags) != (app_alias, app_flags):
-            mismatches.append(
-                f"{ram} GB: install.sh={sh_alias} {sh_flags} "
-                f"vs app={app_alias} {app_flags}"
-            )
-    assert not mismatches, (
-        "install.sh and the desktop app disagree about what to run:\n  "
-        + "\n  ".join(mismatches)
-        + "\n\nThe app's RAMBucketedDefault.tiers is the curated table "
-        "(measured footprints, capability column, monotonic invariant). "
-        "install.sh mirrors it. Update install.sh, not this test."
-    )
+def test_fresh_installer_uses_quickstart_baseline_at_every_ram_size():
+    """First chat optimizes time-to-value, not the browser's largest pick."""
+    compact_alias, _ = _parse_quickstart_choice("compactDefaultChoice")
+    standard_alias, _ = _parse_quickstart_choice("defaultChoice")
+    assert "hardware.physicalRAMGB < 16" in QUICKSTART.read_text()
+    for ram in (4, 8, 15):
+        assert _select_installer_starter(ram) == compact_alias
+    for ram in (16, 18, 24, 32, 48, 64, 96, 256):
+        assert _select_installer_starter(ram) == standard_alias
 
 
-def _render_banner(ram_gb: int) -> str:
-    """Run install.sh's own tier block + quick-start line for ``ram_gb``.
-
-    Asserting that ``RECOMMENDED_FLAGS`` gets *assigned* is not enough:
-    delete ``${RECOMMENDED_FLAGS}`` from the echo and the variable is still
-    set, the assignment test still passes, and the banner silently goes
-    back to printing a command that OOMs a 24 GB Mac. So execute the real
-    lines and read what a user would actually see.
-    """
-    text = INSTALL_SH.read_text()
-    block = re.search(r"(RECOMMENDED_FLAGS=\"\"\n.*?\nfi)\n", text, re.DOTALL)
-    assert block, "tier block not found"
-    echo = [
-        ln.strip()
-        for ln in text.splitlines()
-        if "rapid-mlx serve" in ln and ln.strip().startswith("echo ")
-    ]
-    assert echo, "quick-start serve line not found in install.sh"
-    script = f"RAM_GB={ram_gb}\n{block.group(1)}\n" + "\n".join(echo)
-    return subprocess.run(
-        ["sh", "-c", script], capture_output=True, text=True, timeout=30
-    ).stdout
-
-
-def test_the_banner_prints_the_27b_bare_from_32_gb_up():
-    """AA-Index policy (2026-08-18): every Mac from 32 GB up is handed
-    qwen3.8-27b-4bit, and it needs no tier flags — MTP is baked into the
-    alias and the measured 8K peak (20.0 GB) fits every one of these
-    tiers bare. The gemma flag bundle left the table with gemma."""
-    for ram in (32, 64, 96):
-        printed = _render_banner(ram)
-        assert "qwen3.8-27b-4bit" in printed, f"{ram} GB banner: {printed}"
+def test_cached_choice_is_preferred_only_when_it_fits_the_ram_tier():
+    assert _select_installer_starter(32, ("qwen3.8-27b-4bit",)) == "qwen3.8-27b-4bit"
+    assert _select_installer_starter(16, ("qwen3.8-27b-4bit",)) == "qwen3.5-4b-4bit"
 
 
 def test_the_banner_prints_a_bare_command_where_no_flags_are_needed():
-    """Control: launch flags must not leak onto tiers that do not want
-    them — since the gemma pick retired, that is every tier."""
-    for ram in (8, 16, 24, 32, 64, 96):
-        printed = _render_banner(ram)
-        assert "rapid-mlx serve" in printed
-        assert "--no-mllm" not in printed, f"{ram} GB banner: {printed}"
-
-
-def test_launch_flags_travel_with_the_recommendation():
-    """The flags install.sh prints are the flags the app launches with."""
-    for floor, alias, flags in _parse_app_tiers():
-        if not flags:
-            continue
-        sh_match = [t for t in _parse_install_sh() if t[1] == alias]
-        assert sh_match, f"{alias} needs flags {flags} but install.sh never offers it"
-        for _, _, sh_flags in sh_match:
-            assert sh_flags == flags, (
-                f"{alias}: app launches with {flags}, install.sh prints {sh_flags}"
-            )
+    text = INSTALL_SH.read_text()
+    serve_line = next(
+        line
+        for line in text.splitlines()
+        if line.strip().startswith("echo ") and "rapid-mlx serve" in line
+    )
+    assert "${RECOMMENDED_MODEL}${RECOMMENDED_FLAGS}" in serve_line
 
 
 def test_every_recommended_alias_exists():
@@ -189,12 +93,17 @@ def test_every_recommended_alias_exists():
     from vllm_mlx.model_aliases import list_aliases
 
     known = list_aliases()
-    for source, tiers in (
-        ("install.sh", _parse_install_sh()),
-        ("app", _parse_app_tiers()),
-    ):
-        for _, alias, _ in tiers:
-            assert alias in known, f"{source} recommends unknown alias {alias!r}"
+    installer_aliases = set()
+    cached_candidates = {alias for _, alias, _ in _parse_app_tiers()}
+    for ram in (8, 16, 18, 24, 32, 48, 64, 96):
+        installer_aliases.add(_select_installer_starter(ram))
+        for cached in cached_candidates:
+            selected = _select_installer_starter(ram, (cached,))
+            installer_aliases.add(selected)
+    for alias in installer_aliases:
+        assert alias in known, f"install.sh recommends unknown alias {alias!r}"
+    for _, alias, _ in _parse_app_tiers():
+        assert alias in known, f"app recommends unknown alias {alias!r}"
 
 
 @pytest.mark.parametrize(
@@ -202,19 +111,14 @@ def test_every_recommended_alias_exists():
     [
         (8, "lfm2.5-2.6b-4bit"),
         (16, "qwen3.5-4b-4bit"),
-        (18, "qwen3.5-9b-4bit"),
+        (18, "qwen3.5-4b-4bit"),
     ],
 )
 def test_small_macs_get_something_that_fits(ram, expected):
     """Pinned literally: these laptop tiers are the ones that changed, and a
     regression here is the difference between an 8 GB Mac running a model
     and being told nothing fits."""
-    sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
-    for floor, alias, _ in sh:
-        if ram >= floor:
-            assert alias == expected
-            return
-    pytest.fail(f"no install.sh tier matched {ram} GB")
+    assert _select_installer_starter(ram) == expected
 
 
 def _readme_table_tiers() -> list[tuple[int, str, str, list[str]]]:
@@ -256,21 +160,12 @@ def _readme_table_tiers() -> list[tuple[int, str, str, list[str]]]:
 
 
 def _readme_prose_tiers() -> list[tuple[int, str]]:
-    """``[(floor_gb, alias)]`` from the quick-start sentence.
-
-    The README states the map twice. The prose copy is the one a reader
-    hits first, and it can drift on its own — so it gets its own parse
-    rather than being covered by the table's.
-    """
+    """The quick-start prose pins the two first-chat baselines."""
     text = README.read_text()
-    m = re.search(r"prints a serve command sized to your Mac \(([^)]*)\)", text)
-    assert m, "quick-start tier sentence not found in README.md"
-    return [
-        (int(a), b)
-        for a, b in re.findall(
-            r"(\d+)(?:[–-]\d+)? GB\+? → `([a-z0-9.\-]+)`", m.group(1)
-        )
-    ]
+    assert "prefers a runnable model already cached" in text
+    assert "`lfm2.5-2.6b-4bit` below 16 GB" in text
+    assert "`qwen3.5-4b-4bit` at 16 GB or above" in text
+    return [(8, "lfm2.5-2.6b-4bit"), (16, "qwen3.5-4b-4bit")]
 
 
 def test_readme_table_matches_the_app_tier_for_tier():
@@ -296,14 +191,11 @@ def test_readme_table_matches_the_app_tier_for_tier():
 
 
 def test_readme_prose_matches_the_readme_table():
-    """The README states the map twice; both have to say the same thing."""
-    prose = sorted(_readme_prose_tiers())
-    table = sorted((f, a) for f, a, *_ in _readme_table_tiers())
-    assert prose == table, (
-        "the README's quick-start sentence and its tier table disagree:\n"
-        f"  prose: {prose}\n"
-        f"  table: {table}"
-    )
+    """Installer starters are deliberately smaller than browser smart picks."""
+    assert _readme_prose_tiers() == [
+        (8, "lfm2.5-2.6b-4bit"),
+        (16, "qwen3.5-4b-4bit"),
+    ]
 
 
 def test_readme_one_shot_commands_carry_the_exact_flags():


### PR DESCRIPTION
## Intention

Make the guided installer's first suggested chat model reach useful first value quickly while matching Desktop Quickstart's RAM-safe, cache-aware starter policy. Rebased onto main and reconciled so install.sh and the Desktop Quickstart recommend the SAME first-chat pick per RAM tier.

Fixes #2381.

## Scope

- `<16 GB` fresh installs suggest the safe 1.2B starter `lfm2.5-1b-4bit` — mirroring `QuickstartCoordinator.baselineChoice` (`lowMemoryChoice`), which main moved the sub-16 baseline to under #2432.
- `>=16 GB` fresh installs suggest `qwen3.5-4b-4bit` (`defaultChoice`).
- After installation, the banner prefers a runnable cached model from the curated order only when that model belongs to the detected RAM tier. Each tier's order mirrors `RAMBucketedDefault.preferenceOrder` minus the lowMemory alias the Desktop excludes from automatic selection.
- Cache discovery consumes `rapid-mlx models --cached --json`; it does not scan cache paths or parse presentation text.
- Installer contracts and the README quick-start line describe the same policy.

## Reconciliation note

The PR originally suggested `lfm2.5-2.6b-4bit` below 16 GB. On main, Desktop's sub-16 Quickstart baseline is now the safe 1.2B `lfm2.5-1b-4bit` (lowMemoryChoice, #2432); the 2.6B compact pick is no longer the automatic sub-16 baseline and is excluded from Desktop's cached auto-selection there. install.sh, the shell test, the drift test, and the README were updated to match so the installer and Desktop agree per tier.

## Non-goals

- No catalog, alias, Desktop, engine/server, recommendation JSON, or release-workflow changes.
- No change to the larger Smart/Fast picks shown by `rapid-mlx recipe` and the model browser.
- No model-name, repository-layout, or weight-file heuristics.

## Acceptance

The first-chat suggestion uses the tier baseline when nothing eligible is cached, prefers a known runnable cached choice, and never promotes a cached model above the machine's tier. Cache-query failure falls back safely to the RAM baseline.

## Verification

- Exact head: `162c17c3`.
- Installer shell contracts: 28 passed.
- Recommendation/README contracts: 21 passed.
- Bash syntax, ShellCheck error severity, Ruff (format + lint), and `git diff --check`: passed.