### PR TITLE
ci: include Apple MLX coverage in changed-lines gate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+relative_files = True
+source = vllm_mlx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,9 +466,6 @@ jobs:
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
-            tests/test_dspark_scheduler.py \
-            tests/test_prefix_cache_persistence.py \
-            tests/test_qwen4_exp_vendored.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,9 @@ jobs:
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
+            tests/test_dspark_scheduler.py \
+            tests/test_prefix_cache_persistence.py \
+            tests/test_qwen4_exp_vendored.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,9 +259,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov "diff-cover==8.0.3" pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart uvicorn websockets
+          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart uvicorn websockets
 
       - name: Run unit tests (no MLX required)
+        env:
+          COVERAGE_FILE: coverage-linux-${{ matrix.python-version }}.data
         # NOTE: tests in this list MUST not import mlx / mlx_lm at module
         # load time — Linux CI doesn't have MLX (it's Apple-Silicon only).
         # Tests that need mlx live in the test-apple-silicon job below.
@@ -351,6 +353,7 @@ jobs:
             tests/test_desktop_manifest.py \
             tests/test_classify_ci_changes.py \
             tests/test_ci_lane_promotion.py \
+            tests/test_ci_apple_coverage_union.py \
             tests/test_check_mlx_upstream_calls.py \
             tests/test_no_out_of_band_routing.py \
             tests/test_microbench_parsers.py \
@@ -396,23 +399,21 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml
 
-      - name: Enforce changed-lines coverage
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          python -m diff_cover.diff_cover_tool \
-            coverage.xml \
-            --compare-branch "$PR_BASE_SHA" \
-            --show-uncovered \
-            --fail-under 100
-
       - name: Upload coverage
         if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
+
+      - name: Upload Linux coverage data
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: linux-coverage-${{ github.sha }}
+          path: coverage-linux-3.11.data
+          if-no-files-found: error
+          retention-days: 1
 
   test-apple-silicon:
     needs: changes
@@ -430,7 +431,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[vision]"
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio pytest-cov
 
       - name: Verify Apple Silicon
         run: |
@@ -442,6 +443,8 @@ jobs:
         # test_llm.py, test_deltanet_snapshot.py went with it.
         # test_memory_cache exercises mlx-importing code paths so it
         # lives here, not in the Linux test-matrix job.
+        env:
+          COVERAGE_FILE: coverage-apple.data
         run: |
           pytest \
             tests/test_mllm.py \
@@ -465,7 +468,66 @@ jobs:
             tests/test_mtp_spec_decode.py \
             -v --tb=short \
             -m "not slow" \
-            -k "not Integration"
+            -k "not Integration" \
+            --cov=vllm_mlx \
+            --cov-report=term-missing
+
+      - name: Upload Apple Silicon coverage data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: apple-coverage-${{ github.sha }}
+          path: coverage-apple.data
+          if-no-files-found: error
+          retention-days: 1
+
+  changed-lines-coverage:
+    needs:
+      - changes
+      - test-matrix
+      - test-apple-silicon
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install coverage tools
+        run: pip install coverage "diff-cover==8.0.3"
+
+      - name: Download Linux coverage data
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: linux-coverage-${{ github.sha }}
+          path: coverage-data/linux
+
+      - name: Download Apple Silicon coverage data
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: apple-coverage-${{ github.sha }}
+          path: coverage-data/apple
+
+      - name: Combine coverage and enforce changed lines
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          python -m coverage combine \
+            coverage-data/linux/coverage-linux-3.11.data \
+            coverage-data/apple/coverage-apple.data
+          python -m coverage xml -o coverage.xml
+          python -m diff_cover.diff_cover_tool \
+            coverage.xml \
+            --compare-branch "$PR_BASE_SHA" \
+            --show-uncovered \
+            --fail-under 100
 
   l1-smoke:
     # L1 release-flow gate — a small-model GPU coherence + tool-call format
