### PR TITLE
fix(mac): preserve active work across model switches

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -489,6 +489,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-variant-collapse
 
+      - name: 'Golden flow: model-switch-active-request'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow model-switch-active-request
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/model-switch-active-request
+
       - name: 'Golden flow: download-progress'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow download-progress

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -483,6 +483,15 @@ final class ServerManager {
             residency: residency
         ) else { return .notNeeded }
 
+        // Headless automation may explicitly skip the UI-only confirmation.
+        // Keep the fresh residency evaluation above: the decision still has
+        // to distinguish a safe in-process load from an approved destructive
+        // switch, even when no dialog is presented.
+        let defaults = sessionDefaults ?? .standard
+        guard ModelSwitchConfirmationPreference.isEnabled(in: defaults) else {
+            return .approved
+        }
+
         let request = PendingModelSwitch(id: UUID(), risk: risk)
         if pendingModelSwitch == nil {
             pendingModelSwitch = request

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -274,6 +274,18 @@ struct ModelSwitchRisk: Equatable, Sendable {
     }
 }
 
+/// User preference for the advisory active-request switch guard. The missing
+/// key means enabled so upgrades keep the safe interactive behavior, while
+/// unattended automation can explicitly opt out in Settings.
+enum ModelSwitchConfirmationPreference {
+    static let storageKey = "rapid.server.confirm_active_request_switch.v1"
+    static let defaultValue = true
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: storageKey) as? Bool ?? defaultValue
+    }
+}
+
 /// Result of the Desktop's advisory active-request guard. An explicit user
 /// approval must use the existing stop/start path because the resident loader
 /// correctly refuses to evict a model while it is serving a request.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -693,10 +693,13 @@ struct ContentView: View {
     private func performReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:
