### PR TITLE
fix(mac): make the server log drawer closable

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -110,6 +110,9 @@ struct RapidApp: App {
     @State private var dockPromptStore: DockVisibilityPromptStore
     /// View → Keep Window on Top toggle (session state, not persisted).
     @State private var keepWindowOnTop: Bool = false
+    /// Same defaults key ContentView's footer toggle and drawer close button
+    /// write, so all three stay in lockstep.
+    @AppStorage(ContentView.showLogsKey) private var showLogs: Bool = false
     /// Web-search backend + API key, shared by the tool runner and Settings.
     @State private var webSearch: WebSearchConfig
     /// Per-fetch approval gate for the ``browse`` tool, shared by the tool
@@ -495,6 +498,12 @@ struct RapidApp: App {
                     .onChange(of: keepWindowOnTop) { _, newValue in
                         Self.applyWindowOnTop(newValue)
                     }
+                // A menu path to the log drawer, so its visibility is never
+                // reachable ONLY through a control the drawer itself can push
+                // off screen. The footer toggle and the drawer's own close
+                // button both drive this same flag.
+                Toggle("Show Server Log", isOn: $showLogs)
+                    .keyboardShortcut("l", modifiers: [.command, .shift])
             }
         }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -41,6 +41,33 @@ struct ContentView: View {
     static let minWindowWidth: CGFloat = 720
     static let minWindowHeight: CGFloat = 560
 
+    /// Heights the shell's fixed rows keep for themselves. Named rather than
+    /// inlined because they are the rows that DON'T yield — the detail pane
+    /// absorbs what is left — so it should be obvious where the shell's
+    /// vertical commitments are and how few of them there are.
+
+    /// Floor for the drawer's SCROLLING part — the log itself.
+    static let logDrawerScrollMinHeight: CGFloat = 100
+    /// The drawer's own header: title, close button, and the rule under it
+    /// (11pt text on 5pt padding either side, plus a 1pt divider).
+    static let logDrawerHeaderHeight: CGFloat = 26
+    /// What the drawer commits in the shell. Header + log, not just log: the
+    /// two used to be the same number because the drawer was nothing BUT the
+    /// scroll view, and adding the header inside the same frame quietly took
+    /// its 26pt out of the viewport instead of out of the shell.
+    static let logDrawerMinHeight: CGFloat =
+        logDrawerScrollMinHeight + logDrawerHeaderHeight
+    static let statusFooterMinHeight: CGFloat = 30
+
+    /// Defaults key backing the log drawer's visibility. Shared with the View
+    /// menu command in ``RapidApp`` so both toggles drive one flag.
+    static let showLogsKey = "Rapid.showLogs"
+
+    // There is deliberately no detail-pane height floor here. The detail is a
+    // scrolling surface with no natural vertical minimum; the only vertical
+    // floor in the shell is ``minWindowHeight``, applied once at the root.
+    // See the note beside the detail's `.frame(minWidth: 440)`.
+
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
     @Environment(ChatViewModel.self) private var chat
@@ -65,7 +92,14 @@ struct ContentView: View {
     @State private var section: SidebarSection = .chat
     /// Window-level conversation search, opened from the toolbar.
     @State private var showConversationSearch = false
-    @SceneStorage("Rapid.showLogs") private var showLogs: Bool = false
+    // Was @SceneStorage. Moved to @AppStorage so the View menu command in
+    // RapidApp can drive the same flag — a scene-scoped value is not reachable
+    // from the app's `.commands` block — and so the flag lands somewhere a
+    // stuck user can actually clear (`defaults write com.rapidmlx.rapid
+    // Rapid.showLogs -bool false`). Scene storage lives in opaque state
+    // restoration data. With a single main window the persistence scope is
+    // the same in practice.
+    @AppStorage(ContentView.showLogsKey) private var showLogs: Bool = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
     /// Explicit recovery route from the no-model empty state into the
@@ -444,7 +478,24 @@ struct ContentView: View {
                 // graceful compression. The floor is 720 now, so this has
                 // 80pt of slack; it stays at 440 because it is the detail's
                 // own minimum, not a number derived from the window.
-                .frame(minWidth: 440, minHeight: Self.minWindowHeight)
+                //
+                // WIDTH ONLY, deliberately. There used to be a matching
+                // `minHeight` here — first `Self.minWindowHeight`, then a
+                // smaller "budgeted" number — and both were wrong for the same
+                // reason: the detail is a scrolling surface with no natural
+                // vertical minimum, so any figure it claims is one it will not
+                // give back. Claiming 560 meant the detail alone committed
+                // every point the window could shrink to, and the log drawer
+                // and status footer stacked under it had to come out of
+                // nothing; the footer, being last, was what disappeared.
+                //
+                // The vertical floor belongs to the window and is stated once,
+                // at the root of this view. A row that must keep its height
+                // (the drawer, the footer) declares one; the detail absorbs
+                // whatever is left and compresses when the others need room.
+                // That is the whole invariant, and it needs no arithmetic
+                // between the three.
+                .frame(minWidth: 440)
                     .background(RapidTheme.surfaceCanvas)
             }
             // Background pulls are process-wide, not chat-only.  Keep their
@@ -458,8 +509,17 @@ struct ContentView: View {
                 }
             )
             if showLogs {
-                LogDrawer(server: server)
-                    .frame(minHeight: 100, idealHeight: 150, maxHeight: 220)
+                LogDrawer(server: server, onClose: hideLogs)
+                    // Floor and ideal are both header-inclusive so the LOG
+                    // keeps the 100/150 it had before the header existed. The
+                    // 220 ceiling is left alone on purpose: it bounds what the
+                    // drawer may take from the shell, not what it promises to
+                    // show, and raising it would take space the detail keeps.
+                    .frame(
+                        minHeight: Self.logDrawerMinHeight,
+                        idealHeight: 150 + Self.logDrawerHeaderHeight,
+                        maxHeight: 220
+                    )
                     .accessibilityIdentifier("ContentView.LogDrawer")
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
@@ -1179,13 +1239,19 @@ struct ContentView: View {
         }
     }
 
+    private func setLogs(_ visible: Bool) {
+        withAnimation(RapidMotion.resolve(RapidMotion.standard, reduceMotion: reduceMotion)) {
+            showLogs = visible
+        }
+    }
+
+    private func hideLogs() { setLogs(false) }
+
     private var statusFooter: some View {
         HStack(spacing: 8) {
             SettingsGearButton()
             Button {
-                withAnimation(RapidMotion.resolve(RapidMotion.standard, reduceMotion: reduceMotion)) {
-                    showLogs.toggle()
-                }
+                setLogs(!showLogs)
             } label: {
                 Image(systemName: "terminal")
                     .font(.system(size: 13))
@@ -1201,7 +1267,7 @@ struct ContentView: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 7)
-        .frame(minHeight: 30)
+        .frame(minHeight: Self.statusFooterMinHeight)
         .background(.bar)
     }
 
@@ -1861,12 +1927,61 @@ struct DesktopVersionPill: View {
 private struct LogDrawer: View {
     @Bindable var server: ServerManager
 
+    /// Dismiss the drawer from inside it.
+    ///
+    /// The drawer had no close control of its own: the only way out was the
+    /// terminal toggle in ``statusFooter``, which sits BELOW the drawer in the
+    /// same VStack. When the column over-committed, the footer was the row
+    /// that got clipped — so the control that closes the drawer was the one
+    /// the drawer pushed off screen, with no menu item or shortcut to escape
+    /// through either. The over-commit is fixed separately and properly; this
+    /// exists so the drawer is dismissible on its own terms no matter how the
+    /// layout is squeezed by a later change.
+    var onClose: () -> Void
+
     /// Stable id for the invisible bottom marker we scroll to on every
     /// log append. Lives outside the ``ForEach`` so adding rows can't
     /// invalidate it.
     private static let bottomAnchor = "Rapid.LogDrawer.bottom"
 
     var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            logScroll
+        }
+        // Seal the bottom edge the way ``DownloadStrip`` seals its own. The
+        // log surface is `.textBackgroundColor` and the footer under it is
+        // `.bar`; in light mode those are near enough that without a rule the
+        // two read as one surface, and the footer's icons look like they are
+        // floating on the bottom of the log panel against the window's corner
+        // radius rather than sitting in a strip of their own. An overlay, not
+        // a VStack row, so the rule costs the scroll area no height.
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("Server log")
+                .scaledSystemFont(11, weight: .medium)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Hide logs")
+            .accessibilityLabel("Hide logs")
+            .accessibilityIdentifier("LogDrawer.Close")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(.bar)
+    }
+
+    private var logScroll: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 1) {

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -661,4 +661,88 @@ struct CoreWorkspaceVisualFoundationTests {
             """
         )
     }
+
+    /// The vertical counterpart, and the one that actually bit.
+    ///
+    /// The detail pane used to declare a `minHeight` as well as a `minWidth`.
+    /// It is a scrolling surface with no natural vertical minimum, so whatever
+    /// it claimed it would not give back: at `minWindowHeight` it committed
+    /// every point the window could shrink to, and the log drawer and status
+    /// footer stacked under it had to come out of nothing. The footer, last in
+    /// the column, was what vanished — taking the toggle that closes the
+    /// drawer with it.
+    ///
+    /// Two plausible-looking fixes were tried and both were worse, which is
+    /// why this asserts the ABSENCE of the floor rather than any arithmetic:
+    ///
+    ///   * Budgeting — giving the detail a smaller floor so detail + drawer +
+    ///     footer "fit". A frame minimum can only RAISE a floor, so a number
+    ///     under the pane's real content minimum is inert, and a test summing
+    ///     those constants passes by construction while the footer goes right
+    ///     on disappearing on screen.
+    ///   * Pinning the footer with `.safeAreaInset`. That does keep the footer,
+    ///     but the detail then draws BEHIND it, and the chat composer — which
+    ///     anchors to the bottom of the detail — was clipped by the footer
+    ///     whenever the drawer was closed.
+    ///
+    /// The invariant that actually holds: exactly one vertical floor in the
+    /// shell, at the root, and rows that must keep their height declare one
+    /// while the detail absorbs the remainder.
+    @Test("The detail pane claims no vertical floor of its own")
+    func detailPaneDeclaresNoHeightFloor() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ContentView.swift")
+        #expect(
+            source.contains(".frame(minWidth:440)"),
+            "The detail pane must state its width floor and nothing about height."
+        )
+        #expect(
+            !source.contains(".frame(minWidth:440,minHeight:"),
+            "A detail height floor starves the drawer and footer stacked under it; the shell's only vertical floor is minWindowHeight at the root."
+        )
+        #expect(
+            !source.contains(".safeAreaInset(edge:.bottom"),
+            "Pinning the footer makes the detail draw behind it and clips the chat composer; the footer stays an ordinary row."
+        )
+    }
+
+    /// Geometry is the fix; this is the belt.
+    ///
+    /// A drawer whose only dismiss control lives OUTSIDE it, below it, in a
+    /// container it can overflow, is a one-way door waiting for the next
+    /// layout change. It must be closable on its own terms.
+    @Test("The log drawer carries its own close control")
+    func logDrawerClosesItself() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ContentView.swift")
+        #expect(
+            source.contains(#"accessibilityIdentifier("LogDrawer.Close")"#),
+            "LogDrawer must keep a close control of its own, not rely on the footer toggle it can push off screen."
+        )
+        #expect(
+            source.contains("LogDrawer(server:server,onClose:hideLogs)"),
+            "LogDrawer's close control must be wired to the same flag the footer toggle drives."
+        )
+    }
+
+    /// And the braces: a menu path survives any layout, and puts the flag
+    /// somewhere a stuck user can reach without the window cooperating.
+    @Test("Log drawer visibility has a menu path")
+    func logDrawerHasAMenuCommand() throws {
+        let app = try strippedSource("Sources/Rapid/RapidApp.swift")
+        // `canonicalSource(literals: .preserve)` keeps literal CONTENT but the
+        // whitespace strip still runs inside it, so the menu title canonicalises
+        // to "ShowServerLog". Match what the helper actually emits, not what the
+        // source reads like.
+        #expect(
+            app.contains(#"Toggle("ShowServerLog",isOn:$showLogs)"#),
+            "The View menu must be able to toggle the log drawer independently of the footer control."
+        )
+        #expect(
+            app.contains(#".keyboardShortcut("l",modifiers:[.command,.shift])"#),
+            "The menu command needs a shortcut; a menu the user has to hunt for is barely better than a clipped button."
+        )
+        #expect(
+            app.contains(#"@AppStorage(ContentView.showLogsKey)"#),
+            "The menu command and the in-window controls must read one flag; a scene-scoped value is unreachable from .commands."
+        )
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MountedRecoverySurfacesTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MountedRecoverySurfacesTests.swift
@@ -25,7 +25,10 @@ struct MountedRecoverySurfacesTests {
         #expect(content.contains("FailedReplaceBanner()"))
         #expect(content.contains("DownloadStrip("))
         #expect(content.contains("downloads: downloads"))
-        #expect(content.contains("LogDrawer(server: server)"))
+        // Match the call, not its full argument list: the drawer gained an
+        // `onClose:` so it can be dismissed from inside itself, and this pin is
+        // about the surface being MOUNTED, not about its signature.
+        #expect(content.contains("LogDrawer(server: server"))
         #expect(content.contains("ServerStatusPill(state: server.state)"))
     }
 


### PR DESCRIPTION
## The bug

Opening the server log drawer could leave no way to close it again, and in a
short enough window it took the whole status footer with it. Found on
0.13.0-rc2.

Two screenshots from the reporter, same window, no resize between them:

| drawer closed | drawer open |
|---|---|
| chat composer's `+` and message buttons **clipped** by the status bar | composer intact, footer present |

## Why

The footer was the last row of the shell's `VStack`, and the detail pane above
it declared:

```swift
.frame(minWidth: 440, minHeight: Self.minWindowHeight)   // 560
```

The detail is a scrolling surface with **no natural vertical minimum**, so
whatever it claims it will not give back. Claiming the window's own floor meant
it committed every point the window was allowed to shrink to, and the download
strip, log drawer and footer stacked under it had to come out of nothing. The
footer, being last, was what disappeared.

That mattered more than a missing strip, because the footer held the terminal
toggle and that was the **only** way to hide the drawer — `LogDrawer` had no
close control of its own, and there was no menu item or keyboard shortcut
either. Opening the drawer removed the control that closes it.

## The fix

The detail now states a width floor and nothing about height:

```swift
.frame(minWidth: 440)
```

The invariant is one sentence: **the shell has exactly one vertical floor,
`minWindowHeight`, at the root; rows that must keep their height (drawer,
footer) declare one; the detail absorbs the remainder and compresses when the
others need room.** No arithmetic between the three.

## Two fixes that were tried first

Both look right, and this change *deletes* rather than adds, so it is worth
naming what it is deleting instead of:

1. **Budgeting** — give the detail a smaller floor so `detail + drawer + footer`
   fits inside the window floor. Does nothing: a frame minimum can only RAISE a
   floor, so a number under the pane's real content minimum is inert. The footer
   kept disappearing while a test summing those constants passed by construction
   — a test that manufactures confidence rather than catching the defect.
2. **Pinning the footer** with `.safeAreaInset(edge: .bottom)`. Keeps the footer,
   but the detail then draws *behind* it, and the chat composer — which anchors
   to the bottom of the detail — was clipped by the footer whenever the drawer
   was closed. One clipped control traded for another.

The regression test asserts the **absence** of both, with the reasoning
attached, because each is what a reader would reach for next.

## Belt and braces

Geometry alone should not be the only thing between a user and a stuck panel,
so the drawer is escapable three ways:

- **Its own close button.** `LogDrawer` gets a header with an `✕`. A drawer
  whose only dismiss control lives outside it, below it, in a container it can
  overflow is a trap waiting for the next layout change.
- **View → "Show Server Log" (⇧⌘L).** No layout can clip a menu. Verified ⇧⌘L
  is unused elsewhere in the app.
- **`showLogs` moves `@SceneStorage` → `@AppStorage`.** The menu command needs
  it (a scene-scoped value is unreachable from the app's `.commands` block), and
  it puts the flag in UserDefaults where a stuck user can clear it directly
  (`defaults write com.rapidmlx.rapid Rapid.showLogs -bool false`). Anyone
  currently stuck also comes back on a fresh flag rather than restoring the
  stuck one.

## Verification

Built locally and driven by hand through each case:

- composer intact with the drawer closed — the reported symptom, gone
- footer present at the window's smallest size with the drawer open
- drawer closable from all three controls
- `swift build` clean; AX identifier gate passes (the new `✕` carries
  `LogDrawer.Close`); GUI golden baselines unaffected, since the drawer is
  closed in every golden flow and `ContentView.ToggleLogs` keeps its identifier,
  label and help text

Local `swift test` could not be run in this environment (Command Line Tools
only — `import Testing` fails to resolve in an unrelated vendored test target),
so the three new tests are verified by CI, not locally.