### PR TITLE
fix(mac): project memory after planned model replacement

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -189,17 +189,16 @@ enum ModelSizing {
     /// a larger Mac, yet loading it with little free RAM pushed unified
     /// memory past the danger line.
     ///
-    /// #324: unified memory past ~85% of total can trip the iBoot
-    /// AMCC async-abort firmware path and **kernel-panic the whole
-    /// machine** rather than raise a userspace OOM — so ``.unsafe`` is
-    /// pinned to that ~85% danger line and is a must-confirm block,
-    /// never a silent proceed.
+    /// The host can legitimately use compression and swap near physical RAM,
+    /// so the guard stays advisory from 95–100%. Explicit confirmation begins
+    /// only when the transition projects beyond physical memory. This also
+    /// keeps every measured RAM-tier recommendation below the blocking line.
     enum MemorySafety: String, Sendable, Equatable {
-        /// Projected use < 75% of total — comfortable.
+        /// Projected use < 95% of total — load normally.
         case safe
-        /// 75-85% — will load but risks swap / stalls; warn.
+        /// 95-100% — may compress or swap, but does not block.
         case tight
-        /// ≥ 85% — at/over the kernel-panic danger line; block + confirm.
+        /// > 100% — requires more memory than the Mac physically has.
         case unsafe
     }
 
@@ -239,8 +238,8 @@ enum ModelSizing {
         let gib = Double(1 << 30)
         let footprintBytes = footprintGB * gib
         let projected = (Double(usedBytes) + footprintBytes) / Double(totalBytes)
-        if projected >= 0.85 { return .unsafe }
-        if projected >= 0.75 { return .tight }
+        if projected > 1.0 { return .unsafe }
+        if projected >= 0.95 { return .tight }
         return .safe
     }
 
@@ -263,6 +262,9 @@ enum ModelSizing {
         /// Total unified memory. Needed because the guard is based on
         /// projected utilisation, not on footprint-versus-free alone.
         var totalGB: Double = 0
+        /// Resident model memory the selected lifecycle plan will release
+        /// before loading this target.
+        var plannedReleaseGB: Double = 0
 
         init(
             id: UUID = UUID(),
@@ -272,7 +274,8 @@ enum ModelSizing {
             severity: MemorySafety,
             footprintGB: Double,
             freeGB: Double,
-            totalGB: Double = 0
+            totalGB: Double = 0,
+            plannedReleaseGB: Double = 0
         ) {
             self.id = id
             self.alias = alias
@@ -282,6 +285,7 @@ enum ModelSizing {
             self.footprintGB = footprintGB
             self.freeGB = freeGB
             self.totalGB = totalGB
+            self.plannedReleaseGB = plannedReleaseGB
         }
 
         static func == (lhs: Self, rhs: Self) -> Bool {
@@ -292,6 +296,7 @@ enum ModelSizing {
                 && lhs.footprintGB == rhs.footprintGB
                 && lhs.freeGB == rhs.freeGB
                 && lhs.totalGB == rhs.totalGB
+                && lhs.plannedReleaseGB == rhs.plannedReleaseGB
         }
 
         var title: String {
@@ -314,15 +319,18 @@ enum ModelSizing {
             }
             let usedGB = max(0, totalGB - freeGB)
             let projectedPercent = Int(((usedGB + footprintGB) / totalGB * 100).rounded())
-            let threshold = severity == .unsafe ? 85.0 : 75.0
+            let threshold = severity == .unsafe ? 100.0 : 95.0
             let toFree = max(0, usedGB + footprintGB - threshold / 100 * totalGB)
             let freeAction = max(1, Int(toFree.rounded(.up)))
-            let facts = "Loading it would put memory use at about \(projectedPercent)% of \(Int(totalGB.rounded())) GB."
+            let release = plannedReleaseGB > 0
+                ? "Rapid will first release about \(max(1, Int(plannedReleaseGB.rounded()))) GB from the current model. "
+                : ""
+            let facts = "Loading it would then put memory use at about \(projectedPercent)% of \(Int(totalGB.rounded())) GB."
             switch severity {
             case .unsafe:
-                return facts + " Past about 85%, macOS may freeze or restart. Free about \(freeAction) GB by closing some apps, or pick a smaller model."
+                return release + facts + " That is more memory than this Mac has. Free about \(freeAction) GB by closing some apps, or pick a smaller model."
             case .tight:
-                return facts + " It should load but may stall under longer chats. Consider closing some apps or picking a smaller model."
+                return release + facts + " It should load but may use memory compression or swap under longer chats."
             case .safe:
                 return facts + " There is now enough memory to load it normally."
             }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -323,7 +323,7 @@ enum ModelSizing {
             let toFree = max(0, usedGB + footprintGB - threshold / 100 * totalGB)
             let freeAction = max(1, Int(toFree.rounded(.up)))
             let release = plannedReleaseGB > 0
-                ? "Rapid will first release about \(max(1, Int(plannedReleaseGB.rounded()))) GB from the current model. "
+                ? "The switch accounts for about \(max(1, Int(plannedReleaseGB.rounded()))) GB released from the previous model. "
                 : ""
             let facts = "Loading it would then put memory use at about \(projectedPercent)% of \(Int(totalGB.rounded())) GB."
             switch severity {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -174,7 +174,8 @@ final class MemoryLoadConfirmationQueue {
             ),
             footprintGB: old.footprintGB,
             freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
-            totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
+            totalGB: Double(snapshot.totalBytes) / Double(1 << 30),
+            plannedReleaseGB: old.plannedReleaseGB
         )
     }
 }
@@ -1382,6 +1383,7 @@ final class ServerManager {
                 hfPath: hfPath,
                 estimatedSizeGB: estimate,
                 replaceGroup: replacementGroup,
+                memoryPolicy: replacementGroup == .assistant ? .evictFirstIfNeeded : nil,
                 imageMode: imageMode,
                 performance: perfConfigProvider?(trimmed),
                 port: activePort,
@@ -1453,6 +1455,7 @@ final class ServerManager {
         // mid-``.starting``). ``stop()`` is a noop if child is nil, so
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
+        var replacementMemoryAdmission: MemoryAdmissionContext?
         if child != nil {
             // `ensureServing` can re-enter while a dialog or residency refresh
             // is awaiting. Repeat until the alias we validated is still the
@@ -1480,6 +1483,21 @@ final class ServerManager {
                 }
                 return isServing(trimmed)
             }
+            // The process-replacement path releases the current assistant
+            // before loading its successor. Admission must therefore project
+            // the successor on top of memory *after* that release, not stack
+            // both chat models as if they would coexist. Capture this before
+            // stopping while the residency row and host sample describe the
+            // same live process. Because this branch replaces the whole
+            // sidecar, every resident model row belongs to the release plan;
+            // in-process multi-model loads never receive this credit.
+            replacementMemoryAdmission = memorySnapshotProvider().flatMap {
+                Self.memoryAdmissionForTransition(
+                    host: $0,
+                    residency: residency,
+                    plan: .releaseResidentModels
+                )
+            }
             await stop(preservingLastServedAlias: true)
         }
         let memoryRequestID = UUID()
@@ -1487,6 +1505,7 @@ final class ServerManager {
             alias: trimmed,
             hfPath: hfPath,
             memoryRequestID: memoryRequestID,
+            memoryAdmission: replacementMemoryAdmission,
             catalogEntryHint: provenCatalogEntry
         )
         // ``start`` also returns without spawning when the pre-load
@@ -1515,6 +1534,48 @@ final class ServerManager {
             await awaitStartupSettled(alias: trimmed)
         }
         return isServing(trimmed)
+    }
+
+    enum MemoryResidencyPlan: Sendable, Equatable {
+        case keepResidentModels
+        case releaseResidentModels
+    }
+
+    struct MemoryAdmissionContext: Sendable, Equatable {
+        let snapshot: MemoryProbe.Snapshot
+        let plannedReleaseBytes: UInt64
+    }
+
+    /// One-shot host-memory view for the transition the lifecycle will run.
+    ///
+    /// A process replacement releases every resident engine before spawning
+    /// the target, regardless of whether the outgoing lane is chat, image, or
+    /// audio. An in-process load keeps its residents and therefore receives no
+    /// credit here; the residency loader owns its own admission/eviction plan.
+    /// Returning `nil` for a release with no trustworthy residency evidence
+    /// deliberately preserves the ordinary post-stop live probe.
+    nonisolated static func memoryAdmissionForTransition(
+        host: MemoryProbe.Snapshot,
+        residency: ModelResidencySnapshot,
+        plan: MemoryResidencyPlan
+    ) -> MemoryAdmissionContext? {
+        guard plan == .releaseResidentModels else {
+            return MemoryAdmissionContext(snapshot: host, plannedReleaseBytes: 0)
+        }
+        var reclaimableBytes: UInt64 = 0
+        for resident in residency.models where resident.state != "evicting" {
+            let bytes = resident.measuredBytes ?? resident.estimatedBytes
+            reclaimableBytes += min(bytes, host.usedBytes - reclaimableBytes)
+            if reclaimableBytes == host.usedBytes { break }
+        }
+        guard reclaimableBytes > 0 else { return nil }
+        return MemoryAdmissionContext(
+            snapshot: MemoryProbe.Snapshot(
+                totalBytes: host.totalBytes,
+                usedBytes: host.usedBytes - reclaimableBytes
+            ),
+            plannedReleaseBytes: reclaimableBytes
+        )
     }
 
     /// Rebuild only the named resident engine with its current performance
@@ -1823,6 +1884,7 @@ final class ServerManager {
         bypassMemoryGuard: Bool = false,
         memoryRequestID: UUID? = nil,
         isLaunchAutoStart: Bool = false,
+        memoryAdmission: MemoryAdmissionContext? = nil,
         catalogEntryHint: ModelEntry? = nil
     ) async {
         // Issue #278: a manual restart is the user taking over the
@@ -1868,9 +1930,8 @@ final class ServerManager {
         }
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
-        // stacked on top of what is ALREADY resident, would push unified
-        // memory past ~85% of total can freeze or kernel-panic the whole
-        // Mac — a far worse outcome than declining to load. This is the
+        // stacked on top of what is ALREADY resident, would require more than
+        // physical unified memory is held for explicit confirmation. This is the
         // single choke point every start path funnels through (picker,
         // first message, auto-restart, quickstart), so the check + the
         // confirmation prompt live here once instead of at each call site.
@@ -1888,15 +1949,16 @@ final class ServerManager {
         // Respawn is also recovering a model that ALREADY fit when it first
         // started; a genuine free-RAM drop is bounded by the respawn-attempt
         // budget, and the user's manual restart still routes through the guard.
-        if !bypassMemoryGuard, !isAutoRespawn, let snapshot = memorySnapshotProvider() {
+        if !bypassMemoryGuard, !isAutoRespawn,
+           let snapshot = memoryAdmission?.snapshot ?? memorySnapshotProvider() {
             let footprint = ModelSizing.estimate(alias: trimmedAlias)
             let safety = ModelSizing.memorySafety(
                 footprint: footprint,
                 usedBytes: snapshot.usedBytes,
                 totalBytes: snapshot.totalBytes
             )
-            // Only ``.unsafe`` (>= 85%, the panic line) blocks. ``.tight``
-            // is defined as "will load but risks swap / stalls" — holding
+            // Only ``.unsafe`` (> 100%, beyond physical RAM) blocks. ``.tight``
+            // is defined as "will load but may compress / swap" — holding
             // it behind a modal would fire on ordinary loads (13 GiB used
             // on a 32 GiB Mac + an 11.8 GiB model projects to 77.5%) and
             // train the user to click through the one prompt that matters.
@@ -1923,7 +1985,9 @@ final class ServerManager {
                     severity: safety,
                     footprintGB: footprint.totalGB,
                     freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
-                    totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
+                    totalGB: Double(snapshot.totalBytes) / Double(1 << 30),
+                    plannedReleaseGB: Double(memoryAdmission?.plannedReleaseBytes ?? 0)
+                        / Double(1 << 30)
                 )
                 memoryConfirmations.enqueue(
                     warning: warning,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -162,6 +162,12 @@ final class MemoryLoadConfirmationQueue {
         _ old: ModelSizing.MemoryWarning,
         snapshot: MemoryProbe.Snapshot
     ) -> ModelSizing.MemoryWarning {
+        // Replacement admission reaches this queue only after `ensureServing`
+        // has awaited `stop()`. The fresh host sample therefore already
+        // reflects whatever memory macOS has reclaimed from the old process;
+        // subtracting `plannedReleaseGB` again would understate live use. Keep
+        // the value solely to explain which release the initial projection
+        // accounted for.
         ModelSizing.MemoryWarning(
             id: old.id,
             alias: old.alias,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1590,7 +1590,7 @@ final class ServerManager {
         }
         var reclaimableBytes: UInt64 = 0
         for resident in residency.models where resident.state != "evicting" {
-            let bytes = resident.measuredBytes ?? resident.estimatedBytes
+            let bytes = resident.displayBytes
             reclaimableBytes += min(bytes, host.usedBytes - reclaimableBytes)
             if reclaimableBytes == host.usedBytes { break }
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1552,6 +1552,26 @@ final class ServerManager {
         let plannedReleaseBytes: UInt64
     }
 
+    /// Resolve one process-replacement admission against post-stop host truth.
+    /// The projected pre-stop sample knows which model bytes the transition
+    /// releases; the live sample catches memory another process consumed while
+    /// `stop()` was awaiting termination. The larger used value is the safe
+    /// answer. If either probe is unavailable, retain the evidence we do have.
+    nonisolated static func memorySnapshotForAdmission(
+        planned: MemoryAdmissionContext?,
+        live: MemoryProbe.Snapshot?
+    ) -> MemoryProbe.Snapshot? {
+        guard let planned else { return live }
+        guard let live else { return planned.snapshot }
+        return MemoryProbe.Snapshot(
+            totalBytes: live.totalBytes,
+            usedBytes: min(
+                live.totalBytes,
+                max(live.usedBytes, planned.snapshot.usedBytes)
+            )
+        )
+    }
+
     /// One-shot host-memory view for the transition the lifecycle will run.
     ///
     /// A process replacement releases every resident engine before spawning
@@ -1956,7 +1976,10 @@ final class ServerManager {
         // started; a genuine free-RAM drop is bounded by the respawn-attempt
         // budget, and the user's manual restart still routes through the guard.
         if !bypassMemoryGuard, !isAutoRespawn,
-           let snapshot = memoryAdmission?.snapshot ?? memorySnapshotProvider() {
+           let snapshot = Self.memorySnapshotForAdmission(
+               planned: memoryAdmission,
+               live: memorySnapshotProvider()
+           ) {
             let footprint = ModelSizing.estimate(alias: trimmedAlias)
             let safety = ModelSizing.memorySafety(
                 footprint: footprint,

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -375,6 +375,14 @@ struct ServerResidencyClient {
         }
 
         let detail: Detail?
+        let error: StructuredDetail.Error?
+        let replacementProjection: ResidentReplacementProjection?
+
+        enum CodingKeys: String, CodingKey {
+            case detail
+            case error
+            case replacementProjection = "replacement_projection"
+        }
     }
 
     var session: URLSession = {
@@ -447,16 +455,16 @@ struct ServerResidencyClient {
                 return .unsupported
             }
             let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: data)
-            let detail: String?
-            switch envelope?.detail {
-            case .message(let message):
-                detail = message
+            let nestedDetail: String? = switch envelope?.detail {
+            case .message(let message): message
             case .structured(let structured):
-                detail = structured.replacementProjection?.rejectionMessage(alias: alias)
+                structured.replacementProjection?.rejectionMessage(alias: alias)
                     ?? structured.error?.message
-            case nil:
-                detail = nil
+            case nil: nil
             }
+            let detail = envelope?.replacementProjection?.rejectionMessage(alias: alias)
+                ?? envelope?.error?.message
+                ?? nestedDetail
             return .rejected(detail ?? "The model could not be kept resident (HTTP \(http.statusCode)).")
         } catch {
             return .rejected("The model server could not load another resident model.")

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -346,13 +346,35 @@ struct ServerResidencyClient {
     }
 
     private struct ErrorEnvelope: Decodable {
-        let detail: String?
-        let replacementProjection: ResidentReplacementProjection?
+        struct StructuredDetail: Decodable {
+            struct Error: Decodable {
+                let message: String?
+            }
 
-        enum CodingKeys: String, CodingKey {
-            case detail
-            case replacementProjection = "replacement_projection"
+            let error: Error?
+            let replacementProjection: ResidentReplacementProjection?
+
+            enum CodingKeys: String, CodingKey {
+                case error
+                case replacementProjection = "replacement_projection"
+            }
         }
+
+        enum Detail: Decodable {
+            case message(String)
+            case structured(StructuredDetail)
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                if let message = try? container.decode(String.self) {
+                    self = .message(message)
+                } else {
+                    self = .structured(try container.decode(StructuredDetail.self))
+                }
+            }
+        }
+
+        let detail: Detail?
     }
 
     var session: URLSession = {
@@ -425,8 +447,16 @@ struct ServerResidencyClient {
                 return .unsupported
             }
             let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: data)
-            let detail = envelope?.detail
-                ?? envelope?.replacementProjection?.rejectionMessage(alias: alias)
+            let detail: String?
+            switch envelope?.detail {
+            case .message(let message):
+                detail = message
+            case .structured(let structured):
+                detail = structured.replacementProjection?.rejectionMessage(alias: alias)
+                    ?? structured.error?.message
+            case nil:
+                detail = nil
+            }
             return .rejected(detail ?? "The model could not be kept resident (HTTP \(http.statusCode)).")
         } catch {
             return .rejected("The model server could not load another resident model.")

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -13,6 +13,7 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
     let measuredBytes: UInt64?
     let idleSeconds: Double
     var performance: ResidentPerformanceStatus? = nil
+    var replacementProjection: ResidentReplacementProjection? = nil
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -27,6 +28,7 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
         case measuredBytes = "measured_bytes"
         case idleSeconds = "idle_seconds"
         case performance
+        case replacementProjection = "replacement_projection"
     }
 
     func matches(_ alias: String) -> Bool {
@@ -50,6 +52,55 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
     /// its first request materializes the weights. Never present that partial
     /// delta as smaller than the admission reservation.
     var displayBytes: UInt64 { max(estimatedBytes, measuredBytes ?? 0) }
+}
+
+/// Engine-authored admission plan for an assistant replacement. Desktop sends
+/// the policy but never recreates the engine's role-capacity decision: this
+/// response is the authoritative account of what the load kept or released.
+struct ResidentReplacementProjection: Codable, Sendable, Equatable {
+    struct ModelToFree: Codable, Sendable, Equatable {
+        let id: String
+        let estimatedBytes: UInt64
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case estimatedBytes = "estimated_bytes"
+        }
+    }
+
+    let strategy: String
+    let modelsToFree: [ModelToFree]
+    let currentBytes: UInt64
+    let requestedBytes: UInt64
+    let projectedBytes: UInt64
+    let limitBytes: UInt64
+    let reason: String
+
+    enum CodingKeys: String, CodingKey {
+        case strategy
+        case modelsToFree = "models_to_free"
+        case currentBytes = "current_bytes"
+        case requestedBytes = "requested_bytes"
+        case projectedBytes = "projected_bytes"
+        case limitBytes = "limit_bytes"
+        case reason
+    }
+
+    func rejectionMessage(alias: String) -> String? {
+        guard reason == "role_capacity_insufficient_after_eviction" else { return nil }
+        let gib = Double(UInt64(1) << 30)
+        let releasedGB = modelsToFree.reduce(0.0) {
+            $0 + Double($1.estimatedBytes)
+        } / gib
+        let projectedGB = Double(projectedBytes) / gib
+        let limitGB = Double(limitBytes) / gib
+        let release = releasedGB > 0
+            ? "Rapid can release about \(max(1, Int(releasedGB.rounded()))) GB from the current model, but "
+            : ""
+        return release
+            + "\(alias) would still need about \(Int(projectedGB.rounded())) GB "
+            + "of the \(Int(limitGB.rounded())) GB model-memory budget."
+    }
 }
 
 struct ResidentPerformanceStatus: Codable, Sendable, Equatable {
@@ -271,6 +322,11 @@ enum ResidentModelReplacementGroup: String, Sendable {
     case assistant
 }
 
+enum ResidentMemoryPolicy: String, Sendable, Encodable {
+    case keepThenCommit = "keep_then_commit"
+    case evictFirstIfNeeded = "evict_first_if_needed"
+}
+
 enum ResidentImageMode: String, Sendable, Encodable {
     case generation
     case editing
@@ -283,6 +339,7 @@ struct ServerResidencyClient {
         let estimated_size_gb: Double
         let pin: Bool
         let replace_group: String?
+        let memory_policy: ResidentMemoryPolicy?
         let image_mode: ResidentImageMode?
         let performance: ResidentPerformanceStatus?
         let reload_if_changed: Bool
@@ -290,6 +347,12 @@ struct ServerResidencyClient {
 
     private struct ErrorEnvelope: Decodable {
         let detail: String?
+        let replacementProjection: ResidentReplacementProjection?
+
+        enum CodingKeys: String, CodingKey {
+            case detail
+            case replacementProjection = "replacement_projection"
+        }
     }
 
     var session: URLSession = {
@@ -324,6 +387,7 @@ struct ServerResidencyClient {
         hfPath: String?,
         estimatedSizeGB: Double,
         replaceGroup: ResidentModelReplacementGroup? = nil,
+        memoryPolicy: ResidentMemoryPolicy? = nil,
         imageMode: ResidentImageMode? = nil,
         performance: ModelPerfConfig? = nil,
         reloadIfChanged: Bool = false,
@@ -340,6 +404,7 @@ struct ServerResidencyClient {
                 estimated_size_gb: estimatedSizeGB,
                 pin: false,
                 replace_group: replaceGroup?.rawValue,
+                memory_policy: memoryPolicy,
                 image_mode: imageMode,
                 performance: performance.map(ResidentPerformanceStatus.init),
                 reload_if_changed: reloadIfChanged
@@ -359,7 +424,9 @@ struct ServerResidencyClient {
             if http.statusCode == 404 || http.statusCode == 405 {
                 return .unsupported
             }
-            let detail = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data))?.detail
+            let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: data)
+            let detail = envelope?.detail
+                ?? envelope?.replacementProjection?.rejectionMessage(alias: alias)
             return .rejected(detail ?? "The model could not be kept resident (HTTP \(http.statusCode)).")
         } catch {
             return .rejected("The model server could not load another resident model.")

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -4135,8 +4135,8 @@ struct QuickstartView: View {
 
     /// Return the curated low-memory fallback only when the same snapshot
     /// that blocked the original load says the replacement falls below the
-    /// 85% danger line. This prevents a reassuring "Switch" button from
-    /// merely leading to a second warning. If the snapshot is unavailable,
+    /// blocking beyond-physical-RAM line. This prevents a reassuring "Switch"
+    /// button from merely leading to a second warning. If the snapshot is unavailable,
     /// Cancel still returns to the chooser and the fallback remains visible,
     /// but the warning does not claim it is safe.
     static func lowMemoryRecoveryChoice(

--- a/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchAutoStartMemoryTests.swift
@@ -51,13 +51,13 @@ struct LaunchAutoStartMemoryTests {
         let originalID = try #require(server.pendingMemoryWarning?.id)
         #expect(server.pendingMemoryWarning?.severity == .unsafe)
 
-        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 16 * gib)
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 22 * gib)
         let becameTight = await server.refreshPendingMemoryWarning()
         #expect(becameTight?.old == .unsafe)
         #expect(becameTight?.new == .tight)
         #expect(server.pendingMemoryWarning?.confirmTitle == "Load model")
 
-        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+        snapshots.current = .init(totalBytes: 32 * gib, usedBytes: 16 * gib)
         let becameSafe = await server.refreshPendingMemoryWarning()
         #expect(becameSafe?.old == .tight)
         #expect(becameSafe?.new == .safe)

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -197,7 +197,7 @@ struct MemoryLoadConfirmationQueueTests {
         queue.enqueue(warning: original, requestID: nil)
 
         let result = queue.refreshCurrentWarning(
-            snapshot: .init(totalBytes: 32 * gib, usedBytes: 2 * gib)
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 7 * gib)
         )
         let refreshed = try #require(result)
 

--- a/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryLoadConfirmationQueueTests.swift
@@ -206,6 +206,33 @@ struct MemoryLoadConfirmationQueueTests {
         #expect(refreshed.new.hfPath == original.hfPath)
     }
 
+    @Test("post-stop refresh does not credit the released model twice")
+    func liveRefreshUsesPostStopHostTruth() throws {
+        let gib = UInt64(1 << 30)
+        var queue = MemoryLoadConfirmationQueue()
+        let original = ModelSizing.MemoryWarning(
+            alias: "qwen3.8-27b-4bit",
+            hfPath: nil,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: 20,
+            freeGB: 18,
+            totalGB: 32,
+            plannedReleaseGB: 6
+        )
+        queue.enqueue(warning: original, requestID: nil)
+
+        let result = queue.refreshCurrentWarning(
+            snapshot: .init(totalBytes: 32 * gib, usedBytes: 14 * gib)
+        )
+        let refreshed = try #require(result)
+
+        // The fresh 14 GB sample is post-stop truth. Crediting the old 6 GB a
+        // second time would incorrectly classify 8 + 20 GB as safe.
+        #expect(refreshed.new.severity == .unsafe)
+        #expect(refreshed.new.plannedReleaseGB == 6)
+    }
+
     @Test("refresh is ignored after the visible decision starts launching")
     func liveRefreshCannotRewriteLaunchingDecision() {
         let gib = UInt64(1 << 30)

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -475,6 +475,22 @@ struct ModelResidencyTests {
         #expect(admission.snapshot.usedBytes < host.usedBytes)
     }
 
+    @Test("A zero resident measurement falls back to its admission estimate")
+    func processReplacementCreditsEstimatedBytesWhenMeasurementIsZero() throws {
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14.6),
+            residency: residency(
+                alias: "qwen3.5-9b-4bit",
+                measuredGB: 0,
+                estimatedGB: 6.3,
+                modality: "text"
+            ),
+            plan: .releaseResidentModels
+        ))
+
+        #expect(admission.plannedReleaseBytes == UInt64(6.3 * Double(UInt64(1) << 30)))
+    }
+
     @Test("No resident evidence preserves the ordinary live admission probe")
     func noResidentLeavesAdmissionUnchanged() {
         #expect(ServerManager.memoryAdmissionForTransition(
@@ -566,10 +582,12 @@ struct ModelResidencyTests {
     private func residency(
         alias: String,
         measuredGB: Double,
+        estimatedGB: Double? = nil,
         modality: String
     ) -> ModelResidencySnapshot {
         let gib = Double(UInt64(1) << 30)
         let measuredBytes = UInt64(measuredGB * gib)
+        let estimatedBytes = UInt64((estimatedGB ?? measuredGB) * gib)
         let status = ResidentModelStatus(
             id: alias,
             modelPath: "repo/\(alias)",
@@ -579,7 +597,7 @@ struct ModelResidencyTests {
             pinned: false,
             primary: true,
             activeRequests: 0,
-            estimatedBytes: measuredBytes,
+            estimatedBytes: estimatedBytes,
             measuredBytes: measuredBytes,
             idleSeconds: 0
         )

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -635,8 +635,11 @@ struct ModelResidencyTests {
         #expect(performance["cache_memory_mb"] as? Int == 4096)
     }
 
-    @Test("A typed 507 replacement projection reaches the user-facing rejection")
-    func loadDecodesReplacementProjectionRejection() async {
+    @Test(
+        "A typed 507 replacement projection reaches the user-facing rejection",
+        arguments: [false, true]
+    )
+    func loadDecodesReplacementProjectionRejection(legacyEnvelope: Bool) async {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [ResidencyLoadProjectionRejectProtocol.self]
         var client = ServerResidencyClient()
@@ -649,7 +652,7 @@ struct ModelResidencyTests {
             replaceGroup: .assistant,
             memoryPolicy: .evictFirstIfNeeded,
             port: 8000,
-            bearer: nil
+            bearer: legacyEnvelope ? "legacy-envelope" : nil
         )
 
         guard case .rejected(let message) = result else {
@@ -754,7 +757,12 @@ private final class ResidencyLoadProjectionRejectProtocol: URLProtocol, @uncheck
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        let payload = #"{"detail":{"error":{"message":"insufficient capacity","type":"insufficient_capacity_error","code":"insufficient_capacity_error","param":"estimated_size_gb"},"replacement_projection":{"strategy":"evict_first_if_needed","reason":"role_capacity_insufficient_after_eviction","models_to_free":[{"id":"old-chat","estimated_bytes":6442450944}],"current_bytes":12884901888,"requested_bytes":21474836480,"projected_bytes":27917287424,"limit_bytes":25769803776}}}"#.data(using: .utf8)!
+        let structured = #"{"error":{"message":"insufficient capacity","type":"insufficient_capacity_error","code":"insufficient_capacity_error","param":"estimated_size_gb"},"replacement_projection":{"strategy":"evict_first_if_needed","reason":"role_capacity_insufficient_after_eviction","models_to_free":[{"id":"old-chat","estimated_bytes":6442450944}],"current_bytes":12884901888,"requested_bytes":21474836480,"projected_bytes":27917287424,"limit_bytes":25769803776}}"#
+        let payload = if request.value(forHTTPHeaderField: "Authorization") == "Bearer legacy-envelope" {
+            Data(#"{"detail":\#(structured)}"#.utf8)
+        } else {
+            Data(structured.utf8)
+        }
         let response = HTTPURLResponse(
             url: request.url!, statusCode: 507, httpVersion: "HTTP/1.1", headerFields: nil
         )!

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -605,6 +605,32 @@ struct ModelResidencyTests {
         #expect(performance["cache_memory_mb"] as? Int == 4096)
     }
 
+    @Test("A typed 507 replacement projection reaches the user-facing rejection")
+    func loadDecodesReplacementProjectionRejection() async {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ResidencyLoadProjectionRejectProtocol.self]
+        var client = ServerResidencyClient()
+        client.session = URLSession(configuration: configuration)
+
+        let result = await client.load(
+            alias: "qwen3.8-27b-4bit",
+            hfPath: nil,
+            estimatedSizeGB: 22,
+            replaceGroup: .assistant,
+            memoryPolicy: .evictFirstIfNeeded,
+            port: 8000,
+            bearer: nil
+        )
+
+        guard case .rejected(let message) = result else {
+            Issue.record("Expected the typed 507 to remain a rejected resident load")
+            return
+        }
+        #expect(message.contains("release about 6 GB"))
+        #expect(message.contains("26 GB"))
+        #expect(message.contains("24 GB model-memory budget"))
+    }
+
     @Test("Image residency estimate uses catalog bytes plus runtime margin")
     func imageEstimateUsesDownloadSize() {
         let estimate = ModelSizing.residentEstimateGB(
@@ -691,4 +717,21 @@ private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendab
             if count < 0 { return nil }
         }
     }
+}
+
+private final class ResidencyLoadProjectionRejectProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let payload = #"{"detail":{"error":{"message":"insufficient capacity","type":"insufficient_capacity_error","code":"insufficient_capacity_error","param":"estimated_size_gb"},"replacement_projection":{"strategy":"evict_first_if_needed","reason":"role_capacity_insufficient_after_eviction","models_to_free":[{"id":"old-chat","estimated_bytes":6442450944}],"current_bytes":12884901888,"requested_bytes":21474836480,"projected_bytes":27917287424,"limit_bytes":25769803776}}}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 507, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -484,6 +484,36 @@ struct ModelResidencyTests {
         ) == nil)
     }
 
+    @Test("Post-stop host growth wins over the earlier replacement projection")
+    func postStopGrowthUsesConservativeAdmission() throws {
+        let planned = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14),
+            residency: residency(alias: "old-chat", measuredGB: 6, modality: "text"),
+            plan: .releaseResidentModels
+        ))
+        let resolved = try #require(ServerManager.memorySnapshotForAdmission(
+            planned: planned,
+            live: memorySnapshot(totalGB: 18, usedGB: 10)
+        ))
+
+        #expect(resolved.usedBytes == 10 * UInt64(1 << 30))
+    }
+
+    @Test("A slower post-stop probe cannot discard the measured release credit")
+    func stalePostStopProbeUsesConservativeProjection() throws {
+        let planned = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14),
+            residency: residency(alias: "old-chat", measuredGB: 6, modality: "text"),
+            plan: .releaseResidentModels
+        ))
+        let resolved = try #require(ServerManager.memorySnapshotForAdmission(
+            planned: planned,
+            live: memorySnapshot(totalGB: 18, usedGB: 6)
+        ))
+
+        #expect(resolved.usedBytes == 8 * UInt64(1 << 30))
+    }
+
     @Test("Engine replacement projection produces a truthful insufficient-budget reason")
     func replacementProjectionRejectionCopy() {
         let gib = UInt64(1) << 30

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -28,10 +28,19 @@ struct ModelResidencyTests {
                 "estimated_bytes": 6335076761,
                 "measured_bytes": 5905580032,
                 "idle_seconds": 12.5,
-                "performance": {
+              "performance": {
                   "kv_cache_turboquant": "k8v4",
                   "prefix_cache_enabled": true,
                   "cache_memory_mb": 4096
+                },
+                "replacement_projection": {
+                  "strategy": "evict_first_if_needed",
+                  "models_to_free": [{"id": "old-chat", "estimated_bytes": 6335076761}],
+                  "current_bytes": 10737418240,
+                  "requested_bytes": 6335076761,
+                  "projected_bytes": 10737418240,
+                  "limit_bytes": 34359738368,
+                  "reason": "role_capacity_evict_first_required"
                 }
               }]
             }
@@ -56,6 +65,8 @@ struct ModelResidencyTests {
                 cacheMemoryMB: 4096
             )
         ))
+        #expect(snapshot.models.first?.replacementProjection?.modelsToFree.first?.id == "old-chat")
+        #expect(snapshot.models.first?.replacementProjection?.reason == "role_capacity_evict_first_required")
         #expect(snapshot.audioLanes.isEmpty, "older snapshots remain compatible")
     }
 
@@ -364,6 +375,195 @@ struct ModelResidencyTests {
         #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 4)) == 4)
     }
 
+    @Test("18 GB smart-to-fast replacement credits the measured resident chat model")
+    func smartToFastReplacementDoesNotWarn() throws {
+        let picks = RAMBucketedDefault.picks(forPhysicalRAMGB: 18)
+        let smart = try #require(picks.first)
+        let fast = try #require(picks.last)
+        #expect(smart.alias == "qwen3.5-9b-4bit")
+        #expect(fast.alias == "qwen3.5-4b-4bit")
+
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14.6),
+            residency: residency(
+                alias: smart.alias,
+                measuredGB: 6.3,
+                modality: "text"
+            ),
+            plan: .releaseResidentModels
+        ))
+        let safety = ModelSizing.memorySafety(
+            footprintGB: ModelSizing.estimate(alias: fast.alias).totalGB,
+            usedBytes: admission.snapshot.usedBytes,
+            totalBytes: admission.snapshot.totalBytes
+        )
+
+        #expect(admission.plannedReleaseBytes == UInt64(6.3 * Double(UInt64(1) << 30)))
+        #expect(!ModelSizing.requiresMemoryConfirmation(safety))
+    }
+
+    @Test("Replacing a smaller chat model with 27B still warns")
+    func smallerToLargerReplacementStillWarns() throws {
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 32, usedGB: 20),
+            residency: residency(
+                alias: "qwen3.5-4b-4bit",
+                measuredGB: 4,
+                modality: "text"
+            ),
+            plan: .releaseResidentModels
+        ))
+        let safety = ModelSizing.memorySafety(
+            footprintGB: ModelSizing.estimate(alias: "qwen3.8-27b-4bit").totalGB,
+            usedBytes: admission.snapshot.usedBytes,
+            totalBytes: admission.snapshot.totalBytes
+        )
+
+        #expect(ModelSizing.requiresMemoryConfirmation(safety))
+    }
+
+    @Test("Chat-to-image replacement credits the outgoing chat model")
+    func chatToImageReplacementDoesNotWarn() throws {
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14.6),
+            residency: residency(
+                alias: "qwen3.5-9b-4bit",
+                measuredGB: 6.3,
+                modality: "text"
+            ),
+            plan: .releaseResidentModels
+        ))
+        let safety = ModelSizing.memorySafety(
+            footprintGB: ModelSizing.estimate(alias: "flux2-klein-4b").totalGB,
+            usedBytes: admission.snapshot.usedBytes,
+            totalBytes: admission.snapshot.totalBytes
+        )
+
+        #expect(!ModelSizing.requiresMemoryConfirmation(safety))
+    }
+
+    @Test("Image-to-chat replacement credits the outgoing image model")
+    func imageToChatReplacementDoesNotWarn() throws {
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14),
+            residency: residency(
+                alias: "flux2-klein-4b",
+                measuredGB: 5.9,
+                modality: "image-gen"
+            ),
+            plan: .releaseResidentModels
+        ))
+        let safety = ModelSizing.memorySafety(
+            footprintGB: ModelSizing.estimate(alias: "qwen3.5-4b-4bit").totalGB,
+            usedBytes: admission.snapshot.usedBytes,
+            totalBytes: admission.snapshot.totalBytes
+        )
+
+        #expect(!ModelSizing.requiresMemoryConfirmation(safety))
+    }
+
+    @Test("Process replacement also credits an outgoing audio-only lane")
+    func processReplacementCreditsAudioLane() throws {
+        let host = memorySnapshot(totalGB: 18, usedGB: 14.6)
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: host,
+            residency: residency(alias: "qwen3-asr", measuredGB: 6, modality: "audio"),
+            plan: .releaseResidentModels
+        ))
+
+        #expect(admission.plannedReleaseBytes == 6 * UInt64(1 << 30))
+        #expect(admission.snapshot.usedBytes < host.usedBytes)
+    }
+
+    @Test("No resident evidence preserves the ordinary live admission probe")
+    func noResidentLeavesAdmissionUnchanged() {
+        #expect(ServerManager.memoryAdmissionForTransition(
+            host: memorySnapshot(totalGB: 18, usedGB: 14.6),
+            residency: .empty,
+            plan: .releaseResidentModels
+        ) == nil)
+    }
+
+    @Test("Engine replacement projection produces a truthful insufficient-budget reason")
+    func replacementProjectionRejectionCopy() {
+        let gib = UInt64(1) << 30
+        let projection = ResidentReplacementProjection(
+            strategy: "evict_first_if_needed",
+            modelsToFree: [.init(id: "old-chat", estimatedBytes: 6 * gib)],
+            currentBytes: 12 * gib,
+            requestedBytes: 20 * gib,
+            projectedBytes: 26 * gib,
+            limitBytes: 24 * gib,
+            reason: "role_capacity_insufficient_after_eviction"
+        )
+
+        let message = projection.rejectionMessage(alias: "qwen3.8-27b-4bit")
+        #expect(message?.contains("release about 6 GB") == true)
+        #expect(message?.contains("26 GB") == true)
+        #expect(message?.contains("24 GB model-memory budget") == true)
+        #expect(message?.contains("close some apps") == false)
+    }
+
+    @Test("A keep-resident plan receives no release credit when both models fit")
+    func keepBothFitsWithoutEvictionCredit() throws {
+        let host = memorySnapshot(totalGB: 32, usedGB: 10)
+        let admission = try #require(ServerManager.memoryAdmissionForTransition(
+            host: host,
+            residency: residency(
+                alias: "qwen3.5-4b-4bit",
+                measuredGB: 4,
+                modality: "text"
+            ),
+            plan: .keepResidentModels
+        ))
+        #expect(admission.snapshot == host)
+        #expect(admission.plannedReleaseBytes == 0)
+        #expect(ModelSizing.memorySafety(
+            footprintGB: 4,
+            usedBytes: admission.snapshot.usedBytes,
+            totalBytes: admission.snapshot.totalBytes
+        ) == .safe)
+    }
+
+    private func memorySnapshot(totalGB: Double, usedGB: Double) -> MemoryProbe.Snapshot {
+        let gib = Double(UInt64(1) << 30)
+        return MemoryProbe.Snapshot(
+            totalBytes: UInt64(totalGB * gib),
+            usedBytes: UInt64(usedGB * gib)
+        )
+    }
+
+    private func residency(
+        alias: String,
+        measuredGB: Double,
+        modality: String
+    ) -> ModelResidencySnapshot {
+        let gib = Double(UInt64(1) << 30)
+        let measuredBytes = UInt64(measuredGB * gib)
+        let status = ResidentModelStatus(
+            id: alias,
+            modelPath: "repo/\(alias)",
+            aliases: [alias],
+            modality: modality,
+            state: "resident",
+            pinned: false,
+            primary: true,
+            activeRequests: 0,
+            estimatedBytes: measuredBytes,
+            measuredBytes: measuredBytes,
+            idleSeconds: 0
+        )
+        return ModelResidencySnapshot(
+            memoryLimitBytes: UInt64(18 * gib),
+            memoryUsedBytes: measuredBytes,
+            memoryAvailableBytes: nil,
+            idleTTLSeconds: 0,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [status]
+        )
+    }
+
     @Test("Residency load sends typed performance config and reload intent")
     func loadRequestCarriesPerformance() async throws {
         ResidencyLoadCaptureProtocol.capturedBody = nil
@@ -376,6 +576,8 @@ struct ModelResidencyTests {
             alias: "qwen3.5-4b-4bit",
             hfPath: "mlx-community/Qwen3.5-4B-MLX-4bit",
             estimatedSizeGB: 4,
+            replaceGroup: .assistant,
+            memoryPolicy: .evictFirstIfNeeded,
             imageMode: .editing,
             performance: ModelPerfConfig(
                 kvCacheMode: .turboquantK8V4,
@@ -394,6 +596,8 @@ struct ModelResidencyTests {
         let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
         let performance = try #require(json["performance"] as? [String: Any])
         #expect(json["reload_if_changed"] as? Bool == true)
+        #expect(json["replace_group"] as? String == "assistant")
+        #expect(json["memory_policy"] as? String == "evict_first_if_needed")
         #expect(json["image_mode"] as? String == "editing")
         #expect(performance["kv_cache_dtype"] == nil)
         #expect(performance["kv_cache_turboquant"] as? String == "k8v4")

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -214,7 +214,7 @@ struct ModelSizingTests {
         )
         #expect(w.title.contains("gemma-4-12b"))
         #expect(w.message.contains("121%"))
-        #expect(w.message.contains("release about 6 GB"))
+        #expect(w.message.contains("accounts for about 6 GB released"))
         #expect(w.message.contains("more memory than this Mac has"))
         #expect(w.message.contains("6 GB"))
         #expect(!w.message.contains("only about 9 GB is free"))

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -166,28 +166,29 @@ struct ModelSizingTests {
     func liveGuardCatchesLowFreeMemory() {
         let g = ModelSizing.estimate(alias: "gemma-4-12b") // ~11.8 GB
         let gib: UInt64 = 1 << 30
-        // 64 GB Mac with 50 GB already used → ~14 GB free; projected ~96%
-        // → unsafe. This is the reported near-crash: static classify says
-        // "fits a 64 GB Mac", but live free RAM can't take it.
-        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 50 * gib, totalBytes: 64 * gib) == .unsafe)
+        // 64 GB Mac with 50 GB already used projects to ~96%: advisory,
+        // but not a blocking confirmation while compression/swap can absorb it.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 50 * gib, totalBytes: 64 * gib) == .tight)
+        // Beyond physical RAM requires an explicit decision.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 55 * gib, totalBytes: 64 * gib) == .unsafe)
         // Same Mac idle → comfortable.
         #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 10 * gib, totalBytes: 64 * gib) == .safe)
-        // 32 GB Mac, 14 GB used → ~80% projected → tight (warn, allow).
-        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 14 * gib, totalBytes: 32 * gib) == .tight)
+        // 32 GB Mac, 14 GB used → ~80% projected → ordinary load.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 14 * gib, totalBytes: 32 * gib) == .safe)
     }
 
-    @Test("memorySafety: only >=85% blocks — the 75-85% band still loads")
+    @Test("memorySafety: 95% is advisory and only beyond 100% blocks")
     func liveGuardBlocksOnlyAtDangerLine() {
-        let g = ModelSizing.estimate(alias: "gemma-4-12b") // ~11.8 GB
         let gib: UInt64 = 1 << 30
-        // ServerManager holds a load for confirmation on `.unsafe` ONLY.
-        // 13 GiB used on a 32 GiB Mac projects to ~77.5%: a routine load
-        // on a mid-size Mac. It must classify `.tight`, not `.unsafe` —
-        // prompting here would fire on ordinary loads and train the user
-        // to click through the one prompt that actually matters.
-        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 13 * gib, totalBytes: 32 * gib) == .tight)
-        // Just over the 85% panic line on the same Mac → blocked.
-        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 16 * gib, totalBytes: 32 * gib) == .unsafe)
+        #expect(ModelSizing.memorySafety(
+            footprintGB: 1, usedBytes: 94 * gib, totalBytes: 100 * gib
+        ) == .tight)
+        #expect(ModelSizing.memorySafety(
+            footprintGB: 0, usedBytes: 100 * gib, totalBytes: 100 * gib
+        ) == .tight)
+        #expect(ModelSizing.memorySafety(
+            footprintGB: 1, usedBytes: 100 * gib, totalBytes: 100 * gib
+        ) == .unsafe)
         #expect(!ModelSizing.requiresMemoryConfirmation(.tight))
         #expect(ModelSizing.requiresMemoryConfirmation(.unsafe))
     }