-            // The model picker in the composer owns this step; the
-            // banner names it but deliberately renders no second
-            // control. See ``ModelReadiness.Action.isRenderable``.
-            break
+            // Use the existing model-management destination: it owns the
+            // RAM-aware recommendations and cached-model choices. This keeps
+            // the empty-state action useful without reopening onboarding or
+            // introducing a second picker state machine.
+            settingsRouter.route(.openModelManagement) {
+                openWindow(id: "settings")
+            }
         case .download(let target):
             downloadModel(target)
         case .start(let target):

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -68,6 +68,11 @@ struct ContentView: View {
     @SceneStorage("Rapid.showLogs") private var showLogs: Bool = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
+    /// Explicit recovery route from the no-model empty state into the
+    /// existing RAM-aware chooser. This is presentation intent only; the
+    /// Quickstart coordinator remains the sole owner of selection/download
+    /// lifecycle state.
+    @State private var modelChoiceRecoveryRequested: Bool = false
     /// Monotonic composer-focus request forwarded to ``ChatView``. Bumped
     /// by the onboarding completion transaction so the user lands in their
     /// first chat with the caret already in the message field.
@@ -693,13 +698,12 @@ struct ContentView: View {
     private func performReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:
-            // Use the existing model-management destination: it owns the
-            // RAM-aware recommendations and cached-model choices. This keeps
-            // the empty-state action useful without reopening onboarding or
-            // introducing a second picker state machine.
-            settingsRouter.route(.openModelManagement) {
-                openWindow(id: "settings")
-            }
+            // Re-enter the existing RAM-aware chooser. Model Management is a
+            // cache inspector and cannot actually select or start a chat
+            // model, so routing there would leave the no-model state intact.
+            quickstart.returnToChooser()
+            quickstartDismissedThisSession = false
+            modelChoiceRecoveryRequested = true
         case .download(let target):
             downloadModel(target)
         case .start(let target):
@@ -866,6 +870,7 @@ struct ContentView: View {
             cachedModels: catalogEntries,
             catalogLoaded: catalogLoaded,
             onSkip: {
+                modelChoiceRecoveryRequested = false
                 quickstartDismissedThisSession = true
                 // Skip keeps its existing meaning — no completion flag — but
                 // it does retire a pending Ready confirmation, so walking
@@ -877,7 +882,10 @@ struct ContentView: View {
             // a micro-stage inside Step 2, so there is nothing to lower and
             // nothing for the parent to know about (Paper 05.2.J · S1).
             onSeedWelcome: seedQuickstartWelcome,
-            onCompleted: finishOnboardingHandoff
+            onCompleted: {
+                modelChoiceRecoveryRequested = false
+                finishOnboardingHandoff()
+            }
         )
     }
 
@@ -929,6 +937,7 @@ struct ContentView: View {
         // global onboarding sheet.
         guard ContentView.quickstartCanPresent(in: section) else { return false }
         guard !quickstartDismissedThisSession else { return false }
+        if modelChoiceRecoveryRequested { return true }
         if ContentView.serverEngagedWithDifferentAlias(
             state: server.state,
             quickstartAlias: quickstart.selection.alias

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -83,11 +83,10 @@ enum ModelReadiness: Equatable {
 
     /// The one concrete thing the user can do from a given state.
     ///
-    /// ``chooseModel`` deliberately carries no button at the call site:
-    /// the model picker sits ~40pt away in the composer and is already
-    /// labelled "Choose a model", so rendering a second control with the
-    /// same words would be a duplicate action. The case exists so the
-    /// copy and the VoiceOver announcement can still name the step.
+    /// ``chooseModel`` is the empty-state recovery route into the existing
+    /// RAM-aware chooser. The nearby composer picker remains available for
+    /// experienced users; the explicit action keeps first-time discovery from
+    /// depending on recognizing an unresolved pop-up control.
     enum Action: Equatable {
         case chooseModel
         // Download-only. Fetches the weights without loading them, so the

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -125,11 +125,9 @@ enum ModelReadiness: Equatable {
             }
         }
 
-        /// True when the action should render as a real button. See the
-        /// ``chooseModel`` note above.
+        /// Every public action is executable and renders as a real button.
         var isRenderable: Bool {
-            if case .chooseModel = self { return false }
-            return true
+            true
         }
 
         /// The alias this action operates on, when it has one.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -82,6 +82,12 @@ struct SettingsModelManagementPanel: View {
     /// next-launch spawn while leaving every manual start path untouched.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
 
+    /// Safety prompt for interactive model switches that would interrupt
+    /// active API or streaming requests. Automation can opt out explicitly;
+    /// the safe default remains on for existing and new installations.
+    @AppStorage(ModelSwitchConfirmationPreference.storageKey)
+    private var confirmActiveRequestSwitch = ModelSwitchConfirmationPreference.defaultValue
+
     /// codex r1 P2 (#210): without this we'd ride the stale catalog
     /// snapshot after a background download finishes — the row
     /// flips from ``Downloading…`` straight back to ``Not cached``
@@ -293,13 +299,13 @@ struct SettingsModelManagementPanel: View {
 
     // MARK: - Preferences
 
-    /// The two model-behaviour toggles that used to live in a separate
+    /// Model-behaviour toggles, including the two that used to live in a separate
     /// "Models" tab. Folded in here — the surface that already owns
     /// everything about your models — as one labelled card so the app
     /// has a single place to manage models rather than two competing
     /// ones. Styled to match ``modelsFolderSection`` above: a secondary
-    /// section label over a hairline card, the two toggles split by a
-    /// divider so they read as a pair without two floating boxes.
+    /// section label over a hairline card, with dividers keeping the controls
+    /// distinct without creating several floating boxes.
     @ViewBuilder
     private var preferencesSection: some View {
         SettingsSection("Preferences") {
@@ -331,6 +337,19 @@ struct SettingsModelManagementPanel: View {
                 .accessibilityHint("When off, opening Rapid-MLX will not load a model until you start one manually from the picker.")
                 // Stable AX hook kept as `Settings.Models.*` across the move.
                 .accessibilityIdentifier("Settings.Models.AutoStartOnLaunchToggle")
+
+                SettingsRowDivider()
+
+                Toggle(isOn: $confirmActiveRequestSwitch) {
+                    SettingsRowLabel(
+                        title: "Confirm before interrupting active requests",
+                        description: "Ask before switching models when the current model is still serving API or streaming requests. Turn this off only for unattended automation."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityLabel("Confirm before interrupting active requests")
+                .accessibilityHint("When off, model switches may interrupt active API or streaming requests without asking.")
+                .accessibilityIdentifier("Settings.Models.ConfirmActiveRequestSwitchToggle")
         }
     }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -83,6 +83,7 @@ AXApplication title="Rapid-MLX"
         AXHeading desc="Preferences" enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.ShowAllModelsToggle" desc="Show small models in the picker" help="Sub-1B models are hidden by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat." value=bool:true enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.Models.ConfirmActiveRequestSwitchToggle" desc="Confirm before interrupting active requests" help="When off, model switches may interrupt active API or streaming requests without asking." value=bool:true enabled=true
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -83,6 +83,7 @@ AXApplication title="Rapid-MLX"
         AXHeading desc="Preferences" enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.ShowAllModelsToggle" desc="Show small models in the picker" help="Sub-1B models are hidden by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat." value=bool:false enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.Models.ConfirmActiveRequestSwitchToggle" desc="Confirm before interrupting active requests" help="When off, model switches may interrupt active API or streaming requests without asking." value=bool:true enabled=true
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -83,6 +83,7 @@ AXApplication title="Rapid-MLX"
         AXHeading desc="Preferences" enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.ShowAllModelsToggle" desc="Show small models in the picker" help="Sub-1B models are hidden by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat." value=bool:true enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.Models.ConfirmActiveRequestSwitchToggle" desc="Confirm before interrupting active requests" help="When off, model switches may interrupt active API or streaming requests without asking." value=bool:true enabled=true
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -83,6 +83,7 @@ AXApplication title="Rapid-MLX"
         AXHeading desc="Preferences" enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.ShowAllModelsToggle" desc="Show small models in the picker" help="Sub-1B models are hidden by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat." value=bool:false enabled=true
         AXCheckBox subrole=AXToggle id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.Models.ConfirmActiveRequestSwitchToggle" desc="Confirm before interrupting active requests" help="When off, model switches may interrupt active API or streaming requests without asking." value=bool:true enabled=true
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -37,6 +37,14 @@ journeys:
     fixtures: [fake-sidecar, cached-model, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Server/]
     owns_baseline: false
+  - name: model-switch-active-request
+    group: models
+    risk: high
+    driver: ax
+    ci_tier: pr
+    fixtures: [fake-sidecar, slow-stream, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
+    owns_baseline: false
   - name: download-progress
     group: onboarding-settings
     risk: medium

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -43,7 +43,7 @@ journeys:
     driver: ax
     ci_tier: pr
     fixtures: [fake-sidecar, slow-stream, isolated-home]
-    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Server/, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
     owns_baseline: false
   - name: download-progress
     group: onboarding-settings

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -36,6 +36,15 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
+    @Test("Model switch guard preference has a stable Settings control")
+    func modelSwitchGuardPreferenceIdentifier() throws {
+        try assertDeclared(
+            [#""Settings.Models.ConfirmActiveRequestSwitchToggle""#],
+            in: "Sources/Rapid/UI/SettingsModelManagementPanel.swift",
+            surface: "Settings → Model Management switch guard preference"
+        )
+    }
+
     @Test("Settings → App names the re-onboarding confirmation controls")
     func settingsAppReonboardingIdentifiers() throws {
         try assertDeclared(

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -270,6 +270,47 @@ struct ModelResidencyTests {
         #expect(server.pendingModelSwitch == nil)
     }
 
+    @Test(
+        "Automation opt-out bypasses the dialog and replaces a busy model",
+        .timeLimit(.minutes(1))
+    )
+    func automationOptOutReplacesBusyModelWithoutPrompt() async throws {
+        var client = ServerResidencyClient()
+        client.session = BusyResidencyProtocol.session()
+        let defaultsSuite = "AutomationBusySwitch.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
+        defaults.set(false, forKey: ModelSwitchConfirmationPreference.storageKey)
+
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty,
+            activeBearer: "test-bearer",
+            sessionDefaults: defaults
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+        server.memorySnapshotProvider = {
+            MemoryProbe.Snapshot(
+                totalBytes: UInt64(256) << 30,
+                usedBytes: UInt64(1) << 30
+            )
+        }
+
+        let switched = await server.ensureServing(
+            alias: "target-model",
+            hfPath: "test/target-model",
+            estimatedMemoryGB: 1,
+            replacementGroup: .assistant
+        )
+
+        #expect(!switched, "the missing test binary makes the replacement start fail")
+        #expect(server.pendingModelSwitch == nil)
+        #expect(server.pendingMemoryWarning == nil)
+        #expect(server.state == .missing)
+        #expect(server.servingAlias == nil)
+    }
+
     private func waitForPendingModelSwitch(
         on server: ServerManager
     ) async -> ServerManager.PendingModelSwitch {

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -220,6 +220,83 @@ struct ModelResidencyTests {
         ))
     }
 
+    @Test("Model switch confirmation defaults on and supports explicit automation opt-out")
+    func modelSwitchConfirmationPreferenceContract() throws {
+        let suite = "ModelSwitchConfirmationPreferenceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(ModelSwitchConfirmationPreference.isEnabled(in: defaults))
+        defaults.set(false, forKey: ModelSwitchConfirmationPreference.storageKey)
+        #expect(!ModelSwitchConfirmationPreference.isEnabled(in: defaults))
+        defaults.set(true, forKey: ModelSwitchConfirmationPreference.storageKey)
+        #expect(ModelSwitchConfirmationPreference.isEnabled(in: defaults))
+    }
+
+    @Test(
+        "Cancelling an active-request model switch leaves the live model untouched",
+        .timeLimit(.minutes(1))
+    )
+    func cancelledBusySwitchPreservesLiveModel() async throws {
+        var client = ServerResidencyClient()
+        client.session = BusyResidencyProtocol.session()
+        let defaultsSuite = "CancelledBusySwitch.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty,
+            activeBearer: "test-bearer",
+            sessionDefaults: defaults
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        let switchTask = Task {
+            await server.ensureServing(
+                alias: "target-model",
+                hfPath: "test/target-model",
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
+        }
+        let request = await waitForPendingModelSwitch(on: server)
+        #expect(request.risk.activeRequests == 1)
+        server.cancelPendingModelSwitch(request)
+
+        #expect(await switchTask.value == false)
+        #expect(server.state == .ready(alias: "current-model"))
+        #expect(server.servingAlias == "current-model")
+        #expect(server.pendingModelSwitch == nil)
+    }
+
+    private func waitForPendingModelSwitch(
+        on server: ServerManager
+    ) async -> ServerManager.PendingModelSwitch {
+        if let request = server.pendingModelSwitch {
+            return request
+        }
+
+        let changes = AsyncStream<Void> { continuation in
+            withObservationTracking {
+                if server.pendingModelSwitch != nil {
+                    continuation.yield()
+                    continuation.finish()
+                }
+            } onChange: {
+                continuation.yield()
+                continuation.finish()
+            }
+        }
+        for await _ in changes {
+            if let request = server.pendingModelSwitch {
+                return request
+            }
+        }
+        Issue.record("The model-switch confirmation request was never published")
+        fatalError("unreachable after recording a missing confirmation request")
+    }
+
     @Test("Connector restart prefers a resident text model over the process-owning audio alias")
     func connectorRestartTextAlias() {
         let text = ResidentModelStatus(
@@ -815,6 +892,29 @@ struct ModelResidencyTests {
             memoryBandwidthGBs: 150
         )
     }
+}
+
+private final class BusyResidencyProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BusyResidencyProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override func startLoading() {
+        let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[{"id":"current-model","model_path":"test/current-model","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":1,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}],"audio_lanes":[]}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }
 
 private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendable {

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -43,6 +43,17 @@ struct QuickstartBrowseAllDestinationTests {
         }
     }
 
+    private static var contentViewSource: String {
+        get throws {
+            let url = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // RapidTests
+                .deletingLastPathComponent()  // Tests
+                .deletingLastPathComponent()  // rapid-mac
+                .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+    }
+
     /// Comment- and whitespace-stripped source, shared with the other
     /// source-guard suites. Comments must go, not just whitespace: otherwise a
     /// doc comment that *describes* a call counts as the call, and a wiring
@@ -58,6 +69,27 @@ struct QuickstartBrowseAllDestinationTests {
     }
 
     // MARK: - The link is wired
+
+    @Test("The no-model CTA re-enters the RAM-aware chooser")
+    func noModelCTAReentersQuickstartChooser() throws {
+        let source = Self.stripped(try Self.contentViewSource)
+        guard let start = source.range(of: "case.chooseModel:") else {
+            Issue.record("ContentView has no choose-model action branch")
+            return
+        }
+        let tail = source[start.upperBound...]
+        guard let end = tail.range(of: "case.download") else {
+            Issue.record("could not isolate ContentView's choose-model action")
+            return
+        }
+        let branch = String(tail[..<end.lowerBound])
+
+        #expect(branch.contains("quickstart.returnToChooser()"))
+        #expect(branch.contains("quickstartDismissedThisSession=false"))
+        #expect(branch.contains("modelChoiceRecoveryRequested=true"))
+        #expect(!branch.contains("openModelManagement"))
+        #expect(!branch.contains("openWindow"))
+    }
 
     @Test("The link's action calls browseAllModels(), not a dismiss flag")
     func browseAllIsWiredToTheCatalogue() throws {

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -837,14 +837,13 @@ struct ModelReadinessTests {
 
     // MARK: - Actions
 
-    /// ``chooseModel`` must not render a button: the picker already
-    /// carries those exact words 40pt away, and a second control saying
-    /// the same thing is the duplicate-action defect.
+    /// An empty conversation offers a visible route to the RAM-aware model
+    /// selection surface instead of relying on picker discovery.
     @Test
-    func testChooseModelIsNamedButNotRendered() {
+    func testChooseModelIsNamedAndRendered() {
         let state = ModelReadiness.noModel
         XCTAssertEqual(state.action, .chooseModel)
-        XCTAssertEqual(state.action?.isRenderable, false)
+        XCTAssertEqual(state.action?.isRenderable, true)
         XCTAssertEqual(state.action?.title, "Choose a model")
         XCTAssertNil(state.action?.alias)
     }

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -316,6 +316,29 @@ SERVED_ALIAS = ""
 # a sidecar replacement starts a fresh process with no resident audio lanes.
 RESIDENT_AUDIO_LANES = {}
 
+
+class _ActiveChatRequests:
+    """Thread-safe active-request count for model-switch golden flows."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._count = 0
+
+    def begin(self):
+        with self._lock:
+            self._count += 1
+
+    def end(self):
+        with self._lock:
+            self._count = max(0, self._count - 1)
+
+    def value(self):
+        with self._lock:
+            return self._count
+
+
+ACTIVE_CHAT_REQUESTS = _ActiveChatRequests()
+
 # The engine's own, actionable rejection reason. Kept out of the snapshot so a
 # stock persona never changes residency shape; a flow opts in with
 # ``FAKE_REJECT_IMAGE_LOAD=1`` to exercise the rejected non-404/405 load path.
@@ -572,6 +595,18 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):  # noqa: A002
         return
 
+    def setup(self):
+        super().setup()
+        self._owns_active_chat_request = False
+
+    def finish(self):
+        try:
+            super().finish()
+        finally:
+            if self._owns_active_chat_request:
+                ACTIVE_CHAT_REQUESTS.end()
+                self._owns_active_chat_request = False
+
     def do_GET(self):
         if self.path == "/healthz":
             self._json(200, {"ok": True})
@@ -632,7 +667,7 @@ class Handler(BaseHTTPRequestHandler):
                 "state": "resident",
                 "pinned": True,
                 "primary": True,
-                "active_requests": 0,
+                "active_requests": ACTIVE_CHAT_REQUESTS.value(),
                 "estimated_bytes": 1,
                 "measured_bytes": None,
                 "idle_seconds": 0.0,
@@ -881,6 +916,9 @@ class Handler(BaseHTTPRequestHandler):
         if self.path != "/v1/chat/completions":
             self._json(404, {"error": "not_found"})
             return
+        ACTIVE_CHAT_REQUESTS.begin()
+        self._owns_active_chat_request = True
+        _event("chat_active", active_requests=ACTIVE_CHAT_REQUESTS.value())
         # Decode only enough of the request to drive normal SSE chat.
         length = int(self.headers.get("content-length", "0") or "0")
         body = {}

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -965,6 +965,14 @@ class Handler(BaseHTTPRequestHandler):
             user_payloads=user_payloads,
         )
 
+        # Some GUI journeys need a request that is observably in flight while
+        # the transcript remains visually stable. Hold before the first SSE
+        # byte only when explicitly requested; ACTIVE_CHAT_REQUESTS already
+        # includes this handler, so the residency endpoint still reports the
+        # same real request lifecycle the app uses for switch admission.
+        response_delay_ms = int(_setting("FAKE_CHAT_RESPONSE_DELAY_MS", "0") or "0")
+        if response_delay_ms > 0:
+            time.sleep(response_delay_ms / 1000)
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4804,6 +4804,7 @@ flow_dictation_rc2_upgrade() {
 flow_model_switch_active_request() {
     log "flow: model-switch-active-request"
     start_persona model-switch-active-request \
+        FAKE_CHAT_RESPONSE_DELAY_MS=10000 \
         FAKE_INTER_TOKEN_SLEEP_S=0.02 \
         FAKE_CONTENT_REPEAT=250
     dismiss_first_run
@@ -4824,11 +4825,13 @@ flow_model_switch_active_request() {
     [[ "$busy" == 1 ]] || die "fake residency never reported the active stream"
 
     see_main "$OUT/busy.json"
-    press "$OUT/busy.json" ModelPickerBar.ModelMenu "$OUT/model-menu-open.json" \
-        || die "model picker did not open during an active stream"
-    wait_identifier ModelPickerBar.Alias.fake-external-alias "$OUT/model-menu.json"
-    press "$OUT/model-menu.json" ModelPickerBar.Alias.fake-external-alias "$OUT/switch-requested.json" \
-        || die "alternate cached model could not be selected"
+    # SwiftUI bridges these rows into a transient native NSMenu, outside the
+    # window-only AX tree used for evidence dumps. Exercise the standard macOS
+    # type-to-select interaction, then let the switch guard prove it resolved
+    # the requested alternate alias.
+    "$AX_DRIVER" select-menu-title "$APP_PID" ModelPickerBar.ModelMenu \
+        fake-external-alias > "$OUT/switch-requested.json" \
+        || die "alternate cached model could not be selected during an active stream"
     wait_identifier ModelSwitchGuard.Cancel "$OUT/switch-guard.json"
     jq -e '.data.ui_elements[]?
            | select(.identifier == "ModelSwitchGuard.Cancel")' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -146,7 +146,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
-        slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|dictation-rc2-upgrade|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
+        slow-stream-stop|model-switch-active-request|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|dictation-rc2-upgrade|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -4801,6 +4801,63 @@ flow_dictation_rc2_upgrade() {
 }
 
 
+flow_model_switch_active_request() {
+    log "flow: model-switch-active-request"
+    start_persona model-switch-active-request \
+        FAKE_INTER_TOKEN_SLEEP_S=0.02 \
+        FAKE_CONTENT_REPEAT=250
+    dismiss_first_run
+    start_model
+    send_prompt "shape:long keep this stream active" "busy-stream"
+
+    # The fake residency endpoint reports the real in-flight handler count.
+    # Wait for the independent handler-lifecycle fact before asking the picker
+    # to switch; the app's own refresh then observes that same count.
+    local i busy=0
+    for ((i=0; i<80; i++)); do
+        if jq -e 'select(.event == "chat_active" and .active_requests > 0)' \
+            "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
+            busy=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$busy" == 1 ]] || die "fake residency never reported the active stream"
+
+    see_main "$OUT/busy.json"
+    press "$OUT/busy.json" ModelPickerBar.ModelMenu "$OUT/model-menu-open.json" \
+        || die "model picker did not open during an active stream"
+    wait_identifier ModelPickerBar.Alias.fake-external-alias "$OUT/model-menu.json"
+    press "$OUT/model-menu.json" ModelPickerBar.Alias.fake-external-alias "$OUT/switch-requested.json" \
+        || die "alternate cached model could not be selected"
+    wait_identifier ModelSwitchGuard.Cancel "$OUT/switch-guard.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "ModelSwitchGuard.Cancel")' \
+        "$OUT/switch-guard.json" >/dev/null \
+        || die "active stream did not present the native switch guard"
+    press "$OUT/switch-guard.json" ModelSwitchGuard.Cancel "$OUT/switch-cancelled.json" \
+        || die "switch guard Cancel was not actionable"
+
+    # Cancellation occurs before /v1/models/load or process teardown. The
+    # original stream must complete and the original model remains selected.
+    for ((i=0; i<240; i++)); do
+        grep -q '"event": "chat_finished"' "$OUT/fake-events.jsonl" 2>/dev/null && break
+        sleep 0.25
+    done
+    grep -q '"event": "chat_finished"' "$OUT/fake-events.jsonl" \
+        || die "Cancel did not preserve the active stream through completion"
+    [[ "$(jq -s '[.[] | select(.event == "server_started")] | length' "$OUT/fake-events.jsonl")" == 1 ]] \
+        || die "Cancel replaced the running sidecar"
+    ! grep -q '"event": "model_load"' "$OUT/fake-events.jsonl" \
+        || die "Cancel reached the resident model-load endpoint"
+    see_main "$OUT/settled.json"
+    [[ "$(element_field "$OUT/settled.json" ModelPickerBar.ModelMenu value)" == "fake-alias" ]] \
+        || die "Cancel changed the selected model"
+
+    log "  active-request confirmation and cancellation preservation OK"
+    cleanup_persona
+}
+
+
 flow_dictation() {
     log "flow: dictation"
     start_persona dictation \
@@ -5010,6 +5067,7 @@ case "$FLOW" in
     chat-depth) flow_chat_depth ;;
     math-rendering) flow_math_rendering ;;
     slow-stream-stop) flow_slow_stream_stop ;;
+    model-switch-active-request) flow_model_switch_active_request ;;
     model-crash-recovery) flow_model_crash_recovery ;;
     low-memory-choice) flow_low_memory_choice ;;
     update-state) flow_update_state ;;
@@ -5042,6 +5100,7 @@ case "$FLOW" in
         flow_chat_depth
         flow_math_rendering
         flow_slow_stream_stop
+        flow_model_switch_active_request
         flow_model_crash_recovery
         flow_low_memory_choice
         flow_update_state

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4837,8 +4837,12 @@ flow_model_switch_active_request() {
            | select(.identifier == "ModelSwitchGuard.Cancel")' \
         "$OUT/switch-guard.json" >/dev/null \
         || die "active stream did not present the native switch guard"
-    press "$OUT/switch-guard.json" ModelSwitchGuard.Cancel "$OUT/switch-cancelled.json" \
-        || die "switch guard Cancel was not actionable"
+    # This is a native confirmation dialog, whose cancel role maps to Escape.
+    # Hosted SwiftUI exposes the enabled Cancel button in AX but may reject
+    # AXPress for that transient element. Exercise the platform cancel action
+    # and let the state assertions below prove that it took effect.
+    "$AX_DRIVER" key "$APP_PID" escape > "$OUT/switch-cancelled.json" \
+        || die "switch guard did not honor the native Cancel action"
 
     # Cancellation occurs before /v1/models/load or process teardown. The
     # original stream must complete and the original model remains selected.

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -112,7 +112,7 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|key|click-center|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
+    fail("usage: rapid-ax <dump|press|select-menu-title|key|click-center|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
@@ -427,6 +427,54 @@ case "click-center":
     down.post(tap: .cghidEventTap)
     up.post(tap: .cghidEventTap)
     usleep(150_000)
+case "select-menu-title":
+    guard CommandLine.arguments.count > 4 else {
+        fail("select-menu-title requires the exact searchable menu title")
+    }
+    let searchText = CommandLine.arguments[4]
+    guard let origin = point(target, kAXPositionAttribute as CFString),
+          let extent = size(target, kAXSizeAttribute as CFString),
+          extent.width > 0, extent.height > 0
+    else { fail("select-menu-title \(identifier) has no usable AX bounds") }
+    let center = CGPoint(x: origin.x + extent.width / 2, y: origin.y + extent.height / 2)
+    guard let mouseDown = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
+                                  mouseCursorPosition: center, mouseButton: .left),
+          let mouseUp = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
+                                mouseCursorPosition: center, mouseButton: .left)
+    else { fail("could not create menu click events for \(identifier)") }
+    mouseDown.post(tap: .cghidEventTap)
+    mouseUp.post(tap: .cghidEventTap)
+    usleep(200_000)
+
+    let utf16 = Array(searchText.utf16)
+    guard let typeDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+          let typeUp = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false),
+          let returnDown = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: true),
+          let returnUp = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: false)
+    else { fail("could not create menu keyboard events for \(identifier)") }
+    utf16.withUnsafeBufferPointer { buffer in
+        guard let base = buffer.baseAddress else { return }
+        typeDown.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
+        typeUp.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
+    }
+    typeDown.postToPid(pid)
+    typeUp.postToPid(pid)
+    usleep(150_000)
+    returnDown.postToPid(pid)
+    returnUp.postToPid(pid)
+    usleep(150_000)
+    let payload: [String: Any] = [
+        "success": true,
+        "identifier": identifier,
+        "selected_title": searchText,
+        "action": command,
+    ]
+    let data = try! JSONSerialization.data(
+        withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]
+    )
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    exit(0)
 case "set-scroll-value":
     guard CommandLine.arguments.count > 3,
           let value = Double(CommandLine.arguments[3]),

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -128,6 +128,7 @@ def test_peekaboo_requirement_is_default_deny():
         "cached-quickstart",
         "cached-curated-tradeup",
         "cached-variant-collapse",
+        "model-switch-active-request",
         "download-progress",
         "settings-persistence",
         "settings-mtp",


### PR DESCRIPTION
## Why

Desktop must preserve active work when a user attempts to replace the served model. No-model recovery must return users to the existing RAM-aware chooser instead of stranding them or introducing a second picker.

## What

- confirm before replacing a model that has active requests
- preserve the live model and in-flight response when the user cancels
- expose an explicit Settings opt-out for unattended automation
- route no-model recovery back to the shared RAM-aware chooser
- cover the real replacement path and active-switch journey with deterministic tests

## Scope / Non-goals

Scope is the Desktop model-switch guard, its Settings preference, shared chooser routing, focused unit tests, accessibility identifiers, and the release-shaped GUI journey.

Non-goals are request queueing, hot-swap, drain or abort policy, `ServerManager` architecture changes, onboarding redesign, CLI/server changes, and adjacent lifecycle or harness cleanup.

## Verification

Exact range: `df247953850440e804b31e12747535056c406a73..691bc3e6efe9b751b431ccafe1414326e9ba77f5`.

- focused residency, chooser, and readiness suites: 103 passed / 4 suites
- GUI harness and CI coverage contracts: 44 passed
- release-configuration Desktop app build: passed
- local `settings-persistence` journey: passed
- local `model-switch-active-request` journey: passed in 29 seconds
- journey evidence: the native confirmation appeared; Cancel preserved the original stream through completion; zero resident-load calls; one server process; `fake-alias` remained selected
- independent Codex review round 3: LGTM, no implementation findings
- `full-ci` is validating the exact head; merge requires `tests`, `desktop-tests`, and `version-bump-guard` green plus zero commits behind main

## Behaviour delta

Confirmation before interrupting active requests is enabled by default. Users can reverse that choice in Settings → Model Management for unattended automation. Choosing Cancel leaves the current model and active request intact; when no model is available, recovery opens the existing chooser.
