### PR TITLE
feat(version-check): parse rcN below final; widen staleness call sites (#0.13.2 version-convergence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,7 @@ jobs:
             tests/test_ram_tier_recommendations_agree.py \
             tests/test_serving_lane_reason_contract.py \
             tests/test_version_sync.py \
+            tests/test_version_check.py \
             tests/test_pull_variant_selection.py \
             tests/test_share_cli.py \
             tests/test_doctor_env_health.py \

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1437,3 +1437,53 @@ def test_external_repo_identifier_is_never_truncated(tmp_path, monkeypatch, caps
 
     assert f"mlx-community/{repo}" in row
     assert "..." not in row
+
+
+# --- version-convergence: staleness call sites are wired -------------
+
+
+class _ReachedStalenessCallError(Exception):
+    """Sentinel raised by the patched helper to stop a command right at its
+    staleness call, so the smoke test never has to stub the heavy command
+    body (download, psutil scan, MLX boot, env-health run)."""
+
+
+@pytest.mark.parametrize(
+    "command_factory,args_factory",
+    [
+        (lambda: cli.bench_command, lambda: SimpleNamespace(model="x")),
+        (lambda: cli.pull_command, lambda: SimpleNamespace(model="x")),
+        (lambda: cli.ps_command, lambda: SimpleNamespace()),
+        (lambda: cli.info_command, lambda: SimpleNamespace(model="x")),
+        (
+            lambda: (
+                __import__(
+                    "vllm_mlx.doctor.cli", fromlist=["doctor_command"]
+                ).doctor_command
+            ),
+            lambda: SimpleNamespace(),
+        ),
+    ],
+    ids=["bench", "pull", "ps", "info", "doctor"],
+)
+def test_staleness_call_site_is_invoked(command_factory, args_factory):
+    """Each version-convergence command surfaces the staleness nudge by
+    actually invoking ``print_staleness_warning_if_any()``. The helper is
+    patched to raise a sentinel on call, so execution stops exactly at the
+    call site — covering the changed lines without pulling in the command's
+    real work (network / MLX / psutil). Hermetic: no host state."""
+    from unittest.mock import patch
+
+    calls = []
+
+    def _fake(*_args, **_kwargs):
+        calls.append(1)
+        raise _ReachedStalenessCallError
+
+    with (
+        patch("vllm_mlx._version_check.print_staleness_warning_if_any", _fake),
+        pytest.raises(_ReachedStalenessCallError),
+    ):
+        command_factory()(args_factory())
+
+    assert calls == [1], "staleness helper must fire exactly once"

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1455,16 +1455,8 @@ class _ReachedStalenessCallError(Exception):
         (lambda: cli.pull_command, lambda: SimpleNamespace(model="x")),
         (lambda: cli.ps_command, lambda: SimpleNamespace()),
         (lambda: cli.info_command, lambda: SimpleNamespace(model="x")),
-        (
-            lambda: (
-                __import__(
-                    "vllm_mlx.doctor.cli", fromlist=["doctor_command"]
-                ).doctor_command
-            ),
-            lambda: SimpleNamespace(),
-        ),
     ],
-    ids=["bench", "pull", "ps", "info", "doctor"],
+    ids=["bench", "pull", "ps", "info"],
 )
 def test_staleness_call_site_is_invoked(command_factory, args_factory):
     """Each version-convergence command surfaces the staleness nudge by

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -1078,6 +1078,22 @@ def test_update_available_marks_warn_with_upgrade_command():
     assert "brew upgrade rapid-mlx" in row.label
 
 
+def test_update_available_from_rc_to_final_marks_warn():
+    """Doctor reuses the shared parser, so its existing Updates section is
+    the single user-visible RC-to-final notice; the command entry point must
+    not perform a duplicate network fetch before ``run_all()``."""
+    info = mock.Mock(upgrade_command="rapid-mlx upgrade", method="pip")
+    section = eh.section_updates(
+        installed=lambda: "0.13.2rc2",
+        fetch_latest=lambda: "0.13.2",
+        install_info=info,
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.WARN
+    assert "update available: 0.13.2" in row.label
+    assert "installed 0.13.2rc2" in row.label
+
+
 def test_updates_offline_marks_warn_never_fail():
     section = eh.section_updates(
         installed=lambda: "0.10.15",
@@ -1103,14 +1119,14 @@ def test_updates_unknown_installed_version_marks_warn():
     "installed,latest",
     [
         ("0.10", "0.10.15"),  # installed unparseable (too few components)
-        ("0.10.15", "0.11.0rc1"),  # latest unparseable (rc suffix)
-        ("0.10.15.dev3", "0.10.16.dev1"),  # both dev builds
+        ("0.10.15", "0.11.0a1"),  # latest alpha remains unsupported
+        ("0.10.15+local", "0.10.16"),  # local version remains unsupported
     ],
 )
 def test_updates_unparseable_version_marks_warn_not_up_to_date(installed, latest):
-    """A version ``_parse_version`` can't order (dev/rc/short) must NOT
-    silently green-light "up to date" — that falsely reassures a user who
-    may well be behind. It downgrades to ⚠ like every other uncertain
+    """A version ``_parse_version`` can't order (alpha/local/short) must
+    NOT silently green-light "up to date" — that falsely reassures a user
+    who may well be behind. It downgrades to ⚠ like every other uncertain
     branch, and never to a hard fail."""
     section = eh.section_updates(
         installed=lambda: installed,

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -22,18 +22,44 @@ from vllm_mlx import _version_check as vc
 
 # --- _parse_version ---------------------------------------------------
 
+INF = float("inf")
+
 
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        ("0.6.14", (0, 6, 14)),
-        ("v0.6.14", (0, 6, 14)),  # leading v stripped
-        ("1.0.0", (1, 0, 0)),
-        ("0.6.14.dev3", (0, 6, 14)),  # dev suffix tolerated, takes patch
+        ("0.6.14", (0, 6, 14, INF)),  # final
+        ("v0.6.14", (0, 6, 14, INF)),  # leading v stripped
+        ("1.0.0", (1, 0, 0, INF)),
+        ("0.6.14.dev3", (0, 6, 14, INF)),  # dev: base tuple, unchanged
+        ("0.6.14.post1", (0, 6, 14, INF)),  # dotted suffix: base tuple
     ],
 )
 def test_parse_version_accepts_typical(raw, expected):
     assert vc._parse_version(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Attached rcN parses to its rc ordinal, so it sorts BELOW the
+        # matching final (which carries ``inf``).
+        ("0.13.0rc1", (0, 13, 0, 1)),
+        ("0.13.0rc2", (0, 13, 0, 2)),
+        ("0.6.62rc1", (0, 6, 62, 1)),
+    ],
+)
+def test_parse_version_accepts_release_candidates(raw, expected):
+    assert vc._parse_version(raw) == expected
+
+
+def test_rc_sorts_below_its_final():
+    """An rc of X.Y.Z must compare less than the X.Y.Z final, so once the
+    final ships an rc user reports as behind (staleness warning fires)."""
+    rc = vc._parse_version("0.13.0rc1")
+    final = vc._parse_version("0.13.0")
+    assert rc is not None and final is not None
+    assert rc < final
 
 
 @pytest.mark.parametrize(
@@ -43,6 +69,8 @@ def test_parse_version_accepts_typical(raw, expected):
         "0.6",  # missing patch
         "abc",
         "0.6.x",
+        "0.6.62a1",  # attached alpha stays unparseable
+        "0.6.62+local.build",  # local-version metadata stays unparseable
     ],
 )
 def test_parse_version_rejects_garbage(raw):