@@ -208,12 +209,14 @@ struct ModelSizingTests {
     func memoryWarningCopy() {
         let w = ModelSizing.MemoryWarning(
             alias: "gemma-4-12b", hfPath: nil, isAutoRespawn: false,
-            severity: .unsafe, footprintGB: 5.9, freeGB: 8.8, totalGB: 24.0
+            severity: .unsafe, footprintGB: 5.9, freeGB: 0.8, totalGB: 24.0,
+            plannedReleaseGB: 6.3
         )
         #expect(w.title.contains("gemma-4-12b"))
-        #expect(w.message.contains("88%"))
-        #expect(w.message.contains("85%"))
-        #expect(w.message.contains("1 GB"))
+        #expect(w.message.contains("121%"))
+        #expect(w.message.contains("release about 6 GB"))
+        #expect(w.message.contains("more memory than this Mac has"))
+        #expect(w.message.contains("6 GB"))
         #expect(!w.message.contains("only about 9 GB is free"))
         #expect(w.confirmTitle.localizedCaseInsensitiveContains("anyway"))
     }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -517,7 +517,7 @@ struct QuickstartViewTests {
 
     /// Build an ``.unsafe`` memory warning for an alias — the shape
     /// ``ServerManager.start`` parks on when a Quickstart serve would push
-    /// live memory past the 85% panic line.
+    /// live memory beyond physical RAM.
     private func makeWarning(alias: String) -> ModelSizing.MemoryWarning {
         ModelSizing.MemoryWarning(
             alias: alias,
@@ -548,7 +548,7 @@ struct QuickstartViewTests {
                 == QuickstartCoordinator.lowMemoryChoice.alias
         )
 
-        // Under heavier pressure the 0.6B would trip the same guard. Do not
+        // Under heavier pressure the 1.2B would trip the same guard. Do not
         // advertise a reassuring switch that merely opens a second warning.
         let noSafeEscape = ModelSizing.MemoryWarning(
             alias: QuickstartCoordinator.defaultChoice.alias,
@@ -556,7 +556,7 @@ struct QuickstartViewTests {
             isAutoRespawn: false,
             severity: .unsafe,
             footprintGB: recoverable.footprintGB,
-            freeGB: 5.0,
+            freeGB: 3.0,
             totalGB: 18
         )
         #expect(QuickstartView.lowMemoryRecoveryChoice(for: noSafeEscape) == nil)

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -95,13 +95,14 @@ struct RAMBucketedDefaultTests {
         let gib = Double(UInt64(1) << 30)
         for tier in RAMBucketedDefault.tiers {
             for pick in tier.picks {
-                // The transition plan has already released the outgoing model.
-                // Pin the boundary at exactly physical RAM: advisory is allowed,
-                // but a curated pick must not be blocked as "risky" there.
-                let baselineGB = max(0, tier.floorGB - pick.footprintGB)
+                // Footprint and tier floor are independent measured/catalog
+                // values. A curated pick larger than its Mac is invalid even
+                // before live host pressure enters the projection.
+                #expect(pick.footprintGB <= tier.floorGB,
+                        "\(pick.alias) exceeds its own \(tier.floorGB) GB tier")
                 let safety = ModelSizing.memorySafety(
                     footprintGB: pick.footprintGB,
-                    usedBytes: UInt64(baselineGB * gib),
+                    usedBytes: 0,
                     totalBytes: UInt64(tier.floorGB * gib)
                 )
                 #expect(!ModelSizing.requiresMemoryConfirmation(safety),

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -90,6 +90,26 @@ struct RAMBucketedDefaultTests {
         #expect(tier96[1].alias == "qwen3.6-35b-4bit")
     }
 
+    @Test("A tier's measured smart and fast picks never trigger the risky confirmation")
+    func tierPicksStayBelowBlockingGuardrail() {
+        let gib = Double(UInt64(1) << 30)
+        for tier in RAMBucketedDefault.tiers {
+            for pick in tier.picks {
+                // The transition plan has already released the outgoing model.
+                // Pin the boundary at exactly physical RAM: advisory is allowed,
+                // but a curated pick must not be blocked as "risky" there.
+                let baselineGB = max(0, tier.floorGB - pick.footprintGB)
+                let safety = ModelSizing.memorySafety(
+                    footprintGB: pick.footprintGB,
+                    usedBytes: UInt64(baselineGB * gib),
+                    totalBytes: UInt64(tier.floorGB * gib)
+                )
+                #expect(!ModelSizing.requiresMemoryConfirmation(safety),
+                        "\(pick.alias) must load on its own \(tier.floorGB) GB tier")
+            }
+        }
+    }
+
     // MARK: - Launch flags travel with the recommendation, gated by RAM
 
     @Test("Flags apply only when the alias IS the pick for that Mac's RAM")

--- a/tests/test_mtp_stream_contract.py
+++ b/tests/test_mtp_stream_contract.py
@@ -3,12 +3,10 @@
 
 Background
 ----------
-``vllm_mlx/spec_decode/mtp/generator.py:226`` imports
-``generation_stream`` from ``mlx_lm.generate`` and runs every backbone /
-MTP forward inside ``with mx.stream(generation_stream): ... mx.eval(...)``
-blocks. The module-level ``generation_stream`` is set at
-``mlx_lm.generate`` import time to a ``mx.new_thread_local_stream(...)``
-bound to the importer thread.
+The vendored MTP generator runs every backbone/MTP forward inside
+``with mx.stream(generation_stream): ... mx.eval(...)`` blocks. mlx-lm's
+module-level ``generation_stream`` is mutable process state: each resident
+engine worker binds it to that worker's thread-local default stream.
 
 Production paths route around this via
 ``engine_core._init_mlx_step_thread`` which, when the ``mlx-step``
@@ -25,9 +23,10 @@ runs ``mtp_generate_step`` on the pytest main thread crashes at
 
     RuntimeError: There is no Stream(gpu, N) in current thread.
 
-The fix is in the MTP test autouse fixtures: re-bind
-``mlx_lm.generate.generation_stream`` to **this** thread's default
-stream at setup. This file pins both:
+The production fix binds ``mx.default_stream(mx.default_device())`` when the
+MTP generator begins execution on its scheduler-owned step thread, instead of
+consuming that mutable global. Test fixtures still restore the global for
+older direct mlx-lm paths exercised in the suite. This file pins both:
 
   1. **Static guard** — neither MTP test fixture body is allowed to
      call ``mx.new_stream(...)`` or ``mx.new_thread_local_stream(...)``.
@@ -36,15 +35,10 @@ stream at setup. This file pins both:
      fixture used ``mx.new_stream`` and was the immediate cause of the
      7-test crash cluster).
 
-  2. **Dynamic contract** — manually pollute
-     ``mlx_lm.generate.generation_stream`` from a worker thread
-     (simulating what the ``mlx-step`` initialiser does in the real
-     sweep), then run ``mtp_generate_step`` end-to-end on the main
-     thread and assert it does NOT raise. With the buggy fixture (or
-     no fixture at all) this test reproduces the
-     ``Stream(gpu, N) in current thread`` crash; with the fix it
-     passes cleanly because the autouse fixture re-binds
-     ``generation_stream`` before the test body runs.
+  2. **Dynamic production contract** — manually pollute
+     ``mlx_lm.generate.generation_stream`` from a worker thread (the second
+     resident load), then run ``mtp_generate_step`` directly without a
+     fixture reset. It must ignore the foreign stream and complete cleanly.
 """
 
 from __future__ import annotations
@@ -281,56 +275,25 @@ def test_mtp_fixture_setup_restores_generation_stream_after_worker_pollution(
             pass
 
 
-@pytest.mark.parametrize(
-    "test_module_name",
-    ["tests.test_mtp_spec_decode", "tests.test_mtp_lossless"],
-)
-def test_mtp_generate_step_survives_worker_pollution_via_fixture(
-    test_module_name: str,
-):
-    """End-to-end: pollute ``generation_stream`` from a worker thread,
-    drive the MTP autouse fixture's setup, then run ``mtp_generate_step``
-    and assert it yields tokens cleanly.
+def test_mtp_generate_step_owns_stream_after_second_resident_pollution():
+    """A second resident's worker cannot poison the primary MTP generator.
 
-    This is the highest-confidence regression guard: it exercises the
-    EXACT code path that crashes in the failing sweep (``mtp_generate_step``
-    on the pytest main thread, after a worker re-bound
-    ``generation_stream``) and routes recovery through the fixture
-    function under test. No inline reset.
-
-    Codex r2 BLOCKING defense — codex worried that importing
-    ``mtp_generate_step`` BEFORE pollution would let ``generator.py``
-    capture a pre-pollution stream and mask a broken fixture. The
-    concern is empirically false on the current production code path
-    because ``generator.py:226`` does
-    ``from mlx_lm.generate import generation_stream`` INSIDE
-    ``mtp_generate_step``'s body (function-scope, re-read on every
-    call) — verified by
-    ``test_mtp_generator_reads_generation_stream_at_call_time``
-    below. But we still order the imports defensively (pollute FIRST,
-    then import) so a future move of the import to module scope is
-    caught by THIS test rather than silently masking the regression.
+    Loading another resident engine rebinds mlx-lm's process-global stream on
+    that worker. The original MTP primary still executes on its own scheduler
+    thread, so the generator must ignore the foreign global and bind that
+    execution thread's default stream before any model/cache work.
     """
-    # Pollute BEFORE importing ``mtp_generate_step`` — defends against
-    # any future regression that moves the ``from mlx_lm.generate
-    # import generation_stream`` line out of the function body and
-    # into module scope (see paired
-    # ``test_mtp_generator_reads_generation_stream_at_call_time``).
     _pollute_generation_stream_from_worker()
 
     from tests.test_mtp_spec_decode import _MockedQwen35Model
     from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
     from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
 
-    mod = __import__(test_module_name, fromlist=["_reset_mtp_module_state"])
-    fixture_func = _unwrap_fixture_func(mod._reset_mtp_module_state)
-
-    gen = fixture_func()
-    next(gen)
+    polluted = sys.modules["mlx_lm.generate"].generation_stream
     try:
-        # ``mtp_generate_step`` runs against ``mlx_lm.generate.generation_stream``
-        # as set up by the fixture. If the fixture is broken, this crashes
-        # at generator.py:420 (``mx.eval(toks)``).
+        with pytest.raises(RuntimeError, match="Stream"), mx.stream(polluted):
+            _ = (mx.array([1.0]) + mx.array([2.0])).item()
+
         backbone = [7, 11, 13]
         mtp_script = [11]
         model = _MockedQwen35Model(backbone, mtp_script)
@@ -344,70 +307,35 @@ def test_mtp_generate_step_survives_worker_pollution_via_fixture(
                 accept_counter=counter,
             )
         )
+        assert sys.modules["mlx_lm.generate"].generation_stream is polluted
         assert len(emitted) == 3, (
             "mtp_generate_step did not yield the expected 3 tokens — "
-            "the autouse fixture's stream restoration logic is likely "
-            f"broken. Got: {emitted}"
+            "the generator did not bind the scheduler thread's stream. "
+            f"Got: {emitted}"
         )
     finally:
-        try:
-            next(gen)
-        except StopIteration:
-            pass
+        sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
+            mx.default_device()
+        )
 
 
 # ---------------------------------------------------------------------------
-# 3. Production-code contract — the function-scope import is load-bearing
+# 3. Production-code contract — stream ownership is established at execution
 # ---------------------------------------------------------------------------
 
 
-def test_mtp_generator_reads_generation_stream_at_call_time():
-    """``mtp_generate_step`` MUST import ``generation_stream`` at
-    function-call time (function-scope import), not at module-import
-    time (module-scope ``from mlx_lm.generate import generation_stream``).
-
-    The fixture's restoration works by rebinding
-    ``sys.modules['mlx_lm.generate'].generation_stream``. That rebind
-    only flows through to ``mtp_generate_step`` if the function looks
-    up the attribute at every call. If a future refactor moves the
-    import to module scope, the rebind no longer affects already-
-    imported modules and the 7-test crash cluster comes back —
-    silently, because the fixture would still LOOK like it's
-    restoring the stream.
-
-    Codex r2 BLOCKING #1 flagged this exact concern. Pin it here so
-    the regression guard fires loudly if anyone hoists the import.
-
-    Implementation:
-
-    1. Module-scope: ``vllm_mlx.spec_decode.mtp.generator.generation_stream``
-       attribute MUST NOT exist.
-    2. Function source: ``mtp_generate_step``'s source MUST contain
-       a ``from mlx_lm.generate import generation_stream`` line.
-
-    Both checks are AST/source-text based — no runtime import order
-    games.
-    """
+def test_mtp_generator_binds_execution_thread_default_stream():
+    """The vendored generator must not consume mlx-lm's mutable global."""
     import vllm_mlx.spec_decode.mtp.generator as generator_mod
 
-    # 1. Module-scope check.
     assert not hasattr(generator_mod, "generation_stream"), (
-        "`vllm_mlx.spec_decode.mtp.generator.generation_stream` exists "
-        "as a module-level attribute. This means someone moved the "
-        "`from mlx_lm.generate import generation_stream` import out of "
-        "`mtp_generate_step`'s body and into module scope. That breaks "
-        "the test fixture's restoration path because rebinding "
-        "`sys.modules['mlx_lm.generate'].generation_stream` no longer "
-        "affects already-imported modules. Move the import back inside "
-        "`mtp_generate_step` (see generator.py:226 baseline)."
+        "the MTP module must not cache a process-global generation stream"
     )
 
-    # 2. Function-source check.
     src = textwrap.dedent(inspect.getsource(generator_mod.mtp_generate_step))
-    assert "from mlx_lm.generate import generation_stream" in src, (
-        "`mtp_generate_step` no longer imports `generation_stream` at "
-        "call time. The function-scope import is load-bearing — the "
-        "test fixture's stream restoration relies on the function "
-        "looking up `mlx_lm.generate.generation_stream` afresh on every "
-        "call. See generator.py:226 baseline."
+    assert "from mlx_lm.generate import maybe_quantize_kv_cache" in src
+    assert "from mlx_lm.generate import generation_stream" not in src
+    assert "generation_stream = mx.default_stream(mx.default_device())" in src, (
+        "mtp_generate_step must bind the scheduler execution thread's default "
+        "stream before model/cache work"
     )

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1395,6 +1395,88 @@ async def test_evict_first_falls_back_to_safe_admission_without_group_metadata()
 
 
 @pytest.mark.asyncio
+async def test_evict_first_never_subtracts_unattributed_process_footprint():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    footprint = [4 * GIB]
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: footprint[0],
+    )
+    footprint[0] = 6 * GIB
+    # Only the 2 GiB growth after manager configuration is attributable to the
+    # startup model; the 4 GiB server baseline cannot be projected as freed.
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
+        )
+
+    projection = exc_info.value.replacement_projection
+    assert projection is not None
+    assert projection.reason == "role_capacity_insufficient_after_eviction"
+    assert projection.current_bytes == 6 * GIB
+    assert projection.projected_bytes == 8 * GIB
+    loader.assert_not_awaited()
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_evict_first_credits_only_attributed_startup_model_footprint():
+    footprint = [2 * GIB]
+
+    class FootprintEngine(FakeLifecycleEngine):
+        async def stop(self):
+            await super().stop()
+            footprint[0] = 2 * GIB
+
+    registry = ModelRegistry()
+    old_engine = FootprintEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is True
+        assert footprint[0] == 2 * GIB
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: footprint[0],
+    )
+    footprint[0] = 6 * GIB
+    primary_record = manager.register_primary(primary, estimated_bytes=4 * GIB)
+    assert primary_record.measured_bytes == 4 * GIB
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
+    )
+
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.strategy == "evict_first"
+    assert replacement.replacement_projection.current_bytes == 6 * GIB
+    assert replacement.replacement_projection.projected_bytes == 6 * GIB
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
 async def test_busy_reject_precedes_unrelated_capacity_eviction():
     registry = ModelRegistry()
     chat_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1195,6 +1195,94 @@ async def test_evict_first_primary_callback_failure_reopens_old_admission():
 
 
 @pytest.mark.asyncio
