### PR TITLE
fix(mac): use the safe 8 GB Quickstart model

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -30,7 +30,7 @@ private final class RecommendationBundleFinder: NSObject {}
 ///
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
-/// |  8 GB  | lfm2.5-2.6b-4bit    |  3.0 | 64% | 93.5  | lfm2.5-1b-4bit · basic · 208.4   |
+/// |  8 GB  | lfm2.5-2.6b-4bit¹   |  3.0 | 64% | 93.5  | lfm2.5-1b-4bit · basic · 208.4   |
 /// | 16 GB  | qwen3.5-4b-4bit     |  6.0 | 78% | 60.7  | lfm2.5-1b-4bit · basic · 208.4   |
 /// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 35.7  | qwen3.5-4b-4bit · 78% · 60.7     |
 /// | 24 GB  | bonsai-27b-2bit     | 13.0 | 86% | 17.5  | qwen3.5-4b-4bit · 78% · 60.7     |
@@ -38,6 +38,11 @@ private final class RecommendationBundleFinder: NSObject {}
 /// | 48 GB  | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
 /// | 64 GB  | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
 /// | 96 GB+ | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
+///
+/// ¹ The clean 8 GB first-run gate projects the smarter 2.6B pick beyond the
+/// app's usable-memory budget. Quickstart therefore defaults to this tier's
+/// 1.2B fast pick; the recommendation table still offers 2.6B as an informed
+/// capability trade-up.
 ///
 /// Every tier from 32 GB up shares one smart pick (AA-Index policy,
 /// 2026-08-18): qwen3.8-27b-4bit is the highest-scoring open-weights model

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -194,14 +194,24 @@ struct QuickstartRecommendedCard: View {
         .modelRowActivation(onActivate)
         .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
         .accessibilityAddTraits(selected ? .isSelected : [])
-        .accessibilityLabel(accessibilityText)
+        .accessibilityLabel(Self.accessibilityText(for: choice, sizeText: sizeText))
     }
 
     /// Fold the framing, size and attribute pills into the spoken label — the
     /// button overrides its children, so VoiceOver otherwise hears the name
     /// and blurb only.