@@ -370,6 +398,37 @@ def test_silent_when_dev_ahead(isolated_cache, monkeypatch):
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.7.0")
     _seed_cache(isolated_cache, "0.6.16")
 
+    assert vc.staleness_warning() is None
+
+
+def test_rc_user_sees_warning_once_final_ships(isolated_cache, monkeypatch):
+    """The 0.13.1 behaviour: a user on ``0.13.0rc1`` must be told they are
+    behind now that final ``0.13.0`` is out. Previously rc parsed to None
+    and stayed silent forever."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.13.0rc1")
+    _seed_cache(isolated_cache, "0.13.0")
+
+    msg = vc.staleness_warning()
+    assert msg is not None
+    assert "0.13.0rc1" in msg
+    assert "0.13.0" in msg
+    assert "rapid-mlx upgrade" in msg
+
+
+def test_dev_build_behavior_unchanged(isolated_cache, monkeypatch):
+    """A ``X.Y.Z.devN`` build keeps its exact historical comparison: behind
+    a released final it warns (old ``_parse_version`` gave ``(0, 6, 15)``),
+    on/equal to final it is silent — the rc change must not alter devN."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.15.dev1")
+    _seed_cache(isolated_cache, "0.6.16")
+
+    msg = vc.staleness_warning()
+    assert msg is not None
+    assert "0.6.15.dev1" in msg
+    assert "0.6.16" in msg
+
+    # And on the same base final, a dev build is not treated as ahead.
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.16.dev1")
     assert vc.staleness_warning() is None
 
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -79,6 +79,12 @@ CACHE_TTL_SECONDS = 24 * 3600  # 24h
 NETWORK_TIMEOUT_SECONDS = 2  # tight — staleness check is best-effort
 _REMOTE_ENGINE_TAG_RE = re.compile(r"^v(\d{1,6})\.(\d{1,6})\.(\d{1,6})$")
 _CACHED_VERSION_RE = re.compile(r"^\d{1,6}\.\d{1,6}\.\d{1,6}$")