+async def test_evict_first_partial_target_publication_is_cleared_on_failure():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    published: list[ModelEntry | None] = [primary]
+    loaded: list[FakeEngine] = []
+    handoff = Mock()
+
+    async def loader(name: str, path: str | None, performance=None):
+        replacement = entry(name)
+        loaded.append(replacement.engine)
+        return replacement
+
+    def publish_then_fail(replacement):
+        published[0] = replacement
+        if replacement is not None:
+            raise RuntimeError("parser construction failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=publish_then_fail,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="parser construction failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert loaded[0].stopped is True
+    assert published == [None]
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+    handoff.commit.assert_called_once_with(None)
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_cleanup_callback_failure_does_not_mask_publish_error(caplog):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    none_calls = 0
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    def fail_publish_and_cleanup(replacement):
+        nonlocal none_calls
+        if replacement is None:
+            none_calls += 1
+            if none_calls == 2:
+                raise RuntimeError("cleanup clear failed")
+            return
+        raise RuntimeError("original publish failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: Mock(),
+        on_primary_changed=fail_publish_and_cleanup,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="original publish failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert "Failed to clear rejected replacement primary" in caplog.text
+    assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
 async def test_replacement_rejects_before_eviction_when_target_still_does_not_fit():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -895,6 +895,67 @@ async def test_replacement_keeps_rollback_path_when_both_models_fit():
 
 
 @pytest.mark.asyncio
+async def test_keep_then_commit_preserves_existing_idle_lru_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
+    spare_engine = FakeImageEngine()
+    spare = entry("spare-image", spare_engine)
+    registry.add(primary, is_default=True)
+    registry.add(image)
+    registry.add(spare)
+    load_observations: list[tuple[bool, bool]] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        load_observations.append((old_engine.stopped, image_engine.stopped))
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=13 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=4 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=spare,
+            estimated_bytes=1 * GIB,
+            loaded_at=1,
+            last_used_at=1,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=8 * GIB,
+        replace_group="assistant",
+    )
+
+    assert load_observations == [(False, True)]
+    assert old_engine.stopped is True
+    assert spare_engine.stopped is False
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.strategy == "keep_then_commit"
+    assert replacement.replacement_projection.models_to_free == (
+        ("image", 4 * GIB),
+        ("chat-old", 4 * GIB),
+    )
+
+
+@pytest.mark.asyncio
 async def test_replacement_evicts_first_only_when_that_makes_target_fit():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()
@@ -947,6 +1008,65 @@ async def test_replacement_evicts_first_only_when_that_makes_target_fit():
     assert primary_changes == [None, "chat-new"]
     handoff.commit.assert_called_once_with(replacement.entry)
     handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_projection_reuses_idle_lru_for_remaining_capacity():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
+    spare_engine = FakeImageEngine()
+    spare = entry("spare-image", spare_engine)
+    registry.add(primary, is_default=True)
+    registry.add(image)
+    registry.add(spare)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is True
+        assert image_engine.stopped is True
+        assert spare_engine.stopped is False
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=12 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=6 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=spare,
+            estimated_bytes=1 * GIB,
+            loaded_at=1,
+            last_used_at=1,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=10 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+    )
+
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.models_to_free == (
+        ("chat-old", 4 * GIB),
+        ("image", 6 * GIB),
+    )
+    assert replacement.replacement_projection.projected_bytes == 11 * GIB
+    assert registry.default_name == "chat-new"
 
 
 @pytest.mark.asyncio
