### PR TITLE
feat(mac): report consented Desktop activation milestones

### DIFF
--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -53,8 +53,9 @@ so one Mac is not counted as two installs. We collect:
     locals).
   * App version + macOS version + a short context label (e.g.
     `chat_send`, `download_install`).
-* `activation` — once per install for each first successful chat reply,
-  vision reply, delivered dictation transcript, or generated image. The
+* `activation` — once per install for each first successful text chat reply,
+  delivered dictation transcript, or generated image. A vision-reply milestone
+  is reserved in the event schema but is not sent by this version. The
   event-specific payload contains only the closed milestone name and
   `surface: desktop`; it contains no model, timing, count, prompt, response,
   attachment, transcript, generated image, or path.

--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -1,6 +1,6 @@
 # Rapid-MLX Desktop — Privacy Policy
 
-Last updated: 2026-08-18.
+Last updated: 2026-08-27.
 
 Rapid-MLX Desktop ("the App") is a local-first SwiftUI Mac client for the
 `rapid-mlx` inference server. We designed it so that your prompts,
@@ -53,6 +53,11 @@ so one Mac is not counted as two installs. We collect:
     locals).
   * App version + macOS version + a short context label (e.g.
     `chat_send`, `download_install`).
+* `activation` — once per install for each first successful chat reply,
+  vision reply, delivered dictation transcript, or generated image. The
+  event-specific payload contains only the closed milestone name and
+  `surface: desktop`; it contains no model, timing, count, prompt, response,
+  attachment, transcript, generated image, or path.
 * Embedded-engine `session_start`, `session_end`, `request`, and `error`
   events — only after the same opt-in. Depending on the bundled engine
   version, these can include:
@@ -75,7 +80,9 @@ Anonymous telemetry does **not** collect:
 
 The telemetry endpoint is `https://telemetry.rapidmlx.com/v1/events`.
 The receiving Cloudflare Worker strips client IPs before writing to