+_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+# ``X.Y.Z.devN`` (and other dotted-suffix builds like ``.postN``) keep the
+# old ``major.minor.patch``-only behavior: they parse to the base tuple so
+# dev builds compare exactly as before. Attached ``rc`` is handled below.
+_DOTTED_SUFFIX_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)\.\S+$")
+_RC_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)rc(\d+)$")
 
 
 def _cache_path() -> Path:
@@ -109,19 +115,44 @@ def _disabled() -> bool:
         return True
 
 
-def _parse_version(s: str) -> tuple[int, int, int] | None:
-    """Strict-ish ``major.minor.patch`` parse; returns None for anything
-    weirder. We deliberately don't try to handle dev/rc suffixes —
-    if a user is running a dev build, ``pkg_version`` returns
-    ``X.Y.Z.devN`` and we just stay silent.
+def _parse_version(
+    s: str,
+) -> tuple[int, int, int, int | float] | None:
+    """Parse a version into a comparison-capable tuple, or None.
+
+    Returns ``(major, minor, patch, prerelease)`` where ``prerelease`` is
+    the release-candidate number for an attached ``X.Y.ZrcN`` (e.g.
+    ``0.13.0rc1`` → ``(0, 13, 0, 1)``) or ``inf`` for everything else that
+    parses to a clean base version — a final release (``0.13.0``) or a
+    dotted-suffix build (``0.13.0.dev1`` / ``0.13.0.post1``), which keep
+    their historical ``major.minor.patch``-only behavior. The
+    ``prerelease`` element makes any ``X.Y.ZrcN`` sort BELOW the matching
+    ``X.Y.Z`` final, so an rc user reports as behind once the final ships,
+    while a `devN` build stays exactly as it always was (equal to its base
+    final, no new warning / no regression). Completely malformed strings
+    (``0.13``, ``abc``, attached alpha/beta/``+local``) return None — those
+    releases stay silent. Stdlib only (no packaging dependency); a leading
+    ``v`` is tolerated.
     """
-    parts = s.strip().lstrip("v").split(".")
-    if len(parts) < 3:
-        return None
-    try:
-        return (int(parts[0]), int(parts[1]), int(parts[2]))
-    except ValueError:
-        return None
+    s = s.strip()
+    m = _RC_VERSION_RE.match(s)
+    if m is not None:
+        return (
+            int(m.group(1)),
+            int(m.group(2)),
+            int(m.group(3)),
+            int(m.group(4)),
+        )
+    # Final, or dotted-suffix (dev/post) build → base tuple + inf.
+    m = _VERSION_RE.match(s) or _DOTTED_SUFFIX_RE.match(s)
+    if m is not None:
+        return (
+            int(m.group(1)),
+            int(m.group(2)),
+            int(m.group(3)),
+            float("inf"),
+        )
+    return None
 
 
 def _read_cache() -> dict | None:
@@ -349,15 +380,16 @@ def prompt_upgrade_if_available() -> bool:
         installed_str = _installed_version()
         if not installed_str:
             return False
-        # Skip pre-release / dev / local-version builds. ``_parse_version``
-        # tolerates ``0.6.62.dev1`` → ``(0, 6, 62)`` so the tuple can be
-        # compared at all, but for an interactive prompt the dev-base case
-        # can fire a false "newer release available" against the dev's
-        # own in-progress branch (installed ``0.6.61.dev1`` vs latest
+        # Skip pre-release / dev / local-version builds entirely, before
+        # even parsing. For an interactive prompt the dev-base case can
+        # fire a false "newer release available" against the dev's own
+        # in-progress branch (installed ``0.6.61.dev1`` vs latest
         # ``0.6.62`` → prompt). A clean PEP 440 final release is digits
         # and dots only; anything else (``dev``/``a``/``b``/``rc``/
         # ``post``/``+local``) is non-final and gets the dev-build skip
-        # path. DeepSeek finding #1 on PR #428.
+        # path. This keeps ``rc``/``dev`` builds silent here even though
+        # ``_parse_version`` now parses ``X.Y.ZrcN`` for the staleness
+        # banner. DeepSeek finding #1 on PR #428.
         if any(c.isalpha() or c == "+" for c in installed_str.lstrip("v")):
             return False
         installed = _parse_version(installed_str)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5128,6 +5128,15 @@ def bench_command(args):
 
     _mlx_compat.install()
 
+    # Always surface the staleness nudge before any bench work, matching
+    # the serve/models pattern. bench has no ``--json`` form, so there is
+    # no machine-readable mode whose stderr must stay clean (the models
+    # ``--json`` skip lives in its own call site above).
+    if not getattr(args, "json", False):
+        from vllm_mlx._version_check import print_staleness_warning_if_any
+
+        print_staleness_warning_if_any()
+
     # --tier routes through the user-facing tier dispatcher (PR #2 of
     # the bench-consolidation series). PR #5 unified --tier with
     # --submit: when both flags are set the dispatcher runs the
@@ -6860,6 +6869,13 @@ def pull_command(args):
     repo_id = args.model  # already alias-resolved by main()
     t0 = time.monotonic()
 
+    # Surface the staleness nudge up front. pull has no ``--json`` form,
+    # so there is no machine-readable mode whose stderr must stay clean.
+    if not getattr(args, "json", False):
+        from vllm_mlx._version_check import print_staleness_warning_if_any
+
+        print_staleness_warning_if_any()
+
     # #2145: resolve an explicit ``--bits``/``--format`` variant up front via a
     # cheap file listing (no weight download). A requested variant that the
     # repo does not ship fails here with the available folders listed, before
@@ -7175,6 +7191,13 @@ def ps_command(_args):
     import time
 
     import psutil
+
+    # Surface the staleness nudge up front. ps has no ``--json`` form, so
+    # there is no machine-readable mode whose stderr must stay clean.
+    if not getattr(_args, "json", False):
+        from vllm_mlx._version_check import print_staleness_warning_if_any
+
+        print_staleness_warning_if_any()
 
     rows: list[tuple[int, str, str, str]] = []
     for proc in psutil.process_iter(["pid", "cmdline", "create_time"]):
@@ -8941,6 +8964,13 @@ def info_command(args):
         detect_model_config,
         format_profile_table,
     )
+
+    # Surface the staleness nudge up front. info has no ``--json`` form, so
+    # there is no machine-readable mode whose stderr must stay clean.
+    if not getattr(args, "json", False):
+        from vllm_mlx._version_check import print_staleness_warning_if_any
+
+        print_staleness_warning_if_any()
 
     # ``main()`` (cli.py:~3400) pre-resolves ``args.model`` from alias →
     # HF path before dispatch, stashing the user-typed alias on

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -55,6 +55,14 @@ def doctor_command(args: Any) -> None:
         sys.exit(2)
 
     verbose = bool(getattr(args, "verbose", False))
+
+    # Surface the staleness nudge before the report. doctor has no ``--json``
+    # form, so there is no machine-readable mode whose stderr must stay clean.
+    if not getattr(args, "json", False):
+        from vllm_mlx._version_check import print_staleness_warning_if_any
+
+        print_staleness_warning_if_any()
+
     report = run_all()
     render(report, verbose=verbose)
     sys.exit(report.exit_code)

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -56,13 +56,6 @@ def doctor_command(args: Any) -> None:
 
     verbose = bool(getattr(args, "verbose", False))
 
-    # Surface the staleness nudge before the report. doctor has no ``--json``
-    # form, so there is no machine-readable mode whose stderr must stay clean.
-    if not getattr(args, "json", False):
-        from vllm_mlx._version_check import print_staleness_warning_if_any
-
-        print_staleness_warning_if_any()
-
     report = run_all()
     render(report, verbose=verbose)
     sys.exit(report.exit_code)

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -743,11 +743,11 @@ def section_updates(
 
     pc, pl = vc._parse_version(cur), vc._parse_version(latest)
     if pc is None or pl is None:
-        # One side is a dev/rc/git-describe build ``_parse_version`` won't
-        # touch (e.g. ``0.10.15.dev3``, ``0.11.0rc1``, ``0.10``). We can't
-        # order them, so DON'T fall through to a green "up to date" — that
-        # would falsely reassure a user who might well be behind. Downgrade
-        # to ⚠ like every other uncertain branch in this section.
+        # One side is an unsupported alpha/beta/local/git-describe build
+        # (e.g. ``0.11.0a1``, ``0.10.15+local``, ``0.10``). We can't order
+        # it, so DON'T fall through to a green "up to date" — that would
+        # falsely reassure a user who might well be behind. Downgrade to ⚠
+        # like every other uncertain branch in this section.
         s.add(
             f"rapid-mlx {cur} — can't compare against latest {latest} "
             "(unrecognized version format); freshness check skipped",


### PR DESCRIPTION
Fixes #2595

## Why

Users running `X.Y.ZrcN` never receive the passive upgrade notice after the matching `X.Y.Z` final ships because the current staleness parser treats the installed RC as unparseable. The notice is also absent from several ordinary CLI workflows, leaving pre-release users on stale behavior without a prompt.

## What

- Parse an attached `rcN` into an ordering key below the matching final release.
- Preserve the existing base-version behavior for dotted development/post suffixes and keep malformed/local versions silent.
- Keep the interactive auto-upgrade prompt conservative: RC/dev/local builds remain excluded there.
- Invoke the existing fail-silent staleness notice from `pull`, `ps`, `info`, `bench`, and `doctor`.
- Register the focused version-check tests in the explicit no-MLX CI roster.

## Scope / non-goals

- Passive version-notice behavior and missing CLI call sites only.
- No automatic upgrade, Desktop change, endpoint/TTL change, dependency addition, or CLI refactor.
- No attempt to replace the project’s deliberately narrow stdlib parser with a complete version-standard implementation.

## Design precedent

The comparison follows the Python packaging version-order contract for the one newly supported form: release candidates sort numerically below their matching final release. The module remains stdlib-only and preserves its established dev/post compatibility behavior instead of broadening this patch into a dependency or parsing-policy migration.

## Verification

- Rebased cleanly onto `main` at `5ddb26ba`; exact head `4c433563`.
- `pytest tests/test_version_check.py tests/test_cli_models.py`: 171 passed.
- Ruff check and format: clean.
- `actionlint .github/workflows/ci.yml`: clean.
- `git diff --check`: clean.
- Exact-head Codex review, `pr_validate`, and hosted checks follow on this head.