@@ -1031,6 +1151,47 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
     handoff.rollback.assert_not_called()
     assert registry.default_name is None
     assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
+async def test_evict_first_primary_callback_failure_reopens_old_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+
+    def fail_clear(replacement):
+        assert replacement is None
+        raise RuntimeError("primary clear failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=fail_clear,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="primary clear failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    loader.assert_not_awaited()
+    handoff.rollback.assert_called_once_with()
+    handoff.commit.assert_not_called()
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["chat-old"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -855,6 +856,225 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     assert "chat-new" not in registry
     assert "chat-new" not in loaded
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
+
+
+@pytest.mark.asyncio
+async def test_replacement_keeps_rollback_path_when_both_models_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is False
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=10 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+    )
+
+    projection = replacement.replacement_projection
+    assert projection is not None
+    assert projection.strategy == "keep_then_commit"
+    assert projection.reason == "keep_both_fits"
+    assert projection.models_to_free == (("chat-old", 4 * GIB),)
+    assert projection.projected_bytes == 4 * GIB
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_replacement_evicts_first_only_when_that_makes_target_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    load_observations: list[tuple[bool, str | None]] = []
+    primary_changes: list[str | None] = []
+    handoff = Mock()
+
+    async def loader(name: str, path: str | None, performance=None):
+        load_observations.append((old_engine.stopped, registry.default_name))
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda replacement: primary_changes.append(
+            replacement.model_name if replacement is not None else None
+        ),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        replace_mode="wait",
+        memory_policy="evict_first_if_needed",
+    )
+
+    assert load_observations == [(True, None)]
+    projection = replacement.replacement_projection
+    assert projection is not None
+    assert projection.payload() == {
+        "strategy": "evict_first",
+        "reason": "role_capacity_evict_first_required",
+        "models_to_free": [{"id": "chat-old", "estimated_bytes": 4 * GIB}],
+        "current_bytes": 4 * GIB,
+        "requested_bytes": 4 * GIB,
+        "projected_bytes": 4 * GIB,
+        "limit_bytes": 6 * GIB,
+    }
+    assert replacement.primary is True
+    assert replacement.pinned is True
+    assert registry.default_name == "chat-new"
+    assert old_engine.pauses == [("wait", None)]
+    assert primary_changes == [None, "chat-new"]
+    handoff.commit.assert_called_once_with(replacement.entry)
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_load_failure_reports_primary_absent_without_rollback():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    primary_changes: list[str | None] = []
+    handoff_commits: list[str | None] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        raise ImportError("replacement checkpoint is unavailable")
+
+    class Handoff:
+        def __init__(self):
+            self.rollback = Mock()
+
+        def commit(self, replacement):
+            handoff_commits.append(
+                replacement.model_name if replacement is not None else None
+            )
+
+    handoff = Handoff()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda replacement: primary_changes.append(
+            replacement.model_name if replacement is not None else None
+        ),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ImportError, match="unavailable"):
+        await manager.load(
+            "chat-invalid",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert old_engine.stopped is True
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+    assert primary_changes == [None]
+    assert handoff_commits == [None]
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
+    registry = ModelRegistry()
+    old_engine = FailingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda _entry: None,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    loader.assert_not_awaited()
+    handoff.commit.assert_called_once_with(None)
+    handoff.rollback.assert_not_called()
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
+async def test_replacement_rejects_before_eviction_when_target_still_does_not_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        await manager.load(
+            "chat-too-large",
+            estimated_bytes=8 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    projection = exc_info.value.replacement_projection
+    assert projection is not None
+    assert projection.strategy == "reject"
+    assert projection.reason == "role_capacity_insufficient_after_eviction"
+    assert projection.projected_bytes == 8 * GIB
+    loader.assert_not_awaited()
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_unknown_memory_policy():
+    manager, _, _, _ = manager_fixture()
+
+    with pytest.raises(ResidentModelError, match="unsupported memory policy"):
+        await manager.load("chat-new", memory_policy="invented")
 
 
 @pytest.mark.asyncio
@@ -1964,6 +2184,90 @@ def test_residency_control_plane_forwards_abort_replacement_policy(monkeypatch):
     assert response.status_code == 200
     assert old_engine.pauses == [("abort", None)]
     assert registry.default_name == "chat-new"
+    assert response.json()["replacement_projection"] == {
+        "strategy": "keep_then_commit",
+        "reason": "keep_both_fits",
+        "models_to_free": [{"id": "chat-old", "estimated_bytes": 4 * GIB}],
+        "current_bytes": 4 * GIB,
+        "requested_bytes": response.json()["estimated_bytes"],
+        "projected_bytes": response.json()["estimated_bytes"],
+        "limit_bytes": 0,
+    }
+
+
+def test_residency_control_plane_returns_typed_replacement_capacity_projection(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    install_exception_handlers(app)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-too-large",
+                "estimated_size_gb": 8,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 507
+    assert response.json() == {
+        "error": {
+            "message": (
+                "resident model memory ceiling exceeded after projected "
+                "assistant replacement"
+            ),
+            "type": "insufficient_capacity_error",
+            "code": "insufficient_capacity_error",
+            "param": "estimated_size_gb",
+        },
+        "replacement_projection": {
+            "strategy": "reject",
+            "reason": "role_capacity_insufficient_after_eviction",
+            "models_to_free": [{"id": "chat", "estimated_bytes": 4 * GIB}],
+            "current_bytes": 4 * GIB,
+            "requested_bytes": 8 * GIB,
+            "projected_bytes": 8 * GIB,
+            "limit_bytes": 6 * GIB,
+        },
+    }
+    assert loaded == {}
+    assert registry.default_name == "chat"
+
+
+def test_residency_control_plane_preserves_generic_capacity_error(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, _, _, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={"model": "image-too-large", "estimated_size_gb": 8},
+        )
+
+    assert response.status_code == 507
+    assert "memory ceiling exceeded" in response.json()["detail"]
 
 
 def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2564,6 +2564,78 @@ def test_residency_control_plane_returns_typed_replacement_capacity_projection(
     assert registry.default_name == "chat"
 
 
+def test_residency_control_plane_uses_model_path_group_for_destructive_admission(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    profiles = {
+        "chat-alias": SimpleNamespace(modality="text"),
+        "repo/image": SimpleNamespace(modality="image-gen"),
+    }
+    monkeypatch.setattr("vllm_mlx.routes.residency.resolve_profile", profiles.get)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-alias",
+                "model_path": "repo/image",
+                "estimated_size_gb": 4,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 409
+    assert "image-gen" in response.json()["detail"]
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
+
+
+def test_residency_unknown_model_path_falls_back_to_safe_admission(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.resolve_profile",
+        lambda name: SimpleNamespace(modality="text") if name == "chat-alias" else None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-alias",
+                "model_path": "/unknown/local/checkpoint",
+                "estimated_size_gb": 4,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 507
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
+
+
 def test_residency_control_plane_preserves_generic_capacity_error(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -987,6 +987,7 @@ async def test_replacement_evicts_first_only_when_that_makes_target_fit():
         replace_group="assistant",
         replace_mode="wait",
         memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
     )
 
     assert load_observations == [(True, None)]
@@ -1058,6 +1059,7 @@ async def test_evict_first_projection_reuses_idle_lru_for_remaining_capacity():
         estimated_bytes=10 * GIB,
         replace_group="assistant",
         memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
     )
 
     assert replacement.replacement_projection is not None
@@ -1110,6 +1112,7 @@ async def test_evict_first_load_failure_reports_primary_absent_without_rollback(
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert old_engine.stopped is True
@@ -1144,6 +1147,7 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     loader.assert_not_awaited()
@@ -1182,6 +1186,7 @@ async def test_evict_first_primary_callback_failure_reopens_old_admission():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     loader.assert_not_awaited()
@@ -1242,6 +1247,7 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert loaded[0].stopped is True
@@ -1289,6 +1295,7 @@ async def test_evict_first_cleanup_callback_failure_does_not_mask_publish_error(
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert "Failed to clear rejected replacement primary" in caplog.text
@@ -1317,6 +1324,7 @@ async def test_replacement_rejects_before_eviction_when_target_still_does_not_fi
             estimated_bytes=8 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     projection = exc_info.value.replacement_projection
@@ -1337,6 +1345,53 @@ async def test_manager_rejects_unknown_memory_policy():
 
     with pytest.raises(ResidentModelError, match="unsupported memory policy"):
         await manager.load("chat-new", memory_policy="invented")
+
+
+@pytest.mark.asyncio
+async def test_evict_first_rejects_known_wrong_group_before_retiring_primary():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelError, match="image-gen.*not 'assistant'"):
+        await manager.load(
+            "image-model",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="image-gen",
+        )
+
+    loader.assert_not_awaited()
+    assert old_engine.pauses == []
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_evict_first_falls_back_to_safe_admission_without_group_metadata():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+
+    with pytest.raises(ResidentModelCapacityError):
+        await manager.load(
+            "unknown-model",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1199,7 +1199,10 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()
     primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
     registry.add(primary, is_default=True)
+    registry.add(image)
     published: list[ModelEntry | None] = [primary]
     loaded: list[FakeEngine] = []
     handoff = Mock()
@@ -1223,6 +1226,15 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
         on_primary_changed=publish_then_fail,
     )
     manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=1 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+            pinned=True,
+        )
+    )
 
     with pytest.raises(RuntimeError, match="parser construction failed"):
         await manager.load(
@@ -1235,7 +1247,8 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
     assert loaded[0].stopped is True
     assert published == [None]
     assert registry.default_name is None
-    assert manager.snapshot()["models"] == []
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["image"]
+    assert image_engine.stopped is False
     handoff.commit.assert_called_once_with(None)
     handoff.rollback.assert_not_called()
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1158,6 +1158,55 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
 
 
 @pytest.mark.asyncio
+async def test_evict_first_sibling_stop_failure_preserves_primary_publication():
+    registry = ModelRegistry()
+    sibling_engine = FailingStopLifecycleEngine()
+    sibling = entry("chat-sibling", sibling_engine)
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    registry.add(sibling)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+    primary_changes: list[ModelEntry | None] = []
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=primary_changes.append,
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=sibling,
+            estimated_bytes=1 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
+        )
+
+    loader.assert_not_awaited()
+    handoff.rollback.assert_called_once_with()
+    handoff.commit.assert_not_called()
+    assert primary_changes == []
+    assert primary_engine.stopped is False
+    assert primary_engine.paused is False
+    assert registry.default_name == "chat-primary"
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["chat-primary"]
+
+
+@pytest.mark.asyncio
 async def test_evict_first_primary_callback_failure_reopens_old_admission():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -59,6 +59,9 @@ class ModelLoadRequest(BaseModel):
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: StrictBool = False
     replace_mode: Literal["reject", "wait", "abort"] = "reject"
+    memory_policy: Literal["keep_then_commit", "evict_first_if_needed"] = (
+        "evict_first_if_needed"
+    )
 
 
 class ModelPinRequest(BaseModel):
@@ -154,11 +157,26 @@ async def load_resident_model(request: ModelLoadRequest):
             performance=performance,
             reload_if_changed=request.reload_if_changed,
             replace_mode=request.replace_mode,
+            memory_policy=request.memory_policy,
         )
     except HTTPException:
         raise
     except ResidentModelCapacityError as exc:
-        raise HTTPException(status_code=507, detail=str(exc)) from exc
+        projection = exc.replacement_projection
+        if projection is None:
+            raise HTTPException(status_code=507, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=507,
+            detail={
+                "error": {
+                    "message": str(exc),
+                    "type": "insufficient_capacity_error",
+                    "code": "insufficient_capacity_error",
+                    "param": "estimated_size_gb",
+                },
+                "replacement_projection": projection.payload(),
+            },
+        ) from exc
     except ResidentModelError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except Exception as exc:

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -127,6 +127,13 @@ async def load_resident_model(request: ModelLoadRequest):
         profile = resolve_profile(request.model) or (
             resolve_profile(request.model_path) if request.model_path else None
         )
+        resolved_group = None
+        if profile is not None:
+            resolved_group = (
+                "assistant"
+                if profile.modality in {"text", "vision"}
+                else profile.modality
+            )
         if (
             performance is not None
             and profile is not None
@@ -158,6 +165,7 @@ async def load_resident_model(request: ModelLoadRequest):
             reload_if_changed=request.reload_if_changed,
             replace_mode=request.replace_mode,
             memory_policy=request.memory_policy,
+            resolved_group=resolved_group,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -124,9 +124,15 @@ async def load_resident_model(request: ModelLoadRequest):
         performance = (
             request.performance.runtime_value() if request.performance else None
         )
-        profile = resolve_profile(request.model) or (
+        model_profile = resolve_profile(request.model)
+        path_profile = (
             resolve_profile(request.model_path) if request.model_path else None
         )
+        # The loader consumes model_path when supplied, so only that
+        # checkpoint's metadata may authorize destructive admission. An
+        # unknown override falls back to keep-then-commit rather than trusting
+        # the request-facing alias for different weights.
+        profile = path_profile if request.model_path else model_profile
         resolved_group = None
         if profile is not None:
             resolved_group = (

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -928,15 +928,25 @@ class ResidentModelManager:
             handoff = self._on_primary_handoff(old_primary.entry)
         destructive_started = False
         try:
+            # Retire sibling assistants while the healthy primary remains
+            # published. A sibling stop failure can therefore roll back the
+            # handoff without stranding the server's default route.
+            for record in candidates:
+                if record is old_primary:
+                    continue
+                record.pinned = False
+                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
             if old_primary is not None:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(None)
                 self.registry.clear_default()
                 destructive_started = True
-            for record in candidates:
-                record.primary = False
-                record.pinned = False
-                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
+                old_primary.primary = False
+                old_primary.pinned = False
+                await self._evict_locked(
+                    old_primary,
+                    reason=f"replace_{group}_evict_first",
+                )
         except BaseException:
             if handoff is not None:
                 if destructive_started:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -546,19 +546,7 @@ class ResidentModelManager:
         if self.memory_limit_bytes <= 0:
             return
         while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
-            candidates = sorted(
-                (
-                    record
-                    for record in self._records.values()
-                    if record.model_id not in exclude
-                    and not record.pinned
-                    and not record.primary
-                    and record.active_requests == 0
-                    and record.state == "resident"
-                    and _engine_is_idle(record.entry.engine)
-                ),
-                key=lambda record: record.last_used_at,
-            )
+            candidates = self._eviction_candidates_locked(exclude)
             if not candidates:
                 usage = self._accounted_usage()
                 raise ResidentModelCapacityError(
@@ -569,6 +557,23 @@ class ResidentModelManager:
                     "no idle unpinned model is eligible for eviction"
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
+
+    def _eviction_candidates_locked(self, exclude: set[str]) -> list[ResidencyRecord]:
+        """Return the exact idle-LRU order used by admission and eviction."""
+
+        return sorted(
+            (
+                record
+                for record in self._records.values()
+                if record.model_id not in exclude
+                and not record.pinned
+                and not record.primary
+                and record.active_requests == 0
+                and record.state == "resident"
+                and _engine_is_idle(record.entry.engine)
+            ),
+            key=lambda record: record.last_used_at,
+        )
 
     async def load(
         self,
@@ -672,8 +677,8 @@ class ResidentModelManager:
                             "assistant replacement",
                             replacement_projection=projection,
                         )
-                    destructive_replacement = projection.strategy == "evict_first"
-                    if destructive_replacement:
+                    evict_first = projection.strategy == "evict_first"
+                    if evict_first:
                         if replace_mode != "reject":
                             (
                                 candidates,
@@ -688,6 +693,7 @@ class ResidentModelManager:
                             candidates,
                             replace_group,
                         )
+                        destructive_replacement = True
                         paused_engines = []
                 await self._evict_for_locked(
                     estimate,
@@ -793,40 +799,77 @@ class ResidentModelManager:
         current = self._accounted_usage()
         limit = self.memory_limit_bytes
         keep_projected = current + incoming_bytes
-        releasable = tuple(
+        replacement_releasable = tuple(
             (record.model_id, max(record.estimated_bytes, record.measured_bytes))
             for record in candidates
         )
-        evict_projected = (
-            max(0, current - sum(size for _, size in releasable)) + incoming_bytes
+        replacement_ids = {record.model_id for record in candidates}
+        idle_releasable = tuple(
+            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
+            for record in self._eviction_candidates_locked(replacement_ids)
         )
+        replacement_bytes = sum(size for _, size in replacement_releasable)
+        evict_projected = max(0, current - replacement_bytes) + incoming_bytes
         if limit <= 0 or keep_projected <= limit:
             return ReplacementProjection(
                 strategy="keep_then_commit",
                 reason="keep_both_fits",
-                models_to_free=releasable,
+                models_to_free=replacement_releasable,
                 current_bytes=current,
                 requested_bytes=incoming_bytes,
                 projected_bytes=evict_projected,
                 limit_bytes=limit,
             )
-        if memory_policy == "evict_first_if_needed" and evict_projected <= limit:
-            return ReplacementProjection(
-                strategy="evict_first",
-                reason="role_capacity_evict_first_required",
-                models_to_free=releasable,
-                current_bytes=current,
-                requested_bytes=incoming_bytes,
-                projected_bytes=evict_projected,
-                limit_bytes=limit,
+        if memory_policy == "evict_first_if_needed":
+            selected = list(replacement_releasable)
+            for item in idle_releasable:
+                if evict_projected <= limit:
+                    break
+                selected.append(item)
+                evict_projected = max(0, evict_projected - item[1])
+            if evict_projected <= limit:
+                return ReplacementProjection(
+                    strategy="evict_first",
+                    reason="role_capacity_evict_first_required",
+                    models_to_free=tuple(selected),
+                    current_bytes=current,
+                    requested_bytes=incoming_bytes,
+                    projected_bytes=evict_projected,
+                    limit_bytes=limit,
+                )
+        else:
+            selected_idle: list[tuple[str, int]] = []
+            keep_after_lru = keep_projected
+            for item in idle_releasable:
+                if keep_after_lru <= limit:
+                    break
+                selected_idle.append(item)
+                keep_after_lru = max(0, keep_after_lru - item[1])
+            if keep_after_lru <= limit:
+                return ReplacementProjection(
+                    strategy="keep_then_commit",
+                    reason="keep_both_fits",
+                    models_to_free=tuple(selected_idle) + replacement_releasable,
+                    current_bytes=current,
+                    requested_bytes=incoming_bytes,
+                    projected_bytes=max(0, keep_after_lru - replacement_bytes),
+                    limit_bytes=limit,
+                )
+        all_releasable = replacement_releasable + idle_releasable
+        projected_after_all = (
+            max(
+                0,
+                current - sum(size for _, size in all_releasable),
             )
+            + incoming_bytes
+        )
         return ReplacementProjection(
             strategy="reject",
             reason="role_capacity_insufficient_after_eviction",
-            models_to_free=releasable,
+            models_to_free=all_releasable,
             current_bytes=current,
             requested_bytes=incoming_bytes,
-            projected_bytes=evict_projected,
+            projected_bytes=projected_after_all,
             limit_bytes=limit,
         )
 
@@ -841,18 +884,23 @@ class ResidentModelManager:
         handoff = None
         if old_primary is not None and self._on_primary_handoff is not None:
             handoff = self._on_primary_handoff(old_primary.entry)
+        destructive_started = False
         try:
             if old_primary is not None:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(None)
                 self.registry.clear_default()
+                destructive_started = True
             for record in candidates:
                 record.primary = False
                 record.pinned = False
                 await self._evict_locked(record, reason=f"replace_{group}_evict_first")
         except BaseException:
             if handoff is not None:
-                handoff.commit(None)
+                if destructive_started:
+                    handoff.commit(None)
+                else:
+                    handoff.rollback()
             raise
         return handoff, old_primary is not None
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -29,6 +29,15 @@ class ResidentModelError(RuntimeError):
 class ResidentModelCapacityError(ResidentModelError):
     """The configured ceiling cannot admit a model after eligible eviction."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        replacement_projection: ReplacementProjection | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.replacement_projection = replacement_projection
+
 
 class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
@@ -74,6 +83,33 @@ class ResidentPerformanceConfig:
                 "cache_memory_mb": self.cache_memory_mb,
             }.items()
             if value is not None
+        }
+
+
+@dataclass(frozen=True)
+class ReplacementProjection:
+    """Admission truth for one assistant replacement request."""
+
+    strategy: str
+    reason: str
+    models_to_free: tuple[tuple[str, int], ...]
+    current_bytes: int
+    requested_bytes: int
+    projected_bytes: int
+    limit_bytes: int
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "reason": self.reason,
+            "models_to_free": [
+                {"id": model_id, "estimated_bytes": estimated_bytes}
+                for model_id, estimated_bytes in self.models_to_free
+            ],
+            "current_bytes": self.current_bytes,
+            "requested_bytes": self.requested_bytes,
+            "projected_bytes": self.projected_bytes,
+            "limit_bytes": self.limit_bytes,
         }
 
 
@@ -164,6 +200,7 @@ class ResidencyRecord:
     state: str = "resident"
     measured_bytes: int = 0
     performance: ResidentPerformanceConfig | None = None
+    replacement_projection: ReplacementProjection | None = None
     lease_idle: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
 
     def __post_init__(self) -> None:
@@ -545,11 +582,14 @@ class ResidentModelManager:
         performance: ResidentPerformanceConfig | None = None,
         reload_if_changed: bool = False,
         replace_mode: str = "reject",
+        memory_policy: str = "keep_then_commit",
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
             raise ResidentModelError("model must not be empty")
         estimate = max(1, estimated_bytes or estimate_model_bytes(model_name))
+        if memory_policy not in {"keep_then_commit", "evict_first_if_needed"}:
+            raise ResidentModelError(f"unsupported memory policy {memory_policy!r}")
 
         async with self._lock:
             canonical = self._canonical(model_name)
@@ -600,12 +640,16 @@ class ResidentModelManager:
             record: ResidencyRecord | None = None
             candidates: list[ResidencyRecord] = []
             paused_engines: list[object] = []
+            destructive_handoff: PrimaryHandoffLease | None = None
+            destructive_primary = False
+            destructive_replacement = False
+            projection: ReplacementProjection | None = None
             try:
                 if replace_group is not None:
                     if replace_mode == "reject":
-                        # Reject is a non-destructive preflight: close admission
-                        # only after proving the old assistant is already idle,
-                        # so a busy rejection cannot evict unrelated residents.
+                        # Preserve the established busy-before-capacity
+                        # contract without evicting anything: the zero-timeout
+                        # pause closes admission while the projection is read.
                         (
                             candidates,
                             paused_engines,
@@ -613,11 +657,38 @@ class ResidentModelManager:
                             replace_group, replace_mode
                         )
                     else:
-                        # Wait/abort may drain or terminate live traffic. Merely
-                        # identify the protected group here; do not mutate the
-                        # healthy assistant until the replacement has actually
-                        # materialized and passed its modality contract.
-                        candidates = self._replacement_candidates_locked(replace_group)
+                        candidates = self._replacement_candidates_locked(
+                            replace_group,
+                            replace_mode=replace_mode,
+                        )
+                    projection = self._replacement_projection_locked(
+                        estimate,
+                        candidates,
+                        memory_policy,
+                    )
+                    if projection.reason == "role_capacity_insufficient_after_eviction":
+                        raise ResidentModelCapacityError(
+                            "resident model memory ceiling exceeded after projected "
+                            "assistant replacement",
+                            replacement_projection=projection,
+                        )
+                    destructive_replacement = projection.strategy == "evict_first"
+                    if destructive_replacement:
+                        if replace_mode != "reject":
+                            (
+                                candidates,
+                                paused_engines,
+                            ) = await self._quiesce_replacement_group_locked(
+                                replace_group, replace_mode
+                            )
+                        (
+                            destructive_handoff,
+                            destructive_primary,
+                        ) = await self._evict_replacement_before_load_locked(
+                            candidates,
+                            replace_group,
+                        )
+                        paused_engines = []
                 await self._evict_for_locked(
                     estimate,
                     exclude={model_name, *(item.model_id for item in candidates)},
@@ -640,9 +711,14 @@ class ResidentModelManager:
                     last_used_at=now,
                     pinned=pin,
                     performance=performance,
+                    replacement_projection=projection,
                 )
                 group = _effective_replace_group(record.entry, replace_group)
-                if replace_group is not None and replace_mode != "reject":
+                if destructive_replacement:
+                    record.primary = destructive_primary
+                    if destructive_primary:
+                        record.pinned = True
+                elif replace_group is not None and replace_mode != "reject":
                     (
                         candidates,
                         paused_engines,
@@ -657,9 +733,11 @@ class ResidentModelManager:
                 # Keep the replacement private until the old inference engines
                 # have reached the policy boundary. Publication only makes the
                 # already-quiesced replacement visible to residency readers.
-                self.registry.add(entry)
+                self.registry.add(entry, is_default=record.primary)
                 self._index_record(record)
                 self.loads_total += 1
+                if destructive_primary and self._on_primary_changed is not None:
+                    self._on_primary_changed(entry)
                 await self._evict_for_locked(
                     0,
                     exclude={
@@ -667,7 +745,10 @@ class ResidentModelManager:
                         *(item.model_id for item in candidates),
                     },
                 )
-                if group is not None:
+                if destructive_handoff is not None:
+                    destructive_handoff.commit(entry)
+                    destructive_handoff = None
+                if group is not None and not destructive_replacement:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
@@ -694,9 +775,86 @@ class ResidentModelManager:
                                 await result
                         _release_allocator_cache()
                 finally:
-                    await self._resume_engines(paused_engines)
+                    if destructive_handoff is not None:
+                        destructive_handoff.commit(None)
+                    if not destructive_replacement:
+                        await self._resume_engines(paused_engines)
                 raise
             return record
+
+    def _replacement_projection_locked(
+        self,
+        incoming_bytes: int,
+        candidates: list[ResidencyRecord],
+        memory_policy: str,
+    ) -> ReplacementProjection:
+        """Choose rollback-safe or destructive admission before mutation."""
+
+        current = self._accounted_usage()
+        limit = self.memory_limit_bytes
+        keep_projected = current + incoming_bytes
+        releasable = tuple(
+            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
+            for record in candidates
+        )
+        evict_projected = (
+            max(0, current - sum(size for _, size in releasable)) + incoming_bytes
+        )
+        if limit <= 0 or keep_projected <= limit:
+            return ReplacementProjection(
+                strategy="keep_then_commit",
+                reason="keep_both_fits",
+                models_to_free=releasable,
+                current_bytes=current,
+                requested_bytes=incoming_bytes,
+                projected_bytes=evict_projected,
+                limit_bytes=limit,
+            )
+        if memory_policy == "evict_first_if_needed" and evict_projected <= limit:
+            return ReplacementProjection(
+                strategy="evict_first",
+                reason="role_capacity_evict_first_required",
+                models_to_free=releasable,
+                current_bytes=current,
+                requested_bytes=incoming_bytes,
+                projected_bytes=evict_projected,
+                limit_bytes=limit,
+            )
+        return ReplacementProjection(
+            strategy="reject",
+            reason="role_capacity_insufficient_after_eviction",
+            models_to_free=releasable,
+            current_bytes=current,
+            requested_bytes=incoming_bytes,
+            projected_bytes=evict_projected,
+            limit_bytes=limit,
+        )
+
+    async def _evict_replacement_before_load_locked(
+        self,
+        candidates: list[ResidencyRecord],
+        group: str,
+    ) -> tuple[PrimaryHandoffLease | None, bool]:
+        """Destructively retire a quiesced group while holding audio ownership."""
+
+        old_primary = next((record for record in candidates if record.primary), None)
+        handoff = None
+        if old_primary is not None and self._on_primary_handoff is not None:
+            handoff = self._on_primary_handoff(old_primary.entry)
+        try:
+            if old_primary is not None:
+                if self._on_primary_changed is not None:
+                    self._on_primary_changed(None)
+                self.registry.clear_default()
+            for record in candidates:
+                record.primary = False
+                record.pinned = False
+                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
+        except BaseException:
+            if handoff is not None:
+                handoff.commit(None)
+            raise
+        return handoff, old_primary is not None
 
     async def _reload_locked(
         self,
@@ -1218,6 +1376,11 @@ class ResidentModelManager:
                     "idle_seconds": max(0.0, now - record.last_used_at),
                     "performance": (
                         record.performance.payload() if record.performance else None
+                    ),
+                    "replacement_projection": (
+                        record.replacement_projection.payload()
+                        if record.replacement_projection
+                        else None
                     ),
                 }
             )

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -409,6 +409,10 @@ class ResidentModelManager:
         self.idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
         self._clock = clock
         self._memory_reader = memory_reader
+        # Residency is configured before startup loading. Preserve the process
+        # baseline so the protected startup model receives an attributable
+        # footprint instead of treating Python/server memory as releasable.
+        self._baseline_memory_bytes = self._read_memory()
         self._on_primary_handoff = on_primary_handoff
         self._on_primary_changed = on_primary_changed
         self._records: dict[str, ResidencyRecord] = {}
@@ -451,10 +455,10 @@ class ResidentModelManager:
             estimated_bytes=max(
                 1, estimated_bytes or estimate_model_bytes(entry.model_name)
             ),
-            # Process footprint is exposed separately as the authoritative
-            # total. Charging it to the primary row would make that one model
-            # appear to own Python, uvicorn, Metal caches, and every secondary.
-            measured_bytes=0,
+            measured_bytes=max(
+                0,
+                self._read_memory() - self._baseline_memory_bytes,
+            ),
             loaded_at=now,
             last_used_at=now,
             pinned=True,
@@ -822,80 +826,92 @@ class ResidentModelManager:
     ) -> ReplacementProjection:
         """Choose rollback-safe or destructive admission before mutation."""
 
-        current = self._accounted_usage()
+        measured = self._read_memory()
+        reserved = sum(
+            max(record.estimated_bytes, record.measured_bytes)
+            for record in self._records.values()
+            if record.state == "resident"
+        )
+        current = max(measured, reserved)
         limit = self.memory_limit_bytes
-        keep_projected = current + incoming_bytes
-        replacement_releasable = tuple(
-            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
-            for record in candidates
-        )
         replacement_ids = {record.model_id for record in candidates}
-        idle_releasable = tuple(
-            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
-            for record in self._eviction_candidates_locked(replacement_ids)
-        )
-        replacement_bytes = sum(size for _, size in replacement_releasable)
-        evict_projected = max(0, current - replacement_bytes) + incoming_bytes
+        idle_candidates = self._eviction_candidates_locked(replacement_ids)
+
+        def payload(records: list[ResidencyRecord]) -> tuple[tuple[str, int], ...]:
+            return tuple(
+                (
+                    record.model_id,
+                    max(record.estimated_bytes, record.measured_bytes),
+                )
+                for record in records
+            )
+
+        def projected(records: list[ResidencyRecord]) -> int:
+            released_measured = sum(record.measured_bytes for record in records)
+            released_reserved = sum(
+                max(record.estimated_bytes, record.measured_bytes) for record in records
+            )
+            remaining = max(
+                max(0, measured - released_measured),
+                max(0, reserved - released_reserved),
+            )
+            return remaining + incoming_bytes
+
+        keep_projected = current + incoming_bytes
+        evict_projected = projected(candidates)
         if limit <= 0 or keep_projected <= limit:
             return ReplacementProjection(
                 strategy="keep_then_commit",
                 reason="keep_both_fits",
-                models_to_free=replacement_releasable,
+                models_to_free=payload(candidates),
                 current_bytes=current,
                 requested_bytes=incoming_bytes,
                 projected_bytes=evict_projected,
                 limit_bytes=limit,
             )
         if memory_policy == "evict_first_if_needed":
-            selected = list(replacement_releasable)
-            for item in idle_releasable:
+            selected = list(candidates)
+            for record in idle_candidates:
                 if evict_projected <= limit:
                     break
-                selected.append(item)
-                evict_projected = max(0, evict_projected - item[1])
+                selected.append(record)
+                evict_projected = projected(selected)
             if evict_projected <= limit:
                 return ReplacementProjection(
                     strategy="evict_first",
                     reason="role_capacity_evict_first_required",
-                    models_to_free=tuple(selected),
+                    models_to_free=payload(selected),
                     current_bytes=current,
                     requested_bytes=incoming_bytes,
                     projected_bytes=evict_projected,
                     limit_bytes=limit,
                 )
         else:
-            selected_idle: list[tuple[str, int]] = []
+            selected_idle: list[ResidencyRecord] = []
             keep_after_lru = keep_projected
-            for item in idle_releasable:
+            for record in idle_candidates:
                 if keep_after_lru <= limit:
                     break
-                selected_idle.append(item)
-                keep_after_lru = max(0, keep_after_lru - item[1])
+                selected_idle.append(record)
+                keep_after_lru = projected(selected_idle)
             if keep_after_lru <= limit:
                 return ReplacementProjection(
                     strategy="keep_then_commit",
                     reason="keep_both_fits",
-                    models_to_free=tuple(selected_idle) + replacement_releasable,
+                    models_to_free=payload(selected_idle + candidates),
                     current_bytes=current,
                     requested_bytes=incoming_bytes,
-                    projected_bytes=max(0, keep_after_lru - replacement_bytes),
+                    projected_bytes=projected(selected_idle + candidates),
                     limit_bytes=limit,
                 )
-        all_releasable = replacement_releasable + idle_releasable
-        projected_after_all = (
-            max(
-                0,
-                current - sum(size for _, size in all_releasable),
-            )
-            + incoming_bytes
-        )
+        all_releasable = candidates + idle_candidates
         return ReplacementProjection(
             strategy="reject",
             reason="role_capacity_insufficient_after_eviction",
-            models_to_free=all_releasable,
+            models_to_free=payload(all_releasable),
             current_bytes=current,
             requested_bytes=incoming_bytes,
-            projected_bytes=projected_after_all,
+            projected_bytes=projected(all_releasable),
             limit_bytes=limit,
         )
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -588,6 +588,7 @@ class ResidentModelManager:
         reload_if_changed: bool = False,
         replace_mode: str = "reject",
         memory_policy: str = "keep_then_commit",
+        resolved_group: str | None = None,
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -652,6 +653,11 @@ class ResidentModelManager:
             projection: ReplacementProjection | None = None
             try:
                 if replace_group is not None:
+                    if resolved_group is not None and resolved_group != replace_group:
+                        raise ResidentModelError(
+                            f"model {model_name!r} belongs to replacement group "
+                            f"{resolved_group!r}, not {replace_group!r}"
+                        )
                     if replace_mode == "reject":
                         # Preserve the established busy-before-capacity
                         # contract without evicting anything: the zero-timeout
@@ -670,7 +676,11 @@ class ResidentModelManager:
                     projection = self._replacement_projection_locked(
                         estimate,
                         candidates,
-                        memory_policy,
+                        (
+                            memory_policy
+                            if resolved_group == replace_group
+                            else "keep_then_commit"
+                        ),
                     )
                     if projection.reason == "role_capacity_insufficient_after_eviction":
                         raise ResidentModelCapacityError(

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -787,6 +787,10 @@ class ResidentModelManager:
                         destructive_primary_publish_attempted
                         and self._on_primary_changed is not None
                     ):
+                        # Removing the rejected target may auto-promote an
+                        # unrelated secondary. A failed primary publication
+                        # has no valid default until a later load succeeds.
+                        self.registry.clear_default()
                         try:
                             self._on_primary_changed(None)
                         except BaseException:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -647,6 +647,7 @@ class ResidentModelManager:
             paused_engines: list[object] = []
             destructive_handoff: PrimaryHandoffLease | None = None
             destructive_primary = False
+            destructive_primary_publish_attempted = False
             destructive_replacement = False
             projection: ReplacementProjection | None = None
             try:
@@ -743,6 +744,7 @@ class ResidentModelManager:
                 self._index_record(record)
                 self.loads_total += 1
                 if destructive_primary and self._on_primary_changed is not None:
+                    destructive_primary_publish_attempted = True
                     self._on_primary_changed(entry)
                 await self._evict_for_locked(
                     0,
@@ -781,6 +783,16 @@ class ResidentModelManager:
                                 await result
                         _release_allocator_cache()
                 finally:
+                    if (
+                        destructive_primary_publish_attempted
+                        and self._on_primary_changed is not None
+                    ):
+                        try:
+                            self._on_primary_changed(None)
+                        except BaseException:
+                            logger.exception(
+                                "Failed to clear rejected replacement primary"
+                            )
                     if destructive_handoff is not None:
                         destructive_handoff.commit(None)
                     if not destructive_replacement:

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -280,9 +280,14 @@ def mtp_generate_step(
     """
     import inspect as _inspect
 
-    from mlx_lm.generate import generation_stream, maybe_quantize_kv_cache
+    from mlx_lm.generate import maybe_quantize_kv_cache
     from mlx_lm.models import cache as _cache_module
     from mlx_lm.sample_utils import categorical_sampling
+
+    # The global mlx-lm generation stream can be rebound by a different
+    # resident engine's worker. Bind the stream where this generator actually
+    # begins executing so it always belongs to the scheduler-owned step thread.
+    generation_stream = mx.default_stream(mx.default_device())
 
     xtc_special_tokens = xtc_special_tokens or []
     if accept_counter is None:


### PR DESCRIPTION
## Why

Switching from a resident model projected the target on top of memory that the same transition was already releasing. On an 18 GB Mac, replacing the resident 9B chat model with the 4B chat model reported 114% projected use, and switching to the 4B image model reported 98%, even though the outgoing process was being stopped.

## What

- Project whole-sidecar replacements from live used memory minus measured or estimated bytes that the stop will release, reconciled conservatively with a fresh post-stop host probe.
- Keep in-process multi-model admission owned by the residency engine. Desktop assistant replacements request `memory_policy=evict_first_if_needed` and decode the typed `replacement_projection` response for committed state and actionable rejection copy.
- Use the candidate-dogfood balanced guardrail chosen for this release: below 95% loads normally, 95–100% is advisory, and only a projection above physical memory requires risky confirmation.
- Preserve fail-open behavior when trustworthy residency evidence is unavailable.
- Pin chat-to-chat, chat-to-image, image-to-chat, audio-only, no-resident, keep-both, larger-target, live-growth, and RAM-tier invariants.

The matching engine contract is delivered by #2444 in the same integration train. Neither PR is independently landing-ready without the other. Engine head 09e15ab3 also closes the reviewed destructive-rollback default-registry edge.

Requested by the maintainer during 0.13.1 candidate dogfood.

## Safety policy

The former 85% modal was not a macOS allocation limit: unified-memory compression and swap remain available below physical capacity, and the conservative model footprint already reserves runtime and KV headroom. It also blocked the products own curated tier choices during ordinary replacement. The reviewed policy therefore keeps 95–100% visible as `.tight` while reserving the destructive confirmation for a projection that exceeds physical RAM. This is a deliberate product threshold change, not an incidental consequence of the release-credit fix.

## Non-goals

- No engine eviction implementation in this PR.
- No model-name or prefix heuristics.
- No new Settings surface or memory estimator redesign.
- No queueing, hot swap, scheduler, or audio policy changes.

## Local evidence

- Focused memory/residency/Quickstart contracts: 140 passed.
- Full Desktop Swift suite, serial: 2934 passed in 32.83 s.
- Full Desktop Swift suite, parallel: 2934 passed in 17.37 s.
- Release build: running on exact head; previous head passed in 77.65 s.
- Real-host AX: low-memory-choice PASS; dictation PASS.
- `git diff --check`: passed.

Fixes #2439

## Accepted engine policy disposition

The paired engine contract intentionally defaults assistant replacement admission to `evict_first_if_needed`. Admission projects before mutation, selects eviction only when keep-both exceeds the limit and the post-eviction projection fits, returns a typed 507 before eviction when it cannot fit, and forces cross-role loads to `keep_then_commit` so loading chat cannot evict dictation. A failed load after an admitted assistant eviction may leave a reloadable local model state; the maintainer accepted that bounded tradeoff so ordinary model switching succeeds without a false warning.