-storage. Source is open: `github.com/raullenchai/rapidmlx.com` under
+storage. At ingestion it derives a two-letter country code from Cloudflare's
+connection metadata for aggregate reporting (`XX` when unavailable); the IP
+address is never persisted. Source is open: `github.com/raullenchai/rapidmlx.com` under
 `telemetry-worker/`.
 
 ## Opt out

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1853,6 +1853,7 @@ final class ChatViewModel {
         conversationInstruction: String = ""
     ) async {
         var currentPlaceholder = initialPlaceholder
+        var usedImageInput = false
         defer {
             // A stream that outlived a conversation switch must not reset
             // the NEW conversation's streaming state or clear a newer
@@ -1863,6 +1864,7 @@ final class ChatViewModel {
                 if !Task.isCancelled,
                    let delivered = currentMessage(index: currentPlaceholder),
                    delivered.status == .complete,
+                   !usedImageInput,
                    !delivered.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     onProductValueDelivered(.chatReply)
                 }
@@ -1990,6 +1992,11 @@ final class ChatViewModel {
                     supportsImageInput: supportsImageInput
                 )
             }
+            // Classify the delivered value from the authoritative wire
+            // request, not from alias naming or only the newest user row. A
+            // plain-text follow-up can legitimately inherit an accepted image
+            // attachment, and a tool loop can span multiple requests.
+            usedImageInput = usedImageInput || request.imageMessageID != nil
             let outcome = await runOneStream(
                 placeholderIndex: currentPlaceholder,
                 request: request,

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DeferredTelemetryConsentCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DeferredTelemetryConsentCoordinator.swift
@@ -11,11 +11,21 @@ enum ProductValueKind: Equatable, Sendable {
     case chatReply
     case dictationTranscript
     case generatedImage
+
+    var telemetryActivationKind: TelemetryEvent.Activation.Kind {
+        switch self {
+        case .chatReply: .firstChatReply
+        case .dictationTranscript: .firstDictation
+        case .generatedImage: .firstImage
+        }
+    }
 }
 
 @MainActor
 @Observable
 final class DeferredTelemetryConsentCoordinator {
+
+    typealias ActivationReporter = @MainActor (ProductValueKind) async -> Void
 
     private(set) var isPresented = false
     private(set) var triggeringValue: ProductValueKind?
@@ -23,18 +33,28 @@ final class DeferredTelemetryConsentCoordinator {
     @ObservationIgnored private let needsDecision: () -> Bool
     @ObservationIgnored private let recordDecision: (Bool) -> Void
     @ObservationIgnored private let startTelemetrySession: () async -> Void
+    @ObservationIgnored private let reportActivation: ActivationReporter
     @ObservationIgnored private var resolvedThisProcess: Bool
+    /// Typed success only — never a built event, identity, payload, or local
+    /// journal before consent. The first value owns the banner copy while the
+    /// tiny array preserves another approved success that may arrive before a
+    /// user answers the nonmodal invitation.
+    @ObservationIgnored private var pendingActivationKinds: [ProductValueKind] = []
 
     init(
         needsDecision: @escaping () -> Bool = { TelemetryConsent.needsDecision() },
         recordDecision: @escaping (Bool) -> Void = { TelemetryConsent.record(enabled: $0) },
         startTelemetrySession: @escaping () async -> Void = {
             await TelemetrySession.sendStartIfNeeded()
-        }
+        },
+        reportActivation: ActivationReporter? = nil
     ) {
         self.needsDecision = needsDecision
         self.recordDecision = recordDecision
         self.startTelemetrySession = startTelemetrySession
+        self.reportActivation = reportActivation ?? { kind in
+            await DesktopActivationReporter.shared.report(kind.telemetryActivationKind)
+        }
         self.resolvedThisProcess = !needsDecision()
     }
 
@@ -42,10 +62,17 @@ final class DeferredTelemetryConsentCoordinator {
     /// converge on one prompt and an existing durable decision always wins.
     func productValueDelivered(_ kind: ProductValueKind) {
         let decisionIsOwed = needsDecision()
-        guard !resolvedThisProcess, !isPresented, decisionIsOwed else {
-            if !decisionIsOwed { resolvedThisProcess = true }
+        guard decisionIsOwed else {
+            resolvedThisProcess = true
+            Task { await reportActivation(kind) }
             return
         }
+
+        guard !resolvedThisProcess else { return }
+        if !pendingActivationKinds.contains(kind) {
+            pendingActivationKinds.append(kind)
+        }
+        guard !isPresented else { return }
         triggeringValue = kind
         isPresented = true
     }
@@ -71,8 +98,15 @@ final class DeferredTelemetryConsentCoordinator {
         resolvedThisProcess = true
         isPresented = false
         recordDecision(enabled)
+        let activations = pendingActivationKinds
+        pendingActivationKinds.removeAll()
         guard enabled else { return }
-        Task { await startTelemetrySession() }
+        Task {
+            await startTelemetrySession()
+            for kind in activations {
+                await reportActivation(kind)
+            }
+        }
     }
 
     private func resolve(enabled: Bool) {
@@ -80,7 +114,14 @@ final class DeferredTelemetryConsentCoordinator {
         resolvedThisProcess = true
         isPresented = false
         recordDecision(enabled)
+        let activations = pendingActivationKinds
+        pendingActivationKinds.removeAll()
         guard enabled else { return }
-        Task { await startTelemetrySession() }
+        Task {
+            await startTelemetrySession()
+            for kind in activations {
+                await reportActivation(kind)
+            }
+        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
@@ -1,0 +1,100 @@
+import Darwin
+import Foundation
+
+/// Sends the three product-approved Desktop activation milestones through the
+/// existing telemetry envelope. Feature models publish a typed success; this
+/// actor owns consent, once-per-install delivery, and marker persistence.
+///
+/// The order is intentional: consent -> marker lookup -> event construction ->
+/// accepted send -> marker claim. An undecided/declined install therefore does
+/// not create an identifier, event, marker, or pre-consent journal. A transport
+/// failure leaves the milestone retryable, while a rare post-send marker failure
+/// can only produce an at-least-once duplicate that the collector de-duplicates
+/// by client ID.
+actor DesktopActivationReporter {
+    typealias Kind = TelemetryEvent.Activation.Kind
+    typealias Enabled = @Sendable () -> Bool
+    typealias BuildEvent = @Sendable (Kind) -> TelemetryEvent
+    typealias SendEvent = @Sendable (TelemetryEvent) async -> Bool
+
+    static let shared = DesktopActivationReporter()
+
+    private let isEnabled: Enabled
+    private let buildEvent: BuildEvent
+    private let sendEvent: SendEvent
+    private let markerDirectory: URL
+    private var resolvedThisProcess: Set<Kind> = []
+    private var inFlight: Set<Kind> = []
+
+    init(
+        isEnabled: @escaping Enabled = { TelemetryConfig.isEnabled },
+        buildEvent: @escaping BuildEvent = { kind in
+            TelemetryEvent.activation(
+                version: TelemetryClient.currentVersion(),
+                platform: TelemetryClient.currentPlatform(),
+                kind: kind
+            )
+        },
+        sendEvent: @escaping SendEvent = { event in
+            await TelemetryClient().sendBatch([event])
+        },
+        markerDirectory: URL = TelemetryIdentity.sharedTelemetryDirectory()
+    ) {
+        self.isEnabled = isEnabled
+        self.buildEvent = buildEvent
+        self.sendEvent = sendEvent
+        self.markerDirectory = markerDirectory
+    }
+
+    func report(_ kind: Kind) async {
+        guard !resolvedThisProcess.contains(kind), !inFlight.contains(kind) else { return }
+
+        // This is the privacy boundary. Do not even inspect the marker path
+        // until the durable shared consent says telemetry is enabled.
+        guard isEnabled() else { return }
+
+        let marker = markerURL(for: kind)
+        if FileManager.default.fileExists(atPath: marker.path) {
+            resolvedThisProcess.insert(kind)
+            return
+        }
+
+        inFlight.insert(kind)
+        let event = buildEvent(kind)
+        let accepted = await sendEvent(event)
+        inFlight.remove(kind)
+        guard accepted else { return }
+
+        _ = claimMarker(at: marker)
+        resolvedThisProcess.insert(kind)
+    }
+
+    private func markerURL(for kind: Kind) -> URL {
+        markerDirectory.appendingPathComponent(
+            "activation_seen_desktop_\(kind.rawValue)",
+            isDirectory: false
+        )
+    }
+
+    /// Best-effort O_EXCL claim, matching the engine activation marker
+    /// primitive. The kind is a closed enum, so no user-controlled path
+    /// component can escape the shared telemetry directory.
+    private func claimMarker(at url: URL) -> Bool {
+        do {
+            try FileManager.default.createDirectory(
+                at: markerDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch {
+            return false
+        }
+
+        let descriptor = url.path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL, mode_t(0o600))
+        }
+        guard descriptor >= 0 else { return false }
+        close(descriptor)
+        return true
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
@@ -25,6 +25,7 @@ actor DesktopActivationReporter {
     private let markerDirectory: URL
     private var resolvedThisProcess: Set<Kind> = []
     private var inFlight: Set<Kind> = []
+    private var pendingWhileInFlight: Set<Kind> = []
 
     init(
         isEnabled: @escaping Enabled = { TelemetryConfig.isEnabled },
@@ -47,7 +48,11 @@ actor DesktopActivationReporter {
     }
 
     func report(_ kind: Kind) async {
-        guard !resolvedThisProcess.contains(kind), !inFlight.contains(kind) else { return }
+        guard !resolvedThisProcess.contains(kind) else { return }
+        if inFlight.contains(kind) {
+            pendingWhileInFlight.insert(kind)
+            return
+        }
 
         // This is the privacy boundary. Do not even inspect the marker path
         // until the durable shared consent says telemetry is enabled.
@@ -60,32 +65,49 @@ actor DesktopActivationReporter {
         }
 
         inFlight.insert(kind)
+        defer {
+            inFlight.remove(kind)
+            pendingWhileInFlight.remove(kind)
+        }
         let event = buildEvent(kind)
-        let delivery = await sendEvent(event)
-        inFlight.remove(kind)
-        // ``TelemetryClient.sendBatch`` deliberately reports opted-out as a
-        // cleanup-success to its crash-marker caller. Re-check here before
-        // claiming an activation marker so a Settings opt-out racing this send
-        // can never retire a milestone that did not actually leave the Mac.
-        // If consent changed after a real accepted send, leaving the marker
-        // retryable permits only a harmless DISTINCT-client deduplicated replay.
-        switch delivery {
-        case .accepted:
-            guard isEnabled() else { return }
-            _ = claimMarker(at: marker)
-            resolvedThisProcess.insert(kind)
-        case .discard:
-            // A permanent 4xx or invalid local envelope must not turn one
-            // milestone into a request on every later feature success. Keep
-            // the durable marker unclaimed so a future app launch can retry
-            // after an update. An opt-out racing the send also reports
-            // ``discard``; leave that case unresolved so a later Settings
-            // opt-in in this process can still deliver the milestone.
-            if isEnabled() {
+        while true {
+            let delivery = await sendEvent(event)
+            let hasPendingSuccess = pendingWhileInFlight.remove(kind) != nil
+            // ``TelemetryClient.sendBatch`` deliberately reports opted-out as
+            // a cleanup-success to its crash-marker caller. Re-check here
+            // before claiming an activation marker so a Settings opt-out
+            // racing this send can never retire a milestone that did not
+            // actually leave the Mac. If consent changed after a real accepted
+            // send, leaving the marker retryable permits only a harmless
+            // DISTINCT-client deduplicated replay.
+            switch delivery {
+            case .accepted:
+                guard isEnabled() else { return }
+                _ = claimMarker(at: marker)
                 resolvedThisProcess.insert(kind)
+                return
+            case .discard:
+                // A permanent 4xx or invalid local envelope must not turn one
+                // milestone into a request on every later feature success.
+                // Keep the durable marker unclaimed so a future app launch can
+                // retry after an update. An opt-out racing the send also
+                // reports ``discard``; leave that case unresolved so a later
+                // Settings opt-in in this process can still deliver it.
+                if isEnabled() {
+                    resolvedThisProcess.insert(kind)
+                }
+                return
+            case .retry:
+                // A successful product action that arrived while this request
+                // was suspended is the next retry opportunity. Coalesce any
+                // number of such calls into one resend; without one, leave the
+                // milestone unresolved for the next product success.
+                guard hasPendingSuccess, isEnabled() else { return }
+                if FileManager.default.fileExists(atPath: marker.path) {
+                    resolvedThisProcess.insert(kind)
+                    return
+                }
             }
-        case .retry:
-            break
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
@@ -15,7 +15,7 @@ actor DesktopActivationReporter {
     typealias Kind = TelemetryEvent.Activation.Kind
     typealias Enabled = @Sendable () -> Bool
     typealias BuildEvent = @Sendable (Kind) -> TelemetryEvent
-    typealias SendEvent = @Sendable (TelemetryEvent) async -> Bool
+    typealias SendEvent = @Sendable (TelemetryEvent) async -> TelemetryClient.BatchDelivery
 
     static let shared = DesktopActivationReporter()
 
@@ -36,7 +36,7 @@ actor DesktopActivationReporter {
             )
         },
         sendEvent: @escaping SendEvent = { event in
-            await TelemetryClient().sendBatch([event])
+            await TelemetryClient().sendBatchDelivery([event])
         },
         markerDirectory: URL = TelemetryIdentity.sharedTelemetryDirectory()
     ) {
@@ -61,7 +61,7 @@ actor DesktopActivationReporter {
 
         inFlight.insert(kind)
         let event = buildEvent(kind)
-        let accepted = await sendEvent(event)
+        let delivery = await sendEvent(event)
         inFlight.remove(kind)
         // ``TelemetryClient.sendBatch`` deliberately reports opted-out as a
         // cleanup-success to its crash-marker caller. Re-check here before
@@ -69,7 +69,7 @@ actor DesktopActivationReporter {
         // can never retire a milestone that did not actually leave the Mac.
         // If consent changed after a real accepted send, leaving the marker
         // retryable permits only a harmless DISTINCT-client deduplicated replay.
-        guard accepted, isEnabled() else { return }
+        guard delivery == .accepted, isEnabled() else { return }
 
         _ = claimMarker(at: marker)
         resolvedThisProcess.insert(kind)

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
@@ -63,7 +63,13 @@ actor DesktopActivationReporter {
         let event = buildEvent(kind)
         let accepted = await sendEvent(event)
         inFlight.remove(kind)
-        guard accepted else { return }
+        // ``TelemetryClient.sendBatch`` deliberately reports opted-out as a
+        // cleanup-success to its crash-marker caller. Re-check here before
+        // claiming an activation marker so a Settings opt-out racing this send
+        // can never retire a milestone that did not actually leave the Mac.
+        // If consent changed after a real accepted send, leaving the marker
+        // retryable permits only a harmless DISTINCT-client deduplicated replay.
+        guard accepted, isEnabled() else { return }
 
         _ = claimMarker(at: marker)
         resolvedThisProcess.insert(kind)

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/DesktopActivationReporter.swift
@@ -69,10 +69,24 @@ actor DesktopActivationReporter {
         // can never retire a milestone that did not actually leave the Mac.
         // If consent changed after a real accepted send, leaving the marker
         // retryable permits only a harmless DISTINCT-client deduplicated replay.
-        guard delivery == .accepted, isEnabled() else { return }
-
-        _ = claimMarker(at: marker)
-        resolvedThisProcess.insert(kind)
+        switch delivery {
+        case .accepted:
+            guard isEnabled() else { return }
+            _ = claimMarker(at: marker)
+            resolvedThisProcess.insert(kind)
+        case .discard:
+            // A permanent 4xx or invalid local envelope must not turn one
+            // milestone into a request on every later feature success. Keep
+            // the durable marker unclaimed so a future app launch can retry
+            // after an update. An opt-out racing the send also reports
+            // ``discard``; leave that case unresolved so a later Settings
+            // opt-in in this process can still deliver the milestone.
+            if isEnabled() {
+                resolvedThisProcess.insert(kind)
+            }
+        case .retry:
+            break
+        }
     }
 
     private func markerURL(for kind: Kind) -> URL {

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
@@ -22,6 +22,16 @@ import Foundation
 /// the nonisolated method without tripping Swift 6 region-based
 /// sending diagnostics (issue #530).
 struct TelemetryClient: @unchecked Sendable {
+    enum BatchDelivery: Equatable, Sendable {
+        /// The Worker accepted the payload with a 2xx response.
+        case accepted
+        /// Retrying the same payload cannot make it valid (for example 400 or
+        /// an oversized local envelope), so marker-backed callers may discard it.
+        case discard
+        /// The request may succeed later (transport failure, throttling, or 5xx).
+        case retry
+    }
+
     /// Codex audit batch 8 finding T1 (P2): a 307/308 from
     /// ``telemetry.rapidmlx.com`` would replay the POST body to an
     /// arbitrary host with ``URLSession.shared``'s default redirect
@@ -100,14 +110,20 @@ struct TelemetryClient: @unchecked Sendable {
     /// cleanup path runs (there is nothing meaningful to retry).
     @discardableResult
     func sendBatch(_ events: [TelemetryEvent]) async -> Bool {
-        guard TelemetryConfig.isEnabled(defaults: defaults) else { return true }
-        guard !events.isEmpty else { return true }
+        await sendBatchDelivery(events) != .retry
+    }
+
+    /// The typed delivery result for callers whose once-only state must only
+    /// advance after a real Worker acceptance. ``sendBatch`` retains its
+    /// historical cleanup Boolean for crash-marker compatibility.
+    func sendBatchDelivery(_ events: [TelemetryEvent]) async -> BatchDelivery {
+        guard TelemetryConfig.isEnabled(defaults: defaults) else { return .discard }
+        guard !events.isEmpty else { return .discard }
         let envelope: [String: [TelemetryEvent]] = ["batch": events]
-        guard let body = try? JSONEncoder().encode(envelope) else { return false }
+        guard let body = try? JSONEncoder().encode(envelope) else { return .retry }
         // Codex audit batch 8 T2 (P2): refuse oversized batches.
-        // Returning ``true`` lets the caller retire the markers —
-        // the batch would 413 forever; better to drop than retry.
-        guard body.count <= TelemetryClient.maxBodyBytes else { return true }
+        // The batch would 413 forever; better to discard than retry.
+        guard body.count <= TelemetryClient.maxBodyBytes else { return .discard }
         var req = URLRequest(url: TelemetryConfig.endpoint)
         req.httpMethod = "POST"
         req.timeoutInterval = 8
@@ -115,24 +131,24 @@ struct TelemetryClient: @unchecked Sendable {
         req.httpBody = body
         do {
             let (_, response) = try await session.data(for: req)
-            guard let http = response as? HTTPURLResponse else { return false }
+            guard let http = response as? HTTPURLResponse else { return .retry }
             let code = http.statusCode
             if (200..<300).contains(code) {
-                return true
+                return .accepted
             }
-            // Codex audit batch 8 T3 (P2): classify response. 4xx
-            // means the server permanently rejected the payload —
-            // retrying every launch with the same marker just burns
-            // bandwidth and re-pollutes Worker logs with the same
-            // failed schema validation. Treat 4xx as "delete on
-            // disk" by returning ``true``. 5xx and transport errors
-            // (catch branch below) stay retryable.
+            // Codex audit batch 8 T3 (P2): classify response. Most 4xx
+            // responses permanently reject the payload, while timeout and
+            // throttling responses may succeed later. 5xx and transport
+            // errors (catch branch below) also stay retryable.
+            if code == 408 || code == 429 {
+                return .retry
+            }
             if (400..<500).contains(code) {
-                return true
+                return .discard
             }
-            return false
+            return .retry
         } catch {
-            return false
+            return .retry
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
@@ -19,6 +19,7 @@ struct TelemetryEvent: Codable, Sendable {
         case sessionStart = "session_start"
         case sessionEnd = "session_end"
         case error
+        case activation
     }
 
     var schema_version: Int
@@ -32,6 +33,26 @@ struct TelemetryEvent: Codable, Sendable {
     var error_message: String?
     var stack_frames: [String]?
     var context: String?
+    var activation: Activation?
+
+    /// Content-free, once-per-install product milestone. The collector already
+    /// accepts the engine's `activation` discriminator; Desktop reuses that
+    /// audited envelope instead of inventing a second transport or an
+    /// open-ended extras dictionary.
+    struct Activation: Codable, Sendable, Equatable {
+        enum Kind: String, Codable, Sendable, CaseIterable, Hashable {
+            case firstChatReply = "first_chat_reply"
+            case firstDictation = "first_dictation"
+            case firstImage = "first_image"
+        }
+
+        enum Surface: String, Codable, Sendable {
+            case desktop
+        }
+
+        var activation_kind: Kind
+        var surface: Surface
+    }
 
     struct Platform: Codable, Sendable {
         var app: String
@@ -82,7 +103,8 @@ struct TelemetryEvent: Codable, Sendable {
             error_type: nil,
             error_message: nil,
             stack_frames: nil,
-            context: nil
+            context: nil,
+            activation: nil
         )
     }
 
@@ -141,7 +163,36 @@ struct TelemetryEvent: Codable, Sendable {
             stack_frames: stackFrames.prefix(30).map {
                 TelemetryEvent.redact($0, cap: 256)
             },
-            context: context.map { TelemetryEvent.redact($0, cap: 128) }
+            context: context.map { TelemetryEvent.redact($0, cap: 128) },
+            activation: nil
+        )
+    }
+
+    /// Build a Desktop activation only after the caller has crossed the
+    /// explicit-consent gate. Keeping that precondition visible at the type's
+    /// sole construction boundary prevents feature code from accidentally
+    /// creating an identity-bearing event while consent is undecided.
+    static func activation(
+        version: String,
+        platform: Platform,
+        kind: Activation.Kind
+    ) -> TelemetryEvent {
+        return TelemetryEvent(
+            schema_version: TelemetryConfig.schemaVersion,
+            client_id: TelemetryIdentity.clientID(),
+            session_id: TelemetryConfig.sessionID,
+            rapid_mlx_version: version,
+            event: .activation,
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            platform: platform,
+            error_type: nil,
+            error_message: nil,
+            stack_frames: nil,
+            context: nil,
+            activation: Activation(
+                activation_kind: kind,
+                surface: .desktop
+            )
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -569,7 +569,7 @@ struct SettingsView: View {
             Toggle(isOn: telemetryEnabledBinding) {
                 SettingsRowLabel(
                     title: "Send anonymous usage data",
-                    description: "Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. For each first successful chat reply, vision reply, dictation, or image, only the milestone name and “Desktop” are sent. The collector derives a country code but never stores your IP. Never prompts, responses, attachments, keys, account details, or unredacted user paths."
+                    description: "Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. For each first successful text chat reply, dictation, or generated image, only the milestone name and “Desktop” are sent. This version does not send a vision-reply milestone. The collector derives a country code but never stores your IP. Never prompts, responses, attachments, keys, account details, or unredacted user paths."
                 )
             }
             .toggleStyle(TrailingSettingsToggleStyle())

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -569,7 +569,7 @@ struct SettingsView: View {
             Toggle(isOn: telemetryEnabledBinding) {
                 SettingsRowLabel(
                     title: "Send anonymous usage data",
-                    description: "Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. Never prompts, responses, attachments, keys, account details, or unredacted user paths."
+                    description: "Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. For each first successful chat reply, vision reply, dictation, or image, only the milestone name and “Desktop” are sent. The collector derives a country code but never stores your IP. Never prompts, responses, attachments, keys, account details, or unredacted user paths."
                 )
             }
             .toggleStyle(TrailingSettingsToggleStyle())

--- a/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
@@ -18,7 +18,7 @@ struct DeferredTelemetryConsentBanner: View {
                 Text("Help improve Rapid by sharing anonymous usage data?")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(RapidTheme.textPrimary)
-                Text("For each first successful chat reply, vision reply, dictation, or image, only the milestone name and “Desktop” are sent. The collector derives a country code but never stores your IP. Prompts, responses, attachments, and API keys are never collected. Change this anytime in Settings → Privacy.")
+                Text("For each first successful text chat reply, dictation, or generated image, only the milestone name and “Desktop” are sent. This version does not send a vision-reply milestone. The collector derives a country code but never stores your IP. Prompts, responses, attachments, and API keys are never collected. Change this anytime in Settings → Privacy.")
                     .font(.system(size: 12))
                     .foregroundStyle(RapidTheme.textSecondary)
                     .lineLimit(4)

--- a/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
@@ -18,10 +18,10 @@ struct DeferredTelemetryConsentBanner: View {
                 Text("Help improve Rapid by sharing anonymous usage data?")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(RapidTheme.textPrimary)
-                Text("Prompts, responses, attachments, and API keys are never collected. Change this anytime in Settings → Privacy.")
+                Text("For each first successful chat reply, vision reply, dictation, or image, only the milestone name and “Desktop” are sent. The collector derives a country code but never stores your IP. Prompts, responses, attachments, and API keys are never collected. Change this anytime in Settings → Privacy.")
                     .font(.system(size: 12))
                     .foregroundStyle(RapidTheme.textSecondary)
-                    .lineLimit(2)
+                    .lineLimit(4)
             }
 
             Spacer(minLength: RapidTheme.Space.md)

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentCoordinatorTests.swift
@@ -8,6 +8,7 @@ struct DeferredTelemetryConsentCoordinatorTests {
     final class Recorder {
         var decisions: [Bool] = []
         var sessionStarts = 0
+        var activations: [ProductValueKind] = []
     }
 
     private func makeCoordinator(
@@ -17,7 +18,8 @@ struct DeferredTelemetryConsentCoordinatorTests {
         DeferredTelemetryConsentCoordinator(
             needsDecision: { needsDecision },
             recordDecision: { recorder.decisions.append($0) },
-            startTelemetrySession: { recorder.sessionStarts += 1 }
+            startTelemetrySession: { recorder.sessionStarts += 1 },
+            reportActivation: { recorder.activations.append($0) }
         )
     }
 
@@ -48,6 +50,21 @@ struct DeferredTelemetryConsentCoordinatorTests {
         #expect(coordinator.triggeringValue == .chatReply)
     }
 
+    @Test("Every typed success before the answer is emitted only after Share")
+    func pendingKindsWaitForShare() async {
+        let recorder = Recorder()
+        let coordinator = makeCoordinator(recorder: recorder)
+        coordinator.productValueDelivered(.chatReply)
+        coordinator.productValueDelivered(.generatedImage)
+        coordinator.productValueDelivered(.chatReply)
+        #expect(recorder.activations.isEmpty)
+
+        coordinator.share()
+        await Task.yield()
+
+        #expect(recorder.activations == [.chatReply, .generatedImage])
+    }
+
     @Test("An existing durable decision suppresses the invitation")
     func existingDecisionWins() {
         let coordinator = makeCoordinator(needsDecision: false)
@@ -64,6 +81,7 @@ struct DeferredTelemetryConsentCoordinatorTests {
         coordinator.productValueDelivered(.chatReply)
         #expect(recorder.decisions == [false])
         #expect(recorder.sessionStarts == 0)
+        #expect(recorder.activations.isEmpty)
         #expect(!coordinator.isPresented)
     }
 
@@ -75,6 +93,7 @@ struct DeferredTelemetryConsentCoordinatorTests {
         coordinator.close()
         #expect(recorder.decisions == [false])
         #expect(recorder.sessionStarts == 0)
+        #expect(recorder.activations.isEmpty)
         #expect(!coordinator.isPresented)
     }
 
@@ -88,6 +107,7 @@ struct DeferredTelemetryConsentCoordinatorTests {
         await Task.yield()
         #expect(recorder.decisions == [true])
         #expect(recorder.sessionStarts == 1)
+        #expect(recorder.activations == [.chatReply])
         #expect(!coordinator.isPresented)
     }
 
@@ -100,6 +120,7 @@ struct DeferredTelemetryConsentCoordinatorTests {
         await Task.yield()
         #expect(recorder.decisions == [true])
         #expect(recorder.sessionStarts == 1)
+        #expect(recorder.activations == [.chatReply])
         #expect(!coordinator.isPresented)
     }
 
@@ -114,6 +135,27 @@ struct DeferredTelemetryConsentCoordinatorTests {
 
         #expect(recorder.decisions == [false, true])
         #expect(recorder.sessionStarts == 1)
+        #expect(recorder.activations.isEmpty)
         #expect(!coordinator.isPresented)
+    }
+
+    @Test("An already-consented install reports future product value without showing a banner")
+    func existingOptInReportsActivation() async {
+        let recorder = Recorder()
+        let coordinator = makeCoordinator(needsDecision: false, recorder: recorder)
+
+        coordinator.productValueDelivered(.dictationTranscript)
+        await Task.yield()
+
+        #expect(recorder.decisions.isEmpty)
+        #expect(recorder.activations == [.dictationTranscript])
+        #expect(!coordinator.isPresented)
+    }
+
+    @Test("Product-value kinds map to the deployed closed activation vocabulary")
+    func productValueWireMapping() {
+        #expect(ProductValueKind.chatReply.telemetryActivationKind == .firstChatReply)
+        #expect(ProductValueKind.dictationTranscript.telemetryActivationKind == .firstDictation)
+        #expect(ProductValueKind.generatedImage.telemetryActivationKind == .firstImage)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+@testable import Rapid
 
 @Suite("Deferred telemetry consent delivery wiring")
 struct DeferredTelemetryConsentWiringTests {
@@ -32,6 +33,41 @@ struct DeferredTelemetryConsentWiringTests {
         #expect(body.contains("delivered.status == .complete"))
         #expect(body.contains("!delivered.content.trimmingCharacters"))
         #expect(body.contains("onProductValueDelivered(.chatReply)"))
+    }
+
+    @Test("A successful vision turn does not claim the text-only chat milestone")
+    @MainActor
+    func visionReplyDoesNotSignalChatReply() async throws {
+        let image = try ChatImageAttachment(
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: Data("image".utf8)
+        )
+        var deliveredKinds: [ProductValueKind] = []
+        let client = ChatStreamClient(
+            baseURL: URL(string: "fake://rapid-mlx")!,
+            session: ActivationVisionReplyProtocol.session()
+        )
+        let model = ChatViewModel(
+            client: client,
+            persistsConversations: false,
+            onProductValueDelivered: { deliveredKinds.append($0) }
+        )
+
+        model.send(
+            "What is in this photo?",
+            alias: "vision-model",
+            supportsImageInput: true,
+            imageAttachments: [image]
+        )
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        while model.isStreaming, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming, "the canned successful stream must finish")
+        #expect(deliveredKinds.isEmpty)
+        #expect(model.messages.last?.content == "ok")
     }
 
     @Test("Dictation signals after transcript delivery and history persistence")
@@ -94,4 +130,33 @@ struct DeferredTelemetryConsentWiringTests {
         #expect(privacy.contains("two-letter country code"))
         #expect(normalizedPrivacy.contains("the IP address is never persisted"))
     }
+}
+
+private final class ActivationVisionReplyProtocol: URLProtocol, @unchecked Sendable {
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ActivationVisionReplyProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let body = """
+        data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n
+        data: [DONE]\n
+        """.data(using: .utf8)!
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -76,4 +76,22 @@ struct DeferredTelemetryConsentWiringTests {
                 "Escape belongs to the active app interaction; only an explicit click may decline")
         #expect(!banner.contains("@FocusState"))
     }
+
+    @Test("Every consent surface discloses the Desktop activation shape and country derivation")
+    func activationDisclosureContract() throws {
+        let banner = try Self.source("Sources/Rapid/UI/TelemetryConsentView.swift")
+        let settings = try Self.source("Sources/Rapid/UI/SettingsView.swift")
+        let privacy = try Self.source("PRIVACY.md")
+        let normalizedPrivacy = privacy.split(whereSeparator: \Character.isWhitespace).joined(separator: " ")
+
+        for surface in [banner, settings] {
+            #expect(surface.contains("first successful chat reply, vision reply, dictation, or image"))
+            #expect(surface.contains("only the milestone name and “Desktop”"))
+            #expect(surface.contains("derives a country code but never stores your IP"))
+        }
+        #expect(privacy.contains("`activation` — once per install"))
+        #expect(privacy.contains("`surface: desktop`"))
+        #expect(privacy.contains("two-letter country code"))
+        #expect(normalizedPrivacy.contains("the IP address is never persisted"))
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -121,11 +121,14 @@ struct DeferredTelemetryConsentWiringTests {
         let normalizedPrivacy = privacy.split(whereSeparator: \Character.isWhitespace).joined(separator: " ")
 
         for surface in [banner, settings] {
-            #expect(surface.contains("first successful chat reply, vision reply, dictation, or image"))
+            #expect(surface.contains("first successful text chat reply, dictation, or generated image"))
+            #expect(surface.contains("does not send a vision-reply milestone"))
             #expect(surface.contains("only the milestone name and “Desktop”"))
             #expect(surface.contains("derives a country code but never stores your IP"))
         }
         #expect(privacy.contains("`activation` — once per install"))
+        #expect(privacy.contains("vision-reply milestone"))
+        #expect(privacy.contains("is reserved in the event schema but is not sent by this version"))
         #expect(privacy.contains("`surface: desktop`"))
         #expect(privacy.contains("two-letter country code"))
         #expect(normalizedPrivacy.contains("the IP address is never persisted"))

--- a/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
@@ -130,21 +130,57 @@ struct DesktopActivationReporterTests {
         )
     }
 
-    @Test("A rejected activation never claims the accepted-delivery marker")
-    func rejectedSendDoesNotClaim() async {
+    @Test("A permanent rejection is suppressed for this process without claiming the accepted marker")
+    func rejectedSendDoesNotRepeatOrClaim() async {
         let directory = temporaryDirectory("rejected")
         defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = ActivationReporterProbe()
         let reporter = DesktopActivationReporter(
             isEnabled: { true },
             buildEvent: { event($0) },
-            sendEvent: { _ in .discard },
+            sendEvent: { event in
+                await probe.didSend(event)
+                return .discard
+            },
             markerDirectory: directory
         )
 
         await reporter.report(.firstChatReply)
+        await reporter.report(.firstChatReply)
 
+        #expect(await probe.sentCount == 1)
         #expect(
             !FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_chat_reply")
+                    .path
+            )
+        )
+    }
+
+    @Test("Consent revoked during a discarded send stays retryable after Settings opt-in")
+    func revokedDiscardCanRetry() async {
+        let directory = temporaryDirectory("discarded-revoked")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = ActivationReporterProbe(results: [.discard, .accepted])
+        let reporter = DesktopActivationReporter(
+            isEnabled: { probe.isEnabled },
+            buildEvent: { event($0) },
+            sendEvent: { event in
+                let result = await probe.nextResult(for: event)
+                if result == .discard { probe.isEnabled = false }
+                return result
+            },
+            markerDirectory: directory
+        )
+
+        await reporter.report(.firstChatReply)
+        probe.isEnabled = true
+        await reporter.report(.firstChatReply)
+
+        #expect(await probe.sentCount == 2)
+        #expect(
+            FileManager.default.fileExists(
                 atPath: directory
                     .appendingPathComponent("activation_seen_desktop_first_chat_reply")
                     .path

--- a/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
@@ -58,7 +58,7 @@ struct DesktopActivationReporterTests {
             },
             sendEvent: { event in
                 await probe.didSend(event)
-                return true
+                return .accepted
             },
             markerDirectory: directory
         )
@@ -82,7 +82,7 @@ struct DesktopActivationReporterTests {
                 buildEvent: { event($0) },
                 sendEvent: { event in
                     await probe.didSend(event)
-                    return true
+                    return .accepted
                 },
                 markerDirectory: directory
             )
@@ -109,7 +109,7 @@ struct DesktopActivationReporterTests {
     func failedSendRetries() async {
         let directory = temporaryDirectory("retry")
         defer { try? FileManager.default.removeItem(at: directory) }
-        let probe = ActivationReporterProbe(results: [false, true])
+        let probe = ActivationReporterProbe(results: [.retry, .accepted])
         let reporter = DesktopActivationReporter(
             isEnabled: { true },
             buildEvent: { event($0) },
@@ -130,6 +130,28 @@ struct DesktopActivationReporterTests {
         )
     }
 
+    @Test("A rejected activation never claims the accepted-delivery marker")
+    func rejectedSendDoesNotClaim() async {
+        let directory = temporaryDirectory("rejected")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let reporter = DesktopActivationReporter(
+            isEnabled: { true },
+            buildEvent: { event($0) },
+            sendEvent: { _ in .discard },
+            markerDirectory: directory
+        )
+
+        await reporter.report(.firstChatReply)
+
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_chat_reply")
+                    .path
+            )
+        )
+    }
+
     @Test("Consent revoked during send never burns the once marker")
     func revokeDuringSendDoesNotClaim() async {
         let directory = temporaryDirectory("revoked")
@@ -141,7 +163,7 @@ struct DesktopActivationReporterTests {
             sendEvent: { event in
                 await probe.didSend(event)
                 probe.isEnabled = false
-                return true
+                return .accepted
             },
             markerDirectory: directory
         )
@@ -163,10 +185,10 @@ private final class ActivationReporterProbe: @unchecked Sendable {
     private let lock = NSLock()
     private var builds = 0
     private var sent: [TelemetryEvent] = []
-    private var results: [Bool]
+    private var results: [TelemetryClient.BatchDelivery]
     private var enabled = true
 
-    init(results: [Bool] = []) {
+    init(results: [TelemetryClient.BatchDelivery] = []) {
         self.results = results
     }
 
@@ -191,10 +213,10 @@ private final class ActivationReporterProbe: @unchecked Sendable {
         lock.withLock { sent.append(event) }
     }
 
-    func nextResult(for event: TelemetryEvent) async -> Bool {
+    func nextResult(for event: TelemetryEvent) async -> TelemetryClient.BatchDelivery {
         lock.withLock {
             sent.append(event)
-            return results.isEmpty ? true : results.removeFirst()
+            return results.isEmpty ? .accepted : results.removeFirst()
         }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Desktop activation telemetry", .serialized)
+struct DesktopActivationReporterTests {
+    private func temporaryDirectory(_ label: String) -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rapid-desktop-activation-\(label)-\(UUID().uuidString)")
+    }
+
+    private func event(_ kind: TelemetryEvent.Activation.Kind) -> TelemetryEvent {
+        TelemetryEvent(
+            schema_version: 1,
+            client_id: "11111111-2222-3333-4444-555555555555",
+            session_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            rapid_mlx_version: "0.13.2",
+            event: .activation,
+            timestamp: "2026-08-26T17:00:00Z",
+            platform: .init(
+                app: "rapid-desktop",
+                os: "macos",
+                os_version: "26.0.0",
+                arch: "arm64"
+            ),
+            error_type: nil,
+            error_message: nil,
+            stack_frames: nil,
+            context: nil,
+            activation: .init(activation_kind: kind, surface: .desktop)
+        )
+    }
+
+    @Test("Activation wire reuses the deployed two-field activation payload")
+    func activationWireShape() throws {
+        let data = try JSONEncoder().encode(event(.firstChatReply))
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["event"] as? String == "activation")
+        let activation = try #require(json["activation"] as? [String: Any])
+        #expect(activation["activation_kind"] as? String == "first_chat_reply")
+        #expect(activation["surface"] as? String == "desktop")
+        #expect(Set(activation.keys) == ["activation_kind", "surface"])
+        #expect(json["request"] == nil)
+        #expect(json["session"] == nil)
+    }
+
+    @Test("Declined consent touches no event, network, identity, marker, or directory")
+    func disabledDoesNothing() async {
+        let directory = temporaryDirectory("disabled")
+        let probe = ActivationReporterProbe()
+        let reporter = DesktopActivationReporter(
+            isEnabled: { false },
+            buildEvent: { kind in
+                probe.didBuild()
+                return event(kind)
+            },
+            sendEvent: { event in
+                await probe.didSend(event)
+                return true
+            },
+            markerDirectory: directory
+        )
+
+        await reporter.report(.firstChatReply)
+
+        #expect(probe.buildCount == 0)
+        #expect(await probe.sentCount == 0)
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    @Test("Accepted activation sends once and a new process observes its marker")
+    func acceptedThenMarked() async throws {
+        let directory = temporaryDirectory("accepted")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = ActivationReporterProbe()
+
+        func makeReporter() -> DesktopActivationReporter {
+            DesktopActivationReporter(
+                isEnabled: { true },
+                buildEvent: { event($0) },
+                sendEvent: { event in
+                    await probe.didSend(event)
+                    return true
+                },
+                markerDirectory: directory
+            )
+        }
+
+        let first = makeReporter()
+        await first.report(.firstDictation)
+        await first.report(.firstDictation)
+        #expect(await probe.sentCount == 1)
+
+        let second = makeReporter()
+        await second.report(.firstDictation)
+        #expect(await probe.sentCount == 1)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_dictation")
+                    .path
+            )
+        )
+    }
+
+    @Test("Transport failure leaves the activation retryable")
+    func failedSendRetries() async {
+        let directory = temporaryDirectory("retry")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = ActivationReporterProbe(results: [false, true])
+        let reporter = DesktopActivationReporter(
+            isEnabled: { true },
+            buildEvent: { event($0) },
+            sendEvent: { event in await probe.nextResult(for: event) },
+            markerDirectory: directory
+        )
+
+        await reporter.report(.firstImage)
+        await reporter.report(.firstImage)
+
+        #expect(await probe.sentCount == 2)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_image")
+                    .path
+            )
+        )
+    }
+}
+
+private final class ActivationReporterProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var builds = 0
+    private var sent: [TelemetryEvent] = []
+    private var results: [Bool]
+
+    init(results: [Bool] = []) {
+        self.results = results
+    }
+
+    var buildCount: Int {
+        lock.withLock { builds }
+    }
+
+    var sentCount: Int {
+        get async { lock.withLock { sent.count } }
+    }
+
+    func didBuild() {
+        lock.withLock { builds += 1 }
+    }
+
+    func didSend(_ event: TelemetryEvent) async {
+        lock.withLock { sent.append(event) }
+    }
+
+    func nextResult(for event: TelemetryEvent) async -> Bool {
+        lock.withLock {
+            sent.append(event)
+            return results.isEmpty ? true : results.removeFirst()
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
@@ -129,6 +129,34 @@ struct DesktopActivationReporterTests {
             )
         )
     }
+
+    @Test("Consent revoked during send never burns the once marker")
+    func revokeDuringSendDoesNotClaim() async {
+        let directory = temporaryDirectory("revoked")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = ActivationReporterProbe()
+        let reporter = DesktopActivationReporter(
+            isEnabled: { probe.isEnabled },
+            buildEvent: { event($0) },
+            sendEvent: { event in
+                await probe.didSend(event)
+                probe.isEnabled = false
+                return true
+            },
+            markerDirectory: directory
+        )
+
+        await reporter.report(.firstChatReply)
+
+        #expect(await probe.sentCount == 1)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_chat_reply")
+                    .path
+            )
+        )
+    }
 }
 
 private final class ActivationReporterProbe: @unchecked Sendable {
@@ -136,6 +164,7 @@ private final class ActivationReporterProbe: @unchecked Sendable {
     private var builds = 0
     private var sent: [TelemetryEvent] = []
     private var results: [Bool]
+    private var enabled = true
 
     init(results: [Bool] = []) {
         self.results = results
@@ -147,6 +176,11 @@ private final class ActivationReporterProbe: @unchecked Sendable {
 
     var sentCount: Int {
         get async { lock.withLock { sent.count } }
+    }
+
+    var isEnabled: Bool {
+        get { lock.withLock { enabled } }
+        set { lock.withLock { enabled = newValue } }
     }
 
     func didBuild() {

--- a/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DesktopActivationReporterTests.swift
@@ -130,6 +130,36 @@ struct DesktopActivationReporterTests {
         )
     }
 
+    @Test("A concurrent success retries an in-flight transport failure", .timeLimit(.minutes(1)))
+    func concurrentSuccessRetriesFailedInFlightSend() async {
+        let directory = temporaryDirectory("concurrent-retry")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = InFlightActivationRetryProbe()
+        let reporter = DesktopActivationReporter(
+            isEnabled: { true },
+            buildEvent: { event($0) },
+            sendEvent: { event in await probe.send(event) },
+            markerDirectory: directory
+        )
+
+        let first = Task { await reporter.report(.firstImage) }
+        await probe.waitUntilFirstSendStarted()
+        // Actor reentrancy admits this call while the first transport awaits.
+        // It must become a retry opportunity rather than disappear.
+        await reporter.report(.firstImage)
+        await probe.failFirstSend()
+        await first.value
+
+        #expect(await probe.sentCount == 2)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("activation_seen_desktop_first_image")
+                    .path
+            )
+        )
+    }
+
     @Test("A permanent rejection is suppressed for this process without claiming the accepted marker")
     func rejectedSendDoesNotRepeatOrClaim() async {
         let directory = temporaryDirectory("rejected")
@@ -214,6 +244,40 @@ struct DesktopActivationReporterTests {
                     .path
             )
         )
+    }
+}
+
+private actor InFlightActivationRetryProbe {
+    private var sends = 0
+    private var firstSendStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstDelivery: CheckedContinuation<TelemetryClient.BatchDelivery, Never>?
+
+    var sentCount: Int { sends }
+
+    func send(_ event: TelemetryEvent) async -> TelemetryClient.BatchDelivery {
+        _ = event
+        sends += 1
+        guard sends == 1 else { return .accepted }
+        return await withCheckedContinuation { continuation in
+            firstDelivery = continuation
+            firstSendStarted = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+        }
+    }
+
+    func waitUntilFirstSendStarted() async {
+        guard !firstSendStarted else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func failFirstSend() {
+        firstDelivery?.resume(returning: .retry)
+        firstDelivery = nil
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
@@ -803,6 +803,27 @@ struct TelemetryAuditBatch8Contracts {
         #expect(TelemetryAuditURLProtocol.requestCount == 1)
     }
 
+    @Test("typed batch delivery distinguishes acceptance, rejection, and throttling")
+    func sendBatchDeliveryClassifiesResponses() async {
+        let defaults = TelemetryAuditDefaultsSandbox()
+        defer { defaults.tearDown() }
+        defaults.setTelemetryEnabled(true)
+        var client = TelemetryClient()
+        client.session = TelemetryAuditURLProtocol.session()
+
+        TelemetryAuditURLProtocol.stub(statusCode: 204)
+        #expect(await client.sendBatchDelivery([event()]) == .accepted)
+
+        TelemetryAuditURLProtocol.stub(statusCode: 422)
+        #expect(await client.sendBatchDelivery([event()]) == .discard)
+
+        TelemetryAuditURLProtocol.stub(statusCode: 429)
+        #expect(await client.sendBatchDelivery([event()]) == .retry)
+
+        TelemetryAuditURLProtocol.stub(statusCode: 408)
+        #expect(await client.sendBatchDelivery([event()]) == .retry)
+    }
+
     @Test("sendBatch returns false for transient 5xx response")
     func sendBatchReturnsFalseFor5xx() async {
         let defaults = TelemetryAuditDefaultsSandbox()

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -262,6 +262,9 @@ class Sink(BaseHTTPRequestHandler):
         payload = self.rfile.read(length)
         event = None
         timestamp = None
+        activation_kind = None
+        activation_surface = None
+        activation_keys = []
         try:
             envelope = json.loads(payload)
             batch = envelope.get("batch") if isinstance(envelope, dict) else None
@@ -269,6 +272,11 @@ class Sink(BaseHTTPRequestHandler):
             if isinstance(first, dict):
                 event = first.get("event") if isinstance(first.get("event"), str) else None
                 timestamp = first.get("timestamp") if isinstance(first.get("timestamp"), str) else None
+                activation = first.get("activation")
+                if isinstance(activation, dict):
+                    activation_kind = activation.get("activation_kind")
+                    activation_surface = activation.get("surface")
+                    activation_keys = sorted(activation)
         except (UnicodeDecodeError, json.JSONDecodeError):
             pass
         record = {
@@ -277,6 +285,9 @@ class Sink(BaseHTTPRequestHandler):
             "bytes": length,
             "event": event,
             "timestamp": timestamp,
+            "activation_kind": activation_kind,
+            "activation_surface": activation_surface,
+            "activation_keys": activation_keys,
         }
         with write_lock, open(request_log, "a", encoding="utf-8") as stream:
             stream.write(json.dumps(record, sort_keys=True) + "\n")
@@ -380,6 +391,45 @@ assert_one_telemetry_request() {
         || die "Settings opt-in did not produce a new session_start during $stage"
 }
 
+assert_share_activation_requests() {
+    local stage="$1"
+    local expected_kind="$2"
+    local evidence="$OUT/telemetry-$stage.json"
+    local count=0
+    for _ in {1..120}; do
+        kill -0 "$TELEMETRY_SINK_PID" 2>/dev/null \
+            || die "loopback telemetry sink exited during $stage"
+        count="$(wc -l < "$TELEMETRY_SINK_LOG" | tr -d '[:space:]')"
+        [[ "$count" -ge 2 ]] && break
+        sleep 0.05
+    done
+    # A short quiet period turns "the two expected requests arrived" into
+    # "exactly those two requests arrived" rather than racing a third send.
+    sleep 0.5
+    count="$(wc -l < "$TELEMETRY_SINK_LOG" | tr -d '[:space:]')"
+    jq -s --arg stage "$stage" --arg log "$TELEMETRY_SINK_LOG" \
+        --arg expected_kind "$expected_kind" \
+        '{stage: $stage, request_count: length, request_log: $log,
+          expected_activation_kind: $expected_kind, requests: .}' \
+        "$TELEMETRY_SINK_LOG" > "$evidence"
+    [[ "$count" == 2 ]] \
+        || die "Share produced $count telemetry requests instead of session_start plus one activation"
+    jq -e '. as $evidence |
+        ([.requests[] | select(.event == "session_start")] | length) == 1
+        and ([.requests[] | select(.event == "activation")] | length) == 1
+        and ([.requests[] | select(
+            .event == "activation"
+            and .method == "POST"
+            and .path == "/v1/events"
+            and .bytes > 0
+            and .activation_kind == $evidence.expected_activation_kind
+            and .activation_surface == "desktop"
+            and .activation_keys == ["activation_kind", "surface"]
+        )] | length) == 1' \
+        "$evidence" >/dev/null \
+        || die "Share did not produce exactly one valid $expected_kind Desktop activation"
+}
+
 finish() {
     local status=$?
     set +e
@@ -463,7 +513,7 @@ start_persona() {
     # opt-out. They test their named feature, not the one-time consent invite;
     # leaving the preference absent would make the first successful result add
     # an unrelated banner midway through dozens of snapshots.
-    if [[ "$name" != "fresh-install" ]]; then
+    if [[ "$name" != "fresh-install" && "$name" != "fresh-install-share" ]]; then
         env HOME="$PERSONA/home" CFFIXED_USER_HOME="$PERSONA/home" \
             /usr/bin/defaults write "$BUNDLE_ID" \
             com.rapidmlx.rapid.telemetry.enabled -bool false
@@ -1546,6 +1596,31 @@ flow_fresh_install() {
         "$OUT/telemetry-settings-opt-in.json" \
         || die "Settings telemetry opt-in is not pressable"
     assert_one_telemetry_request settings-opt-in "$opt_in_not_before"
+    cleanup_persona
+    cleanup_telemetry_sink
+
+    # A second pristine profile takes the affirmative path. Keep it separate
+    # so the decline/no-re-ask contract above remains intact while this lane
+    # proves that a success retained before consent becomes one accepted,
+    # content-free activation only after Share.
+    log "  consent Share emits one accepted first-chat activation"
+    start_telemetry_sink "$OUT_ROOT/fresh-install-share"
+    start_persona fresh-install-share FAKE_INCLUDE_STARTER=1 \
+        RAPID_GUI_HARDWARE_FIXTURE=1 RAPID_HARDWARE_RAM_GB=$GOLDEN_RAM_GB \
+        RAPID_HARDWARE_BRAND="$GOLDEN_BRAND" \
+        RAPID_MLX_TELEMETRY_ENDPOINT="http://127.0.0.1:$TELEMETRY_SINK_PORT/v1/events"
+    dismiss_first_run
+    assert_no_telemetry_requests share-before-first-value
+    start_model
+    send_prompt "Say hello in one short sentence." "share-activation"
+    wait_identifier TelemetryConsent.PostValueBanner "$OUT/share-consent-visible.json"
+    assert_no_telemetry_requests share-before-decision
+    press "$OUT/share-consent-visible.json" TelemetryConsent.PostValue.Share \
+        "$OUT/share-consent-accepted.json" \
+        || die "Share was not actionable after the first successful reply"
+    assert_share_activation_requests share-accepted first_chat_reply
+    [[ -f "$PERSONA/home/.rapid-mlx/activation_seen_desktop_first_chat_reply" ]] \
+        || die "accepted first_chat_reply did not claim its once-per-install marker"
     cleanup_persona
     cleanup_telemetry_sink
 }

--- a/docs/telemetry-activation.md
+++ b/docs/telemetry-activation.md
@@ -1,6 +1,6 @@
 # Telemetry activation / engagement semantics
 
-**Spec version: `1`** (`vllm_mlx.telemetry.activation_spec.ACTIVATION_SPEC_VERSION`)
+**Spec version: `2`** (`vllm_mlx.telemetry.activation_spec.ACTIVATION_SPEC_VERSION`)
 · Status: **active** · Owner: growth
 
 This document is the single, versioned source of truth for what counts as
@@ -39,6 +39,10 @@ below): the client suppresses repeats locally on a best-effort basis, and the
 | CLI `chat` stream completes normally with ≥1 completion token | ✅ engaged | `first_inference` | `surface = cli`. Emitted after the stream drains normally, not at the first token — a partially consumed / client-cancelled stream is conservatively not counted. **Implemented.** |
 | `rapid-mlx pull <alias>` completes successfully | ✅ activation | `model_pull` | `surface = cli`; NOT inference-engaged. **Implemented.** |
 | Agent integration setup completes AND its connection check passes | ✅ activation | `agent_setup` | `surface = cli`; integration activation. **Spec'd; wiring deferred** — `rapid-mlx launch` has no engine connection check today; that check must land first (see below). |
+| Desktop receives its first successful text-only assistant reply | ✅ Desktop activation | `first_chat_reply` | `surface = desktop`. **Implemented.** |
+| Desktop receives its first successful assistant reply to a vision turn | ✅ Desktop activation | `first_vision_reply` | `surface = desktop`. **Spec'd; wiring deferred.** |
+| Desktop delivers its first successful dictation transcript | ✅ Desktop activation | `first_dictation` | `surface = desktop`. **Implemented.** |
+| Desktop generates its first image | ✅ Desktop activation | `first_image` | `surface = desktop`. **Implemented.** Editing an existing image does not count. |
 
 ## What does NOT count
 
@@ -77,8 +81,10 @@ sampled** — unlike `request`). Envelope is the standard telemetry envelope
 the event-specific payload is:
 
 ```json
-{ "activation_kind": "first_inference" | "model_pull" | "agent_setup",
-  "surface":         "cli" | "api" }
+{ "activation_kind": "first_inference" | "model_pull" | "agent_setup"
+                   | "first_chat_reply" | "first_vision_reply"
+                   | "first_dictation" | "first_image",
+  "surface":         "cli" | "api" | "desktop" }
 ```
 
 No prompt, no completion, no content of any kind — two enums only. This is
@@ -99,14 +105,15 @@ it can never become a high-volume stream.
 
 ### Delivery semantics — at-least-once, deduped by `client_id`
 
-Each `activation_kind` is guarded by a local marker file
-`~/.rapid-mlx/activation_seen_<kind>`, created with exclusive
-(`O_CREAT | O_EXCL`) semantics — the same primitive as `mark_first_session`.
-In the common case the first emission claims the marker and every later call
-(this process, via an in-memory latch; other processes, via the marker) is a
-silent no-op.
+Each engine `activation_kind` is guarded by a local marker file
+`~/.rapid-mlx/activation_seen_<kind>`; Desktop uses
+`activation_seen_desktop_<kind>` in the same shared directory. Both are
+created with exclusive (`O_CREAT | O_EXCL`) semantics — the same primitive as
+`mark_first_session`. In the common case the first accepted emission claims
+the marker and every later call (this process, via an in-memory latch; other
+processes, via the marker) is a silent no-op.
 
-The client deliberately does **not** attempt exactly-once across processes.
+The engine client deliberately does **not** attempt exactly-once across processes.
 It **enqueues first, then claims the marker**, so a transient envelope/enqueue
 failure leaves the marker unclaimed and the next successful inference simply
 retries — an install is never permanently dropped from the funnel by one
@@ -120,12 +127,21 @@ harmless, dedup-able duplicate (at-least-once). The marker is a local empty
 file; only the derived enum pair ever leaves the machine, and only when
 telemetry is enabled.
 
+Desktop uses the same at-least-once contract with one stricter transport
+boundary: it sends first and claims its marker only after the collector returns
+`2xx`. Transport errors, `408`, `429`, and `5xx` remain retryable; a permanent
+non-retryable rejection is not reported as accepted. Consent is re-checked
+before the marker is claimed, so an opt-out racing an accepted send can produce
+only a de-duplicable retry, never a burned milestone.
+
 `kind` is validated against the allowlist before it is ever interpolated into
 the marker filename, so no caller-controlled string can escape `~/.rapid-mlx`.
 
 ### `surface` resolution
 
-`surface` distinguishes the CLI REPL from the HTTP API. Because
+`surface` distinguishes the CLI REPL, HTTP API, and native Desktop app.
+Desktop always emits the literal `desktop`; it never derives this label from a
+model, feature name, or request. Because
 `rapid-mlx chat` runs inference by spawning its own ephemeral `serve` and
 looping through `/v1/chat/completions`, the `first_inference` milestone is
 emitted at the **server-side** success chokepoint for both surfaces; the
@@ -175,6 +191,10 @@ until then the enum value is reserved and never emitted.
 - **Activation funnel**: `model_pull` → `first_inference`, and
   `agent_setup` as the integration path, all keyed on the shared
   `client_id`.
+- **Desktop activation**: count only events with `surface = desktop`, grouped
+  by the four Desktop kinds. Never add them to engine `first_inference`
+  (`surface = cli|api`): the shared consent/client ID means one install can
+  legitimately emit both.
 
 Both this document and the repository tests (`tests/test_telemetry_activation.py`)
 reference `ACTIVATION_SPEC_VERSION`. Any change to the rules above bumps

--- a/docs/telemetry-activation.md
+++ b/docs/telemetry-activation.md
@@ -89,6 +89,11 @@ the event-specific payload is:
 
 No prompt, no completion, no content of any kind — two enums only. This is
 the same privacy class as the `first_session` / `auto_selected` booleans.
+Kinds and surfaces are a closed pair contract, not independent allowlists: only
+the combinations listed in the milestone table above are valid. Engine
+`first_inference` may use `cli` or `api`; `model_pull` and `agent_setup` use
+`cli`; every Desktop kind uses `desktop`. Producers drop any other pairing
+before creating a marker or event.
 
 ### Why a dedicated event and not derivation from `request`
 

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -99,6 +99,9 @@ def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():
     assert '"bytes": length' in sink
     assert '"event": event' in sink
     assert '"timestamp": timestamp' in sink
+    assert '"activation_kind": activation_kind' in sink
+    assert '"activation_surface": activation_surface' in sink
+    assert '"activation_keys": activation_keys' in sink
     assert 'RAPID_MLX_TELEMETRY_ENDPOINT="http://127.0.0.1:' in fresh_install
     expected_stages = (
         "before-onboarding",
@@ -135,6 +138,12 @@ def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():
     assert 'sleep "$settling_seconds"' in positive_control
     assert "loopback telemetry sink exited while settling" in positive_control
     assert "opt_in_not_before" in fresh_install
+    assert "TelemetryConsent.PostValue.Share" in fresh_install
+    assert (
+        "assert_share_activation_requests share-accepted first_chat_reply"
+        in fresh_install
+    )
+    assert "activation_seen_desktop_first_chat_reply" in fresh_install
 
 
 def test_each_fault_fails_with_its_own_message():

--- a/tests/test_telemetry_activation.py
+++ b/tests/test_telemetry_activation.py
@@ -56,8 +56,18 @@ def test_kinds_and_surfaces_are_the_allowlist():
         "first_inference",
         "model_pull",
         "agent_setup",
+        "first_chat_reply",
+        "first_vision_reply",
+        "first_dictation",
+        "first_image",
     } == spec.ACTIVATION_KINDS
-    assert {"cli", "api"} == spec.ACTIVATION_SURFACES
+    assert {
+        "first_chat_reply",
+        "first_vision_reply",
+        "first_dictation",
+        "first_image",
+    } == spec.DESKTOP_ACTIVATION_KINDS
+    assert {"cli", "api", "desktop"} == spec.ACTIVATION_SURFACES
 
 
 def test_health_and_models_are_not_inference_endpoints():

--- a/tests/test_telemetry_activation.py
+++ b/tests/test_telemetry_activation.py
@@ -68,6 +68,16 @@ def test_kinds_and_surfaces_are_the_allowlist():
         "first_image",
     } == spec.DESKTOP_ACTIVATION_KINDS
     assert {"cli", "api", "desktop"} == spec.ACTIVATION_SURFACES
+    assert {
+        ("first_inference", "cli"),
+        ("first_inference", "api"),
+        ("model_pull", "cli"),
+        ("agent_setup", "cli"),
+        ("first_chat_reply", "desktop"),
+        ("first_vision_reply", "desktop"),
+        ("first_dictation", "desktop"),
+        ("first_image", "desktop"),
+    } == spec.ACTIVATION_KIND_SURFACE_PAIRS
 
 
 def test_health_and_models_are_not_inference_endpoints():
@@ -468,6 +478,29 @@ def test_activation_drops_unknown_surface(opted_in, stub_queue):
     emit.activation(activation_kind="first_inference", surface="api")
     assert len(stub_queue) == 1
     assert stub_queue[0]["activation"]["surface"] == "api"
+
+
+@pytest.mark.parametrize(
+    "activation_kind,surface",
+    [
+        ("first_inference", "desktop"),
+        ("model_pull", "api"),
+        ("agent_setup", "desktop"),
+        ("first_chat_reply", "cli"),
+        ("first_vision_reply", "api"),
+        ("first_dictation", "cli"),
+        ("first_image", "api"),
+    ],
+)
+def test_activation_drops_invalid_kind_surface_pair(
+    opted_in, stub_queue, activation_kind, surface
+):
+    from vllm_mlx.telemetry import emit, state
+
+    emit.activation(activation_kind=activation_kind, surface=surface)
+
+    assert stub_queue == []
+    assert not state.activation_marker_path(activation_kind).exists()
 
 
 def test_activation_is_not_request_sampled(opted_in, stub_queue, monkeypatch):

--- a/vllm_mlx/telemetry/activation_spec.py
+++ b/vllm_mlx/telemetry/activation_spec.py
@@ -45,7 +45,8 @@ ACTIVATION_KINDS: frozenset[str] = (
 )
 
 # Where the milestone happened. ``cli`` = the interactive REPL / a CLI
-# subcommand; ``api`` = the HTTP server serving an external caller.
+# subcommand; ``api`` = the HTTP server serving an external caller;
+# ``desktop`` = the native Mac app.
 SURFACE_CLI = "cli"
 SURFACE_API = "api"
 SURFACE_DESKTOP = "desktop"

--- a/vllm_mlx/telemetry/activation_spec.py
+++ b/vllm_mlx/telemetry/activation_spec.py
@@ -25,24 +25,6 @@ ACTIVATION_FIRST_CHAT_REPLY = "first_chat_reply"
 ACTIVATION_FIRST_VISION_REPLY = "first_vision_reply"
 ACTIVATION_FIRST_DICTATION = "first_dictation"
 ACTIVATION_FIRST_IMAGE = "first_image"
-DESKTOP_ACTIVATION_KINDS: frozenset[str] = frozenset(
-    {
-        ACTIVATION_FIRST_CHAT_REPLY,
-        ACTIVATION_FIRST_VISION_REPLY,
-        ACTIVATION_FIRST_DICTATION,
-        ACTIVATION_FIRST_IMAGE,
-    }
-)
-ACTIVATION_KINDS: frozenset[str] = (
-    frozenset(
-        {
-            ACTIVATION_FIRST_INFERENCE,
-            ACTIVATION_MODEL_PULL,
-            ACTIVATION_AGENT_SETUP,
-        }
-    )
-    | DESKTOP_ACTIVATION_KINDS
-)
 
 # Where the milestone happened. ``cli`` = the interactive REPL / a CLI
 # subcommand; ``api`` = the HTTP server serving an external caller;
@@ -50,9 +32,35 @@ ACTIVATION_KINDS: frozenset[str] = (
 SURFACE_CLI = "cli"
 SURFACE_API = "api"
 SURFACE_DESKTOP = "desktop"
-ACTIVATION_SURFACES: frozenset[str] = frozenset(
-    {SURFACE_CLI, SURFACE_API, SURFACE_DESKTOP}
+ACTIVATION_KIND_SURFACE_PAIRS: frozenset[tuple[str, str]] = frozenset(
+    {
+        (ACTIVATION_FIRST_INFERENCE, SURFACE_CLI),
+        (ACTIVATION_FIRST_INFERENCE, SURFACE_API),
+        (ACTIVATION_MODEL_PULL, SURFACE_CLI),
+        (ACTIVATION_AGENT_SETUP, SURFACE_CLI),
+        (ACTIVATION_FIRST_CHAT_REPLY, SURFACE_DESKTOP),
+        (ACTIVATION_FIRST_VISION_REPLY, SURFACE_DESKTOP),
+        (ACTIVATION_FIRST_DICTATION, SURFACE_DESKTOP),
+        (ACTIVATION_FIRST_IMAGE, SURFACE_DESKTOP),
+    }
 )
+ACTIVATION_KINDS: frozenset[str] = frozenset(
+    kind for kind, _ in ACTIVATION_KIND_SURFACE_PAIRS
+)
+ACTIVATION_SURFACES: frozenset[str] = frozenset(
+    surface for _, surface in ACTIVATION_KIND_SURFACE_PAIRS
+)
+DESKTOP_ACTIVATION_KINDS: frozenset[str] = frozenset(
+    kind
+    for kind, surface in ACTIVATION_KIND_SURFACE_PAIRS
+    if surface == SURFACE_DESKTOP
+)
+
+
+def is_allowed_activation(activation_kind: str, surface: str) -> bool:
+    """Return whether a milestone is valid on the supplied product surface."""
+    return (activation_kind, surface) in ACTIVATION_KIND_SURFACE_PAIRS
+
 
 # ``rapid-mlx chat`` spawns its own ephemeral ``serve`` and drives it over
 # HTTP, so first_inference is emitted at the server-side success chokepoint

--- a/vllm_mlx/telemetry/activation_spec.py
+++ b/vllm_mlx/telemetry/activation_spec.py
@@ -33,13 +33,16 @@ DESKTOP_ACTIVATION_KINDS: frozenset[str] = frozenset(
         ACTIVATION_FIRST_IMAGE,
     }
 )
-ACTIVATION_KINDS: frozenset[str] = frozenset(
-    {
-        ACTIVATION_FIRST_INFERENCE,
-        ACTIVATION_MODEL_PULL,
-        ACTIVATION_AGENT_SETUP,
-    }
-) | DESKTOP_ACTIVATION_KINDS
+ACTIVATION_KINDS: frozenset[str] = (
+    frozenset(
+        {
+            ACTIVATION_FIRST_INFERENCE,
+            ACTIVATION_MODEL_PULL,
+            ACTIVATION_AGENT_SETUP,
+        }
+    )
+    | DESKTOP_ACTIVATION_KINDS
+)
 
 # Where the milestone happened. ``cli`` = the interactive REPL / a CLI
 # subcommand; ``api`` = the HTTP server serving an external caller.

--- a/vllm_mlx/telemetry/activation_spec.py
+++ b/vllm_mlx/telemetry/activation_spec.py
@@ -15,25 +15,40 @@ from __future__ import annotations
 
 # Bump in lockstep with docs/telemetry-activation.md whenever what counts
 # as engaged/activated changes (new kind, changed success predicate, ...).
-ACTIVATION_SPEC_VERSION = 1
+ACTIVATION_SPEC_VERSION = 2
 
 # The funnel milestones. Each fires at most once per install (client_id).
 ACTIVATION_FIRST_INFERENCE = "first_inference"
 ACTIVATION_MODEL_PULL = "model_pull"
 ACTIVATION_AGENT_SETUP = "agent_setup"
+ACTIVATION_FIRST_CHAT_REPLY = "first_chat_reply"
+ACTIVATION_FIRST_VISION_REPLY = "first_vision_reply"
+ACTIVATION_FIRST_DICTATION = "first_dictation"
+ACTIVATION_FIRST_IMAGE = "first_image"
+DESKTOP_ACTIVATION_KINDS: frozenset[str] = frozenset(
+    {
+        ACTIVATION_FIRST_CHAT_REPLY,
+        ACTIVATION_FIRST_VISION_REPLY,
+        ACTIVATION_FIRST_DICTATION,
+        ACTIVATION_FIRST_IMAGE,
+    }
+)
 ACTIVATION_KINDS: frozenset[str] = frozenset(
     {
         ACTIVATION_FIRST_INFERENCE,
         ACTIVATION_MODEL_PULL,
         ACTIVATION_AGENT_SETUP,
     }
-)
+) | DESKTOP_ACTIVATION_KINDS
 
 # Where the milestone happened. ``cli`` = the interactive REPL / a CLI
 # subcommand; ``api`` = the HTTP server serving an external caller.
 SURFACE_CLI = "cli"
 SURFACE_API = "api"
-ACTIVATION_SURFACES: frozenset[str] = frozenset({SURFACE_CLI, SURFACE_API})
+SURFACE_DESKTOP = "desktop"
+ACTIVATION_SURFACES: frozenset[str] = frozenset(
+    {SURFACE_CLI, SURFACE_API, SURFACE_DESKTOP}
+)
 
 # ``rapid-mlx chat`` spawns its own ephemeral ``serve`` and drives it over
 # HTTP, so first_inference is emitted at the server-side success chokepoint
@@ -46,8 +61,9 @@ CHAT_SPAWN_ENV = "RAPID_MLX_CHAT_SPAWN"
 # Generative endpoints whose successful, non-empty completion counts as
 # engagement.
 #
-# Spec v1 DEFINES engagement as chat-completions engagement — this is an
-# explicit, versioned scope decision, not an accidental omission.
+# The engine inference scope remains chat-completions engagement in spec v2;
+# v2 adds Desktop milestone kinds and does not expand engine endpoints. This
+# is an explicit, versioned scope decision, not an accidental omission.
 # ``/v1/chat/completions`` (streaming + non-streaming) is the dominant surface
 # (all CLI ``chat`` traffic auto-spawns a server that loops through it, plus
 # the bulk of direct API usage) and is the single endpoint instrumented with
@@ -56,9 +72,9 @@ CHAT_SPAWN_ENV = "RAPID_MLX_CHAT_SPAWN"
 # ``/v1/completions`` (routes/completions.py) and ``/v1/messages``
 # (routes/anthropic.py) are separate, generative, and NOT part of the v1
 # engagement contract: an install that inferences exclusively through them is
-# out of scope for v1's engaged metric by definition. Listing them here without
+# out of scope for the engine's engaged metric by definition. Listing them here without
 # wiring would over-promise coverage the code doesn't deliver; wiring them is a
-# deliberate v2 item that MUST bump ``ACTIVATION_SPEC_VERSION`` and update the
+# deliberate future item that MUST bump ``ACTIVATION_SPEC_VERSION`` and update the
 # dashboard in lockstep. See docs/telemetry-activation.md.
 INFERENCE_ENDPOINTS: frozenset[str] = frozenset(
     {

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -676,29 +676,26 @@ def activation(*, activation_kind: str, surface: str) -> None:
     DISTINCT ``client_id``, so a rare duplicate collapses to one engaged
     install. This is deliberate; see ``docs/telemetry-activation.md``.
 
-    Consent-gated like every emit. Both ``activation_kind`` AND ``surface`` are
-    validated against the allowlists in ``telemetry.activation_spec``; an
-    off-list value in EITHER drops the event entirely (rather than coercing a
-    bad surface to ``api``, which would silently mislabel data and hide an
-    instrumentation bug). So no caller-controlled free-form text ever reaches
-    the payload. Two enums only: no prompt, no completion, no content. See
-    ``docs/telemetry-activation.md``.
+    Consent-gated like every emit. The ``activation_kind`` / ``surface`` pair
+    is validated against the closed combinations in
+    ``telemetry.activation_spec``; an invalid pair drops the event entirely
+    (rather than coercing a bad surface to ``api``, which would silently
+    mislabel data and hide an instrumentation bug). So no caller-controlled
+    free-form text ever reaches the payload. Two enums only: no prompt, no
+    completion, no content. See ``docs/telemetry-activation.md``.
     """
     from vllm_mlx.telemetry.activation_spec import (
-        ACTIVATION_KINDS,
-        ACTIVATION_SURFACES,
+        is_allowed_activation,
     )
     from vllm_mlx.telemetry.state import (
         activation_marker_path,
         claim_activation_marker,
     )
 
-    if activation_kind not in ACTIVATION_KINDS:
-        return
-    # An off-allowlist surface is an instrumentation bug, not user input; drop
-    # the event (like an unknown kind) so it surfaces as "missing data" rather
-    # than data silently misattributed to ``api``.
-    if surface not in ACTIVATION_SURFACES:
+    # An invalid kind/surface pair is an instrumentation bug, not user input;
+    # drop it so the fault surfaces as missing data rather than a milestone
+    # silently attributed to the wrong product surface.
+    if not is_allowed_activation(activation_kind, surface):
         return
     # Cheap, lock-free short-circuit once this process has resolved the kind.
     # This is the steady-state path: the synchronous marker filesystem work
@@ -714,7 +711,7 @@ def activation(*, activation_kind: str, surface: str) -> None:
     # later, their next successful inference still emits.
     if not is_enabled():
         return
-    surface_norm = surface  # already validated against ACTIVATION_SURFACES above
+    surface_norm = surface  # validated with activation_kind above
     with _activation_lock:
         if activation_kind in _activation_latched:
             return

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -711,7 +711,7 @@ def activation(*, activation_kind: str, surface: str) -> None:
     # later, their next successful inference still emits.
     if not is_enabled():
         return
-    surface_norm = surface  # validated with activation_kind above
+    surface_norm = surface  # already validated against ACTIVATION_SURFACES above
     with _activation_lock:
         if activation_kind in _activation_latched:
             return

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -140,16 +140,18 @@ class ActivationPayload:
     once per install per ``activation_kind``.
     """
 
-    activation_kind: str  # "first_inference" | "model_pull" | "agent_setup"
-    surface: str  # "cli" | "api"
+    # Closed allowlists live in activation_spec.py. Spec v2 adds the Desktop
+    # milestone kinds and surface without changing this wire shape.
+    activation_kind: str
+    surface: str
 
 
 @dataclass(frozen=True)
 class TelemetryPayload:
     """The complete on-the-wire envelope.
 
-    Exactly one of ``session`` / ``request`` / ``error`` is populated
-    per payload — the discriminator is the ``event`` field.
+    Exactly one of ``session`` / ``request`` / ``error`` / ``activation`` is
+    populated per payload — the discriminator is the ``event`` field.
     """
 
     schema_version: int


### PR DESCRIPTION
## Why

After explicit telemetry consent, report the first successful Desktop chat reply, delivered dictation transcript, and generated image as content-free activation milestones. This measures whether the app delivered useful work without weakening the consent boundary.

Five original consent-flow commits already shipped in Desktop 0.13.1 and are intentionally absent. The current delta starts at the activation layer on top of the landed #2424 sink-proof harness.

Fixes #2542

## What

- reuse the deployed activation envelope with `surface=desktop`
- emit only `first_chat_reply`, `first_dictation`, and `first_image`
- reserve `first_vision_reply` in activation spec v2 without producing it yet
- retain typed success kinds only while consent is undecided
- construct and send events only after explicit opt-in
- claim an atomic once-per-install marker only after a `2xx` response
- retry transport, `408`, `429`, and `5xx` failures without a pre-consent journal; coalesce a same-kind success that arrives while delivery is in flight
- disclose the exact milestone shape and server-derived country aggregation in the consent banner, Settings, and Privacy policy
- prove the Share path against the isolated loopback telemetry sink

## Scope / Non-goals

Scope is the Desktop activation reporter, consent-coordinator wiring, typed delivery result, spec v2 allowlists and documentation, user disclosure, and focused wire-level evidence.

Non-goals are collector or worker changes; telemetry envelope expansion; the `first_vision_reply` producer; daily UTC `session_start` re-arming; and client-side install-date, return-day, country, or IP derivation.

## Design precedent

The design follows established opt-in desktop telemetry patterns: keep successful feature outcomes as typed in-memory state before a decision, construct the analytics client and identity only after consent, keep the preference reversible in Settings, and advance a durable once-only marker only after accepted delivery. The implementation adapts the existing Rapid-MLX activation envelope and atomic marker primitive instead of adding a second transport or lifecycle.

## Behaviour delta

Before this PR, an opted-in Desktop sent session and error telemetry but no content-free activation milestone. After this PR, the first accepted chat-reply, dictation, and generated-image milestones each send exactly `{activation_kind, surface}` once per install. Default-off behavior, decline behavior, and all pre-consent network behavior remain unchanged.

## Verification

Exact range: `b20564400457506b1575f5671b214402412de6d8..281862b5def8a5f8ecd7cb3731cc4c4b6230949e`.

- Desktop telemetry and consent Swift suites: 90/90 passed (including the deterministic in-flight retry case)
- activation and GUI harness contracts on Python 3.12: 91/91 passed
- current-main release-shaped fresh-profile GUI journey: PASS; zero sink requests before consent, durable decline/no re-ask, reversible Settings opt-in, and Share produced exactly one `session_start` plus one `first_chat_reply` activation POST with keys exactly `activation_kind` and `surface`
- `git diff --check`: passed
- exact-head hosted checks and the Mac merge queue remain the final integration gate