-    private var accessibilityText: String {
+    static func accessibilityText(
+        for choice: QuickstartModelChoice,
+        sizeText: String
+    ) -> String {
         var parts = [choice.displayName]
+        // Below 16 GB the existing lowest-memory choice is deliberately the
+        // automatic starter. Preserve both facts in its spoken category: the
+        // visual START HERE badge must not erase the capability trade-off that
+        // this same row announces when it is an optional fallback.
+        if choice.alias == QuickstartCoordinator.lowMemoryChoice.alias {
+            parts.append("Lowest memory")
+        }
         parts.append("recommended starter")
         parts.append(choice.blurb)
         if !sizeText.isEmpty { parts.append("download \(sizeText)") }

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -167,9 +167,7 @@ struct QuickstartRecommendedCard: View {
                         Text(choice.displayName)
                             .scaledSystemFont(15, weight: .semibold)
                             .foregroundStyle(RapidTheme.textPrimary)
-                        if choice.isStarter {
-                            OnboardingBadge(text: "START HERE", tone: .ink)
-                        }
+                        OnboardingBadge(text: "START HERE", tone: .ink)
                         Spacer(minLength: 8)
                         if !sizeText.isEmpty {
                             Text(sizeText)
@@ -204,7 +202,7 @@ struct QuickstartRecommendedCard: View {
     /// and blurb only.
     private var accessibilityText: String {
         var parts = [choice.displayName]
-        if choice.isStarter { parts.append("recommended starter") }
+        parts.append("recommended starter")
         parts.append(choice.blurb)
         if !sizeText.isEmpty { parts.append("download \(sizeText)") }
         parts.append("on-device, fits this Mac")

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -336,6 +336,11 @@ final class QuickstartCoordinator {
         var excluded = CacheAwareDefault.retiredAutomaticAliases
         if baseline.alias != lowMemoryChoice.alias {
             excluded.insert(lowMemoryChoice.alias)
+        } else {
+            // Clean 8 GB validation puts the 2.6B option beyond the usable-RAM
+            // guard. A cached copy still avoids a download, but does not make
+            // that load safe enough to become the automatic first run.
+            excluded.insert(compactDefaultChoice.alias)
         }
         guard let alias = CacheAwareDefault.pick(
             catalog: eligibleCatalog,

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -260,7 +260,9 @@ final class QuickstartCoordinator {
         tier: .starter
     )
 
-    /// Smaller quality-floor starter for Macs below 16 GB RAM.
+    /// Smarter optional choice for Macs below 16 GB RAM. Clean 8 GB hardware
+    /// validation showed that loading it projects beyond the app's usable RAM
+    /// budget, so first run defaults to ``lowMemoryChoice`` instead.
     static let compactDefaultChoice = QuickstartModelChoice(
         alias: "lfm2.5-2.6b-4bit",
         displayName: "LFM2.5 · 2.6B",
@@ -323,16 +325,18 @@ final class QuickstartCoordinator {
 
     /// Hardware-aware first-run policy. The existing cache-aware policy is the
     /// eligibility SSOT for cached choices; onboarding adds only its explicit
-    /// 16 GB baseline and excludes the 1.2B manual fallback from automatic
-    /// selection.
+    /// 16 GB baseline. The 1.2B choice is automatic only when it is already
+    /// the sub-16 GB baseline; larger Macs keep it as an explicit fallback.
     static func defaultChoice(
         hardware: MacHardware,
         catalog: [ModelEntry]
     ) -> QuickstartModelChoice {
         let baseline = baselineChoice(hardware: hardware)
         let eligibleCatalog = catalog.filter { $0.kind == .chat }
-        let excluded = CacheAwareDefault.retiredAutomaticAliases
-            .union([lowMemoryChoice.alias])
+        var excluded = CacheAwareDefault.retiredAutomaticAliases
+        if baseline.alias != lowMemoryChoice.alias {
+            excluded.insert(lowMemoryChoice.alias)
+        }
         guard let alias = CacheAwareDefault.pick(
             catalog: eligibleCatalog,
             hardware: hardware,
@@ -356,7 +360,7 @@ final class QuickstartCoordinator {
     /// Cached preference is deliberately layered only by ``defaultChoice``.
     static func baselineChoice(hardware: MacHardware) -> QuickstartModelChoice {
         hardware.physicalRAMGB < 16
-            ? compactDefaultChoice
+            ? lowMemoryChoice
             : defaultChoice
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -421,7 +421,9 @@ Open the picker any time to switch models.
     /// RAM-only starter identity for this launch. Unlike ``choice.tier``, this
     /// is contextual: 1.2B is the starter below 16 GB and remains the explicit
     /// low-memory fallback everywhere else.
-    private var baselineStarterAlias = QuickstartCoordinator.defaultChoice.alias
+    private var baselineStarterAlias = QuickstartCoordinator.defaultChoice.alias {
+        didSet { defaults.set(baselineStarterAlias, forKey: Self.baselineStarterAliasKey) }
+    }
     /// False after the user or persisted session chose a concrete model, so a
     /// later catalog refresh can never replace explicit intent.
     private var selectionUsesAutomaticPolicy = true
@@ -850,6 +852,7 @@ Open the picker any time to switch models.
     /// ``enterDownloading``, ``skipForNow``, selecting a different alias,
     /// and ``_testingReset``.
     static let pendingReadyAliasKey: String = "rapid.quickstart.v1.pendingReadyAlias"
+    static let baselineStarterAliasKey: String = "rapid.quickstart.v1.baselineStarterAlias"
 
     /// Provenance for "this install has been inside setup before and never
     /// finished it" (Paper 05.1 state 18 — "Relaunch, setup incomplete").
@@ -914,6 +917,8 @@ Open the picker any time to switch models.
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        self.baselineStarterAlias = defaults.string(forKey: Self.baselineStarterAliasKey)
+            ?? Self.defaultChoice.alias
         self.done = defaults.bool(forKey: Self.storageKey)
         self.legacyDone = defaults.bool(forKey: Self.legacyStorageKey)
         // History only. Nothing below reconstructs a phase, a selection or a
@@ -1006,6 +1011,7 @@ Open the picker any time to switch models.
         catalogSort = .familyThenSize
         catalogScrollID = nil
         selection = Self.defaultChoice
+        baselineStarterAlias = Self.defaultChoice.alias
         selectionUsesAutomaticPolicy = true
         hasSeededWelcome = false
         awaitingWelcomeSeed = false
@@ -1030,6 +1036,7 @@ Open the picker any time to switch models.
         defaults.removeObject(forKey: Self.awaitingSeedKey)
         defaults.removeObject(forKey: Self.awaitingSeedAliasKey)
         defaults.removeObject(forKey: Self.pendingReadyAliasKey)
+        defaults.removeObject(forKey: Self.baselineStarterAliasKey)
     }
 
     /// The name 44 call sites in the suite and ``DevSnapshot`` already use.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -359,9 +359,11 @@ final class QuickstartCoordinator {
     /// RAM-only baseline shared by onboarding and the persistent picker row.
     /// Cached preference is deliberately layered only by ``defaultChoice``.
     static func baselineChoice(hardware: MacHardware) -> QuickstartModelChoice {
-        hardware.physicalRAMGB < 16
-            ? lowMemoryChoice
-            : defaultChoice
+        baselineChoice(physicalRAMGB: hardware.physicalRAMGB)
+    }
+
+    static func baselineChoice(physicalRAMGB: Double) -> QuickstartModelChoice {
+        physicalRAMGB < 16 ? lowMemoryChoice : defaultChoice
     }
 
     /// UserDefaults key for the persistent "Quickstart already
@@ -2404,7 +2406,9 @@ struct QuickstartView: View {
 
                     if !list.recommended.isEmpty {
                         OnboardingGroupLabel(
-                            text: "RECOMMENDED FOR YOUR \(Self.wholeGB(hardware.physicalRAMGB)) MAC"
+                            text: Self.recommendedGroupLabel(
+                                physicalRAMGB: hardware.physicalRAMGB
+                            )
                         )
                         .padding(.top, 14)
                         ForEach(list.recommended) { choice in
@@ -2996,7 +3000,9 @@ struct QuickstartView: View {
                 }
                 if !list.recommended.isEmpty {
                     OnboardingGroupLabel(
-                        text: "RECOMMENDED FOR YOUR \(Self.wholeGB(hardware.physicalRAMGB)) MAC"
+                        text: Self.recommendedGroupLabel(
+                            physicalRAMGB: hardware.physicalRAMGB
+                        )
                     )
                     .padding(.top, 14)
                     ForEach(list.recommended) { choice in
@@ -3285,9 +3291,7 @@ struct QuickstartView: View {
     ) -> Shortlist {
         let choices = QuickstartCoordinator.onboardingChoices
         let starterAlias = physicalRAMGB.map {
-            $0 < 16
-                ? QuickstartCoordinator.compactDefaultChoice.alias
-                : QuickstartCoordinator.defaultChoice.alias
+            QuickstartCoordinator.baselineChoice(physicalRAMGB: $0).alias
         } ?? QuickstartCoordinator.defaultChoice.alias
         var cachedPresentation = quickstartCachedPresentation(catalog, limit: 6)
         // A catalog-preferred authored choice can sit just beyond the bounded
@@ -3312,9 +3316,10 @@ struct QuickstartView: View {
         var recommended: [QuickstartModelChoice] = []
         if let ram = physicalRAMGB {
             var excluded = existingAliases
-            excluded.formUnion(
-                choices.filter { $0.isStarter || $0.isLowMemory }.map(\.alias)
-            )
+            excluded.insert(starterAlias)
+            if starterAlias != QuickstartCoordinator.lowMemoryChoice.alias {
+                excluded.insert(QuickstartCoordinator.lowMemoryChoice.alias)
+            }
             recommended = Self.recommendedChoices(
                 from: RAMBucketedDefault.picks(forPhysicalRAMGB: ram),
                 authored: choices,
@@ -3338,17 +3343,29 @@ struct QuickstartView: View {
             cached: existing,
             cachedAlternates: cachedPresentation.alternates,
             starters: choices.filter {
-                $0.isStarter
-                    && $0.alias == starterAlias
-                    && !existingAliases.contains($0.alias)
+                $0.alias == starterAlias && !existingAliases.contains($0.alias)
             },
             recommended: recommended,
-            lowMemory: choices.filter { $0.isLowMemory && !existingAliases.contains($0.alias) },
+            lowMemory: choices.filter {
+                $0.isLowMemory
+                    && $0.alias != starterAlias
+                    && !existingAliases.contains($0.alias)
+            },
             tradeUps: tradeUps,
             yourPick: native.contains(selection)
                 ? nil
                 : onboardingCatalogModels(catalog).first { $0.alias == selection }
         )
+    }
+
+    /// The smallest tier's smart pick remains an explicit capability upgrade,
+    /// not the automatic recommendation: clean 8 GB validation showed that it
+    /// crosses the usable-memory guard. The row itself still owns the exact
+    /// measured warning and Load Anyway decision.
+    static func recommendedGroupLabel(physicalRAMGB: Double) -> String {
+        physicalRAMGB < 16
+            ? "OPTIONAL — MORE CAPABLE, USES MORE MEMORY"
+            : "RECOMMENDED FOR YOUR \(wholeGB(physicalRAMGB)) MAC"
     }
 
     /// Map the SSOT's RAM-tier picks into renderable wizard choices.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -389,7 +389,7 @@ final class QuickstartCoordinator {
     /// manually selected alternative gets a plainer intro without implying it
     /// was downloaded specifically for setup.
     var seedMessage: String {
-        if selection.isStarter {
+        if selection.alias == baselineStarterAlias {
             return """
 You're chatting with \(selection.displayName) — a model picked so you can start \
 chatting in about a minute. Open the picker any time to trade up to a larger \
@@ -413,6 +413,10 @@ Open the picker any time to switch models.
     /// ContentView visibility gate's alias check) reads this instead of
     /// a pinned constant.
     private(set) var selection: QuickstartModelChoice = QuickstartCoordinator.defaultChoice
+    /// RAM-only starter identity for this launch. Unlike ``choice.tier``, this
+    /// is contextual: 1.2B is the starter below 16 GB and remains the explicit
+    /// low-memory fallback everywhere else.
+    private var baselineStarterAlias = QuickstartCoordinator.defaultChoice.alias
     /// False after the user or persisted session chose a concrete model, so a
     /// later catalog refresh can never replace explicit intent.
     private var selectionUsesAutomaticPolicy = true
@@ -734,6 +738,7 @@ Open the picker any time to switch models.
     /// the selection is still automatic.
     func applyDefaultChoice(hardware: MacHardware, catalog: [ModelEntry]) {
         guard case .idle = phase, selectionUsesAutomaticPolicy else { return }
+        baselineStarterAlias = Self.baselineChoice(hardware: hardware).alias
         selection = Self.defaultChoice(hardware: hardware, catalog: catalog)
     }
 
@@ -741,6 +746,7 @@ Open the picker any time to switch models.
     /// cache refreshes must not retarget a starter the chooser already shows.
     func settleDefaultChoice(hardware: MacHardware, catalog: [ModelEntry]) {
         guard case .idle = phase, selectionUsesAutomaticPolicy else { return }
+        baselineStarterAlias = Self.baselineChoice(hardware: hardware).alias
         selection = Self.defaultChoice(hardware: hardware, catalog: catalog)
         selectionUsesAutomaticPolicy = false
     }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -14,7 +14,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton id="GitHub.Star.EmptyState" desc="Star on GitHub" help="Opens the Rapid-MLX repository in your browser" enabled=true
-          AXGroup desc="lfm2.5-2.6b-4bit isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
+          AXGroup desc="lfm2.5-1b-4bit isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="Readiness.Action" desc="Download" enabled=true
@@ -25,7 +25,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.ConversationInstructions" desc="Conversation system prompt" help="Conversation system prompt" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
-          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-2.6b-4bit before sending." enabled=false
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-1b-4bit before sending." enabled=false
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -14,7 +14,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton id="GitHub.Star.EmptyState" desc="Star on GitHub" help="Opens the Rapid-MLX repository in your browser" enabled=true
-          AXGroup desc="lfm2.5-1b-4bit isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
+          AXGroup desc="lfm2.5-1b-4bit isn't downloaded yet, It downloads once (~<size>), then starts in seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="Readiness.Action" desc="Download" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
         AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. recommended starter. For basic chat only; less accurate and not recommended for tools.. download ~<size>. on-device, fits this Mac" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. Lowest memory. recommended starter. For basic chat only; less accurate and not recommended for tools.. download ~<size>. on-device, fits this Mac" enabled=true
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. A lighter everyday model chosen to fit lower-memory Macs.. download <size> · 64%" enabled=true
         AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -10,9 +10,9 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
         AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. recommended starter. A lighter everyday model chosen to fit lower-memory Macs.. download <size>. on-device, fits this Mac" enabled=true
-        AXStaticText value=text enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. Lowest memory. For basic chat only; less accurate and not recommended for tools. Download ~<size>" enabled=true
+        AXStaticText value=text enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. A lighter everyday model chosen to fit lower-memory Macs.. download <size>. on-device, fits this Mac" enabled=true
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 9B. Strong all-rounder if you have the RAM to spare.. download <size>" enabled=true
         AXButton id="Quickstart.BrowseAll" desc="Browse all models" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
         AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. For basic chat only; less accurate and not recommended for tools.. download ~<size>. on-device, fits this Mac" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. recommended starter. For basic chat only; less accurate and not recommended for tools.. download ~<size>. on-device, fits this Mac" enabled=true
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. A lighter everyday model chosen to fit lower-memory Macs.. download <size> · 64%" enabled=true
         AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -10,9 +10,9 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
         AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. Lowest memory. For basic chat only; less accurate and not recommended for tools. Download ~<size>" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. For basic chat only; less accurate and not recommended for tools.. download ~<size>. on-device, fits this Mac" enabled=true
         AXStaticText value=text enabled=true
-        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. A lighter everyday model chosen to fit lower-memory Macs.. download <size>. on-device, fits this Mac" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 2.6B. A lighter everyday model chosen to fit lower-memory Macs.. download <size> · 64%" enabled=true
         AXStaticText value=text enabled=true
         AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 9B. Strong all-rounder if you have the RAM to spare.. download <size>" enabled=true
         AXButton id="Quickstart.BrowseAll" desc="Browse all models" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -66,6 +66,22 @@ struct QuickstartStarterPolicyTests {
         #expect(coordinator.seedMessage.contains("a model picked so you can start"))
     }
 
+    @Test("The automatic 8 GB choice keeps its lowest-memory spoken category")
+    func lowMemoryStarterAccessibilityCategory() {
+        let lowMemoryLabel = QuickstartRecommendedCard.accessibilityText(
+            for: QuickstartCoordinator.lowMemoryChoice,
+            sizeText: "720 MB"
+        )
+        let standardLabel = QuickstartRecommendedCard.accessibilityText(
+            for: QuickstartCoordinator.defaultChoice,
+            sizeText: "2.9 GB"
+        )
+
+        #expect(lowMemoryLabel.contains("Lowest memory"))
+        #expect(lowMemoryLabel.contains("recommended starter"))
+        #expect(!standardLabel.contains("Lowest memory"))
+    }
+
     @Test("The 8 GB starter provenance survives a deferred-seed relaunch")
     func baselineStarterSurvivesRelaunch() {
         let suite = "QuickstartStarterPolicyTests.relaunch.\(UUID().uuidString)"

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -131,6 +131,19 @@ struct QuickstartStarterPolicyTests {
         ).alias == "lfm2.5-1b-4bit")
     }
 
+    @Test("A cached 2.6B model cannot bypass the safe 8 GB automatic baseline")
+    func cachedCompactUpgradeRemainsManual() {
+        let catalog = [
+            entry("lfm2.5-1b-4bit"),
+            entry("lfm2.5-2.6b-4bit", cached: true),
+            entry("qwen3.5-4b-4bit"),
+        ]
+
+        #expect(QuickstartCoordinator.defaultChoice(
+            hardware: hardware(8), catalog: catalog
+        ).alias == "lfm2.5-1b-4bit")
+    }
+
     @Test("The chooser presents one hardware-fit starter, not two competing recommendations")
     func shortlistHasOneStarter() {
         let catalog = [

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -120,16 +120,21 @@ struct QuickstartStarterPolicyTests {
     @Test("The chooser presents one hardware-fit starter, not two competing recommendations")
     func shortlistHasOneStarter() {
         let catalog = [
+            entry("lfm2.5-1b-4bit"),
             entry("lfm2.5-2.6b-4bit"),
             entry("qwen3.5-4b-4bit"),
         ]
 
         let compact = QuickstartView.shortlist(
             catalog: catalog,
-            selection: "lfm2.5-2.6b-4bit",
+            selection: "lfm2.5-1b-4bit",
             physicalRAMGB: 8
         )
-        #expect(compact.starters.map(\.alias) == ["lfm2.5-2.6b-4bit"])
+        #expect(compact.starters.map(\.alias) == ["lfm2.5-1b-4bit"])
+        #expect(compact.lowMemory.isEmpty)
+        #expect(compact.recommended.map(\.alias) == ["lfm2.5-2.6b-4bit"])
+        #expect(QuickstartView.recommendedGroupLabel(physicalRAMGB: 8)
+            == "OPTIONAL — MORE CAPABLE, USES MORE MEMORY")
 
         let standard = QuickstartView.shortlist(
             catalog: catalog,

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -62,6 +62,20 @@ struct QuickstartStarterPolicyTests {
         coordinator.applyDefaultChoice(hardware: hardware(8), catalog: [])
 
         #expect(coordinator.selection.alias == "lfm2.5-1b-4bit")
+        #expect(coordinator.seedMessage.contains("a model picked so you can start"))
+    }
+
+    @Test("The 1.2B choice remains a fallback, not a starter, on a 16 GB Mac")
+    func lowMemoryChoiceIsContextual() {
+        let coordinator = QuickstartCoordinator()
+        coordinator.applyDefaultChoice(
+            hardware: hardware(16),
+            catalog: [entry("qwen3.5-4b-4bit"), entry("lfm2.5-1b-4bit")]
+        )
+        coordinator.select(QuickstartCoordinator.lowMemoryChoice)
+
+        #expect(!coordinator.seedMessage.contains("a model picked so you can start"))
+        #expect(coordinator.seedMessage.contains("running entirely on your Mac"))
     }
 
     @Test("An eligible cached chat model wins without a download")

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -28,19 +28,20 @@ struct QuickstartStarterPolicyTests {
         )
     }
 
-    @Test("RAM threshold chooses 2.6B below 16 GB and Qwen 4B at 16 GB or above")
+    @Test("RAM threshold chooses 1.2B below 16 GB and Qwen 4B at 16 GB or above")
     func ramMatrix() {
         let catalog = [
+            entry("lfm2.5-1b-4bit"),
             entry("lfm2.5-2.6b-4bit"),
             entry("qwen3.5-4b-4bit"),
         ]
 
         #expect(QuickstartCoordinator.defaultChoice(
             hardware: hardware(8), catalog: catalog
-        ).alias == "lfm2.5-2.6b-4bit")
+        ).alias == "lfm2.5-1b-4bit")
         #expect(QuickstartCoordinator.defaultChoice(
             hardware: hardware(15.99), catalog: catalog
-        ).alias == "lfm2.5-2.6b-4bit")
+        ).alias == "lfm2.5-1b-4bit")
         #expect(QuickstartCoordinator.defaultChoice(
             hardware: hardware(16), catalog: catalog
         ).alias == "qwen3.5-4b-4bit")
@@ -49,7 +50,7 @@ struct QuickstartStarterPolicyTests {
         ).alias == "qwen3.5-4b-4bit")
         #expect(QuickstartCoordinator.baselineChoice(
             hardware: hardware(8)
-        ).alias == "lfm2.5-2.6b-4bit")
+        ).alias == "lfm2.5-1b-4bit")
         #expect(QuickstartCoordinator.baselineChoice(
             hardware: hardware(16)
         ).alias == "qwen3.5-4b-4bit")
@@ -60,7 +61,7 @@ struct QuickstartStarterPolicyTests {
         let coordinator = QuickstartCoordinator()
         coordinator.applyDefaultChoice(hardware: hardware(8), catalog: [])
 
-        #expect(coordinator.selection.alias == "lfm2.5-2.6b-4bit")
+        #expect(coordinator.selection.alias == "lfm2.5-1b-4bit")
     }
 
     @Test("An eligible cached chat model wins without a download")
@@ -78,6 +79,7 @@ struct QuickstartStarterPolicyTests {
     @Test("A cached standard starter stays visible when it wins below 16 GB")
     func cachedStandardStarterRemainsVisible() {
         let catalog = [
+            entry("lfm2.5-1b-4bit"),
             entry("lfm2.5-2.6b-4bit"),
             entry("qwen3.5-4b-4bit", cached: true),
         ]
@@ -99,6 +101,7 @@ struct QuickstartStarterPolicyTests {
     @Test("An 8 GB Mac does not promote a cached model that fails its fit contract")
     func cachedStandardStarterMustFit() {
         let catalog = [
+            entry("lfm2.5-1b-4bit"),
             entry("lfm2.5-2.6b-4bit"),
             entry("qwen3.5-4b-4bit", cached: true),
         ]
@@ -111,7 +114,7 @@ struct QuickstartStarterPolicyTests {
         #expect(QuickstartCoordinator.defaultChoice(
             hardware: machine,
             catalog: catalog
-        ).alias == "lfm2.5-2.6b-4bit")
+        ).alias == "lfm2.5-1b-4bit")
     }
 
     @Test("The chooser presents one hardware-fit starter, not two competing recommendations")
@@ -241,11 +244,12 @@ struct QuickstartStarterPolicyTests {
         let coordinator = QuickstartCoordinator()
         coordinator.applyDefaultChoice(hardware: hardware(15.99), catalog: [])
         coordinator.advanceToChooseModel()
-        #expect(coordinator.selection.alias == "lfm2.5-2.6b-4bit")
+        #expect(coordinator.selection.alias == "lfm2.5-1b-4bit")
 
         coordinator.settleDefaultChoice(
             hardware: hardware(15.99),
             catalog: [
+                entry("lfm2.5-1b-4bit"),
                 entry("lfm2.5-2.6b-4bit"),
                 entry("qwen3.5-4b-4bit", cached: true),
             ]

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Rapid
 
@@ -63,6 +64,22 @@ struct QuickstartStarterPolicyTests {
 
         #expect(coordinator.selection.alias == "lfm2.5-1b-4bit")
         #expect(coordinator.seedMessage.contains("a model picked so you can start"))
+    }
+
+    @Test("The 8 GB starter provenance survives a deferred-seed relaunch")
+    func baselineStarterSurvivesRelaunch() {
+        let suite = "QuickstartStarterPolicyTests.relaunch.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let first = QuickstartCoordinator(defaults: defaults)
+        first.applyDefaultChoice(hardware: hardware(8), catalog: [])
+        defaults.set(true, forKey: QuickstartCoordinator.awaitingSeedKey)
+        defaults.set(first.selection.alias, forKey: QuickstartCoordinator.awaitingSeedAliasKey)
+
+        let relaunched = QuickstartCoordinator(defaults: defaults)
+        #expect(relaunched.selection.alias == "lfm2.5-1b-4bit")
+        #expect(relaunched.seedMessage.contains("a model picked so you can start"))
     }
 
     @Test("The 1.2B choice remains a fallback, not a starter, on a 16 GB Mac")

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -573,13 +573,14 @@ struct Step2ModelSelectionBehaviorTests {
                 "32 GB shows the smart 27B; the fast 4B is already the starter")
     }
 
-    @Test("The starter is never duplicated inside the recommended row")
+    @Test("The safe 8 GB starter is not duplicated by its optional capability upgrade")
     func starterEqualFastPickIsDroppedFromRecommended() {
-        // At 8 GB the smart pick is the starter and the fast pick is the
-        // explicit low-memory card, so neither belongs in a duplicate row.
+        // At 8 GB the fast pick is the automatic starter. The smart pick stays
+        // visible once as an explicit, memory-guarded capability upgrade.
         let list = QuickstartView.shortlist(catalog: [], selection: "", physicalRAMGB: 8)
-        #expect(list.recommended.isEmpty,
-                "starter and low-memory picks are deduplicated against their authored cards")
+        #expect(list.starters.map(\.alias) == ["lfm2.5-1b-4bit"])
+        #expect(list.lowMemory.isEmpty)
+        #expect(list.recommended.map(\.alias) == ["lfm2.5-2.6b-4bit"])
     }
 
     @Test("No RAM argument means no recommended row")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1280,14 +1280,14 @@ flow_fresh_install() {
     see_main "$OUT/compact.json"
     baseline onboarding-direction-d.compact "$OUT/compact.json"
     press "$OUT/compact.json" Quickstart.GetStarted "$OUT/get-started.json"
-    wait_selected Quickstart.Choice.lfm2.5-2.6b-4bit "$OUT/chooser-settled.json"
+    wait_selected Quickstart.Choice.lfm2.5-1b-4bit "$OUT/chooser-settled.json"
     baseline onboarding-direction-d.compact-chooser "$OUT/chooser-settled.json"
     press "$OUT/chooser-settled.json" Quickstart.Footer.Back "$OUT/chooser-back.json"
     wait_identifier Quickstart.Skip "$OUT/welcome-returned.json"
     press "$OUT/welcome-returned.json" Quickstart.Skip "$OUT/quickstart-skip.json"
     wait_identifier rapid.chat.compose "$OUT/steady.json"
     selected_model="$(element_field "$OUT/steady.json" ModelPickerBar.ModelMenu value)"
-    [[ "$selected_model" == *"lfm2.5-2.6b-4bit"* ]] \
+    [[ "$selected_model" == *"lfm2.5-1b-4bit"* ]] \
         || die "#2219: 8 GB onboarding selected '$selected_model' instead of the compact starter"
     for id in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
         jq -e --arg id "$id" '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/steady.json" >/dev/null \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -27,8 +27,8 @@ FAKE_IMAGE_ALIAS="fake-image-alias"
 # the operator's release Mac), so every persona that renders the chooser
 # pins the same tier to keep its AX baseline deterministic.
 # 8 = the 8 GB tier, which is exactly what the committed compact-chooser
-# baseline captures (smart lfm2.5-2.6B; its fast pick lfm2.5-1B equals the
-# starter, so the row renders just the one card). Pinning 8 also happens to
+# baseline captures (safe fast pick lfm2.5-1B as the starter; smart
+# lfm2.5-2.6B as the optional memory-guarded capability upgrade). Pinning 8 also happens to
 # be the safe tier for cached-curated-tradeup: its assertion needs
 # qwen3.5-4b to stay a native curated trade-up, which 8 GB guarantees
 # (16/24/32 GB hosts fold qwen3.5-4b into the recommended row instead).


### PR DESCRIPTION
Requested by the maintainer during 0.13.1 first-run dogfood.

## Why
A clean 8 GB Mac projects the previous 2.6B starter at 108% of usable RAM and requires **Load Anyway**, making the default onboarding path look unsafe.

## What
- default sub-16 GB Quickstart to the existing LFM2.5 1.2B fast pick
- preserve eligible cached-model preference and the 16 GB+ Qwen 4B policy
- keep the 2.6B model available as an explicit capability trade-up
- update the focused policy contract and fresh-install AX expectation

## Non-goals
No catalog redesign, recommendation score changes, model removal, engine/server changes, or wizard redesign.

## Local evidence
- focused Swift onboarding/policy suites: 217 passed
- RAM/GUI source contracts: 89 passed
- release-shaped Desktop build: passed