### PR TITLE
ci(l1-smoke): relocate qwen3.5-9b-4bit off hosted L1 to the Studio tier-1 gate (#2419)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             full_gate="$FULL_CI"
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
             if [ "$full_gate" = true ]; then
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             else
               echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             fi
@@ -66,7 +66,7 @@ jobs:
               echo 'desktop=true'
               echo 'docs_only=false'
               echo 'full_gate=true'
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}'
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}'
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -570,13 +570,17 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # Two GOLDEN models run coherence + the engine contract. The remaining 4B
+    # GOLDEN models run coherence + the engine contract. The Qwen3.5-9B is the
+    # largest lane (#2419: top-telemetry cover) at ~6GB 4-bit — at the ~7GB edge,
+    # so it is coherence + engine-contract and watched for OOM flakes. The
+    # remaining 4B
     # aliases run contract-only: forcing a zero-argument call factors model
     # competence out while still covering multi-turn replay, streaming channel
     # routing, and native-marker leaks (#1677).
-    # Each model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB
-    # model comfortably. A 3-4B model is fine for a coherence/parser gate — it
-    # is not a chat-quality eval, which stays on the 35B L2 tier.
+    # Each model runs on its own runner (parallel) so lanes do not share RAM.
+    # The 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
+    # Bonsai-27B) are 15-38GB and exceed this free runner's ~7GB budget — they stay
+    # on the self-hosted 35B Studio (L2) tier, not on L1.
     #
     # Gemma3 is multimodal but this contract is text/tool-only, so the smoke
     # script forces ``--no-mllm`` and exercises its LM backbone without pulling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             full_gate="$FULL_CI"
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
             if [ "$full_gate" = true ]; then
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
             else
               echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             fi
@@ -66,7 +66,7 @@ jobs:
               echo 'desktop=true'
               echo 'docs_only=false'
               echo 'full_gate=true'
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}'
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}'
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -570,17 +570,18 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # GOLDEN models run coherence + the engine contract. The Qwen3.5-9B is the
-    # largest lane (#2419: top-telemetry cover) at ~6GB 4-bit — at the ~7GB edge,
-    # so it is coherence + engine-contract and watched for OOM flakes. The
-    # remaining 4B
+    # GOLDEN models run coherence + the engine contract. The 4B
     # aliases run contract-only: forcing a zero-argument call factors model
     # competence out while still covering multi-turn replay, streaming channel
     # routing, and native-marker leaks (#1677).
     # Each model runs on its own runner (parallel) so lanes do not share RAM.
-    # The 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
-    # Bonsai-27B) are 15-38GB and exceed this free runner's ~7GB budget — they stay
-    # on the self-hosted 35B Studio (L2) tier, not on L1.
+    # The Qwen3.5-9B (#2419 top-telemetry cover) was tried here and relocated off
+    # L1: its runtime footprint is ~8.7 GB (vllm_mlx/model_recommendations.json,
+    # SSOT — bucketed at the 18 GB floor) vs this runner's ~7 GB, and the
+    # coherence serve OOMs (server unreachable, 503) under the gate. It, like the
+    # 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
+    # Bonsai-27B, 15-38GB), exceeds this free runner's ~7GB budget — they stay on
+    # the self-hosted 35B Studio tier-1 gate (L2), not on L1.
     #
     # Gemma3 is multimodal but this contract is text/tool-only, so the smoke
     # script forces ``--no-mllm`` and exercises its LM backbone without pulling


### PR DESCRIPTION
Closes #2419

## Why
#2419 wants the telemetry **top-10** usage lanes represented in the L1
smoke roster. `qwen3.5-9b-4bit` (telemetry #2, 83 uses) was added to the
hosted `l1-smoke` matrix — but it **does not fit the FREE macos-14 runner
(~7 GB RAM)**. The coherence+engine-contract serve OOMs under the gate:
the server is killed mid-generate, so the check sees "server unreachable"
(503), not a clean OOM log. This PR relocates that lane to the
self-hosted **Studio tier-1 gate (L2)** rather than leaving a permanently
red hosted lane.

## What
- Remove `qwen3.5-9b-4bit` from both hosted `l1_matrix` definitions (the
  full-ci promoted matrix and the merge/push matrix). The hosted L1 keeps
  the 4B lanes that fit.
- Update the `l1-smoke` comment to document the relocation and the SSOT
  footprint evidence, folding the 9B into the existing "15-38 GB lanes
  stay on the self-hosted 35B Studio (L2) tier" boundary.

## Design precedent
The mechanism for "a top-telemetry lane that cannot fit the free hosted
runner" already exists in this file: the 26-35B lanes (Qwen3.6-35B-A3B,
Qwen3.8/3.6-27B, Gemma-4-26B, Bonsai-27B) are documented as living on the
self-hosted 35B Studio tier-1 gate (L2), not enumerated on L1. The 9B now
joins that documented set. No new abstraction: the Studio tier-1 gate is
the existing `agent-gate.yml` `tier1-smoke` job on
`[self-hosted, macOS, rapidmlx-studio]`, which already accepts any model
alias via its `workflow_dispatch` input — so the 9B is reachable there the
same way the other L2 lanes are, without a per-PR self-hosted trigger
(which must never run fork code on self-hosted hardware).

## Verification
- Footprint source: `vllm_mlx/model_recommendations.json` (SSOT) lists
  `qwen3.5-9b-4bit` at `footprint_gb: 8.7`, bucketed at the **18 GB floor`
  — vs the macos-14 runner's ~7 GB. Weights alone are ~6.0 GB (HF
  `mlx-community/Qwen3.5-9B-4bit`); runtime footprint is 8.7 GB, which
  exceeds 7 GB.
- Prior head `c4587bb8` (9B in the matrix, full-ci) failed the coherence
  lane job 98581599323 (503 / server unreachable mid-gate). Removing the
  9B makes the hosted L1 lanes all fit within budget.
- `check_workflow_expressions.py` and `l1_matrix` JSON validation: see
  "Checks run locally".

## Scope / Non-goals
- No change to any other hosted or Studio lane.
- No `agent-gate.yml` change (its `workflow_dispatch` input already covers
  any alias on the Studio gate; adding a 4-bit removal from the hosted L1
  is the bounded relocation). A per-PR Studio job is a deliberate
  non-goal (self-hosted security boundary).
- No timeout edits, no tests changed.

## Checks run locally
- `l1_matrix` JSON literals both parse (5-lane full / 1-lane reduced; 9B absent).
- `check_workflow_expressions.py` / `check_gha_pinning.py` pass on the new head.