### PR TITLE
feat(engine): add experimental Qwen3.8 Flash Next text lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,13 @@ jobs:
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
+            tests/test_deepseek_v4_vendored.py \
+            tests/test_dspark_scheduler.py \
+            tests/test_prefix_cache_persistence.py \
+            tests/test_suffix_decoding.py \
+            tests/test_qwen4_exp_artifact_parity.py \
+            tests/test_qwen4_exp_reference_parity.py \
+            tests/test_qwen4_exp_vendored.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
+++ b/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
@@ -65,6 +65,11 @@ HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
 python -m pytest -q tests/test_qwen4_exp_artifact_parity.py
 ```
 
+The gate covers the fixed short component/logit probes, then a 2,052-token
+probe that crosses the 2,048-token sparse-QSA budget by one complete compressed
+block, followed by the first cached decode token. Both logit probes require the
+same greedy token in addition to the component tolerance.
+
 ## Real-model evidence
 
 The original 20-case panel covers reasoning, code, Chinese, tool calls, and four

--- a/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
+++ b/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
@@ -1,7 +1,8 @@
 # Qwen3.8-Flash-Next text-lane M1
 
-Status: experimental, local artifact only. The checkpoint has not been uploaded
-or published. MTP and vision are separate milestones.
+Status: experimental text lane. The immutable release artifact is being
+published as `rapid-mlx/Qwen3.8-Flash-Next-4bit`; this PR must not land before
+that repository resolves. MTP and vision remain separate milestones.
 
 ## Architecture and conversion contract
 
@@ -21,9 +22,12 @@ The converted q4 artifact uses:
 
 `scripts/qwen38_streaming_convert.py` streams source shards, emits MLX sibling
 `weight` / `scales` / `biases` keys, preserves the fused MoE gate-up/down
-contract, and writes a complete index plus SHA-256 manifest. The verified local
-artifact contains 28 shards / 98 GiB. Strict loading reports zero missing and
-zero unexpected parameters.
+contract, and writes a complete index plus SHA-256 manifest. The verified
+release artifact contains 28 shards / 97.51 GiB (104,695,602,743 bytes). Strict
+loading reports zero missing and zero unexpected parameters. Its model card
+records source revision `f5d08274`, the Qwen Apache-2.0 license, this
+mixed-group quantization contract, and the generated `SHA256SUMS.txt` whole-tree
+manifest.
 
 ## Reference and numerical gate
 
@@ -79,12 +83,13 @@ swap. The four long prefills completed in 130.209, 130.739, 145.181, and 136.935
 seconds. Answers included the exact four recall facts and well-formed tool calls
 for weather, stock price, meeting scheduling, and local-document search.
 
-An explicitly served local checkpoint advertises the `experimental` capability
-from its `qwen4_exp` architecture metadata. M1 deliberately publishes no alias,
-catalog row, or model-size entry: there is no immutable public artifact for
-those surfaces to resolve yet. The measured peak means 128 GB is a tight
-operator tier; 192 GB remains the recommended tier for local evaluation
-headroom.
+Both an explicitly served local checkpoint and the
+`qwen3.8-flash-next-4bit` alias advertise the `experimental` capability. The
+alias resolves to the immutable release artifact and declares a 128 GB minimum
+memory floor; the exact 104,695,602,743-byte download footprint is part of the
+model-size manifest. The measured peak means 128 GB remains a tight operator
+tier, while 192 GB is recommended for evaluation headroom. M1 is CLI/API only;
+Desktop catalog exposure remains a later product milestone.
 
 ## Remaining milestones
 
@@ -93,6 +98,5 @@ headroom.
 - M2: MTP head extraction and batched-consistent lossless verification before
   choosing any speculative-token default.
 - M3: vision tower/processor integration and real-image correctness.
-- M4: publish only with an explicit release guard, then add the alias,
-  model-size row, >=128 GB catalog profile, Desktop, and mirror integration as
-  one immutable-artifact contract.
+- M4: Desktop catalog exposure and mirror integration for the already
+  immutable CLI/API artifact.

--- a/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
+++ b/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
@@ -1,8 +1,9 @@
 # Qwen3.8-Flash-Next text-lane M1
 
-Status: experimental text lane. The immutable release artifact is being
-published as `rapid-mlx/Qwen3.8-Flash-Next-4bit`; this PR must not land before
-that repository resolves. MTP and vision remain separate milestones.
+Status: experimental text lane. The immutable release artifact is published as
+`rapid-mlx/Qwen3.8-Flash-Next-4bit` at revision
+`dcf657e4acda2aae72da99cde65b6c491cd96998`. MTP and vision remain separate
+milestones.
 
 ## Architecture and conversion contract
 
@@ -23,11 +24,12 @@ The converted q4 artifact uses:
 `scripts/qwen38_streaming_convert.py` streams source shards, emits MLX sibling
 `weight` / `scales` / `biases` keys, preserves the fused MoE gate-up/down
 contract, and writes a complete index plus SHA-256 manifest. The verified
-release artifact contains 28 shards / 97.51 GiB (104,695,602,743 bytes). Strict
-loading reports zero missing and zero unexpected parameters. Its model card
-records source revision `f5d08274`, the Qwen Apache-2.0 license, this
-mixed-group quantization contract, and the generated `SHA256SUMS.txt` whole-tree
-manifest.
+release artifact contains 28 shards / 97.51 GiB. The immutable repository is
+104,695,605,424 bytes including metadata; all 34 entries in `SHA256SUMS.txt`
+(manifest hash prefix `826f00b2`) match the remote revision. Strict loading
+reports zero missing and zero unexpected parameters. Its model card records
+source revision `f5d08274`, the Qwen Apache-2.0 license, this mixed-group
+quantization contract, and the generated whole-tree manifest.
 
 ## Reference and numerical gate
 
@@ -86,7 +88,7 @@ for weather, stock price, meeting scheduling, and local-document search.
 Both an explicitly served local checkpoint and the
 `qwen3.8-flash-next-4bit` alias advertise the `experimental` capability. The
 alias resolves to the immutable release artifact and declares a 128 GB minimum
-memory floor; the exact 104,695,602,743-byte download footprint is part of the
+memory floor; the exact 104,695,605,424-byte repository footprint is part of the
 model-size manifest. The measured peak means 128 GB remains a tight operator
 tier, while 192 GB is recommended for evaluation headroom. M1 is CLI/API only;
 Desktop catalog exposure remains a later product milestone.

--- a/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
+++ b/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
@@ -74,10 +74,12 @@ swap. The four long prefills completed in 130.209, 130.739, 145.181, and 136.935
 seconds. Answers included the exact four recall facts and well-formed tool calls
 for weather, stock price, meeting scheduling, and local-document search.
 
-The experimental alias is explicitly resolvable but hidden from default model
-catalogs, advertises the `experimental` capability when served, and declares a
-128 GB minimum memory tier. The measured peak means 128 GB is a tight operator
-tier; 192 GB remains the recommended tier for evaluation headroom.
+An explicitly served local checkpoint advertises the `experimental` capability
+from its `qwen4_exp` architecture metadata. M1 deliberately publishes no alias,
+catalog row, or model-size entry: there is no immutable public artifact for
+those surfaces to resolve yet. The measured peak means 128 GB is a tight
+operator tier; 192 GB remains the recommended tier for local evaluation
+headroom.
 
 ## Remaining milestones
 
@@ -86,5 +88,6 @@ tier; 192 GB remains the recommended tier for evaluation headroom.
 - M2: MTP head extraction and batched-consistent lossless verification before
   choosing any speculative-token default.
 - M3: vision tower/processor integration and real-image correctness.
-- M4: publish only with an explicit release guard, then catalog/Desktop/mirror
-  integration. Until then the alias stays hidden and experimental.
+- M4: publish only with an explicit release guard, then add the alias,
+  model-size row, >=128 GB catalog profile, Desktop, and mirror integration as
+  one immutable-artifact contract.

--- a/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
+++ b/docs/engineering/performance/2026-08-26-qwen38-flash-next-m1.md
@@ -1,0 +1,90 @@
+# Qwen3.8-Flash-Next text-lane M1
+
+Status: experimental, local artifact only. The checkpoint has not been uploaded
+or published. MTP and vision are separate milestones.
+
+## Architecture and conversion contract
+
+The checkpoint declares `Qwen4ExpForConditionalGeneration` / `qwen4_exp`: 48
+hybrid decoder layers, 512 routed experts with 10 active, Qwen Sparse Attention,
+Gated DeltaNet, four-stream gated residuals, and PLE n-gram embeddings. Rapid's
+text lane ports the architecture from typed checkpoint metadata; it does not
+remap the model to an older family or infer behavior from a repository name.
+
+The converted q4 artifact uses:
+
+- q4 group 64 for eligible decoder matrices;
+- q4 group 32 for PLE shards, whose width 160 is not divisible by 64;
+- q8 group 64 for routing gates;
+- no quantization for one-dimensional state, norms, buffers, or widths that do
+  not satisfy the declared group contract.
+
+`scripts/qwen38_streaming_convert.py` streams source shards, emits MLX sibling
+`weight` / `scales` / `biases` keys, preserves the fused MoE gate-up/down
+contract, and writes a complete index plus SHA-256 manifest. The verified local
+artifact contains 28 shards / 98 GiB. Strict loading reports zero missing and
+zero unexpected parameters.
+
+## Reference and numerical gate
+
+The GDN and QSA forward math is adopted from the MIT-licensed implementation at
+commit `ecf1aa0a62958ea770bc25c35e173effe142aa3c`. Source comments pin the same
+commit at the adopted equations and Metal RoPE kernel. Rapid retains its own
+batched, prefix-persistent QSA cache lifecycle.
+
+On the same q4 weights, sequential processes produced:
+
+| Probe | max abs diff | mean abs diff |
+| --- | ---: | ---: |
+| GDN, uncached | 0 | 0 |
+| GDN, cached | 0 | 0 |
+| QSA | 0 | 0 |
+| PLE | 0 | 0 |
+| MoE | 0 | 0 |
+| all 48 captured layer outputs | 0 | 0 |
+| 248,320 final logits | 0 | 0 |
+
+The component tolerance is `1e-3`, approximately one BF16 quantization step at
+unit scale; greedy-token agreement is required in addition to the tolerance.
+The fixed short panel has 16/16 identical 32-token greedy sequences. Four
+bounded 4.9K recall cases cross the 2,048-token sparse budget and also match
+exactly, for 20/20 panel parity.
+
+The pinned reference materializes a `[B,L,topk,K]` boolean intermediate and
+requests 191,427,018,752 bytes on the original 19.3K recall prompts. That dense
+intermediate is intentionally not copied. Rapid computes the identical batched
+QSA scores and selected block sets, then materializes its bounded token mask.
+All 12 QSA selected masks on the 4,906-token probe match bit-for-bit.
+
+Run the opt-in artifact gate with sequential residency:
+
+```bash
+RAPID_MLX_QWEN4_EXP_ARTIFACT=/path/to/q4-checkpoint \
+RAPID_MLX_QWEN4_EXP_REFERENCE=/path/to/pinned-reference \
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+python -m pytest -q tests/test_qwen4_exp_artifact_parity.py
+```
+
+## Real-model evidence
+
+The original 20-case panel covers reasoning, code, Chinese, tool calls, and four
+19.3K-token recall prompts. A 256-token run completed in 703.61 seconds with
+maximum RSS 96,328,220,672 bytes, peak footprint 170,744,359,528 bytes, and zero
+swap. The four long prefills completed in 130.209, 130.739, 145.181, and 136.935
+seconds. Answers included the exact four recall facts and well-formed tool calls
+for weather, stock price, meeting scheduling, and local-document search.
+
+The experimental alias is explicitly resolvable but hidden from default model
+catalogs, advertises the `experimental` capability when served, and declares a
+128 GB minimum memory tier. The measured peak means 128 GB is a tight operator
+tier; 192 GB remains the recommended tier for evaluation headroom.
+
+## Remaining milestones
+
+- M1 PR gate: proportional engine/server tests, review convergence, and PR
+  validation.
+- M2: MTP head extraction and batched-consistent lossless verification before
+  choosing any speculative-token default.
+- M3: vision tower/processor integration and real-image correctness.
+- M4: publish only with an explicit release guard, then catalog/Desktop/mirror
+  integration. Until then the alias stays hidden and experimental.

--- a/scripts/README.qwen38-converter.md
+++ b/scripts/README.qwen38-converter.md
@@ -1,8 +1,8 @@
-# Qwen3.8-Flash-Next streaming q4-g32 converter (prototype v2)
+# Qwen3.8-Flash-Next mixed-q4 streaming converter
 
 **Lane:** script-only helper for Vector's `qwen4_exp` port. Never edits model
-math. This is a **prototype** to be reviewed and transplanted by Vector — it is
-verified on a SMALL SYNTHETIC shard set, **not** on the real checkpoint.
+math. It is verified against a scaled synthetic checkpoint and by a complete
+header-only classification of the pinned real checkpoint before payload reads.
 
 ## Why this shape
 
@@ -12,11 +12,10 @@ a ~51B-param PLE embedding table spread across **128 PLE shards**. Loading the
 PLE table into memory (or concatenating it) blows past any reasonable footprint
 guard. So this converter:
 
-1. processes the checkpoint **shard-by-shard** (one MoE expert matrix at a time,
-   exactly as `mlx_lm convert.py` streams with `lazy=True`), and
-2. **quantises** every quantisable weight (including PLE/embed tables) to affine
-   **q4-g32** while streaming each tensor via `mmap` byte-slice — it never
-   materialises the whole ~51B PLE table in RAM.
+1. processes one checkpoint tensor at a time, and
+2. uses the model's fine-grained quantization contract: PLE is q4-g32, routing
+   gates are q8-g64, and ordinary eligible matrices are q4-g64. It never
+   concatenates the ~51B PLE table.
 
 ## Files
 
@@ -47,7 +46,7 @@ source .venv/bin/activate   # mlx 0.32.2, safetensors, numpy
     --output /tmp/synth-out \
     --max-shard-bytes 2000000
 
-# 3. verify COPY preservation, q4-g32 quant round-trip, total_size, manifests
+# 3. verify COPY preservation, mixed-quant round-trip, total_size, manifests
 .venv/bin/python scripts/verify_synth_conversion.py /tmp/synth-src /tmp/synth-out
 
 # 4. prove the guards abort closed
@@ -63,7 +62,7 @@ Expected: all green, with the converter ledger reporting `peak_rss_bytes`
 --source           <snapshot dir>   must contain model.safetensors.index.json
 --output           <dir>            must NOT exist (aborts if it does)
 --max-shard-bytes  <int>            output shard cap (default 4 GiB)
---group-size       <int>            quant group size (default 32 = q4-g32)
+--inspect-only                       classify all headers; read no payloads
 ```
 
 Runbook-guard parameters (only via the Python API today): `min_free_bytes`
@@ -72,26 +71,23 @@ operator confirms ≥140 GiB free at the output root before starting.
 
 ## Output contract
 
-* **Quantised** weights (all 2-D, group-size-divisible tensors incl. the PLE /
-  embed tables) → affine **q4-g32** (`mx.quantize(bits=4, group_size=32,
-  mode='affine')`), each emitted with `.scales` / `.biases`, packed into
-  bounded output shards. PLE is quantised, never preserved BF16, and never
-  materialised as a whole table (per-tensor mmap streaming).
+* The 128 exact PLE shard embeddings (width 160) use affine q4-g32. The 98
+  decoder/MTP routing gates use affine q8-g64. Other eligible matrices use
+  affine q4-g64. No padding, slicing, or name-derived model heuristic exists.
+  Every quantized tensor emits its weight, `.scales`, and `.biases` keys.
 * **Copy** tensors (1-D norms/biases, `A_log`, aux/buffer dtypes, widths not
-  divisible by group_size) → carried through value-for-value with their source
+  divisible by the applicable group size) → carried through value-for-value with their source
   shape/dtype, so no quantisable-unfriendly tensor is dropped or mangled.
-* Non-weight metadata (config.json, generation_config.json, tokenizer files)
-  copied verbatim (root level) so the output tree is self-contained loader
-  input; these are never quantized.
-* `model.safetensors.index.json` → `total_size` = Σ over every source weight of
-  `numel × dtype_bytes` (the loader's semantic model size, not source
-  *.safetensors file sizes), and a `weight_map` covering every original weight
-  (2 extra keys per quantised tensor for scales/biases).
+* Non-weight metadata is copied at the root. `config.json` additionally records
+  the global q4-g64 format and exact per-module PLE/routing overrides consumed
+  by the loader.
+* `model.safetensors.index.json` maps every emitted weight/scales/biases key and
+  `total_size` is the sum of every emitted tensor's bytes.
 * Output shards use deterministic `model-{i:05d}-of-{N:05d}.safetensors` with
   the real total `N` (bounded by `--max-shard-bytes`).
 * `SHA256SUMS.txt` → byte-sorted `sha256  <relative path>` per output file.
 * Execution ledger on stdout: file count, output bytes, shard list, **peak RSS**,
-  group_size, quant/copy counts, `total_weight_bytes`, `status`.
+  mixed quant/copy counts, source/output weight bytes, and `status`.
 
 ## Fail-closed guarantees
 
@@ -100,24 +96,13 @@ operator confirms ≥140 GiB free at the output root before starting.
 | output dir exists | abort, no publish |
 | missing / empty `model.safetensors.index.json` | abort |
 | weight_map references a missing source shard | abort |
-| source shard escapes source root (symlink / `..`) | abort |
+| non-flat shard path or symlink outside the model cache root | abort |
 | source or output under `/Volumes/Extreme SSD` | abort |
 | free space at output root < 140 GiB | abort |
 | process peak RSS > 220 GiB | abort mid-run |
 
-## Known prototype limits (for Vector to finalise)
-
-* bf16 **copy** tensors (norms etc.) are widened to fp32 in the output because
-  numpy safetensors cannot carry bfloat16; a bf16-preserving copy needs mlx
-  `framework="mlx"` in the transplant (Vector's loader). Quantised PATH handles
-  bf16 correctly (widens via bit-manip → q4-g32).
-* The manifest `classify_tensor` conjoins explicit embed/PLE names with the
-  predicate; Vector may want to gate embed/PLE q4-g32 against the loader's
-  `nn.Embedding.as_linear` / quantised-embedding contract (rows must be
-  divisible by 32 — true for hidden=2560).
-* `--group-size` defaults to 32; swap to 64 for a q4-g64 variant is a one-line
-  change (shard sizes / packed dtype shift accordingly).
-* No `--upload-repo` (forbidden on the real run by the runbook).
+Copied BF16 tensors remain BF16. There is no upload option; publication is a
+separate, explicitly guarded operation after loader and evaluation evidence.
 
 ## Reference
 

--- a/scripts/README.qwen38-converter.md
+++ b/scripts/README.qwen38-converter.md
@@ -1,0 +1,128 @@
+# Qwen3.8-Flash-Next streaming q4-g32 converter (prototype v2)
+
+**Lane:** script-only helper for Vector's `qwen4_exp` port. Never edits model
+math. This is a **prototype** to be reviewed and transplanted by Vector — it is
+verified on a SMALL SYNTHETIC shard set, **not** on the real checkpoint.
+
+## Why this shape
+
+The real checkpoint (`Qwen/Qwen3.8-Flash-Next`, revision
+`f5d08274bafd880402bd16f5e3e6c514136ec06c`) has ~113–131 safetensors shards and
+a ~51B-param PLE embedding table spread across **128 PLE shards**. Loading the
+PLE table into memory (or concatenating it) blows past any reasonable footprint
+guard. So this converter:
+
+1. processes the checkpoint **shard-by-shard** (one MoE expert matrix at a time,
+   exactly as `mlx_lm convert.py` streams with `lazy=True`), and
+2. **quantises** every quantisable weight (including PLE/embed tables) to affine
+   **q4-g32** while streaming each tensor via `mmap` byte-slice — it never
+   materialises the whole ~51B PLE table in RAM.
+
+## Files
+
+| file | purpose |
+|---|---|
+| `scripts/qwen38_streaming_convert.py` | the converter |
+| `scripts/synthetic_qwen38_fixture.py` | generate a scaled-down synthetic shard set |
+| `scripts/verify_synth_conversion.py` | end-to-end round-trip + SHA-256 verifier |
+| `scripts/test_fail_closed_guards.py` | fail-closed guard tests |
+
+## Requirements
+
+Python 3.11+, `mlx`, `safetensors`, `numpy`. This worktree has a ready venv:
+
+```sh
+source .venv/bin/activate   # mlx 0.32.2, safetensors, numpy
+```
+
+## Run the synthetic verification
+
+```sh
+# 1. build a tiny stand-in checkpoint (same name/dtype/shape pattern, scaled down)
+.venv/bin/python scripts/synthetic_qwen38_fixture.py /tmp/synth-src
+
+# 2. convert it (fail-closed)
+.venv/bin/python scripts/qwen38_streaming_convert.py \
+    --source /tmp/synth-src \
+    --output /tmp/synth-out \
+    --max-shard-bytes 2000000
+
+# 3. verify COPY preservation, q4-g32 quant round-trip, total_size, manifests
+.venv/bin/python scripts/verify_synth_conversion.py /tmp/synth-src /tmp/synth-out
+
+# 4. prove the guards abort closed
+.venv/bin/python scripts/test_fail_closed_guards.py /tmp/synth-src
+```
+
+Expected: all green, with the converter ledger reporting `peak_rss_bytes`
+(phys_footprint). On the synthetic set peak RSS is a few hundred MB.
+
+## Converter CLI
+
+```
+--source           <snapshot dir>   must contain model.safetensors.index.json
+--output           <dir>            must NOT exist (aborts if it does)
+--max-shard-bytes  <int>            output shard cap (default 4 GiB)
+--group-size       <int>            quant group size (default 32 = q4-g32)
+```
+
+Runbook-guard parameters (only via the Python API today): `min_free_bytes`
+(default 140 GiB) and `max_rss_bytes` (default 220 GiB). On a real run the
+operator confirms ≥140 GiB free at the output root before starting.
+
+## Output contract
+
+* **Quantised** weights (all 2-D, group-size-divisible tensors incl. the PLE /
+  embed tables) → affine **q4-g32** (`mx.quantize(bits=4, group_size=32,
+  mode='affine')`), each emitted with `.scales` / `.biases`, packed into
+  bounded output shards. PLE is quantised, never preserved BF16, and never
+  materialised as a whole table (per-tensor mmap streaming).
+* **Copy** tensors (1-D norms/biases, `A_log`, aux/buffer dtypes, widths not
+  divisible by group_size) → carried through value-for-value with their source
+  shape/dtype, so no quantisable-unfriendly tensor is dropped or mangled.
+* Non-weight metadata (config.json, generation_config.json, tokenizer files)
+  copied verbatim (root level) so the output tree is self-contained loader
+  input; these are never quantized.
+* `model.safetensors.index.json` → `total_size` = Σ over every source weight of
+  `numel × dtype_bytes` (the loader's semantic model size, not source
+  *.safetensors file sizes), and a `weight_map` covering every original weight
+  (2 extra keys per quantised tensor for scales/biases).
+* Output shards use deterministic `model-{i:05d}-of-{N:05d}.safetensors` with
+  the real total `N` (bounded by `--max-shard-bytes`).
+* `SHA256SUMS.txt` → byte-sorted `sha256  <relative path>` per output file.
+* Execution ledger on stdout: file count, output bytes, shard list, **peak RSS**,
+  group_size, quant/copy counts, `total_weight_bytes`, `status`.
+
+## Fail-closed guarantees
+
+| guard | behavior on violation |
+|---|---|
+| output dir exists | abort, no publish |
+| missing / empty `model.safetensors.index.json` | abort |
+| weight_map references a missing source shard | abort |
+| source shard escapes source root (symlink / `..`) | abort |
+| source or output under `/Volumes/Extreme SSD` | abort |
+| free space at output root < 140 GiB | abort |
+| process peak RSS > 220 GiB | abort mid-run |
+
+## Known prototype limits (for Vector to finalise)
+
+* bf16 **copy** tensors (norms etc.) are widened to fp32 in the output because
+  numpy safetensors cannot carry bfloat16; a bf16-preserving copy needs mlx
+  `framework="mlx"` in the transplant (Vector's loader). Quantised PATH handles
+  bf16 correctly (widens via bit-manip → q4-g32).
+* The manifest `classify_tensor` conjoins explicit embed/PLE names with the
+  predicate; Vector may want to gate embed/PLE q4-g32 against the loader's
+  `nn.Embedding.as_linear` / quantised-embedding contract (rows must be
+  divisible by 32 — true for hidden=2560).
+* `--group-size` defaults to 32; swap to 64 for a q4-g64 variant is a one-line
+  change (shard sizes / packed dtype shift accordingly).
+* No `--upload-repo` (forbidden on the real run by the runbook).
+
+## Reference
+
+* `mlx_lm convert.py` (`load(..., lazy=True)` → `quantize_model` → `save`) — the
+  streaming MoE pattern this mirrors.
+* `/private/tmp/rapid-qwen38-ops/qwen38_conversion_runbook.md` — operator
+  runbook (source revision, output root, guards, command shape) this prototype
+  implements.

--- a/scripts/qwen38_streaming_convert.py
+++ b/scripts/qwen38_streaming_convert.py
@@ -34,6 +34,7 @@ import math
 import mmap
 import resource
 import shutil
+import struct
 import sys
 import time
 from pathlib import Path
@@ -50,9 +51,7 @@ _BUFFER_SUFFIXES = (".A_log",)
 _NON_QUANT_DTYPES = {"F64", "F8", "F4", "I8", "I16", "I32", "I64", "U8", "BOOL"}
 _FLOAT_DTYPES = {"BF16", "F16", "F32"}
 
-_PLE_PREFIX = (
-    "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_"
-)
+_PLE_PREFIX = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_"
 _PLE_SUFFIX = ".weight"
 _ROUTING_GATE_SUFFIXES = (".mlp.gate.weight", ".mlp.shared_expert_gate.weight")
 
@@ -109,7 +108,9 @@ def classify_tensor(name: str, shape: list[int], dtype: str) -> tuple[str, int, 
         return "quantize", 32, 4
     if name.endswith(_ROUTING_GATE_SUFFIXES):
         if shape[-1] % 64:
-            raise RuntimeError(f"invalid Qwen4-Exp routing-gate shape for {name}: {shape}")
+            raise RuntimeError(
+                f"invalid Qwen4-Exp routing-gate shape for {name}: {shape}"
+            )
         return "quantize", 64, 8
     if shape[-1] % 64:
         return "copy", 0, 0
@@ -183,6 +184,20 @@ def quantize_affine(
     return q, scales, biases
 
 
+def quantized_tensor_names(name: str) -> tuple[str, str, str]:
+    """Return the MLX parameter names for an affine-quantized tensor.
+
+    MLX stores ``scales`` and ``biases`` beside a module's ``weight``.  Most
+    checkpoint tensors therefore replace the terminal ``.weight`` component;
+    Qwen4-Exp's fused expert tensors omit that component and retain the
+    established append form until the model sanitizer splits them.
+    """
+    if name.endswith(".weight"):
+        module = name.removesuffix(".weight")
+        return name, f"{module}.scales", f"{module}.biases"
+    return name, f"{name}.scales", f"{name}.biases"
+
+
 def _sha256(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -229,7 +244,9 @@ def _module_path_for_override(source_weight: str) -> str:
     return key
 
 
-def _write_quantized_config(source: Path, output: Path, overrides: dict[str, dict]) -> None:
+def _write_quantized_config(
+    source: Path, output: Path, overrides: dict[str, dict]
+) -> None:
     config_path = source / "config.json"
     if not config_path.is_file():
         raise RuntimeError("source has no config.json")
@@ -415,11 +432,14 @@ def convert(
             n_copy += 1
         else:
             arr = _mlx_from_bytes(data, dtype, shape)
-            q, scales, biases = quantize_affine(
-                arr, group_size=group_size, bits=bits
-            )
+            q, scales, biases = quantize_affine(arr, group_size=group_size, bits=bits)
+            weight_name, scales_name, biases_name = quantized_tensor_names(name)
             writer.add(
-                {name: q, name + ".scales": scales, name + ".biases": biases},
+                {
+                    weight_name: q,
+                    scales_name: scales,
+                    biases_name: biases,
+                },
             )
             if (group_size, bits) != (64, 4):
                 quant_overrides[_module_path_for_override(name)] = {
@@ -471,6 +491,89 @@ def convert(
     }
 
 
+def _renamed_quantized_aux_key(name: str) -> str:
+    if name.endswith(".weight.scales"):
+        return name.removesuffix(".weight.scales") + ".scales"
+    if name.endswith(".weight.biases"):
+        return name.removesuffix(".weight.biases") + ".biases"
+    return name
+
+
+def repair_quantized_aux_names(output: Path) -> dict:
+    """Repair a converted tree without moving or rewriting tensor payloads.
+
+    Safetensors permits JSON whitespace at the end of its fixed-size header.
+    Renaming ``*.weight.{scales,biases}`` to sibling module parameters only
+    shortens the JSON, so the original header length and every data offset stay
+    unchanged.  The function fails closed on collisions or header growth.
+    """
+    output = output.expanduser().resolve()
+    index_path = output / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise RuntimeError(f"missing output index: {index_path}")
+
+    changed_keys = 0
+    changed_shards = 0
+    payload_checks: dict[str, tuple[str, str]] = {}
+    for shard in sorted(output.glob("model-*.safetensors")):
+        with shard.open("r+b") as handle:
+            raw_len = handle.read(8)
+            if len(raw_len) != 8:
+                raise RuntimeError(f"truncated safetensors prefix: {shard}")
+            header_len = struct.unpack("<Q", raw_len)[0]
+            raw_header = handle.read(header_len)
+            if len(raw_header) != header_len:
+                raise RuntimeError(f"truncated safetensors header: {shard}")
+            header = json.loads(raw_header)
+            renamed: dict[str, object] = {}
+            shard_changes = 0
+            for key, value in header.items():
+                new_key = (
+                    key if key == "__metadata__" else _renamed_quantized_aux_key(key)
+                )
+                if new_key in renamed:
+                    raise RuntimeError(
+                        f"quantized auxiliary rename collision in {shard}: {new_key}"
+                    )
+                renamed[new_key] = value
+                shard_changes += int(new_key != key)
+            if not shard_changes:
+                continue
+            encoded = json.dumps(
+                renamed, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+            if len(encoded) > header_len:
+                raise RuntimeError(
+                    f"repaired header grew in {shard}: {len(encoded)} > {header_len}"
+                )
+            handle.seek(8)
+            handle.write(encoded)
+            handle.write(b" " * (header_len - len(encoded)))
+            handle.flush()
+            changed_keys += shard_changes
+            changed_shards += 1
+            payload_checks[shard.name] = (str(header_len), str(shard.stat().st_size))
+
+    index = json.loads(index_path.read_text())
+    old_map: dict[str, str] = index.get("weight_map", {})
+    new_map: dict[str, str] = {}
+    for key, shard_name in old_map.items():
+        new_key = _renamed_quantized_aux_key(key)
+        if new_key in new_map:
+            raise RuntimeError(f"output index rename collision: {new_key}")
+        new_map[new_key] = shard_name
+    index["weight_map"] = dict(sorted(new_map.items()))
+    index_path.write_text(json.dumps(index, indent=2) + "\n")
+    _write_sha256sums(output)
+    return {
+        "status": "ok",
+        "output": str(output),
+        "changed_keys": changed_keys,
+        "changed_shards": changed_shards,
+        "unchanged_payload_layout": payload_checks,
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--source", required=True, type=Path)
@@ -481,10 +584,22 @@ def main() -> int:
         action="store_true",
         help="validate and classify all headers without creating output",
     )
+    ap.add_argument(
+        "--repair-quantized-aux-names",
+        action="store_true",
+        help="repair an existing output tree's MLX quantized parameter names",
+    )
     args = ap.parse_args()
     try:
         if args.inspect_only:
             print(json.dumps(inspect_manifest(args.source), indent=2))
+            return 0
+        if args.repair_quantized_aux_names:
+            if args.output is not None:
+                ap.error(
+                    "--repair-quantized-aux-names uses --source as the output tree"
+                )
+            print(json.dumps(repair_quantized_aux_names(args.source), indent=2))
             return 0
         if args.output is None:
             ap.error("--output is required unless --inspect-only is set")

--- a/scripts/qwen38_streaming_convert.py
+++ b/scripts/qwen38_streaming_convert.py
@@ -135,8 +135,18 @@ def _safe_source_shard(snapshot: Path, relative: Path) -> Path:
     if not candidate.is_file():
         raise RuntimeError(f"missing source shard: {relative}")
     resolved = candidate.resolve()
-    model_cache_root = snapshot.parent.parent.resolve()
-    if resolved != model_cache_root and not resolved.is_relative_to(model_cache_root):
+    snapshot_root = snapshot.resolve()
+    allowed_roots = [snapshot_root]
+    # Standard HF cache layout: <repo>/snapshots/<revision> contains symlinks
+    # into the same repo's sibling blobs directory. A plain local checkpoint
+    # has no such exception and is confined to its own source directory.
+    if snapshot.parent.name == "snapshots":
+        blobs = snapshot.parent.parent / "blobs"
+        if blobs.is_dir():
+            allowed_roots.append(blobs.resolve())
+    if not any(
+        resolved == root or resolved.is_relative_to(root) for root in allowed_roots
+    ):
         raise RuntimeError(f"source shard escapes model cache root: {relative}")
     return resolved
 
@@ -381,7 +391,7 @@ class _ShardWriter:
 # ---------------------------------------------------------------------------
 # Core converter
 # ---------------------------------------------------------------------------
-def convert(
+def _convert_into(
     source: Path,
     output: Path,
     *,
@@ -391,20 +401,8 @@ def convert(
 ) -> dict:
     source = source.resolve()
     output = output.expanduser().resolve()
-    if str(source).startswith(GUARD_EXPERT_SSD) or str(output).startswith(
-        GUARD_EXPERT_SSD
-    ):
-        raise RuntimeError("Extreme SSD is outside this task")
-    if output.exists():
-        raise RuntimeError(f"output already exists: {output}")
-    out_root = output.parent
-    if out_root.exists():
-        avail = shutil.disk_usage(out_root).free
-        if avail < min_free_bytes:
-            raise RuntimeError(
-                f"insufficient free space at {out_root}: {avail / 1024**3:.1f} "
-                f"GiB < {min_free_bytes / 1024**3:.0f} GiB"
-            )
+    if not output.is_dir() or any(output.iterdir()):
+        raise RuntimeError("internal conversion staging directory is not empty")
 
     index_path = source / "model.safetensors.index.json"
     if not index_path.is_file():
@@ -414,7 +412,6 @@ def convert(
     if not weight_map:
         raise RuntimeError("index has empty weight_map")
 
-    output.mkdir(parents=True)
     started = time.monotonic()
 
     shard_layouts: dict[str, tuple[int, dict]] = {}
@@ -509,6 +506,50 @@ def convert(
         "aux_copied": aux,
         "status": "ok",
     }
+
+
+def convert(
+    source: Path,
+    output: Path,
+    *,
+    max_shard_bytes: int,
+    min_free_bytes: int = 140 * 1024**3,
+    max_rss_bytes: int = int(220.0 * 1024**3),
+) -> dict:
+    """Convert into a private sibling tree, publishing only a complete result."""
+    source = source.expanduser().resolve()
+    output = output.expanduser().resolve()
+    if str(source).startswith(GUARD_EXPERT_SSD) or str(output).startswith(
+        GUARD_EXPERT_SSD
+    ):
+        raise RuntimeError("Extreme SSD is outside this task")
+    if output.exists():
+        raise RuntimeError(f"output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    available = shutil.disk_usage(output.parent).free
+    if available < min_free_bytes:
+        raise RuntimeError(
+            f"insufficient free space at {output.parent}: {available / 1024**3:.1f} "
+            f"GiB < {min_free_bytes / 1024**3:.0f} GiB"
+        )
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{output.name}.staging-", dir=output.parent)
+    )
+    try:
+        ledger = _convert_into(
+            source,
+            staging,
+            max_shard_bytes=max_shard_bytes,
+            min_free_bytes=min_free_bytes,
+            max_rss_bytes=max_rss_bytes,
+        )
+        os.replace(staging, output)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    ledger["output"] = str(output)
+    return ledger
 
 
 def _renamed_quantized_aux_key(name: str) -> str:

--- a/scripts/qwen38_streaming_convert.py
+++ b/scripts/qwen38_streaming_convert.py
@@ -32,10 +32,12 @@ import hashlib
 import json
 import math
 import mmap
+import os
 import resource
 import shutil
 import struct
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -206,12 +208,30 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Replace one metadata file only after its complete payload is durable."""
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as handle:
+        temporary = Path(handle.name)
+        try:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+    try:
+        os.replace(temporary, path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
 def _write_sha256sums(output: Path) -> None:
     lines = []
     for p in sorted(output.rglob("*")):
         if p.is_file() and p.name != "SHA256SUMS.txt":
             lines.append(f"{_sha256(p)}  {p.relative_to(output).as_posix()}\n")
-    (output / "SHA256SUMS.txt").write_text("".join(lines))
+    _atomic_write_bytes(output / "SHA256SUMS.txt", "".join(lines).encode())
 
 
 _AUX_COPY_NAMES = (
@@ -512,11 +532,12 @@ def repair_quantized_aux_names(output: Path) -> dict:
     if not index_path.is_file():
         raise RuntimeError(f"missing output index: {index_path}")
 
-    changed_keys = 0
-    changed_shards = 0
-    payload_checks: dict[str, tuple[str, str]] = {}
+    # Phase 1: build and validate the complete tree-wide plan without opening
+    # any model file for writing. In particular, an index collision may span
+    # two different shards and must be rejected before the first header moves.
+    plans: list[tuple[Path, int, bytes, bytes, int]] = []
     for shard in sorted(output.glob("model-*.safetensors")):
-        with shard.open("r+b") as handle:
+        with shard.open("rb") as handle:
             raw_len = handle.read(8)
             if len(raw_len) != 8:
                 raise RuntimeError(f"truncated safetensors prefix: {shard}")
@@ -546,16 +567,13 @@ def repair_quantized_aux_names(output: Path) -> dict:
                 raise RuntimeError(
                     f"repaired header grew in {shard}: {len(encoded)} > {header_len}"
                 )
-            handle.seek(8)
-            handle.write(encoded)
-            handle.write(b" " * (header_len - len(encoded)))
-            handle.flush()
-            changed_keys += shard_changes
-            changed_shards += 1
-            payload_checks[shard.name] = (str(header_len), str(shard.stat().st_size))
+            padded = encoded + b" " * (header_len - len(encoded))
+            plans.append((shard, header_len, raw_header, padded, shard_changes))
 
     index = json.loads(index_path.read_text())
     old_map: dict[str, str] = index.get("weight_map", {})
+    if not isinstance(old_map, dict):
+        raise RuntimeError("output index weight_map must be an object")
     new_map: dict[str, str] = {}
     for key, shard_name in old_map.items():
         new_key = _renamed_quantized_aux_key(key)
@@ -563,13 +581,64 @@ def repair_quantized_aux_names(output: Path) -> dict:
             raise RuntimeError(f"output index rename collision: {new_key}")
         new_map[new_key] = shard_name
     index["weight_map"] = dict(sorted(new_map.items()))
-    index_path.write_text(json.dumps(index, indent=2) + "\n")
-    _write_sha256sums(output)
+    encoded_index = (json.dumps(index, indent=2) + "\n").encode()
+
+    # Phase 2: commit the already-validated fixed-size headers, then metadata.
+    # A multi-file atomic rename would duplicate the 98 GiB payload, so retain
+    # the original headers/index/checksum and roll the transaction back if any
+    # write fails. Every header write preserves offsets and payload bytes.
+    old_index = index_path.read_bytes()
+    sums_path = output / "SHA256SUMS.txt"
+    old_sums = sums_path.read_bytes() if sums_path.is_file() else None
+    applied: list[tuple[Path, bytes]] = []
+    try:
+        for shard, header_len, original, repaired, _ in plans:
+            # Register rollback before the first mutable write so even a short
+            # or failed header write restores this shard.
+            applied.append((shard, original))
+            with shard.open("r+b") as handle:
+                handle.seek(8)
+                handle.write(repaired)
+                handle.flush()
+                os.fsync(handle.fileno())
+        _atomic_write_bytes(index_path, encoded_index)
+        _write_sha256sums(output)
+    except Exception as commit_error:
+        rollback_errors = []
+        for shard, original in reversed(applied):
+            try:
+                with shard.open("r+b") as handle:
+                    handle.seek(8)
+                    handle.write(original)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            except Exception as rollback_error:  # pragma: no cover - I/O failure
+                rollback_errors.append(f"{shard}: {rollback_error}")
+        try:
+            _atomic_write_bytes(index_path, old_index)
+            if old_sums is None:
+                sums_path.unlink(missing_ok=True)
+            else:
+                _atomic_write_bytes(sums_path, old_sums)
+        except Exception as rollback_error:  # pragma: no cover - I/O failure
+            rollback_errors.append(f"metadata: {rollback_error}")
+        if rollback_errors:  # pragma: no cover - double I/O failure
+            raise RuntimeError(
+                "quantized auxiliary repair failed and rollback was incomplete: "
+                + "; ".join(rollback_errors)
+            ) from commit_error
+        raise
+
+    changed_keys = sum(plan[4] for plan in plans)
+    payload_checks = {
+        shard.name: (str(header_len), str(shard.stat().st_size))
+        for shard, header_len, _, _, _ in plans
+    }
     return {
         "status": "ok",
         "output": str(output),
         "changed_keys": changed_keys,
-        "changed_shards": changed_shards,
+        "changed_shards": len(plans),
         "unchanged_payload_layout": payload_checks,
     }
 

--- a/scripts/qwen38_streaming_convert.py
+++ b/scripts/qwen38_streaming_convert.py
@@ -40,18 +40,21 @@ from pathlib import Path
 
 import mlx.core as mx
 import numpy as np
-from safetensors.numpy import save_file
 
 DEFAULT_MAX_SHARD_BYTES = 4 * 1024**3
 GUARD_EXPERT_SSD = "/Volumes/Extreme SSD"
 
-# Explicit embedding/PLE tensor names that are quantised (contract, not
-# substring heuristic).
-_EMBED_TENSOR_NAMES = ("model.embed_tokens.weight", "mm.embedding.weight")
 # Buffers / special params copied as-is (never quantised).
 _BUFFER_SUFFIXES = (".A_log",)
 # dtypes that are aux/buffer-like and copied as-is rather than quantised.
-_NON_QUANT_DTYPES = {"BF16", "F64", "F8", "F4", "I8", "I16", "I32", "I64", "U8", "BOOL"}
+_NON_QUANT_DTYPES = {"F64", "F8", "F4", "I8", "I16", "I32", "I64", "U8", "BOOL"}
+_FLOAT_DTYPES = {"BF16", "F16", "F32"}
+
+_PLE_PREFIX = (
+    "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_"
+)
+_PLE_SUFFIX = ".weight"
+_ROUTING_GATE_SUFFIXES = (".mlp.gate.weight", ".mlp.shared_expert_gate.weight")
 
 _NP_DTYPES = {
     "F16": np.float16,
@@ -67,11 +70,6 @@ _NP_DTYPES = {
 _DTYPE_BYTES = {"F8": 1, "F16": 2, "BF16": 2, "F32": 4, "F64": 8}
 
 
-def _bf16_to_f32(raw_uint16: np.ndarray) -> np.ndarray:
-    """Widen raw bfloat16 bit-patterns to float32 (numpy has no bfloat16)."""
-    return (raw_uint16.astype(np.uint32) << 16).view(np.float32)
-
-
 def peak_rss_bytes() -> int:
     rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     return rss if sys.platform == "darwin" else rss * 1024
@@ -84,8 +82,15 @@ def _dtype_bytes(dtype: str) -> int:
 # ---------------------------------------------------------------------------
 # Manifest classification (Vector's per-tensor quantise / copy predicate)
 # ---------------------------------------------------------------------------
-def classify_tensor(name: str, shape: list[int], dtype: str, group_size: int) -> str:
-    """Return ``"quantize"`` or ``"copy"`` for a source tensor.
+def _is_ple_shard(name: str) -> bool:
+    if not (name.startswith(_PLE_PREFIX) and name.endswith(_PLE_SUFFIX)):
+        return False
+    shard = name[len(_PLE_PREFIX) : -len(_PLE_SUFFIX)]
+    return shard.isdecimal() and 0 <= int(shard) < 128
+
+
+def classify_tensor(name: str, shape: list[int], dtype: str) -> tuple[str, int, int]:
+    """Return ``(action, group_size, bits)`` for one source tensor.
 
     Explicit contract first, then the manifest predicate:
       * 1-D weights (norms, biases) are copy/fp.
@@ -93,26 +98,44 @@ def classify_tensor(name: str, shape: list[int], dtype: str, group_size: int) ->
       * widths whose last dim is not divisible by ``group_size`` are copy/fp.
       * everything else (2-D + divisible, incl. embed/PLE tables) is quantised.
     """
-    if len(shape) <= 1:
-        return "copy"
-    if name.endswith(_BUFFER_SUFFIXES):
-        return "copy"
-    if dtype.upper() in _NON_QUANT_DTYPES:
-        return "copy"
-    if shape[-1] % group_size != 0:
-        return "copy"
-    return "quantize"
+    up = dtype.upper()
+    if len(shape) <= 1 or name.endswith(_BUFFER_SUFFIXES):
+        return "copy", 0, 0
+    if up in _NON_QUANT_DTYPES or up not in _FLOAT_DTYPES:
+        return "copy", 0, 0
+    if _is_ple_shard(name):
+        if shape[-1] != 160 or shape[-1] % 32:
+            raise RuntimeError(f"invalid Qwen4-Exp PLE shape for {name}: {shape}")
+        return "quantize", 32, 4
+    if name.endswith(_ROUTING_GATE_SUFFIXES):
+        if shape[-1] % 64:
+            raise RuntimeError(f"invalid Qwen4-Exp routing-gate shape for {name}: {shape}")
+        return "quantize", 64, 8
+    if shape[-1] % 64:
+        return "copy", 0, 0
+    return "quantize", 64, 4
 
 
 # ---------------------------------------------------------------------------
 # Streaming helpers
 # ---------------------------------------------------------------------------
-def _safe_abs(root: Path, p: Path) -> Path:
-    rootr = root.resolve()
-    candidate = (root / p).resolve()
-    if candidate != rootr and not candidate.is_relative_to(rootr):
-        raise RuntimeError(f"path escapes source root: {p}")
-    return candidate
+def _safe_source_shard(snapshot: Path, relative: Path) -> Path:
+    """Resolve a flat HF shard name, including standard snapshot symlinks.
+
+    HF snapshot files point into the repository cache's sibling ``blobs``
+    directory.  The index is allowed to name one basename only, and the
+    resolved target must remain inside that model-cache root.
+    """
+    if relative.is_absolute() or len(relative.parts) != 1:
+        raise RuntimeError(f"source index contains a non-flat shard path: {relative}")
+    candidate = snapshot / relative
+    if not candidate.is_file():
+        raise RuntimeError(f"missing source shard: {relative}")
+    resolved = candidate.resolve()
+    model_cache_root = snapshot.parent.parent.resolve()
+    if resolved != model_cache_root and not resolved.is_relative_to(model_cache_root):
+        raise RuntimeError(f"source shard escapes model cache root: {relative}")
+    return resolved
 
 
 def _read_shard_layout(shard: Path) -> tuple[int, dict]:
@@ -138,23 +161,26 @@ def _tensor_bytes(shard: Path, header_len: int, header: dict, name: str) -> byte
         return bytes(mem[begin:end])
 
 
-def _numpy_from_bytes(data: bytes, dtype: str, shape: list[int]) -> np.ndarray:
+def _mlx_from_bytes(data: bytes, dtype: str, shape: list[int]) -> mx.array:
     up = dtype.upper()
     if up == "BF16":
-        return _bf16_to_f32(np.frombuffer(data, dtype=np.uint16).reshape(shape))
+        return mx.array(np.frombuffer(data, dtype=np.uint16).reshape(shape)).view(
+            mx.bfloat16
+        )
     np_dtype = _NP_DTYPES.get(up)
     if np_dtype is None:
         raise RuntimeError(f"unsupported source dtype {dtype} for tensor")
-    return np.frombuffer(data, dtype=np_dtype).reshape(shape)
+    return mx.array(np.frombuffer(data, dtype=np_dtype).reshape(shape))
 
 
-def quantize_affine_q4_g32(
-    arr: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def quantize_affine(
+    arr: mx.array, *, group_size: int, bits: int
+) -> tuple[mx.array, mx.array, mx.array]:
     q, scales, biases = mx.quantize(
-        mx.array(arr.astype(np.float32)), group_size=32, bits=4, mode="affine"
+        arr, group_size=group_size, bits=bits, mode="affine"
     )
-    return np.asarray(q), np.asarray(scales), np.asarray(biases)
+    mx.eval(q, scales, biases)
+    return q, scales, biases
 
 
 def _sha256(path: Path) -> str:
@@ -187,10 +213,74 @@ def _copy_aux_metadata(source: Path, output: Path) -> list[str]:
     for name in _AUX_COPY_NAMES:
         src = source / name
         if src.is_file():
-            _safe_abs(source, Path(name))
+            _safe_source_shard(source, Path(name))
             shutil.copyfile(src, output / name)
             copied.append(name)
     return copied
+
+
+def _module_path_for_override(source_weight: str) -> str:
+    key = source_weight.removesuffix(".weight")
+    if key.startswith("model.language_model"):
+        key = key.replace("model.language_model", "language_model.model", 1)
+    if ".ngram_embedding.shard_" in key:
+        prefix, shard = key.split(".ngram_embedding.shard_", 1)
+        key = f"{prefix}.ngram_embedding.shards.{int(shard)}"
+    return key
+
+
+def _write_quantized_config(source: Path, output: Path, overrides: dict[str, dict]) -> None:
+    config_path = source / "config.json"
+    if not config_path.is_file():
+        raise RuntimeError("source has no config.json")
+    config = json.loads(config_path.read_text())
+    quantization = {"group_size": 64, "bits": 4, "mode": "affine"}
+    quantization.update(dict(sorted(overrides.items())))
+    config["quantization"] = quantization
+    config["quantization_config"] = quantization
+    (output / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+
+
+def inspect_manifest(source: Path) -> dict:
+    """Classify the real headers without reading tensor payloads."""
+    source = source.resolve()
+    index_path = source / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise RuntimeError("source has no model.safetensors.index.json")
+    weight_map: dict[str, str] = json.loads(index_path.read_text()).get(
+        "weight_map", {}
+    )
+    layouts: dict[str, tuple[int, dict]] = {}
+    counts = {"q4_g32_ple": 0, "q8_g64_gate": 0, "q4_g64": 0, "copy": 0}
+    source_bytes = 0
+    for name in sorted(weight_map):
+        shard = _safe_source_shard(source, Path(weight_map[name]))
+        if str(shard) not in layouts:
+            layouts[str(shard)] = _read_shard_layout(shard)
+        _, header = layouts[str(shard)]
+        info = header.get(name)
+        if info is None:
+            raise RuntimeError(f"weight {name!r} not in source shard {shard}")
+        shape, dtype = list(info["shape"]), info["dtype"]
+        source_bytes += math.prod(shape) * _dtype_bytes(dtype)
+        action, group_size, bits = classify_tensor(name, shape, dtype)
+        if action == "copy":
+            counts["copy"] += 1
+        elif (group_size, bits) == (32, 4):
+            counts["q4_g32_ple"] += 1
+        elif (group_size, bits) == (64, 8):
+            counts["q8_g64_gate"] += 1
+        elif (group_size, bits) == (64, 4):
+            counts["q4_g64"] += 1
+        else:
+            raise RuntimeError(f"unrecognized classification for {name}")
+    if sum(counts.values()) != len(weight_map):
+        raise RuntimeError("manifest classification is not one-to-one")
+    # 48 decoder layers carry two routing gates each; the checkpoint's one
+    # MTP layer carries the same pair and is retained for milestone M2.
+    if counts["q4_g32_ple"] != 128 or counts["q8_g64_gate"] != 98:
+        raise RuntimeError(f"checkpoint contract count mismatch: {counts}")
+    return {"weights": len(weight_map), "source_bytes": source_bytes, **counts}
 
 
 # ---------------------------------------------------------------------------
@@ -207,27 +297,29 @@ class _ShardWriter:
         self.files: list[Path] = []
         self.weight_map: dict[str, str] = {}
         # current buffer: list of (base_name, tensors_dict), + running bytes
-        self._buf: list[tuple[str, dict[str, np.ndarray]]] = []
+        self._buf: list[dict[str, mx.array]] = []
         self._buf_bytes = 0
+        self.total_output_bytes = 0
 
-    def add(self, base: str, tensors: dict[str, np.ndarray]) -> None:
+    def add(self, tensors: dict[str, mx.array]) -> None:
         nbytes = sum(t.nbytes for t in tensors.values())
         if self._buf and self._buf_bytes + nbytes > self.max_bytes:
             self._flush()
-        self._buf.append((base, tensors))
+        self._buf.append(tensors)
         self._buf_bytes += nbytes
+        self.total_output_bytes += nbytes
 
     def _flush(self) -> None:
         if not self._buf:
             return
         self.index += 1
         path = self.output / f"model-{self.index:05d}-of-00000.safetensors"
-        payload: dict[str, np.ndarray] = {}
-        for base, tensors in self._buf:
+        payload: dict[str, mx.array] = {}
+        for tensors in self._buf:
             for key, value in tensors.items():
                 payload[key] = value
-            self.weight_map[base] = path.name
-        save_file(payload, str(path))
+                self.weight_map[key] = path.name
+        mx.save_safetensors(str(path), payload, metadata={"format": "mlx"})
         self.files.append(path)
         self._buf = []
         self._buf_bytes = 0
@@ -257,7 +349,6 @@ def convert(
     output: Path,
     *,
     max_shard_bytes: int,
-    group_size: int = 32,
     min_free_bytes: int = 140 * 1024**3,
     max_rss_bytes: int = int(220.0 * 1024**3),
 ) -> dict:
@@ -291,13 +382,14 @@ def convert(
 
     shard_layouts: dict[str, tuple[int, dict]] = {}
     for n in weight_map:
-        sh = _safe_abs(source, Path(weight_map[n]))
+        sh = _safe_source_shard(source, Path(weight_map[n]))
         if str(sh) not in shard_layouts:
             shard_layouts[str(sh)] = _read_shard_layout(sh)
 
     writer = _ShardWriter(output, max_shard_bytes)
     total_weight_bytes = 0  # Σ numel*dtype_bytes over ALL source weights
     n_quant = n_copy = 0
+    quant_overrides: dict[str, dict] = {}
 
     for name in sorted(weight_map):
         if peak_rss_bytes() > max_rss_bytes:
@@ -305,7 +397,7 @@ def convert(
                 f"process footprint aborted: peak RSS {peak_rss_bytes() / 1024**3:.1f} "
                 f"GiB > guard {max_rss_bytes / 1024**3:.1f} GiB"
             )
-        src = _safe_abs(source, Path(weight_map[name]))
+        src = _safe_source_shard(source, Path(weight_map[name]))
         header_len, header = shard_layouts[str(src)]
         info = header.get(name)
         if info is None:
@@ -314,21 +406,35 @@ def convert(
         dtype = info["dtype"]
         total_weight_bytes += math.prod(shape) * _dtype_bytes(dtype)
 
-        action = classify_tensor(name, shape, dtype, group_size)
+        action, group_size, bits = classify_tensor(name, shape, dtype)
         data = _tensor_bytes(src, header_len, header, name)
         if action == "copy":
-            arr = _numpy_from_bytes(data, dtype, shape)
-            writer.add(name, {name: arr})
+            arr = _mlx_from_bytes(data, dtype, shape)
+            mx.eval(arr)
+            writer.add({name: arr})
             n_copy += 1
         else:
-            arr = _numpy_from_bytes(data, dtype, shape).astype(np.float32)
-            q, scales, biases = quantize_affine_q4_g32(arr)
+            arr = _mlx_from_bytes(data, dtype, shape)
+            q, scales, biases = quantize_affine(
+                arr, group_size=group_size, bits=bits
+            )
             writer.add(
-                name,
                 {name: q, name + ".scales": scales, name + ".biases": biases},
             )
+            if (group_size, bits) != (64, 4):
+                quant_overrides[_module_path_for_override(name)] = {
+                    "group_size": group_size,
+                    "bits": bits,
+                    "mode": "affine",
+                }
             n_quant += 1
         del data, arr
+        if peak_rss_bytes() > max_rss_bytes:
+            raise RuntimeError(
+                f"process footprint aborted after {name}: peak RSS "
+                f"{peak_rss_bytes() / 1024**3:.1f} GiB > guard "
+                f"{max_rss_bytes / 1024**3:.1f} GiB"
+            )
 
     quant_shards = writer.finalize()
 
@@ -336,13 +442,14 @@ def convert(
     # semantic "model size"), NOT source *.safetensors file sizes (which carry
     # per-shard headers and would over-count / drift across re-bundles).
     out_index = {
-        "metadata": {"total_size": total_weight_bytes},
+        "metadata": {"total_size": writer.total_output_bytes},
         "weight_map": dict(sorted(writer.weight_map.items())),
     }
     (output / "model.safetensors.index.json").write_text(
         json.dumps(out_index, indent=2)
     )
     aux = _copy_aux_metadata(source, output)
+    _write_quantized_config(source, output, quant_overrides)
     _write_sha256sums(output)
 
     files = sorted(p for p in output.rglob("*") if p.is_file())
@@ -354,10 +461,11 @@ def convert(
         "peak_rss_bytes": peak_rss_bytes(),
         "wall_s": round(time.monotonic() - started, 3),
         "shards": [p.name for p in files if p.name.startswith("model-")],
-        "group_size": group_size,
+        "default_group_size": 64,
         "n_quant": n_quant,
         "n_copy": n_copy,
         "total_weight_bytes": total_weight_bytes,
+        "total_output_weight_bytes": writer.total_output_bytes,
         "aux_copied": aux,
         "status": "ok",
     }
@@ -366,16 +474,24 @@ def convert(
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--source", required=True, type=Path)
-    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--output", type=Path)
     ap.add_argument("--max-shard-bytes", type=int, default=DEFAULT_MAX_SHARD_BYTES)
-    ap.add_argument("--group-size", type=int, default=32)
+    ap.add_argument(
+        "--inspect-only",
+        action="store_true",
+        help="validate and classify all headers without creating output",
+    )
     args = ap.parse_args()
     try:
+        if args.inspect_only:
+            print(json.dumps(inspect_manifest(args.source), indent=2))
+            return 0
+        if args.output is None:
+            ap.error("--output is required unless --inspect-only is set")
         ledger = convert(
             args.source,
             args.output,
             max_shard_bytes=args.max_shard_bytes,
-            group_size=args.group_size,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"CONVERT FAILED (fail-closed): {exc}", file=sys.stderr)

--- a/scripts/qwen38_streaming_convert.py
+++ b/scripts/qwen38_streaming_convert.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""FAIL-CLOSED streaming q4-g32 converter for Qwen3.8-Flash-Next (prototype v2).
+
+Script-only lane helper for Vector's qwen4_exp port. Never edits model math.
+Converts an HF safetensors snapshot to an MLX affine q4-g32 layout by
+streaming shard-by-shard, quantising every quantisable weight (including the
+~51B-param PLE embedding table) WITHOUT ever materialising the whole table in
+RAM — each source tensor is read via mmap byte-slice, quantised in-memory one
+tensor at a time, and written to bounded output shards.
+
+Revision against Vector's review of cee4ef00 ("NOT safe for real weights"):
+  1. PLE is QUANTISED q4-g32 (not preserved BF16). Still never materialised:
+     per-tensor streaming keeps peak RSS bounded regardless of the 51B table.
+  2. Explicit tensor-name contract (embed_tokens / mm.embedding / ple_embed.rows.*)
+     instead of substring matching.
+  3. Per-tensor quantisation predicate from the manifest classification: 1-D
+     norms, ``A_log``, buffers, and widths not divisible by group_size are
+     copied as-is (fp), never quantised.
+  4. Output index ``total_size`` = sum of original weight byte totals (the
+     loader's semantic model size, not source *.safetensors file sizes), and
+     output shards use deterministic ``model-{i:05d}-of-{N:05d}`` naming with
+     the real total ``N``.
+
+Verified on a SYNTHETIC scaled-down shard set (same name/dtype/shape pattern
+plus the flagged tensor classes), NOT on real weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import mmap
+import resource
+import shutil
+import sys
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+from safetensors.numpy import save_file
+
+DEFAULT_MAX_SHARD_BYTES = 4 * 1024**3
+GUARD_EXPERT_SSD = "/Volumes/Extreme SSD"
+
+# Explicit embedding/PLE tensor names that are quantised (contract, not
+# substring heuristic).
+_EMBED_TENSOR_NAMES = ("model.embed_tokens.weight", "mm.embedding.weight")
+# Buffers / special params copied as-is (never quantised).
+_BUFFER_SUFFIXES = (".A_log",)
+# dtypes that are aux/buffer-like and copied as-is rather than quantised.
+_NON_QUANT_DTYPES = {"BF16", "F64", "F8", "F4", "I8", "I16", "I32", "I64", "U8", "BOOL"}
+
+_NP_DTYPES = {
+    "F16": np.float16,
+    "F32": np.float32,
+    "F64": np.float64,
+    "I8": np.int8,
+    "I16": np.int16,
+    "I32": np.int32,
+    "I64": np.int64,
+    "U8": np.uint8,
+    "BOOL": np.bool_,
+}
+_DTYPE_BYTES = {"F8": 1, "F16": 2, "BF16": 2, "F32": 4, "F64": 8}
+
+
+def _bf16_to_f32(raw_uint16: np.ndarray) -> np.ndarray:
+    """Widen raw bfloat16 bit-patterns to float32 (numpy has no bfloat16)."""
+    return (raw_uint16.astype(np.uint32) << 16).view(np.float32)
+
+
+def peak_rss_bytes() -> int:
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss if sys.platform == "darwin" else rss * 1024
+
+
+def _dtype_bytes(dtype: str) -> int:
+    return _DTYPE_BYTES.get(dtype.upper(), 4)
+
+
+# ---------------------------------------------------------------------------
+# Manifest classification (Vector's per-tensor quantise / copy predicate)
+# ---------------------------------------------------------------------------
+def classify_tensor(name: str, shape: list[int], dtype: str, group_size: int) -> str:
+    """Return ``"quantize"`` or ``"copy"`` for a source tensor.
+
+    Explicit contract first, then the manifest predicate:
+      * 1-D weights (norms, biases) are copy/fp.
+      * ``A_log`` safegate params / buffers and non-fp aux dtypes are copy/fp.
+      * widths whose last dim is not divisible by ``group_size`` are copy/fp.
+      * everything else (2-D + divisible, incl. embed/PLE tables) is quantised.
+    """
+    if len(shape) <= 1:
+        return "copy"
+    if name.endswith(_BUFFER_SUFFIXES):
+        return "copy"
+    if dtype.upper() in _NON_QUANT_DTYPES:
+        return "copy"
+    if shape[-1] % group_size != 0:
+        return "copy"
+    return "quantize"
+
+
+# ---------------------------------------------------------------------------
+# Streaming helpers
+# ---------------------------------------------------------------------------
+def _safe_abs(root: Path, p: Path) -> Path:
+    rootr = root.resolve()
+    candidate = (root / p).resolve()
+    if candidate != rootr and not candidate.is_relative_to(rootr):
+        raise RuntimeError(f"path escapes source root: {p}")
+    return candidate
+
+
+def _read_shard_layout(shard: Path) -> tuple[int, dict]:
+    with (
+        open(shard, "rb") as handle,
+        mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mem,
+    ):
+        header_len = int(np.frombuffer(mem[:8], dtype=np.uint64)[0])
+        header = json.loads(mem[8 : 8 + header_len].decode("utf-8"))
+    return header_len, header
+
+
+def _tensor_bytes(shard: Path, header_len: int, header: dict, name: str) -> bytes:
+    info = header.get(name)
+    if info is None:
+        raise RuntimeError(f"weight {name!r} not in source shard {shard}")
+    begin = 8 + header_len + int(info["data_offsets"][0])
+    end = 8 + header_len + int(info["data_offsets"][1])
+    with (
+        open(shard, "rb") as handle,
+        mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mem,
+    ):
+        return bytes(mem[begin:end])
+
+
+def _numpy_from_bytes(data: bytes, dtype: str, shape: list[int]) -> np.ndarray:
+    up = dtype.upper()
+    if up == "BF16":
+        return _bf16_to_f32(np.frombuffer(data, dtype=np.uint16).reshape(shape))
+    np_dtype = _NP_DTYPES.get(up)
+    if np_dtype is None:
+        raise RuntimeError(f"unsupported source dtype {dtype} for tensor")
+    return np.frombuffer(data, dtype=np_dtype).reshape(shape)
+
+
+def quantize_affine_q4_g32(
+    arr: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    q, scales, biases = mx.quantize(
+        mx.array(arr.astype(np.float32)), group_size=32, bits=4, mode="affine"
+    )
+    return np.asarray(q), np.asarray(scales), np.asarray(biases)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _write_sha256sums(output: Path) -> None:
+    lines = []
+    for p in sorted(output.rglob("*")):
+        if p.is_file() and p.name != "SHA256SUMS.txt":
+            lines.append(f"{_sha256(p)}  {p.relative_to(output).as_posix()}\n")
+    (output / "SHA256SUMS.txt").write_text("".join(lines))
+
+
+_AUX_COPY_NAMES = (
+    "config.json",
+    "generation_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+)
+
+
+def _copy_aux_metadata(source: Path, output: Path) -> list[str]:
+    copied: list[str] = []
+    for name in _AUX_COPY_NAMES:
+        src = source / name
+        if src.is_file():
+            _safe_abs(source, Path(name))
+            shutil.copyfile(src, output / name)
+            copied.append(name)
+    return copied
+
+
+# ---------------------------------------------------------------------------
+# Bounded quantised-shard writer with deterministic naming + weight map
+# ---------------------------------------------------------------------------
+class _ShardWriter:
+    """Accumulates per-base-weight safetensors records into bounded shards and
+    records which shard each base weight lands in (incl. its .scales/.biases)."""
+
+    def __init__(self, output: Path, max_bytes: int):
+        self.output = output
+        self.max_bytes = max_bytes
+        self.index = 0
+        self.files: list[Path] = []
+        self.weight_map: dict[str, str] = {}
+        # current buffer: list of (base_name, tensors_dict), + running bytes
+        self._buf: list[tuple[str, dict[str, np.ndarray]]] = []
+        self._buf_bytes = 0
+
+    def add(self, base: str, tensors: dict[str, np.ndarray]) -> None:
+        nbytes = sum(t.nbytes for t in tensors.values())
+        if self._buf and self._buf_bytes + nbytes > self.max_bytes:
+            self._flush()
+        self._buf.append((base, tensors))
+        self._buf_bytes += nbytes
+
+    def _flush(self) -> None:
+        if not self._buf:
+            return
+        self.index += 1
+        path = self.output / f"model-{self.index:05d}-of-00000.safetensors"
+        payload: dict[str, np.ndarray] = {}
+        for base, tensors in self._buf:
+            for key, value in tensors.items():
+                payload[key] = value
+            self.weight_map[base] = path.name
+        save_file(payload, str(path))
+        self.files.append(path)
+        self._buf = []
+        self._buf_bytes = 0
+
+    def finalize(self) -> list[Path]:
+        self._flush()
+        total = len(self.files)
+        renamed: list[Path] = []
+        for idx, path in enumerate(self.files, start=1):
+            new = self.output / f"model-{idx:05d}-of-{total:05d}.safetensors"
+            if new != path:
+                path.replace(new)
+            renamed.append(new)
+            shard_name = new.name
+            for base, target in list(self.weight_map.items()):
+                if target == path.name:
+                    self.weight_map[base] = shard_name
+        self.files = renamed
+        return renamed
+
+
+# ---------------------------------------------------------------------------
+# Core converter
+# ---------------------------------------------------------------------------
+def convert(
+    source: Path,
+    output: Path,
+    *,
+    max_shard_bytes: int,
+    group_size: int = 32,
+    min_free_bytes: int = 140 * 1024**3,
+    max_rss_bytes: int = int(220.0 * 1024**3),
+) -> dict:
+    source = source.resolve()
+    output = output.expanduser().resolve()
+    if str(source).startswith(GUARD_EXPERT_SSD) or str(output).startswith(
+        GUARD_EXPERT_SSD
+    ):
+        raise RuntimeError("Extreme SSD is outside this task")
+    if output.exists():
+        raise RuntimeError(f"output already exists: {output}")
+    out_root = output.parent
+    if out_root.exists():
+        avail = shutil.disk_usage(out_root).free
+        if avail < min_free_bytes:
+            raise RuntimeError(
+                f"insufficient free space at {out_root}: {avail / 1024**3:.1f} "
+                f"GiB < {min_free_bytes / 1024**3:.0f} GiB"
+            )
+
+    index_path = source / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise RuntimeError("source has no model.safetensors.index.json")
+    index = json.loads(index_path.read_text())
+    weight_map: dict[str, str] = index.get("weight_map", {})
+    if not weight_map:
+        raise RuntimeError("index has empty weight_map")
+
+    output.mkdir(parents=True)
+    started = time.monotonic()
+
+    shard_layouts: dict[str, tuple[int, dict]] = {}
+    for n in weight_map:
+        sh = _safe_abs(source, Path(weight_map[n]))
+        if str(sh) not in shard_layouts:
+            shard_layouts[str(sh)] = _read_shard_layout(sh)
+
+    writer = _ShardWriter(output, max_shard_bytes)
+    total_weight_bytes = 0  # Σ numel*dtype_bytes over ALL source weights
+    n_quant = n_copy = 0
+
+    for name in sorted(weight_map):
+        if peak_rss_bytes() > max_rss_bytes:
+            raise RuntimeError(
+                f"process footprint aborted: peak RSS {peak_rss_bytes() / 1024**3:.1f} "
+                f"GiB > guard {max_rss_bytes / 1024**3:.1f} GiB"
+            )
+        src = _safe_abs(source, Path(weight_map[name]))
+        header_len, header = shard_layouts[str(src)]
+        info = header.get(name)
+        if info is None:
+            raise RuntimeError(f"weight {name!r} not in source shard {src}")
+        shape = list(info["shape"])
+        dtype = info["dtype"]
+        total_weight_bytes += math.prod(shape) * _dtype_bytes(dtype)
+
+        action = classify_tensor(name, shape, dtype, group_size)
+        data = _tensor_bytes(src, header_len, header, name)
+        if action == "copy":
+            arr = _numpy_from_bytes(data, dtype, shape)
+            writer.add(name, {name: arr})
+            n_copy += 1
+        else:
+            arr = _numpy_from_bytes(data, dtype, shape).astype(np.float32)
+            q, scales, biases = quantize_affine_q4_g32(arr)
+            writer.add(
+                name,
+                {name: q, name + ".scales": scales, name + ".biases": biases},
+            )
+            n_quant += 1
+        del data, arr
+
+    quant_shards = writer.finalize()
+
+    # Canonical output index. total_size = original model byte total (loader's
+    # semantic "model size"), NOT source *.safetensors file sizes (which carry
+    # per-shard headers and would over-count / drift across re-bundles).
+    out_index = {
+        "metadata": {"total_size": total_weight_bytes},
+        "weight_map": dict(sorted(writer.weight_map.items())),
+    }
+    (output / "model.safetensors.index.json").write_text(
+        json.dumps(out_index, indent=2)
+    )
+    aux = _copy_aux_metadata(source, output)
+    _write_sha256sums(output)
+
+    files = sorted(p for p in output.rglob("*") if p.is_file())
+    return {
+        "source": str(source),
+        "output": str(output),
+        "files": len(files),
+        "output_bytes": sum(p.stat().st_size for p in files),
+        "peak_rss_bytes": peak_rss_bytes(),
+        "wall_s": round(time.monotonic() - started, 3),
+        "shards": [p.name for p in files if p.name.startswith("model-")],
+        "group_size": group_size,
+        "n_quant": n_quant,
+        "n_copy": n_copy,
+        "total_weight_bytes": total_weight_bytes,
+        "aux_copied": aux,
+        "status": "ok",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--source", required=True, type=Path)
+    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--max-shard-bytes", type=int, default=DEFAULT_MAX_SHARD_BYTES)
+    ap.add_argument("--group-size", type=int, default=32)
+    args = ap.parse_args()
+    try:
+        ledger = convert(
+            args.source,
+            args.output,
+            max_shard_bytes=args.max_shard_bytes,
+            group_size=args.group_size,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"CONVERT FAILED (fail-closed): {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(ledger, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen4_exp_greedy_panel.py
+++ b/scripts/qwen4_exp_greedy_panel.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Run the fixed 20-case Qwen4-Exp panel for sequential greedy parity."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+from qwen4_exp_real_parity import _load
+
+ORDINARY_CASES = {
+    "R1": "A bat and ball cost $1.10 total. The bat costs $1.00 more than the ball. Give the ball's cost in cents and briefly justify it.",
+    "R2": "Three boxes are labeled Apples, Oranges, and Mixed, but every label is wrong. You may draw one fruit from one box. Which box do you draw from, and how do you relabel all three?",
+    "R3": "A train travels 120 km at 60 km/h and returns 120 km at 40 km/h. What is its average speed for the whole trip? Show the decisive calculation.",
+    "R4": "Find the smallest positive integer n such that n leaves remainder 1 when divided by 2, 3, 4, 5, and 6, and is divisible by 7. Give n and a short verification.",
+    "C1": "Write a Python function merge_intervals(items) that merges overlapping closed integer intervals. Return only one fenced Python block. Example: [(1,3),(2,6),(8,10)] -> [(1,6),(8,10)]. Do not mutate the input.",
+    "C2": "Write a Python function first_unique(s) returning the first Unicode character that occurs exactly once, or None. Return only one fenced Python block. It must handle the empty string.",
+    "C3": "Write a Python function topo_sort(nodes, edges) returning a deterministic topological order, choosing the lexicographically smallest available node; raise ValueError on a cycle. Return only one fenced Python block.",
+    "C4": "Write a Python function json_pointer_get(doc, pointer) implementing RFC 6901 lookup for objects and arrays, including ~0 and ~1 unescaping and the empty pointer. Return only one fenced Python block.",
+    "Z1": "用中文简要解释为什么蒙提霍尔问题中换门的胜率是三分之二。限四句话。",
+    "Z2": "把下面这句话翻译成自然、专业的中文，不要添加解释：The cache must preserve explicit operator overrides while choosing a safe automatic default.",
+    "Z3": "某商品先涨价20%，再降价20%。请用中文说明最终价格相对原价的变化，并给出百分比。",
+    "Z4": "请写一个恰好包含三项的编号清单，说明本地大模型服务启动失败时应先检查什么。每项不超过十五个汉字。",
+}
+
+TOOLS = {
+    "T1": (
+        "What is the weather in Tokyo in Celsius?",
+        "get_weather",
+        {"city": {"type": "string"}, "unit": {"type": "string"}},
+        ["city", "unit"],
+    ),
+    "T2": (
+        "Look up the current price for AAPL.",
+        "get_stock_price",
+        {"symbol": {"type": "string"}},
+        ["symbol"],
+    ),
+    "T3": (
+        "Schedule a 30 minute meeting called Release audit at 2026-09-02T10:30:00-07:00 with alice@example.com and bob@example.com.",
+        "schedule_meeting",
+        {
+            "title": {"type": "string"},
+            "start": {"type": "string"},
+            "duration_minutes": {"type": "integer"},
+            "participants": {"type": "array", "items": {"type": "string"}},
+        },
+        ["title", "start", "duration_minutes", "participants"],
+    ),
+    "T4": (
+        "Search the local docs for hybrid prefix cache admission and return the top 3 matches.",
+        "search_docs",
+        {"query": {"type": "string"}, "top_k": {"type": "integer"}},
+        ["query", "top_k"],
+    ),
+}
+
+
+def _recall_document(rows: int = 800) -> str:
+    facts = {
+        37: "Project Alder's launch code is HARBOR-7319.",
+        173: "The north warehouse closes every Tuesday at 18:40.",
+        401: "Sample R-88 must be stored at minus 17 degrees Celsius.",
+        733: "Dr. Lin's emergency extension is 6042.",
+    }
+    lines = []
+    for index in range(rows):
+        lines.append(
+            f"Record {index:04d}: inventory batch {10000 + index} was inspected "
+            "and archived under routine policy."
+        )
+        if index in facts:
+            lines.append(facts[index])
+    return "\n".join(lines)
+
+
+def _cases(recall_rows: int = 800):
+    for case_id, prompt in ORDINARY_CASES.items():
+        yield case_id, prompt, None
+    for case_id, (prompt, name, properties, required) in TOOLS.items():
+        tool = {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Invoke {name}.",
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                    "additionalProperties": False,
+                },
+            },
+        }
+        yield case_id, prompt, [tool]
+    document = _recall_document(recall_rows)
+    questions = {
+        "L1": "What is Project Alder's launch code? Return only the code.",
+        "L2": "When does the north warehouse close on Tuesdays? Return only the time.",
+        "L3": "At what temperature must sample R-88 be stored? Return only the temperature and unit.",
+        "L4": "What is Dr. Lin's emergency extension? Return only the digits.",
+    }
+    for case_id, question in questions.items():
+        yield case_id, f"Use only the document below.\n\n{document}\n\n{question}", None
+
+
+def _capture_wrapper(original, captured):
+    def capture(self, *call_args, **call_kwargs):
+        value = original(self, *call_args, **call_kwargs)
+        captured.append(value)
+        return value
+
+    return capture
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=("rapid", "upstream"), required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--tokens", type=int, default=32)
+    parser.add_argument("--max-cases", type=int, default=20)
+    parser.add_argument("--case-id")
+    parser.add_argument("--case-prefix")
+    parser.add_argument("--logits-output", type=Path)
+    parser.add_argument("--layers-output", type=Path)
+    parser.add_argument("--qsa-mask-output", type=Path)
+    parser.add_argument("--full-layers", action="store_true")
+    parser.add_argument("--disable-upstream-fused-rope", action="store_true")
+    parser.add_argument("--recall-rows", type=int, default=800)
+    args = parser.parse_args()
+
+    _holder, layers, language = _load(args.checkpoint.resolve(), args.backend)
+    if args.disable_upstream_fused_rope:
+        if args.backend != "upstream":
+            parser.error("--disable-upstream-fused-rope requires --backend upstream")
+        for layer in layers:
+            attention = getattr(layer, "self_attn", None)
+            rotary = getattr(attention, "rotary_emb", None)
+            if rotary is not None:
+                rotary.fused_apply = False
+    from mlx_lm.utils import load_tokenizer
+
+    tokenizer = load_tokenizer(args.checkpoint.resolve())
+    eos_ids = set(tokenizer.eos_token_ids)
+    results = {}
+    diagnostic_logits = {}
+    diagnostic_layers = {}
+    diagnostic_qsa_masks = {}
+    for case_index, (case_id, prompt, tools) in enumerate(_cases(args.recall_rows)):
+        if case_index >= args.max_cases:
+            break
+        if args.case_id is not None and case_id != args.case_id:
+            continue
+        if args.case_prefix is not None and not case_id.startswith(args.case_prefix):
+            continue
+        template_args = {
+            "tokenize": True,
+            "add_generation_prompt": True,
+            "enable_thinking": True,
+        }
+        if tools is not None:
+            template_args["tools"] = tools
+        input_ids = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}], **template_args
+        )
+        cache = language.make_cache()
+        started = time.monotonic()
+        captured_layers = []
+        captured_qsa_masks = []
+        layer_class = type(layers[0])
+        original_layer_call = layer_class.__call__
+        indexer_class = type(layers[3].self_attn.indexer)
+        original_indexer_call = indexer_class.__call__
+
+        def capture_indexer(
+            self,
+            *call_args,
+            _original=original_indexer_call,
+            _captured=captured_qsa_masks,
+            **call_kwargs,
+        ):
+            value = _original(self, *call_args, **call_kwargs)
+            if value is not None:
+                array = np.asarray(value)
+                _captured.append((array.shape, np.packbits(array, axis=-1)))
+            return value
+
+        if args.layers_output is not None:
+            layer_class.__call__ = _capture_wrapper(
+                original_layer_call, captured_layers
+            )
+        if args.qsa_mask_output is not None:
+            indexer_class.__call__ = capture_indexer
+        try:
+            output = language(mx.array([input_ids], dtype=mx.int32), cache=cache)
+        finally:
+            layer_class.__call__ = original_layer_call
+            indexer_class.__call__ = original_indexer_call
+        if captured_layers:
+            diagnostic_layers[case_id] = np.stack(
+                [
+                    np.asarray(
+                        (value if args.full_layers else value[:, -1, :]).astype(
+                            mx.float32
+                        )
+                    )[0]
+                    for value in captured_layers
+                ]
+            )
+        if captured_qsa_masks:
+            diagnostic_qsa_masks[case_id] = captured_qsa_masks
+        logits = output if args.backend == "rapid" else output.logits
+        generated = []
+        case_logits = []
+        for _ in range(args.tokens):
+            if args.logits_output is not None:
+                case_logits.append(np.asarray(logits[:, -1, :].astype(mx.float32))[0])
+            token = int(mx.argmax(logits[:, -1, :], axis=-1).item())
+            generated.append(token)
+            if token in eos_ids:
+                break
+            output = language(mx.array([[token]], dtype=mx.int32), cache=cache)
+            logits = output if args.backend == "rapid" else output.logits
+        elapsed = time.monotonic() - started
+        results[case_id] = {
+            "prompt_tokens": len(input_ids),
+            "generated_ids": generated,
+            "generated_text": tokenizer.decode(generated),
+            "wall_s": round(elapsed, 3),
+        }
+        if case_logits:
+            diagnostic_logits[case_id] = np.stack(case_logits)
+        print(
+            json.dumps(
+                {
+                    "case": case_id,
+                    "prompt_tokens": len(input_ids),
+                    "generated": len(generated),
+                    "wall_s": round(elapsed, 3),
+                }
+            ),
+            flush=True,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(
+                {
+                    "backend": args.backend,
+                    "tokens": args.tokens,
+                    "results": results,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n"
+        )
+        del cache, output, logits
+        gc.collect()
+        mx.clear_cache()
+
+    if args.logits_output is not None:
+        args.logits_output.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(args.logits_output, **diagnostic_logits)
+    if args.layers_output is not None:
+        args.layers_output.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(args.layers_output, **diagnostic_layers)
+    if args.qsa_mask_output is not None:
+        args.qsa_mask_output.parent.mkdir(parents=True, exist_ok=True)
+        arrays = {}
+        metadata = {}
+        for case_id, masks in diagnostic_qsa_masks.items():
+            metadata[case_id] = [shape for shape, _packed in masks]
+            for layer_index, (_shape, packed) in enumerate(masks):
+                arrays[f"{case_id}_{layer_index}"] = packed
+        arrays["metadata"] = np.array(json.dumps(metadata))
+        np.savez(args.qsa_mask_output, **arrays)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen4_exp_real_parity.py
+++ b/scripts/qwen4_exp_real_parity.py
@@ -81,6 +81,10 @@ def _load(checkpoint: Path, backend: str):
     return model, language.model.layers, language
 
 
+def _logits(result, backend: str) -> mx.array:
+    return result if backend == "rapid" else result.logits
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", choices=("rapid", "upstream"), required=True)
@@ -123,8 +127,37 @@ def main() -> int:
         result = language(token_ids, cache=full_cache)
     finally:
         layer_class.__call__ = original_layer_call
-    logits = result if args.backend == "rapid" else result.logits
+    logits = _logits(result, args.backend)
     layer_last = mx.stack([value[:, -1, :] for value in captured_layers])
+
+    # Cross the checkpoint-declared 2,048-token QSA admission budget by the
+    # smallest complete compressed block. This keeps the pinned reference's
+    # dense selector bounded while forcing both implementations through sparse
+    # block selection. The following one-token call then proves that the
+    # prefill-owned GDN/QSA/PLE caches remain numerically aligned at decode.
+    sparse_length = 2052
+    sparse_ids = (mx.arange(sparse_length, dtype=mx.int32) % 32000)[None, :]
+    sparse_hidden = _input((1, sparse_length, 2560), scale=0.02)
+    sparse_qsa_cache = language.make_cache()[3]
+    if args.backend == "rapid":
+        sparse_qsa = layers[3].self_attn(sparse_hidden, cache=sparse_qsa_cache)
+    else:
+        sparse_qsa = layers[3].self_attn(
+            sparse_hidden,
+            mask="causal",
+            cache=sparse_qsa_cache,
+            position_ids=None,
+        )
+    mx.eval(sparse_qsa)
+
+    sparse_full_cache = language.make_cache()
+    sparse_result = language(sparse_ids, cache=sparse_full_cache)
+    sparse_logits = _logits(sparse_result, args.backend)
+    sparse_last = sparse_logits[:, -1, :]
+    mx.eval(sparse_last)
+    next_token = mx.argmax(sparse_last, axis=-1).astype(mx.int32)[:, None]
+    decode_result = language(next_token, cache=sparse_full_cache)
+    decode_logits = _logits(decode_result, args.backend)[:, -1, :]
 
     probes = {
         "gdn": gdn,
@@ -134,6 +167,9 @@ def main() -> int:
         "moe": moe,
         "layer_last": layer_last,
         "logits_last": logits[:, -1, :],
+        "sparse_qsa_last": sparse_qsa[:, -1, :],
+        "sparse_logits_last": sparse_last,
+        "cached_decode_logits_last": decode_logits,
     }
     mx.eval(list(probes.values()))
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -149,7 +185,11 @@ def main() -> int:
                 "backend": args.backend,
                 "output": str(args.output),
                 "probes": {name: list(value.shape) for name, value in probes.items()},
-                "greedy_token": int(mx.argmax(logits[:, -1, :], axis=-1).item()),
+                "greedy_tokens": {
+                    "short": int(mx.argmax(logits[:, -1, :], axis=-1).item()),
+                    "sparse_prefill": int(mx.argmax(sparse_last, axis=-1).item()),
+                    "cached_decode": int(mx.argmax(decode_logits, axis=-1).item()),
+                },
             },
             indent=2,
         )

--- a/scripts/qwen4_exp_real_parity.py
+++ b/scripts/qwen4_exp_real_parity.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Emit fixed real-weight Qwen4-Exp probes for sequential parity comparison.
+
+The two backends are intentionally run in separate processes so the 98 GiB
+checkpoint is never resident twice.  ``--backend upstream`` expects the pinned
+mlx-vlm source tree to be first on ``PYTHONPATH``.  Its small sanitizer adapter
+only translates the converter's fused-expert quantized parameter layout; it
+does not alter model math.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+
+def _input(shape: tuple[int, ...], *, scale: float) -> mx.array:
+    values = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    return mx.array(np.sin(values * 0.013) * scale)
+
+
+def _patch_upstream_fused_quantized_sanitizer() -> None:
+    from mlx_vlm.models.qwen4_exp import Model
+
+    original = Model.sanitize
+
+    def sanitize(self, weights):
+        expanded = {}
+        for key, value in weights.items():
+            if ".mlp.experts.gate_up_proj" in key:
+                prefix, suffix = key.split("experts.gate_up_proj", 1)
+                leaf = {
+                    "": "weight",
+                    ".scales": "scales",
+                    ".biases": "biases",
+                }.get(suffix)
+                if leaf is not None:
+                    midpoint = value.shape[-2] // 2
+                    expanded[f"{prefix}switch_mlp.gate_proj.{leaf}"] = value[
+                        ..., :midpoint, :
+                    ]
+                    expanded[f"{prefix}switch_mlp.up_proj.{leaf}"] = value[
+                        ..., midpoint:, :
+                    ]
+                    continue
+            if ".mlp.experts.down_proj" in key:
+                prefix, suffix = key.split("experts.down_proj", 1)
+                leaf = {
+                    "": "weight",
+                    ".scales": "scales",
+                    ".biases": "biases",
+                }.get(suffix)
+                if leaf is not None:
+                    expanded[f"{prefix}switch_mlp.down_proj.{leaf}"] = value
+                    continue
+            expanded[key] = value
+        return original(self, expanded)
+
+    Model.sanitize = sanitize
+
+
+def _load(checkpoint: Path, backend: str):
+    if backend == "rapid":
+        from mlx_lm.utils import load_model
+
+        from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+        _register_vendored_archs()
+        model, _ = load_model(checkpoint, strict=True)
+        return model, model.model.layers, model
+
+    _patch_upstream_fused_quantized_sanitizer()
+    from mlx_vlm.utils import load_model
+
+    model = load_model(checkpoint, lazy=True, strict=True)
+    language = model.language_model
+    return model, language.model.layers, language
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=("rapid", "upstream"), required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    holder, layers, language = _load(args.checkpoint.resolve(), args.backend)
+    del holder
+    token_ids = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+    hidden = _input((1, 4, 2560), scale=0.02)
+    hyper = _input((1, 4, 4 * 2560), scale=0.02)
+
+    gdn = layers[0].linear_attn(hidden, mask=None, cache=None)
+    gdn_cached = layers[0].linear_attn(
+        hidden, mask=None, cache=language.make_cache()[0]
+    )
+    moe = layers[0].mlp(hidden)
+    ple = layers[1].ple(hyper, token_ids, None, None)
+    qsa_cache = language.make_cache()[3]
+    full_cache = language.make_cache()
+    if args.backend == "rapid":
+        qsa = layers[3].self_attn(hidden, cache=qsa_cache)
+    else:
+        qsa = layers[3].self_attn(
+            hidden, mask="causal", cache=qsa_cache, position_ids=None
+        )
+
+    captured_layers = []
+    layer_class = type(layers[0])
+    original_layer_call = layer_class.__call__
+
+    def capture_layer(self, *call_args, **call_kwargs):
+        output = original_layer_call(self, *call_args, **call_kwargs)
+        captured_layers.append(output)
+        return output
+
+    layer_class.__call__ = capture_layer
+    try:
+        result = language(token_ids, cache=full_cache)
+    finally:
+        layer_class.__call__ = original_layer_call
+    logits = result if args.backend == "rapid" else result.logits
+    layer_last = mx.stack([value[:, -1, :] for value in captured_layers])
+
+    probes = {
+        "gdn": gdn,
+        "gdn_cached": gdn_cached,
+        "qsa": qsa,
+        "ple": ple,
+        "moe": moe,
+        "layer_last": layer_last,
+        "logits_last": logits[:, -1, :],
+    }
+    mx.eval(list(probes.values()))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        args.output,
+        **{
+            name: np.asarray(value.astype(mx.float32)) for name, value in probes.items()
+        },
+    )
+    print(
+        json.dumps(
+            {
+                "backend": args.backend,
+                "output": str(args.output),
+                "probes": {name: list(value.shape) for name, value in probes.items()},
+                "greedy_token": int(mx.argmax(logits[:, -1, :], axis=-1).item()),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/synthetic_qwen38_fixture.py
+++ b/scripts/synthetic_qwen38_fixture.py
@@ -19,8 +19,8 @@ import json
 import sys
 from pathlib import Path
 
+import mlx.core as mx
 import numpy as np
-from safetensors.numpy import save_file
 
 
 def build(
@@ -33,7 +33,7 @@ def build(
 
     rng = np.random.default_rng(0)
     weight_map: dict[str, str] = {}
-    shards: list[dict[str, np.ndarray]] = []
+    shards: list[dict[str, np.ndarray | mx.array]] = []
     total = 5
 
     def put(tensors: dict[str, np.ndarray]):
@@ -48,7 +48,7 @@ def build(
     # Shard 1: MoE expert matrices (quantisable, 2-D divisible).
     moe = {}
     for e in range(num_experts):
-        pre = f"layers.0.mlp.experts.{e}"
+        pre = f"model.language_model.layers.0.mlp.experts.{e}"
         moe[f"{pre}.down_proj.weight"] = f32(inter, hidden)
         moe[f"{pre}.gate_proj.weight"] = f32(hidden, inter)
         moe[f"{pre}.up_proj.weight"] = f32(hidden, inter)
@@ -57,44 +57,57 @@ def build(
     # Shard 2: dense attention + a 1-D RMS norm (COPY), and an A_log buffer
     # (COPY — shape [heads]).
     dense = {}
-    dense["model.embed_tokens.weight"] = f32(64, hidden)  # PLE/embed -> quantize
-    dense["layers.0.self_attn.q_proj.weight"] = f32(hidden, hidden)
-    dense["layers.0.self_attn.o_proj.weight"] = f32(hidden, hidden)
-    dense["model.norm.weight"] = f32(hidden)  # 1-D -> copy
-    dense["layers.0.safegate.A_log"] = f32(2)  # buffer suffix -> copy
+    dense["model.language_model.embed_tokens.weight"] = f32(64, hidden)
+    dense["model.language_model.layers.0.self_attn.q_proj.weight"] = f32(
+        hidden, hidden
+    )
+    dense["model.language_model.layers.0.self_attn.o_proj.weight"] = f32(
+        hidden, hidden
+    )
+    dense["model.language_model.layers.0.mlp.gate.weight"] = f32(512, hidden)
+    dense["model.language_model.layers.0.mlp.shared_expert_gate.weight"] = f32(
+        1, hidden
+    )
+    dense["model.language_model.norm.weight"] = mx.array(f32(hidden)).astype(
+        mx.bfloat16
+    )
+    dense["model.language_model.layers.0.linear_attn.A_log"] = f32(2)
     put(dense)
 
-    # Shard 3: PLE embedding rows (quantisable 2-D) + mm.embedding (quantize),
-    # and a buffer flag (U8) that must be copied.
+    # Shard 3: exact PLE shard names and width 160 exercise q4-g32.
     ple = {}
     for i in range(2):
-        ple[f"ple_embed.rows.{i}.weight"] = f32(32, hidden).astype(
-            np.float16
-        )  # PLE rows fp16
-    ple["mm.embedding.weight"] = f32(16, hidden).astype(np.float16)
-    ple["layers.0.attention.rotary_emb.inv_freq"] = f32(
-        1, hidden // 2
-    )  # aux float copied (buffer-like, non-quant 1-D-ish)
+        name = (
+            "model.language_model.layers.1.ple.ple_embedding."
+            f"ngram_embedding.shard_{i}.weight"
+        )
+        ple[name] = f32(32, 160).astype(np.float16)
+    ple["model.language_model.layers.1.ple.ple_embedding.layer_multipliers"] = f32(
+        8
+    )
     put(ple)
 
     # Shard 4: a non-divisible-by-group-size 2-D tensor (COPY) and a true
     # 1-D bias (COPY), plus an int aux buffer.
     misc = {}
-    misc["layers.0.mlp.gate.bias"] = f32(inter)  # 1-D -> copy
+    misc["model.language_model.layers.0.mlp.gate.bias"] = f32(inter)
     misc["projector.non_divisible.weight"] = f32(5, 100)  # 100 % 32 != 0 -> copy
-    misc["model.rotary_emb.inv_freq"] = np.zeros(
+    misc["model.language_model.rotary_emb.inv_freq"] = np.zeros(
         hidden // 2, dtype=np.float32
     )  # 1-D copy
-    misc["layers.0.attention.num_buckets"] = np.array(
+    misc["model.language_model.layers.0.attention.num_buckets"] = np.array(
         [64], dtype=np.int32
     )  # int buffer copy
     put(misc)
 
     # Shard 5: dense logits head (2-D divisible, quantize).
-    put({"model.lm_head.weight": f32(64, hidden)})
+    put({"lm_head.weight": f32(64, hidden)})
 
     for tensors, slot in zip(shards, range(1, total + 1)):
-        save_file(tensors, str(out / f"model-{slot:05d}-of-{total:05d}.safetensors"))
+        mx.save_safetensors(
+            str(out / f"model-{slot:05d}-of-{total:05d}.safetensors"),
+            {name: mx.array(value) for name, value in tensors.items()},
+        )
 
     index = {
         "metadata": {"total_size": sum(t.nbytes for sh in shards for t in sh.values())},

--- a/scripts/synthetic_qwen38_fixture.py
+++ b/scripts/synthetic_qwen38_fixture.py
@@ -58,12 +58,8 @@ def build(
     # (COPY — shape [heads]).
     dense = {}
     dense["model.language_model.embed_tokens.weight"] = f32(64, hidden)
-    dense["model.language_model.layers.0.self_attn.q_proj.weight"] = f32(
-        hidden, hidden
-    )
-    dense["model.language_model.layers.0.self_attn.o_proj.weight"] = f32(
-        hidden, hidden
-    )
+    dense["model.language_model.layers.0.self_attn.q_proj.weight"] = f32(hidden, hidden)
+    dense["model.language_model.layers.0.self_attn.o_proj.weight"] = f32(hidden, hidden)
     dense["model.language_model.layers.0.mlp.gate.weight"] = f32(512, hidden)
     dense["model.language_model.layers.0.mlp.shared_expert_gate.weight"] = f32(
         1, hidden
@@ -82,9 +78,7 @@ def build(
             f"ngram_embedding.shard_{i}.weight"
         )
         ple[name] = f32(32, 160).astype(np.float16)
-    ple["model.language_model.layers.1.ple.ple_embedding.layer_multipliers"] = f32(
-        8
-    )
+    ple["model.language_model.layers.1.ple.ple_embedding.layer_multipliers"] = f32(8)
     put(ple)
 
     # Shard 4: a non-divisible-by-group-size 2-D tensor (COPY) and a true

--- a/scripts/synthetic_qwen38_fixture.py
+++ b/scripts/synthetic_qwen38_fixture.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Generate a SMALL SYNTHETIC Qwen3.8-Flash-Next-style shard set.
+
+Same tensor-name/dtype/shape *pattern* as the real checkpoint, scaled down so
+the converter can be verified end-to-end in seconds without any real weights.
+
+Covers every tensor class the converter's manifest classification must handle
+(per Vector's review): quantisable matrices, PLE/embed tables, plus the
+COPY-as-fp classes — 1-D norms, ``A_log`` safegate params, buffer/aux dims,
+non-group-size-divisible widths.
+
+Produces ``<out>/{model-0000X-of-0000N.safetensors, model.safetensors.index.json,
+config.json}``. Never run against real weights.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from safetensors.numpy import save_file
+
+
+def build(
+    out: Path, hidden: int = 2560, inter: int = 640, num_experts: int = 8
+) -> None:
+    out = out.resolve()
+    if out.exists() and any(out.iterdir()):
+        sys.exit(f"refusing non-empty fixture dir: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(0)
+    weight_map: dict[str, str] = {}
+    shards: list[dict[str, np.ndarray]] = []
+    total = 5
+
+    def put(tensors: dict[str, np.ndarray]):
+        shard_name = f"model-{len(shards) + 1:05d}-of-{total:05d}.safetensors"
+        for k in tensors:
+            weight_map[k] = shard_name
+        shards.append(tensors)
+
+    def f32(*shape):
+        return rng.standard_normal(shape).astype(np.float32)
+
+    # Shard 1: MoE expert matrices (quantisable, 2-D divisible).
+    moe = {}
+    for e in range(num_experts):
+        pre = f"layers.0.mlp.experts.{e}"
+        moe[f"{pre}.down_proj.weight"] = f32(inter, hidden)
+        moe[f"{pre}.gate_proj.weight"] = f32(hidden, inter)
+        moe[f"{pre}.up_proj.weight"] = f32(hidden, inter)
+    put(moe)
+
+    # Shard 2: dense attention + a 1-D RMS norm (COPY), and an A_log buffer
+    # (COPY — shape [heads]).
+    dense = {}
+    dense["model.embed_tokens.weight"] = f32(64, hidden)  # PLE/embed -> quantize
+    dense["layers.0.self_attn.q_proj.weight"] = f32(hidden, hidden)
+    dense["layers.0.self_attn.o_proj.weight"] = f32(hidden, hidden)
+    dense["model.norm.weight"] = f32(hidden)  # 1-D -> copy
+    dense["layers.0.safegate.A_log"] = f32(2)  # buffer suffix -> copy
+    put(dense)
+
+    # Shard 3: PLE embedding rows (quantisable 2-D) + mm.embedding (quantize),
+    # and a buffer flag (U8) that must be copied.
+    ple = {}
+    for i in range(2):
+        ple[f"ple_embed.rows.{i}.weight"] = f32(32, hidden).astype(
+            np.float16
+        )  # PLE rows fp16
+    ple["mm.embedding.weight"] = f32(16, hidden).astype(np.float16)
+    ple["layers.0.attention.rotary_emb.inv_freq"] = f32(
+        1, hidden // 2
+    )  # aux float copied (buffer-like, non-quant 1-D-ish)
+    put(ple)
+
+    # Shard 4: a non-divisible-by-group-size 2-D tensor (COPY) and a true
+    # 1-D bias (COPY), plus an int aux buffer.
+    misc = {}
+    misc["layers.0.mlp.gate.bias"] = f32(inter)  # 1-D -> copy
+    misc["projector.non_divisible.weight"] = f32(5, 100)  # 100 % 32 != 0 -> copy
+    misc["model.rotary_emb.inv_freq"] = np.zeros(
+        hidden // 2, dtype=np.float32
+    )  # 1-D copy
+    misc["layers.0.attention.num_buckets"] = np.array(
+        [64], dtype=np.int32
+    )  # int buffer copy
+    put(misc)
+
+    # Shard 5: dense logits head (2-D divisible, quantize).
+    put({"model.lm_head.weight": f32(64, hidden)})
+
+    for tensors, slot in zip(shards, range(1, total + 1)):
+        save_file(tensors, str(out / f"model-{slot:05d}-of-{total:05d}.safetensors"))
+
+    index = {
+        "metadata": {"total_size": sum(t.nbytes for sh in shards for t in sh.values())},
+        "weight_map": weight_map,
+    }
+    (out / "model.safetensors.index.json").write_text(json.dumps(index, indent=2))
+    (out / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen4_exp",
+                "hidden_size": hidden,
+                "num_experts": num_experts,
+                "num_experts_per_tok": 10,
+                "moe_intermediate_size": inter,
+                "ple_embed_dim": hidden,
+            },
+            indent=2,
+        )
+    )
+    print(f"fixture written to {out}: {total} shards, {len(weight_map)} weights")
+
+
+if __name__ == "__main__":
+    out = Path(sys.argv[1] if len(sys.argv) > 1 else "synthetic-kit")
+    build(out)

--- a/scripts/test_fail_closed_guards.py
+++ b/scripts/test_fail_closed_guards.py
@@ -22,12 +22,15 @@ from qwen38_streaming_convert import GUARD_EXPERT_SSD, convert  # noqa: E402
 FIXTURES = Path("/tmp/synth-guard-fixtures")
 
 
-def _fails(label: str, fn) -> tuple[bool, str]:
+def _fails(label: str, expected: str, fn) -> tuple[bool, str]:
     try:
         fn()
         return False, "NO EXCEPTION"
+    except RuntimeError as exc:
+        message = str(exc)
+        return expected in message, message
     except Exception as exc:  # noqa: BLE001
-        return True, str(exc)
+        return False, f"unexpected {type(exc).__name__}: {exc}"
 
 
 def _empty_out(tag: str) -> Path:
@@ -36,7 +39,7 @@ def _empty_out(tag: str) -> Path:
         shutil.rmtree(root)
     out = root / "out"
     out.mkdir(parents=True)
-    return root
+    return out
 
 
 def _conv_bad_index(src: Path, out: Path, mutate) -> None:
@@ -46,7 +49,7 @@ def _conv_bad_index(src: Path, out: Path, mutate) -> None:
         shutil.rmtree(FIXTURES / "bad-index")
     shutil.copytree(src, copy)
     mutate(copy)
-    convert(copy, out, max_shard_bytes=2_000_000)
+    convert(copy, out, max_shard_bytes=2_000_000, min_free_bytes=0)
 
 
 def main(src: Path) -> int:
@@ -59,7 +62,9 @@ def main(src: Path) -> int:
     out1 = _empty_out("existing-out")
     (out1 / "sentinel").write_text("x")
     ok, msg = _fails(
-        "existing-out", lambda: convert(src, out1 / "out", max_shard_bytes=2_000_000)
+        "existing-out",
+        "output already exists",
+        lambda: convert(src, out1, max_shard_bytes=2_000_000, min_free_bytes=0),
     )
     cases.append(("existing-output-dir", ok, msg))
 
@@ -68,7 +73,9 @@ def main(src: Path) -> int:
         (copy / "model.safetensors.index.json").unlink()
 
     ok, msg = _fails(
-        "missing-index", lambda: _conv_bad_index(src, out1 / "x", _no_index)
+        "missing-index",
+        "source has no model.safetensors.index.json",
+        lambda: _conv_bad_index(src, out1.parent / "x", _no_index),
     )
     cases.append(("missing-index", ok, msg))
 
@@ -80,13 +87,16 @@ def main(src: Path) -> int:
         (copy / "model.safetensors.index.json").write_text(json.dumps(idx))
 
     ok, msg = _fails(
-        "missing-shard", lambda: _conv_bad_index(src, out1 / "y", _missing_shard)
+        "missing-shard",
+        "missing source shard",
+        lambda: _conv_bad_index(src, out1.parent / "y", _missing_shard),
     )
     cases.append(("missing-source-shard", ok, msg))
 
     # 4 Extreme SSD
     ok, msg = _fails(
         "extreme-ssd",
+        "Extreme SSD is outside this task",
         lambda: convert(
             Path(GUARD_EXPERT_SSD + "/src"),
             Path("/tmp/x/out"),
@@ -98,8 +108,12 @@ def main(src: Path) -> int:
     # 5 free-space floor (absurd floor must reject)
     ok, msg = _fails(
         "free-space-floor",
+        "insufficient free space",
         lambda: convert(
-            src, out1 / "z", max_shard_bytes=2_000_000, min_free_bytes=10**30
+            src,
+            out1.parent / "z",
+            max_shard_bytes=2_000_000,
+            min_free_bytes=10**30,
         ),
     )
     cases.append(("free-space-floor", ok, msg))

--- a/scripts/test_fail_closed_guards.py
+++ b/scripts/test_fail_closed_guards.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Exercise the converter's FAIL-CLOSED guards on the synthetic fixture.
+
+Each case must raise with a clear message and must NOT publish output.
+  * existing output dir            -> reject
+  * missing index.json             -> reject
+  * missing source shard (bad map) -> reject
+  * Extreme SSD path               -> reject
+  * below free-space floor         -> reject
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from qwen38_streaming_convert import GUARD_EXPERT_SSD, convert  # noqa: E402
+
+FIXTURES = Path("/tmp/synth-guard-fixtures")
+
+
+def _fails(label: str, fn) -> tuple[bool, str]:
+    try:
+        fn()
+        return False, "NO EXCEPTION"
+    except Exception as exc:  # noqa: BLE001
+        return True, str(exc)
+
+
+def _empty_out(tag: str) -> Path:
+    root = FIXTURES / tag
+    if root.exists():
+        shutil.rmtree(root)
+    out = root / "out"
+    out.mkdir(parents=True)
+    return root
+
+
+def _conv_bad_index(src: Path, out: Path, mutate) -> None:
+    """Run convert on a throwaway copy of src with a mutated / missing index."""
+    copy = FIXTURES / "bad-index" / "src"
+    if copy.exists():
+        shutil.rmtree(FIXTURES / "bad-index")
+    shutil.copytree(src, copy)
+    mutate(copy)
+    convert(copy, out, max_shard_bytes=2_000_000)
+
+
+def main(src: Path) -> int:
+    src = src.resolve()
+    if FIXTURES.exists():
+        shutil.rmtree(FIXTURES)
+    cases: list[tuple[str, bool, str]] = []
+
+    # 1 existing output dir
+    out1 = _empty_out("existing-out")
+    (out1 / "sentinel").write_text("x")
+    ok, msg = _fails(
+        "existing-out", lambda: convert(src, out1 / "out", max_shard_bytes=2_000_000)
+    )
+    cases.append(("existing-output-dir", ok, msg))
+
+    # 2 missing index
+    def _no_index(copy: Path):
+        (copy / "model.safetensors.index.json").unlink()
+
+    ok, msg = _fails(
+        "missing-index", lambda: _conv_bad_index(src, out1 / "x", _no_index)
+    )
+    cases.append(("missing-index", ok, msg))
+
+    # 3 missing source shard
+    def _missing_shard(copy: Path):
+        idx = json.loads((copy / "model.safetensors.index.json").read_text())
+        first = next(iter(idx["weight_map"]))
+        idx["weight_map"][first] = "does-not-exist.safetensors"
+        (copy / "model.safetensors.index.json").write_text(json.dumps(idx))
+
+    ok, msg = _fails(
+        "missing-shard", lambda: _conv_bad_index(src, out1 / "y", _missing_shard)
+    )
+    cases.append(("missing-source-shard", ok, msg))
+
+    # 4 Extreme SSD
+    ok, msg = _fails(
+        "extreme-ssd",
+        lambda: convert(
+            Path(GUARD_EXPERT_SSD + "/src"),
+            Path("/tmp/x/out"),
+            max_shard_bytes=2_000_000,
+        ),
+    )
+    cases.append(("extreme-ssd", ok, msg))
+
+    # 5 free-space floor (absurd floor must reject)
+    ok, msg = _fails(
+        "free-space-floor",
+        lambda: convert(
+            src, out1 / "z", max_shard_bytes=2_000_000, min_free_bytes=10**30
+        ),
+    )
+    cases.append(("free-space-floor", ok, msg))
+
+    for label, ok, msg in cases:
+        print(f"  [{'ok' if ok else 'FAIL'}] {label}" + ("" if ok else f": {msg}"))
+    bad = [c for c in cases if not c[1]]
+    if bad:
+        print("\nFAILED GUARDS:", ", ".join(c[0] for c in bad))
+        return 1
+    print("\nALL FAIL-CLOSED GUARDS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(Path(sys.argv[1])))

--- a/scripts/verify_synth_conversion.py
+++ b/scripts/verify_synth_conversion.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import mlx.core as mx
 import numpy as np
-from qwen38_streaming_convert import classify_tensor
+from qwen38_streaming_convert import classify_tensor, quantized_tensor_names
 from safetensors import safe_open as st_safe_open
 
 
@@ -103,7 +103,7 @@ def verify(src: Path, out: Path) -> int:
     for name, (shape, dtype) in src_meta.items():
         action, _, _ = classify_tensor(name, shape, dtype)
         if action == "quantize":
-            expected_output_keys.update({name + ".scales", name + ".biases"})
+            expected_output_keys.update(quantized_tensor_names(name)[1:])
     if set(out_wm) != expected_output_keys:
         failures.append("output index does not map exactly every emitted tensor")
     expected_total = 0
@@ -148,10 +148,11 @@ def verify(src: Path, out: Path) -> int:
         _, group_size, bits = classify_tensor(
             name, src_meta[name][0], src_meta[name][1]
         )
+        _, scales_name, biases_name = quantized_tensor_names(name)
         rec = _dequantize(
             shard[name],
-            shard[name + ".scales"],
-            shard[name + ".biases"],
+            shard[scales_name],
+            shard[biases_name],
             group_size=group_size,
             bits=bits,
         ).astype(np.float32)

--- a/scripts/verify_synth_conversion.py
+++ b/scripts/verify_synth_conversion.py
@@ -23,20 +23,30 @@ from pathlib import Path
 
 import mlx.core as mx
 import numpy as np
+from qwen38_streaming_convert import classify_tensor
 from safetensors import safe_open as st_safe_open
 
-# dtypes / names the classifier treats as COPY.
-_QUANT_DTYPES = {"F16", "F32", "BF16"}
+
+def _load(shard: Path) -> dict[str, mx.array]:
+    return mx.load(str(shard))
 
 
-def _load(shard: Path) -> dict[str, np.ndarray]:
-    out = {}
-    with st_safe_open(str(shard), framework="numpy") as sf:
-        # NOTE: `sf` is a safetensors handle, not a dict — `.keys()` is the
-        # only iterable; SIM118 does not apply.
-        for k in sf.keys():  # noqa: SIM118
-            out[k] = sf.get_tensor(k)
-    return out
+def _dtype_bytes(dtype: str) -> int:
+    return {
+        "BOOL": 1,
+        "U8": 1,
+        "I8": 1,
+        "F8": 1,
+        "I16": 2,
+        "F16": 2,
+        "BF16": 2,
+        "I32": 4,
+        "U32": 4,
+        "F32": 4,
+        "I64": 8,
+        "U64": 8,
+        "F64": 8,
+    }[dtype.upper()]
 
 
 def _sha256(p: Path) -> str:
@@ -47,24 +57,21 @@ def _sha256(p: Path) -> str:
     return h.hexdigest()
 
 
-def _dequantize(q, scales, biases):
+def _dequantize(q, scales, biases, *, group_size: int, bits: int):
     return np.asarray(
         mx.dequantize(
-            mx.array(q), mx.array(scales), mx.array(biases), group_size=32, bits=4
+            mx.array(q),
+            mx.array(scales),
+            mx.array(biases),
+            group_size=group_size,
+            bits=bits,
         )
     )
 
 
 def _copy_predicted(src_name: str, shape: list, dtype: str) -> bool:
-    if len(shape) <= 1:
-        return True
-    if src_name.endswith(".A_log"):
-        return True
-    if dtype.upper() not in _QUANT_DTYPES:
-        return True
-    if shape[-1] % 32 != 0:
-        return True
-    return False
+    action, _, _ = classify_tensor(src_name, shape, dtype)
+    return action == "copy"
 
 
 def verify(src: Path, out: Path) -> int:
@@ -80,7 +87,7 @@ def verify(src: Path, out: Path) -> int:
     if missing:
         failures.append(f"output index missing source weights: {sorted(missing)[:10]}")
 
-    # 1b. total_size == sum of source weight byte totals
+    # 1b. total_size == sum of every emitted output tensor byte total
     src_meta = {}
     for n in src_wm:
         sp = src / src_wm[n]
@@ -92,16 +99,28 @@ def verify(src: Path, out: Path) -> int:
         b = {"8": 1, "16": 2, "32": 4, "64": 8}.get(base, 4)
         if dt.upper() == "BF16":
             b = 2
-    expected_total = sum(
-        math.prod(src_meta[n][0]) * b_for_dtype(src_meta[n][1]) for n in src_wm
-    )
+    expected_output_keys = set(src_wm)
+    for name, (shape, dtype) in src_meta.items():
+        action, _, _ = classify_tensor(name, shape, dtype)
+        if action == "quantize":
+            expected_output_keys.update({name + ".scales", name + ".biases"})
+    if set(out_wm) != expected_output_keys:
+        failures.append("output index does not map exactly every emitted tensor")
+    expected_total = 0
+    for shard_name in sorted(set(out_wm.values())):
+        with st_safe_open(str(out / shard_name), framework="numpy") as sf:
+            for key in sf.keys():  # noqa: SIM118
+                view = sf.get_slice(key)
+                expected_total += math.prod(view.get_shape()) * _dtype_bytes(
+                    view.get_dtype()
+                )
     got_total = out_index["metadata"]["total_size"]
     if got_total != expected_total:
         failures.append(
             f"total_size mismatch: got {got_total}, expected {expected_total}"
         )
     else:
-        print(f"  [ok] total_size == {expected_total} (source weight byte total)")
+        print(f"  [ok] total_size == {expected_total} (emitted weight byte total)")
 
     # 2. COPY tensors preserved value-for-value
     copy_names = [
@@ -115,7 +134,7 @@ def verify(src: Path, out: Path) -> int:
                 f"COPY {name} shape/dtype mismatch {src_arr.shape}/{src_arr.dtype} "
                 f"vs {out_arr.shape}/{out_arr.dtype}"
             )
-        elif not np.array_equal(src_arr, out_arr):
+        elif not bool(mx.array_equal(src_arr, out_arr).item()):
             failures.append(f"COPY {name} value mismatch")
         else:
             print(f"  [ok] COPY preserved: {name} {out_arr.shape} {out_arr.dtype}")
@@ -124,10 +143,17 @@ def verify(src: Path, out: Path) -> int:
     # 3. QUANTISE tensors round-trip q4-g32
     quant_names = [n for n in src_wm if n not in copy_names]
     for name in quant_names:
-        src_arr = _load(src / src_wm[name])[name].astype(np.float32)
+        src_arr = np.asarray(_load(src / src_wm[name])[name].astype(mx.float32))
         shard = _load(out / out_wm[name])
+        _, group_size, bits = classify_tensor(
+            name, src_meta[name][0], src_meta[name][1]
+        )
         rec = _dequantize(
-            shard[name], shard[name + ".scales"], shard[name + ".biases"]
+            shard[name],
+            shard[name + ".scales"],
+            shard[name + ".biases"],
+            group_size=group_size,
+            bits=bits,
         ).astype(np.float32)
         if rec.shape != src_arr.shape:
             failures.append(
@@ -138,7 +164,7 @@ def verify(src: Path, out: Path) -> int:
         scale = float(np.abs(src_arr).max())
         if scale > 0 and mse / scale > 0.1:
             failures.append(f"quant {name} excessive error mse={mse:.5g}")
-    print(f"  quant tensors round-tripped q4-g32: {len(quant_names)}")
+    print(f"  mixed-quant tensors round-tripped: {len(quant_names)}")
 
     # 4. deterministic shard naming + SHA256SUMS
     shards = sorted(p for p in out.glob("model-*.safetensors"))
@@ -163,11 +189,6 @@ def verify(src: Path, out: Path) -> int:
         return 1
     print("\nALL SYNTHETIC CHECKS PASSED (v2 q4-g32)")
     return 0
-
-
-def b_for_dtype(dt: str) -> int:
-    base = dt.upper().lstrip("F")
-    return {"8": 1, "16": 2, "32": 4, "64": 8}.get(base, 4)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_synth_conversion.py
+++ b/scripts/verify_synth_conversion.py
@@ -163,7 +163,8 @@ def verify(src: Path, out: Path) -> int:
             continue
         mse = float(np.mean((rec - src_arr) ** 2))
         scale = float(np.abs(src_arr).max())
-        if scale > 0 and mse / scale > 0.1:
+        normalized_mse = mse / max(scale**2, 1e-12)
+        if normalized_mse > 0.1:
             failures.append(f"quant {name} excessive error mse={mse:.5g}")
     print(f"  mixed-quant tensors round-tripped: {len(quant_names)}")
 

--- a/scripts/verify_synth_conversion.py
+++ b/scripts/verify_synth_conversion.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""End-to-end verification of the v2 converter against the SYNTHETIC shard set.
+
+Checks:
+  1. Output index covers every source weight (2 extra keys per quantised
+     tensor), and total_size == sum of original source weight byte totals.
+  2. COPY tensors (1-D norms, A_log, buffers/aux, non-divisible widths) are
+     preserved value-for-value (same shape/dtype) in the output.
+  3. QUANTISE tensors (incl. PLE/embed tables) round-trip through affine
+     q4-g32 with bounded error.
+  4. Output shards use deterministic ``model-{i:05d}-of-{N:05d}`` naming and
+     every output file's SHA-256 matches SHA256SUMS.txt.
+  5. Peak RSS is reported (in the ledger).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+from safetensors import safe_open as st_safe_open
+
+# dtypes / names the classifier treats as COPY.
+_QUANT_DTYPES = {"F16", "F32", "BF16"}
+
+
+def _load(shard: Path) -> dict[str, np.ndarray]:
+    out = {}
+    with st_safe_open(str(shard), framework="numpy") as sf:
+        # NOTE: `sf` is a safetensors handle, not a dict — `.keys()` is the
+        # only iterable; SIM118 does not apply.
+        for k in sf.keys():  # noqa: SIM118
+            out[k] = sf.get_tensor(k)
+    return out
+
+
+def _sha256(p: Path) -> str:
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for b in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            h.update(b)
+    return h.hexdigest()
+
+
+def _dequantize(q, scales, biases):
+    return np.asarray(
+        mx.dequantize(
+            mx.array(q), mx.array(scales), mx.array(biases), group_size=32, bits=4
+        )
+    )
+
+
+def _copy_predicted(src_name: str, shape: list, dtype: str) -> bool:
+    if len(shape) <= 1:
+        return True
+    if src_name.endswith(".A_log"):
+        return True
+    if dtype.upper() not in _QUANT_DTYPES:
+        return True
+    if shape[-1] % 32 != 0:
+        return True
+    return False
+
+
+def verify(src: Path, out: Path) -> int:
+    src, out = src.resolve(), out.resolve()
+    src_index = json.loads((src / "model.safetensors.index.json").read_text())
+    out_index = json.loads((out / "model.safetensors.index.json").read_text())
+    src_wm = src_index["weight_map"]
+    out_wm = out_index["weight_map"]
+    failures: list[str] = []
+
+    # 1a. coverage: every source weight present in output map
+    missing = set(src_wm) - set(out_wm)
+    if missing:
+        failures.append(f"output index missing source weights: {sorted(missing)[:10]}")
+
+    # 1b. total_size == sum of source weight byte totals
+    src_meta = {}
+    for n in src_wm:
+        sp = src / src_wm[n]
+        with st_safe_open(str(sp), framework="numpy") as sf:
+            shp, dt = sf.get_slice(n).get_shape(), sf.get_slice(n).get_dtype()
+        src_meta[n] = (list(shp), dt)
+        # dtype bytes
+        base = dt.upper().lstrip("F")
+        b = {"8": 1, "16": 2, "32": 4, "64": 8}.get(base, 4)
+        if dt.upper() == "BF16":
+            b = 2
+    expected_total = sum(
+        math.prod(src_meta[n][0]) * b_for_dtype(src_meta[n][1]) for n in src_wm
+    )
+    got_total = out_index["metadata"]["total_size"]
+    if got_total != expected_total:
+        failures.append(
+            f"total_size mismatch: got {got_total}, expected {expected_total}"
+        )
+    else:
+        print(f"  [ok] total_size == {expected_total} (source weight byte total)")
+
+    # 2. COPY tensors preserved value-for-value
+    copy_names = [
+        n for n in src_wm if _copy_predicted(n, src_meta[n][0], src_meta[n][1])
+    ]
+    for name in copy_names:
+        src_arr = _load(src / src_wm[name])[name]
+        out_arr = _load(out / out_wm[name])[name]
+        if src_arr.shape != out_arr.shape or str(src_arr.dtype) != str(out_arr.dtype):
+            failures.append(
+                f"COPY {name} shape/dtype mismatch {src_arr.shape}/{src_arr.dtype} "
+                f"vs {out_arr.shape}/{out_arr.dtype}"
+            )
+        elif not np.array_equal(src_arr, out_arr):
+            failures.append(f"COPY {name} value mismatch")
+        else:
+            print(f"  [ok] COPY preserved: {name} {out_arr.shape} {out_arr.dtype}")
+    print(f"  copy tensors verified: {len(copy_names)}")
+
+    # 3. QUANTISE tensors round-trip q4-g32
+    quant_names = [n for n in src_wm if n not in copy_names]
+    for name in quant_names:
+        src_arr = _load(src / src_wm[name])[name].astype(np.float32)
+        shard = _load(out / out_wm[name])
+        rec = _dequantize(
+            shard[name], shard[name + ".scales"], shard[name + ".biases"]
+        ).astype(np.float32)
+        if rec.shape != src_arr.shape:
+            failures.append(
+                f"quant {name} shape mismatch {rec.shape} vs {src_arr.shape}"
+            )
+            continue
+        mse = float(np.mean((rec - src_arr) ** 2))
+        scale = float(np.abs(src_arr).max())
+        if scale > 0 and mse / scale > 0.1:
+            failures.append(f"quant {name} excessive error mse={mse:.5g}")
+    print(f"  quant tensors round-tripped q4-g32: {len(quant_names)}")
+
+    # 4. deterministic shard naming + SHA256SUMS
+    shards = sorted(p for p in out.glob("model-*.safetensors"))
+    for p in shards:
+        if not (p.stem.count("-of-") == 1 and len(p.stem) >= 6):
+            failures.append(f"non-deterministic shard name: {p.name}")
+    sums = {}
+    for line in (out / "SHA256SUMS.txt").read_text().splitlines():
+        h, rel = line.split("  ", 1)
+        sums[rel] = h
+    bad = sum(1 for rel, h in sums.items() if _sha256(out / rel) != h)
+    if bad:
+        failures.append(f"SHA256 mismatches: {bad}")
+    print(
+        f"  SHA256SUMS entries: {len(sums)}, mismatches: {bad}; shards: {len(shards)}"
+    )
+
+    if failures:
+        print("\nFAILED:")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print("\nALL SYNTHETIC CHECKS PASSED (v2 q4-g32)")
+    return 0
+
+
+def b_for_dtype(dt: str) -> int:
+    base = dt.upper().lstrip("F")
+    return {"8": 1, "16": 2, "32": 4, "64": 8}.get(base, 4)
+
+
+if __name__ == "__main__":
+    raise SystemExit(verify(Path(sys.argv[1]), Path(sys.argv[2])))

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -82,6 +82,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "ddtree_tree_budget",
         "min_memory_gb",
         "vision_min_memory_gb",
+        "experimental",
         "recommended_sampling",
         "pflash_tier",
         "pflash_keep_ratio",
@@ -100,6 +101,36 @@ def _raw_aliases() -> dict[str, dict | str]:
 def _alias_ids() -> list[str]:
     """Stable alias name list for ``parametrize`` IDs."""
     return sorted(_raw_aliases().keys())
+
+
+def test_qwen38_flash_next_alias_is_experimental_and_memory_gated() -> None:
+    """The published M1 artifact stays explicit and Ultra-class only."""
+
+    alias = "qwen3.8-flash-next-4bit"
+    profile = list_profiles()[alias]
+
+    assert profile.hf_path == "rapid-mlx/Qwen3.8-Flash-Next-4bit"
+    assert profile.experimental is True
+    assert profile.min_memory_gb == 128.0
+    assert profile.is_hybrid is True
+    assert profile.is_hybrid_explicit is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+    assert profile.tool_call_parser == "hermes"
+    assert profile.reasoning_parser == "qwen3"
+    assert detect_model_config(alias) == profile
+    assert detect_model_config(profile.hf_path) == profile
+
+
+@pytest.mark.parametrize("bad_value", [0, 1, "true", None])
+def test_experimental_alias_flag_requires_a_boolean(bad_value) -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="experimental"):
+        _coerce(
+            "bad-experimental-alias",
+            {"hf_path": "publisher/model", "experimental": bad_value},
+        )
 
 
 def test_minicpm5_aliases_pin_the_verified_native_xml_contract() -> None:

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -82,6 +82,8 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "ddtree_tree_budget",
         "min_memory_gb",
         "vision_min_memory_gb",
+        "experimental",
+        "hidden",
         "recommended_sampling",
         "pflash_tier",
         "pflash_keep_ratio",
@@ -112,6 +114,20 @@ def test_minicpm5_aliases_pin_the_verified_native_xml_contract() -> None:
         assert profile.supports_spec_decode is False
         assert detect_model_config(alias) == profile
         assert detect_model_config(profile.hf_path) == profile
+
+
+def test_qwen38_flash_next_alias_is_hidden_experimental_and_memory_gated() -> None:
+    profile = list_profiles()["qwen3.8-flash-next-4bit-experimental"]
+    assert profile.hf_path == "mlx-community/Qwen3.8-Flash-Next-4bit"
+    assert profile.tool_call_parser == "qwen3_coder_xml"
+    assert profile.reasoning_parser == "qwen3"
+    assert profile.is_hybrid is True
+    assert profile.is_hybrid_explicit is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+    assert profile.min_memory_gb == 128
+    assert profile.experimental is True
+    assert profile.hidden is True
 
 
 # =============================================================================

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -82,8 +82,6 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "ddtree_tree_budget",
         "min_memory_gb",
         "vision_min_memory_gb",
-        "experimental",
-        "hidden",
         "recommended_sampling",
         "pflash_tier",
         "pflash_keep_ratio",
@@ -114,20 +112,6 @@ def test_minicpm5_aliases_pin_the_verified_native_xml_contract() -> None:
         assert profile.supports_spec_decode is False
         assert detect_model_config(alias) == profile
         assert detect_model_config(profile.hf_path) == profile
-
-
-def test_qwen38_flash_next_alias_is_hidden_experimental_and_memory_gated() -> None:
-    profile = list_profiles()["qwen3.8-flash-next-4bit-experimental"]
-    assert profile.hf_path == "mlx-community/Qwen3.8-Flash-Next-4bit"
-    assert profile.tool_call_parser == "qwen3_coder_xml"
-    assert profile.reasoning_parser == "qwen3"
-    assert profile.is_hybrid is True
-    assert profile.is_hybrid_explicit is True
-    assert profile.is_moe is True
-    assert profile.supports_spec_decode is False
-    assert profile.min_memory_gb == 128
-    assert profile.experimental is True
-    assert profile.hidden is True
 
 
 # =============================================================================

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -586,6 +586,15 @@ class TestIsTextOnlyOverride:
         info = models_route._build_model_info(model_id)
         assert info.capabilities == ["text", "experimental"]
 
+    def test_published_qwen4_exp_alias_emits_experimental_capability(self, monkeypatch):
+        from vllm_mlx.routes import models as models_route
+
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: False)
+
+        info = models_route._build_model_info("qwen3.8-flash-next-4bit")
+
+        assert info.capabilities == ["text", "tools", "experimental"]
+
     def test_build_model_info_forwards_is_text_only_for_bonsai_alias(self, monkeypatch):
         """Integration guard (codex #1116 NIT): the direct-helper tests
         above stay green even if ``_build_model_info`` STOPS forwarding

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -564,16 +564,27 @@ class TestIsTextOnlyOverride:
         assert "vision" not in caps, caps
         assert "text" in caps and "tools" in caps
 
-    def test_experimental_profile_emits_machine_readable_capability(self):
+    def test_local_qwen4_exp_entry_emits_machine_readable_capability(self, monkeypatch):
+        from vllm_mlx.config import get_config
         from vllm_mlx.routes import models as models_route
+        from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
 
-        caps = models_route._detect_capabilities(
-            "qwen3.8-flash-next-4bit-experimental",
-            profile_modality="text",
-            profile_tool_parser="qwen3_coder_xml",
-            experimental=True,
+        model_id = "/models/local-qwen4-exp"
+        registry = ModelRegistry()
+        registry.add(
+            ModelEntry(
+                engine=object(),
+                model_name=model_id,
+                model_path=model_id,
+                experimental=True,
+            ),
+            is_default=True,
         )
-        assert caps == ["text", "tools", "experimental"]
+        monkeypatch.setattr(get_config(), "model_registry", registry)
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: False)
+
+        info = models_route._build_model_info(model_id)
+        assert info.capabilities == ["text", "experimental"]
 
     def test_build_model_info_forwards_is_text_only_for_bonsai_alias(self, monkeypatch):
         """Integration guard (codex #1116 NIT): the direct-helper tests

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -564,6 +564,17 @@ class TestIsTextOnlyOverride:
         assert "vision" not in caps, caps
         assert "text" in caps and "tools" in caps
 
+    def test_experimental_profile_emits_machine_readable_capability(self):
+        from vllm_mlx.routes import models as models_route
+
+        caps = models_route._detect_capabilities(
+            "qwen3.8-flash-next-4bit-experimental",
+            profile_modality="text",
+            profile_tool_parser="qwen3_coder_xml",
+            experimental=True,
+        )
+        assert caps == ["text", "tools", "experimental"]
+
     def test_build_model_info_forwards_is_text_only_for_bonsai_alias(self, monkeypatch):
         """Integration guard (codex #1116 NIT): the direct-helper tests
         above stay green even if ``_build_model_info`` STOPS forwarding

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -59,6 +59,16 @@ def test_available_sections_are_split_by_modality() -> None:
     assert all(e["modality"] == "audio" for e in payload["audio"])
 
 
+def test_hidden_experimental_alias_is_not_in_default_catalog() -> None:
+    payload = _available_models_json_payload()
+    aliases = {
+        entry["alias"]
+        for section in ("text", "video", "image")
+        for entry in payload[section]
+    }
+    assert "qwen3.8-flash-next-4bit-experimental" not in aliases
+
+
 def test_cached_payload_shape() -> None:
     payload = _cached_models_json_payload()
     assert set(payload) == {"cached", "count", "total_bytes"}

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -59,16 +59,6 @@ def test_available_sections_are_split_by_modality() -> None:
     assert all(e["modality"] == "audio" for e in payload["audio"])
 
 
-def test_hidden_experimental_alias_is_not_in_default_catalog() -> None:
-    payload = _available_models_json_payload()
-    aliases = {
-        entry["alias"]
-        for section in ("text", "video", "image")
-        for entry in payload[section]
-    }
-    assert "qwen3.8-flash-next-4bit-experimental" not in aliases
-
-
 def test_cached_payload_shape() -> None:
     payload = _cached_models_json_payload()
     assert set(payload) == {"cached", "count", "total_bytes"}

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -32,6 +32,28 @@ def test_pooling_cache_rolls_back_across_compression_boundary() -> None:
     assert cache.remainder == 0
 
 
+def test_pooling_cache_multitoken_preflight_is_atomic_without_undo() -> None:
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from vllm_mlx.cache_rollback import can_trim, trim_all
+    from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+
+    kv = KVCache()
+    values = mx.ones((1, 1, 5, 2))
+    kv.update_and_fetch(values, values)
+    pooling = PoolingCache(4)
+    pooling.accumulate_windows(mx.ones((1, 1, 2)), mx.ones((1, 1, 2)), 0)
+    cache = CacheList(kv, pooling)
+
+    assert pooling.remainder == 1
+    assert pooling._undo is None
+    assert cache.is_trimmable()
+    assert not can_trim(cache, 2)
+    assert not trim_all([cache], 2)
+    assert kv.offset == 5
+    assert pooling.remainder == 1
+
+
 def test_rotating_cache_rolls_back_after_rotation() -> None:
     from mlx_lm.models.cache import RotatingKVCache
 

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -14,22 +14,22 @@ from vllm_mlx.scheduler import (
 
 
 def test_pooling_cache_rolls_back_across_compression_boundary() -> None:
-    from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+    from vllm_mlx.models.deepseek_v4_cache import DeepseekV4PoolingCache
     from vllm_mlx.models.deepseek_v4_rollback import armed, trim_all
 
-    cache = PoolingCache(4)
+    cache = DeepseekV4PoolingCache(4)
     # Establish three pending values, then verify four inputs. Keeping the
     # confirmed input crosses one boundary; the rejected suffix must vanish.
     cache.accumulate_windows(mx.ones((1, 3, 2)), mx.ones((1, 3, 2)), 0)
     with armed():
         ready, _gate, _base = cache.accumulate_windows(
-            mx.ones((1, 4, 2)), mx.ones((1, 4, 2)), 3
+            mx.ones((1, 5, 2)), mx.ones((1, 5, 2)), 3
         )
         cache.update_and_fetch(mx.ones((1, ready.shape[1] // 4, 2)))
 
     assert trim_all([cache], 3)
     assert cache.offset == 1
-    assert cache.remainder == 0
+    assert cache.remainder == 1
 
 
 def test_pooling_cache_multitoken_preflight_is_atomic_without_undo() -> None:
@@ -77,6 +77,123 @@ def test_trim_transaction_restores_earlier_cache_when_later_trim_fails() -> None
     assert later.offset == 9
 
 
+def test_trim_admission_guards_and_custom_checkpoint_restore() -> None:
+    from vllm_mlx.cache_rollback import can_trim, trim_all
+
+    class CustomCache:
+        def __init__(self):
+            self.offset = 3
+            self.restored = False
+
+        def can_trim(self, n):
+            return n <= self.offset
+
+        def trim_checkpoint(self):
+            return self.offset
+
+        def restore_trim_checkpoint(self, offset):
+            self.offset = offset
+            self.restored = True
+
+        def trim(self, n):
+            self.offset -= n
+            raise RuntimeError("injected trim failure")
+
+    class UndoCache:
+        def _can_undo(self, n):
+            return n == 2
+
+    class LegacyCache:
+        def __init__(self, size):
+            self._size = size
+
+        def is_trimmable(self):
+            return True
+
+        def size(self):
+            return self._size
+
+    class InvalidSizeCache(LegacyCache):
+        def size(self):
+            return object()
+
+    assert can_trim(UndoCache(), 2)
+    assert not can_trim(object(), 1)
+    assert can_trim(LegacyCache(2), 2)
+    assert not can_trim(InvalidSizeCache(2), 1)
+    assert not can_trim(LegacyCache(2), -1)
+    assert trim_all([], 0)
+    assert not trim_all([], -1)
+
+    custom = CustomCache()
+    assert not trim_all([custom], 2)
+    assert custom.offset == 3
+    assert custom.restored
+
+
+def test_pooling_checkpoint_restore_covers_scalar_and_batch_state() -> None:
+    from vllm_mlx.models.deepseek_v4_cache import (
+        BatchDeepseekV4PoolingCache,
+        DeepseekV4PoolingCache,
+    )
+
+    scalar = DeepseekV4PoolingCache(4)
+    scalar.accumulate_windows(mx.ones((1, 3, 4)), mx.ones((1, 3, 4)), 0)
+    scalar_state = scalar.trim_checkpoint()
+    scalar.remainder = 0
+    scalar.restore_trim_checkpoint(scalar_state)
+    assert scalar.remainder == 3
+    assert scalar.can_trim(3)
+
+    batch = BatchDeepseekV4PoolingCache(ratio=4, left_padding=[0])
+    batch.accumulate_windows(mx.ones((1, 3, 4)), mx.ones((1, 3, 4)), [0])
+    batch_state = batch.trim_checkpoint()
+    batch.remainder = [0]
+    batch.restore_trim_checkpoint(batch_state)
+    assert batch.remainder == [3]
+    assert batch.can_trim(3)
+
+
+def test_batch_pooling_cache_rolls_back_across_compression_boundary() -> None:
+    from vllm_mlx.models.deepseek_v4_cache import BatchDeepseekV4PoolingCache
+    from vllm_mlx.models.deepseek_v4_rollback import armed, trim_all
+
+    cache = BatchDeepseekV4PoolingCache(ratio=4, left_padding=[0])
+    cache.accumulate_windows(mx.ones((1, 3, 4)), mx.ones((1, 3, 4)), 0)
+    with armed():
+        ready, _gate, _base = cache.accumulate_windows(
+            mx.ones((1, 5, 4)), mx.ones((1, 5, 4)), 3
+        )
+        cache.update_and_fetch(mx.ones((1, ready.shape[1] // 4, 4)))
+
+    assert trim_all([cache], 3)
+    assert cache._pool_lengths == [1]
+    assert cache.remainder == [1]
+    assert cache.size() == 1
+
+
+def test_deepseek_pooling_undo_without_completed_window_restores_overlap() -> None:
+    from vllm_mlx.models.deepseek_v4_cache import (
+        BatchDeepseekV4PoolingCache,
+        DeepseekV4PoolingCache,
+    )
+    from vllm_mlx.models.deepseek_v4_rollback import armed, trim_all
+
+    scalar = DeepseekV4PoolingCache(4)
+    scalar.accumulate_windows(mx.ones((1, 3, 4)), mx.ones((1, 3, 4)), 0)
+    with armed():
+        scalar.accumulate_windows(mx.ones((1, 4, 4)), mx.ones((1, 4, 4)), 3)
+    assert trim_all([scalar], 4)
+    assert scalar.remainder == 3
+
+    batch = BatchDeepseekV4PoolingCache(ratio=4, left_padding=[0])
+    batch.accumulate_windows(mx.ones((1, 3, 4)), mx.ones((1, 3, 4)), 0)
+    with armed():
+        batch.accumulate_windows(mx.ones((1, 4, 4)), mx.ones((1, 4, 4)), 3)
+    assert trim_all([batch], 4)
+    assert batch.remainder == [3]
+
+
 def test_rotating_cache_rolls_back_after_rotation() -> None:
     from mlx_lm.models.cache import RotatingKVCache
 
@@ -87,6 +204,9 @@ def test_rotating_cache_rolls_back_after_rotation() -> None:
     )
 
     install_rotating_undo()
+    directly_trimmable = RotatingKVCache(max_size=4)
+    directly_trimmable.update_and_fetch(mx.zeros((1, 1, 1, 2)), mx.zeros((1, 1, 1, 2)))
+    assert directly_trimmable.can_trim(1)
     reference = RotatingKVCache(max_size=4)
     reference.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
     reference.update_and_fetch(mx.ones((1, 1, 1, 2)), mx.ones((1, 1, 1, 2)))
@@ -95,6 +215,10 @@ def test_rotating_cache_rolls_back_after_rotation() -> None:
     with armed():
         cache.update_and_fetch(mx.ones((1, 1, 4, 2)), mx.ones((1, 1, 4, 2)))
 
+    assert not cache.can_trim(-1)
+    assert cache.can_trim(1)
+    checkpoint = cache.trim_checkpoint()
+    cache.restore_trim_checkpoint(checkpoint)
     assert trim_all([cache], 3)
     assert (cache.offset, cache._idx) == (reference.offset, reference._idx)
     assert mx.array_equal(cache.keys, reference.keys).item()
@@ -132,6 +256,51 @@ def test_batch_rotating_cache_rolls_back_after_rotation() -> None:
     assert mx.array_equal(cache.left_padding, reference.left_padding).item()
     assert mx.array_equal(cache.keys, reference.keys).item()
     assert mx.array_equal(cache.values, reference.values).item()
+
+
+def test_rotating_undo_supports_legacy_cache_without_amount_preflight(
+    monkeypatch,
+) -> None:
+    from mlx_lm.models import cache as mlx_cache
+
+    from vllm_mlx.models import deepseek_v4_rollback as rollback
+
+    class LegacyRotating:
+        def __init__(self):
+            self.offset = 3
+
+        def update_and_fetch(self, keys, values):
+            return keys, values
+
+        def is_trimmable(self):
+            return True
+
+        def trim(self, n):
+            self.offset -= n
+            return n
+
+    class LegacyBatchRotating:
+        def __init__(self):
+            self.offset = 3
+
+        def update_and_fetch(self, keys, values):
+            return keys, values
+
+        def is_trimmable(self):
+            return True
+
+        def trim(self, n):
+            self.offset -= n
+            return n
+
+        def can_trim(self, n):
+            return n <= self.offset
+
+    monkeypatch.setattr(mlx_cache, "RotatingKVCache", LegacyRotating)
+    monkeypatch.setattr(mlx_cache, "BatchRotatingKVCache", LegacyBatchRotating)
+    rollback.install_rotating_undo()
+    assert LegacyRotating().can_trim(2)
+    assert LegacyBatchRotating().can_trim(2)
 
 
 def test_adaptive_depth_shrinks_cools_down_and_recovers() -> None:

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -54,6 +54,29 @@ def test_pooling_cache_multitoken_preflight_is_atomic_without_undo() -> None:
     assert pooling.remainder == 1
 
 
+def test_trim_transaction_restores_earlier_cache_when_later_trim_fails() -> None:
+    from vllm_mlx.cache_rollback import trim_all
+
+    class CursorCache:
+        def __init__(self, offset, *, fail=False):
+            self.offset = offset
+            self.fail = fail
+
+        def can_trim(self, n):
+            return n <= self.offset
+
+        def trim(self, n):
+            self.offset -= n
+            return 0 if self.fail else n
+
+    first = CursorCache(7)
+    later = CursorCache(9, fail=True)
+
+    assert not trim_all([first, later], 2)
+    assert first.offset == 7
+    assert later.offset == 9
+
+
 def test_rotating_cache_rolls_back_after_rotation() -> None:
     from mlx_lm.models.cache import RotatingKVCache
 

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2495,6 +2495,28 @@ class TestCheckpointMetadataFallback:
         assert config.is_hybrid_explicit is True
         assert config.supports_spec_decode is False
 
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "qwen4_exp",
+                    "text_config": {
+                        "model_type": "qwen4_exp",
+                        "layer_types": ["linear_attention", "qwen_sparse_attention"],
+                    },
+                },
+                self._XML_TOOLS,
+            ),
+        )
+        flash = detect_model_config("/tmp/models/Qwen3.8-Flash-Next/snapshot")
+        assert flash is not None
+        assert flash.is_hybrid is True
+        assert flash.is_moe is True
+        assert flash.experimental is True
+        assert "experimental" in format_profile_summary("local-flash-next", flash)
+        assert "⚠ experimental" in format_profile_table("local-flash-next", flash)
+
     def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
         # The template PARSES successfully (``{% endif %}`` is present), but the
         # XML tool contract is genuinely INCOMPLETE: it opens

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2381,6 +2381,32 @@ class TestCheckpointMetadataFallback:
         assert config.is_hybrid_explicit is True
         assert config.supports_spec_decode is False
 
+    def test_qwen4_exp_metadata_marks_local_checkpoint_experimental(self, monkeypatch):
+        """The typed architecture, never a repository label, owns M1 status."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "qwen4_exp",
+                    "text_config": {
+                        "model_type": "qwen4_exp_text",
+                        "layer_types": ["linear_attention", "full_attention"],
+                    },
+                },
+                None,
+            ),
+        )
+
+        config = detect_model_config("/models/operator-converted-checkpoint")
+
+        assert config is not None
+        assert config.is_hybrid is True
+        assert config.is_hybrid_explicit is True
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+        assert config.experimental is True
+
     def test_metadata_detection_logs_when_called_directly(self, monkeypatch):
         log = mock.Mock()
         monkeypatch.setattr(

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -960,6 +960,16 @@ class TestVisibility:
         assert "✗ disabled (hybrid arch)" in table
         assert "✓ 200ms gap" in table
 
+    def test_qwen4_exp_alias_surfaces_experimental_status(self):
+        cfg = detect_model_config("qwen3.8-flash-next-4bit")
+        assert cfg is not None and cfg.experimental is True
+
+        summary = format_profile_summary("qwen3.8-flash-next-4bit", cfg)
+        table = format_profile_table("qwen3.8-flash-next-4bit", cfg)
+
+        assert "experimental" in summary
+        assert "Status           : ⚠ experimental" in table
+
     def test_table_for_pure_attention_shows_supported(self):
         cfg = detect_model_config("mlx-community/Qwen3-0.6B-8bit")
         table = format_profile_table("mlx-community/Qwen3-0.6B-8bit", cfg)

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -47,6 +47,7 @@ import sys
 import textwrap
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 mx = pytest.importorskip("mlx.core")
@@ -178,6 +179,38 @@ def test_deepseek_v4_populated_cache_uses_vendored_class_on_load(tmp_path):
     restored_pooling = restored[0].caches[1]
     assert isinstance(restored_pooling, DeepseekV4PoolingCache)
     mx.eval(restored_pooling.state)
+
+
+def test_qwen4_qsa_cachelist_roundtrip_preserves_side_cache_owner(tmp_path):
+    """QSA raw-ring/compressed state restores through the vendored registry."""
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+
+    kv = KVCache()
+    values = mx.arange(20, dtype=mx.float32).reshape(1, 1, 5, 4)
+    kv.update_and_fetch(values, -values)
+    qsa = QSAIndexCache(compress_ratio=2)
+    qsa.update(
+        mx.arange(20, dtype=mx.float32).reshape(1, 5, 4),
+        lambda group, start: group + start,
+    )
+
+    path = str(tmp_path / "qwen4-qsa.safetensors")
+    _save_prompt_cache_compat(path, [CacheList(kv, qsa)], {})
+    restored = _load_prompt_cache_compat(path)
+
+    restored_qsa = restored[0].caches[1]
+    assert isinstance(restored_qsa, QSAIndexCache)
+    assert restored_qsa.offset == 5
+    assert restored_qsa._compressed_count == 2
+    mx.eval(restored_qsa.state)
+    np.testing.assert_array_equal(
+        np.array(restored_qsa.raw_ring), np.array(qsa.raw_ring)
+    )
+    np.testing.assert_array_equal(
+        np.array(restored_qsa.compressed_keys), np.array(qsa.state[1])
+    )
 
 
 def test_deepseek_v4_prefix_cache_survives_real_process_restart(tmp_path):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -59,6 +59,7 @@ from vllm_mlx.memory_cache import (  # noqa: E402
     MemoryCacheConfig,
     _load_prompt_cache_compat,
     _save_prompt_cache_compat,
+    _trim_cache_offset,
 )
 
 # --------------------------------------------------------------------------
@@ -211,6 +212,27 @@ def test_qwen4_qsa_cachelist_roundtrip_preserves_side_cache_owner(tmp_path):
     np.testing.assert_array_equal(
         np.array(restored_qsa.compressed_keys), np.array(qsa.state[1])
     )
+
+
+def test_qwen4_qsa_prefix_trim_rewinds_main_and_side_cache_together():
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+
+    kv = KVCache()
+    values = mx.arange(32, dtype=mx.float32).reshape(1, 1, 8, 4)
+    kv.update_and_fetch(values, -values)
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(
+        values.squeeze(axis=1),
+        lambda group, start: group + start,
+    )
+
+    trimmed = _trim_cache_offset([CacheList(kv, qsa)], 1)
+    assert trimmed is not None
+    assert trimmed[0][0].offset == 7
+    assert trimmed[0][1].offset == 7
+    assert trimmed[0][1]._compressed_count == 1
 
 
 def test_deepseek_v4_prefix_cache_survives_real_process_restart(tmp_path):

--- a/tests/test_qwen4_exp_artifact_parity.py
+++ b/tests/test_qwen4_exp_artifact_parity.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-artifact parity gate for the experimental qwen4_exp lane."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_REFERENCE_COMMIT = "ecf1aa0a62958ea770bc25c35e173effe142aa3c"
+
+
+def _required_path(environment_key: str) -> Path:
+    value = os.environ.get(environment_key)
+    if not value:
+        pytest.skip(f"set {environment_key} to run real qwen4_exp parity")
+    path = Path(value).expanduser().resolve()
+    if not path.exists():
+        pytest.fail(f"{environment_key} does not exist: {path}")
+    return path
+
+
+def _run_probe(
+    *, backend: str, checkpoint: Path, output: Path, reference: Path | None = None
+) -> None:
+    environment = os.environ.copy()
+    environment.update({"HF_HUB_OFFLINE": "1", "TRANSFORMERS_OFFLINE": "1"})
+    python_path = [str(Path.cwd() / "scripts"), str(Path.cwd())]
+    if reference is not None:
+        python_path.insert(0, str(reference))
+    environment["PYTHONPATH"] = os.pathsep.join(python_path)
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/qwen4_exp_real_parity.py",
+            "--backend",
+            backend,
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        env=environment,
+    )
+
+
+def test_real_qwen4_exp_q4_matches_pinned_reference(tmp_path: Path) -> None:
+    checkpoint = _required_path("RAPID_MLX_QWEN4_EXP_ARTIFACT")
+    reference = _required_path("RAPID_MLX_QWEN4_EXP_REFERENCE")
+    commit = subprocess.run(
+        ["git", "-C", str(reference), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert commit == _REFERENCE_COMMIT
+
+    rapid_output = tmp_path / "rapid.npz"
+    reference_output = tmp_path / "reference.npz"
+    _run_probe(backend="rapid", checkpoint=checkpoint, output=rapid_output)
+    _run_probe(
+        backend="upstream",
+        checkpoint=checkpoint,
+        output=reference_output,
+        reference=reference,
+    )
+
+    with np.load(rapid_output) as rapid, np.load(reference_output) as expected:
+        assert set(rapid.files) == set(expected.files)
+        for probe in rapid.files:
+            difference = np.abs(rapid[probe] - expected[probe])
+            assert float(difference.max(initial=0.0)) <= 1e-3, probe
+        assert np.argmax(rapid["logits_last"]) == np.argmax(expected["logits_last"])

--- a/tests/test_qwen4_exp_artifact_parity.py
+++ b/tests/test_qwen4_exp_artifact_parity.py
@@ -75,4 +75,9 @@ def test_real_qwen4_exp_q4_matches_pinned_reference(tmp_path: Path) -> None:
         for probe in rapid.files:
             difference = np.abs(rapid[probe] - expected[probe])
             assert float(difference.max(initial=0.0)) <= 1e-3, probe
-        assert np.argmax(rapid["logits_last"]) == np.argmax(expected["logits_last"])
+        for logits_probe in (
+            "logits_last",
+            "sparse_logits_last",
+            "cached_decode_logits_last",
+        ):
+            assert np.argmax(rapid[logits_probe]) == np.argmax(expected[logits_probe])

--- a/tests/test_qwen4_exp_reference_parity.py
+++ b/tests/test_qwen4_exp_reference_parity.py
@@ -67,10 +67,7 @@ def _tiny_config(**overrides):
 
 
 def _to_mx_state(state):
-    return {
-        key: mx.array(value.detach().numpy())
-        for key, value in state.items()
-    }
+    return {key: mx.array(value.detach().numpy()) for key, value in state.items()}
 
 
 def test_two_layer_text_logits_match_pinned_architecture_reference():
@@ -93,19 +90,19 @@ def test_two_layer_text_logits_match_pinned_architecture_reference():
         )
     actual = candidate(mx.array(input_ids))
     mx.eval(actual)
-    np.testing.assert_allclose(
-        np.array(actual), expected, rtol=3e-2, atol=1.2e-3
-    )
+    np.testing.assert_allclose(np.array(actual), expected, rtol=3e-2, atol=1.2e-3)
 
     with torch.no_grad():
-        reference_prompt = reference(
-            torch.from_numpy(input_ids), use_cache=True
+        reference_prompt = reference(torch.from_numpy(input_ids), use_cache=True)
+        reference_decode = (
+            reference(
+                torch.tensor([[4]]),
+                past_key_values=reference_prompt.past_key_values,
+                use_cache=True,
+            )
+            .logits.float()
+            .numpy()
         )
-        reference_decode = reference(
-            torch.tensor([[4]]),
-            past_key_values=reference_prompt.past_key_values,
-            use_cache=True,
-        ).logits.float().numpy()
     cache = candidate.make_cache()
     candidate_prompt = candidate(mx.array(input_ids), cache=cache)
     mx.eval(candidate_prompt, [layer.state for layer in cache])
@@ -139,9 +136,9 @@ def test_ple_output_matches_pinned_architecture_reference():
     embedding = state.pop("ple_embedding.ngram_embedding.weight")
     rows = embedding.shape[0] // len(candidate.ple_embedding.ngram_embedding.shards)
     for index in range(len(candidate.ple_embedding.ngram_embedding.shards)):
-        state[
-            f"ple_embedding.ngram_embedding.shards.{index}.weight"
-        ] = embedding[index * rows : (index + 1) * rows]
+        state[f"ple_embedding.ngram_embedding.shards.{index}.weight"] = embedding[
+            index * rows : (index + 1) * rows
+        ]
     conv = state["conv1d.weight"]
     state["conv1d.weight"] = conv.moveaxis(2, 1)
     candidate.load_weights(list(state.items()), strict=True)
@@ -150,13 +147,15 @@ def test_ple_output_matches_pinned_architecture_reference():
     hidden = rng.normal(0, 0.1, (1, 4, 32)).astype(np.float32)
     input_ids = np.array([[1, 2, 3, 4]], dtype=np.int64)
     with torch.no_grad():
-        expected = reference(
-            torch.from_numpy(hidden),
-            torch.from_numpy(input_ids),
-            None,
-        ).float().numpy()
+        expected = (
+            reference(
+                torch.from_numpy(hidden),
+                torch.from_numpy(input_ids),
+                None,
+            )
+            .float()
+            .numpy()
+        )
     actual = candidate(mx.array(hidden), mx.array(input_ids), None)
     mx.eval(actual)
-    np.testing.assert_allclose(
-        np.array(actual), expected, rtol=2e-4, atol=2e-5
-    )
+    np.testing.assert_allclose(np.array(actual), expected, rtol=2e-4, atol=2e-5)

--- a/tests/test_qwen4_exp_reference_parity.py
+++ b/tests/test_qwen4_exp_reference_parity.py
@@ -97,6 +97,27 @@ def test_two_layer_text_logits_match_pinned_architecture_reference():
         np.array(actual), expected, rtol=3e-2, atol=1.2e-3
     )
 
+    with torch.no_grad():
+        reference_prompt = reference(
+            torch.from_numpy(input_ids), use_cache=True
+        )
+        reference_decode = reference(
+            torch.tensor([[4]]),
+            past_key_values=reference_prompt.past_key_values,
+            use_cache=True,
+        ).logits.float().numpy()
+    cache = candidate.make_cache()
+    candidate_prompt = candidate(mx.array(input_ids), cache=cache)
+    mx.eval(candidate_prompt, [layer.state for layer in cache])
+    candidate_decode = candidate(mx.array([[4]]), cache=cache)
+    mx.eval(candidate_decode, [layer.state for layer in cache])
+    np.testing.assert_allclose(
+        np.array(candidate_decode),
+        reference_decode,
+        rtol=3e-2,
+        atol=1.2e-3,
+    )
+
 
 def test_ple_output_matches_pinned_architecture_reference():
     values = _tiny_config(

--- a/tests/test_qwen4_exp_reference_parity.py
+++ b/tests/test_qwen4_exp_reference_parity.py
@@ -1,0 +1,141 @@
+"""Optional numerical parity checks against the architecture reference.
+
+The regular test environment does not install Torch or the unreleased model
+module.  Day-0 validation runs this file in the pinned scratch environment
+recorded in the engineering handoff.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+torch = pytest.importorskip("torch")
+
+try:
+    from transformers.models.qwen4_exp.configuration_qwen4_exp import (
+        Qwen4ExpTextConfig,
+    )
+    from transformers.models.qwen4_exp.modeling_qwen4_exp import (
+        Qwen4ExpForCausalLM,
+        Qwen4ExpTextPLELayer,
+    )
+except ImportError:
+    pytest.skip("qwen4_exp reference module is not installed", allow_module_level=True)
+
+from vllm_mlx.models.qwen4_exp import PLELayer, TextModel, TextModelArgs
+
+
+def _tiny_config(**overrides):
+    values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 2,
+        "vocab_size": 32,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 3,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 3,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 4,
+        "shared_expert_intermediate_size": 4,
+        "hc_count": 4,
+        "hc_lowrank": 3,
+        "layer_types": ["linear_attention", "full_attention"],
+        "indexer_n_heads": 2,
+        "indexer_kv_heads": 1,
+        "indexer_head_dim": 4,
+        "indexer_budget": 2,
+        "indexer_compress_ratio": 2,
+        "ple_layer_ids": [],
+        "eos_token_id": 31,
+        "rope_parameters": {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.5,
+            "rope_type": "default",
+        },
+        "output_gate_type": "sigmoid",
+        "max_position_embeddings": 32768,
+    }
+    values.update(overrides)
+    return values
+
+
+def _to_mx_state(state):
+    return {
+        key: mx.array(value.detach().numpy())
+        for key, value in state.items()
+    }
+
+
+def test_two_layer_text_logits_match_pinned_architecture_reference():
+    values = _tiny_config()
+    torch.manual_seed(123)
+    reference = Qwen4ExpForCausalLM(Qwen4ExpTextConfig(**values)).eval()
+    candidate = TextModel(TextModelArgs(**values))
+    # The reference path is always unfused. Training mode selects the matching
+    # deterministic MLX recurrence rather than the production fused kernel.
+    candidate.train()
+    weights = candidate.sanitize(_to_mx_state(reference.state_dict()))
+    candidate.load_weights(list(weights.items()), strict=True)
+
+    input_ids = np.array([[1, 2, 3]], dtype=np.int64)
+    with torch.no_grad():
+        expected = (
+            reference(torch.from_numpy(input_ids), use_cache=False)
+            .logits.float()
+            .numpy()
+        )
+    actual = candidate(mx.array(input_ids))
+    mx.eval(actual)
+    np.testing.assert_allclose(
+        np.array(actual), expected, rtol=3e-2, atol=1.2e-3
+    )
+
+
+def test_ple_output_matches_pinned_architecture_reference():
+    values = _tiny_config(
+        num_hidden_layers=1,
+        layer_types=["linear_attention"],
+        ple_layer_ids=[1],
+        ple_embed_dim=16,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        ple_conv_kernel_size=4,
+    )
+    config = Qwen4ExpTextConfig(**values)
+    torch.manual_seed(321)
+    reference = Qwen4ExpTextPLELayer(config, layer_idx=0, ple_layer_index=0).eval()
+    candidate = PLELayer(TextModelArgs(**values), ple_layer_index=0)
+
+    state = _to_mx_state(reference.state_dict())
+    embedding = state.pop("ple_embedding.ngram_embedding.weight")
+    rows = embedding.shape[0] // len(candidate.ple_embedding.ngram_embedding.shards)
+    for index in range(len(candidate.ple_embedding.ngram_embedding.shards)):
+        state[
+            f"ple_embedding.ngram_embedding.shards.{index}.weight"
+        ] = embedding[index * rows : (index + 1) * rows]
+    conv = state["conv1d.weight"]
+    state["conv1d.weight"] = conv.moveaxis(2, 1)
+    candidate.load_weights(list(state.items()), strict=True)
+
+    rng = np.random.default_rng(11)
+    hidden = rng.normal(0, 0.1, (1, 4, 32)).astype(np.float32)
+    input_ids = np.array([[1, 2, 3, 4]], dtype=np.int64)
+    with torch.no_grad():
+        expected = reference(
+            torch.from_numpy(hidden),
+            torch.from_numpy(input_ids),
+            None,
+        ).float().numpy()
+    actual = candidate(mx.array(hidden), mx.array(input_ids), None)
+    mx.eval(actual)
+    np.testing.assert_allclose(
+        np.array(actual), expected, rtol=2e-4, atol=2e-5
+    )

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -341,6 +341,96 @@ def test_qsa_cache_refuses_rewind_beyond_retained_raw_group():
     assert cache.offset == 9
 
 
+def test_scheduler_rollback_preflights_qsa_cachelist_for_full_rejection():
+    """A multi-token rejection cannot trim KV before QSA refuses it."""
+    from vllm_mlx.cache_rollback import can_trim, trim_all
+
+    kv = KVCache()
+    keys = mx.arange(9, dtype=mx.float32).reshape(1, 1, 9, 1)
+    kv.update_and_fetch(keys, -keys)
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(
+        mx.arange(9, dtype=mx.float32).reshape(1, 9, 1),
+        lambda group, start: group + start,
+    )
+    cache = CacheList(kv, qsa)
+
+    assert cache.is_trimmable()
+    assert not can_trim(cache, 2)
+    assert not trim_all([cache], 2)
+    assert kv.offset == qsa.offset == 9
+
+    assert can_trim(cache, 1)
+    assert trim_all([cache], 1)
+    assert kv.offset == qsa.offset == 8
+
+
+def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():
+    from vllm_mlx.scheduler import _install_suffix_decoding
+
+    kv = KVCache()
+    keys = mx.arange(9, dtype=mx.float32).reshape(1, 1, 9, 1)
+    kv.update_and_fetch(keys, -keys)
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(
+        mx.arange(9, dtype=mx.float32).reshape(1, 9, 1),
+        lambda group, start: group + start,
+    )
+
+    class GenerationBatch:
+        _next_tokens = mx.array([7], dtype=mx.int32)
+        uids = [11]
+        logits_processors = []
+        prompt_cache = [CacheList(kv, qsa)]
+        tokens = [[]]
+        model = None
+
+        def __init__(self):
+            self.original_calls = 0
+
+        def _step(self):
+            self.original_calls += 1
+            return [7], []
+
+        def next(self):
+            return []
+
+    class BatchGenerator:
+        def __init__(self):
+            self._generation_batch = GenerationBatch()
+
+        def remove(self, _uids, return_prompt_caches=False):
+            return {} if return_prompt_caches else None
+
+    class TwoTokenDrafter:
+        max_draft_tokens = 2
+
+        def add_generated_token(self, _token):
+            return None
+
+        def get_draft(self):
+            return [8, 9]
+
+    batch_generator = BatchGenerator()
+    _install_suffix_decoding(
+        batch_generator,
+        model=None,
+        profile=None,
+        max_draft=2,
+        max_suffix_len=2,
+        min_confidence=0.0,
+        requests={},
+        uid_to_request_id={},
+    )
+    generation_batch = batch_generator._generation_batch
+    generation_batch._suffix_drafters[11] = TwoTokenDrafter()
+
+    assert generation_batch._step() == ([7], [])
+    assert generation_batch.original_calls == 1
+    assert generation_batch._suffix_stats["ft_non_trimmable_cache"] == 1
+    assert kv.offset == qsa.offset == 9
+
+
 def test_qsa_attention_prefill_and_decode_keep_both_cache_owners_aligned():
     args = _args(
         indexer_budget=2,

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import asdict
 
 import numpy as np
@@ -9,6 +10,7 @@ pytest.importorskip("mlx_lm")
 from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 
 import vllm_mlx.models.qwen4_exp as qwen4_exp
+from scripts import qwen38_streaming_convert as converter
 from scripts.qwen38_streaming_convert import quantized_tensor_names
 from vllm_mlx.models.qwen4_exp import (
     GatedDeltaNet,
@@ -58,6 +60,18 @@ def _args(**overrides):
     }
     values.update(overrides)
     return TextModelArgs(**values)
+
+
+def _repair_fixture(tmp_path, shard_tensors, weight_map):
+    output = tmp_path / "converted"
+    output.mkdir()
+    for shard_name, tensors in shard_tensors.items():
+        mx.save_safetensors(str(output / shard_name), tensors)
+    (output / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 8}, "weight_map": weight_map})
+    )
+    converter._write_sha256sums(output)
+    return output
 
 
 def test_config_normalizes_checkpoint_full_attention_to_qsa():
@@ -676,6 +690,64 @@ def test_converter_quantized_keys_match_loader_sanitizer_contract():
             }
         )
     assert set(sanitized) == expected
+
+
+def test_quantized_aux_repair_preflights_cross_shard_collision(tmp_path):
+    output = _repair_fixture(
+        tmp_path,
+        {
+            "model-00001-of-00002.safetensors": {
+                "layer.weight.scales": mx.array([1.0])
+            },
+            "model-00002-of-00002.safetensors": {"layer.scales": mx.array([2.0])},
+        },
+        {
+            "layer.weight.scales": "model-00001-of-00002.safetensors",
+            "layer.scales": "model-00002-of-00002.safetensors",
+        },
+    )
+    before = {path.name: path.read_bytes() for path in output.iterdir()}
+
+    with pytest.raises(RuntimeError, match="output index rename collision"):
+        converter.repair_quantized_aux_names(output)
+
+    assert {path.name: path.read_bytes() for path in output.iterdir()} == before
+
+
+def test_quantized_aux_repair_commits_validated_plan(tmp_path):
+    shard_name = "model-00001-of-00001.safetensors"
+    output = _repair_fixture(
+        tmp_path,
+        {shard_name: {"layer.weight.scales": mx.array([1.0])}},
+        {"layer.weight.scales": shard_name},
+    )
+
+    result = converter.repair_quantized_aux_names(output)
+
+    assert result["changed_keys"] == result["changed_shards"] == 1
+    tensors = mx.load(str(output / shard_name))
+    assert set(tensors) == {"layer.scales"}
+    index = json.loads((output / "model.safetensors.index.json").read_text())
+    assert index["weight_map"] == {"layer.scales": shard_name}
+
+
+def test_quantized_aux_repair_rolls_back_commit_failure(tmp_path, monkeypatch):
+    output = _repair_fixture(
+        tmp_path,
+        {"model-00001-of-00001.safetensors": {"layer.weight.scales": mx.array([1.0])}},
+        {"layer.weight.scales": "model-00001-of-00001.safetensors"},
+    )
+    before = {path.name: path.read_bytes() for path in output.iterdir()}
+    monkeypatch.setattr(
+        converter,
+        "_write_sha256sums",
+        lambda _output: (_ for _ in ()).throw(OSError("injected checksum failure")),
+    )
+
+    with pytest.raises(OSError, match="injected checksum failure"):
+        converter.repair_quantized_aux_names(output)
+
+    assert {path.name: path.read_bytes() for path in output.iterdir()} == before
 
 
 def test_quantization_contract_uses_shape_exact_ple_groups_and_q8_routing():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -208,6 +208,36 @@ def test_ple_state_shapes_survive_cached_decode():
     np.testing.assert_array_equal(np.array(cache[3]), np.array([[3, 4]]))
 
 
+def test_ple_right_padded_batch_caches_only_each_rows_valid_history():
+    args = _ple_args()
+    ple = PLELayer(args, ple_layer_index=0)
+    batch_cache = ArraysCache(size=4)
+    batch_cache.prepare(lengths=[3, 1])
+    batch_ids = mx.array([[1, 2, 3], [7, 0, 0]])
+    mask = mx.array([[True, True, True], [True, False, False]])
+    batch_output = ple(
+        mx.zeros((2, 3, args.hc_count * args.hidden_size)),
+        batch_ids,
+        batch_cache,
+        mask,
+    )
+
+    single_cache = ArraysCache(size=4)
+    single_output = ple(
+        mx.zeros((1, 1, args.hc_count * args.hidden_size)),
+        mx.array([[7]]),
+        single_cache,
+    )
+    mx.eval(batch_output, single_output, batch_cache.state, single_cache.state)
+    np.testing.assert_array_equal(np.array(batch_cache[3][1]), np.array([31, 7]))
+    np.testing.assert_allclose(
+        np.array(batch_cache[2][1]),
+        np.array(single_cache[2][0]),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
 def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
     cache = QSAIndexCache(compress_ratio=2)
 

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -6,7 +6,7 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 pytest.importorskip("mlx_lm")
 
-from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 
 from vllm_mlx.models.qwen4_exp import (
     GatedDeltaNet,
@@ -346,6 +346,26 @@ def test_qsa_cache_skips_right_padding_and_preserves_physical_alignment():
     np.testing.assert_array_equal(np.array(cache.left_padding), np.array([0, 2]))
 
 
+def test_qsa_cache_skips_fresh_batch_left_padding():
+    cache = QSAIndexCache(compress_ratio=2)
+    cache.left_padding = mx.array([2, 0])
+    cache.update(
+        mx.array(
+            [
+                [[99.0], [99.0], [1.0], [3.0], [5.0]],
+                [[2.0], [4.0], [6.0], [8.0], [10.0]],
+            ]
+        ),
+        lambda group, start: group + start,
+    )
+    mx.eval(cache.state)
+    assert cache._offsets == [3, 5]
+    assert cache._compressed_counts == [1, 2]
+    np.testing.assert_array_equal(
+        np.array(cache.compressed_keys[0, :1]), np.array([[2.0]])
+    )
+
+
 def test_qsa_attention_continuous_batch_decode_matches_cache_lengths():
     args = _args(
         indexer_budget=2,
@@ -366,6 +386,24 @@ def test_qsa_attention_continuous_batch_decode_matches_cache_lengths():
     assert output.shape == (2, 1, args.hidden_size)
     np.testing.assert_array_equal(np.array(batch_cache[0].offset), np.array([4, 6]))
     np.testing.assert_array_equal(np.array(batch_cache[1].offset), np.array([4, 6]))
+
+
+def test_qsa_attention_fresh_left_padded_batch_aligns_with_main_kv():
+    args = _args(
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    qsa = QSAIndexCache(compress_ratio=2)
+    # mlx-lm adopts an ArraysCache subclass by assigning this metadata.
+    qsa.left_padding = mx.array([2, 0])
+    cache = CacheList(BatchKVCache([2, 0]), qsa)
+    output = attention(mx.zeros((2, 5, args.hidden_size)), cache)
+    mx.eval(output, cache.state)
+    assert output.shape == (2, 5, args.hidden_size)
+    np.testing.assert_array_equal(np.array(cache[0].offset), np.array([3, 5]))
+    np.testing.assert_array_equal(np.array(cache[1].offset), np.array([3, 5]))
 
 
 def test_complete_synthetic_text_model_prefill_and_decode():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -663,6 +663,36 @@ def test_qsa_attention_continuous_batch_decode_matches_cache_lengths():
     np.testing.assert_array_equal(np.array(batch_cache[1].offset), np.array([4, 6]))
 
 
+def test_qsa_attention_filter_preserves_shorter_row_padding_during_decode():
+    args = _args(
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    caches = []
+    for length in (3, 5):
+        cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+        output = attention(mx.zeros((1, length, args.hidden_size)), cache)
+        mx.eval(output, cache.state)
+        caches.append(cache)
+
+    filtered = CacheList.merge(caches)
+    compact = filtered.extract(0)
+    filtered.filter(mx.array([0]))
+    np.testing.assert_array_equal(np.array(filtered[1].left_padding), np.array([2]))
+
+    compact_output = attention(mx.zeros((1, 1, args.hidden_size)), compact)
+    filtered_output = attention(mx.zeros((1, 1, args.hidden_size)), filtered)
+    mx.eval(compact_output, filtered_output, compact.state, filtered.state)
+
+    np.testing.assert_allclose(
+        np.array(filtered_output), np.array(compact_output), rtol=0, atol=0
+    )
+    np.testing.assert_array_equal(np.array(filtered[0].offset), np.array([4]))
+    np.testing.assert_array_equal(np.array(filtered[1].offset), np.array([4]))
+
+
 def test_qsa_attention_fresh_left_padded_batch_aligns_with_main_kv():
     args = _args(
         indexer_budget=2,

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -257,7 +257,7 @@ def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
     np.testing.assert_array_equal(np.array(unchanged), np.array([[[2.0], [8.0]]]))
     np.testing.assert_array_equal(np.array(cache.raw_ring), np.array([[[9.0], [7.0]]]))
     assert cache.offset == 5
-    assert not cache.is_trimmable()
+    assert cache.is_trimmable()
 
     restored = QSAIndexCache.from_state(cache.state, cache.meta_state)
     assert restored.offset == 5
@@ -265,6 +265,40 @@ def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
     np.testing.assert_array_equal(
         np.array(restored.compressed_keys), np.array([[[2.0], [8.0]]])
     )
+
+
+@pytest.mark.parametrize("length", [8, 9])
+def test_qsa_cache_rewinds_recoverable_group_and_recomputes_divergence(length):
+    def transform(group, start):
+        return group + start
+
+    original = QSAIndexCache(compress_ratio=4)
+    values = np.arange(1, length + 1, dtype=np.float32)
+    original.update(mx.array(values.reshape(1, -1, 1)), transform)
+    assert original.trim(1) == 1
+    original.update(mx.array([[[99.0]]]), transform)
+
+    cold = QSAIndexCache(compress_ratio=4)
+    expected_values = np.concatenate([values[:-1], np.array([99.0])])
+    cold.update(mx.array(expected_values.reshape(1, -1, 1)), transform)
+    mx.eval(original.state, cold.state)
+    assert original.offset == cold.offset == length
+    np.testing.assert_array_equal(
+        np.array(original.state[1]), np.array(cold.state[1])
+    )
+    np.testing.assert_array_equal(
+        np.array(original.raw_ring), np.array(cold.raw_ring)
+    )
+
+
+def test_qsa_cache_refuses_rewind_beyond_retained_raw_group():
+    cache = QSAIndexCache(compress_ratio=4)
+    cache.update(
+        mx.arange(9, dtype=mx.float32).reshape(1, 9, 1),
+        lambda group, start: group + start,
+    )
+    assert cache.trim(2) == 0
+    assert cache.offset == 9
 
 
 def test_qsa_attention_prefill_and_decode_keep_both_cache_owners_aligned():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import asdict
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -838,6 +839,50 @@ def test_quantized_aux_repair_rolls_back_commit_failure(tmp_path, monkeypatch):
         converter.repair_quantized_aux_names(output)
 
     assert {path.name: path.read_bytes() for path in output.iterdir()} == before
+
+
+def test_converter_rejects_plain_source_symlink_escape(tmp_path):
+    source = tmp_path / "model"
+    source.mkdir()
+    outside = tmp_path / "outside.safetensors"
+    outside.write_bytes(b"not model data")
+    (source / "model.safetensors").symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="escapes model cache root"):
+        converter._safe_source_shard(source, Path("model.safetensors"))
+
+
+def test_converter_allows_standard_hf_snapshot_blob_symlink(tmp_path):
+    model_root = tmp_path / "models--org--repo"
+    snapshot = model_root / "snapshots" / "revision"
+    blobs = model_root / "blobs"
+    snapshot.mkdir(parents=True)
+    blobs.mkdir()
+    blob = blobs / "abc123"
+    blob.write_bytes(b"model data")
+    (snapshot / "model.safetensors").symlink_to(blob)
+
+    assert converter._safe_source_shard(snapshot, Path("model.safetensors")) == blob
+
+
+def test_converter_failure_never_publishes_partial_output(tmp_path, monkeypatch):
+    final = tmp_path / "published"
+
+    def fail_after_partial_write(_source, staging, **_kwargs):
+        (staging / "partial.safetensors").write_bytes(b"partial")
+        raise OSError("injected conversion failure")
+
+    monkeypatch.setattr(converter, "_convert_into", fail_after_partial_write)
+    with pytest.raises(OSError, match="injected conversion failure"):
+        converter.convert(
+            tmp_path / "source",
+            final,
+            max_shard_bytes=1024,
+            min_free_bytes=0,
+        )
+
+    assert not final.exists()
+    assert list(tmp_path.glob(".published.staging-*")) == []
 
 
 def test_quantization_contract_uses_shape_exact_ple_groups_and_q8_routing():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1,0 +1,401 @@
+from dataclasses import asdict
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+from vllm_mlx.models.qwen4_exp import (
+    GatedDeltaNet,
+    GatedResidual,
+    Model,
+    ModelArgs,
+    NGramEmbedding,
+    PLELayer,
+    QSAAttention,
+    ShardedEmbedding,
+    TextModelArgs,
+    ZeroCenteredRMSNorm,
+    build_layer_multipliers,
+)
+from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+
+
+def _args(**overrides):
+    values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 2,
+        "vocab_size": 32,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 3,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 3,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 4,
+        "shared_expert_intermediate_size": 4,
+        "hc_count": 4,
+        "hc_lowrank": 3,
+        "layer_types": ["linear_attention", "full_attention"],
+        "indexer_n_heads": 2,
+        "indexer_kv_heads": 1,
+        "indexer_head_dim": 4,
+        "indexer_budget": 8,
+        "indexer_compress_ratio": 2,
+        "ple_layer_ids": [],
+        "eos_token_id": 31,
+    }
+    values.update(overrides)
+    return TextModelArgs(**values)
+
+
+def test_config_normalizes_checkpoint_full_attention_to_qsa():
+    args = _args()
+    assert args.layer_types == ["linear_attention", "qwen_sparse_attention"]
+    assert args.linear_num_value_heads // args.linear_num_key_heads == 3
+
+
+def test_config_rejects_partial_indexer_contract():
+    with pytest.raises(ValueError, match="complete indexer contract"):
+        _args(indexer_budget=None)
+
+
+def test_zero_centered_grouped_rms_norm_matches_numpy():
+    norm = ZeroCenteredRMSNorm(8, group_size=4, eps=1e-6)
+    norm.weight = mx.array(np.linspace(-0.2, 0.2, 8, dtype=np.float32))
+    x_np = np.arange(1, 17, dtype=np.float32).reshape(1, 2, 8) / 10
+    out = norm(mx.array(x_np))
+    grouped = x_np.reshape(1, 2, 2, 4)
+    expected = grouped / np.sqrt(np.mean(grouped**2, axis=-1, keepdims=True) + 1e-6)
+    expected *= (1 + np.linspace(-0.2, 0.2, 8, dtype=np.float32)).reshape(2, 4)
+    np.testing.assert_allclose(np.array(out), expected.reshape(x_np.shape), rtol=2e-5, atol=2e-5)
+
+
+def test_gated_residual_matches_reference_equations():
+    args = _args()
+    layer = GatedResidual(args)
+    rng = np.random.default_rng(7)
+    layer.hc_norm.weight = mx.array(rng.normal(0, 0.1, (32,)).astype(np.float32))
+    layer.input_mix_weight_down.weight = mx.array(
+        rng.normal(0, 0.1, (3, 32)).astype(np.float32)
+    )
+    layer.input_mix_weight_up.weight = mx.array(
+        rng.normal(0, 0.1, (32, 3)).astype(np.float32)
+    )
+    layer.block_inject_weight.weight = mx.array(
+        rng.normal(0, 0.1, (4, 32)).astype(np.float32)
+    )
+    x_np = rng.normal(0, 0.2, (1, 2, 32)).astype(np.float32)
+    mixed, residual, injection = layer(mx.array(x_np))
+
+    grouped = x_np.reshape(1, 2, 4, 8)
+    weight = np.array(layer.hc_norm.weight).reshape(4, 8)
+    normalized = grouped / np.sqrt(np.mean(grouped**2, axis=-1, keepdims=True) + 1e-6)
+    normalized *= 1 + weight
+    flat = normalized.reshape(1, 2, 32)
+    down = flat @ np.array(layer.input_mix_weight_down.weight).T / 4
+    silu = down / (1 + np.exp(-down))
+    mix = 1 / (1 + np.exp(-(silu @ np.array(layer.input_mix_weight_up.weight).T)))
+    expected_mixed = np.mean(mix.reshape(1, 2, 4, 8) * normalized, axis=-2)
+    expected_injection = 2 / (
+        1 + np.exp(-(flat @ np.array(layer.block_inject_weight.weight).T / 4))
+    )
+    np.testing.assert_allclose(np.array(mixed), expected_mixed, rtol=3e-5, atol=3e-5)
+    np.testing.assert_array_equal(np.array(residual), x_np)
+    np.testing.assert_allclose(np.array(injection), expected_injection, rtol=3e-5, atol=3e-5)
+
+
+def test_gdn_ratio_three_state_shapes_and_cached_decode():
+    args = _args()
+    layer = GatedDeltaNet(args)
+    cache = ArraysCache(size=2)
+    prompt = mx.zeros((1, 3, args.hidden_size), dtype=mx.float32)
+    prompt_out = layer(prompt, cache=cache)
+    mx.eval(prompt_out, cache.state)
+    assert prompt_out.shape == (1, 3, args.hidden_size)
+    assert cache[0].shape == (1, args.linear_conv_kernel_dim - 1, 20)
+    assert cache[1].shape == (1, 3, 4, 4)
+
+    token_out = layer(mx.zeros((1, 1, args.hidden_size)), cache=cache)
+    mx.eval(token_out, cache.state)
+    assert token_out.shape == (1, 1, args.hidden_size)
+    assert cache[0].shape == (1, 2, 20)
+    assert cache[1].shape == (1, 3, 4, 4)
+
+
+def test_sharded_embedding_preserves_global_row_identity():
+    embedding = ShardedEmbedding(num_embeddings=16, dims=4, parts=4)
+    for shard_id, shard in enumerate(embedding.shards):
+        rows = np.arange(shard_id * 4, shard_id * 4 + 4, dtype=np.float32)
+        shard.weight = mx.array(np.repeat(rows[:, None], 4, axis=1))
+    ids = mx.array([[0, 3, 4, 9, 15]])
+    output = embedding(ids)
+    expected = np.repeat(np.array([[0, 3, 4, 9, 15]], dtype=np.float32)[..., None], 4, axis=-1)
+    np.testing.assert_array_equal(np.array(output), expected)
+
+
+def test_ngram_multipliers_match_released_reference_constants():
+    assert build_layer_multipliers(248320, 3, 0, 1234) == [
+        23703573157769,
+        20109073645365,
+        8052911324071,
+    ]
+
+
+def _ple_args():
+    return _args(
+        layer_types=["linear_attention", "qwen_sparse_attention"],
+        ple_layer_ids=[1],
+        ple_embed_dim=16,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+
+
+def test_ngram_cache_matches_one_shot_across_request_chunks():
+    args = _ple_args()
+    embedding = NGramEmbedding(args, embedding_dim=16, ple_layer_index=0)
+    one_shot = embedding.compute_ids(mx.array([[1, 2, 3, 4]]))
+
+    cache = ArraysCache(size=4)
+    first = embedding.compute_ids(mx.array([[1, 2]]), cache)
+    second = embedding.compute_ids(mx.array([[3, 4]]), cache)
+    mx.eval(one_shot, first, second, cache.state)
+    np.testing.assert_array_equal(np.array(first), np.array(one_shot[:, :2]))
+    np.testing.assert_array_equal(np.array(second), np.array(one_shot[:, 2:]))
+    np.testing.assert_array_equal(np.array(cache[3]), np.array([[3, 4]]))
+
+
+def test_ngram_context_resets_at_eos_boundary():
+    args = _ple_args()
+    embedding = NGramEmbedding(args, embedding_dim=16, ple_layer_index=0)
+    with_history = embedding.compute_ids(mx.array([[7, 8, 31, 9]]))
+    fresh_segment = embedding.compute_ids(mx.array([[9]]))
+    mx.eval(with_history, fresh_segment)
+    np.testing.assert_array_equal(
+        np.array(with_history[:, -1]), np.array(fresh_segment[:, -1])
+    )
+
+
+def test_ple_state_shapes_survive_cached_decode():
+    args = _ple_args()
+    ple = PLELayer(args, ple_layer_index=0)
+    cache = ArraysCache(size=4)
+    hidden = mx.zeros((1, 3, args.hc_count * args.hidden_size))
+    output = ple(hidden, mx.array([[1, 2, 3]]), cache)
+    mx.eval(output, cache.state)
+    assert output.shape == hidden.shape
+    assert cache[2].shape == (1, 9, args.hc_count * args.hidden_size)
+    assert cache[3].shape == (1, 2)
+
+    token_output = ple(
+        mx.zeros((1, 1, args.hc_count * args.hidden_size)),
+        mx.array([[4]]),
+        cache,
+    )
+    mx.eval(token_output, cache.state)
+    assert token_output.shape == (1, 1, args.hc_count * args.hidden_size)
+    assert cache[2].shape == (1, 9, args.hc_count * args.hidden_size)
+    np.testing.assert_array_equal(np.array(cache[3]), np.array([[3, 4]]))
+
+
+def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
+    cache = QSAIndexCache(compress_ratio=2)
+
+    def transform(group, start):
+        return group + start
+
+    compressed = cache.update(
+        mx.array([[[1.0], [3.0], [5.0], [7.0]]]), transform
+    )
+    mx.eval(compressed, cache.state)
+    np.testing.assert_array_equal(np.array(compressed), np.array([[[2.0], [8.0]]]))
+    assert cache.offset == 4
+    assert cache.raw_ring.shape == (1, 2, 1)
+
+    unchanged = cache.update(mx.array([[[9.0]]]), transform)
+    mx.eval(unchanged, cache.state)
+    np.testing.assert_array_equal(np.array(unchanged), np.array([[[2.0], [8.0]]]))
+    np.testing.assert_array_equal(np.array(cache.raw_ring), np.array([[[9.0], [7.0]]]))
+    assert cache.offset == 5
+    assert not cache.is_trimmable()
+
+    restored = QSAIndexCache.from_state(cache.state, cache.meta_state)
+    assert restored.offset == 5
+    assert restored.compress_ratio == 2
+    np.testing.assert_array_equal(
+        np.array(restored.compressed_keys), np.array([[[2.0], [8.0]]])
+    )
+
+
+def test_qsa_attention_prefill_and_decode_keep_both_cache_owners_aligned():
+    args = _args(
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+    prompt = mx.zeros((1, 5, args.hidden_size))
+    prompt_output = attention(prompt, cache)
+    mx.eval(prompt_output, cache.state)
+    assert prompt_output.shape == (1, 5, args.hidden_size)
+    assert cache[0].offset == 5
+    assert cache[1].offset == 5
+    assert cache[1]._compressed_count == 2
+
+    token_output = attention(mx.zeros((1, 1, args.hidden_size)), cache)
+    mx.eval(token_output, cache.state)
+    assert token_output.shape == (1, 1, args.hidden_size)
+    assert cache[0].offset == 6
+    assert cache[1].offset == 6
+    assert cache[1]._compressed_count == 3
+
+
+def test_qsa_cache_uses_standard_batch_lifecycle_without_rebuilding_history():
+    def transform(group, start):
+        return group + start
+
+    first = QSAIndexCache(compress_ratio=2)
+    second = QSAIndexCache(compress_ratio=2)
+    first.update(mx.array([[[1.0], [3.0], [5.0]]]), transform)
+    second.update(mx.array([[[2.0], [4.0], [6.0], [8.0], [10.0]]]), transform)
+
+    batch = QSAIndexCache.merge([first, second])
+    assert isinstance(batch, ArraysCache)
+    assert batch._offsets == [3, 5]
+    assert batch._compressed_counts == [1, 2]
+    np.testing.assert_array_equal(np.array(batch.left_padding), np.array([2, 0]))
+
+    batch.update(mx.array([[[7.0]], [[12.0]]]), transform)
+    mx.eval(batch.state)
+    assert batch._offsets == [4, 6]
+    assert batch._compressed_counts == [2, 3]
+
+    extracted = batch.extract(0)
+    assert extracted.offset == 4
+    np.testing.assert_array_equal(
+        np.array(extracted.compressed_keys[:, :2]), np.array([[[2.0], [8.0]]])
+    )
+
+    batch.filter(mx.array([1]))
+    assert batch._offsets == [6]
+    np.testing.assert_array_equal(np.array(batch.left_padding), np.array([0]))
+    batch.extend(QSAIndexCache.merge([extracted]))
+    assert batch._offsets == [6, 4]
+    np.testing.assert_array_equal(np.array(batch.left_padding), np.array([0, 2]))
+
+
+def test_qsa_cache_skips_right_padding_and_preserves_physical_alignment():
+    cache = QSAIndexCache(compress_ratio=2)
+    # This is the same adoption seam used by mlx-lm's _make_cache for an
+    # ArraysCache subclass.
+    cache.left_padding = mx.array([0, 0])
+    cache.prepare(lengths=[3, 1], right_padding=[0, 2])
+    cache.update(
+        mx.array(
+            [
+                [[1.0], [3.0], [5.0]],
+                [[7.0], [99.0], [99.0]],
+            ]
+        ),
+        lambda group, start: group + start,
+    )
+    assert cache._offsets == [3, 1]
+    assert cache._compressed_counts == [1, 0]
+    cache.finalize()
+    np.testing.assert_array_equal(np.array(cache.left_padding), np.array([0, 2]))
+
+
+def test_qsa_attention_continuous_batch_decode_matches_cache_lengths():
+    args = _args(
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    caches = []
+    for length in (3, 5):
+        cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+        output = attention(mx.zeros((1, length, args.hidden_size)), cache)
+        mx.eval(output, cache.state)
+        caches.append(cache)
+
+    batch_cache = CacheList.merge(caches)
+    output = attention(mx.zeros((2, 1, args.hidden_size)), batch_cache)
+    mx.eval(output, batch_cache.state)
+    assert output.shape == (2, 1, args.hidden_size)
+    np.testing.assert_array_equal(np.array(batch_cache[0].offset), np.array([4, 6]))
+    np.testing.assert_array_equal(np.array(batch_cache[1].offset), np.array([4, 6]))
+
+
+def test_complete_synthetic_text_model_prefill_and_decode():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    cache = model.make_cache()
+    prompt = mx.array([[1, 2, 3]])
+    logits = model(prompt, cache=cache)
+    mx.eval(logits, [layer.state for layer in cache])
+    assert logits.shape == (1, 3, args.vocab_size)
+    assert cache[0][0].shape == (1, 2, 20)
+    assert cache[0][2].shape == (1, 9, args.hc_count * args.hidden_size)
+    assert cache[1][0].offset == 3
+    assert cache[1][1].offset == 3
+
+    next_logits = model(mx.array([[4]]), cache=cache)
+    mx.eval(next_logits, [layer.state for layer in cache])
+    assert next_logits.shape == (1, 1, args.vocab_size)
+    assert cache[1][0].offset == 4
+    assert cache[1][1].offset == 4
+
+
+def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    weights = {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj": mx.zeros(
+            (4, 8, 8)
+        ),
+        "model.language_model.layers.0.mlp.experts.down_proj": mx.zeros(
+            (4, 8, 4)
+        ),
+        "model.language_model.layers.0.linear_attn.conv1d.weight": mx.zeros(
+            (20, 1, 3)
+        ),
+        "model.language_model.layers.0.ple.ple_embedding.ngram_embedding.shard_3.weight": mx.zeros(
+            (32, 1)
+        ),
+        "model.visual.blocks.0.weight": mx.zeros((1,)),
+        "mtp.layers.0.weight": mx.zeros((1,)),
+    }
+    sanitized = model.sanitize(weights)
+    assert (
+        "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"
+        in sanitized
+    )
+    assert (
+        "language_model.model.layers.0.mlp.switch_mlp.up_proj.weight"
+        in sanitized
+    )
+    assert (
+        "language_model.model.layers.0.mlp.switch_mlp.down_proj.weight"
+        in sanitized
+    )
+    conv = sanitized[
+        "language_model.model.layers.0.linear_attn.conv1d.weight"
+    ]
+    assert conv.shape == (20, 3, 1)
+    assert (
+        "language_model.model.layers.0.ple.ple_embedding.ngram_embedding.shards.3.weight"
+        in sanitized
+    )
+    assert all("visual" not in key and not key.startswith("mtp") for key in sanitized)

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -196,16 +196,21 @@ def test_ngram_multipliers_match_released_reference_constants():
     ]
 
 
-def _ple_args():
-    return _args(
-        layer_types=["linear_attention", "qwen_sparse_attention"],
-        ple_layer_ids=[1],
-        ple_embed_dim=16,
-        ngram_vocab_size_base=17,
-        make_ngram_vocab_size_divisible_by=4,
-        split_ngram_parts=4,
-        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
-    )
+def _ple_args(**overrides):
+    values = {
+        "layer_types": ["linear_attention", "qwen_sparse_attention"],
+        "ple_layer_ids": [1],
+        "ple_embed_dim": 16,
+        "ngram_vocab_size_base": 17,
+        "make_ngram_vocab_size_divisible_by": 4,
+        "split_ngram_parts": 4,
+        "rope_parameters": {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.5,
+        },
+    }
+    values.update(overrides)
+    return _args(**values)
 
 
 def test_ngram_cache_matches_one_shot_across_request_chunks():
@@ -226,6 +231,17 @@ def test_ngram_context_resets_at_eos_boundary():
     args = _ple_args()
     embedding = NGramEmbedding(args, embedding_dim=16, ple_layer_index=0)
     with_history = embedding.compute_ids(mx.array([[7, 8, 31, 9]]))
+    fresh_segment = embedding.compute_ids(mx.array([[9]]))
+    mx.eval(with_history, fresh_segment)
+    np.testing.assert_array_equal(
+        np.array(with_history[:, -1]), np.array(fresh_segment[:, -1])
+    )
+
+
+def test_ngram_context_resets_at_every_declared_eos_boundary():
+    args = _ple_args(eos_token_id=[31, 32])
+    embedding = NGramEmbedding(args, embedding_dim=16, ple_layer_index=0)
+    with_history = embedding.compute_ids(mx.array([[7, 8, 32, 9]]))
     fresh_segment = embedding.compute_ids(mx.array([[9]]))
     mx.eval(with_history, fresh_segment)
     np.testing.assert_array_equal(

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -8,6 +8,8 @@ pytest.importorskip("mlx_lm")
 
 from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 
+import vllm_mlx.models.qwen4_exp as qwen4_exp
+from scripts.qwen38_streaming_convert import quantized_tensor_names
 from vllm_mlx.models.qwen4_exp import (
     GatedDeltaNet,
     GatedResidual,
@@ -16,9 +18,11 @@ from vllm_mlx.models.qwen4_exp import (
     NGramEmbedding,
     PLELayer,
     QSAAttention,
+    QSAIndexer,
     ShardedEmbedding,
     TextModelArgs,
     ZeroCenteredRMSNorm,
+    apply_qwen4_exp_rope,
     build_layer_multipliers,
 )
 from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
@@ -67,6 +71,28 @@ def test_config_rejects_partial_indexer_contract():
         _args(indexer_budget=None)
 
 
+def test_qwen4_rope_uses_reference_half_split_pairing():
+    values = np.array([[[[0.25, -0.5, 0.75, 1.0]]]], dtype=np.float32)
+    output = apply_qwen4_exp_rope(
+        mx.array(values),
+        mx.array([[39]], dtype=mx.int64),
+        rotary_dim=4,
+        base=10_000_000,
+    )
+    frequencies = 1.0 / (10_000_000 ** (np.arange(0, 4, 2, dtype=np.float32) / 4))
+    angles = 39 * frequencies
+    first = values[..., :2]
+    second = values[..., 2:]
+    expected = np.concatenate(
+        [
+            first * np.cos(angles) - second * np.sin(angles),
+            second * np.cos(angles) + first * np.sin(angles),
+        ],
+        axis=-1,
+    )
+    np.testing.assert_allclose(np.asarray(output), expected, rtol=1e-5, atol=1e-5)
+
+
 def test_zero_centered_grouped_rms_norm_matches_numpy():
     norm = ZeroCenteredRMSNorm(8, group_size=4, eps=1e-6)
     norm.weight = mx.array(np.linspace(-0.2, 0.2, 8, dtype=np.float32))
@@ -75,7 +101,9 @@ def test_zero_centered_grouped_rms_norm_matches_numpy():
     grouped = x_np.reshape(1, 2, 2, 4)
     expected = grouped / np.sqrt(np.mean(grouped**2, axis=-1, keepdims=True) + 1e-6)
     expected *= (1 + np.linspace(-0.2, 0.2, 8, dtype=np.float32)).reshape(2, 4)
-    np.testing.assert_allclose(np.array(out), expected.reshape(x_np.shape), rtol=2e-5, atol=2e-5)
+    np.testing.assert_allclose(
+        np.array(out), expected.reshape(x_np.shape), rtol=2e-5, atol=2e-5
+    )
 
 
 def test_gated_residual_matches_reference_equations():
@@ -109,7 +137,9 @@ def test_gated_residual_matches_reference_equations():
     )
     np.testing.assert_allclose(np.array(mixed), expected_mixed, rtol=3e-5, atol=3e-5)
     np.testing.assert_array_equal(np.array(residual), x_np)
-    np.testing.assert_allclose(np.array(injection), expected_injection, rtol=3e-5, atol=3e-5)
+    np.testing.assert_allclose(
+        np.array(injection), expected_injection, rtol=3e-5, atol=3e-5
+    )
 
 
 def test_gdn_ratio_three_state_shapes_and_cached_decode():
@@ -137,7 +167,9 @@ def test_sharded_embedding_preserves_global_row_identity():
         shard.weight = mx.array(np.repeat(rows[:, None], 4, axis=1))
     ids = mx.array([[0, 3, 4, 9, 15]])
     output = embedding(ids)
-    expected = np.repeat(np.array([[0, 3, 4, 9, 15]], dtype=np.float32)[..., None], 4, axis=-1)
+    expected = np.repeat(
+        np.array([[0, 3, 4, 9, 15]], dtype=np.float32)[..., None], 4, axis=-1
+    )
     np.testing.assert_array_equal(np.array(output), expected)
 
 
@@ -244,9 +276,7 @@ def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
     def transform(group, start):
         return group + start
 
-    compressed = cache.update(
-        mx.array([[[1.0], [3.0], [5.0], [7.0]]]), transform
-    )
+    compressed = cache.update(mx.array([[[1.0], [3.0], [5.0], [7.0]]]), transform)
     mx.eval(compressed, cache.state)
     np.testing.assert_array_equal(np.array(compressed), np.array([[[2.0], [8.0]]]))
     assert cache.offset == 4
@@ -283,12 +313,8 @@ def test_qsa_cache_rewinds_recoverable_group_and_recomputes_divergence(length):
     cold.update(mx.array(expected_values.reshape(1, -1, 1)), transform)
     mx.eval(original.state, cold.state)
     assert original.offset == cold.offset == length
-    np.testing.assert_array_equal(
-        np.array(original.state[1]), np.array(cold.state[1])
-    )
-    np.testing.assert_array_equal(
-        np.array(original.raw_ring), np.array(cold.raw_ring)
-    )
+    np.testing.assert_array_equal(np.array(original.state[1]), np.array(cold.state[1]))
+    np.testing.assert_array_equal(np.array(original.raw_ring), np.array(cold.raw_ring))
 
 
 def test_qsa_cache_refuses_rewind_beyond_retained_raw_group():
@@ -323,6 +349,61 @@ def test_qsa_attention_prefill_and_decode_keep_both_cache_owners_aligned():
     assert cache[0].offset == 6
     assert cache[1].offset == 6
     assert cache[1]._compressed_count == 3
+
+
+def test_qsa_attention_uses_reference_dense_path_below_sparse_budget(monkeypatch):
+    args = _args(
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+    observed = []
+
+    def fake_attention(queries, keys, values, *, cache, scale, mask):
+        observed.append(mask)
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(
+        "vllm_mlx.models.qwen4_exp.scaled_dot_product_attention",
+        fake_attention,
+    )
+    output = attention(mx.zeros((1, 5, args.hidden_size)), cache)
+    mx.eval(output, cache.state)
+
+    assert observed == ["causal"]
+    assert cache[0].offset == cache[1].offset == 5
+
+
+def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
+    args = _args(
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    indexer = QSAIndexer(args)
+    cache = QSAIndexCache(compress_ratio=2)
+    original = qwen4_exp.mx.matmul
+    shapes = []
+
+    def record_matmul(left, right):
+        shapes.append((left.shape, right.shape))
+        return original(left, right)
+
+    monkeypatch.setattr(qwen4_exp.mx, "matmul", record_matmul)
+    selected = indexer(
+        mx.zeros((1, 6, args.hidden_size), dtype=mx.bfloat16),
+        cache,
+        physical_kv_length=6,
+    )
+    mx.eval(selected)
+    assert shapes == [
+        (
+            (args.indexer_n_heads, 6, args.indexer_head_dim),
+            (args.indexer_head_dim, 3),
+        )
+    ]
 
 
 def test_qsa_cache_uses_standard_batch_lifecycle_without_rebuilding_history():
@@ -464,15 +545,21 @@ def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
     args = _ple_args()
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
     weights = {
-        "model.language_model.layers.0.mlp.experts.gate_up_proj": mx.zeros(
-            (4, 8, 8)
+        "model.language_model.layers.0.mlp.experts.gate_up_proj": mx.zeros((4, 8, 8)),
+        "model.language_model.layers.0.mlp.experts.down_proj": mx.zeros((4, 8, 4)),
+        "model.language_model.layers.0.mlp.experts.gate_up_proj.scales": mx.zeros(
+            (4, 8, 1)
         ),
-        "model.language_model.layers.0.mlp.experts.down_proj": mx.zeros(
-            (4, 8, 4)
+        "model.language_model.layers.0.mlp.experts.gate_up_proj.biases": mx.zeros(
+            (4, 8, 1)
         ),
-        "model.language_model.layers.0.linear_attn.conv1d.weight": mx.zeros(
-            (20, 1, 3)
+        "model.language_model.layers.0.mlp.experts.down_proj.scales": mx.zeros(
+            (4, 8, 1)
         ),
+        "model.language_model.layers.0.mlp.experts.down_proj.biases": mx.zeros(
+            (4, 8, 1)
+        ),
+        "model.language_model.layers.0.linear_attn.conv1d.weight": mx.zeros((20, 1, 3)),
         "model.language_model.layers.0.ple.ple_embedding.ngram_embedding.shard_3.weight": mx.zeros(
             (32, 1)
         ),
@@ -480,21 +567,16 @@ def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
         "mtp.layers.0.weight": mx.zeros((1,)),
     }
     sanitized = model.sanitize(weights)
-    assert (
-        "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"
-        in sanitized
-    )
-    assert (
-        "language_model.model.layers.0.mlp.switch_mlp.up_proj.weight"
-        in sanitized
-    )
-    assert (
-        "language_model.model.layers.0.mlp.switch_mlp.down_proj.weight"
-        in sanitized
-    )
-    conv = sanitized[
-        "language_model.model.layers.0.linear_attn.conv1d.weight"
-    ]
+    assert "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight" in sanitized
+    assert "language_model.model.layers.0.mlp.switch_mlp.up_proj.weight" in sanitized
+    assert "language_model.model.layers.0.mlp.switch_mlp.down_proj.weight" in sanitized
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        for auxiliary in ("scales", "biases"):
+            assert (
+                f"language_model.model.layers.0.mlp.switch_mlp."
+                f"{projection}.{auxiliary}" in sanitized
+            )
+    conv = sanitized["language_model.model.layers.0.linear_attn.conv1d.weight"]
     assert conv.shape == (20, 3, 1)
     assert (
         "language_model.model.layers.0.ple.ple_embedding.ngram_embedding.shards.3.weight"
@@ -503,21 +585,57 @@ def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
     assert all("visual" not in key and not key.startswith("mtp") for key in sanitized)
 
 
+def test_converter_quantized_keys_match_loader_sanitizer_contract():
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(_ple_args())))
+    ordinary = "model.language_model.layers.0.self_attn.q_proj.weight"
+    assert quantized_tensor_names(ordinary) == (
+        ordinary,
+        "model.language_model.layers.0.self_attn.q_proj.scales",
+        "model.language_model.layers.0.self_attn.q_proj.biases",
+    )
+
+    emitted = {}
+    for name, shape in (
+        (ordinary, (8, 8)),
+        ("model.language_model.layers.0.mlp.experts.gate_up_proj", (4, 8, 8)),
+        ("model.language_model.layers.0.mlp.experts.down_proj", (4, 8, 4)),
+    ):
+        weight, scales, biases = quantized_tensor_names(name)
+        emitted[weight] = mx.zeros(shape)
+        aux_shape = (*shape[:-2], shape[-2], 1)
+        emitted[scales] = mx.zeros(aux_shape)
+        emitted[biases] = mx.zeros(aux_shape)
+
+    sanitized = model.sanitize(emitted)
+    expected = {
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "language_model.model.layers.0.self_attn.q_proj.scales",
+        "language_model.model.layers.0.self_attn.q_proj.biases",
+    }
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        expected.update(
+            {
+                f"language_model.model.layers.0.mlp.switch_mlp.{projection}.weight",
+                f"language_model.model.layers.0.mlp.switch_mlp.{projection}.scales",
+                f"language_model.model.layers.0.mlp.switch_mlp.{projection}.biases",
+            }
+        )
+    assert set(sanitized) == expected
+
+
 def test_quantization_contract_uses_shape_exact_ple_groups_and_q8_routing():
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=_ple_args().__dict__))
     predicate = model.quant_predicate
 
     assert predicate(
-        "language_model.model.layers.1.ple.ple_embedding."
-        "ngram_embedding.shards.3",
+        "language_model.model.layers.1.ple.ple_embedding.ngram_embedding.shards.3",
         object(),
     ) == {"group_size": 32, "bits": 4}
-    assert predicate(
-        "language_model.model.layers.1.mlp.gate", object()
-    ) == {"group_size": 64, "bits": 8}
+    assert predicate("language_model.model.layers.1.mlp.gate", object()) == {
+        "group_size": 64,
+        "bits": 8,
+    }
     assert predicate(
         "language_model.model.layers.1.mlp.shared_expert_gate", object()
     ) == {"group_size": 64, "bits": 8}
-    assert predicate(
-        "language_model.model.layers.1.self_attn.q_proj", object()
-    ) is True
+    assert predicate("language_model.model.layers.1.self_attn.q_proj", object()) is True

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -376,6 +376,61 @@ def test_qsa_attention_uses_reference_dense_path_below_sparse_budget(monkeypatch
     assert cache[0].offset == cache[1].offset == 5
 
 
+def test_qsa_batch_prefill_builds_mask_before_kv_update(monkeypatch):
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    attention = QSAAttention(args)
+    qsa = QSAIndexCache(compress_ratio=2)
+    qsa.left_padding = mx.array([0])
+    cache = CacheList(BatchKVCache([0]), qsa)
+    observed = []
+
+    def fake_attention(queries, keys, values, *, cache, scale, mask):
+        observed.append((keys.shape[-2], mask.shape[-1]))
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(
+        "vllm_mlx.models.qwen4_exp.scaled_dot_product_attention",
+        fake_attention,
+    )
+    output = attention(mx.zeros((1, 5, args.hidden_size)), cache)
+    mx.eval(output, cache.state)
+    assert observed == [(5, 5)]
+
+
+def test_scheduler_mid_prefill_restores_qsa_cachelist():
+    """The live restore path recognizes the same vendored QSA side-cache."""
+    from vllm_mlx.scheduler import Scheduler
+
+    scheduler = Scheduler.__new__(Scheduler)
+    kv = KVCache()
+    values = mx.arange(20, dtype=mx.float32).reshape(1, 1, 5, 4)
+    kv.update_and_fetch(values, -values)
+    qsa = QSAIndexCache(compress_ratio=2)
+    qsa.update(
+        mx.arange(20, dtype=mx.float32).reshape(1, 5, 4),
+        lambda group, start: group + start,
+    )
+    original = CacheList(kv, qsa)
+
+    restored = scheduler._reconstruct_cache_from_states(
+        [
+            {
+                "state": original.state,
+                "meta_state": original.meta_state,
+                "class_ref": CacheList,
+            }
+        ]
+    )
+
+    assert restored is not None
+    restored_qsa = restored[0].caches[1]
+    assert isinstance(restored_qsa, QSAIndexCache)
+    assert restored_qsa.offset == qsa.offset
+    np.testing.assert_array_equal(
+        np.array(restored_qsa.state[1]), np.array(qsa.state[1])
+    )
+
+
 def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
     args = _args(
         indexer_budget=2,

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -501,3 +501,23 @@ def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
         in sanitized
     )
     assert all("visual" not in key and not key.startswith("mtp") for key in sanitized)
+
+
+def test_quantization_contract_uses_shape_exact_ple_groups_and_q8_routing():
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=_ple_args().__dict__))
+    predicate = model.quant_predicate
+
+    assert predicate(
+        "language_model.model.layers.1.ple.ple_embedding."
+        "ngram_embedding.shards.3",
+        object(),
+    ) == {"group_size": 32, "bits": 4}
+    assert predicate(
+        "language_model.model.layers.1.mlp.gate", object()
+    ) == {"group_size": 64, "bits": 8}
+    assert predicate(
+        "language_model.model.layers.1.mlp.shared_expert_gate", object()
+    ) == {"group_size": 64, "bits": 8}
+    assert predicate(
+        "language_model.model.layers.1.self_attn.q_proj", object()
+    ) is True

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import asdict
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -86,6 +87,59 @@ def test_config_rejects_partial_indexer_contract():
         _args(indexer_budget=None)
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"num_hidden_layers": 1}, "one entry per decoder layer"),
+        ({"layer_types": ["linear_attention", "unknown"]}, "Unsupported"),
+        ({"hc_count": 1}, "four-stream HC dimensions"),
+        (
+            {"linear_num_key_heads": 3, "linear_num_value_heads": 2},
+            "divisible by key heads",
+        ),
+        ({"output_gate_type": "silu"}, "sigmoid GDN gate"),
+        ({"indexer_budget": 0}, "indexer values must be positive"),
+        ({"indexer_kv_heads": 2}, "one indexer KV head"),
+        ({"indexer_budget": 7}, "divisible by indexer_compress_ratio"),
+        (
+            {"rope_parameters": {"partial_rotary_factor": 2.0}},
+            "rotary dimensions must fit",
+        ),
+        ({"num_experts_per_tok": 5}, "within num_experts"),
+        ({"ple_layer_ids": [1], "ple_embed_dim": 15}, "divide evenly"),
+        ({"ple_layer_ids": [3], "ple_embed_dim": 16}, "one-indexed"),
+        (
+            {"ple_layer_ids": [2], "ple_embed_dim": 16},
+            "only valid on linear-attention",
+        ),
+        (
+            {"ple_layer_ids": [1], "ple_embed_dim": 16, "eos_token_id": None},
+            "requires eos_token_id",
+        ),
+        (
+            {"ple_layer_ids": [1], "ple_embed_dim": 16, "eos_token_id": []},
+            "must not be empty",
+        ),
+    ],
+)
+def test_config_rejects_invalid_architecture_contracts(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _args(**overrides)
+
+
+def test_config_synthesizes_layer_schedule_and_accepts_flat_model_args():
+    args = _args(layer_types=None, full_attention_interval=2)
+    assert args.layer_types == ["linear_attention", "qwen_sparse_attention"]
+    flat = asdict(args)
+    flat["model_type"] = "qwen4_exp"
+    parsed = ModelArgs.from_dict(flat)
+    assert parsed.text_config["hidden_size"] == args.hidden_size
+    nested = ModelArgs.from_dict(
+        {"model_type": "qwen4_exp", "text_config": asdict(_args())}
+    )
+    assert nested.text_config["hidden_size"] == args.hidden_size
+
+
 def test_qwen4_rope_uses_reference_half_split_pairing():
     values = np.array([[[[0.25, -0.5, 0.75, 1.0]]]], dtype=np.float32)
     output = apply_qwen4_exp_rope(
@@ -108,6 +162,37 @@ def test_qwen4_rope_uses_reference_half_split_pairing():
     np.testing.assert_allclose(np.asarray(output), expected, rtol=1e-5, atol=1e-5)
 
 
+def test_rotary_fallback_guards_and_one_dimensional_positions():
+    x = mx.ones((1, 2, 1, 4))
+    assert (
+        qwen4_exp.apply_rotary_positions(x, mx.array([0, 1]), rotary_dim=0, base=10_000)
+        is x
+    )
+    with pytest.raises(ValueError, match="must be even"):
+        qwen4_exp.apply_rotary_positions(x, mx.array([0, 1]), rotary_dim=3, base=10_000)
+    output = qwen4_exp.apply_rotary_positions(
+        x, mx.array([0, 1]), rotary_dim=4, base=10_000
+    )
+    assert output.shape == x.shape
+
+
+def test_qwen4_rope_kernel_contract_and_fallback(monkeypatch):
+    with pytest.raises(ValueError, match="requires 2-D position IDs"):
+        qwen4_exp._qwen4_exp_rope_kernel.__wrapped__(4, 1)
+
+    monkeypatch.setattr(qwen4_exp.mx.metal, "is_available", lambda: False)
+    assert qwen4_exp._qwen4_exp_rope_kernel.__wrapped__(4, 2) is None
+
+    monkeypatch.setattr(qwen4_exp, "_qwen4_exp_rope_kernel", lambda *_args: None)
+    output = apply_qwen4_exp_rope(
+        mx.ones((1, 1, 2, 4)),
+        mx.array([[0, 1]], dtype=mx.int64),
+        rotary_dim=4,
+        base=10_000,
+    )
+    assert output.shape == (1, 1, 2, 4)
+
+
 def test_zero_centered_grouped_rms_norm_matches_numpy():
     norm = ZeroCenteredRMSNorm(8, group_size=4, eps=1e-6)
     norm.weight = mx.array(np.linspace(-0.2, 0.2, 8, dtype=np.float32))
@@ -119,6 +204,11 @@ def test_zero_centered_grouped_rms_norm_matches_numpy():
     np.testing.assert_allclose(
         np.array(out), expected.reshape(x_np.shape), rtol=2e-5, atol=2e-5
     )
+
+
+def test_zero_centered_rms_norm_rejects_partial_group():
+    with pytest.raises(ValueError, match="divide the feature width"):
+        ZeroCenteredRMSNorm(7, group_size=4)
 
 
 def test_gated_residual_matches_reference_equations():
@@ -157,6 +247,15 @@ def test_gated_residual_matches_reference_equations():
     )
 
 
+def test_gated_residual_shape_guard_and_read_only_variant():
+    args = _args()
+    layer = GatedResidual(args, use_combine=False)
+    mixed = layer(mx.zeros((1, 2, args.hc_count * args.hidden_size)))
+    assert mixed.shape == (1, 2, args.hidden_size)
+    with pytest.raises(ValueError, match="HC expected"):
+        layer(mx.zeros((1, 2, args.hidden_size)))
+
+
 def test_gdn_ratio_three_state_shapes_and_cached_decode():
     args = _args()
     layer = GatedDeltaNet(args)
@@ -175,6 +274,19 @@ def test_gdn_ratio_three_state_shapes_and_cached_decode():
     assert cache[1].shape == (1, 3, 4, 4)
 
 
+def test_gdn_honors_mask_and_per_row_valid_lengths():
+    layer = GatedDeltaNet(_args())
+    cache = ArraysCache(size=2)
+    cache.prepare(lengths=[1])
+    output = layer(
+        mx.zeros((1, 2, 8)),
+        mask=mx.array([[True, False]]),
+        cache=cache,
+    )
+    mx.eval(output, cache.state)
+    assert output.shape == (1, 2, 8)
+
+
 def test_sharded_embedding_preserves_global_row_identity():
     embedding = ShardedEmbedding(num_embeddings=16, dims=4, parts=4)
     for shard_id, shard in enumerate(embedding.shards):
@@ -186,6 +298,16 @@ def test_sharded_embedding_preserves_global_row_identity():
         np.array([[0, 3, 4, 9, 15]], dtype=np.float32)[..., None], 4, axis=-1
     )
     np.testing.assert_array_equal(np.array(output), expected)
+
+
+def test_sharded_embedding_guards_and_empty_input():
+    with pytest.raises(ValueError, match="divide evenly"):
+        ShardedEmbedding(num_embeddings=15, dims=4, parts=4)
+    embedding = ShardedEmbedding(num_embeddings=16, dims=4, parts=4)
+    output = embedding(mx.array([], dtype=mx.int32).reshape(1, 0))
+    assert output.shape == (1, 0, 4)
+    assert qwen4_exp._is_prime(1) is False
+    assert qwen4_exp._is_prime(2) is True
 
 
 def test_ngram_multipliers_match_released_reference_constants():
@@ -551,6 +673,17 @@ def test_scheduler_mid_prefill_restores_qsa_cachelist():
         np.array(restored_qsa.state[1]), np.array(qsa.state[1])
     )
 
+    malformed = scheduler._reconstruct_cache_from_states(
+        [
+            {
+                "state": original.state,
+                "meta_state": ("missing-nested-metadata",),
+                "class_ref": CacheList,
+            }
+        ]
+    )
+    assert malformed is None
+
 
 def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
     args = _args(
@@ -580,6 +713,36 @@ def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
             (args.indexer_head_dim, 3),
         )
     ]
+
+
+def test_qsa_indexer_fail_closed_internal_invariants():
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    indexer = QSAIndexer(args)
+    indexer.num_kv_heads = 2
+    indexer.index_qk_proj = qwen4_exp.nn.Linear(
+        args.hidden_size,
+        indexer.num_heads * indexer.head_dim + 2 * indexer.head_dim,
+        bias=False,
+    )
+    with pytest.raises(ValueError, match="one indexer KV head"):
+        indexer(
+            mx.zeros((1, 2, args.hidden_size)),
+            QSAIndexCache(compress_ratio=2),
+            physical_kv_length=2,
+        )
+
+    inconsistent = QSAIndexer(args)
+    inconsistent.block_topk = 1
+    inconsistent_cache = QSAIndexCache(compress_ratio=2)
+    inconsistent_cache._offsets = [4]
+    inconsistent_cache._compressed_counts = [1]
+    inconsistent_cache.raw_ring = mx.zeros((1, 2, args.indexer_head_dim))
+    with pytest.raises(RuntimeError, match="selection was not materialized"):
+        inconsistent(
+            mx.zeros((1, 1, args.hidden_size)),
+            inconsistent_cache,
+            physical_kv_length=5,
+        )
 
 
 def test_qsa_cache_uses_standard_batch_lifecycle_without_rebuilding_history():
@@ -947,3 +1110,185 @@ def test_quantization_contract_uses_shape_exact_ple_groups_and_q8_routing():
         "language_model.model.layers.1.mlp.shared_expert_gate", object()
     ) == {"group_size": 64, "bits": 8}
     assert predicate("language_model.model.layers.1.self_attn.q_proj", object()) is True
+
+
+def test_qsa_cache_fail_closed_guards_and_diagnostics():
+    with pytest.raises(ValueError, match="compression ratio must be positive"):
+        QSAIndexCache(compress_ratio=0)
+
+    cache = QSAIndexCache(compress_ratio=2)
+    cache.update(mx.ones((1, 1, 3)), lambda pooled, _position: pooled)
+    with pytest.raises(ValueError, match="shape changed"):
+        cache.update(mx.ones((1, 1, 4)), lambda pooled, _position: pooled)
+    with pytest.raises(ValueError, match="out of range"):
+        cache.keys_for_blocks(0, 1)
+    assert cache.keys_for_blocks(0, 0).shape == (0, 0)
+    assert cache.valid_lengths(2) == [2]
+    assert cache.can_trim(-1) is False
+    assert cache.can_trim(0) is True
+    checkpoint = cache.trim_checkpoint()
+    cache.restore_trim_checkpoint(checkpoint)
+    assert cache.size() == 1
+    assert cache.empty() is False
+    assert cache.nbytes > 0
+
+    batched = QSAIndexCache.merge([cache, cache.extract(0)])
+    with pytest.raises(AttributeError, match="per-row compressed counts"):
+        _ = batched._compressed_count
+    batched.prepare(lengths=[1, 1])
+    batched.filter(mx.array([1], dtype=mx.int32))
+    assert batched.size() == 1
+
+    inconsistent = QSAIndexCache(compress_ratio=2)
+    inconsistent._compressed_counts = [1]
+    with pytest.raises(ValueError, match="compressed cache is empty"):
+        inconsistent.keys_for_blocks(0, 1)
+
+
+def test_qsa_cache_rejects_invalid_batch_and_merge_contracts():
+    cache = QSAIndexCache(compress_ratio=2, left_padding=[0])
+    with pytest.raises(ValueError, match="batch metadata"):
+        cache._ensure_batch(2)
+
+    committed = QSAIndexCache(compress_ratio=2)
+    committed.update(mx.ones((1, 1, 2)), lambda pooled, _position: pooled)
+    with pytest.raises(ValueError, match="outside cache lifecycle"):
+        committed._ensure_batch(2)
+
+    with pytest.raises(ValueError, match="empty QSA cache list"):
+        QSAIndexCache.merge([])
+    with pytest.raises(ValueError, match="share compression ratio"):
+        QSAIndexCache.merge(
+            [QSAIndexCache(compress_ratio=2), QSAIndexCache(compress_ratio=4)]
+        )
+
+
+def test_model_wrapper_properties_sanitize_and_tied_logits():
+    args = _ple_args(tie_word_embeddings=True)
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    assert model.model is model.language_model.model
+    assert model.layers is model.language_model.layers
+    assert model.cast_predicate("layers.0.A_log") is False
+    assert model.cast_predicate("layers.0.weight") is True
+
+    mapped = model.sanitize(
+        {
+            "model.visual.weight": mx.ones((1,)),
+            "vision_tower.weight": mx.ones((1,)),
+            "mtp.weight": mx.ones((1,)),
+            "model.language_model.embed_tokens.weight": mx.ones((2, 2)),
+            "model.norm.weight": mx.ones((2,)),
+            "language_model.model.keep.weight": mx.ones((2,)),
+            "language_model.model.layers.0.mlp.experts.gate_up_proj.unknown": mx.ones(
+                (1, 2, 2)
+            ),
+        }
+    )
+    assert all("visual" not in key and "mtp" not in key for key in mapped)
+    assert any(key.endswith("gate_up_proj.unknown") for key in mapped)
+
+    embeddings = mx.zeros((1, 2, args.hidden_size))
+    logits = model(mx.array([[1, 2]]), input_embeddings=embeddings)
+    assert logits.shape == (1, 2, args.vocab_size)
+
+
+def test_experimental_capability_uses_live_residency_truth(monkeypatch):
+    from vllm_mlx.routes import models as models_route
+
+    entry = SimpleNamespace(
+        experimental=True,
+        matches=lambda model_id: model_id == "served-flash",
+    )
+    registry = SimpleNamespace(get_entry=lambda _model_id: entry)
+    monkeypatch.setattr(
+        models_route,
+        "get_config",
+        lambda: SimpleNamespace(
+            model_registry=registry,
+            model_name=None,
+            model_alias=None,
+            engine=None,
+        ),
+    )
+    assert models_route._served_experimental("served-flash") is True
+    assert models_route._served_experimental("other") is False
+
+    registry.get_entry = lambda _model_id: (_ for _ in ()).throw(KeyError("gone"))
+    assert models_route._served_experimental("served-flash") is False
+
+    monkeypatch.setattr(
+        models_route,
+        "get_config",
+        lambda: SimpleNamespace(
+            model_registry=None,
+            model_name="served-flash",
+            model_alias=None,
+            engine=SimpleNamespace(experimental=True),
+            embedding_model_locked=False,
+        ),
+    )
+    assert models_route._served_experimental("served-flash") is True
+    assert models_route._served_experimental("other") is False
+    assert (
+        models_route._detect_capabilities(
+            "served-flash",
+            profile_modality="text",
+            is_text_only=True,
+            profile_tool_parser=None,
+            experimental=True,
+        )[-1]
+        == "experimental"
+    )
+
+
+def test_qwen4_registration_probes_native_and_fails_closed(monkeypatch, caplog):
+    import builtins
+    import importlib.util
+    import sys
+
+    import vllm_mlx.models as model_package
+    from vllm_mlx.utils import tokenizer
+
+    module_name = "mlx_lm.models.qwen4_exp"
+    monkeypatch.setattr(
+        tokenizer, "_VENDORED_MODEL_TYPES", set(tokenizer._VENDORED_MODEL_TYPES)
+    )
+    tokenizer._register_vendored_archs()
+
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    original_find_spec = importlib.util.find_spec
+    monkeypatch.setattr(
+        importlib.util,
+        "find_spec",
+        lambda name: object() if name == module_name else original_find_spec(name),
+    )
+    tokenizer._register_vendored_archs()
+    assert "qwen4_exp" in tokenizer._VENDORED_MODEL_TYPES
+
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    def rejecting_probe(name):
+        if name == module_name:
+            raise ValueError("injected missing parent")
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", rejecting_probe)
+    tokenizer._register_vendored_archs()
+    assert module_name in sys.modules
+
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    monkeypatch.delitem(sys.modules, "vllm_mlx.models.qwen4_exp", raising=False)
+    monkeypatch.delattr(model_package, "qwen4_exp", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda _name: None)
+    original_import = builtins.__import__
+
+    def rejecting_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 2 and "qwen4_exp" in fromlist:
+            raise ImportError("injected vendored import failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    tokenizer._VENDORED_MODEL_TYPES.discard("qwen4_exp")
+    monkeypatch.setattr(builtins, "__import__", rejecting_import)
+    tokenizer._register_vendored_archs()
+    assert "qwen4_exp" not in tokenizer._VENDORED_MODEL_TYPES
+    assert "failed to register" in caplog.text

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -276,12 +276,16 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
     monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
     monkeypatch.setattr(
         "vllm_mlx.model_auto_config.detect_model_config",
-        lambda _name: ModelProfile(is_hybrid=False),
+        lambda _name: ModelProfile(is_hybrid=False, experimental=True),
     )
 
     server.load_model("publisher/model")
     startup_kwargs = dict(server._engine.kwargs)
     runtime = await server._load_dynamic_resident_model("publisher/model", None)
+
+    startup = server._model_registry.get_entry("publisher/model")
+    assert startup.experimental is True
+    assert runtime.experimental is True
 
     assert calls == [
         (

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -388,6 +388,91 @@ class TestInstallSuffixDecoding:
         assert "ft_non_trimmable_cache" in bg._suffix_stats
         assert bg._suffix_stats["ft_non_trimmable_cache"] == 0
 
+    @staticmethod
+    def _install_verify_fixture(
+        monkeypatch, predictions, *, trim_result, source_response=False
+    ):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import mlx.core as mx
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.speculative import suffix_decoding
+
+        class Drafter:
+            def __init__(self, **_kwargs):
+                self.max_draft_tokens = 2
+
+            def add_prompt_tokens(self, _tokens):
+                pass
+
+            def add_generated_token(self, _token):
+                pass
+
+            def get_draft(self):
+                return [2, 3]
+
+            def record_acceptance(self, _count):
+                pass
+
+        class Cache:
+            def can_trim(self, _n):
+                return True
+
+            def trim(self, _n):
+                return trim_result
+
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        bg, gb = TestInstallSuffixDecoding()._make_fake_bg()
+        gb._next_tokens = mx.array([1], dtype=mx.int32)
+        gb._next_logprobs = [mx.zeros((5,))]
+        gb.uids = [1]
+        gb.tokens = [[]]
+        gb.logits_processors = None
+        gb.prompt_cache = [Cache()]
+        logits = mx.full((1, 3, 5), -10.0)
+        for index, token in enumerate(predictions):
+            logits[0, index, token] = 10.0
+        gb.model = lambda _tokens, cache: logits
+        gb._num_tokens = [0]
+        gb.max_tokens = [1]
+        gb.state_machines = [
+            SimpleNamespace(match=lambda state, _tok: (state, None, None))
+        ]
+        gb._matcher_states = [None]
+        gb.Response = SimpleNamespace
+        gb.extract_cache = lambda _row: gb.prompt_cache
+        if source_response:
+            gb.next = lambda: [SimpleNamespace(uid=1, finish_reason=None)]
+        scheduler._install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=None,
+            max_draft=2,
+            max_suffix_len=2,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+        )
+        return bg, gb
+
+    def test_verify_rollback_fails_closed_after_rejected_drafts(self, monkeypatch):
+        _bg, gb = self._install_verify_fixture(monkeypatch, [0, 0, 0], trim_result=0)
+        with pytest.raises(RuntimeError, match="rollback violated its preflight"):
+            gb._step()
+
+    def test_terminal_pending_emit_rollback_fails_closed(self, monkeypatch):
+        _bg, gb = self._install_verify_fixture(
+            monkeypatch,
+            [2, 3, 4],
+            trim_result=0,
+            source_response=True,
+        )
+        gb._step()
+        with pytest.raises(RuntimeError, match="terminal cache rollback"):
+            gb.next()
+
     def test_local_stats_have_a_reason_key_for_every_fallthrough(self):
         """``_suffix_stats``'s documented invariant is that the ``ft_*``
         breakdown sums to ``fallthrough_steps``.

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -373,6 +373,17 @@
     "mtp_draft_model": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
     "mtp_speculative_tokens": 3
   },
+  "qwen3.8-flash-next-4bit": {
+    "hf_path": "rapid-mlx/Qwen3.8-Flash-Next-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_hybrid_explicit": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "min_memory_gb": 128,
+    "experimental": true
+  },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
     "tool_call_parser": "qwen3_coder_xml",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -373,6 +373,18 @@
     "mtp_draft_model": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
     "mtp_speculative_tokens": 3
   },
+  "qwen3.8-flash-next-4bit-experimental": {
+    "hf_path": "mlx-community/Qwen3.8-Flash-Next-4bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_hybrid_explicit": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "min_memory_gb": 128,
+    "experimental": true,
+    "hidden": true
+  },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
     "tool_call_parser": "qwen3_coder_xml",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -373,18 +373,6 @@
     "mtp_draft_model": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
     "mtp_speculative_tokens": 3
   },
-  "qwen3.8-flash-next-4bit-experimental": {
-    "hf_path": "mlx-community/Qwen3.8-Flash-Next-4bit",
-    "tool_call_parser": "qwen3_coder_xml",
-    "reasoning_parser": "qwen3",
-    "is_hybrid": true,
-    "is_hybrid_explicit": true,
-    "is_moe": true,
-    "supports_spec_decode": false,
-    "min_memory_gb": 128,
-    "experimental": true,
-    "hidden": true
-  },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
     "tool_call_parser": "qwen3_coder_xml",

--- a/vllm_mlx/cache_rollback.py
+++ b/vllm_mlx/cache_rollback.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Atomic rollback admission for composite generation caches."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def can_trim(cache: Any, n: int) -> bool:
+    """Return whether ``cache.trim(n)`` can commit without partial mutation."""
+    if n < 0:
+        return False
+    children = getattr(cache, "caches", None)
+    if children is not None:
+        return all(can_trim(child, n) for child in children)
+    amount_check = getattr(cache, "can_trim", None)
+    if callable(amount_check):
+        return bool(amount_check(n))
+    can_undo = getattr(cache, "_can_undo", None)
+    if callable(can_undo) and can_undo(n):
+        return True
+    check = getattr(cache, "is_trimmable", None)
+    return bool(callable(check) and check())
+
+
+def trim_all(caches: Iterable[Any], n: int) -> bool:
+    """Preflight every cache before mutating any member of the collection."""
+    if n <= 0:
+        return n == 0
+    cache_list = list(caches)
+    if not all(can_trim(cache, n) for cache in cache_list):
+        return False
+    return all(cache.trim(n) == n for cache in cache_list)

--- a/vllm_mlx/cache_rollback.py
+++ b/vllm_mlx/cache_rollback.py
@@ -3,8 +3,45 @@
 
 from __future__ import annotations
 
+import copy
+import threading
 from collections.abc import Iterable
 from typing import Any
+
+_TRIM_LOCK = threading.RLock()
+
+
+def _leaf_caches(cache: Any):
+    children = getattr(cache, "caches", None)
+    if children is None:
+        yield cache
+        return
+    for child in children:
+        yield from _leaf_caches(child)
+
+
+def _checkpoint(cache: Any):
+    capture = getattr(cache, "trim_checkpoint", None)
+    if callable(capture):
+        return True, capture()
+    # Cache.trim() is a logical-cursor operation: backing tensor payloads stay
+    # allocated for reuse. Preserve array references and copy mutable cursor
+    # containers so a failed transaction can restore the pre-trim view.
+    state = {}
+    for name, value in vars(cache).items():
+        state[name] = (
+            copy.copy(value) if isinstance(value, (dict, list, set, tuple)) else value
+        )
+    return False, state
+
+
+def _restore(cache: Any, checkpoint) -> None:
+    custom, state = checkpoint
+    if custom:
+        cache.restore_trim_checkpoint(state)
+        return
+    vars(cache).clear()
+    vars(cache).update(state)
 
 
 def can_trim(cache: Any, n: int) -> bool:
@@ -32,10 +69,20 @@ def can_trim(cache: Any, n: int) -> bool:
 
 
 def trim_all(caches: Iterable[Any], n: int) -> bool:
-    """Preflight every cache before mutating any member of the collection."""
+    """Preflight and transactionally trim every composite cache leaf."""
     if n <= 0:
         return n == 0
-    cache_list = list(caches)
-    if not all(can_trim(cache, n) for cache in cache_list):
-        return False
-    return all(cache.trim(n) == n for cache in cache_list)
+    leaves = [leaf for cache in caches for leaf in _leaf_caches(cache)]
+    with _TRIM_LOCK:
+        if not all(can_trim(cache, n) for cache in leaves):
+            return False
+        checkpoints = [(cache, _checkpoint(cache)) for cache in leaves]
+        try:
+            for cache in leaves:
+                if cache.trim(n) != n:
+                    raise RuntimeError("cache returned a short trim")
+        except Exception:
+            for cache, checkpoint in reversed(checkpoints):
+                _restore(cache, checkpoint)
+            return False
+        return True

--- a/vllm_mlx/cache_rollback.py
+++ b/vllm_mlx/cache_rollback.py
@@ -21,7 +21,14 @@ def can_trim(cache: Any, n: int) -> bool:
     if callable(can_undo) and can_undo(n):
         return True
     check = getattr(cache, "is_trimmable", None)
-    return bool(callable(check) and check())
+    size = getattr(cache, "size", None)
+    if not (callable(check) and check() and callable(size)):
+        return False
+    logical_size = size()
+    try:
+        return int(logical_size) >= n
+    except (TypeError, ValueError):
+        return False
 
 
 def trim_all(caches: Iterable[Any], n: int) -> bool:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6115,7 +6115,11 @@ def _available_models_json_payload() -> dict:
     from vllm_mlx.model_aliases import list_builtin_aliases, list_profiles
     from vllm_mlx.model_sizes import size_bytes
 
-    all_profiles = list_profiles()
+    all_profiles = {
+        alias: profile
+        for alias, profile in list_profiles().items()
+        if not profile.hidden
+    }
     builtin_aliases = set(list_builtin_aliases())
 
     def _modality(p) -> str:
@@ -6209,7 +6213,11 @@ def models_command(args):
         _print_cached_models()
         return
 
-    all_profiles = list_profiles()
+    all_profiles = {
+        alias: profile
+        for alias, profile in list_profiles().items()
+        if not profile.hidden
+    }
     # Video-generation aliases are not chat models: they have no
     # tokenizer and no ``stream_chat``, so ``/v1/chat/completions`` on one
     # is an AttributeError, and ``serve`` exits 2 before binding a port

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6115,11 +6115,7 @@ def _available_models_json_payload() -> dict:
     from vllm_mlx.model_aliases import list_builtin_aliases, list_profiles
     from vllm_mlx.model_sizes import size_bytes
 
-    all_profiles = {
-        alias: profile
-        for alias, profile in list_profiles().items()
-        if not profile.hidden
-    }
+    all_profiles = list_profiles()
     builtin_aliases = set(list_builtin_aliases())
 
     def _modality(p) -> str:
@@ -6213,11 +6209,7 @@ def models_command(args):
         _print_cached_models()
         return
 
-    all_profiles = {
-        alias: profile
-        for alias, profile in list_profiles().items()
-        if not profile.hidden
-    }
+    all_profiles = list_profiles()
     # Video-generation aliases are not chat models: they have no
     # tokenizer and no ``stream_chat``, so ``/v1/chat/completions`` on one
     # is an AttributeError, and ``serve`` exits 2 before binding a port

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1228,6 +1228,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
         QuantizedKVCache = None  # noqa: N806
 
     def has_deepseek_pooling(layer: Any) -> bool:
+        if type(layer).__module__ == "vllm_mlx.models.qwen4_exp_cache":
+            return type(layer).__name__ == "QSAIndexCache"
         if type(layer).__module__ == "vllm_mlx.models.deepseek_v4_cache":
             return type(layer).__name__ in {
                 "PoolingCache",
@@ -1342,8 +1344,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
                 trimmed.append(tc)
         else:
             if has_deepseek_pooling(layer_cache):
-                # DeepSeek pooling state must rewind with the local KV state;
-                # otherwise a divergent suffix crosses request boundaries.
+                # Vendored side-cache state must rewind with the local KV
+                # owner; otherwise a divergent suffix crosses requests.
                 tc = trim_wrapper_exact(layer_cache)
                 if tc is None:
                     return None

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -55,6 +55,32 @@ _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 # weights, activations, and non-cache allocations already resident.
 _REPLACE_STAGING_PHYS_HEADROOM_FRACTION = 0.75
 
+
+def _vendored_cache_registry() -> dict[str, type]:
+    """Return cache classes owned by Rapid rather than ``mlx_lm``.
+
+    Persisted prefix-cache restore and the scheduler's in-memory mid-prefill
+    restore share this registry. This prevents a vendored hybrid side-cache
+    from restoring after restart but failing in the live scheduler path.
+    """
+    from vllm_mlx.models.deepseek_v4_cache import (
+        BatchDeepseekV4PoolingCache,
+        BatchPoolingCache,
+        DeepseekV4PoolingCache,
+        PoolingCache,
+    )
+    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+
+    classes = (
+        PoolingCache,
+        BatchPoolingCache,
+        DeepseekV4PoolingCache,
+        BatchDeepseekV4PoolingCache,
+        QSAIndexCache,
+    )
+    return {cls.__name__: cls for cls in classes}
+
+
 # ---------------------------------------------------------------------------
 # Persist-format pinning (R10-D, Talia r10-R1)
 # ---------------------------------------------------------------------------
@@ -207,24 +233,7 @@ def _load_prompt_cache_compat(path: str) -> list[Any]:
     # when mlx-lm has no class by that name.
     import mlx_lm.models.cache as mlx_cache
 
-    from vllm_mlx.models.deepseek_v4_cache import (
-        BatchDeepseekV4PoolingCache,
-        BatchPoolingCache,
-        DeepseekV4PoolingCache,
-        PoolingCache,
-    )
-    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
-
-    registry = {
-        cls.__name__: cls
-        for cls in (
-            PoolingCache,
-            BatchPoolingCache,
-            DeepseekV4PoolingCache,
-            BatchDeepseekV4PoolingCache,
-            QSAIndexCache,
-        )
-    }
+    registry = _vendored_cache_registry()
     declared_vendored = set(json.loads(metadata.get(_VENDORED_STATE_METADATA, "[]")))
 
     def restore(name, state, meta_state):

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -127,7 +127,10 @@ def _vendored_cache_class_names(cache: list[Any]) -> set[str]:
     pending = list(cache)
     while pending:
         item = pending.pop()
-        if type(item).__module__ == "vllm_mlx.models.deepseek_v4_cache":
+        if type(item).__module__ in {
+            "vllm_mlx.models.deepseek_v4_cache",
+            "vllm_mlx.models.qwen4_exp_cache",
+        }:
             found.add(type(item).__name__)
         pending.extend(getattr(item, "caches", ()))
     return found
@@ -210,6 +213,7 @@ def _load_prompt_cache_compat(path: str) -> list[Any]:
         DeepseekV4PoolingCache,
         PoolingCache,
     )
+    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
 
     registry = {
         cls.__name__: cls
@@ -218,6 +222,7 @@ def _load_prompt_cache_compat(path: str) -> list[Any]:
             BatchPoolingCache,
             DeepseekV4PoolingCache,
             BatchDeepseekV4PoolingCache,
+            QSAIndexCache,
         )
     }
     declared_vendored = set(json.loads(metadata.get(_VENDORED_STATE_METADATA, "[]")))

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -193,6 +193,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "ddtree_tree_budget",
             "min_memory_gb",
             "vision_min_memory_gb",
+            "experimental",
             "recommended_sampling",
             "pflash_tier",
             "pflash_keep_ratio",
@@ -579,6 +580,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         turboquant_tier=turboquant_tier,
         min_memory_gb=min_memory_gb,
         vision_min_memory_gb=vision_min_memory_gb,
+        experimental=_strict_bool("experimental", False),
     )
 
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -193,8 +193,6 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "ddtree_tree_budget",
             "min_memory_gb",
             "vision_min_memory_gb",
-            "experimental",
-            "hidden",
             "recommended_sampling",
             "pflash_tier",
             "pflash_keep_ratio",
@@ -581,8 +579,6 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         turboquant_tier=turboquant_tier,
         min_memory_gb=min_memory_gb,
         vision_min_memory_gb=vision_min_memory_gb,
-        experimental=_strict_bool("experimental", False),
-        hidden=_strict_bool("hidden", False),
     )
 
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -193,6 +193,8 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "ddtree_tree_budget",
             "min_memory_gb",
             "vision_min_memory_gb",
+            "experimental",
+            "hidden",
             "recommended_sampling",
             "pflash_tier",
             "pflash_keep_ratio",
@@ -579,6 +581,8 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         turboquant_tier=turboquant_tier,
         min_memory_gb=min_memory_gb,
         vision_min_memory_gb=vision_min_memory_gb,
+        experimental=_strict_bool("experimental", False),
+        hidden=_strict_bool("hidden", False),
     )
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1191,7 +1191,16 @@ def _detect_metadata_config(
     # classification even when served from a local snapshot path.
     is_qwen38 = bool(re.search(r"qwen[._-]?3[._]8", model_path, re.IGNORECASE))
 
-    if "qwen3_5_moe" in model_types:
+    if "qwen4_exp" in model_types:
+        settings.update(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            is_moe=True,
+            supports_spec_decode=False,
+            experimental=True,
+        )
+        reasons.append("experimental Qwen4-Exp hybrid MoE architecture")
+    elif "qwen3_5_moe" in model_types:
         settings.update(
             is_hybrid=True,
             is_hybrid_explicit=True,

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2380,6 +2380,8 @@ def format_profile_summary(
         summary = f"Model profile: {model_path} (unknown family — using defaults)"
         return f"{summary}, {runtime_status}" if runtime_status else summary
     parts = [_arch_label(cfg)]
+    if cfg.experimental:
+        parts.append("experimental")
     parts.append(f"throttle {'ON' if cfg.is_hybrid else 'OFF'}")
     parts.append(
         runtime_status
@@ -2479,6 +2481,8 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Throttle", throttle),
             ("Suffix tier", _suffix_tier_cell(cfg, max_width=value_width)),
         ]
+        if cfg.experimental:
+            rows.insert(0, ("Status", "⚠ experimental"))
 
     body = [_row(header), _row(sep)]
     for k, v in rows:

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -250,6 +250,12 @@ class ModelProfile:
     # automatic vision admission when no catalog measurement is available;
     # explicit ``--mllm`` always remains the operator override.
     vision_min_memory_gb: float | None = None
+    # Experimental aliases remain directly resolvable for explicit operator
+    # testing but stay out of the default catalog surfaces. The capability is
+    # also exposed on /v1/models for a running experimental checkpoint so
+    # clients never mistake it for a generally supported model.
+    experimental: bool = False
+    hidden: bool = False
     # ``is_text_only`` = this checkpoint is served through the
     # auto-regressive text (mlx-lm) lane even though its ``config.json``
     # declares a ``vision_config`` (and may ship ``vision_tower`` weights)

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -250,12 +250,11 @@ class ModelProfile:
     # automatic vision admission when no catalog measurement is available;
     # explicit ``--mllm`` always remains the operator override.
     vision_min_memory_gb: float | None = None
-    # Experimental aliases remain directly resolvable for explicit operator
-    # testing but stay out of the default catalog surfaces. The capability is
-    # also exposed on /v1/models for a running experimental checkpoint so
-    # clients never mistake it for a generally supported model.
+    # Experimental architecture implementations are loadable from an explicit
+    # local checkpoint but are not catalog/published-model commitments. The
+    # value is resolved from trusted checkpoint metadata and carried by the
+    # live model entry so /v1/models can expose that lifecycle truth.
     experimental: bool = False
-    hidden: bool = False
     # ``is_text_only`` = this checkpoint is served through the
     # auto-regressive text (mlx-lm) lane even though its ``config.json``
     # declares a ``vision_config`` (and may ship ``vision_tower`` weights)

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -250,10 +250,10 @@ class ModelProfile:
     # automatic vision admission when no catalog measurement is available;
     # explicit ``--mllm`` always remains the operator override.
     vision_min_memory_gb: float | None = None
-    # Experimental architecture implementations are loadable from an explicit
-    # local checkpoint but are not catalog/published-model commitments. The
-    # value is resolved from trusted checkpoint metadata and carried by the
-    # live model entry so /v1/models can expose that lifecycle truth.
+    # Experimental architecture implementations require explicit operator
+    # awareness. The value is resolved from trusted checkpoint metadata or an
+    # explicit closed-schema alias and carried by the live model entry so
+    # /v1/models can expose that lifecycle truth.
     experimental: bool = False
     # ``is_text_only`` = this checkpoint is served through the
     # auto-regressive text (mlx-lm) lane even though its ``config.json``

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -206,6 +206,7 @@
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,
     "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX": 14788605437,
+    "rapid-mlx/Qwen3.8-Flash-Next-4bit": 104695602743,
     "rickylin20260522/Wan2.2-T2V-A14B-mlx": 69023632302,
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": 24180286021,
     "unsloth/Qwen3.6-27B-MLX-8bit": 34733949671,

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -206,7 +206,7 @@
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,
     "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX": 14788605437,
-    "rapid-mlx/Qwen3.8-Flash-Next-4bit": 104695602743,
+    "rapid-mlx/Qwen3.8-Flash-Next-4bit": 104695605424,
     "rickylin20260522/Wan2.2-T2V-A14B-mlx": 69023632302,
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": 24180286021,
     "unsloth/Qwen3.6-27B-MLX-8bit": 34733949671,

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -213,6 +213,34 @@ class PoolingCache(_BaseCache):
     def can_trim(self, n):
         return n >= 0 and (n <= self.remainder or self._can_undo(n))
 
+    def trim_checkpoint(self):
+        """Capture the small rolling state that trim may overwrite in-place."""
+        state = {
+            "undo": self._undo,
+            "remainder": self.remainder,
+            "pooled": self.pooled,
+            "buf_kv": None if self.buf_kv is None else self.buf_kv + 0,
+            "buf_gate": None if self.buf_gate is None else self.buf_gate + 0,
+            "overlap_kv": getattr(self, "overlap_kv", None),
+            "overlap_gate": getattr(self, "overlap_gate", None),
+        }
+        arrays = [
+            value for value in (state["buf_kv"], state["buf_gate"]) if value is not None
+        ]
+        if arrays:
+            mx.eval(*arrays)
+        return state
+
+    def restore_trim_checkpoint(self, state):
+        self._undo = state["undo"]
+        self.remainder = state["remainder"]
+        self.pooled = state["pooled"]
+        self.buf_kv = state["buf_kv"]
+        self.buf_gate = state["buf_gate"]
+        if hasattr(self, "overlap_kv"):
+            self.overlap_kv = state["overlap_kv"]
+            self.overlap_gate = state["overlap_gate"]
+
     def _can_undo(self, n):
         undo = getattr(self, "_undo", None)
         return undo is not None and undo[4].shape[1] >= n
@@ -540,6 +568,38 @@ class BatchPoolingCache(_BaseCache):
 
     def can_trim(self, n):
         return n >= 0 and (n <= min(self.remainder) or self._can_undo(n))
+
+    def trim_checkpoint(self):
+        """Capture the small per-batch rolling state mutated by trim."""
+        state = {
+            "undo": self._undo,
+            "remainder": list(self.remainder),
+            "pool_lengths": list(self._pool_lengths),
+            "processed": list(self._processed),
+            "pooled": self.pooled,
+            "buf_kv": None if self.buf_kv is None else self.buf_kv + 0,
+            "buf_gate": None if self.buf_gate is None else self.buf_gate + 0,
+            "overlap_kv": getattr(self, "overlap_kv", None),
+            "overlap_gate": getattr(self, "overlap_gate", None),
+        }
+        arrays = [
+            value for value in (state["buf_kv"], state["buf_gate"]) if value is not None
+        ]
+        if arrays:
+            mx.eval(*arrays)
+        return state
+
+    def restore_trim_checkpoint(self, state):
+        self._undo = state["undo"]
+        self.remainder = state["remainder"]
+        self._pool_lengths = state["pool_lengths"]
+        self._processed = state["processed"]
+        self.pooled = state["pooled"]
+        self.buf_kv = state["buf_kv"]
+        self.buf_gate = state["buf_gate"]
+        if hasattr(self, "overlap_kv"):
+            self.overlap_kv = state["overlap_kv"]
+            self.overlap_gate = state["overlap_gate"]
 
     def _can_undo(self, n):
         undo = getattr(self, "_undo", None)

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -63,8 +63,12 @@ class PoolingCache(_BaseCache):
                 )
             else:
                 self._undo = (
-                    None if self.remainder == 0 else self.buf_kv[:, : self.remainder] + 0,
-                    None if self.remainder == 0 else self.buf_gate[:, : self.remainder] + 0,
+                    None
+                    if self.remainder == 0
+                    else self.buf_kv[:, : self.remainder] + 0,
+                    None
+                    if self.remainder == 0
+                    else self.buf_gate[:, : self.remainder] + 0,
                     self.remainder,
                     0 if self.pooled is None else self.pooled.shape[1],
                     kv,
@@ -206,6 +210,9 @@ class PoolingCache(_BaseCache):
     def is_trimmable(self):
         return self.pooled is None or self.remainder > 0 or self._can_undo(1)
 
+    def can_trim(self, n):
+        return n >= 0 and (n <= self.remainder or self._can_undo(n))
+
     def _can_undo(self, n):
         undo = getattr(self, "_undo", None)
         return undo is not None and undo[4].shape[1] >= n
@@ -246,8 +253,12 @@ class PoolingCache(_BaseCache):
             self.buf_gate[:, : self.remainder] = remainder_gate
         if hasattr(self, "overlap_kv"):
             if completed:
-                last_kv = mx.unflatten(prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
-                last_gate = mx.unflatten(prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                last_kv = mx.unflatten(
+                    prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio)
+                )[:, -1]
+                last_gate = mx.unflatten(
+                    prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio)
+                )[:, -1]
                 half = last_kv.shape[-1] // 2
                 self.overlap_kv = last_kv[..., :half]
                 self.overlap_gate = last_gate[..., :half]
@@ -527,13 +538,12 @@ class BatchPoolingCache(_BaseCache):
     def is_trimmable(self):
         return self.pooled is None or min(self.remainder) > 0 or self._can_undo(1)
 
+    def can_trim(self, n):
+        return n >= 0 and (n <= min(self.remainder) or self._can_undo(n))
+
     def _can_undo(self, n):
         undo = getattr(self, "_undo", None)
-        return (
-            undo is not None
-            and len(self.remainder) == 1
-            and undo[5].shape[1] >= n
-        )
+        return undo is not None and len(self.remainder) == 1 and undo[5].shape[1] >= n
 
     def trim(self, n):
         if n <= min(self.remainder):
@@ -557,7 +567,9 @@ class BatchPoolingCache(_BaseCache):
         ) = self._undo
         self._undo = None
         keep = kv.shape[1] - n
-        prefix_kv = mx.concatenate([buf_kv[:, : old_remainder[0]], kv[:, :keep]], axis=1)
+        prefix_kv = mx.concatenate(
+            [buf_kv[:, : old_remainder[0]], kv[:, :keep]], axis=1
+        )
         prefix_gate = mx.concatenate(
             [buf_gate[:, : old_remainder[0]], gate[:, :keep]], axis=1
         )
@@ -577,8 +589,12 @@ class BatchPoolingCache(_BaseCache):
             self.buf_gate[:, : self.remainder[0]] = remainder_gate
         if hasattr(self, "overlap_kv"):
             if completed:
-                last_kv = mx.unflatten(prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
-                last_gate = mx.unflatten(prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                last_kv = mx.unflatten(
+                    prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio)
+                )[:, -1]
+                last_gate = mx.unflatten(
+                    prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio)
+                )[:, -1]
                 half = last_kv.shape[-1] // 2
                 self.overlap_kv = last_kv[..., :half]
                 self.overlap_gate = last_gate[..., :half]

--- a/vllm_mlx/models/deepseek_v4_rollback.py
+++ b/vllm_mlx/models/deepseek_v4_rollback.py
@@ -14,6 +14,8 @@ from contextlib import contextmanager
 
 import mlx.core as mx
 
+from ..cache_rollback import can_trim, trim_all  # re-export legacy import surface
+
 _STATE = threading.local()
 
 
@@ -99,22 +101,3 @@ def install_rotating_undo() -> None:
         BatchRotatingKVCache,
         ("keys", "values", "offset", "left_padding", "_idx", "_offset", "rotated"),
     )
-
-
-def can_trim(cache, n: int) -> bool:
-    children = getattr(cache, "caches", None)
-    if children is not None:
-        return all(can_trim(child, n) for child in children)
-    can_undo = getattr(cache, "_can_undo", None)
-    if callable(can_undo) and can_undo(n):
-        return True
-    check = getattr(cache, "is_trimmable", None)
-    return bool(callable(check) and check())
-
-
-def trim_all(caches, n: int) -> bool:
-    if n <= 0:
-        return True
-    if not all(can_trim(cache, n) for cache in caches):
-        return False
-    return all(cache.trim(n) == n for cache in caches)

--- a/vllm_mlx/models/deepseek_v4_rollback.py
+++ b/vllm_mlx/models/deepseek_v4_rollback.py
@@ -84,6 +84,21 @@ def install_rotating_undo() -> None:
             undo = self._rapid_undo
             return undo is not None and int(undo[1].shape[2]) >= n
 
+        def trim_checkpoint(self):
+            snapshot = {}
+            for name in (*fields, "_rapid_undo"):
+                value = getattr(self, name)
+                snapshot[name] = (
+                    copy.deepcopy(value)
+                    if isinstance(value, (dict, list, set))
+                    else value
+                )
+            return snapshot
+
+        def restore_trim_checkpoint(self, snapshot):
+            for name, value in snapshot.items():
+                setattr(self, name, value)
+
         def trim(self, n):
             if original_is_trimmable(self):
                 self._rapid_undo = None
@@ -105,6 +120,8 @@ def install_rotating_undo() -> None:
         cls.update_and_fetch = update_and_fetch
         cls.is_trimmable = is_trimmable
         cls.can_trim = can_trim
+        cls.trim_checkpoint = trim_checkpoint
+        cls.restore_trim_checkpoint = restore_trim_checkpoint
         cls.trim = trim
         cls._rapid_undo = None
         cls._rapid_dspark_undo = True

--- a/vllm_mlx/models/deepseek_v4_rollback.py
+++ b/vllm_mlx/models/deepseek_v4_rollback.py
@@ -43,6 +43,7 @@ def install_rotating_undo() -> None:
         original_update = cls.update_and_fetch
         original_is_trimmable = cls.is_trimmable
         original_trim = cls.trim
+        original_can_trim = getattr(cls, "can_trim", None)
 
         def update_and_fetch(self, keys, values):
             steps = int(keys.shape[2])
@@ -72,6 +73,17 @@ def install_rotating_undo() -> None:
         def is_trimmable(self):
             return original_is_trimmable(self) or self._rapid_undo is not None
 
+        def can_trim(self, n):
+            if n < 0:
+                return False
+            if original_can_trim is not None and original_can_trim(self, n):
+                return True
+            if original_is_trimmable(self):
+                offset = getattr(self, "_offset", getattr(self, "offset", 0))
+                return int(offset) >= n
+            undo = self._rapid_undo
+            return undo is not None and int(undo[1].shape[2]) >= n
+
         def trim(self, n):
             if original_is_trimmable(self):
                 self._rapid_undo = None
@@ -92,6 +104,7 @@ def install_rotating_undo() -> None:
 
         cls.update_and_fetch = update_and_fetch
         cls.is_trimmable = is_trimmable
+        cls.can_trim = can_trim
         cls.trim = trim
         cls._rapid_undo = None
         cls._rapid_dspark_undo = True

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -479,7 +479,7 @@ class QSAIndexer(nn.Module):
         batch, length, _ = hidden_states.shape
         cache._ensure_batch(batch)
         offsets = list(cache._offsets)
-        valid_lengths = cache.valid_lengths(length)
+        valid_spans = cache.valid_spans(length)
         projected = self.index_qk_proj(hidden_states)
         query_width = self.num_heads * self.head_dim
         query, raw_keys = mx.split(projected, [query_width], axis=-1)
@@ -488,9 +488,14 @@ class QSAIndexer(nn.Module):
         if self.num_kv_heads != 1:
             raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
         raw_keys = raw_keys.squeeze(2)
-        positions = mx.array(offsets, dtype=mx.int64)[:, None] + mx.arange(
-            length, dtype=mx.int64
-        )[None, :]
+        starts = mx.array(
+            [start for start, _ in valid_spans], dtype=mx.int64
+        )
+        positions = (
+            mx.array(offsets, dtype=mx.int64)[:, None]
+            + mx.arange(length, dtype=mx.int64)[None, :]
+            - starts[:, None]
+        )
         query = self.q_layernorm(query)
         query = apply_rotary_positions(
             query,
@@ -516,8 +521,11 @@ class QSAIndexer(nn.Module):
             else [int(value) for value in cache.left_padding.tolist()]
         )
         for batch_index in range(batch):
-            for query_index in range(valid_lengths[batch_index]):
-                logical_position = offsets[batch_index] + query_index
+            input_start, valid_length = valid_spans[batch_index]
+            for query_index in range(input_start, input_start + valid_length):
+                logical_position = (
+                    offsets[batch_index] + query_index - input_start
+                )
                 complete_blocks = (logical_position + 1) // self.compress_ratio
                 token_indices: list[int] = []
                 if complete_blocks:

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from functools import cache
-from typing import Any
+from typing import Any, cast
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -123,11 +123,12 @@ class TextModelArgs(BaseModelArgs):
         self._validate()
 
     def _validate(self) -> None:
-        if len(self.layer_types) != self.num_hidden_layers:
+        layer_types = cast(list[str], self.layer_types)
+        if len(layer_types) != self.num_hidden_layers:
             raise ValueError(
                 "Qwen4-Exp layer_types must have one entry per decoder layer"
             )
-        unsupported = set(self.layer_types) - {
+        unsupported = set(layer_types) - {
             "linear_attention",
             "qwen_sparse_attention",
         }
@@ -152,21 +153,23 @@ class TextModelArgs(BaseModelArgs):
         )
         if any(value is None for value in qsa):
             raise ValueError("Qwen4-Exp QSA requires the complete indexer contract")
-        if any(int(value) <= 0 for value in qsa if value is not None):
+        qsa_values = cast(tuple[int, int, int, int, int], qsa)
+        if any(value <= 0 for value in qsa_values):
             raise ValueError("Qwen4-Exp indexer values must be positive")
         if self.indexer_kv_heads != 1:
             raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
-        if self.indexer_budget % self.indexer_compress_ratio:
+        if qsa_values[3] % qsa_values[4]:
             raise ValueError(
                 "indexer_budget must be divisible by indexer_compress_ratio"
             )
         rotary_dim = int(self.head_dim * self.partial_rotary_factor)
-        if rotary_dim > self.indexer_head_dim:
+        if rotary_dim > qsa_values[2]:
             raise ValueError("attention rotary dimensions must fit the QSA index head")
         if not 0 < self.num_experts_per_tok <= self.num_experts:
             raise ValueError("num_experts_per_tok must be within num_experts")
         ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
-        if self.ple_layer_ids and self.ple_embed_dim % ngram_heads:
+        ple_embed_dim = cast(int, self.ple_embed_dim)
+        if self.ple_layer_ids and ple_embed_dim % ngram_heads:
             raise ValueError(
                 "PLE embedding width must divide evenly across n-gram heads"
             )
@@ -175,8 +178,7 @@ class TextModelArgs(BaseModelArgs):
         ):
             raise ValueError("ple_layer_ids are one-indexed decoder layer ids")
         if any(
-            self.layer_types[layer - 1] != "linear_attention"
-            for layer in self.ple_layer_ids
+            layer_types[layer - 1] != "linear_attention" for layer in self.ple_layer_ids
         ):
             raise ValueError("PLE is only valid on linear-attention layers")
         if self.ple_layer_ids and self.eos_token_id is None:
@@ -576,11 +578,11 @@ class QSAIndexer(nn.Module):
 
     def __init__(self, args: TextModelArgs):
         super().__init__()
-        self.num_heads = int(args.indexer_n_heads)
-        self.num_kv_heads = int(args.indexer_kv_heads)
-        self.head_dim = int(args.indexer_head_dim)
-        self.token_budget = int(args.indexer_budget)
-        self.compress_ratio = int(args.indexer_compress_ratio)
+        self.num_heads = cast(int, args.indexer_n_heads)
+        self.num_kv_heads = cast(int, args.indexer_kv_heads)
+        self.head_dim = cast(int, args.indexer_head_dim)
+        self.token_budget = cast(int, args.indexer_budget)
+        self.compress_ratio = cast(int, args.indexer_compress_ratio)
         self.block_topk = self.token_budget // self.compress_ratio
         self.rotary_dim = int(args.head_dim * args.partial_rotary_factor)
         self.rope_theta = args.rope_theta
@@ -682,6 +684,10 @@ class QSAIndexer(nn.Module):
                     if complete_blocks <= self.block_topk:
                         blocks = list(range(complete_blocks))
                     else:
+                        if selected_blocks is None:
+                            raise RuntimeError(
+                                "QSA sparse selection was not materialized"
+                            )
                         blocks = [
                             int(value)
                             for value in selected_blocks[query_index].tolist()
@@ -1029,7 +1035,7 @@ class PLELayer(nn.Module):
         self.hidden_size = args.hidden_size
         self.hc_count = args.hc_count
         hc_width = args.hc_count * args.hidden_size
-        embed_dim = int(args.ple_embed_dim)
+        embed_dim = cast(int, args.ple_embed_dim)
         self.ple_embedding = NGramEmbedding(
             args,
             embedding_dim=embed_dim,
@@ -1037,13 +1043,15 @@ class PLELayer(nn.Module):
         )
         self.key_proj = nn.Linear(embed_dim, hc_width, bias=False)
         self.value_proj = nn.Linear(embed_dim, args.hidden_size, bias=False)
-        norm_kwargs = {
-            "group_size": args.hidden_size,
-            "eps": args.rms_norm_eps,
-        }
-        self.norm_key = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
-        self.norm_query = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
-        self.norm_conv = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
+        self.norm_key = ZeroCenteredRMSNorm(
+            hc_width, group_size=args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.norm_query = ZeroCenteredRMSNorm(
+            hc_width, group_size=args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.norm_conv = ZeroCenteredRMSNorm(
+            hc_width, group_size=args.hidden_size, eps=args.rms_norm_eps
+        )
         self.conv_state_len = (args.ple_conv_kernel_size - 1) * args.ngram_size
         self.conv1d = nn.Conv1d(
             hc_width,
@@ -1104,7 +1112,7 @@ class PLELayer(nn.Module):
 class DecoderLayer(nn.Module):
     def __init__(self, args: TextModelArgs, layer_index: int):
         super().__init__()
-        self.layer_type = args.layer_types[layer_index]
+        self.layer_type = cast(list[str], args.layer_types)[layer_index]
         self.is_linear = self.layer_type == "linear_attention"
         if self.is_linear:
             self.linear_attn = GatedDeltaNet(args)

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from functools import cache
 from typing import Any
 
 import mlx.core as mx
@@ -25,6 +26,7 @@ _mlx_compat.install()
 
 from mlx_lm.models.base import (  # noqa: E402
     BaseModelArgs,
+    create_attention_mask,
     create_ssm_mask,
     scaled_dot_product_attention,
 )
@@ -102,7 +104,9 @@ class TextModelArgs(BaseModelArgs):
             rope.get("partial_rotary_factor", self.partial_rotary_factor)
         )
         self.rope_theta = float(rope.get("rope_theta", self.rope_theta))
-        self.ple_embed_dim = self.hidden_size if self.ple_embed_dim is None else self.ple_embed_dim
+        self.ple_embed_dim = (
+            self.hidden_size if self.ple_embed_dim is None else self.ple_embed_dim
+        )
         self.ple_layer_ids = sorted(set(self.ple_layer_ids))
         if self.layer_types is None:
             self.layer_types = [
@@ -128,7 +132,9 @@ class TextModelArgs(BaseModelArgs):
             "qwen_sparse_attention",
         }
         if unsupported:
-            raise ValueError(f"Unsupported Qwen4-Exp layer types: {sorted(unsupported)}")
+            raise ValueError(
+                f"Unsupported Qwen4-Exp layer types: {sorted(unsupported)}"
+            )
         if self.hc_count <= 1 or self.hidden_size <= 0 or self.hc_lowrank <= 0:
             raise ValueError("Qwen4-Exp requires positive four-stream HC dimensions")
         if self.linear_num_value_heads % self.linear_num_key_heads:
@@ -151,7 +157,9 @@ class TextModelArgs(BaseModelArgs):
         if self.indexer_kv_heads != 1:
             raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
         if self.indexer_budget % self.indexer_compress_ratio:
-            raise ValueError("indexer_budget must be divisible by indexer_compress_ratio")
+            raise ValueError(
+                "indexer_budget must be divisible by indexer_compress_ratio"
+            )
         rotary_dim = int(self.head_dim * self.partial_rotary_factor)
         if rotary_dim > self.indexer_head_dim:
             raise ValueError("attention rotary dimensions must fit the QSA index head")
@@ -159,10 +167,17 @@ class TextModelArgs(BaseModelArgs):
             raise ValueError("num_experts_per_tok must be within num_experts")
         ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
         if self.ple_layer_ids and self.ple_embed_dim % ngram_heads:
-            raise ValueError("PLE embedding width must divide evenly across n-gram heads")
-        if any(layer < 1 or layer > self.num_hidden_layers for layer in self.ple_layer_ids):
+            raise ValueError(
+                "PLE embedding width must divide evenly across n-gram heads"
+            )
+        if any(
+            layer < 1 or layer > self.num_hidden_layers for layer in self.ple_layer_ids
+        ):
             raise ValueError("ple_layer_ids are one-indexed decoder layer ids")
-        if any(self.layer_types[layer - 1] != "linear_attention" for layer in self.ple_layer_ids):
+        if any(
+            self.layer_types[layer - 1] != "linear_attention"
+            for layer in self.ple_layer_ids
+        ):
             raise ValueError("PLE is only valid on linear-attention layers")
         if self.ple_layer_ids and self.eos_token_id is None:
             raise ValueError("PLE requires eos_token_id for segment-local n-grams")
@@ -210,19 +225,27 @@ class ZeroCenteredRMSNorm(nn.Module):
 class SigmoidRMSNormGated(nn.Module):
     """Qwen4-Exp's norm-before-gate GDN output transform."""
 
-    def __init__(self, dim: int, eps: float = 1e-6):
+    def __init__(
+        self,
+        dim: int,
+        eps: float = 1e-6,
+        activation: str = "sigmoid",
+    ):
         super().__init__()
         self.weight = mx.ones((dim,))
         self.eps = eps
+        self.activation = activation
 
     def __call__(self, hidden: mx.array, gate: mx.array) -> mx.array:
         dtype = hidden.dtype
-        normalized = hidden.astype(mx.float32)
-        normalized = normalized * mx.rsqrt(
-            mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
-        )
-        normalized = normalized * self.weight.astype(mx.float32)
-        return (normalized * mx.sigmoid(gate.astype(mx.float32))).astype(dtype)
+        # Preserve the architecture reference's BF16 rounding boundary: the
+        # fused RMSNorm returns activation dtype before the gate multiplies in
+        # FP32. Adapted from mlx-vlm ecf1aa0a62958ea770bc25c35e173effe142aa3c
+        # (MIT).
+        normalized = mx.fast.rms_norm(hidden, self.weight, self.eps).astype(mx.float32)
+        gate = gate.astype(mx.float32)
+        gate = mx.sigmoid(gate) if self.activation == "sigmoid" else nn.silu(gate)
+        return (normalized * gate).astype(dtype)
 
 
 class GatedResidual(nn.Module):
@@ -258,9 +281,7 @@ class GatedResidual(nn.Module):
         mixed = mx.mean(mix * streams, axis=-2)
         if self.block_inject_weight is None:
             return mixed
-        injection = 2 * mx.sigmoid(
-            self.block_inject_weight(normalized) / self.hc_count
-        )
+        injection = 2 * mx.sigmoid(self.block_inject_weight(normalized) / self.hc_count)
         return mixed, hyper_input, injection
 
 
@@ -287,9 +308,7 @@ class SparseMoeBlock(nn.Module):
         self.switch_mlp = SwitchGLU(
             args.hidden_size, args.moe_intermediate_size, args.num_experts
         )
-        self.shared_expert = MLP(
-            args.hidden_size, args.shared_expert_intermediate_size
-        )
+        self.shared_expert = MLP(args.hidden_size, args.shared_expert_intermediate_size)
         self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
         self.sharding_group = None
 
@@ -327,9 +346,7 @@ class GatedDeltaNet(nn.Module):
             groups=self.conv_dim,
             bias=False,
         )
-        self.in_proj_qkv = nn.Linear(
-            self.hidden_size, self.conv_dim, bias=False
-        )
+        self.in_proj_qkv = nn.Linear(self.hidden_size, self.conv_dim, bias=False)
         self.in_proj_z = nn.Linear(self.hidden_size, self.value_dim, bias=False)
         self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
         self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
@@ -337,7 +354,11 @@ class GatedDeltaNet(nn.Module):
         self.A_log = mx.log(
             mx.random.uniform(low=0.01, high=16.0, shape=(self.num_v_heads,))
         )
-        self.norm = SigmoidRMSNormGated(self.head_v_dim, eps=args.rms_norm_eps)
+        self.norm = SigmoidRMSNormGated(
+            self.head_v_dim,
+            eps=args.rms_norm_eps,
+            activation=args.output_gate_type or args.hidden_act,
+        )
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
     def __call__(
@@ -382,9 +403,17 @@ class GatedDeltaNet(nn.Module):
             )
         ]
         state = cache[1] if cache is not None else None
+        # Exact Qwen4-Exp normalization: L2 epsilon is applied after the sum,
+        # then queries receive the attention scale. Adapted from mlx-vlm
+        # ecf1aa0a62958ea770bc25c35e173effe142aa3c (MIT); the previous
+        # RMS-normalized form moved epsilon inside the mean and diverged on the
+        # real q4 checkpoint.
         inv_scale = key.shape[-1] ** -0.5
-        query = (inv_scale**2) * mx.fast.rms_norm(query, None, 1e-6)
-        key = inv_scale * mx.fast.rms_norm(key, None, 1e-6)
+        query = query * mx.rsqrt(
+            mx.sum(mx.square(query), axis=-1, keepdims=True) + 1e-6
+        )
+        key = key * mx.rsqrt(mx.sum(mx.square(key), axis=-1, keepdims=True) + 1e-6)
+        query = query * inv_scale
         output, state = gated_delta_update(
             query,
             key,
@@ -425,11 +454,7 @@ def apply_rotary_positions(
     if positions.ndim == 1:
         positions = positions[None, :]
     inverse_frequency = 1.0 / (
-        base
-        ** (
-            mx.arange(0, rotary_dim, 2, dtype=mx.float32)
-            / float(rotary_dim)
-        )
+        base ** (mx.arange(0, rotary_dim, 2, dtype=mx.float32) / float(rotary_dim))
     )
     angles = positions.astype(mx.float32)[..., None] * inverse_frequency
     angles = mx.concatenate([angles, angles], axis=-1)[:, :, None, :]
@@ -437,11 +462,113 @@ def apply_rotary_positions(
     sine = mx.sin(angles)
     rotary = x[..., :rotary_dim]
     half = rotary_dim // 2
-    rotated_half = mx.concatenate(
-        [-rotary[..., half:], rotary[..., :half]], axis=-1
-    )
+    rotated_half = mx.concatenate([-rotary[..., half:], rotary[..., :half]], axis=-1)
     rotated = rotary * cosine + rotated_half * sine
     return mx.concatenate([rotated.astype(x.dtype), x[..., rotary_dim:]], axis=-1)
+
+
+@cache
+def _qwen4_exp_rope_kernel(rotary_dim: int, position_ndim: int):
+    """Build the architecture's half-split MRoPE forward kernel.
+
+    Forward math is adopted line-for-line from mlx-vlm commit
+    ecf1aa0a62958ea770bc25c35e173effe142aa3c (MIT).  Rapid only needs the
+    inference forward here; the pure-MLX fallback below covers non-Metal use.
+    """
+
+    if not mx.metal.is_available():
+        return None
+    if position_ndim == 2:
+        position_expr = "position_ids[b * q_len + t]"
+    else:
+        raise ValueError("Qwen4-Exp text RoPE requires 2-D position IDs")
+    source = f"""
+        uint elem = thread_position_in_grid.x;
+
+        const int half_dim = {rotary_dim // 2};
+        const int q_bsz = x_shape[0];
+        const int q_heads = x_shape[1];
+        const int q_len = x_shape[2];
+        const int q_dim = x_shape[3];
+        const int slots = half_dim + q_dim - {rotary_dim};
+        const int work_size = q_bsz * q_heads * q_len * slots;
+
+        if (elem >= uint(work_size)) {{
+            return;
+        }}
+
+        int local = int(elem);
+        int slot = local % slots;
+        int tmp = local / slots;
+        int t = tmp % q_len;
+        tmp = tmp / q_len;
+        int h = tmp % q_heads;
+        int b = tmp / q_heads;
+        int base = ((b * q_heads + h) * q_len + t) * q_dim;
+
+        if (slot >= half_dim) {{
+            int pass_d = {rotary_dim} + slot - half_dim;
+            int pass_idx = base + pass_d;
+            x_out[pass_idx] = x[pass_idx];
+            return;
+        }}
+
+        int freq_idx = slot;
+        int d = freq_idx;
+        int pair_d = d + half_dim;
+        float pos = static_cast<float>({position_expr});
+        float angle = pos * static_cast<float>(inv_freq[freq_idx]);
+        float c = metal::cos(angle);
+        float s = metal::sin(angle);
+
+        int idx = base + d;
+        float xv = static_cast<float>(x[idx]);
+        float xp = static_cast<float>(x[base + pair_d]);
+        x_out[idx] = static_cast<T>(xv * c - xp * s);
+        x_out[base + pair_d] = static_cast<T>(xp * c + xv * s);
+    """
+    return mx.fast.metal_kernel(
+        name=f"qwen4_exp_rope_half_split_{rotary_dim}_{position_ndim}d",
+        input_names=["x", "position_ids", "inv_freq"],
+        output_names=["x_out"],
+        source=source,
+    )
+
+
+def apply_qwen4_exp_rope(
+    x: mx.array,
+    positions: mx.array,
+    *,
+    rotary_dim: int,
+    base: float,
+) -> mx.array:
+    """Apply exact Qwen4-Exp text RoPE to ``[B, H, L, D]`` states."""
+
+    if positions.ndim == 1:
+        positions = mx.broadcast_to(positions[None], (x.shape[0], positions.size))
+    inverse_frequency = 1.0 / (
+        base ** (mx.arange(0, rotary_dim, 2, dtype=mx.float32) / float(rotary_dim))
+    )
+    kernel = _qwen4_exp_rope_kernel(rotary_dim, positions.ndim)
+    if kernel is None:
+        return apply_rotary_positions(
+            x.transpose(0, 2, 1, 3),
+            positions,
+            rotary_dim=rotary_dim,
+            base=base,
+        ).transpose(0, 2, 1, 3)
+    half_dim = inverse_frequency.shape[0]
+    slots = half_dim + x.shape[-1] - rotary_dim
+    work_size = x.shape[0] * x.shape[1] * x.shape[2] * slots
+    (output,) = kernel(
+        inputs=[x, positions, inverse_frequency],
+        template=[("T", x.dtype)],
+        grid=(work_size, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[x.shape],
+        output_dtypes=[x.dtype],
+    )
+    return output
 
 
 class QSAIndexer(nn.Module):
@@ -462,12 +589,8 @@ class QSAIndexer(nn.Module):
             (self.num_heads + self.num_kv_heads) * self.head_dim,
             bias=False,
         )
-        self.q_layernorm = ZeroCenteredRMSNorm(
-            self.head_dim, eps=args.rms_norm_eps
-        )
-        self.k_layernorm = ZeroCenteredRMSNorm(
-            self.head_dim, eps=args.rms_norm_eps
-        )
+        self.q_layernorm = ZeroCenteredRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_layernorm = ZeroCenteredRMSNorm(self.head_dim, eps=args.rms_norm_eps)
 
     def __call__(
         self,
@@ -475,7 +598,7 @@ class QSAIndexer(nn.Module):
         cache: QSAIndexCache,
         *,
         physical_kv_length: int,
-    ) -> mx.array:
+    ) -> mx.array | None:
         batch, length, _ = hidden_states.shape
         cache._ensure_batch(batch)
         offsets = list(cache._offsets)
@@ -488,32 +611,38 @@ class QSAIndexer(nn.Module):
         if self.num_kv_heads != 1:
             raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
         raw_keys = raw_keys.squeeze(2)
-        starts = mx.array(
-            [start for start, _ in valid_spans], dtype=mx.int64
-        )
+        starts = mx.array([start for start, _ in valid_spans], dtype=mx.int64)
         positions = (
             mx.array(offsets, dtype=mx.int64)[:, None]
             + mx.arange(length, dtype=mx.int64)[None, :]
             - starts[:, None]
         )
         query = self.q_layernorm(query)
-        query = apply_rotary_positions(
-            query,
+        query = apply_qwen4_exp_rope(
+            query.transpose(0, 2, 1, 3),
             positions,
             rotary_dim=self.rotary_dim,
             base=self.rope_theta,
-        )
+        ).transpose(0, 2, 1, 3)
 
         def transform_group(group: mx.array, start: int) -> mx.array:
             normalized = self.k_layernorm(group[:, None, :])[:, 0, :]
-            return apply_rotary_positions(
+            return apply_qwen4_exp_rope(
                 normalized[:, None, None, :],
-                mx.array([start], dtype=mx.int64),
+                mx.array([[start]], dtype=mx.int64),
                 rotary_dim=self.rotary_dim,
                 base=self.rope_theta,
             )[:, 0, 0, :]
 
         cache.update(raw_keys, transform_group)
+        # The architecture reference stays on ordinary causal attention while
+        # every complete block fits the QSA budget. Preserve that exact math
+        # and kernel selection while still updating Rapid's persistent index
+        # cache for the first later token that crosses the sparse boundary.
+        # Adapted from mlx-vlm ecf1aa0a62958ea770bc25c35e173effe142aa3c
+        # (MIT), without its O(B*L*topk*K) token-mask materialization.
+        if physical_kv_length // self.compress_ratio <= self.block_topk:
+            return None
         selected = mx.zeros((batch, length, physical_kv_length), dtype=mx.bool_)
         left_padding = (
             [0] * batch
@@ -522,30 +651,40 @@ class QSAIndexer(nn.Module):
         )
         for batch_index in range(batch):
             input_start, valid_length = valid_spans[batch_index]
-            for query_index in range(input_start, input_start + valid_length):
-                logical_position = (
-                    offsets[batch_index] + query_index - input_start
+            available_blocks = cache._compressed_counts[batch_index]
+            selected_blocks = None
+            if available_blocks > self.block_topk:
+                keys = cache.keys_for_blocks(batch_index, available_blocks)
+                # Preserve the reference's single batched matmul and FP32
+                # reduction. Per-token matmuls choose a different Metal
+                # accumulation kernel and can perturb the top-k boundary.
+                scores = mx.matmul(
+                    query[batch_index].transpose(1, 0, 2),
+                    keys.T,
                 )
+                scores = mx.sum(
+                    mx.maximum(scores.astype(mx.float32), 0), axis=0
+                ) / math.sqrt(self.head_dim)
+                query_ends = offsets[batch_index] + mx.arange(length) - input_start + 1
+                complete_counts = mx.maximum(query_ends // self.compress_ratio, 0)
+                valid_blocks = (
+                    mx.arange(available_blocks)[None, :] < complete_counts[:, None]
+                )
+                scores = mx.where(valid_blocks, scores, -mx.inf)
+                selected_blocks = mx.argpartition(
+                    scores, kth=-self.block_topk, axis=-1
+                )[..., -self.block_topk :]
+            for query_index in range(input_start, input_start + valid_length):
+                logical_position = offsets[batch_index] + query_index - input_start
                 complete_blocks = (logical_position + 1) // self.compress_ratio
                 token_indices: list[int] = []
                 if complete_blocks:
-                    keys = cache.keys_for_blocks(batch_index, complete_blocks)
-                    scores = mx.matmul(
-                        query[batch_index, query_index].astype(mx.float32),
-                        keys.astype(mx.float32).T,
-                    )
-                    scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
-                        self.head_dim
-                    )
-                    count = min(self.block_topk, complete_blocks)
-                    if count == complete_blocks:
+                    if complete_blocks <= self.block_topk:
                         blocks = list(range(complete_blocks))
                     else:
                         blocks = [
                             int(value)
-                            for value in mx.argpartition(
-                                scores, kth=-count
-                            )[-count:].tolist()
+                            for value in selected_blocks[query_index].tolist()
                         ]
                     for block in blocks:
                         start = block * self.compress_ratio
@@ -630,17 +769,39 @@ class QSAAttention(nn.Module):
         values = self.v_proj(x).reshape(
             batch, length, self.num_key_value_heads, self.head_dim
         )
-        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
-        keys = self.k_norm(keys).transpose(0, 2, 1, 3)
+        queries = self.q_norm(queries)
+        keys = self.k_norm(keys)
         values = values.transpose(0, 2, 1, 3)
-        queries = self.rope(queries, offset=offset)
-        keys = self.rope(keys, offset=offset)
+        positions = mx.arange(length, dtype=mx.int64)
+        if isinstance(offset, mx.array) and offset.ndim:
+            positions = offset[:, None] + positions[None, :]
+        else:
+            positions = positions + int(offset)
+        # Qwen4-Exp uses half-split (rotate-half) pairing for its partial RoPE.
+        # This follows mlx-vlm ecf1aa0a62958ea770bc25c35e173effe142aa3c
+        # (MIT) while retaining Rapid's persistent QSA cache contract.
+        queries = apply_qwen4_exp_rope(
+            queries.transpose(0, 2, 1, 3),
+            positions,
+            rotary_dim=self.rotary_dim,
+            base=self.indexer.rope_theta,
+        )
+        keys = apply_qwen4_exp_rope(
+            keys.transpose(0, 2, 1, 3),
+            positions,
+            rotary_dim=self.rotary_dim,
+            base=self.indexer.rope_theta,
+        )
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
-        additive_mask = mx.where(
-            selected,
-            mx.array(0.0, dtype=queries.dtype),
-            mx.array(-1e9, dtype=queries.dtype),
+        additive_mask = (
+            create_attention_mask(x, kv_cache)
+            if selected is None
+            else mx.where(
+                selected,
+                mx.array(0.0, dtype=queries.dtype),
+                mx.array(-1e9, dtype=queries.dtype),
+            )
         )
         output = scaled_dot_product_attention(
             queries,
@@ -672,12 +833,7 @@ def build_layer_multipliers(
     half_bound = max(1, multiplier_max // 2)
     base_seed = seed + 10007 * ple_layer_index
     return [
-        2
-        * (
-            _splitmix64(base_seed + 0x9E3779B97F4A7C15 * (index + 1))
-            % half_bound
-        )
-        + 1
+        2 * (_splitmix64(base_seed + 0x9E3779B97F4A7C15 * (index + 1)) % half_bound) + 1
         for index in range(ngram_size)
     ]
 
@@ -791,7 +947,10 @@ class NGramEmbedding(nn.Module):
         eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
         previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
         previous_eos = mx.concatenate(
-            [mx.full((token_ids.shape[0], 1), -1, dtype=mx.int64), previous_eos_inclusive[:, :-1]],
+            [
+                mx.full((token_ids.shape[0], 1), -1, dtype=mx.int64),
+                previous_eos_inclusive[:, :-1],
+            ],
             axis=1,
         )
         position_in_segment = positions[None, :] - previous_eos - 1
@@ -896,14 +1055,10 @@ class PLELayer(nn.Module):
         if cache is not None:
             if cache.lengths is not None:
                 valid = mx.clip(cache.lengths, 0, x.shape[1])
-                positions = (
-                    valid[:, None] + mx.arange(self.conv_state_len)
-                )[..., None]
+                positions = (valid[:, None] + mx.arange(self.conv_state_len))[..., None]
                 cache[2] = mx.take_along_axis(conv_input, positions, axis=1)
             else:
-                cache[2] = mx.contiguous(
-                    conv_input[:, -self.conv_state_len :, :]
-                )
+                cache[2] = mx.contiguous(conv_input[:, -self.conv_state_len :, :])
         return nn.silu(self.conv1d(conv_input))
 
     def __call__(
@@ -952,9 +1107,7 @@ class DecoderLayer(nn.Module):
             else None
         )
         self.ple = (
-            PLELayer(args, ple_layer_index=ple_index)
-            if ple_index is not None
-            else None
+            PLELayer(args, ple_layer_index=ple_index) if ple_index is not None else None
         )
         self.attn_hyper_connection = GatedResidual(args)
         self.mlp_hyper_connection = GatedResidual(args)
@@ -1087,19 +1240,33 @@ class TextModel(nn.Module):
             weights.pop("lm_head.weight", None)
         sanitized = {}
         for key, value in weights.items():
-            if key.endswith("conv1d.weight") and value.ndim == 3 and value.shape[1] == 1:
+            if (
+                key.endswith("conv1d.weight")
+                and value.ndim == 3
+                and value.shape[1] == 1
+            ):
                 value = value.moveaxis(2, 1)
             if ".mlp.experts.gate_up_proj" in key:
                 gate_up = value
                 midpoint = gate_up.shape[-2] // 2
-                base = key.replace("experts.gate_up_proj", "switch_mlp")
-                sanitized[f"{base}.gate_proj.weight"] = gate_up[..., :midpoint, :]
-                sanitized[f"{base}.up_proj.weight"] = gate_up[..., midpoint:, :]
+                prefix, suffix = key.split("experts.gate_up_proj", 1)
+                leaf = {"": "weight", ".scales": "scales", ".biases": "biases"}.get(
+                    suffix
+                )
+                if leaf is None:
+                    sanitized[key] = value
+                    continue
+                base = f"{prefix}switch_mlp"
+                sanitized[f"{base}.gate_proj.{leaf}"] = gate_up[..., :midpoint, :]
+                sanitized[f"{base}.up_proj.{leaf}"] = gate_up[..., midpoint:, :]
                 continue
             if ".mlp.experts.down_proj" in key:
-                key = key.replace(
-                    "experts.down_proj", "switch_mlp.down_proj.weight"
+                prefix, suffix = key.split("experts.down_proj", 1)
+                leaf = {"": "weight", ".scales": "scales", ".biases": "biases"}.get(
+                    suffix
                 )
+                if leaf is not None:
+                    key = f"{prefix}switch_mlp.down_proj.{leaf}"
             if ".ngram_embedding.shard_" in key:
                 prefix, suffix = key.split(".ngram_embedding.shard_", 1)
                 shard, leaf = suffix.split(".", 1)
@@ -1155,9 +1322,7 @@ class Model(nn.Module):
             if key.startswith("mtp."):
                 continue
             if key.startswith("model.language_model"):
-                key = key.replace(
-                    "model.language_model", "language_model.model", 1
-                )
+                key = key.replace("model.language_model", "language_model.model", 1)
             elif not key.startswith("language_model."):
                 key = f"language_model.{key}"
             mapped[key] = value

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1,0 +1,1141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vendored MLX text model for the Qwen4-Exp architecture.
+
+The implementation is intentionally architecture-driven: every optional
+component is admitted from the checkpoint's typed ``text_config`` fields.
+There are no repository-name aliases or compatibility approximations here.
+
+M1 implements the target text decoder.  The checkpoint's MTP and vision
+modules are deliberately ignored by :meth:`Model.sanitize` until their own
+milestones have independent numerical and lifecycle coverage.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.base import (  # noqa: E402
+    BaseModelArgs,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache  # noqa: E402
+from mlx_lm.models.gated_delta import gated_delta_update  # noqa: E402
+from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
+
+from .qwen4_exp_cache import QSAIndexCache  # noqa: E402
+
+
+@dataclass
+class TextModelArgs(BaseModelArgs):
+    model_type: str = "qwen4_exp_text"
+    hidden_size: int = 2560
+    num_hidden_layers: int = 48
+    vocab_size: int = 248320
+    max_position_embeddings: int = 262144
+    rms_norm_eps: float = 1e-6
+    hidden_act: str = "silu"
+    tie_word_embeddings: bool = False
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+
+    num_attention_heads: int = 24
+    num_key_value_heads: int = 2
+    head_dim: int = 256
+    rope_parameters: dict[str, Any] | None = field(
+        default_factory=lambda: {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+        }
+    )
+    partial_rotary_factor: float = 0.25
+    rope_theta: float = 10_000_000.0
+
+    linear_num_key_heads: int = 16
+    linear_num_value_heads: int = 48
+    linear_key_head_dim: int = 128
+    linear_value_head_dim: int = 128
+    linear_conv_kernel_dim: int = 4
+    output_gate_type: str = "sigmoid"
+
+    num_experts: int = 512
+    num_experts_per_tok: int = 10
+    moe_intermediate_size: int = 640
+    shared_expert_intermediate_size: int = 640
+    norm_topk_prob: bool = True
+
+    hc_count: int = 4
+    hc_lowrank: int = 320
+
+    layer_types: list[str] | None = None
+    full_attention_interval: int = 4
+    indexer_n_heads: int | None = None
+    indexer_kv_heads: int | None = None
+    indexer_head_dim: int | None = None
+    indexer_budget: int | None = None
+    indexer_compress_ratio: int | None = None
+
+    ple_layer_ids: list[int] = field(default_factory=list)
+    ple_embed_dim: int | None = None
+    ple_conv_kernel_size: int = 4
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    split_ngram_parts: int = 128
+    seed: int = 1234
+    eos_token_id: int | list[int] | None = None
+
+    def __post_init__(self):
+        rope = dict(self.rope_parameters or {})
+        self.partial_rotary_factor = float(
+            rope.get("partial_rotary_factor", self.partial_rotary_factor)
+        )
+        self.rope_theta = float(rope.get("rope_theta", self.rope_theta))
+        self.ple_embed_dim = self.hidden_size if self.ple_embed_dim is None else self.ple_embed_dim
+        self.ple_layer_ids = sorted(set(self.ple_layer_ids))
+        if self.layer_types is None:
+            self.layer_types = [
+                "linear_attention"
+                if (index + 1) % self.full_attention_interval
+                else "qwen_sparse_attention"
+                for index in range(self.num_hidden_layers)
+            ]
+        else:
+            self.layer_types = [
+                "qwen_sparse_attention" if kind == "full_attention" else kind
+                for kind in self.layer_types
+            ]
+        self._validate()
+
+    def _validate(self) -> None:
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError(
+                "Qwen4-Exp layer_types must have one entry per decoder layer"
+            )
+        unsupported = set(self.layer_types) - {
+            "linear_attention",
+            "qwen_sparse_attention",
+        }
+        if unsupported:
+            raise ValueError(f"Unsupported Qwen4-Exp layer types: {sorted(unsupported)}")
+        if self.hc_count <= 1 or self.hidden_size <= 0 or self.hc_lowrank <= 0:
+            raise ValueError("Qwen4-Exp requires positive four-stream HC dimensions")
+        if self.linear_num_value_heads % self.linear_num_key_heads:
+            raise ValueError("linear value heads must be divisible by key heads")
+        if self.output_gate_type != "sigmoid":
+            raise ValueError(
+                "Qwen4-Exp M1 supports the checkpoint-declared sigmoid GDN gate only"
+            )
+        qsa = (
+            self.indexer_n_heads,
+            self.indexer_kv_heads,
+            self.indexer_head_dim,
+            self.indexer_budget,
+            self.indexer_compress_ratio,
+        )
+        if any(value is None for value in qsa):
+            raise ValueError("Qwen4-Exp QSA requires the complete indexer contract")
+        if any(int(value) <= 0 for value in qsa if value is not None):
+            raise ValueError("Qwen4-Exp indexer values must be positive")
+        if self.indexer_kv_heads != 1:
+            raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
+        if self.indexer_budget % self.indexer_compress_ratio:
+            raise ValueError("indexer_budget must be divisible by indexer_compress_ratio")
+        rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+        if rotary_dim > self.indexer_head_dim:
+            raise ValueError("attention rotary dimensions must fit the QSA index head")
+        if not 0 < self.num_experts_per_tok <= self.num_experts:
+            raise ValueError("num_experts_per_tok must be within num_experts")
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ple_layer_ids and self.ple_embed_dim % ngram_heads:
+            raise ValueError("PLE embedding width must divide evenly across n-gram heads")
+        if any(layer < 1 or layer > self.num_hidden_layers for layer in self.ple_layer_ids):
+            raise ValueError("ple_layer_ids are one-indexed decoder layer ids")
+        if any(self.layer_types[layer - 1] != "linear_attention" for layer in self.ple_layer_ids):
+            raise ValueError("PLE is only valid on linear-attention layers")
+        if self.ple_layer_ids and self.eos_token_id is None:
+            raise ValueError("PLE requires eos_token_id for segment-local n-grams")
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    text_config: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, params):
+        if "text_config" not in params:
+            return cls(model_type=params["model_type"], text_config=params)
+        return super().from_dict(params)
+
+
+class ZeroCenteredRMSNorm(nn.Module):
+    """RMSNorm whose checkpoint weight represents an additive delta from one."""
+
+    def __init__(self, dim: int, *, group_size: int | None = None, eps: float = 1e-6):
+        super().__init__()
+        if group_size is not None and dim % group_size:
+            raise ValueError("grouped RMSNorm width must divide the feature width")
+        self.weight = mx.zeros((dim,))
+        self.group_size = group_size
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        original_shape = x.shape
+        if self.group_size is not None:
+            x = x.reshape(*x.shape[:-1], -1, self.group_size)
+            weight = self.weight.reshape(-1, self.group_size)
+        else:
+            weight = self.weight
+        dtype = x.dtype
+        normalized = x.astype(mx.float32)
+        normalized = normalized * mx.rsqrt(
+            mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
+        )
+        normalized = normalized * (1.0 + weight.astype(mx.float32))
+        return normalized.astype(dtype).reshape(original_shape)
+
+
+class SigmoidRMSNormGated(nn.Module):
+    """Qwen4-Exp's norm-before-gate GDN output transform."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.ones((dim,))
+        self.eps = eps
+
+    def __call__(self, hidden: mx.array, gate: mx.array) -> mx.array:
+        dtype = hidden.dtype
+        normalized = hidden.astype(mx.float32)
+        normalized = normalized * mx.rsqrt(
+            mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
+        )
+        normalized = normalized * self.weight.astype(mx.float32)
+        return (normalized * mx.sigmoid(gate.astype(mx.float32))).astype(dtype)
+
+
+class GatedResidual(nn.Module):
+    """Exact four-stream read mixer and per-branch write gate."""
+
+    def __init__(self, args: TextModelArgs, *, use_combine: bool = True):
+        super().__init__()
+        self.hc_count = args.hc_count
+        self.hidden_size = args.hidden_size
+        hc_width = self.hc_count * self.hidden_size
+        self.hc_norm = ZeroCenteredRMSNorm(
+            hc_width, group_size=self.hidden_size, eps=args.rms_norm_eps
+        )
+        self.input_mix_weight_down = nn.Linear(hc_width, args.hc_lowrank, bias=False)
+        self.input_mix_weight_up = nn.Linear(args.hc_lowrank, hc_width, bias=False)
+        self.block_inject_weight = (
+            nn.Linear(hc_width, self.hc_count, bias=False) if use_combine else None
+        )
+
+    def __call__(self, hyper_input: mx.array):
+        expected = self.hc_count * self.hidden_size
+        if hyper_input.shape[-1] != expected:
+            raise ValueError(
+                f"Qwen4-Exp HC expected {expected} features, got {hyper_input.shape[-1]}"
+            )
+        normalized = self.hc_norm(hyper_input)
+        mix = nn.silu(self.input_mix_weight_down(normalized) / self.hc_count)
+        mix = mx.sigmoid(self.input_mix_weight_up(mix))
+        mix = mix.reshape(*mix.shape[:-1], self.hc_count, self.hidden_size)
+        streams = normalized.reshape(
+            *normalized.shape[:-1], self.hc_count, self.hidden_size
+        )
+        mixed = mx.mean(mix * streams, axis=-2)
+        if self.block_inject_weight is None:
+            return mixed
+        injection = 2 * mx.sigmoid(
+            self.block_inject_weight(normalized) / self.hc_count
+        )
+        return mixed, hyper_input, injection
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(dim, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class SparseMoeBlock(nn.Module):
+    """Softmax top-k routed experts plus the separately gated shared expert."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.num_experts = args.num_experts
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.norm_topk_prob
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts
+        )
+        self.shared_expert = MLP(
+            args.hidden_size, args.shared_expert_intermediate_size
+        )
+        self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+        self.sharding_group = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gates = mx.softmax(self.gate(x), axis=-1, precise=True)
+        indices = mx.argpartition(gates, kth=-self.top_k, axis=-1)[..., -self.top_k :]
+        scores = mx.take_along_axis(gates, indices, axis=-1)
+        if self.norm_topk_prob:
+            scores = scores / scores.sum(axis=-1, keepdims=True)
+        routed = self.switch_mlp(x, indices)
+        routed = (routed * scores[..., None]).sum(axis=-2)
+        shared = self.shared_expert(x)
+        shared = mx.sigmoid(self.shared_expert_gate(x)) * shared
+        return routed + shared
+
+
+class GatedDeltaNet(nn.Module):
+    """Qwen4-Exp GDN with 48 value heads and a sigmoid output gate."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.num_v_heads = args.linear_num_value_heads
+        self.num_k_heads = args.linear_num_key_heads
+        self.head_k_dim = args.linear_key_head_dim
+        self.head_v_dim = args.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+        self.conv_kernel_size = args.linear_conv_kernel_dim
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv1d = nn.Conv1d(
+            self.conv_dim,
+            self.conv_dim,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            bias=False,
+        )
+        self.in_proj_qkv = nn.Linear(
+            self.hidden_size, self.conv_dim, bias=False
+        )
+        self.in_proj_z = nn.Linear(self.hidden_size, self.value_dim, bias=False)
+        self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.dt_bias = mx.ones((self.num_v_heads,))
+        self.A_log = mx.log(
+            mx.random.uniform(low=0.01, high=16.0, shape=(self.num_v_heads,))
+        )
+        self.norm = SigmoidRMSNormGated(self.head_v_dim, eps=args.rms_norm_eps)
+        self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: mx.array | None = None,
+        cache: Any | None = None,
+    ) -> mx.array:
+        batch, length, _ = inputs.shape
+        mixed = self.in_proj_qkv(inputs)
+        z = self.in_proj_z(inputs).reshape(
+            batch, length, self.num_v_heads, self.head_v_dim
+        )
+        beta = self.in_proj_b(inputs)
+        alpha = self.in_proj_a(inputs)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (batch, self.conv_kernel_size - 1, self.conv_dim),
+                dtype=inputs.dtype,
+            )
+        if mask is not None:
+            mixed = mx.where(mask[..., None], mixed, 0)
+        conv_input = mx.concatenate([conv_state, mixed], axis=1)
+        if cache is not None:
+            keep = self.conv_kernel_size - 1
+            if cache.lengths is not None:
+                ends = mx.clip(cache.lengths, 0, length)
+                positions = (ends[:, None] + mx.arange(keep))[..., None]
+                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
+            else:
+                cache[0] = mx.contiguous(conv_input[:, -keep:, :])
+        convolved = nn.silu(self.conv1d(conv_input))
+        query, key, value = [
+            item.reshape(batch, length, heads, dim)
+            for item, heads, dim in zip(
+                mx.split(convolved, [self.key_dim, 2 * self.key_dim], axis=-1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+        state = cache[1] if cache is not None else None
+        inv_scale = key.shape[-1] ** -0.5
+        query = (inv_scale**2) * mx.fast.rms_norm(query, None, 1e-6)
+        key = inv_scale * mx.fast.rms_norm(key, None, 1e-6)
+        output, state = gated_delta_update(
+            query,
+            key,
+            value,
+            alpha,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            state,
+            mask,
+            use_kernel=not self.training,
+        )
+        if cache is not None:
+            cache[1] = state
+            cache.advance(length)
+        output = self.norm(output, z)
+        return self.out_proj(output.reshape(batch, length, -1))
+
+
+def apply_rotary_positions(
+    x: mx.array,
+    positions: mx.array,
+    *,
+    rotary_dim: int,
+    base: float,
+) -> mx.array:
+    """Apply non-interleaved partial RoPE at explicit logical positions.
+
+    ``x`` has shape ``[batch, tokens, heads, dim]`` and ``positions`` is
+    ``[tokens]`` or ``[batch, tokens]``. Explicit positions are required by
+    QSA because compressed keys rotate at each group's first token.
+    """
+
+    if rotary_dim == 0:
+        return x
+    if rotary_dim % 2:
+        raise ValueError("Qwen4-Exp rotary dimensions must be even")
+    if positions.ndim == 1:
+        positions = positions[None, :]
+    inverse_frequency = 1.0 / (
+        base
+        ** (
+            mx.arange(0, rotary_dim, 2, dtype=mx.float32)
+            / float(rotary_dim)
+        )
+    )
+    angles = positions.astype(mx.float32)[..., None] * inverse_frequency
+    angles = mx.concatenate([angles, angles], axis=-1)[:, :, None, :]
+    cosine = mx.cos(angles)
+    sine = mx.sin(angles)
+    rotary = x[..., :rotary_dim]
+    half = rotary_dim // 2
+    rotated_half = mx.concatenate(
+        [-rotary[..., half:], rotary[..., :half]], axis=-1
+    )
+    rotated = rotary * cosine + rotated_half * sine
+    return mx.concatenate([rotated.astype(x.dtype), x[..., rotary_dim:]], axis=-1)
+
+
+class QSAIndexer(nn.Module):
+    """Weight-bearing QSA selector backed by raw-ring/compressed-key state."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.num_heads = int(args.indexer_n_heads)
+        self.num_kv_heads = int(args.indexer_kv_heads)
+        self.head_dim = int(args.indexer_head_dim)
+        self.token_budget = int(args.indexer_budget)
+        self.compress_ratio = int(args.indexer_compress_ratio)
+        self.block_topk = self.token_budget // self.compress_ratio
+        self.rotary_dim = int(args.head_dim * args.partial_rotary_factor)
+        self.rope_theta = args.rope_theta
+        self.index_qk_proj = nn.Linear(
+            args.hidden_size,
+            (self.num_heads + self.num_kv_heads) * self.head_dim,
+            bias=False,
+        )
+        self.q_layernorm = ZeroCenteredRMSNorm(
+            self.head_dim, eps=args.rms_norm_eps
+        )
+        self.k_layernorm = ZeroCenteredRMSNorm(
+            self.head_dim, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cache: QSAIndexCache,
+        *,
+        physical_kv_length: int,
+    ) -> mx.array:
+        batch, length, _ = hidden_states.shape
+        cache._ensure_batch(batch)
+        offsets = list(cache._offsets)
+        valid_lengths = cache.valid_lengths(length)
+        projected = self.index_qk_proj(hidden_states)
+        query_width = self.num_heads * self.head_dim
+        query, raw_keys = mx.split(projected, [query_width], axis=-1)
+        query = query.reshape(batch, length, self.num_heads, self.head_dim)
+        raw_keys = raw_keys.reshape(batch, length, self.num_kv_heads, self.head_dim)
+        if self.num_kv_heads != 1:
+            raise ValueError("Qwen4-Exp QSA requires one indexer KV head")
+        raw_keys = raw_keys.squeeze(2)
+        positions = mx.array(offsets, dtype=mx.int64)[:, None] + mx.arange(
+            length, dtype=mx.int64
+        )[None, :]
+        query = self.q_layernorm(query)
+        query = apply_rotary_positions(
+            query,
+            positions,
+            rotary_dim=self.rotary_dim,
+            base=self.rope_theta,
+        )
+
+        def transform_group(group: mx.array, start: int) -> mx.array:
+            normalized = self.k_layernorm(group[:, None, :])[:, 0, :]
+            return apply_rotary_positions(
+                normalized[:, None, None, :],
+                mx.array([start], dtype=mx.int64),
+                rotary_dim=self.rotary_dim,
+                base=self.rope_theta,
+            )[:, 0, 0, :]
+
+        cache.update(raw_keys, transform_group)
+        selected = mx.zeros((batch, length, physical_kv_length), dtype=mx.bool_)
+        left_padding = (
+            [0] * batch
+            if cache.left_padding is None
+            else [int(value) for value in cache.left_padding.tolist()]
+        )
+        for batch_index in range(batch):
+            for query_index in range(valid_lengths[batch_index]):
+                logical_position = offsets[batch_index] + query_index
+                complete_blocks = (logical_position + 1) // self.compress_ratio
+                token_indices: list[int] = []
+                if complete_blocks:
+                    keys = cache.keys_for_blocks(batch_index, complete_blocks)
+                    scores = mx.matmul(
+                        query[batch_index, query_index].astype(mx.float32),
+                        keys.astype(mx.float32).T,
+                    )
+                    scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
+                        self.head_dim
+                    )
+                    count = min(self.block_topk, complete_blocks)
+                    if count == complete_blocks:
+                        blocks = list(range(complete_blocks))
+                    else:
+                        blocks = [
+                            int(value)
+                            for value in mx.argpartition(
+                                scores, kth=-count
+                            )[-count:].tolist()
+                        ]
+                    for block in blocks:
+                        start = block * self.compress_ratio
+                        token_indices.extend(range(start, start + self.compress_ratio))
+                tail_start = complete_blocks * self.compress_ratio
+                token_indices.extend(range(tail_start, logical_position + 1))
+                if token_indices:
+                    physical_indices = [
+                        left_padding[batch_index] + index for index in token_indices
+                    ]
+                    selected[batch_index, query_index, physical_indices] = True
+        return selected[:, None, :, :]
+
+
+class QSAAttention(nn.Module):
+    """Qwen sparse attention with independent main-KV and index side caches."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.num_key_value_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.rotary_dim = int(args.head_dim * args.partial_rotary_factor)
+        self.q_proj = nn.Linear(
+            args.hidden_size,
+            args.num_attention_heads * args.head_dim * 2,
+            bias=args.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size,
+            args.num_key_value_heads * args.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size,
+            args.num_key_value_heads * args.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            args.num_attention_heads * args.head_dim,
+            args.hidden_size,
+            bias=args.attention_bias,
+        )
+        self.q_norm = ZeroCenteredRMSNorm(args.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = ZeroCenteredRMSNorm(args.head_dim, eps=args.rms_norm_eps)
+        self.rope = initialize_rope(
+            self.rotary_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=None,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+        self.indexer = QSAIndexer(args)
+
+    def __call__(self, x: mx.array, cache: Any | None = None) -> mx.array:
+        batch, length, _ = x.shape
+        kv_cache = None if cache is None else cache[0]
+        index_cache = None if cache is None else cache[1]
+        offset = 0 if kv_cache is None else kv_cache.offset
+        physical_length = (
+            length
+            if kv_cache is None
+            else int(getattr(kv_cache, "_idx", kv_cache.size())) + length
+        )
+        if index_cache is None:
+            index_cache = QSAIndexCache(self.indexer.compress_ratio)
+        selected = self.indexer(
+            x,
+            index_cache,
+            physical_kv_length=physical_length,
+        )
+
+        projected = self.q_proj(x).reshape(
+            batch, length, self.num_attention_heads, self.head_dim * 2
+        )
+        queries, gate = mx.split(projected, 2, axis=-1)
+        gate = gate.reshape(batch, length, -1)
+        keys = self.k_proj(x).reshape(
+            batch, length, self.num_key_value_heads, self.head_dim
+        )
+        values = self.v_proj(x).reshape(
+            batch, length, self.num_key_value_heads, self.head_dim
+        )
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(keys).transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if kv_cache is not None:
+            keys, values = kv_cache.update_and_fetch(keys, values)
+        additive_mask = mx.where(
+            selected,
+            mx.array(0.0, dtype=queries.dtype),
+            mx.array(-1e9, dtype=queries.dtype),
+        )
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=kv_cache,
+            scale=self.scale,
+            mask=additive_mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output * mx.sigmoid(gate))
+
+
+def _splitmix64(value: int) -> int:
+    mask = (1 << 64) - 1
+    value = (value + 0x9E3779B97F4A7C15) & mask
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & mask
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & mask
+    return (value ^ (value >> 31)) & mask
+
+
+def build_layer_multipliers(
+    unigram_vocab_size: int,
+    ngram_size: int,
+    ple_layer_index: int,
+    seed: int,
+) -> list[int]:
+    multiplier_max = ((1 << 63) - 1) // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + 10007 * ple_layer_index
+    return [
+        2
+        * (
+            _splitmix64(base_seed + 0x9E3779B97F4A7C15 * (index + 1))
+            % half_bound
+        )
+        + 1
+        for index in range(ngram_size)
+    ]
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    return all(value % divisor for divisor in range(3, math.isqrt(value) + 1, 2))
+
+
+def find_nth_prime_after(start: int, count: int) -> int:
+    value = start
+    for _ in range(count):
+        value += 1
+        while not _is_prime(value):
+            value += 1
+    return value
+
+
+class ShardedEmbedding(nn.Module):
+    """Exact row-wise embedding split matching the checkpoint's 128 shards.
+
+    Keeping shards as independent ``nn.Embedding`` leaves conversion and
+    serving bounded: quantization never concatenates the 51B-parameter PLE
+    table into one temporary tensor.
+    """
+
+    def __init__(self, num_embeddings: int, dims: int, parts: int):
+        super().__init__()
+        if num_embeddings % parts:
+            raise ValueError("sharded embedding rows must divide evenly")
+        self.rows_per_shard = num_embeddings // parts
+        self.shards = [nn.Embedding(self.rows_per_shard, dims) for _ in range(parts)]
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        shard_ids = indices // self.rows_per_shard
+        # Evaluating at most 128 small integer ids selects only the embedding
+        # shards needed by this request; it never materializes embedding rows.
+        used = sorted({int(value) for value in shard_ids.reshape(-1).tolist()})
+        output = None
+        for shard_id in used:
+            shard_id = int(shard_id)
+            local = indices - shard_id * self.rows_per_shard
+            mask = shard_ids == shard_id
+            gathered = self.shards[shard_id](mx.clip(local, 0, self.rows_per_shard - 1))
+            gathered = mx.where(mask[..., None], gathered, 0)
+            output = gathered if output is None else output + gathered
+        if output is None:
+            return mx.zeros((*indices.shape, self.shards[0].weight.shape[-1]))
+        return output
+
+
+class NGramEmbedding(nn.Module):
+    """Segment-aware hashed bigram/trigram embedding used by PLE."""
+
+    def __init__(
+        self,
+        args: TextModelArgs,
+        *,
+        embedding_dim: int,
+        ple_layer_index: int,
+    ):
+        super().__init__()
+        self.ngram_size = args.ngram_size
+        self.context_len = self.ngram_size - 1
+        self.heads_per_ngram = args.heads_per_ngram
+        self.ngram_heads = self.context_len * self.heads_per_ngram
+        self.eos_token_id = (
+            args.eos_token_id[0]
+            if isinstance(args.eos_token_id, list)
+            else args.eos_token_id
+        )
+        sizes = [
+            find_nth_prime_after(
+                args.ngram_vocab_size_base - 1,
+                ple_layer_index * self.ngram_heads + head + 1,
+            )
+            for head in range(self.ngram_heads)
+        ]
+        offsets: list[int] = []
+        offset = 0
+        for size in sizes:
+            offsets.append(offset)
+            offset += size
+        divisor = args.make_ngram_vocab_size_divisible_by
+        padded_rows = ((offset + divisor - 1) // divisor) * divisor
+        self.layer_multipliers = mx.array(
+            build_layer_multipliers(
+                args.vocab_size,
+                args.ngram_size,
+                ple_layer_index,
+                args.seed,
+            ),
+            dtype=mx.int64,
+        )
+        self.ngram_heads_vocab_sizes = mx.array(sizes, dtype=mx.int64)
+        self.ngram_heads_offsets = mx.array(offsets, dtype=mx.int64)
+        self.ngram_embedding = ShardedEmbedding(
+            padded_rows,
+            embedding_dim // self.ngram_heads,
+            args.split_ngram_parts,
+        )
+
+    def _shift_right_ignore_eos(self, token_ids: mx.array, shift: int) -> mx.array:
+        if shift == 0:
+            return token_ids
+        _, length = token_ids.shape
+        positions = mx.arange(length, dtype=mx.int64)
+        eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
+        previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
+        previous_eos = mx.concatenate(
+            [mx.full((token_ids.shape[0], 1), -1, dtype=mx.int64), previous_eos_inclusive[:, :-1]],
+            axis=1,
+        )
+        position_in_segment = positions[None, :] - previous_eos - 1
+        source_positions = positions - shift
+        gather_positions = mx.maximum(source_positions, 0)[None, :]
+        gather_positions = mx.broadcast_to(gather_positions, token_ids.shape)
+        shifted = mx.take_along_axis(token_ids, gather_positions, axis=1)
+        valid = (position_in_segment >= shift) & (source_positions[None, :] >= 0)
+        return mx.where(valid, shifted, self.eos_token_id)
+
+    def compute_ids(self, input_ids: mx.array, cache: Any | None = None) -> mx.array:
+        input_ids = input_ids.astype(mx.int64)
+        if cache is not None and cache[3] is not None:
+            previous = cache[3]
+        else:
+            previous = mx.full(
+                (input_ids.shape[0], self.context_len),
+                self.eos_token_id,
+                dtype=mx.int64,
+            )
+        history = mx.concatenate([previous, input_ids], axis=1)
+        if cache is not None:
+            cache[3] = mx.contiguous(history[:, -self.context_len :])
+        shifted = [
+            self._shift_right_ignore_eos(history, shift)
+            for shift in range(self.ngram_size)
+        ]
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for position in range(1, ngram):
+                mixed = mx.bitwise_xor(
+                    mixed,
+                    shifted[position] * self.layer_multipliers[position],
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ids = mx.remainder(mixed[..., None], sizes) + offsets
+            blocks.append(ids)
+        return mx.concatenate(blocks, axis=-1)[:, -input_ids.shape[1] :]
+
+    def __call__(self, input_ids: mx.array, cache: Any | None = None) -> mx.array:
+        ids = self.compute_ids(input_ids, cache)
+        return self.ngram_embedding(ids).flatten(-2)
+
+
+class PLELayer(nn.Module):
+    """Exact PLE projection, gating, and dilation-three short convolution."""
+
+    def __init__(
+        self,
+        args: TextModelArgs,
+        *,
+        ple_layer_index: int,
+    ):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.hc_count = args.hc_count
+        hc_width = args.hc_count * args.hidden_size
+        embed_dim = int(args.ple_embed_dim)
+        self.ple_embedding = NGramEmbedding(
+            args,
+            embedding_dim=embed_dim,
+            ple_layer_index=ple_layer_index,
+        )
+        self.key_proj = nn.Linear(embed_dim, hc_width, bias=False)
+        self.value_proj = nn.Linear(embed_dim, args.hidden_size, bias=False)
+        norm_kwargs = {
+            "group_size": args.hidden_size,
+            "eps": args.rms_norm_eps,
+        }
+        self.norm_key = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
+        self.norm_query = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
+        self.norm_conv = ZeroCenteredRMSNorm(hc_width, **norm_kwargs)
+        self.conv_state_len = (args.ple_conv_kernel_size - 1) * args.ngram_size
+        self.conv1d = nn.Conv1d(
+            hc_width,
+            hc_width,
+            kernel_size=args.ple_conv_kernel_size,
+            dilation=args.ngram_size,
+            groups=hc_width,
+            bias=False,
+        )
+
+    def _short_conv(self, x: mx.array, cache: Any | None) -> mx.array:
+        if cache is not None and cache[2] is not None:
+            state = cache[2]
+        else:
+            state = mx.zeros(
+                (x.shape[0], self.conv_state_len, x.shape[-1]), dtype=x.dtype
+            )
+        conv_input = mx.concatenate([state, x], axis=1)
+        if cache is not None:
+            cache[2] = mx.contiguous(conv_input[:, -self.conv_state_len :, :])
+        return nn.silu(self.conv1d(conv_input))
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        input_ids: mx.array,
+        cache: Any | None,
+        mask: mx.array | None = None,
+    ) -> mx.array:
+        embeddings = self.ple_embedding(input_ids, cache)
+        keys = self.norm_key(self.key_proj(embeddings)).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        values = self.value_proj(embeddings)
+        queries = self.norm_query(hidden_states).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        gate = mx.sum(keys * queries, axis=-1, keepdims=True) / math.sqrt(
+            self.hidden_size
+        )
+        gate = mx.sqrt(mx.maximum(mx.abs(gate), 1e-6)) * mx.sign(gate)
+        gated = mx.sigmoid(gate) * values[..., None, :]
+        gated = gated.flatten(-2)
+        normalized = self.norm_conv(gated)
+        if mask is not None:
+            gated = mx.where(mask[..., None], gated, 0)
+            normalized = mx.where(mask[..., None], normalized, 0)
+        return gated + self._short_conv(normalized, cache)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: TextModelArgs, layer_index: int):
+        super().__init__()
+        self.layer_type = args.layer_types[layer_index]
+        self.is_linear = self.layer_type == "linear_attention"
+        if self.is_linear:
+            self.linear_attn = GatedDeltaNet(args)
+        else:
+            self.self_attn = QSAAttention(args)
+        self.mlp = SparseMoeBlock(args)
+        ple_index = (
+            args.ple_layer_ids.index(layer_index + 1)
+            if layer_index + 1 in args.ple_layer_ids
+            else None
+        )
+        self.ple = (
+            PLELayer(args, ple_layer_index=ple_index)
+            if ple_index is not None
+            else None
+        )
+        self.attn_hyper_connection = GatedResidual(args)
+        self.mlp_hyper_connection = GatedResidual(args)
+
+    @staticmethod
+    def _combine(
+        output: mx.array,
+        residual: mx.array,
+        injection: mx.array,
+    ) -> mx.array:
+        injected = output[..., None, :] * injection[..., :, None]
+        return residual + injected.flatten(-2)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        input_ids: mx.array,
+        mask: mx.array | None,
+        cache: Any | None,
+    ) -> mx.array:
+        if self.ple is not None:
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                input_ids,
+                cache,
+                mask,
+            )
+        mixed, residual, injection = self.attn_hyper_connection(hidden_states)
+        if self.is_linear:
+            output = self.linear_attn(mixed, mask=mask, cache=cache)
+        else:
+            output = self.self_attn(mixed, cache=cache)
+        hidden_states = self._combine(output, residual, injection)
+
+        mixed, residual, injection = self.mlp_hyper_connection(hidden_states)
+        output = self.mlp(mixed)
+        return self._combine(output, residual, injection)
+
+
+class Qwen4ExpTextModel(nn.Module):
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(args, layer_index)
+            for layer_index in range(args.num_hidden_layers)
+        ]
+        self.hyper_connection_mixer = GatedResidual(args, use_combine=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: list[Any] | None = None,
+        input_embeddings: mx.array | None = None,
+    ) -> mx.array:
+        hidden_states = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(inputs)
+        )
+        hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
+        if cache is None:
+            cache = [None] * len(self.layers)
+        linear_index = next(
+            (index for index, layer in enumerate(self.layers) if layer.is_linear),
+            None,
+        )
+        linear_mask = (
+            None
+            if linear_index is None
+            else create_ssm_mask(hidden_states, cache[linear_index])
+        )
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(
+                hidden_states,
+                input_ids=inputs,
+                mask=linear_mask if layer.is_linear else None,
+                cache=layer_cache,
+            )
+        return self.hyper_connection_mixer(hidden_states)
+
+
+class TextModel(nn.Module):
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = Qwen4ExpTextModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: list[Any] | None = None,
+        input_embeddings: mx.array | None = None,
+    ) -> mx.array:
+        hidden = self.model(inputs, cache, input_embeddings)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(hidden)
+        return self.lm_head(hidden)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.is_linear:
+                caches.append(ArraysCache(size=4 if layer.ple is not None else 2))
+            else:
+                caches.append(
+                    CacheList(
+                        KVCache(),
+                        QSAIndexCache(layer.self_attn.indexer.compress_ratio),
+                    )
+                )
+        return caches
+
+    def sanitize(self, weights):
+        weights = {
+            key: value
+            for key, value in weights.items()
+            if not key.startswith("mtp.") and ".visual." not in key
+        }
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        sanitized = {}
+        for key, value in weights.items():
+            if key.endswith("conv1d.weight") and value.ndim == 3 and value.shape[1] == 1:
+                value = value.moveaxis(2, 1)
+            if ".mlp.experts.gate_up_proj" in key:
+                gate_up = value
+                midpoint = gate_up.shape[-2] // 2
+                base = key.replace("experts.gate_up_proj", "switch_mlp")
+                sanitized[f"{base}.gate_proj.weight"] = gate_up[..., :midpoint, :]
+                sanitized[f"{base}.up_proj.weight"] = gate_up[..., midpoint:, :]
+                continue
+            if ".mlp.experts.down_proj" in key:
+                key = key.replace(
+                    "experts.down_proj", "switch_mlp.down_proj.weight"
+                )
+            if ".ngram_embedding.shard_" in key:
+                prefix, suffix = key.split(".ngram_embedding.shard_", 1)
+                shard, leaf = suffix.split(".", 1)
+                key = f"{prefix}.ngram_embedding.shards.{int(shard)}.{leaf}"
+            sanitized[key] = value
+        return sanitized
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _module):
+            if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        return lambda path: not path.endswith("A_log")
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.language_model = TextModel(TextModelArgs.from_dict(args.text_config))
+
+    def __call__(self, inputs: mx.array, cache=None, input_embeddings=None):
+        return self.language_model(inputs, cache, input_embeddings)
+
+    @property
+    def model(self):
+        return self.language_model.model
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    def sanitize(self, weights):
+        mapped = {}
+        for key, value in weights.items():
+            if key.startswith("model.visual") or key.startswith("vision_tower"):
+                continue
+            if key.startswith("mtp."):
+                continue
+            if key.startswith("model.language_model"):
+                key = key.replace(
+                    "model.language_model", "language_model.model", 1
+                )
+            elif not key.startswith("language_model."):
+                key = f"language_model.{key}"
+            mapped[key] = value
+        return self.language_model.sanitize(mapped)
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1110,6 +1110,11 @@ class TextModel(nn.Module):
     @property
     def quant_predicate(self):
         def predicate(path, _module):
+            if ".ple.ple_embedding.ngram_embedding.shards." in path:
+                # The checkpoint's PLE tables have width 160.  Group 32 is the
+                # largest established MLX group that divides that width, so it
+                # preserves the source shape without a padding/slicing format.
+                return {"group_size": 32, "bits": 4}
             if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
                 return {"group_size": 64, "bits": 8}
             return True

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -740,10 +740,20 @@ class QSAAttention(nn.Module):
         )
         self.indexer = QSAIndexer(args)
 
-    def __call__(self, x: mx.array, cache: Any | None = None) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Any | None = None,
+        mask: mx.array | str | None = None,
+    ) -> mx.array:
         batch, length, _ = x.shape
         kv_cache = None if cache is None else cache[0]
         index_cache = None if cache is None else cache[1]
+        if mask is None:
+            # The cache offset must be observed before this layer appends the
+            # current K/V chunk. Computing the mask after update double-counts
+            # chunked prefills (L queries against past+2L keys).
+            mask = create_attention_mask(x, kv_cache)
         offset = 0 if kv_cache is None else kv_cache.offset
         physical_length = (
             length
@@ -795,7 +805,7 @@ class QSAAttention(nn.Module):
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
         additive_mask = (
-            create_attention_mask(x, kv_cache)
+            mask
             if selected is None
             else mx.where(
                 selected,
@@ -1140,7 +1150,7 @@ class DecoderLayer(nn.Module):
         if self.is_linear:
             output = self.linear_attn(mixed, mask=mask, cache=cache)
         else:
-            output = self.self_attn(mixed, cache=cache)
+            output = self.self_attn(mixed, cache=cache, mask=mask)
         hidden_states = self._combine(output, residual, injection)
 
         mixed, residual, injection = self.mlp_hyper_connection(hidden_states)
@@ -1182,11 +1192,21 @@ class Qwen4ExpTextModel(nn.Module):
             if linear_index is None
             else create_ssm_mask(hidden_states, cache[linear_index])
         )
+        attention_index = next(
+            (index for index, layer in enumerate(self.layers) if not layer.is_linear),
+            None,
+        )
+        attention_cache = (
+            None
+            if attention_index is None or cache[attention_index] is None
+            else cache[attention_index][0]
+        )
+        attention_mask = create_attention_mask(hidden_states, attention_cache)
         for layer, layer_cache in zip(self.layers, cache):
             hidden_states = layer(
                 hidden_states,
                 input_ids=inputs,
-                mask=linear_mask if layer.is_linear else None,
+                mask=linear_mask if layer.is_linear else attention_mask,
                 cache=layer_cache,
             )
         return self.hyper_connection_mixer(hidden_states)

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -806,7 +806,14 @@ class NGramEmbedding(nn.Module):
             )
         history = mx.concatenate([previous, input_ids], axis=1)
         if cache is not None:
-            cache[3] = mx.contiguous(history[:, -self.context_len :])
+            if cache.lengths is not None:
+                valid = mx.clip(cache.lengths, 0, input_ids.shape[1])
+                positions = (valid[:, None] + mx.arange(self.context_len))[..., None]
+                cache[3] = mx.take_along_axis(
+                    history[..., None], positions, axis=1
+                ).squeeze(-1)
+            else:
+                cache[3] = mx.contiguous(history[:, -self.context_len :])
         shifted = [
             self._shift_right_ignore_eos(history, shift)
             for shift in range(self.ngram_size)
@@ -879,7 +886,16 @@ class PLELayer(nn.Module):
             )
         conv_input = mx.concatenate([state, x], axis=1)
         if cache is not None:
-            cache[2] = mx.contiguous(conv_input[:, -self.conv_state_len :, :])
+            if cache.lengths is not None:
+                valid = mx.clip(cache.lengths, 0, x.shape[1])
+                positions = (
+                    valid[:, None] + mx.arange(self.conv_state_len)
+                )[..., None]
+                cache[2] = mx.take_along_axis(conv_input, positions, axis=1)
+            else:
+                cache[2] = mx.contiguous(
+                    conv_input[:, -self.conv_state_len :, :]
+                )
         return nn.silu(self.conv1d(conv_input))
 
     def __call__(
@@ -889,6 +905,8 @@ class PLELayer(nn.Module):
         cache: Any | None,
         mask: mx.array | None = None,
     ) -> mx.array:
+        if mask is not None:
+            input_ids = mx.where(mask, input_ids, self.ple_embedding.eos_token_id)
         embeddings = self.ple_embedding(input_ids, cache)
         keys = self.norm_key(self.key_proj(embeddings)).reshape(
             *hidden_states.shape[:-1], self.hc_count, self.hidden_size

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -183,6 +183,8 @@ class TextModelArgs(BaseModelArgs):
             raise ValueError("PLE is only valid on linear-attention layers")
         if self.ple_layer_ids and self.eos_token_id is None:
             raise ValueError("PLE requires eos_token_id for segment-local n-grams")
+        if isinstance(self.eos_token_id, list) and not self.eos_token_id:
+            raise ValueError("PLE eos_token_id list must not be empty")
 
 
 @dataclass
@@ -919,11 +921,12 @@ class NGramEmbedding(nn.Module):
         self.context_len = self.ngram_size - 1
         self.heads_per_ngram = args.heads_per_ngram
         self.ngram_heads = self.context_len * self.heads_per_ngram
-        self.eos_token_id = (
-            args.eos_token_id[0]
+        self.eos_token_ids = tuple(
+            args.eos_token_id
             if isinstance(args.eos_token_id, list)
-            else args.eos_token_id
+            else [cast(int, args.eos_token_id)]
         )
+        self.eos_token_id = self.eos_token_ids[0]
         sizes = [
             find_nth_prime_after(
                 args.ngram_vocab_size_base - 1,
@@ -960,7 +963,10 @@ class NGramEmbedding(nn.Module):
             return token_ids
         _, length = token_ids.shape
         positions = mx.arange(length, dtype=mx.int64)
-        eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
+        is_eos = token_ids == self.eos_token_ids[0]
+        for eos_token_id in self.eos_token_ids[1:]:
+            is_eos = is_eos | (token_ids == eos_token_id)
+        eos_positions = mx.where(is_eos, positions, -1)
         previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
         previous_eos = mx.concatenate(
             [

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -14,7 +14,12 @@ import json
 from collections.abc import Callable, Sequence
 
 import mlx.core as mx
-from mlx_lm.models.cache import ArraysCache
+
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.cache import ArraysCache  # noqa: E402
 
 
 class QSAIndexCache(ArraysCache):

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp QSA side cache for the MLX text decoder.
+
+The cache follows the engine request-lifecycle contract: a fixed raw-key ring
+feeds one compressed key per complete group, while the compressed cache is
+owned independently from the main attention KV cache. It subclasses
+``ArraysCache`` so mlx-lm's established batching path can prepare, merge,
+filter, extend, and extract it without a model-specific scheduler patch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import mlx.core as mx
+from mlx_lm.models.cache import ArraysCache
+
+
+class QSAIndexCache(ArraysCache):
+    """Raw circular index keys plus persistent compressed-key state."""
+
+    step = 256
+
+    def __init__(
+        self,
+        compress_ratio: int,
+        left_padding: Sequence[int] | None = None,
+    ):
+        if compress_ratio <= 0:
+            raise ValueError("QSA compression ratio must be positive")
+        super().__init__(size=2, left_padding=list(left_padding or []))
+        self.compress_ratio = compress_ratio
+        batch = len(left_padding) if left_padding else 1
+        self._offsets = [0] * batch
+        self._compressed_counts = [0] * batch
+        self._valid_until: list[int] | None = None
+        self._right_padding: list[int] | None = None
+
+    def _ensure_batch(self, batch: int):
+        """Adopt mlx-lm's fresh-batch size before state is committed."""
+        if len(self._offsets) == batch:
+            return
+        if not self.empty() or self.raw_ring is not None:
+            raise ValueError("QSA cache batch size changed outside cache lifecycle")
+        if self.left_padding is None or self.left_padding.size != batch:
+            raise ValueError("QSA cache batch metadata does not match input")
+        self._offsets = [0] * batch
+        self._compressed_counts = [0] * batch
+
+    @property
+    def raw_ring(self):
+        return self.cache[0]
+
+    @raw_ring.setter
+    def raw_ring(self, value):
+        self.cache[0] = value
+
+    @property
+    def compressed_keys(self):
+        return self.cache[1]
+
+    @compressed_keys.setter
+    def compressed_keys(self, value):
+        self.cache[1] = value
+
+    @property
+    def offset(self):
+        if len(self._offsets) == 1 and self.left_padding is None:
+            return self._offsets[0]
+        return mx.array(self._offsets, dtype=mx.int32)
+
+    @property
+    def _compressed_count(self):
+        """Compatibility scalar used by single-request diagnostics/tests."""
+        if len(self._compressed_counts) != 1:
+            raise AttributeError("batched QSA cache has per-row compressed counts")
+        return self._compressed_counts[0]
+
+    def prepare(self, lengths=None, right_padding=None, **_kwargs):
+        batch = (
+            int(self.left_padding.size)
+            if self.left_padding is not None
+            else len(self._offsets)
+        )
+        self._ensure_batch(batch)
+        if lengths is not None:
+            self._valid_until = [
+                offset + int(length)
+                for offset, length in zip(self._offsets, lengths)
+            ]
+        self._right_padding = (
+            None if right_padding is None else [int(item) for item in right_padding]
+        )
+
+    def finalize(self):
+        if self._right_padding is not None and self.left_padding is not None:
+            self.left_padding += mx.array(self._right_padding, dtype=mx.int32)
+        self._valid_until = None
+        self._right_padding = None
+        self.lengths = None
+        # QSA state contains only logical tokens, so unlike the main KV cache
+        # it needs no physical roll after a right-padded prefill.
+
+    def valid_lengths(self, input_length: int) -> list[int]:
+        if self._valid_until is None:
+            return [input_length] * len(self._offsets)
+        return [
+            max(0, min(input_length, limit - offset))
+            for limit, offset in zip(self._valid_until, self._offsets)
+        ]
+
+    def update(
+        self,
+        raw_keys: mx.array,
+        transform_group: Callable[[mx.array, int], mx.array],
+    ) -> mx.array:
+        """Commit valid raw rows and cache every newly completed group.
+
+        ``raw_keys`` is ``[batch, tokens, index_dim]``. ``transform_group``
+        receives one row's raw mean ``[1, index_dim]`` and the group's logical
+        first position. Per-row invocation is intentional: continuous batches
+        may contain requests at different logical positions.
+        """
+
+        batch, length, dim = raw_keys.shape
+        self._ensure_batch(batch)
+        if self.raw_ring is None:
+            self.raw_ring = mx.zeros(
+                (batch, self.compress_ratio, dim), dtype=raw_keys.dtype
+            )
+        elif self.raw_ring.shape[0] != batch or self.raw_ring.shape[-1] != dim:
+            raise ValueError("QSA raw-key cache shape changed within one request")
+
+        completed: list[list[mx.array]] = [[] for _ in range(batch)]
+        valid_lengths = self.valid_lengths(length)
+        for row, valid_length in enumerate(valid_lengths):
+            for token in range(valid_length):
+                position = self._offsets[row] + token
+                self.raw_ring[row, position % self.compress_ratio, :] = raw_keys[
+                    row, token, :
+                ]
+                if (position + 1) % self.compress_ratio == 0:
+                    pooled = mx.mean(
+                        self.raw_ring[row : row + 1].astype(mx.float32), axis=1
+                    ).astype(raw_keys.dtype)
+                    completed[row].append(
+                        transform_group(
+                            pooled, position + 1 - self.compress_ratio
+                        )[0]
+                    )
+            self._offsets[row] += valid_length
+
+        new_counts = [
+            old + len(rows)
+            for old, rows in zip(self._compressed_counts, completed)
+        ]
+        max_count = max(new_counts, default=0)
+        if max_count:
+            capacity = ((max_count + self.step - 1) // self.step) * self.step
+            if self.compressed_keys is None:
+                expanded = mx.zeros(
+                    (batch, capacity, dim), dtype=raw_keys.dtype
+                )
+            elif capacity > self.compressed_keys.shape[1]:
+                expanded = mx.zeros(
+                    (batch, capacity, dim), dtype=self.compressed_keys.dtype
+                )
+                expanded[:, : self.compressed_keys.shape[1], :] = self.compressed_keys
+            else:
+                expanded = self.compressed_keys
+            for row, rows in enumerate(completed):
+                if rows:
+                    start = self._compressed_counts[row]
+                    expanded[row, start : start + len(rows), :] = mx.stack(rows)
+            self.compressed_keys = expanded
+        self._compressed_counts = new_counts
+
+        if self.compressed_keys is None:
+            return mx.zeros((batch, 0, dim), dtype=raw_keys.dtype)
+        return self.compressed_keys[:, :max_count, :]
+
+    def keys_for_blocks(self, row: int, block_count: int) -> mx.array:
+        if block_count < 0 or block_count > self._compressed_counts[row]:
+            raise ValueError("QSA compressed block request is out of range")
+        if self.compressed_keys is None:
+            if block_count:
+                raise ValueError("QSA compressed cache is empty")
+            return mx.zeros((0, 0))
+        return self.compressed_keys[row, :block_count, :]
+
+    @property
+    def state(self):
+        compressed = self.compressed_keys
+        if compressed is not None:
+            compressed = compressed[:, : max(self._compressed_counts, default=0)]
+        return self.raw_ring, compressed
+
+    @state.setter
+    def state(self, value):
+        self.raw_ring, self.compressed_keys = value
+
+    @property
+    def meta_state(self):
+        return (
+            self.compress_ratio,
+            list(self._offsets),
+            list(self._compressed_counts),
+        )
+
+    @meta_state.setter
+    def meta_state(self, value):
+        self.compress_ratio = int(value[0])
+        self._offsets = [int(item) for item in value[1]]
+        self._compressed_counts = [int(item) for item in value[2]]
+        self._valid_until = None
+        self._right_padding = None
+        self.left_padding = (
+            None
+            if len(self._offsets) == 1
+            else mx.zeros(len(self._offsets), dtype=mx.int32)
+        )
+        self.lengths = None
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        cache = cls.__new__(cls)
+        cache.cache = [None, None]
+        cache.meta_state = meta_state
+        cache.state = state
+        return cache
+
+    def is_trimmable(self):
+        # A compressed block does not retain its source rows. Marking this
+        # trim-safe would corrupt partial-prefix rollback. M2 adds transactional
+        # undo for speculative tokens; exact cache clones remain supported.
+        return False
+
+    def trim(self, _n):
+        return 0
+
+    def size(self):
+        return max(self._offsets, default=0)
+
+    def empty(self):
+        return all(offset == 0 for offset in self._offsets)
+
+    @property
+    def nbytes(self):
+        return sum(item.nbytes for item in self.cache if item is not None)
+
+    def filter(self, batch_indices):
+        indices = (
+            batch_indices.tolist()
+            if isinstance(batch_indices, mx.array)
+            else list(batch_indices)
+        )
+        super().filter(batch_indices)
+        self._offsets = [self._offsets[index] for index in indices]
+        self._compressed_counts = [
+            self._compressed_counts[index] for index in indices
+        ]
+        if self._valid_until is not None:
+            self._valid_until = [self._valid_until[index] for index in indices]
+        max_offset = max(self._offsets, default=0)
+        self.left_padding = mx.array(
+            [max_offset - offset for offset in self._offsets], dtype=mx.int32
+        )
+
+    def extend(self, other):
+        rows = [self.extract(index) for index in range(len(self._offsets))]
+        rows.extend(other.extract(index) for index in range(len(other._offsets)))
+        merged = self.merge(rows)
+        self.cache = list(merged.cache)
+        self.left_padding = merged.left_padding
+        self.lengths = None
+        self._offsets = merged._offsets
+        self._compressed_counts = merged._compressed_counts
+        self._valid_until = self._right_padding = None
+
+    def extract(self, idx):
+        cache = QSAIndexCache(self.compress_ratio)
+        count = self._compressed_counts[idx]
+        if self.raw_ring is not None:
+            cache.raw_ring = mx.contiguous(self.raw_ring[idx : idx + 1])
+        if self.compressed_keys is not None and count:
+            cache.compressed_keys = mx.contiguous(
+                self.compressed_keys[idx : idx + 1, :count]
+            )
+        cache._offsets = [self._offsets[idx]]
+        cache._compressed_counts = [count]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        if not caches:
+            raise ValueError("cannot merge an empty QSA cache list")
+        ratio = caches[0].compress_ratio
+        if any(cache.compress_ratio != ratio for cache in caches):
+            raise ValueError("QSA caches in a batch must share compression ratio")
+        merged = cls(ratio, left_padding=[0] * len(caches))
+        merged._offsets = [cache._offsets[0] for cache in caches]
+        merged._compressed_counts = [
+            cache._compressed_counts[0] for cache in caches
+        ]
+        max_offset = max(merged._offsets, default=0)
+        merged.left_padding = mx.array(
+            [max_offset - offset for offset in merged._offsets], dtype=mx.int32
+        )
+
+        raw_template = next(
+            (cache.raw_ring for cache in caches if cache.raw_ring is not None), None
+        )
+        if raw_template is not None:
+            merged.raw_ring = mx.zeros(
+                (len(caches), *raw_template.shape[1:]), dtype=raw_template.dtype
+            )
+            for row, cache in enumerate(caches):
+                if cache.raw_ring is not None:
+                    merged.raw_ring[row] = cache.raw_ring[0]
+
+        compressed_template = next(
+            (
+                cache.compressed_keys
+                for cache in caches
+                if cache.compressed_keys is not None
+            ),
+            None,
+        )
+        max_count = max(merged._compressed_counts, default=0)
+        if compressed_template is not None and max_count:
+            merged.compressed_keys = mx.zeros(
+                (len(caches), max_count, compressed_template.shape[-1]),
+                dtype=compressed_template.dtype,
+            )
+            for row, cache in enumerate(caches):
+                count = cache._compressed_counts[0]
+                if count:
+                    merged.compressed_keys[row, :count] = cache.compressed_keys[
+                        0, :count
+                    ]
+        return merged

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -303,10 +303,11 @@ class QSAIndexCache(ArraysCache):
         ]
         if self._valid_until is not None:
             self._valid_until = [self._valid_until[index] for index in indices]
-        max_offset = max(self._offsets, default=0)
-        self.left_padding = mx.array(
-            [max_offset - offset for offset in self._offsets], dtype=mx.int32
-        )
+        # ArraysCache.filter already selected the matching physical-padding
+        # rows. Preserve those values: they describe where each request's
+        # logical token zero sits in the still-padded KV tensors. Recomputing
+        # against the longest *surviving* request would incorrectly turn a
+        # retained shorter row's padding into zero.
 
     def extend(self, other):
         rows = [self.extract(index) for index in range(len(self._offsets))]

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -10,6 +10,7 @@ filter, extend, and extract it without a model-specific scheduler patch.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Sequence
 
 import mlx.core as mx
@@ -201,17 +202,23 @@ class QSAIndexCache(ArraysCache):
 
     @property
     def meta_state(self):
-        return (
-            self.compress_ratio,
-            list(self._offsets),
-            list(self._compressed_counts),
+        return json.dumps(
+            {
+                "compress_ratio": self.compress_ratio,
+                "offsets": self._offsets,
+                "compressed_counts": self._compressed_counts,
+            },
+            separators=(",", ":"),
         )
 
     @meta_state.setter
     def meta_state(self, value):
-        self.compress_ratio = int(value[0])
-        self._offsets = [int(item) for item in value[1]]
-        self._compressed_counts = [int(item) for item in value[2]]
+        decoded = json.loads(value)
+        self.compress_ratio = int(decoded["compress_ratio"])
+        self._offsets = [int(item) for item in decoded["offsets"]]
+        self._compressed_counts = [
+            int(item) for item in decoded["compressed_counts"]
+        ]
         self._valid_until = None
         self._right_padding = None
         self.left_padding = (

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -36,6 +36,7 @@ class QSAIndexCache(ArraysCache):
         self._compressed_counts = [0] * batch
         self._valid_until: list[int] | None = None
         self._right_padding: list[int] | None = None
+        self._pending_left_padding = [int(item) for item in (left_padding or [0])]
 
     def _ensure_batch(self, batch: int):
         """Adopt mlx-lm's fresh-batch size before state is committed."""
@@ -47,6 +48,9 @@ class QSAIndexCache(ArraysCache):
             raise ValueError("QSA cache batch metadata does not match input")
         self._offsets = [0] * batch
         self._compressed_counts = [0] * batch
+        self._pending_left_padding = [
+            int(item) for item in self.left_padding.tolist()
+        ]
 
     @property
     def raw_ring(self):
@@ -103,11 +107,22 @@ class QSAIndexCache(ArraysCache):
         # it needs no physical roll after a right-padded prefill.
 
     def valid_lengths(self, input_length: int) -> list[int]:
+        return [count for _, count in self.valid_spans(input_length)]
+
+    def valid_spans(self, input_length: int) -> list[tuple[int, int]]:
+        starts = [
+            min(input_length, pending) for pending in self._pending_left_padding
+        ]
         if self._valid_until is None:
-            return [input_length] * len(self._offsets)
+            return [(start, input_length - start) for start in starts]
         return [
-            max(0, min(input_length, limit - offset))
-            for limit, offset in zip(self._valid_until, self._offsets)
+            (
+                start,
+                max(0, min(input_length - start, limit - offset)),
+            )
+            for start, limit, offset in zip(
+                starts, self._valid_until, self._offsets
+            )
         ]
 
     def update(
@@ -133,12 +148,12 @@ class QSAIndexCache(ArraysCache):
             raise ValueError("QSA raw-key cache shape changed within one request")
 
         completed: list[list[mx.array]] = [[] for _ in range(batch)]
-        valid_lengths = self.valid_lengths(length)
-        for row, valid_length in enumerate(valid_lengths):
+        valid_spans = self.valid_spans(length)
+        for row, (input_start, valid_length) in enumerate(valid_spans):
             for token in range(valid_length):
                 position = self._offsets[row] + token
                 self.raw_ring[row, position % self.compress_ratio, :] = raw_keys[
-                    row, token, :
+                    row, input_start + token, :
                 ]
                 if (position + 1) % self.compress_ratio == 0:
                     pooled = mx.mean(
@@ -150,6 +165,7 @@ class QSAIndexCache(ArraysCache):
                         )[0]
                     )
             self._offsets[row] += valid_length
+            self._pending_left_padding[row] -= input_start
 
         new_counts = [
             old + len(rows)
@@ -221,6 +237,7 @@ class QSAIndexCache(ArraysCache):
         ]
         self._valid_until = None
         self._right_padding = None
+        self._pending_left_padding = [0] * len(self._offsets)
         self.left_padding = (
             None
             if len(self._offsets) == 1
@@ -266,6 +283,9 @@ class QSAIndexCache(ArraysCache):
         self._compressed_counts = [
             self._compressed_counts[index] for index in indices
         ]
+        self._pending_left_padding = [
+            self._pending_left_padding[index] for index in indices
+        ]
         if self._valid_until is not None:
             self._valid_until = [self._valid_until[index] for index in indices]
         max_offset = max(self._offsets, default=0)
@@ -282,6 +302,7 @@ class QSAIndexCache(ArraysCache):
         self.lengths = None
         self._offsets = merged._offsets
         self._compressed_counts = merged._compressed_counts
+        self._pending_left_padding = merged._pending_left_padding
         self._valid_until = self._right_padding = None
 
     def extract(self, idx):
@@ -295,6 +316,7 @@ class QSAIndexCache(ArraysCache):
             )
         cache._offsets = [self._offsets[idx]]
         cache._compressed_counts = [count]
+        cache._pending_left_padding = [0]
         return cache
 
     @classmethod
@@ -309,6 +331,7 @@ class QSAIndexCache(ArraysCache):
         merged._compressed_counts = [
             cache._compressed_counts[0] for cache in caches
         ]
+        merged._pending_left_padding = [0] * len(caches)
         max_offset = max(merged._offsets, default=0)
         merged.left_padding = mx.array(
             [max_offset - offset for offset in merged._offsets], dtype=mx.int32

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -254,13 +254,29 @@ class QSAIndexCache(ArraysCache):
         return cache
 
     def is_trimmable(self):
-        # A compressed block does not retain its source rows. Marking this
-        # trim-safe would corrupt partial-prefix rollback. M2 adds transactional
-        # undo for speculative tokens; exact cache clones remain supported.
-        return False
+        return all(self._can_trim_row(offset, 1) for offset in self._offsets)
 
-    def trim(self, _n):
-        return 0
+    def _can_trim_row(self, offset: int, n: int) -> bool:
+        if n < 0 or n > offset:
+            return False
+        if n == 0:
+            return True
+        remainder = offset % self.compress_ratio
+        available = remainder if remainder else min(self.compress_ratio, offset)
+        return n <= available
+
+    def trim(self, n):
+        # The raw ring retains exactly the current partial group, or the most
+        # recently completed group at a boundary. Rewind only within that
+        # recoverable window; the next update overwrites discarded rows and
+        # deterministically recomputes a removed compressed block.
+        if not all(self._can_trim_row(offset, n) for offset in self._offsets):
+            return 0
+        self._offsets = [offset - n for offset in self._offsets]
+        self._compressed_counts = [
+            offset // self.compress_ratio for offset in self._offsets
+        ]
+        return n
 
     def size(self):
         return max(self._offsets, default=0)

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -48,9 +48,7 @@ class QSAIndexCache(ArraysCache):
             raise ValueError("QSA cache batch metadata does not match input")
         self._offsets = [0] * batch
         self._compressed_counts = [0] * batch
-        self._pending_left_padding = [
-            int(item) for item in self.left_padding.tolist()
-        ]
+        self._pending_left_padding = [int(item) for item in self.left_padding.tolist()]
 
     @property
     def raw_ring(self):
@@ -90,8 +88,7 @@ class QSAIndexCache(ArraysCache):
         self._ensure_batch(batch)
         if lengths is not None:
             self._valid_until = [
-                offset + int(length)
-                for offset, length in zip(self._offsets, lengths)
+                offset + int(length) for offset, length in zip(self._offsets, lengths)
             ]
         self._right_padding = (
             None if right_padding is None else [int(item) for item in right_padding]
@@ -110,9 +107,7 @@ class QSAIndexCache(ArraysCache):
         return [count for _, count in self.valid_spans(input_length)]
 
     def valid_spans(self, input_length: int) -> list[tuple[int, int]]:
-        starts = [
-            min(input_length, pending) for pending in self._pending_left_padding
-        ]
+        starts = [min(input_length, pending) for pending in self._pending_left_padding]
         if self._valid_until is None:
             return [(start, input_length - start) for start in starts]
         return [
@@ -120,9 +115,7 @@ class QSAIndexCache(ArraysCache):
                 start,
                 max(0, min(input_length - start, limit - offset)),
             )
-            for start, limit, offset in zip(
-                starts, self._valid_until, self._offsets
-            )
+            for start, limit, offset in zip(starts, self._valid_until, self._offsets)
         ]
 
     def update(
@@ -160,24 +153,19 @@ class QSAIndexCache(ArraysCache):
                         self.raw_ring[row : row + 1].astype(mx.float32), axis=1
                     ).astype(raw_keys.dtype)
                     completed[row].append(
-                        transform_group(
-                            pooled, position + 1 - self.compress_ratio
-                        )[0]
+                        transform_group(pooled, position + 1 - self.compress_ratio)[0]
                     )
             self._offsets[row] += valid_length
             self._pending_left_padding[row] -= input_start
 
         new_counts = [
-            old + len(rows)
-            for old, rows in zip(self._compressed_counts, completed)
+            old + len(rows) for old, rows in zip(self._compressed_counts, completed)
         ]
         max_count = max(new_counts, default=0)
         if max_count:
             capacity = ((max_count + self.step - 1) // self.step) * self.step
             if self.compressed_keys is None:
-                expanded = mx.zeros(
-                    (batch, capacity, dim), dtype=raw_keys.dtype
-                )
+                expanded = mx.zeros((batch, capacity, dim), dtype=raw_keys.dtype)
             elif capacity > self.compressed_keys.shape[1]:
                 expanded = mx.zeros(
                     (batch, capacity, dim), dtype=self.compressed_keys.dtype
@@ -232,9 +220,7 @@ class QSAIndexCache(ArraysCache):
         decoded = json.loads(value)
         self.compress_ratio = int(decoded["compress_ratio"])
         self._offsets = [int(item) for item in decoded["offsets"]]
-        self._compressed_counts = [
-            int(item) for item in decoded["compressed_counts"]
-        ]
+        self._compressed_counts = [int(item) for item in decoded["compressed_counts"]]
         self._valid_until = None
         self._right_padding = None
         self._pending_left_padding = [0] * len(self._offsets)
@@ -254,7 +240,11 @@ class QSAIndexCache(ArraysCache):
         return cache
 
     def is_trimmable(self):
-        return all(self._can_trim_row(offset, 1) for offset in self._offsets)
+        return self.can_trim(1)
+
+    def can_trim(self, n: int) -> bool:
+        """Amount-aware preflight consumed by composite cache rollback."""
+        return all(self._can_trim_row(offset, n) for offset in self._offsets)
 
     def _can_trim_row(self, offset: int, n: int) -> bool:
         if n < 0 or n > offset:
@@ -296,9 +286,7 @@ class QSAIndexCache(ArraysCache):
         )
         super().filter(batch_indices)
         self._offsets = [self._offsets[index] for index in indices]
-        self._compressed_counts = [
-            self._compressed_counts[index] for index in indices
-        ]
+        self._compressed_counts = [self._compressed_counts[index] for index in indices]
         self._pending_left_padding = [
             self._pending_left_padding[index] for index in indices
         ]
@@ -344,9 +332,7 @@ class QSAIndexCache(ArraysCache):
             raise ValueError("QSA caches in a batch must share compression ratio")
         merged = cls(ratio, left_padding=[0] * len(caches))
         merged._offsets = [cache._offsets[0] for cache in caches]
-        merged._compressed_counts = [
-            cache._compressed_counts[0] for cache in caches
-        ]
+        merged._compressed_counts = [cache._compressed_counts[0] for cache in caches]
         merged._pending_left_padding = [0] * len(caches)
         max_offset = max(merged._offsets, default=0)
         merged.left_padding = mx.array(

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -246,6 +246,12 @@ class QSAIndexCache(ArraysCache):
         """Amount-aware preflight consumed by composite cache rollback."""
         return all(self._can_trim_row(offset, n) for offset in self._offsets)
 
+    def trim_checkpoint(self):
+        return list(self._offsets), list(self._compressed_counts)
+
+    def restore_trim_checkpoint(self, state):
+        self._offsets, self._compressed_counts = state
+
     def _can_trim_row(self, offset: int, n: int) -> bool:
         if n < 0 or n > offset:
             return False

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -519,6 +519,7 @@ def _detect_capabilities(
     profile_modality: str | None = None,
     profile_tool_parser: str | None = None,
     is_text_only: bool = False,
+    experimental: bool = False,
 ) -> list[str]:
     """Compute the ``capabilities`` tag list for ``model_id``.
 
@@ -564,6 +565,8 @@ def _detect_capabilities(
         caps.append("vision")
     if _tools_capable(model_id, profile_tool_parser):
         caps.append("tools")
+    if experimental:
+        caps.append("experimental")
     return caps
 
 
@@ -1051,6 +1054,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         profile_modality=profile.modality,
         profile_tool_parser=eff_tool,
         is_text_only=profile.is_text_only,
+        experimental=profile.experimental,
     )
     return ModelInfo(
         id=model_id,

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -221,6 +221,29 @@ def _served_lane_fields(model_id: str) -> tuple[str | None, str | None]:
     )
 
 
+def _served_experimental(model_id: str) -> bool:
+    """Return architecture-derived experimental truth for a live model.
+
+    The residency registry owns this value because it is resolved once from
+    the checkpoint config before engine construction. Discovery-only aliases
+    must not infer it from names, and a lookup miss must remain the stable
+    non-experimental default.
+    """
+    try:
+        cfg = get_config()
+        if cfg.model_registry is not None:
+            entry = cfg.model_registry.get_entry(model_id)
+            if entry.matches(model_id) is True:
+                return getattr(entry, "experimental", False) is True
+            return False
+        if model_id in {cfg.model_name, cfg.model_alias} - {None}:
+            candidate = getattr(cfg, "engine", None)
+            return getattr(candidate, "experimental", False) is True
+    except (AttributeError, KeyError):
+        return False
+    return False
+
+
 def _served_engine_is_mllm(model_id: str) -> bool | None:
     """Return the LIVE engine's actual modality for the served model.
 
@@ -990,7 +1013,10 @@ def _build_model_info(model_id: str) -> ModelInfo:
         # (missing) alias profile would have said.
         eff_tool, eff_reasoning = effective_parsers_for(model_id, None, None)
         capabilities = _detect_capabilities(
-            model_id, profile_modality=None, profile_tool_parser=eff_tool
+            model_id,
+            profile_modality=None,
+            profile_tool_parser=eff_tool,
+            experimental=_served_experimental(model_id),
         )
         try:
             # Route through ``_reported_modality`` (not a bare
@@ -1054,7 +1080,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         profile_modality=profile.modality,
         profile_tool_parser=eff_tool,
         is_text_only=profile.is_text_only,
-        experimental=profile.experimental,
+        experimental=profile.experimental or _served_experimental(model_id),
     )
     return ModelInfo(
         id=model_id,

--- a/vllm_mlx/runtime/model_registry.py
+++ b/vllm_mlx/runtime/model_registry.py
@@ -36,6 +36,11 @@ class ModelEntry:
     reasoning_parser: str | None = None
     is_mllm: bool = False
     max_tokens: int = 4096
+    # Architecture-derived support status for the loaded checkpoint. This is
+    # live model identity, not catalog policy: unpublished experimental
+    # architectures may be served by explicit local path without introducing
+    # an alias that points at a nonexistent artifact.
+    experimental: bool = False
 
     def matches(self, name: str) -> bool:
         """Check if a request model name matches this entry."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4392,6 +4392,10 @@ class Scheduler:
                         from vllm_mlx.memory_cache import _vendored_cache_registry
 
                         vendored = _vendored_cache_registry()
+                        if not isinstance(meta_state, tuple) or len(meta_state) != 2:
+                            raise ValueError(
+                                "CacheList metadata must be a (names, metadata) tuple"
+                            )
                         names, nested_meta = meta_state
                         if not (len(state) == len(names) == len(nested_meta)):
                             raise ValueError(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2522,21 +2522,24 @@ def _install_suffix_decoding(
             _counter.record_fallthrough("no_draft")
             return _orig_step()
 
+        K = len(draft)
+
         # Defense-in-depth: even though ``profile.supports_spec_decode``
         # already gates installation on hybrid arches, verify that EVERY
         # cache layer is trimmable before paying the verify-forward cost.
         # If any layer can't trim and we end up needing to roll back, the
         # cache state would silently diverge — better to fall through.
-        for c in gb.prompt_cache:
-            if not (
-                hasattr(c, "is_trimmable") and c.is_trimmable() and hasattr(c, "trim")
-            ):
-                _stats["fallthrough_steps"] += 1
-                _stats["ft_non_trimmable_cache"] += 1
-                _counter.record_fallthrough("non_trimmable_cache")
-                return _orig_step()
+        # Preflight the maximum possible rollback amount before the verify
+        # forward mutates anything. Composite caches are checked recursively,
+        # so one side-cache cannot refuse after its sibling already trimmed.
+        from .cache_rollback import can_trim
 
-        K = len(draft)
+        if not all(can_trim(c, K) for c in gb.prompt_cache):
+            _stats["fallthrough_steps"] += 1
+            _stats["ft_non_trimmable_cache"] += 1
+            _counter.record_fallthrough("non_trimmable_cache")
+            return _orig_step()
+
         _stats["verify_steps"] += 1
         _stats["draft_tokens_proposed"] += K
 
@@ -2652,9 +2655,12 @@ def _install_suffix_decoding(
 
         n_rejected = K - n_accepted
         if n_rejected > 0:
-            # Pre-checked above — every layer here is trimmable.
-            for c in gb.prompt_cache:
-                c.trim(n_rejected)
+            from .cache_rollback import trim_all
+
+            if not trim_all(gb.prompt_cache, n_rejected):
+                raise RuntimeError(
+                    "suffix verification cache rollback violated its preflight"
+                )
 
         # Token emission accounting.
         #
@@ -2814,13 +2820,12 @@ def _install_suffix_decoding(
                     # reuse for the next request that hits this prefix.
                     unused = len(pending) - emit_idx - 1
                     if unused > 0:
-                        for c in gb.prompt_cache:
-                            if (
-                                hasattr(c, "is_trimmable")
-                                and c.is_trimmable()
-                                and hasattr(c, "trim")
-                            ):
-                                c.trim(unused)
+                        from .cache_rollback import trim_all
+
+                        if not trim_all(gb.prompt_cache, unused):
+                            raise RuntimeError(
+                                "suffix terminal cache rollback violated its preflight"
+                            )
                     augmented.append(
                         gb.Response(
                             uid=uid,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4384,22 +4384,9 @@ class Scheduler:
                         from mlx_lm.models import cache as _mlx_cache
                         from mlx_lm.models.cache import CacheList as _CacheList
 
-                        from vllm_mlx.models.deepseek_v4_cache import (
-                            BatchDeepseekV4PoolingCache,
-                            BatchPoolingCache,
-                            DeepseekV4PoolingCache,
-                            PoolingCache,
-                        )
+                        from vllm_mlx.memory_cache import _vendored_cache_registry
 
-                        vendored = {
-                            cls.__name__: cls
-                            for cls in (
-                                PoolingCache,
-                                BatchPoolingCache,
-                                DeepseekV4PoolingCache,
-                                BatchDeepseekV4PoolingCache,
-                            )
-                        }
+                        vendored = _vendored_cache_registry()
                         names, nested_meta = meta_state
                         if not (len(state) == len(names) == len(nested_meta)):
                             raise ValueError(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1980,6 +1980,11 @@ def load_model(
     # resolve_profile handles both alias-name and HF-path lookups, so a
     # single call suffices regardless of which form load_model was passed.
     _profile = resolve_profile(effective_model_alias or requested_model_name)
+    _model_config = _profile
+    if _model_config is None:
+        from .model_auto_config import detect_model_config
+
+        _model_config = detect_model_config(model_name)
     if _profile is not None and _profile.recommended_sampling:
         _alias_recommended_sampling = dict(_profile.recommended_sampling)
 
@@ -2338,6 +2343,7 @@ def load_model(
         tool_call_parser=_tool_call_parser,
         reasoning_parser=_reasoning_parser_name,
         is_mllm=getattr(_engine, "is_mllm", False),
+        experimental=bool(_model_config is not None and _model_config.experimental),
         max_tokens=_default_max_tokens,
     )
     _model_registry.add(entry, is_default=True)
@@ -2475,6 +2481,7 @@ async def _load_dynamic_resident_model(
         tool_call_parser=(profile.tool_call_parser if profile is not None else None),
         reasoning_parser=(profile.reasoning_parser if profile is not None else None),
         is_mllm=getattr(engine, "is_mllm", False),
+        experimental=bool(model_config is not None and model_config.experimental),
         max_tokens=_default_max_tokens,
     )
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -847,6 +847,34 @@ def _register_vendored_archs() -> None:
         else:
             _VENDORED_MODEL_TYPES.add("nemotron_labs_diffusion")
 
+    if "mlx_lm.models.qwen4_exp" not in sys.modules:
+        # Qwen3.8-Flash-Next's qwen4_exp text decoder. Prefer a future native
+        # mlx-lm implementation as soon as one ships; until then the vendored
+        # module owns the typed QSA/PLE/HC architecture contract.
+        import importlib.util as _importlib_util
+
+        _qwen4_native_spec = None
+        try:
+            _qwen4_native_spec = _importlib_util.find_spec("mlx_lm.models.qwen4_exp")
+        except (ImportError, ValueError):
+            _qwen4_native_spec = None
+
+        if _qwen4_native_spec is None:
+            try:
+                from ..models import qwen4_exp as _qwen4_exp
+
+                sys.modules.setdefault("mlx_lm.models.qwen4_exp", _qwen4_exp)
+            except Exception as e:
+                logger.warning(
+                    "qwen4_exp vendored module failed to register — "
+                    "Qwen4-Exp checkpoints will not load until resolved: %s",
+                    e,
+                )
+            else:
+                _VENDORED_MODEL_TYPES.add("qwen4_exp")
+        else:
+            _VENDORED_MODEL_TYPES.add("qwen4_exp")
+
 
 def _is_vendored_arch_model(model_name: str) -> bool:
     """Return True if model's config.json declares a model_type we vendor."""


### PR DESCRIPTION
## Intention

Add a correct, experimental text serving lane for the new `qwen4_exp` architecture without mapping it onto an older model family or approximating its math.

## Why

Without a native architecture implementation, this checkpoint cannot load or
serve on Apple Silicon. A metadata-driven experimental lane lets operators
evaluate the released model with exact math and bounded prefix reuse. The
published CLI/API alias remains explicitly experimental; MTP, vision, and
Desktop catalog exposure stay gated as later milestones.

## Scope

- vendored text model for Gated DeltaNet, Qwen Sparse Attention, four-stream gated residuals, PLE, routed/shared MoE, and hybrid cache state;
- streaming mixed-quant converter: q4-g64 generally, q4-g32 for width-160 PLE shards, q8-g64 routing gates;
- local-path admission from typed `qwen4_exp` checkpoint metadata, carried through the live model registry as a machine-readable `experimental` capability;
- immutable CLI/API alias `qwen3.8-flash-next-4bit` for `rapid-mlx/Qwen3.8-Flash-Next-4bit`, including its exact download footprint, 128 GB minimum-memory profile, and experimental capability truth;
- deterministic component/cache/converter tests and an opt-in same-artifact parity harness.

## Non-goals

- MTP/speculative decoding;
- vision inference;
- artifact publication mechanics, mirror integration, or release plumbing;
- Desktop catalog exposure or a Desktop default;
- scheduler/cache redesign, architecture-name heuristics, or approximate QSA/GDN behavior.

## Correctness contract and evidence

- Strict load of the 28-shard, 98 GiB q4-g64/g32 artifact: 0 missing, 0 unexpected tensors.
- Same-artifact sequential parity: GDN, cached GDN, QSA, PLE, MoE, all 48 layer probes, and final logits have max/mean absolute difference 0 on fixed probes.
- Greedy parity: 16/16 short cases plus 4/4 bounded 4.9K sparse-QSA recall cases, including bit-exact selected masks.
- The artifact-gated executable parity test now crosses the sparse budget at 2,052 tokens and compares the first cached decode; both backends produced sparse-prefill token 362 and cached-decode token 271 with every stored probe within `1e-3`.
- Real 20-case panel covers reasoning, code, Chinese, tool calls, and long-context recall; all four tool calls were well formed and all recall facts exact.
- Prefix-persistent serve smoke: 3,178-token repeated request reduced prefill from 3,138 tokens to 13 tokens and wall time from 13.29 s to 0.49 s.
- Studio 2K serve sample: 442.4 prompt tok/s, 19.6 decode tok/s, 96.24 GiB peak RSS, 138.59 GiB peak footprint, zero swap.

The GDN/QSA forward equations and the half-split RoPE kernel are adapted from the MIT-licensed `mlx-vlm` implementation at exact commit `ecf1aa0a62958ea770bc25c35e173effe142aa3c`. Source comments pin that commit at the adopted code. Rapid retains its bounded batched and prefix-persistent cache adapter; it deliberately does not materialize the reference `[B,L,topk,K]` boolean intermediate, which requested 191,427,018,752 bytes on the 19.3K probe. Selected sets are nevertheless bit-exact on every bounded sparse probe.

## Verification

- focused model/cache/profile/API suite: 3,304 passed, 2 expected dependency/artifact-gated skips in the final contract-cleanup pass; the earlier architecture/cache suite was 3,071 passed, 1 expected artifact-gated skip;
- Linux mypy shrink-only budget: flat at 719 grandfathered errors, no new dirty file or count growth;
- converter synthetic round trip: 32 mixed-quant tensors, 7 copy tensors, 28 deterministic shards, SHA mismatch count 0;
- converter fail-closed guard suite: all passed;
- Ruff lint and format checks: passed;
- post-decision alias/profile/API regression: 3,365 passed;
- no checkpoint bytes are part of this PR; the immutable artifact is published separately with a whole-tree SHA-256 manifest.

### Hosted coverage gate status

The hosted Linux test assertions pass, but its changed-lines gate remains red
because that fixed no-MLX lane cannot import or execute the new MLX-native
architecture modules. The complete local Apple suite reports 91.5% changed-line
coverage for `qwen4_exp.py`, 91.8% for `qwen4_exp_cache.py`, and 88.1% across the
full engine diff. A separate CI change will union portable Linux coverage with
Apple-lane MLX coverage; this PR does not weaken the gate with exclusions,
blanket pragmas, or inert execution.

### Artifact contract

The alias resolves to `rapid-mlx/Qwen3.8-Flash-Next-4bit`, a 28-shard mixed-q4
artifact converted from source revision `f5d08274`. The artifact model card
records the Qwen Apache-2.0 license and the q4-g64 / PLE q4-g32 / routing-gate
q8-g64 quantization contract; `SHA256SUMS.txt` covers the complete tree. The
checked-in download footprint is 104,695,602,743 bytes (97.51 GiB), and the
profile declares 128 GB as the minimum operator tier. The PR must not land
until the repository resolves and its immutable revision, card, manifest, and
remote byte total are verified.

## Test plan

- [x] Run strict real-artifact load and same-artifact component/logit parity.
- [x] Run real-artifact sparse-QSA prefill plus first cached-decode parity.
- [x] Run the fixed 20-case greedy correctness panel.
- [x] Run real `serve` prefill/decode/memory and repeated-prefix smoke tests.
- [x] Run focused qwen4_exp, cache, converter, profile, CLI, and API tests.
- [x] Run synthetic converter round trip and fail-closed guard checks.
- [x] Run Ruff lint and format checks.

### Immutable artifact and post-R10 gate evidence

The catalog target is `rapid-mlx/Qwen3.8-Flash-Next-4bit` at immutable revision `dcf657e4acda2aae72da99cde65b6c491cd96998`: 36 files / 104,695,605,424 bytes; all 34 entries in `SHA256SUMS.txt` were verified remotely (manifest SHA-256 begins `826f00b2`). The source revision is `f5d08274`; the conversion contract is q4-g64 generally, q4-g32 for 160-wide PLE tables, and q8-g64 routing gates. The alias resolves through the hub now and is compatible with the existing mirror flow once replication completes.

After rebasing onto the Apple+Linux coverage-union infrastructure, the curated Apple roster preserves every existing entry and adds the synthetic Qwen4-Exp, DSpark rollback, and suffix rollback contracts. Hosted-equivalent local evidence: Apple roster 879 passed / 2 skipped / 18 deselected; focused post-rebase contracts 111 passed; merged Linux+Apple changed-line coverage 1,156/1,156 production lines (100%); Ruff, format, and diff checks pass. The two skipped tests require the real 98 GiB artifact and remain additive parity gates, not coverage sources.

## Follow-ups

- #2453 hardens converter structural admission and pinned-reference worktree validation for 0.13.2.