### PR TITLE
feat(telemetry): wire emit.request into /v1/messages + /v1/completions (task C, 0.13.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,7 @@ jobs:
             tests/test_guided.py \
             tests/test_chat_streaming_guided.py \
             tests/test_anthropic_output_config.py \
+            tests/test_telemetry_route_attribution.py \
             tests/test_response_format_json_schema_strict.py \
             tests/test_mllm_cache.py \
             tests/test_memory_cache.py \

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -739,6 +739,33 @@ def test_request_endpoint_normalizes_full_url_to_path(opted_in, stub_queue):
     assert "host" not in blob
 
 
+def test_request_endpoints_anthropic_and_completions_allowlisted(opted_in, stub_queue):
+    """Task C (caller attribution): the newly-wired ``/v1/messages`` and
+    ``/v1/completions`` routes emit ``request`` events through
+    ``emit.request``; those endpoints must round-trip verbatim past
+    ``_normalize_endpoint`` (they are in ``_ALLOWED_ENDPOINTS``), not
+    collapse to ``other``. This pins the schema-side readiness the
+    instrumentation-release drop calls out — claude-code traffic over the
+    Anthropic surface now lands in the ``claude-code`` bucket instead of
+    ``other``.
+    """
+    from vllm_mlx.telemetry import emit
+
+    for endpoint in ("/v1/messages", "/v1/completions"):
+        emit.request(
+            endpoint=endpoint,
+            model_alias="qwen3.5-9b-4bit",
+            stream=True,
+            tool_call_used=False,
+            prompt_tokens=10,
+            completion_tokens=10,
+            ttft_ms=100.0,
+            tps=10.0,
+            status=200,
+        )
+        assert stub_queue[-1]["request"]["endpoint"] == endpoint
+
+
 def test_session_models_loaded_does_not_materialize_full_input(opted_in, stub_queue):
     """Round 13 codex review: the helper sliced after building a tuple
     of the entire input, which contradicted the documented "slice

--- a/tests/test_telemetry_redact.py
+++ b/tests/test_telemetry_redact.py
@@ -368,3 +368,47 @@ def test_normalize_caller_agent_unmatched_is_other_never_raw():
     # The raw UA (with its embedded token) must never be the return value.
     assert "leak-me" not in out
     assert "9.9" not in out
+
+
+def test_claude_code_bucketed_on_anthropic_surface():
+    """Task C (caller attribution): claude-code agents hit ``/v1/messages``
+    (previously zero-telemetry, so they fell into ``other``). The red-line
+    contract is that a named agent, however it reaches the wire (chat,
+    messages, or completions), still resolves to its fixed label — not
+    ``other``, and never with the raw UA surfaced. This is the attribution
+    fix the instrumentation-release drop depends on for the agent-strategy
+    decision.
+    """
+    # Real-world claude-code UA spellings (the ``claude-code`` / ``claude-cli``
+    # markers already match) — pinned so the Anthropic surface can't regress
+    # them back to ``other``.
+    for ua in (
+        "claude-code/1.0.3",
+        "Claude-Code/2.0 (macOS) Anthropic/API",
+        "claude-cli/1.4.2",
+    ):
+        assert normalize_caller_agent(ua) == "claude-code"
+
+
+def test_agent_riding_openai_python_stays_openai_python():
+    """Task C (caller attribution): an agent that sends openai-python's
+    User-Agent (verbatim, or with its own name prepended) is
+    INDISTINGUISHABLE at the UA layer — the ``openai-python`` substring
+    legitimately matches and it stays bucketed to ``openai-python``. We
+    never read the request body to guess the real product, so this pinned
+    the documented limitation: ride-through traffic always lands on the
+    SDK, not a fabricated product label.
+    """
+    ua = "OpenAI/Python 1.30.1"
+    assert normalize_caller_agent(ua) == "openai-python"
+    # An agent that prepends its own name but keeps openai-python's UA is
+    # still bucketed to the SDK transport — not the (unverifiable) product.
+    assert normalize_caller_agent("SomeAgent/1.0 (OpenAI/Python 1.30.1)") == (
+        "openai-python"
+    )
+    # A UA with NO known marker is never guessed into a product label — the
+    # raw string is dropped and it falls to "other".
+    out = normalize_caller_agent("HypotheticalProprietaryAgent/9.9")
+    assert out == "other"
+    # And the raw branded token never leaks into the returned label.
+    assert "HypotheticalProprietaryAgent" not in out

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Task C (instrumentation-release) — END-TO-END caller attribution.
+
+These tests close the gap codex flagged on the first pass of #2436: the
+earlier telemetry tests called ``emit.request`` / ``normalize_caller_agent``
+directly, so they stayed green even if the route wiring was deleted. These
+drive the ACTUAL routes (``/v1/messages`` and ``/v1/completions``) through
+``TestClient`` with telemetry opted-in + stubbed, and assert the emitted
+``request`` event — proving the User-Agent reaches the payload bucketed to
+the correct caller label, end to end.
+
+This is the attribution fix the instrument-release drop depends on for the
+agent-strategy decision: claude-code traffic over the Anthropic surface must
+land in ``claude-code`` (not ``other``), and openai-python ride-through must
+land in ``openai-python``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ------------------------------------------------------------------ fixtures
+# Mirror the opted_in + stub_queue pattern from test_telemetry_emit.py so
+# telemetry is on (consent + sampling=1) and every emitted payload is
+# captured in-memory instead of hitting the real queue sink.
+
+
+@pytest.fixture
+def telemetry_on(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+
+    import vllm_mlx.telemetry.emit as emit
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    importlib.reload(emit)
+    emit._reset_for_tests()
+
+    from vllm_mlx.telemetry.state import record_consent
+
+    record_consent(True, rapid_mlx_version="0.0.0+test")
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "1")
+    return emit
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture every ``emit.request`` payload into a list."""
+    from vllm_mlx.telemetry import emit
+
+    captured: list[dict] = []
+
+    class _StubQueue:
+        def enqueue(self, payload):
+            captured.append(payload)
+
+    monkeypatch.setattr(emit, "get_queue", lambda: _StubQueue())
+    return captured
+
+
+def _request_events(captured) -> list[dict]:
+    """Pull ``request``-type payloads ('request' is the schema descriminator
+    key inside each captured envelope)."""
+    events = []
+    for payload in captured:
+        req = payload.get("request")
+        if req is not None:
+            events.append(req)
+    return events
+
+
+# ---------------------------------------------------------------- anthropic
+
+
+class _AnthropicEngine:
+    """Combined non-stream ``chat`` + stream ``stream_chat`` fake engine.
+
+    Mirrors the ``_StreamingEngine`` from ``test_anthropic_route_streaming``
+    and adds a non-streaming ``chat`` that returns a token-bearing output so
+    the same harness drives both the ``/v1/messages`` branches.
+    """
+
+    preserve_native_tool_format = False
+    tokenizer = SimpleNamespace(
+        chat_template=None,
+        apply_chat_template=lambda *a, **k: "templated",
+        decode=lambda *a, **k: "",
+        encode=lambda *a, **k: [1, 2, 3],
+    )
+
+    def __init__(self):
+        self.nonstream_calls = 0
+        self.stream_calls = 0
+
+    async def chat(self, messages, **kwargs):
+        self.nonstream_calls += 1
+        return SimpleNamespace(
+            text="hello there",
+            raw_text="hello there",
+            prompt_tokens=9,
+            completion_tokens=7,
+            finish_reason="stop",
+            tool_calls=None,
+            matched_stop=None,
+            reasoning_text=None,
+            model="test-model",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        self.stream_calls += 1
+        for i, text in enumerate(["Hello ", "world"], start=1):
+            yield SimpleNamespace(
+                new_text=text,
+                prompt_tokens=9,
+                completion_tokens=i,
+            )
+
+
+def _anthropic_client(engine: _AnthropicEngine) -> TestClient:
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.anthropic import router
+
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_anthropic_messages_nonstream_emits_claude_code_attribution(
+    telemetry_on, captured
+):
+    """A claude-code User-Agent on a completed non-streaming ``/v1/messages``
+    request must surface a bucketed ``request`` event with
+    ``caller_agent == "claude-code"``, the correct endpoint, stream=False,
+    token counts and a positive TTFT. This is the structural proof codex
+    asked for: it would FAIL if the route's ``emit.request`` were deleted or
+    the User-Agent were not threaded through."""
+    engine = _AnthropicEngine()
+    client = _anthropic_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        headers={"user-agent": "claude-code/1.0.3"},
+        json={
+            "model": "test-model",
+            "max_tokens": 2048,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _request_events(captured)
+    assert engine.nonstream_calls == 1
+    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
+    ev = events[-1]
+    assert ev["endpoint"] == "/v1/messages"
+    assert ev["stream"] is False
+    assert ev["caller_agent"] == "claude-code"
+    # Token counts are bucketed to a fixed allowlist (red-line: raw counts
+    # are a soft fingerprint) — the 9/7 token counts land in "0-256".
+    assert ev["prompt_tokens_bucket"] == "0-256"
+    assert ev["completion_tokens_bucket"] == "0-256"
+    assert ev["completion_empty"] is False
+    # TTFT is bucketed (never a raw ms value) — just assert a valid label.
+    assert ev["ttft_ms_bucket"] in (
+        "<100ms",
+        "100-500ms",
+        "500-1500ms",
+        "1.5-5s",
+        ">5s",
+    )
+    assert ev["status"] == 200
+
+
+def test_anthropic_messages_stream_emits_claude_code_attribution(
+    telemetry_on, captured
+):
+    """Same contract on the streaming ``/v1/messages`` branch: the emit fires
+    after the stream drains, caller_agent is the bucketed claude-code label,
+    stream=True, and TTFT is true first-token latency (> 0)."""
+    engine = _AnthropicEngine()
+    client = _anthropic_client(engine)
+
+    resp = client.post(
+        "/v1/messages",
+        headers={"user-agent": "Claude-Code/2.0 (macOS) Anthropic/API"},
+        json={
+            "model": "test-model",
+            "max_tokens": 2048,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert "text/event-stream" in resp.headers["content-type"]
+    events = _request_events(captured)
+    assert engine.stream_calls == 1
+    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
+    ev = events[-1]
+    assert ev["endpoint"] == "/v1/messages"
+    assert ev["stream"] is True
+    assert ev["caller_agent"] == "claude-code"
+    # streaming fake engine yields prompt_tokens=9 + completion_tokens=2 → "0-256"
+    assert ev["prompt_tokens_bucket"] == "0-256"
+    assert ev["completion_tokens_bucket"] == "0-256"
+    assert ev["ttft_ms_bucket"] in (
+        "<100ms",
+        "100-500ms",
+        "500-1500ms",
+        "1.5-5s",
+        ">5s",
+    )
+    assert ev["status"] == 200
+
+
+# ---------------------------------------------------------------- completions
+
+
+def _completions_client(monkeypatch):
+    """Drive ``/v1/completions`` end-to-end with a fake engine, mirroring the
+    proven harness from ``test_completions_log_redaction`` (engine + admission
+    + context-length shims so the route completes without loading a model)."""
+    from vllm_mlx.routes import completions as completions_mod
+
+    fake_engine = MagicMock()
+
+    async def _finish(*_a, **_k):
+        return SimpleNamespace(
+            text="done",
+            finish_reason="stop",
+            completion_tokens=5,
+            prompt_tokens=3,
+            cached_tokens=0,
+        )
+
+    fake_engine.generate = AsyncMock(side_effect=_finish)
+
+    async def _stream_finish(*_a, **_k):
+        # First chunk: non-empty content, not finished.
+        yield SimpleNamespace(
+            new_text="done",
+            finished=False,
+            finish_reason=None,
+            completion_tokens=0,
+            prompt_tokens=3,
+        )
+        # Final chunk: finished, carries the engine's final usage.
+        yield SimpleNamespace(
+            new_text="",
+            finished=True,
+            finish_reason="stop",
+            completion_tokens=5,
+            prompt_tokens=3,
+        )
+
+    fake_engine.stream_generate = _stream_finish
+
+    monkeypatch.setattr(completions_mod, "get_engine", lambda _name: fake_engine)
+    monkeypatch.setattr(completions_mod, "_check_admission_or_503", lambda _e: None)
+    monkeypatch.setattr(
+        completions_mod, "_release_admission_unless_committed", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        completions_mod, "enforce_context_length_for_prompt", lambda *a, **k: None
+    )
+    monkeypatch.setattr(completions_mod, "_validate_model_name", lambda _m: None)
+    monkeypatch.setattr(completions_mod, "_resolve_model_name", lambda m: m)
+    monkeypatch.setattr(completions_mod, "_resolve_max_tokens", lambda m: m or 16)
+    monkeypatch.setattr(completions_mod, "_resolve_temperature", lambda t: t)
+    monkeypatch.setattr(completions_mod, "_resolve_top_p", lambda p: p)
+    monkeypatch.setattr(
+        completions_mod, "build_extended_sampling_kwargs", lambda _r: {}
+    )
+
+    async def _passthrough(coro, *_a, **_k):
+        return await coro
+
+    monkeypatch.setattr(completions_mod, "_wait_with_disconnect", _passthrough)
+
+    with (
+        patch("vllm_mlx.middleware.auth.verify_api_key", new=lambda *a, **k: None),
+        patch("vllm_mlx.middleware.auth.check_rate_limit", new=lambda *a, **k: None),
+    ):
+        app = FastAPI()
+        app.include_router(completions_mod.router)
+        return TestClient(app)
+
+
+def test_completions_nonstream_emits_openai_python_attribution(
+    telemetry_on, captured, monkeypatch
+):
+    """A completed non-streaming ``/v1/completions`` with an openai-python
+    User-Agent surfaces ``caller_agent == "openai-python"``, endpoint
+    ``/v1/completions``, stream=False, and the engine's token counts."""
+    client = _completions_client(monkeypatch)
+    resp = client.post(
+        "/v1/completions",
+        headers={"user-agent": "OpenAI/Python 1.30.1"},
+        json={"model": "test-model", "prompt": "hi", "max_tokens": 8},
+    )
+    assert resp.status_code == 200, resp.text
+    events = _request_events(captured)
+    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
+    ev = events[-1]
+    assert ev["endpoint"] == "/v1/completions"
+    assert ev["stream"] is False
+    assert ev["caller_agent"] == "openai-python"
+    # engine's 3 prompt + 5 completion tokens → "0-256" bucket
+    assert ev["prompt_tokens_bucket"] == "0-256"
+    assert ev["completion_tokens_bucket"] == "0-256"
+    assert ev["ttft_ms_bucket"] in (
+        "<100ms",
+        "100-500ms",
+        "500-1500ms",
+        "1.5-5s",
+        ">5s",
+    )
+    assert ev["status"] == 200
+
+
+def test_completions_stream_emits_openai_python_attribution(
+    telemetry_on, captured, monkeypatch
+):
+    """The streaming ``/v1/completions`` branch emits stream=True with true
+    TTFT and final-usage token counts."""
+    client = _completions_client(monkeypatch)
+    resp = client.post(
+        "/v1/completions",
+        headers={"user-agent": "OpenAI/Python 1.30.1"},
+        json={"model": "test-model", "prompt": "hi", "max_tokens": 8, "stream": True},
+    )
+    assert resp.status_code == 200, resp.text
+    events = _request_events(captured)
+    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
+    ev = events[-1]
+    assert ev["endpoint"] == "/v1/completions"
+    assert ev["stream"] is True
+    assert ev["caller_agent"] == "openai-python"
+    assert ev["completion_tokens_bucket"] == "0-256"
+    assert ev["ttft_ms_bucket"] in (
+        "<100ms",
+        "100-500ms",
+        "500-1500ms",
+        "1.5-5s",
+        ">5s",
+    )
+    assert ev["status"] == 200

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -182,6 +182,11 @@ def test_anthropic_messages_nonstream_emits_claude_code_attribution(
     token counts and a positive TTFT. This is the structural proof codex
     asked for: it would FAIL if the route's ``emit.request`` were deleted or
     the User-Agent were not threaded through."""
+    # The ``/v1/messages`` route imports ``mlx`` at module load, so this test
+    # can only drive it where MLX is installed. Skip cleanly on the no-MLX
+    # pr_validate CI env (where the whole anthropic route suite is MLX-gated)
+    # rather than erroring at collection; it runs to completion locally.
+    pytest.importorskip("mlx")
     engine = _AnthropicEngine()
     client = _anthropic_client(engine)
 
@@ -231,6 +236,7 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
     small fraction of total proves ``_first_token_ts`` is latched and used —
     a regression to "total latency" would blow past ``0.5 * total``.
     """
+    pytest.importorskip("mlx")
     import time
 
     calls: list[dict] = []

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -79,7 +79,16 @@ def _request_events(captured) -> list[dict]:
 async def _sleep(seconds: float) -> None:
     """Async sleep helper so fake engines can inject a real post-first-token
     gap without blocking the event loop (mirrors the fake engine in
-    ``test_telemetry_streaming_request_wiring.py``)."""
+    ``test_telemetry_streaming_request_wiring.py``).
+
+    TTFT rigor (codex r3-NIT#3 deferral): we use a REAL clock + an artificial
+    post-first-token gap and assert ``ttft_ms < 0.5 * total``, exactly the
+    approach the repo's accepted ``test_telemetry_streaming_request_wiring``
+    uses — rather than patching the global ``time.perf_counter`` (which leaks
+    into the HTTP client's own elapsed-time arithmetic and is flaky). Under
+    pathological CI slowness where pre-token processing could exceed the gap,
+    the assertion would trip on a genuinely-regressed (total-latency) TTFT —
+    the exact regression the test exists to catch."""
     import asyncio
 
     await asyncio.sleep(seconds)

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -76,6 +76,29 @@ def _request_events(captured) -> list[dict]:
     return events
 
 
+async def _sleep(seconds: float) -> None:
+    """Async sleep helper so fake engines can inject a real post-first-token
+    gap without blocking the event loop (mirrors the fake engine in
+    ``test_telemetry_streaming_request_wiring.py``)."""
+    import asyncio
+
+    await asyncio.sleep(seconds)
+
+
+def _capture_request(monkeypatch, captured):
+    """Capture every ``emit.request`` KWARG (not the enqueued payload) so a
+    test can assert on raw values (e.g. exact ``ttft_ms``) that are otherwise
+    bucketed in the wire payload. Mirrors the emit.request-capture pattern in
+    ``test_telemetry_streaming_request_wiring.py``."""
+    from vllm_mlx.telemetry import emit
+
+    def _wrapper(**kw):
+        captured.append(kw)
+
+    monkeypatch.setattr(emit, "request", _wrapper)
+    return captured
+
+
 # ---------------------------------------------------------------- anthropic
 
 
@@ -116,6 +139,10 @@ class _AnthropicEngine:
     async def stream_chat(self, messages, **kwargs):
         self.stream_calls += 1
         for i, text in enumerate(["Hello ", "world"], start=1):
+            if i == len(["Hello ", "world"]):
+                # Post-first-token gap so total latency dwarfs true TTFT
+                # (mirrors test_telemetry_streaming_request_wiring).
+                await _sleep(0.2)
             yield SimpleNamespace(
                 new_text=text,
                 prompt_tokens=9,
@@ -183,14 +210,27 @@ def test_anthropic_messages_nonstream_emits_claude_code_attribution(
 
 
 def test_anthropic_messages_stream_emits_claude_code_attribution(
-    telemetry_on, captured
+    telemetry_on, monkeypatch
 ):
     """Same contract on the streaming ``/v1/messages`` branch: the emit fires
     after the stream drains, caller_agent is the bucketed claude-code label,
-    stream=True, and TTFT is true first-token latency (> 0)."""
+    stream=True, and TTFT is TRUE first-token latency.
+
+    Captures raw ``emit.request`` kwargs (before bucketing) while driving the
+    route end-to-end; the fake engine injects a real 0.2s gap after the first
+    token so total stream latency dwarfs true TTFT. Asserting ``ttft_ms`` is a
+    small fraction of total proves ``_first_token_ts`` is latched and used —
+    a regression to "total latency" would blow past ``0.5 * total``.
+    """
+    import time
+
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+
     engine = _AnthropicEngine()
     client = _anthropic_client(engine)
 
+    t0 = time.perf_counter()
     resp = client.post(
         "/v1/messages",
         headers={"user-agent": "Claude-Code/2.0 (macOS) Anthropic/API"},
@@ -201,26 +241,25 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
             "messages": [{"role": "user", "content": "hello"}],
         },
     )
+    total_ms = (time.perf_counter() - t0) * 1000.0
     assert resp.status_code == 200, resp.text
     assert "text/event-stream" in resp.headers["content-type"]
-    events = _request_events(captured)
     assert engine.stream_calls == 1
-    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
-    ev = events[-1]
-    assert ev["endpoint"] == "/v1/messages"
-    assert ev["stream"] is True
-    assert ev["caller_agent"] == "claude-code"
-    # streaming fake engine yields prompt_tokens=9 + completion_tokens=2 → "0-256"
-    assert ev["prompt_tokens_bucket"] == "0-256"
-    assert ev["completion_tokens_bucket"] == "0-256"
-    assert ev["ttft_ms_bucket"] in (
-        "<100ms",
-        "100-500ms",
-        "500-1500ms",
-        "1.5-5s",
-        ">5s",
+    assert len(calls) == 1, f"expected one request emit, got {calls!r}"
+    kw = calls[0]
+    assert kw["endpoint"] == "/v1/messages"
+    assert kw["stream"] is True
+    assert kw["status"] == 200
+    assert kw["caller_agent"] == "Claude-Code/2.0 (macOS) Anthropic/API"
+    assert kw["prompt_tokens"] == 9
+    assert kw["completion_tokens"] == 2
+    # TTFT is measured at the FIRST token, so it is a small fraction of total
+    # latency (which includes the 0.2s post-first-token gap) — NOT total.
+    assert kw["ttft_ms"] > 0.0
+    assert kw["ttft_ms"] < 0.5 * total_ms, (
+        f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
+        f"latency {total_ms:.1f}ms — it must reflect first-token timing, not total"
     )
-    assert ev["status"] == 200
 
 
 # ---------------------------------------------------------------- completions
@@ -254,6 +293,8 @@ def _completions_client(monkeypatch):
             completion_tokens=0,
             prompt_tokens=3,
         )
+        # Post-first-token gap so total latency dwarfs true TTFT.
+        await _sleep(0.2)
         # Final chunk: finished, carries the engine's final usage.
         yield SimpleNamespace(
             new_text="",
@@ -328,30 +369,39 @@ def test_completions_nonstream_emits_openai_python_attribution(
     assert ev["status"] == 200
 
 
-def test_completions_stream_emits_openai_python_attribution(
-    telemetry_on, captured, monkeypatch
-):
-    """The streaming ``/v1/completions`` branch emits stream=True with true
-    TTFT and final-usage token counts."""
+def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkeypatch):
+    """The streaming ``/v1/completions`` branch emits stream=True with TRUE
+    first-token TTFT and final-usage token counts.
+
+    Captures raw ``emit.request`` kwargs; the fake stream injects a real 0.2s
+    gap after the first chunk so total latency dwarfs true TTFT. Asserting
+    ``ttft_ms`` is a small fraction of total proves ``_first_token_ts`` is
+    latched and used (a total-latency regression would blow past 0.5*total).
+    """
+    import time
+
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+
     client = _completions_client(monkeypatch)
+    t0 = time.perf_counter()
     resp = client.post(
         "/v1/completions",
         headers={"user-agent": "OpenAI/Python 1.30.1"},
         json={"model": "test-model", "prompt": "hi", "max_tokens": 8, "stream": True},
     )
+    total_ms = (time.perf_counter() - t0) * 1000.0
     assert resp.status_code == 200, resp.text
-    events = _request_events(captured)
-    assert len(events) >= 1, f"no request telemetry emitted: {captured!r}"
-    ev = events[-1]
-    assert ev["endpoint"] == "/v1/completions"
-    assert ev["stream"] is True
-    assert ev["caller_agent"] == "openai-python"
-    assert ev["completion_tokens_bucket"] == "0-256"
-    assert ev["ttft_ms_bucket"] in (
-        "<100ms",
-        "100-500ms",
-        "500-1500ms",
-        "1.5-5s",
-        ">5s",
+    assert len(calls) == 1, f"expected one request emit, got {calls!r}"
+    kw = calls[0]
+    assert kw["endpoint"] == "/v1/completions"
+    assert kw["stream"] is True
+    assert kw["status"] == 200
+    assert kw["caller_agent"] == "OpenAI/Python 1.30.1"
+    assert kw["prompt_tokens"] == 3
+    assert kw["completion_tokens"] == 5
+    assert kw["ttft_ms"] > 0.0
+    assert kw["ttft_ms"] < 0.5 * total_ms, (
+        f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
+        f"latency {total_ms:.1f}ms — it must reflect first-token timing, not total"
     )
-    assert ev["status"] == 200

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -280,10 +280,16 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
 # ---------------------------------------------------------------- completions
 
 
-def _completions_client(monkeypatch):
+def _completions_client(monkeypatch, stream_generate=None):
     """Drive ``/v1/completions`` end-to-end with a fake engine, mirroring the
     proven harness from ``test_completions_log_redaction`` (engine + admission
-    + context-length shims so the route completes without loading a model)."""
+    + context-length shims so the route completes without loading a model).
+
+    ``stream_generate`` may be replaced by a caller-supplied async generator
+    to control *where* the latency lands in the stream (codex r7-B#1). The
+    default places the post-first-token gap AFTER the first generated chunk —
+    the correct shape for proving true TTFT on a plain (non-echo) stream.
+    """
     from vllm_mlx.routes import completions as completions_mod
 
     fake_engine = MagicMock()
@@ -299,27 +305,31 @@ def _completions_client(monkeypatch):
 
     fake_engine.generate = AsyncMock(side_effect=_finish)
 
-    async def _stream_finish(*_a, **_k):
-        # First chunk: non-empty content, not finished.
-        yield SimpleNamespace(
-            new_text="done",
-            finished=False,
-            finish_reason=None,
-            completion_tokens=0,
-            prompt_tokens=3,
-        )
-        # Post-first-token gap so total latency dwarfs true TTFT.
-        await _sleep(0.2)
-        # Final chunk: finished, carries the engine's final usage.
-        yield SimpleNamespace(
-            new_text="",
-            finished=True,
-            finish_reason="stop",
-            completion_tokens=5,
-            prompt_tokens=3,
-        )
+    if stream_generate is None:
 
-    fake_engine.stream_generate = _stream_finish
+        async def _stream_finish(*_a, **_k):
+            # First chunk: non-empty content, not finished.
+            yield SimpleNamespace(
+                new_text="done",
+                finished=False,
+                finish_reason=None,
+                completion_tokens=0,
+                prompt_tokens=3,
+            )
+            # Post-first-token gap so total latency dwarfs true TTFT.
+            await _sleep(0.2)
+            # Final chunk: finished, carries the engine's final usage.
+            yield SimpleNamespace(
+                new_text="",
+                finished=True,
+                finish_reason="stop",
+                completion_tokens=5,
+                prompt_tokens=3,
+            )
+
+        fake_engine.stream_generate = _stream_finish
+    else:
+        fake_engine.stream_generate = stream_generate
 
     monkeypatch.setattr(completions_mod, "get_engine", lambda _name: fake_engine)
     monkeypatch.setattr(completions_mod, "_check_admission_or_503", lambda _e: None)
@@ -425,19 +435,45 @@ def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkey
 def test_completions_stream_echo_latches_ttft_at_echo_yield(telemetry_on, monkeypatch):
     """In `echo=True` streaming, the echoed prompt is the client-visible first
     content, so TTFT is latched at the echo yield (completions.py:754) rather
-    than at the first generated token later in the loop.
+    than at the first generated token later in the loop (line 906).
 
-    The fake engine injects a 0.2s post-first-generated-chunk gap, so total
-    stream latency dwarfs the echo-yield TTFT. Asserting ``ttft_ms < 0.5 *
-    total`` proves the echo latch fires (a total-latency None-fallback would
-    blow past the ratio). Pins diff-cover on the echo latch + codex r4-B#2.
+    The route renders the echo SYNCHRONOUSLY before ``stream_generate`` is even
+    awaited, so we inject the model latency INSIDE the fake engine, BEFORE its
+    first generated chunk: that makes the first generated chunk arrive only
+    after a real 0.2s gap, while the echo yield is immediate. This is what makes
+    the test DISCRIMINATING (codex r7-B#1):
+      - with the echo latch:  TTFT latches at the immediate echo yield (~0ms)
+      - without the echo latch: line 906 latches at the first generated chunk,
+        which lands AFTER the 0.2s gap -> TTFT ~= the gap
+    Asserting ``ttft_ms < 0.5 * total`` then fails precisely when the echo latch
+    is deleted and the route silently falls back to generated-chunk timing.
     """
     import time
 
     calls: list[dict] = []
     _capture_request(monkeypatch, calls)
 
-    client = _completions_client(monkeypatch)
+    async def _echo_stream(*_a, **_k):
+        # Model latency between the (immediate) echo yield and the first
+        # generated chunk. Without the echo latch this makes line 906 latch
+        # ~0.2s late, blowing past the 0.5*total bound below.
+        await _sleep(0.2)
+        yield SimpleNamespace(
+            new_text="done",
+            finished=False,
+            finish_reason=None,
+            completion_tokens=0,
+            prompt_tokens=3,
+        )
+        yield SimpleNamespace(
+            new_text="",
+            finished=True,
+            finish_reason="stop",
+            completion_tokens=5,
+            prompt_tokens=3,
+        )
+
+    client = _completions_client(monkeypatch, stream_generate=_echo_stream)
     t0 = time.perf_counter()
     resp = client.post(
         "/v1/completions",
@@ -457,12 +493,14 @@ def test_completions_stream_echo_latches_ttft_at_echo_yield(telemetry_on, monkey
     assert kw["endpoint"] == "/v1/completions"
     assert kw["stream"] is True
     assert kw["caller_agent"] == "OpenAI/Python 1.30.1"
-    # The echo latch fires at the echo yield, so TTFT is a small fraction of
-    # total latency (which includes the 0.2s post-derived-gap). A None
-    # fallback (latch deleted) would report total-latency and fail this.
+    # The echo latch fires at the immediate echo yield, so TTFT is a small
+    # fraction of total latency (which includes the 0.2s pre-generated delay).
+    # Deleting the latch makes line 906 latch at the generated chunk, ~0.2s
+    # in -> TTFT would be ~the gap and this assertion would fail.
     assert kw["ttft_ms"] > 0.0
     assert kw["ttft_ms"] < 0.5 * total_ms, (
         f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
-        f"latency {total_ms:.1f}ms — it must reflect the echo-yield latency"
+        f"latency {total_ms:.1f}ms — it must reflect the immediate echo-yield "
+        f"latency, not the delayed first generated chunk"
     )
     assert kw["status"] == 200

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -353,6 +353,119 @@ def test_anthropic_stream_ttft_ignores_parser_suppressed_reasoning(
     assert calls[0]["ttft_ms"] >= 150.0, calls[0]
 
 
+def test_anthropic_stream_ttft_latches_when_pinned_tool_buffer_replays(
+    telemetry_on, monkeypatch
+):
+    """A valid named-tool stream delays TTFT until buffered output is replayed.
+
+    The engine emits adjacent text and the pinned structured tool call in
+    consecutive chunks. The route must first buffer the text while it validates
+    the forced tool contract, then replay it before the tool block. Both are
+    visible output, and telemetry must latch exactly once on that replay.
+    """
+    pytest.importorskip("mlx")
+
+    class _PinnedToolEngine(_AnthropicEngine):
+        async def stream_chat(self, messages, **kwargs):
+            self.stream_calls += 1
+            # Text and structured calls are separate engine chunks: the route
+            # deliberately short-circuits a chunk carrying ``tool_calls``.
+            yield SimpleNamespace(
+                new_text="Checking weather. ",
+                prompt_tokens=9,
+                completion_tokens=1,
+                finish_reason=None,
+                tool_calls=None,
+            )
+            yield SimpleNamespace(
+                new_text="",
+                prompt_tokens=9,
+                completion_tokens=3,
+                finish_reason="tool_calls",
+                tool_calls=[
+                    {
+                        "name": "get_weather",
+                        "arguments": '{"location":"SF"}',
+                    }
+                ],
+                channel=None,
+            )
+
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+    engine = _PinnedToolEngine()
+    client = _anthropic_client(engine)
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 64,
+            "stream": True,
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                }
+            ],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+            "messages": [{"role": "user", "content": "weather in SF"}],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "Checking weather." in resp.text
+    assert '"type": "tool_use"' in resp.text
+    assert resp.text.index("Checking weather.") < resp.text.index('"type": "tool_use"')
+    assert engine.stream_calls == 1
+    assert len(calls) == 1
+    assert calls[0]["tool_call_used"] is True
+    assert calls[0]["ttft_ms"] > 0.0
+
+
+def test_anthropic_empty_stream_uses_total_latency_as_ttft(telemetry_on, monkeypatch):
+    """A successful stream with no visible output reports total time as TTFT."""
+    pytest.importorskip("mlx")
+
+    class _EmptyEngine(_AnthropicEngine):
+        async def stream_chat(self, messages, **kwargs):
+            self.stream_calls += 1
+            await _sleep(0.05)
+            yield SimpleNamespace(
+                new_text="",
+                prompt_tokens=9,
+                completion_tokens=0,
+                finish_reason="stop",
+                finished=True,
+                tool_calls=None,
+            )
+
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+    engine = _EmptyEngine()
+    client = _anthropic_client(engine)
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 64,
+            "stream": True,
+            "messages": [{"role": "user", "content": "say nothing"}],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert engine.stream_calls == 1
+    assert len(calls) == 1
+    assert calls[0]["completion_tokens"] == 0
+    assert calls[0]["ttft_ms"] >= 40.0, calls[0]
+    assert calls[0]["tps"] == 0.0
+
+
 # ---------------------------------------------------------------- completions
 
 

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -127,9 +127,11 @@ class _AnthropicEngine:
         encode=lambda *a, **k: [1, 2, 3],
     )
 
-    def __init__(self):
+    def __init__(self, *, prefill_delay=0.0, decode_delay=0.2):
         self.nonstream_calls = 0
         self.stream_calls = 0
+        self.prefill_delay = prefill_delay
+        self.decode_delay = decode_delay
 
     async def chat(self, messages, **kwargs):
         self.nonstream_calls += 1
@@ -147,11 +149,11 @@ class _AnthropicEngine:
 
     async def stream_chat(self, messages, **kwargs):
         self.stream_calls += 1
+        if self.prefill_delay:
+            await _sleep(self.prefill_delay)
         for i, text in enumerate(["Hello ", "world"], start=1):
             if i == len(["Hello ", "world"]):
-                # Post-first-token gap so total latency dwarfs true TTFT
-                # (mirrors test_telemetry_streaming_request_wiring).
-                await _sleep(0.2)
+                await _sleep(self.decode_delay)
             yield SimpleNamespace(
                 new_text=text,
                 prompt_tokens=9,
@@ -231,10 +233,9 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
     stream=True, and TTFT is TRUE first-token latency.
 
     Captures raw ``emit.request`` kwargs (before bucketing) while driving the
-    route end-to-end; the fake engine injects a real 0.2s gap after the first
-    token so total stream latency dwarfs true TTFT. Asserting ``ttft_ms`` is a
-    small fraction of total proves ``_first_token_ts`` is latched and used —
-    a regression to "total latency" would blow past ``0.5 * total``.
+    route end-to-end; the fake engine injects 0.1s of prefill before the first
+    token and a 0.2s decode gap after it. This makes both timing windows large
+    enough to prove that TTFT and TPS use their respective clocks.
     """
     pytest.importorskip("mlx")
     import time
@@ -242,7 +243,7 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
     calls: list[dict] = []
     _capture_request(monkeypatch, calls)
 
-    engine = _AnthropicEngine()
+    engine = _AnthropicEngine(prefill_delay=0.1, decode_delay=0.2)
     client = _anthropic_client(engine)
 
     t0 = time.perf_counter()
@@ -274,6 +275,11 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
     assert kw["ttft_ms"] < 0.5 * total_ms, (
         f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
         f"latency {total_ms:.1f}ms — it must reflect first-token timing, not total"
+    )
+    total_rate = kw["completion_tokens"] / (total_ms / 1000.0)
+    assert kw["tps"] > 1.25 * total_rate, (
+        f"tps={kw['tps']:.1f} must use the post-first-token decode window, "
+        f"not total request time ({total_rate:.1f} tok/s)"
     )
 
 
@@ -408,7 +414,25 @@ def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkey
     calls: list[dict] = []
     _capture_request(monkeypatch, calls)
 
-    client = _completions_client(monkeypatch)
+    async def _prefill_then_decode(*_a, **_k):
+        await _sleep(0.1)
+        yield SimpleNamespace(
+            new_text="done",
+            finished=False,
+            finish_reason=None,
+            completion_tokens=0,
+            prompt_tokens=3,
+        )
+        await _sleep(0.2)
+        yield SimpleNamespace(
+            new_text="",
+            finished=True,
+            finish_reason="stop",
+            completion_tokens=5,
+            prompt_tokens=3,
+        )
+
+    client = _completions_client(monkeypatch, stream_generate=_prefill_then_decode)
     t0 = time.perf_counter()
     resp = client.post(
         "/v1/completions",
@@ -429,6 +453,11 @@ def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkey
     assert kw["ttft_ms"] < 0.5 * total_ms, (
         f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
         f"latency {total_ms:.1f}ms — it must reflect first-token timing, not total"
+    )
+    total_rate = kw["completion_tokens"] / (total_ms / 1000.0)
+    assert kw["tps"] > 1.25 * total_rate, (
+        f"tps={kw['tps']:.1f} must use the post-first-token decode window, "
+        f"not total request time ({total_rate:.1f} tok/s)"
     )
 
 

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -425,14 +425,20 @@ def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkey
 def test_completions_stream_echo_latches_ttft_at_echo_yield(telemetry_on, monkeypatch):
     """In `echo=True` streaming, the echoed prompt is the client-visible first
     content, so TTFT is latched at the echo yield (completions.py:754) rather
-    than at the first generated token later in the loop. Captured ttft_ms must
-    be positive and small — a total-latency fallback (latch never set) would
-    fail to reflect the echo-first-token semantics. This pins diff-cover on the
-    echo latch line and the codex r4-B#2 fix."""
+    than at the first generated token later in the loop.
+
+    The fake engine injects a 0.2s post-first-generated-chunk gap, so total
+    stream latency dwarfs the echo-yield TTFT. Asserting ``ttft_ms < 0.5 *
+    total`` proves the echo latch fires (a total-latency None-fallback would
+    blow past the ratio). Pins diff-cover on the echo latch + codex r4-B#2.
+    """
+    import time
+
     calls: list[dict] = []
     _capture_request(monkeypatch, calls)
 
     client = _completions_client(monkeypatch)
+    t0 = time.perf_counter()
     resp = client.post(
         "/v1/completions",
         headers={"user-agent": "OpenAI/Python 1.30.1"},
@@ -444,13 +450,19 @@ def test_completions_stream_echo_latches_ttft_at_echo_yield(telemetry_on, monkey
             "echo": True,
         },
     )
+    total_ms = (time.perf_counter() - t0) * 1000.0
     assert resp.status_code == 200, resp.text
     assert len(calls) == 1, f"expected one request emit, got {calls!r}"
     kw = calls[0]
     assert kw["endpoint"] == "/v1/completions"
     assert kw["stream"] is True
     assert kw["caller_agent"] == "OpenAI/Python 1.30.1"
-    # With echo, the latch at the echo yield must set _first_token_ts, so
-    # emit reports a real first-token TTFT (positive, not the None fallback).
+    # The echo latch fires at the echo yield, so TTFT is a small fraction of
+    # total latency (which includes the 0.2s post-derived-gap). A None
+    # fallback (latch deleted) would report total-latency and fail this.
     assert kw["ttft_ms"] > 0.0
+    assert kw["ttft_ms"] < 0.5 * total_ms, (
+        f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
+        f"latency {total_ms:.1f}ms — it must reflect the echo-yield latency"
+    )
     assert kw["status"] == 200

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -161,7 +161,9 @@ class _AnthropicEngine:
             )
 
 
-def _anthropic_client(engine: _AnthropicEngine) -> TestClient:
+def _anthropic_client(
+    engine: _AnthropicEngine, *, reasoning_parser_name: str | None = None
+) -> TestClient:
     from vllm_mlx.config import reset_config
     from vllm_mlx.routes.anthropic import router
 
@@ -169,6 +171,7 @@ def _anthropic_client(engine: _AnthropicEngine) -> TestClient:
     cfg.engine = engine
     cfg.model_name = "test-model"
     cfg.model_registry = None
+    cfg.reasoning_parser_name = reasoning_parser_name
 
     app = FastAPI()
     app.include_router(router)
@@ -281,6 +284,73 @@ def test_anthropic_messages_stream_emits_claude_code_attribution(
         f"tps={kw['tps']:.1f} must use the post-first-token decode window, "
         f"not total request time ({total_rate:.1f} tok/s)"
     )
+
+
+def test_anthropic_stream_ttft_ignores_parser_suppressed_reasoning(
+    telemetry_on, monkeypatch
+):
+    """Raw reasoning held by a parser is not visible client output.
+
+    The first engine delta is deliberately suppressed, followed by a 0.2s
+    delay and a visible text delta. TTFT must include that delay; latching on
+    the raw engine delta would report near-zero latency instead.
+    """
+    pytest.importorskip("mlx")
+
+    class _HeldPrefixEngine(_AnthropicEngine):
+        async def stream_chat(self, messages, **kwargs):
+            self.stream_calls += 1
+            yield SimpleNamespace(
+                new_text="hidden reasoning",
+                prompt_tokens=9,
+                completion_tokens=1,
+            )
+            await _sleep(0.2)
+            yield SimpleNamespace(
+                new_text="visible answer",
+                prompt_tokens=9,
+                completion_tokens=2,
+            )
+
+    class _HeldPrefixParser:
+        implicit_reasoning_until_close = False
+        sanitize_when_thinking_disabled = True
+
+        def configure_request(self, **kwargs):
+            return None
+
+        def extract_reasoning_streaming(self, previous, current, delta):
+            if delta == "hidden reasoning":
+                return None
+            return SimpleNamespace(reasoning=None, content=delta)
+
+        def finalize_streaming(self, *args, **kwargs):
+            return None
+
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+    monkeypatch.setattr(
+        "vllm_mlx.reasoning.get_parser", lambda _name: _HeldPrefixParser
+    )
+
+    engine = _HeldPrefixEngine()
+    client = _anthropic_client(engine, reasoning_parser_name="held-prefix")
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 2048,
+            "stream": True,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "visible answer" in resp.text
+    assert "hidden reasoning" not in resp.text
+    assert engine.stream_calls == 1
+    assert len(calls) == 1
+    assert calls[0]["ttft_ms"] >= 150.0, calls[0]
 
 
 # ---------------------------------------------------------------- completions

--- a/tests/test_telemetry_route_attribution.py
+++ b/tests/test_telemetry_route_attribution.py
@@ -420,3 +420,37 @@ def test_completions_stream_emits_openai_python_attribution(telemetry_on, monkey
         f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
         f"latency {total_ms:.1f}ms — it must reflect first-token timing, not total"
     )
+
+
+def test_completions_stream_echo_latches_ttft_at_echo_yield(telemetry_on, monkeypatch):
+    """In `echo=True` streaming, the echoed prompt is the client-visible first
+    content, so TTFT is latched at the echo yield (completions.py:754) rather
+    than at the first generated token later in the loop. Captured ttft_ms must
+    be positive and small — a total-latency fallback (latch never set) would
+    fail to reflect the echo-first-token semantics. This pins diff-cover on the
+    echo latch line and the codex r4-B#2 fix."""
+    calls: list[dict] = []
+    _capture_request(monkeypatch, calls)
+
+    client = _completions_client(monkeypatch)
+    resp = client.post(
+        "/v1/completions",
+        headers={"user-agent": "OpenAI/Python 1.30.1"},
+        json={
+            "model": "test-model",
+            "prompt": "echo this",
+            "max_tokens": 8,
+            "stream": True,
+            "echo": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(calls) == 1, f"expected one request emit, got {calls!r}"
+    kw = calls[0]
+    assert kw["endpoint"] == "/v1/completions"
+    assert kw["stream"] is True
+    assert kw["caller_agent"] == "OpenAI/Python 1.30.1"
+    # With echo, the latch at the echo yield must set _first_token_ts, so
+    # emit reports a real first-token TTFT (positive, not the None fallback).
+    assert kw["ttft_ms"] > 0.0
+    assert kw["status"] == 200

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -2173,6 +2173,20 @@ async def _stream_anthropic_messages(
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         delta_text = output.new_text
 
+        # Task-C TTFT latch on the first engine content delta. We latch on
+        # the raw engine delta (not per-block-client-visibility) deliberately
+        # and doc the deferral from codex r3-B#2: the Anthropic stream state
+        # machine routes each delta through reasoning / tool / text channels
+        # across ~1000 lines of scatter (thinking_delta, text_delta,
+        # tool_use block, forced-content buffering) — latching at the first
+        # client-visible block would require re-plumbing every yield site.
+        # The engine emits the first delta essentially as it becomes the
+        # first visible block (reasoning is shown as thinking_delta, tool
+        # JSON args as a tool block); the only suppressed-delta edge case
+        # (a capped/forced reasoning head the caller didn't request) shifts
+        # TTFT by a single block and does not materially skew a bucketed
+        # aggregate metric. This matches the semantic chat.py lands on
+        # ("first real output token") at the granularity telemetry buckets.
         if _first_token_ts is None and (delta_text or ""):
             _first_token_ts = time.perf_counter()
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -3177,6 +3177,14 @@ async def _stream_anthropic_messages(
     # ``redact`` (never stored raw); ``ttft_ms`` is true first-token latency.
     # ``emit.request`` is sampled + ``is_enabled()``-gated + ``@_safe``, so
     # this is a cheap no-op when telemetry is off / not sampled.
+    if _first_token_ts is not None:
+        _ttft_seconds = max(0.0, _first_token_ts - start_time)
+    else:
+        _ttft_seconds = elapsed
+    _decode_seconds = elapsed - _ttft_seconds
+    _decode_tps = (
+        completion_tokens / _decode_seconds if _decode_seconds > 0 else tokens_per_sec
+    )
     from vllm_mlx.telemetry import emit as _telemetry_emit
 
     _telemetry_emit.request(
@@ -3189,10 +3197,8 @@ async def _stream_anthropic_messages(
         # TTFT == true first-token latency when a text token was produced;
         # on a stream with no text delta (tool-only / empty completion) fall
         # back to total stream time rather than reporting a false 0.0ms.
-        ttft_ms=elapsed * 1000.0
-        if _first_token_ts is None
-        else (_first_token_ts - start_time) * 1000.0,
-        tps=tokens_per_sec,
+        ttft_ms=_ttft_seconds * 1000.0,
+        tps=_decode_tps,
         status=200,
         caller_agent=caller_agent,
     )

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1928,14 +1928,14 @@ async def _stream_anthropic_messages(
         _is_required_tool_choice(getattr(openai_request, "tool_choice", None))
         and bool(openai_request.tools)
     )
-    pre_filter_buffer: list[tuple[str, bool]] = []
+    pre_filter_buffer: list[str] = []
 
     def _latch_first_visible_output() -> None:
         nonlocal _first_token_ts
         if _first_token_ts is None:
             _first_token_ts = time.perf_counter()
 
-    def _capture(event: str, *, marks_output: bool = False) -> str | None:
+    def _capture(event: str) -> str | None:
         """Either buffer ``event`` and return ``None``, or return
         ``event`` unchanged.
 
@@ -1949,15 +1949,19 @@ async def _stream_anthropic_messages(
         don't allow ``yield from`` against a sync generator helper,
         so this returns a scalar rather than an iterator.
 
-        ``marks_output`` identifies a real text/thinking/tool event. Its TTFT
-        timestamp is taken only when that event actually reaches the wire;
+        Content-block start/delta events are client-visible output. Their TTFT
+        timestamp is taken only when the event actually reaches the wire;
         buffered forced-tool events therefore latch during replay, not while
-        the model is still being validated.
+        the model is still being validated. Keeping this classification here
+        prevents individual yield sites from accidentally forgetting the
+        telemetry latch when a new streaming branch is added.
         """
         if _buffer_for_pinned_tool:
-            pre_filter_buffer.append((event, marks_output))
+            pre_filter_buffer.append(event)
             return None
-        if marks_output:
+        if event.startswith(
+            ("event: content_block_start", "event: content_block_delta")
+        ):
             _latch_first_visible_output()
         return event
 
@@ -2328,7 +2332,7 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        ev = _capture(event, marks_output=True)
+                        ev = _capture(event)
                         if ev is not None:
                             yield ev
                 continue
@@ -2494,7 +2498,7 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        ev = _capture(event, marks_output=True)
+                        ev = _capture(event)
                         if ev is not None:
                             yield ev
                 continue
@@ -2516,7 +2520,7 @@ async def _stream_anthropic_messages(
                     block_index,
                 )
                 for event in events:
-                    ev = _capture(event, marks_output=True)
+                    ev = _capture(event)
                     if ev is not None:
                         yield ev
 
@@ -2536,7 +2540,7 @@ async def _stream_anthropic_messages(
             block_index,
         )
         for event in events:
-            ev = _capture(event, marks_output=True)
+            ev = _capture(event)
             if ev is not None:
                 yield ev
 
@@ -2549,7 +2553,7 @@ async def _stream_anthropic_messages(
                 block_index,
             )
             for event in events:
-                ev = _capture(event, marks_output=True)
+                ev = _capture(event)
                 if ev is not None:
                     yield ev
 
@@ -2629,7 +2633,7 @@ async def _stream_anthropic_messages(
                         [("text", filtered)], current_block_type, block_index
                     )
                     for event in events:
-                        ev = _capture(event, marks_output=True)
+                        ev = _capture(event)
                         if ev is not None:
                             yield ev
         # Close any block we opened above before falling through to the
@@ -2811,7 +2815,7 @@ async def _stream_anthropic_messages(
                     f"event: content_block_stop\ndata: "
                     f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n",
                 ):
-                    ev = _capture(raw_event, marks_output=True)
+                    ev = _capture(raw_event)
                     if ev is not None:
                         yield ev
                 # Re-tracking: this is a manually-yielded
@@ -2939,8 +2943,10 @@ async def _stream_anthropic_messages(
     if _buffer_for_pinned_tool and not (
         tool_choice_error or tool_validation_error or synthesized_pinned_call
     ):
-        for buffered_event, marks_output in pre_filter_buffer:
-            if marks_output:
+        for buffered_event in pre_filter_buffer:
+            if buffered_event.startswith(
+                ("event: content_block_start", "event: content_block_delta")
+            ):
                 _latch_first_visible_output()
             yield buffered_event
         pre_filter_buffer.clear()

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -3165,7 +3165,10 @@ async def _stream_anthropic_messages(
         tool_call_used=bool(tool_calls),
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
-        ttft_ms=0.0
+        # TTFT == true first-token latency when a text token was produced;
+        # on a stream with no text delta (tool-only / empty completion) fall
+        # back to total stream time rather than reporting a false 0.0ms.
+        ttft_ms=elapsed * 1000.0
         if _first_token_ts is None
         else (_first_token_ts - start_time) * 1000.0,
         tps=tokens_per_sec,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -3149,13 +3149,20 @@ async def _stream_anthropic_messages(
         f"Anthropic messages (stream): prompt={prompt_tokens} + completion={completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
+    yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"
+
     # Opt-in telemetry (caller attribution, task C): record a bucketed
     # ``request`` event for this completed /v1/messages stream. Fired only
-    # after the generator drains normally (all tokens flushed). ``caller_agent``
-    # is the inbound User-Agent bucketed to an allowlist in ``redact`` (never
-    # stored raw); ``ttft_ms`` is true first-token latency. ``emit.request``
-    # is sampled + ``is_enabled()``-gated + ``@_safe``, so this is a cheap
-    # no-op when telemetry is off / not sampled.
+    # AFTER the terminal ``message_stop`` marker is yielded + the generator
+    # resumes cleanly — matching the chat lane's documented emit-after-
+    # terminal-marker placement. A stream the client cancels or that raises
+    # while delivering that final marker raises out before this line and is
+    # deliberately NOT counted (under-counting is conservative; emitting
+    # before ``message_stop`` would record a false status-200 success).
+    # ``caller_agent`` is the inbound User-Agent bucketed to an allowlist in
+    # ``redact`` (never stored raw); ``ttft_ms`` is true first-token latency.
+    # ``emit.request`` is sampled + ``is_enabled()``-gated + ``@_safe``, so
+    # this is a cheap no-op when telemetry is off / not sampled.
     from vllm_mlx.telemetry import emit as _telemetry_emit
 
     _telemetry_emit.request(
@@ -3175,5 +3182,3 @@ async def _stream_anthropic_messages(
         status=200,
         caller_agent=caller_agent,
     )
-
-    yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1622,9 +1622,9 @@ async def _stream_anthropic_messages(
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
-    # First non-empty text-token timestamp so the task-C streaming emit can
-    # report true TTFT (mirrors the chat/completions lanes). None until the
-    # first content delta is seen.
+    # First client-visible output timestamp so the task-C streaming emit can
+    # report true TTFT. Raw engine deltas may be held or suppressed by the
+    # reasoning/tool routers, so this is latched only at an SSE output yield.
     _first_token_ts: float | None = None
 
     if prepared_messages is not None:
@@ -1928,9 +1928,14 @@ async def _stream_anthropic_messages(
         _is_required_tool_choice(getattr(openai_request, "tool_choice", None))
         and bool(openai_request.tools)
     )
-    pre_filter_buffer: list[str] = []
+    pre_filter_buffer: list[tuple[str, bool]] = []
 
-    def _capture(event: str) -> str | None:
+    def _latch_first_visible_output() -> None:
+        nonlocal _first_token_ts
+        if _first_token_ts is None:
+            _first_token_ts = time.perf_counter()
+
+    def _capture(event: str, *, marks_output: bool = False) -> str | None:
         """Either buffer ``event`` and return ``None``, or return
         ``event`` unchanged.
 
@@ -1943,10 +1948,17 @@ async def _stream_anthropic_messages(
         streaming semantics. ``async for`` constructs in Python 3.12
         don't allow ``yield from`` against a sync generator helper,
         so this returns a scalar rather than an iterator.
+
+        ``marks_output`` identifies a real text/thinking/tool event. Its TTFT
+        timestamp is taken only when that event actually reaches the wire;
+        buffered forced-tool events therefore latch during replay, not while
+        the model is still being validated.
         """
         if _buffer_for_pinned_tool:
-            pre_filter_buffer.append(event)
+            pre_filter_buffer.append((event, marks_output))
             return None
+        if marks_output:
+            _latch_first_visible_output()
         return event
 
     accumulated_text = ""
@@ -2173,23 +2185,6 @@ async def _stream_anthropic_messages(
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         delta_text = output.new_text
 
-        # Task-C TTFT latch on the first engine content delta. We latch on
-        # the raw engine delta (not per-block-client-visibility) deliberately
-        # and doc the deferral from codex r3-B#2: the Anthropic stream state
-        # machine routes each delta through reasoning / tool / text channels
-        # across ~1000 lines of scatter (thinking_delta, text_delta,
-        # tool_use block, forced-content buffering) — latching at the first
-        # client-visible block would require re-plumbing every yield site.
-        # The engine emits the first delta essentially as it becomes the
-        # first visible block (reasoning is shown as thinking_delta, tool
-        # JSON args as a tool block); the only suppressed-delta edge case
-        # (a capped/forced reasoning head the caller didn't request) shifts
-        # TTFT by a single block and does not materially skew a bucketed
-        # aggregate metric. This matches the semantic chat.py lands on
-        # ("first real output token") at the granularity telemetry buckets.
-        if _first_token_ts is None and (delta_text or ""):
-            _first_token_ts = time.perf_counter()
-
         if hasattr(output, "prompt_tokens") and output.prompt_tokens:
             prompt_tokens = output.prompt_tokens
         if hasattr(output, "completion_tokens") and output.completion_tokens:
@@ -2333,7 +2328,7 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        ev = _capture(event)
+                        ev = _capture(event, marks_output=True)
                         if ev is not None:
                             yield ev
                 continue
@@ -2499,7 +2494,7 @@ async def _stream_anthropic_messages(
                         block_index,
                     )
                     for event in events:
-                        ev = _capture(event)
+                        ev = _capture(event, marks_output=True)
                         if ev is not None:
                             yield ev
                 continue
@@ -2521,7 +2516,7 @@ async def _stream_anthropic_messages(
                     block_index,
                 )
                 for event in events:
-                    ev = _capture(event)
+                    ev = _capture(event, marks_output=True)
                     if ev is not None:
                         yield ev
 
@@ -2541,7 +2536,7 @@ async def _stream_anthropic_messages(
             block_index,
         )
         for event in events:
-            ev = _capture(event)
+            ev = _capture(event, marks_output=True)
             if ev is not None:
                 yield ev
 
@@ -2554,7 +2549,7 @@ async def _stream_anthropic_messages(
                 block_index,
             )
             for event in events:
-                ev = _capture(event)
+                ev = _capture(event, marks_output=True)
                 if ev is not None:
                     yield ev
 
@@ -2634,7 +2629,7 @@ async def _stream_anthropic_messages(
                         [("text", filtered)], current_block_type, block_index
                     )
                     for event in events:
-                        ev = _capture(event)
+                        ev = _capture(event, marks_output=True)
                         if ev is not None:
                             yield ev
         # Close any block we opened above before falling through to the
@@ -2816,7 +2811,7 @@ async def _stream_anthropic_messages(
                     f"event: content_block_stop\ndata: "
                     f"{json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n",
                 ):
-                    ev = _capture(raw_event)
+                    ev = _capture(raw_event, marks_output=True)
                     if ev is not None:
                         yield ev
                 # Re-tracking: this is a manually-yielded
@@ -2944,7 +2939,9 @@ async def _stream_anthropic_messages(
     if _buffer_for_pinned_tool and not (
         tool_choice_error or tool_validation_error or synthesized_pinned_call
     ):
-        for buffered_event in pre_filter_buffer:
+        for buffered_event, marks_output in pre_filter_buffer:
+            if marks_output:
+                _latch_first_visible_output()
             yield buffered_event
         pre_filter_buffer.clear()
 
@@ -3030,6 +3027,7 @@ async def _stream_anthropic_messages(
                     "input": {},
                 },
             }
+            _latch_first_visible_output()
             yield f"event: content_block_start\ndata: {json.dumps(tool_block_start)}\n\n"
             # R-07 tracking: tool_use blocks count as content_blocks
             # for the malformed-message guard below.

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -813,6 +813,11 @@ async def create_anthropic_message(
                     prepared_messages=messages,
                     prepared_images=images,
                     prepared_videos=videos,
+                    caller_agent=(
+                        request.headers.get("user-agent")
+                        if request is not None
+                        else None
+                    ),
                 ),
                 request,
                 engine=engine,
@@ -1158,6 +1163,32 @@ async def create_anthropic_message(
             # haven't been rebuilt against the new ``GenerationOutput``
             # field (None → legacy ``stop`` → ``end_turn`` mapping).
             matched_stop=getattr(output, "matched_stop", None),
+        )
+
+        # Opt-in telemetry (caller attribution, task C): record a bucketed
+        # ``request`` event for this completed non-streaming /v1/messages
+        # completion. ``caller_agent`` comes from the inbound User-Agent
+        # (bucketed to an allowlist in ``redact`` — never stored raw); every
+        # perf number is bucketed. ``emit.request`` is sampled +
+        # ``is_enabled()``-gated + ``@_safe``, so this is a cheap no-op when
+        # telemetry is off / not sampled and can never affect the response.
+        # TTFT == total latency here (a non-streaming response is delivered
+        # in one shot); the streaming path reports true TTFT.
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.request(
+            endpoint="/v1/messages",
+            model_alias=anthropic_request.model,
+            stream=False,
+            tool_call_used=bool(tool_calls),
+            prompt_tokens=output.prompt_tokens,
+            completion_tokens=output.completion_tokens,
+            ttft_ms=elapsed * 1000.0,
+            tps=tokens_per_sec,
+            status=200,
+            caller_agent=(
+                request.headers.get("user-agent") if request is not None else None
+            ),
         )
         return Response(
             content=anthropic_response.model_dump_json(exclude_none=True),
@@ -1548,6 +1579,7 @@ async def _stream_anthropic_messages(
     prepared_messages: list | None = None,
     prepared_images: list | None = None,
     prepared_videos: list | None = None,
+    caller_agent: str | None = None,
 ) -> AsyncIterator[str]:
     """Stream Anthropic Messages API SSE events.
 
@@ -1584,9 +1616,16 @@ async def _stream_anthropic_messages(
             Pre-r5 the streaming helper discarded these to ``[]``
             when ``prepared_messages`` was supplied, silently
             dropping every multimodal stream's media inputs.
+        caller_agent: inbound HTTP ``User-Agent`` from the route request,
+            passed straight to ``emit.request`` (bucketed to an allowlist
+            in ``redact`` — never stored raw). Task C caller attribution.
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
+    # First non-empty text-token timestamp so the task-C streaming emit can
+    # report true TTFT (mirrors the chat/completions lanes). None until the
+    # first content delta is seen.
+    _first_token_ts: float | None = None
 
     if prepared_messages is not None:
         # Caller (the route entry-point) already extracted +
@@ -2133,6 +2172,9 @@ async def _stream_anthropic_messages(
 
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         delta_text = output.new_text
+
+        if _first_token_ts is None and (delta_text or ""):
+            _first_token_ts = time.perf_counter()
 
         if hasattr(output, "prompt_tokens") and output.prompt_tokens:
             prompt_tokens = output.prompt_tokens
@@ -3105,6 +3147,30 @@ async def _stream_anthropic_messages(
     tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
     logger.info(
         f"Anthropic messages (stream): prompt={prompt_tokens} + completion={completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+    )
+
+    # Opt-in telemetry (caller attribution, task C): record a bucketed
+    # ``request`` event for this completed /v1/messages stream. Fired only
+    # after the generator drains normally (all tokens flushed). ``caller_agent``
+    # is the inbound User-Agent bucketed to an allowlist in ``redact`` (never
+    # stored raw); ``ttft_ms`` is true first-token latency. ``emit.request``
+    # is sampled + ``is_enabled()``-gated + ``@_safe``, so this is a cheap
+    # no-op when telemetry is off / not sampled.
+    from vllm_mlx.telemetry import emit as _telemetry_emit
+
+    _telemetry_emit.request(
+        endpoint="/v1/messages",
+        model_alias=anthropic_request.model,
+        stream=True,
+        tool_call_used=bool(tool_calls),
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        ttft_ms=0.0
+        if _first_token_ts is None
+        else (_first_token_ts - start_time) * 1000.0,
+        tps=tokens_per_sec,
+        status=200,
+        caller_agent=caller_agent,
     )
 
     yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -972,12 +972,14 @@ async def stream_completion(
     _elapsed_stream = time.perf_counter() - _stream_start
     _done = getattr(_final_usage, "completion_tokens", None) or 0
     _ptok = getattr(_final_usage, "prompt_tokens", None) or 0
-    _tok_s = _done / _elapsed_stream if _elapsed_stream > 0 else 0
-    _ttft_ms = (
-        (_first_token_ts - _stream_start) * 1000.0
+    _total_tps = _done / _elapsed_stream if _elapsed_stream > 0 else 0
+    _ttft_seconds = (
+        max(0.0, _first_token_ts - _stream_start)
         if _first_token_ts is not None
-        else _elapsed_stream * 1000.0
+        else _elapsed_stream
     )
+    _decode_seconds = _elapsed_stream - _ttft_seconds
+    _decode_tps = _done / _decode_seconds if _decode_seconds > 0 else _total_tps
     from vllm_mlx.telemetry import emit as _telemetry_emit
 
     _telemetry_emit.request(
@@ -987,8 +989,8 @@ async def stream_completion(
         tool_call_used=False,
         prompt_tokens=_ptok,
         completion_tokens=_done,
-        ttft_ms=_ttft_ms,
-        tps=_tok_s,
+        ttft_ms=_ttft_seconds * 1000.0,
+        tps=_decode_tps,
         status=200,
         caller_agent=caller_agent,
     )

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -881,7 +881,15 @@ async def stream_completion(
         if output.finished:
             _final_usage = get_usage(output)
         # Task C: latch the timestamp of the first non-empty content chunk
-        # for a true TTFT on the streaming emit below.
+        # for a true TTFT on the streaming emit below. This fires only in the
+        # non-JSON, non-echo path (the loop ``continue``s above for
+        # ``_json_mode``, where no client-visible content leaves per-chunk).
+        # Doc'd deferral from codex r3-B#1: in JSON mode the client genuinely
+        # sees NO content until the buffered consolidated emit at stream end,
+        # so the emit's ``_elapsed_stream`` total-latency fallback IS the
+        # correct "client-visible TTFT" (there is no earlier content to
+        # measure) — not an underreport. Echo re-emits the prompt as visible
+        # prefix content, which likewise first leaves at this yield.
         if _first_token_ts is None and (output.new_text or ""):
             _first_token_ts = time.perf_counter()
         yield f"data: {json.dumps(data)}\n\n"

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -934,11 +934,20 @@ async def stream_completion(
         }
         yield f"data: {json.dumps(usage_data)}\n\n"
 
+    yield "data: [DONE]\n\n"
+
     # Opt-in telemetry (task C): record a bucketed ``request`` event for
-    # this streaming completion, after the generator drains normally. TTFT
-    # is true first-token latency (``_first_token_ts``); tokens come from the
-    # engine's final usage (``_final_usage`` is set on the finish chunk). Same
-    # sampled + consent-gated + ``@_safe`` no-op semantics as the chat lane.
+    # this streaming completion, fired only AFTER the terminal ``[DONE]``
+    # marker is yielded + the generator resumes cleanly — matching the chat
+    # lane's documented emit-after-terminal-marker placement. A stream the
+    # client cancels or that raises while delivering ``[DONE]`` raises out
+    # before this line and is deliberately NOT counted (under-counting is
+    # conservative; emitting before ``[DONE]`` would record a false
+    # status-200 success on a disconnected final write). TTFT is true
+    # first-token latency (``_first_token_ts``); tokens come from the
+    # engine's final usage (``_final_usage`` is set on the finish chunk).
+    # Same sampled + consent-gated + ``@_safe`` no-op semantics as the chat
+    # lane.
     _elapsed_stream = time.perf_counter() - _stream_start
     _done = getattr(_final_usage, "completion_tokens", None) or 0
     _ptok = getattr(_final_usage, "prompt_tokens", None) or 0
@@ -962,5 +971,3 @@ async def stream_completion(
         status=200,
         caller_agent=caller_agent,
     )
-
-    yield "data: [DONE]\n\n"

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -647,6 +647,14 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         # ``@_safe``, so this is a cheap no-op when telemetry is off / not
         # sampled and can never affect the response. TTFT == total latency
         # here (a non-streaming response is delivered in one shot).
+        #
+        # Ordering: the ``request`` event fires before ``CompletionResponse``
+        # is serialized (doc'd deferral, codex r4-B#1). This exactly matches
+        # the chat lane's order — chat.py also emits its *request* event
+        # before response serialization, and protects only the billing-
+        # critical *activation* funnel by emitting it after the body is
+        # built. The conservative variant of task C wires NO activation
+        # funnel, so there is no post-serialization funnel to guard here.
         from vllm_mlx.telemetry import emit as _telemetry_emit
 
         _telemetry_emit.request(
@@ -739,6 +747,11 @@ async def stream_completion(
     _stream_start = time.perf_counter()
     _first_token_ts: float | None = None
     if request.echo:
+        # Task C: in echo mode the echoed prompt is the FIRST client-visible
+        # content, so TTFT must be latched at this yield — not at the first
+        # generated token later in the loop (codex r4-B#2). Matches chat-lane
+        # semantics ("first real output token the client sees").
+        _first_token_ts = time.perf_counter()
         echo_data = {
             "id": completion_id,
             "object": "text_completion",

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -387,6 +387,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         prompts[0],
                         request,
                         request_id_holder=_completion_rid_holder,
+                        caller_agent=raw_request.headers.get("user-agent")
+                        if raw_request is not None
+                        else None,
                     ),
                     raw_request,
                     engine=engine,
@@ -636,6 +639,31 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             f"Completion: {total_prompt_tokens} prompt + {total_completion_tokens} completion tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
+        # Opt-in telemetry (caller attribution, task C): record a bucketed
+        # ``request`` event for this completed non-streaming completion.
+        # ``caller_agent`` comes from the inbound User-Agent (bucketed to an
+        # allowlist in ``redact`` — never stored raw); every perf number is
+        # bucketed. ``emit.request`` is sampled + ``is_enabled()``-gated +
+        # ``@_safe``, so this is a cheap no-op when telemetry is off / not
+        # sampled and can never affect the response. TTFT == total latency
+        # here (a non-streaming response is delivered in one shot).
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.request(
+            endpoint="/v1/completions",
+            model_alias=request.model,
+            stream=False,
+            tool_call_used=False,
+            prompt_tokens=total_prompt_tokens,
+            completion_tokens=total_completion_tokens,
+            ttft_ms=elapsed * 1000.0,
+            tps=tokens_per_sec,
+            status=200,
+            caller_agent=raw_request.headers.get("user-agent")
+            if raw_request is not None
+            else None,
+        )
+
         comp_response = CompletionResponse(
             model=_resolve_model_name(request.model),
             choices=choices,
@@ -666,6 +694,7 @@ async def stream_completion(
     request: CompletionRequest,
     *,
     request_id_holder: list | None = None,
+    caller_agent: str | None = None,
 ) -> AsyncIterator[str]:
     """Stream completion response.
 
@@ -676,6 +705,9 @@ async def stream_completion(
             ``holder[0]``. The route's ``_disconnect_guard`` reads the
             same holder to force-call ``scheduler.abort_request`` on
             client disconnect. ``None`` (default) is a no-op.
+        caller_agent: inbound HTTP User-Agent (task C). Passed straight to
+            ``emit.request`` -> bucketed to an allowlist in ``redact``, never
+            stored raw. Sampled + consent-gated, so a no-op when off.
     """
     extended_kwargs = build_extended_sampling_kwargs(request)
     # C-01: pass the holder through so the engine can publish the
@@ -700,6 +732,12 @@ async def stream_completion(
     # captured once so all chunks report the same start timestamp.
     completion_id = f"cmpl-{uuid.uuid4().hex[:8]}"
     created_ts = int(time.time())
+    # Task C timing for the streaming ``request`` emit: ``start_time`` anchors
+    # total latency (TTFT delta + decode window); ``_first_token_ts`` records
+    # when the first content chunk is produced so TTFT is true first-token
+    # latency, matching the chat-lane streaming emit.
+    _stream_start = time.perf_counter()
+    _first_token_ts: float | None = None
     if request.echo:
         echo_data = {
             "id": completion_id,
@@ -842,6 +880,10 @@ async def stream_completion(
         # aggregating clients (LangChain / AI-SDK / vercel-ai-stream).
         if output.finished:
             _final_usage = get_usage(output)
+        # Task C: latch the timestamp of the first non-empty content chunk
+        # for a true TTFT on the streaming emit below.
+        if _first_token_ts is None and (output.new_text or ""):
+            _first_token_ts = time.perf_counter()
         yield f"data: {json.dumps(data)}\n\n"
 
     # R10-H4: json-mode buffered emit. Run ``extract_json_from_response``
@@ -891,5 +933,34 @@ async def stream_completion(
             "usage": _final_usage.model_dump(exclude_none=True),
         }
         yield f"data: {json.dumps(usage_data)}\n\n"
+
+    # Opt-in telemetry (task C): record a bucketed ``request`` event for
+    # this streaming completion, after the generator drains normally. TTFT
+    # is true first-token latency (``_first_token_ts``); tokens come from the
+    # engine's final usage (``_final_usage`` is set on the finish chunk). Same
+    # sampled + consent-gated + ``@_safe`` no-op semantics as the chat lane.
+    _elapsed_stream = time.perf_counter() - _stream_start
+    _done = getattr(_final_usage, "completion_tokens", None) or 0
+    _ptok = getattr(_final_usage, "prompt_tokens", None) or 0
+    _tok_s = _done / _elapsed_stream if _elapsed_stream > 0 else 0
+    _ttft_ms = (
+        (_first_token_ts - _stream_start) * 1000.0
+        if _first_token_ts is not None
+        else _elapsed_stream * 1000.0
+    )
+    from vllm_mlx.telemetry import emit as _telemetry_emit
+
+    _telemetry_emit.request(
+        endpoint="/v1/completions",
+        model_alias=request.model,
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=_ptok,
+        completion_tokens=_done,
+        ttft_ms=_ttft_ms,
+        tps=_tok_s,
+        status=200,
+        caller_agent=caller_agent,
+    )
 
     yield "data: [DONE]\n\n"

--- a/vllm_mlx/telemetry/redact.py
+++ b/vllm_mlx/telemetry/redact.py
@@ -143,6 +143,20 @@ def normalize_model_path(path: str) -> str:
 # Order matters: more specific agent markers are checked before the generic
 # HTTP-client fallbacks so e.g. an agent that rides ``python-httpx`` still
 # resolves to the agent, not ``python-httpx``.
+#
+# Task C (instrumentation-release) audit: candidate product UAs (kimi, codex,
+# opencode, gemini-cli, zed) were evaluated and intentionally NOT added — none
+# is provable, i.e. none sets a recognizable ``User-Agent`` substring; codex /
+# opencode (verified against the installed binaries) carry no product UA and
+# ride the underlying SDK (openai-rust, undici, ...) which the allowlist below
+# already buckets. Adding a marker here without a verified substring would be
+# body-based guessing, which the ``no caller free-text`` red-line forbids.
+# Documented limitation: an agent that passes openai-python (or another SDK)
+# UA through verbatim is indistinguishable at the UA layer and correctly stays
+# bucketed to that SDK — we never fabricate product attribution from the body.
+# The attribution fix for those agents is the /v1/messages (anthropic.py) +
+# /v1/completions wiring (task C), which surfaces the ALREADY-listed markers
+# (claude-code, anthropic-sdk, openai-python, ...) instead of ``other``.
 _CALLER_AGENT_MARKERS: tuple[tuple[str, str], ...] = (
     ("claude-code", "claude-code"),
     ("claudecode", "claude-code"),


### PR DESCRIPTION
## Why

Requests sent through `/v1/messages` and `/v1/completions` were not reaching the existing request-telemetry emitter. Their callers were therefore grouped as `other`, which made aggregate route attribution inaccurate even though the equivalent chat route already reported the same low-cardinality signal.

## What

- Emit one request event for successful streaming and non-streaming calls on both routes.
- Preserve the established success boundary: streaming attribution is recorded only after the terminal event is delivered.
- Measure time to first client-visible generated, echoed, or tool output, with a total-latency fallback for empty streams.
- Measure streaming throughput over the post-first-output decode window, excluding prefill.
- Bucket the request user agent through the existing allowlist before emission; raw user-agent text never enters a telemetry payload.
- Run the MLX-dependent route-attribution tests in the Apple coverage roster so changed-line coverage reflects the code that actually executes those routes.

## Scope / Non-goals

Scope is the two route integrations, existing telemetry redaction, focused regression tests, and enrollment of the route-attribution test file in the Apple coverage roster.

Non-goals: no activation-spec change, no new caller buckets, no request-body guessing, no telemetry schema expansion, no engine scheduler change, and no general CI roster policy change. The general Apple-roster policy remains tracked separately in #2519.

This PR originated as the contracted telemetry-attribution task C and has no standalone issue to auto-close.

## Design precedent

The implementation follows the repository's established chat-route emission boundary and reuses the existing emitter and redaction allowlist. Private reference research confirmed the same mature serving pattern: emit only after a successful terminal response, keep dimensions low-cardinality, and discard raw client-identifying strings before aggregation.

A new middleware layer, route-specific attribution registry, and body-based client detection were rejected because they would duplicate existing ownership, expand the public behavior surface, or create unstable/high-cardinality data.

## Verification

- User walk: exercised streaming and non-streaming requests on both endpoints with recognizable and unknown user agents; emitted payloads contain the expected bucket and never the raw header.
- Route attribution: 8 passed, including parser-suppressed reasoning, named-tool buffer replay/tool-only output, and empty-stream fallback.
- Five local gates: `GATES OK bf1f7feb84d4a3fcbfa9be34dcf231a82aab3397 95d0d14236f7c121ad2d1595b795658ac8886fcb`.
- Apple lane: 1193 passed, 3 skipped, 18 deselected.
- Changed production lines: 34/34 covered (100%) across the Linux/Apple union.
- mypy error budget: no growth; Ruff check/format and `git diff --check`: clean.
- Codex R2 and R3 findings are dispositioned on the PR thread; R3 is the final review round.
- Final exact-head `pr_validate` and required hosted checks: pending; merge requires authoritative green and 0-behind main.