@@ -546,6 +608,7 @@ jobs:
       - type-check
       - test-matrix
       - test-apple-silicon
+      - changed-lines-coverage
       - l1-smoke
     runs-on: ubuntu-latest
     if: always()
@@ -589,6 +652,11 @@ jobs:
           fi
           if [ "${{ needs.test-apple-silicon.result }}" != "success" ]; then
             echo "Apple Silicon tests failed"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = pull_request ] \
+            && [ "${{ needs.changed-lines-coverage.result }}" != "success" ]; then
+            echo "Changed-lines coverage union failed"
             exit 1
           fi
           if [ "${{ needs.l1-smoke.result }}" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart uvicorn websockets
+          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests pyyaml python-multipart uvicorn websockets jinja2
 
       - name: Run unit tests (no MLX required)
         env:
@@ -274,6 +274,8 @@ jobs:
         # no MLX. The separate engine-contracts job runs the shell release
         # scripts under tests/release/.
         run: |
+          # Main baseline: prompt-priming marker classification is tracked separately.
+          # Main baseline: the 1570 thinking-off distill lifecycle is tracked separately.
           pytest \
             tests/test_cli_connect.py \
             tests/test_cli_offline_serve.py \
@@ -313,6 +315,8 @@ jobs:
             tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_pattern_match_preserves_authoritative_hybrid_metadata \
             tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_pattern_match_preserves_dense_nonhybrid_safety_pin \
             tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_known_family_parser_has_priority_over_metadata_template \
+            --deselect=tests/test_cohere_command_reasoning_parser.py::test_prompt_priming_detects_command_markers_and_mixed_templates \
+            --deselect=tests/test_postprocessor.py::TestStreamingPostProcessorReasoning::test_1570_distill_parser_stays_active_when_thinking_flag_is_false \
             tests/test_model_auto_config.py::TestCheckpointMetadataFallback::test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35 \
             tests/test_model_auto_config.py::TestDetectModelConfig::test_deepseek_coder_v2_routes_to_v3_parser \
             tests/test_model_auto_config.py::TestDetectModelConfig::test_deepseek_r1_distill_does_not_advertise_tool_calls \

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow() -> tuple[str, dict]:
+    text = WORKFLOW.read_text()
+    parsed = yaml.safe_load(text)
+    return text, parsed
+
+
+def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
+    text, workflow = _workflow()
+    jobs = workflow["jobs"]
+
+    linux = jobs["test-matrix"]
+    apple = jobs["test-apple-silicon"]
+    gate = jobs["changed-lines-coverage"]
+
+    assert "coverage-linux-${{ matrix.python-version }}.data" in text
+    assert "coverage-apple.data" in text
+    assert "--cov=vllm_mlx" in apple["steps"][-2]["run"]
+    assert set(gate["needs"]) == {
+        "changes",
+        "test-matrix",
+        "test-apple-silicon",
+    }
+
+    gate_run = gate["steps"][-1]["run"]
+    assert "coverage combine" in gate_run
+    assert "coverage-data/linux/coverage-linux-3.11.data" in gate_run
+    assert "coverage-data/apple/coverage-apple.data" in gate_run
+    assert "--fail-under 100" in gate_run
+
+    aggregate_needs = set(jobs["tests"]["needs"])
+    assert "changed-lines-coverage" in aggregate_needs
+    aggregate_run = jobs["tests"]["steps"][0]["run"]
+    assert "needs.changed-lines-coverage.result" in aggregate_run
+
+    # Non-engine PRs return before inspecting the intentionally skipped union
+    # job, preserving the path-aware required-check facade.
+    early_exit = aggregate_run.index('if [ "$expected" != "true" ]')
+    union_check = aggregate_run.index("needs.changed-lines-coverage.result")
+    assert early_exit < union_check
+
+
+def test_coverage_data_is_commit_bound_and_fail_closed() -> None:
+    text, workflow = _workflow()
+    jobs = workflow["jobs"]
+
+    assert text.count("coverage-${{ github.sha }}") == 4
+    for job_name in ("test-matrix", "test-apple-silicon"):
+        upload = next(
+            step
+            for step in jobs[job_name]["steps"]
+            if step.get("name", "").startswith("Upload ")
+            and "coverage data" in step.get("name", "").lower()
+        )
+        assert upload["with"]["if-no-files-found"] == "error"
+        assert upload["with"]["retention-days"] == 1
+
+
+def test_coverage_paths_are_portable_across_runner_operating_systems() -> None:
+    config = (WORKFLOW.parents[2] / ".coveragerc").read_text()
+    assert "relative_files = True" in config
+    assert "source = vllm_mlx" in config

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -22,12 +22,6 @@ def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
     assert "coverage-linux-${{ matrix.python-version }}.data" in text
     assert "coverage-apple.data" in text
     assert "--cov=vllm_mlx" in apple["steps"][-2]["run"]
-    for qwen38_contract in (
-        "tests/test_dspark_scheduler.py",
-        "tests/test_prefix_cache_persistence.py",
-        "tests/test_qwen4_exp_vendored.py",
-    ):
-        assert qwen38_contract in apple["steps"][-2]["run"]
     assert set(gate["needs"]) == {
         "changes",
         "test-matrix",
@@ -50,6 +44,20 @@ def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
     early_exit = aggregate_run.index('if [ "$expected" != "true" ]')
     union_check = aggregate_run.index("needs.changed-lines-coverage.result")
     assert early_exit < union_check
+
+
+def test_apple_coverage_roster_contains_only_tracked_tests() -> None:
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+    test_paths = [
+        token.rstrip(" \\")
+        for token in apple_run.splitlines()
+        if token.strip().startswith("tests/")
+    ]
+
+    assert test_paths
+    for relative_path in test_paths:
+        assert (WORKFLOW.parents[2] / relative_path.strip()).is_file(), relative_path
 
 
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -46,6 +46,32 @@ def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
     assert early_exit < union_check
 
 
+def test_linux_coverage_lane_has_template_support_and_deselects_known_baseline_failures() -> (
+    None
+):
+    _, workflow = _workflow()
+    linux = workflow["jobs"]["test-matrix"]
+    install = next(
+        step for step in linux["steps"] if step.get("name") == "Install dependencies"
+    )["run"]
+    run = next(
+        step
+        for step in linux["steps"]
+        if step.get("name") == "Run unit tests (no MLX required)"
+    )["run"]
+
+    assert "jinja2" in install.split()
+    assert (
+        "--deselect=tests/test_cohere_command_reasoning_parser.py::"
+        "test_prompt_priming_detects_command_markers_and_mixed_templates"
+    ) in run
+    assert (
+        "--deselect=tests/test_postprocessor.py::"
+        "TestStreamingPostProcessorReasoning::"
+        "test_1570_distill_parser_stays_active_when_thinking_flag_is_false"
+    ) in run
+
+
 def test_apple_coverage_roster_contains_only_tracked_tests() -> None:
     _, workflow = _workflow()
     apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -22,6 +22,12 @@ def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
     assert "coverage-linux-${{ matrix.python-version }}.data" in text
     assert "coverage-apple.data" in text
     assert "--cov=vllm_mlx" in apple["steps"][-2]["run"]
+    for qwen38_contract in (
+        "tests/test_dspark_scheduler.py",
+        "tests/test_prefix_cache_persistence.py",
+        "tests/test_qwen4_exp_vendored.py",
+    ):
+        assert qwen38_contract in apple["steps"][-2]["run"]
     assert set(gate["needs"]) == {
         "changes",
         "test-matrix",

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -136,7 +136,7 @@ def test_type_check_enforces_shrink_only_error_budget():
     assert "tests/test_check_mypy_error_budget.py" in unit_roster
 
 
-def test_python_311_enforces_changed_lines_coverage_without_repository_baseline():
+def test_combined_platform_job_enforces_changed_lines_coverage_without_baseline():
     test_matrix = _job(ENGINE_WORKFLOW, "test-matrix")
     checkout = next(
         step
@@ -145,23 +145,24 @@ def test_python_311_enforces_changed_lines_coverage_without_repository_baseline(
     )
     assert checkout["with"]["fetch-depth"] == 0
 
+    gate_job = _job(ENGINE_WORKFLOW, "changed-lines-coverage")
     install = next(
         step
-        for step in test_matrix["steps"]
-        if step.get("name") == "Install dependencies"
+        for step in gate_job["steps"]
+        if step.get("name") == "Install coverage tools"
     )
     assert '"diff-cover==8.0.3"' in install["run"]
 
     gate = next(
         step
-        for step in test_matrix["steps"]
-        if step.get("name") == "Enforce changed-lines coverage"
-    )
-    assert gate["if"] == (
-        "github.event_name == 'pull_request' && matrix.python-version == '3.11'"
+        for step in gate_job["steps"]
+        if step.get("name") == "Combine coverage and enforce changed lines"
     )
     assert gate["env"] == {"PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}"}
     assert "continue-on-error" not in gate
+    assert "coverage combine" in gate["run"]
+    assert "coverage-data/linux/coverage-linux-3.11.data" in gate["run"]
+    assert "coverage-data/apple/coverage-apple.data" in gate["run"]
     assert "coverage.xml" in gate["run"]
     assert '--compare-branch "$PR_BASE_SHA"' in gate["run"]
     assert "--show-uncovered" in gate["run"]


### PR DESCRIPTION
## Why

The changed-lines coverage gate currently sees only Linux tests, so changes in MLX-native modules can fail coverage even when the corresponding Apple Silicon contracts execute those lines. This makes the gate accurately combine both platform lanes while preserving the existing 100% threshold.

## Scope

- upload commit-bound raw coverage data from Python 3.11 Linux tests
- collect and upload raw coverage data from the curated Apple Silicon MLX test set
- combine both reports in a dedicated fail-closed job before `diff-cover`
- keep the stable `tests` required-check facade responsible for the final verdict
- add executable workflow contracts for provenance, portability, aggregation, and lane dependencies

## Non-goals

- no product, engine, model, or Desktop behavior changes
- no coverage exclusions, pragmas, or threshold changes
- no CI path-routing or required-check changes
- no expansion of the curated Apple Silicon test roster

## Acceptance criteria

- Linux-only and Apple/MLX coverage data combine into one portable XML report
- missing artifacts or a failed union makes `tests` fail closed for engine PRs
- non-engine PR routing remains unchanged
- an integration proof with the Qwen3.8 Flash Next branch demonstrates that its MLX-native tests contribute to the combined report; that feature branch owns its roster additions

## Hosted-lane baseline disposition

- the explicit-template contracts require `jinja2`, so the Linux lane now installs it instead of excluding valid coverage
- current `main` independently reproduces the mixed-template prompt-priming failure tracked in #2445; only that exact node is deselected
- current `main` independently reproduces the 1570 distill lifecycle failure tracked in #2446; only that exact node is deselected
- all other contracts in both source files remain in the roster

## Evidence

- exact-head local PR validation: MERGE-SAFE; 19,153 passed, 97 skipped, 22 deselected, 6 xfailed, 1 xpassed
- workflow contracts after lane correction: 14 passed
- same-env baseline A/B: both parser failures reproduce on `origin/main@aaa2b8a9`; corrected roster 207 passed, 2 exact deselections
- real coverage union: Linux 324 passed + Apple/MLX 113 passed; two raw data files combined; XML generated
- Qwen3.8 Flash Next integration proof: 137 real-MLX tests passed
- Codex R4 was LGTM before the hosted-lane correction; final scoped verification follows on the corrected head
- Ruff and diff check: passed