### PR TITLE
fix(residency): evict replaced assistant when required

### DIFF
--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1395,6 +1395,88 @@ async def test_evict_first_falls_back_to_safe_admission_without_group_metadata()
 
 
 @pytest.mark.asyncio
+async def test_evict_first_never_subtracts_unattributed_process_footprint():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    footprint = [4 * GIB]
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: footprint[0],
+    )
+    footprint[0] = 6 * GIB
+    # Only the 2 GiB growth after manager configuration is attributable to the
+    # startup model; the 4 GiB server baseline cannot be projected as freed.
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
+        )
+
+    projection = exc_info.value.replacement_projection
+    assert projection is not None
+    assert projection.reason == "role_capacity_insufficient_after_eviction"
+    assert projection.current_bytes == 6 * GIB
+    assert projection.projected_bytes == 8 * GIB
+    loader.assert_not_awaited()
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_evict_first_credits_only_attributed_startup_model_footprint():
+    footprint = [2 * GIB]
+
+    class FootprintEngine(FakeLifecycleEngine):
+        async def stop(self):
+            await super().stop()
+            footprint[0] = 2 * GIB
+
+    registry = ModelRegistry()
+    old_engine = FootprintEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is True
+        assert footprint[0] == 2 * GIB
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: footprint[0],
+    )
+    footprint[0] = 6 * GIB
+    primary_record = manager.register_primary(primary, estimated_bytes=4 * GIB)
+    assert primary_record.measured_bytes == 4 * GIB
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
+    )
+
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.strategy == "evict_first"
+    assert replacement.replacement_projection.current_bytes == 6 * GIB
+    assert replacement.replacement_projection.projected_bytes == 6 * GIB
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
 async def test_busy_reject_precedes_unrelated_capacity_eviction():
     registry = ModelRegistry()
     chat_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1195,6 +1195,94 @@ async def test_evict_first_primary_callback_failure_reopens_old_admission():
 
 
 @pytest.mark.asyncio
+async def test_evict_first_partial_target_publication_is_cleared_on_failure():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    published: list[ModelEntry | None] = [primary]
+    loaded: list[FakeEngine] = []
+    handoff = Mock()
+
+    async def loader(name: str, path: str | None, performance=None):
+        replacement = entry(name)
+        loaded.append(replacement.engine)
+        return replacement
+
+    def publish_then_fail(replacement):
+        published[0] = replacement
+        if replacement is not None:
+            raise RuntimeError("parser construction failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=publish_then_fail,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="parser construction failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert loaded[0].stopped is True
+    assert published == [None]
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+    handoff.commit.assert_called_once_with(None)
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_cleanup_callback_failure_does_not_mask_publish_error(caplog):
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    none_calls = 0
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    def fail_publish_and_cleanup(replacement):
+        nonlocal none_calls
+        if replacement is None:
+            none_calls += 1
+            if none_calls == 2:
+                raise RuntimeError("cleanup clear failed")
+            return
+        raise RuntimeError("original publish failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: Mock(),
+        on_primary_changed=fail_publish_and_cleanup,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="original publish failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert "Failed to clear rejected replacement primary" in caplog.text
+    assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
 async def test_replacement_rejects_before_eviction_when_target_still_does_not_fit():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -895,6 +895,67 @@ async def test_replacement_keeps_rollback_path_when_both_models_fit():
 
 
 @pytest.mark.asyncio
+async def test_keep_then_commit_preserves_existing_idle_lru_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
+    spare_engine = FakeImageEngine()
+    spare = entry("spare-image", spare_engine)
+    registry.add(primary, is_default=True)
+    registry.add(image)
+    registry.add(spare)
+    load_observations: list[tuple[bool, bool]] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        load_observations.append((old_engine.stopped, image_engine.stopped))
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=13 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=4 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=spare,
+            estimated_bytes=1 * GIB,
+            loaded_at=1,
+            last_used_at=1,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=8 * GIB,
+        replace_group="assistant",
+    )
+
+    assert load_observations == [(False, True)]
+    assert old_engine.stopped is True
+    assert spare_engine.stopped is False
+    assert replacement.primary is True
+    assert registry.default_name == "chat-new"
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.strategy == "keep_then_commit"
+    assert replacement.replacement_projection.models_to_free == (
+        ("image", 4 * GIB),
+        ("chat-old", 4 * GIB),
+    )
+
+
+@pytest.mark.asyncio
 async def test_replacement_evicts_first_only_when_that_makes_target_fit():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()
@@ -947,6 +1008,65 @@ async def test_replacement_evicts_first_only_when_that_makes_target_fit():
     assert primary_changes == [None, "chat-new"]
     handoff.commit.assert_called_once_with(replacement.entry)
     handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_projection_reuses_idle_lru_for_remaining_capacity():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
+    spare_engine = FakeImageEngine()
+    spare = entry("spare-image", spare_engine)
+    registry.add(primary, is_default=True)
+    registry.add(image)
+    registry.add(spare)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is True
+        assert image_engine.stopped is True
+        assert spare_engine.stopped is False
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=12 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=6 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=spare,
+            estimated_bytes=1 * GIB,
+            loaded_at=1,
+            last_used_at=1,
+        )
+    )
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=10 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+    )
+
+    assert replacement.replacement_projection is not None
+    assert replacement.replacement_projection.models_to_free == (
+        ("chat-old", 4 * GIB),
+        ("image", 6 * GIB),
+    )
+    assert replacement.replacement_projection.projected_bytes == 11 * GIB
+    assert registry.default_name == "chat-new"
 
 
 @pytest.mark.asyncio
@@ -1031,6 +1151,47 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
     handoff.rollback.assert_not_called()
     assert registry.default_name is None
     assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
+async def test_evict_first_primary_callback_failure_reopens_old_admission():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+
+    def fail_clear(replacement):
+        assert replacement is None
+        raise RuntimeError("primary clear failed")
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=fail_clear,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="primary clear failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    loader.assert_not_awaited()
+    handoff.rollback.assert_called_once_with()
+    handoff.commit.assert_not_called()
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["chat-old"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -855,6 +856,225 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     assert "chat-new" not in registry
     assert "chat-new" not in loaded
     assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
+
+
+@pytest.mark.asyncio
+async def test_replacement_keeps_rollback_path_when_both_models_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        assert old_engine.stopped is False
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=10 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        memory_policy="evict_first_if_needed",
+    )
+
+    projection = replacement.replacement_projection
+    assert projection is not None
+    assert projection.strategy == "keep_then_commit"
+    assert projection.reason == "keep_both_fits"
+    assert projection.models_to_free == (("chat-old", 4 * GIB),)
+    assert projection.projected_bytes == 4 * GIB
+    assert old_engine.stopped is True
+    assert registry.default_name == "chat-new"
+
+
+@pytest.mark.asyncio
+async def test_replacement_evicts_first_only_when_that_makes_target_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    load_observations: list[tuple[bool, str | None]] = []
+    primary_changes: list[str | None] = []
+    handoff = Mock()
+
+    async def loader(name: str, path: str | None, performance=None):
+        load_observations.append((old_engine.stopped, registry.default_name))
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda replacement: primary_changes.append(
+            replacement.model_name if replacement is not None else None
+        ),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = await manager.load(
+        "chat-new",
+        estimated_bytes=4 * GIB,
+        replace_group="assistant",
+        replace_mode="wait",
+        memory_policy="evict_first_if_needed",
+    )
+
+    assert load_observations == [(True, None)]
+    projection = replacement.replacement_projection
+    assert projection is not None
+    assert projection.payload() == {
+        "strategy": "evict_first",
+        "reason": "role_capacity_evict_first_required",
+        "models_to_free": [{"id": "chat-old", "estimated_bytes": 4 * GIB}],
+        "current_bytes": 4 * GIB,
+        "requested_bytes": 4 * GIB,
+        "projected_bytes": 4 * GIB,
+        "limit_bytes": 6 * GIB,
+    }
+    assert replacement.primary is True
+    assert replacement.pinned is True
+    assert registry.default_name == "chat-new"
+    assert old_engine.pauses == [("wait", None)]
+    assert primary_changes == [None, "chat-new"]
+    handoff.commit.assert_called_once_with(replacement.entry)
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_load_failure_reports_primary_absent_without_rollback():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    primary_changes: list[str | None] = []
+    handoff_commits: list[str | None] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        raise ImportError("replacement checkpoint is unavailable")
+
+    class Handoff:
+        def __init__(self):
+            self.rollback = Mock()
+
+        def commit(self, replacement):
+            handoff_commits.append(
+                replacement.model_name if replacement is not None else None
+            )
+
+    handoff = Handoff()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda replacement: primary_changes.append(
+            replacement.model_name if replacement is not None else None
+        ),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ImportError, match="unavailable"):
+        await manager.load(
+            "chat-invalid",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert old_engine.stopped is True
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+    assert primary_changes == [None]
+    assert handoff_commits == [None]
+    handoff.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
+    registry = ModelRegistry()
+    old_engine = FailingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=lambda _entry: None,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    loader.assert_not_awaited()
+    handoff.commit.assert_called_once_with(None)
+    handoff.rollback.assert_not_called()
+    assert registry.default_name is None
+    assert manager.snapshot()["models"] == []
+
+
+@pytest.mark.asyncio
+async def test_replacement_rejects_before_eviction_when_target_still_does_not_fit():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        await manager.load(
+            "chat-too-large",
+            estimated_bytes=8 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    projection = exc_info.value.replacement_projection
+    assert projection is not None
+    assert projection.strategy == "reject"
+    assert projection.reason == "role_capacity_insufficient_after_eviction"
+    assert projection.projected_bytes == 8 * GIB
+    loader.assert_not_awaited()
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_unknown_memory_policy():
+    manager, _, _, _ = manager_fixture()
+
+    with pytest.raises(ResidentModelError, match="unsupported memory policy"):
+        await manager.load("chat-new", memory_policy="invented")
 
 
 @pytest.mark.asyncio
@@ -1964,6 +2184,90 @@ def test_residency_control_plane_forwards_abort_replacement_policy(monkeypatch):
     assert response.status_code == 200
     assert old_engine.pauses == [("abort", None)]
     assert registry.default_name == "chat-new"
+    assert response.json()["replacement_projection"] == {
+        "strategy": "keep_then_commit",
+        "reason": "keep_both_fits",
+        "models_to_free": [{"id": "chat-old", "estimated_bytes": 4 * GIB}],
+        "current_bytes": 4 * GIB,
+        "requested_bytes": response.json()["estimated_bytes"],
+        "projected_bytes": response.json()["estimated_bytes"],
+        "limit_bytes": 0,
+    }
+
+
+def test_residency_control_plane_returns_typed_replacement_capacity_projection(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    install_exception_handlers(app)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-too-large",
+                "estimated_size_gb": 8,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 507
+    assert response.json() == {
+        "error": {
+            "message": (
+                "resident model memory ceiling exceeded after projected "
+                "assistant replacement"
+            ),
+            "type": "insufficient_capacity_error",
+            "code": "insufficient_capacity_error",
+            "param": "estimated_size_gb",
+        },
+        "replacement_projection": {
+            "strategy": "reject",
+            "reason": "role_capacity_insufficient_after_eviction",
+            "models_to_free": [{"id": "chat", "estimated_bytes": 4 * GIB}],
+            "current_bytes": 4 * GIB,
+            "requested_bytes": 8 * GIB,
+            "projected_bytes": 8 * GIB,
+            "limit_bytes": 6 * GIB,
+        },
+    }
+    assert loaded == {}
+    assert registry.default_name == "chat"
+
+
+def test_residency_control_plane_preserves_generic_capacity_error(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, _, _, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={"model": "image-too-large", "estimated_size_gb": 8},
+        )
+
+    assert response.status_code == 507
+    assert "memory ceiling exceeded" in response.json()["detail"]
 
 
 def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2564,6 +2564,78 @@ def test_residency_control_plane_returns_typed_replacement_capacity_projection(
     assert registry.default_name == "chat"
 
 
+def test_residency_control_plane_uses_model_path_group_for_destructive_admission(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    profiles = {
+        "chat-alias": SimpleNamespace(modality="text"),
+        "repo/image": SimpleNamespace(modality="image-gen"),
+    }
+    monkeypatch.setattr("vllm_mlx.routes.residency.resolve_profile", profiles.get)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-alias",
+                "model_path": "repo/image",
+                "estimated_size_gb": 4,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 409
+    assert "image-gen" in response.json()["detail"]
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
+
+
+def test_residency_unknown_model_path_falls_back_to_safe_admission(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.resolve_profile",
+        lambda name: SimpleNamespace(modality="text") if name == "chat-alias" else None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat-alias",
+                "model_path": "/unknown/local/checkpoint",
+                "estimated_size_gb": 4,
+                "replace_group": "assistant",
+            },
+        )
+
+    assert response.status_code == 507
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
+
+
 def test_residency_control_plane_preserves_generic_capacity_error(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -987,6 +987,7 @@ async def test_replacement_evicts_first_only_when_that_makes_target_fit():
         replace_group="assistant",
         replace_mode="wait",
         memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
     )
 
     assert load_observations == [(True, None)]
@@ -1058,6 +1059,7 @@ async def test_evict_first_projection_reuses_idle_lru_for_remaining_capacity():
         estimated_bytes=10 * GIB,
         replace_group="assistant",
         memory_policy="evict_first_if_needed",
+        resolved_group="assistant",
     )
 
     assert replacement.replacement_projection is not None
@@ -1110,6 +1112,7 @@ async def test_evict_first_load_failure_reports_primary_absent_without_rollback(
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert old_engine.stopped is True
@@ -1144,6 +1147,7 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     loader.assert_not_awaited()
@@ -1182,6 +1186,7 @@ async def test_evict_first_primary_callback_failure_reopens_old_admission():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     loader.assert_not_awaited()
@@ -1242,6 +1247,7 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert loaded[0].stopped is True
@@ -1289,6 +1295,7 @@ async def test_evict_first_cleanup_callback_failure_does_not_mask_publish_error(
             estimated_bytes=4 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     assert "Failed to clear rejected replacement primary" in caplog.text
@@ -1317,6 +1324,7 @@ async def test_replacement_rejects_before_eviction_when_target_still_does_not_fi
             estimated_bytes=8 * GIB,
             replace_group="assistant",
             memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
         )
 
     projection = exc_info.value.replacement_projection
@@ -1337,6 +1345,53 @@ async def test_manager_rejects_unknown_memory_policy():
 
     with pytest.raises(ResidentModelError, match="unsupported memory policy"):
         await manager.load("chat-new", memory_policy="invented")
+
+
+@pytest.mark.asyncio
+async def test_evict_first_rejects_known_wrong_group_before_retiring_primary():
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(ResidentModelError, match="image-gen.*not 'assistant'"):
+        await manager.load(
+            "image-model",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="image-gen",
+        )
+
+    loader.assert_not_awaited()
+    assert old_engine.pauses == []
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+
+
+@pytest.mark.asyncio
+async def test_evict_first_falls_back_to_safe_admission_without_group_metadata():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=6)
+
+    with pytest.raises(ResidentModelCapacityError):
+        await manager.load(
+            "unknown-model",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+        )
+
+    assert loaded == {}
+    assert registry.default_name == "chat"
+    assert registry.get_engine("chat").stopped is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1199,7 +1199,10 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()
     primary = entry("chat-old", old_engine)
+    image_engine = FakeImageEngine()
+    image = entry("image", image_engine)
     registry.add(primary, is_default=True)
+    registry.add(image)
     published: list[ModelEntry | None] = [primary]
     loaded: list[FakeEngine] = []
     handoff = Mock()
@@ -1223,6 +1226,15 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
         on_primary_changed=publish_then_fail,
     )
     manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=image,
+            estimated_bytes=1 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+            pinned=True,
+        )
+    )
 
     with pytest.raises(RuntimeError, match="parser construction failed"):
         await manager.load(
@@ -1235,7 +1247,8 @@ async def test_evict_first_partial_target_publication_is_cleared_on_failure():
     assert loaded[0].stopped is True
     assert published == [None]
     assert registry.default_name is None
-    assert manager.snapshot()["models"] == []
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["image"]
+    assert image_engine.stopped is False
     handoff.commit.assert_called_once_with(None)
     handoff.rollback.assert_not_called()
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1158,6 +1158,55 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
 
 
 @pytest.mark.asyncio
+async def test_evict_first_sibling_stop_failure_preserves_primary_publication():
+    registry = ModelRegistry()
+    sibling_engine = FailingStopLifecycleEngine()
+    sibling = entry("chat-sibling", sibling_engine)
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    registry.add(sibling)
+    registry.add(primary, is_default=True)
+    loader = AsyncMock()
+    handoff = Mock()
+    primary_changes: list[ModelEntry | None] = []
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=6 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_handoff=lambda _entry: handoff,
+        on_primary_changed=primary_changes.append,
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=sibling,
+            estimated_bytes=1 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+            memory_policy="evict_first_if_needed",
+            resolved_group="assistant",
+        )
+
+    loader.assert_not_awaited()
+    handoff.rollback.assert_called_once_with()
+    handoff.commit.assert_not_called()
+    assert primary_changes == []
+    assert primary_engine.stopped is False
+    assert primary_engine.paused is False
+    assert registry.default_name == "chat-primary"
+    assert [item["id"] for item in manager.snapshot()["models"]] == ["chat-primary"]
+
+
+@pytest.mark.asyncio
 async def test_evict_first_primary_callback_failure_reopens_old_admission():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -59,6 +59,9 @@ class ModelLoadRequest(BaseModel):
     performance: ModelPerformanceRequest | None = None
     reload_if_changed: StrictBool = False
     replace_mode: Literal["reject", "wait", "abort"] = "reject"
+    memory_policy: Literal["keep_then_commit", "evict_first_if_needed"] = (
+        "evict_first_if_needed"
+    )
 
 
 class ModelPinRequest(BaseModel):
@@ -154,11 +157,26 @@ async def load_resident_model(request: ModelLoadRequest):
             performance=performance,
             reload_if_changed=request.reload_if_changed,
             replace_mode=request.replace_mode,
+            memory_policy=request.memory_policy,
         )
     except HTTPException:
         raise
     except ResidentModelCapacityError as exc:
-        raise HTTPException(status_code=507, detail=str(exc)) from exc
+        projection = exc.replacement_projection
+        if projection is None:
+            raise HTTPException(status_code=507, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=507,
+            detail={
+                "error": {
+                    "message": str(exc),
+                    "type": "insufficient_capacity_error",
+                    "code": "insufficient_capacity_error",
+                    "param": "estimated_size_gb",
+                },
+                "replacement_projection": projection.payload(),
+            },
+        ) from exc
     except ResidentModelError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except Exception as exc:

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -127,6 +127,13 @@ async def load_resident_model(request: ModelLoadRequest):
         profile = resolve_profile(request.model) or (
             resolve_profile(request.model_path) if request.model_path else None
         )
+        resolved_group = None
+        if profile is not None:
+            resolved_group = (
+                "assistant"
+                if profile.modality in {"text", "vision"}
+                else profile.modality
+            )
         if (
             performance is not None
             and profile is not None
@@ -158,6 +165,7 @@ async def load_resident_model(request: ModelLoadRequest):
             reload_if_changed=request.reload_if_changed,
             replace_mode=request.replace_mode,
             memory_policy=request.memory_policy,
+            resolved_group=resolved_group,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -124,9 +124,15 @@ async def load_resident_model(request: ModelLoadRequest):
         performance = (
             request.performance.runtime_value() if request.performance else None
         )
-        profile = resolve_profile(request.model) or (
+        model_profile = resolve_profile(request.model)
+        path_profile = (
             resolve_profile(request.model_path) if request.model_path else None
         )
+        # The loader consumes model_path when supplied, so only that
+        # checkpoint's metadata may authorize destructive admission. An
+        # unknown override falls back to keep-then-commit rather than trusting
+        # the request-facing alias for different weights.
+        profile = path_profile if request.model_path else model_profile
         resolved_group = None
         if profile is not None:
             resolved_group = (

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -928,15 +928,25 @@ class ResidentModelManager:
             handoff = self._on_primary_handoff(old_primary.entry)
         destructive_started = False
         try:
+            # Retire sibling assistants while the healthy primary remains
+            # published. A sibling stop failure can therefore roll back the
+            # handoff without stranding the server's default route.
+            for record in candidates:
+                if record is old_primary:
+                    continue
+                record.pinned = False
+                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
             if old_primary is not None:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(None)
                 self.registry.clear_default()
                 destructive_started = True
-            for record in candidates:
-                record.primary = False
-                record.pinned = False
-                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
+                old_primary.primary = False
+                old_primary.pinned = False
+                await self._evict_locked(
+                    old_primary,
+                    reason=f"replace_{group}_evict_first",
+                )
         except BaseException:
             if handoff is not None:
                 if destructive_started:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -546,19 +546,7 @@ class ResidentModelManager:
         if self.memory_limit_bytes <= 0:
             return
         while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
-            candidates = sorted(
-                (
-                    record
-                    for record in self._records.values()
-                    if record.model_id not in exclude
-                    and not record.pinned
-                    and not record.primary
-                    and record.active_requests == 0
-                    and record.state == "resident"
-                    and _engine_is_idle(record.entry.engine)
-                ),
-                key=lambda record: record.last_used_at,
-            )
+            candidates = self._eviction_candidates_locked(exclude)
             if not candidates:
                 usage = self._accounted_usage()
                 raise ResidentModelCapacityError(
@@ -569,6 +557,23 @@ class ResidentModelManager:
                     "no idle unpinned model is eligible for eviction"
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
+
+    def _eviction_candidates_locked(self, exclude: set[str]) -> list[ResidencyRecord]:
+        """Return the exact idle-LRU order used by admission and eviction."""
+
+        return sorted(
+            (
+                record
+                for record in self._records.values()
+                if record.model_id not in exclude
+                and not record.pinned
+                and not record.primary
+                and record.active_requests == 0
+                and record.state == "resident"
+                and _engine_is_idle(record.entry.engine)
+            ),
+            key=lambda record: record.last_used_at,
+        )
 
     async def load(
         self,
@@ -672,8 +677,8 @@ class ResidentModelManager:
                             "assistant replacement",
                             replacement_projection=projection,
                         )
-                    destructive_replacement = projection.strategy == "evict_first"
-                    if destructive_replacement:
+                    evict_first = projection.strategy == "evict_first"
+                    if evict_first:
                         if replace_mode != "reject":
                             (
                                 candidates,
@@ -688,6 +693,7 @@ class ResidentModelManager:
                             candidates,
                             replace_group,
                         )
+                        destructive_replacement = True
                         paused_engines = []
                 await self._evict_for_locked(
                     estimate,
@@ -793,40 +799,77 @@ class ResidentModelManager:
         current = self._accounted_usage()
         limit = self.memory_limit_bytes
         keep_projected = current + incoming_bytes
-        releasable = tuple(
+        replacement_releasable = tuple(
             (record.model_id, max(record.estimated_bytes, record.measured_bytes))
             for record in candidates
         )
-        evict_projected = (
-            max(0, current - sum(size for _, size in releasable)) + incoming_bytes
+        replacement_ids = {record.model_id for record in candidates}
+        idle_releasable = tuple(
+            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
+            for record in self._eviction_candidates_locked(replacement_ids)
         )
+        replacement_bytes = sum(size for _, size in replacement_releasable)
+        evict_projected = max(0, current - replacement_bytes) + incoming_bytes
         if limit <= 0 or keep_projected <= limit:
             return ReplacementProjection(
                 strategy="keep_then_commit",
                 reason="keep_both_fits",
-                models_to_free=releasable,
+                models_to_free=replacement_releasable,
                 current_bytes=current,
                 requested_bytes=incoming_bytes,
                 projected_bytes=evict_projected,
                 limit_bytes=limit,
             )
-        if memory_policy == "evict_first_if_needed" and evict_projected <= limit:
-            return ReplacementProjection(
-                strategy="evict_first",
-                reason="role_capacity_evict_first_required",
-                models_to_free=releasable,
-                current_bytes=current,
-                requested_bytes=incoming_bytes,
-                projected_bytes=evict_projected,
-                limit_bytes=limit,
+        if memory_policy == "evict_first_if_needed":
+            selected = list(replacement_releasable)
+            for item in idle_releasable:
+                if evict_projected <= limit:
+                    break
+                selected.append(item)
+                evict_projected = max(0, evict_projected - item[1])
+            if evict_projected <= limit:
+                return ReplacementProjection(
+                    strategy="evict_first",
+                    reason="role_capacity_evict_first_required",
+                    models_to_free=tuple(selected),
+                    current_bytes=current,
+                    requested_bytes=incoming_bytes,
+                    projected_bytes=evict_projected,
+                    limit_bytes=limit,
+                )
+        else:
+            selected_idle: list[tuple[str, int]] = []
+            keep_after_lru = keep_projected
+            for item in idle_releasable:
+                if keep_after_lru <= limit:
+                    break
+                selected_idle.append(item)
+                keep_after_lru = max(0, keep_after_lru - item[1])
+            if keep_after_lru <= limit:
+                return ReplacementProjection(
+                    strategy="keep_then_commit",
+                    reason="keep_both_fits",
+                    models_to_free=tuple(selected_idle) + replacement_releasable,
+                    current_bytes=current,
+                    requested_bytes=incoming_bytes,
+                    projected_bytes=max(0, keep_after_lru - replacement_bytes),
+                    limit_bytes=limit,
+                )
+        all_releasable = replacement_releasable + idle_releasable
+        projected_after_all = (
+            max(
+                0,
+                current - sum(size for _, size in all_releasable),
             )
+            + incoming_bytes
+        )
         return ReplacementProjection(
             strategy="reject",
             reason="role_capacity_insufficient_after_eviction",
-            models_to_free=releasable,
+            models_to_free=all_releasable,
             current_bytes=current,
             requested_bytes=incoming_bytes,
-            projected_bytes=evict_projected,
+            projected_bytes=projected_after_all,
             limit_bytes=limit,
         )
 
@@ -841,18 +884,23 @@ class ResidentModelManager:
         handoff = None
         if old_primary is not None and self._on_primary_handoff is not None:
             handoff = self._on_primary_handoff(old_primary.entry)
+        destructive_started = False
         try:
             if old_primary is not None:
                 if self._on_primary_changed is not None:
                     self._on_primary_changed(None)
                 self.registry.clear_default()
+                destructive_started = True
             for record in candidates:
                 record.primary = False
                 record.pinned = False
                 await self._evict_locked(record, reason=f"replace_{group}_evict_first")
         except BaseException:
             if handoff is not None:
-                handoff.commit(None)
+                if destructive_started:
+                    handoff.commit(None)
+                else:
+                    handoff.rollback()
             raise
         return handoff, old_primary is not None
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -29,6 +29,15 @@ class ResidentModelError(RuntimeError):
 class ResidentModelCapacityError(ResidentModelError):
     """The configured ceiling cannot admit a model after eligible eviction."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        replacement_projection: ReplacementProjection | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.replacement_projection = replacement_projection
+
 
 class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
@@ -74,6 +83,33 @@ class ResidentPerformanceConfig:
                 "cache_memory_mb": self.cache_memory_mb,
             }.items()
             if value is not None
+        }
+
+
+@dataclass(frozen=True)
+class ReplacementProjection:
+    """Admission truth for one assistant replacement request."""
+
+    strategy: str
+    reason: str
+    models_to_free: tuple[tuple[str, int], ...]
+    current_bytes: int
+    requested_bytes: int
+    projected_bytes: int
+    limit_bytes: int
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "reason": self.reason,
+            "models_to_free": [
+                {"id": model_id, "estimated_bytes": estimated_bytes}
+                for model_id, estimated_bytes in self.models_to_free
+            ],
+            "current_bytes": self.current_bytes,
+            "requested_bytes": self.requested_bytes,
+            "projected_bytes": self.projected_bytes,
+            "limit_bytes": self.limit_bytes,
         }
 
 
@@ -164,6 +200,7 @@ class ResidencyRecord:
     state: str = "resident"
     measured_bytes: int = 0
     performance: ResidentPerformanceConfig | None = None
+    replacement_projection: ReplacementProjection | None = None
     lease_idle: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
 
     def __post_init__(self) -> None:
@@ -545,11 +582,14 @@ class ResidentModelManager:
         performance: ResidentPerformanceConfig | None = None,
         reload_if_changed: bool = False,
         replace_mode: str = "reject",
+        memory_policy: str = "keep_then_commit",
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
             raise ResidentModelError("model must not be empty")
         estimate = max(1, estimated_bytes or estimate_model_bytes(model_name))
+        if memory_policy not in {"keep_then_commit", "evict_first_if_needed"}:
+            raise ResidentModelError(f"unsupported memory policy {memory_policy!r}")
 
         async with self._lock:
             canonical = self._canonical(model_name)
@@ -600,12 +640,16 @@ class ResidentModelManager:
             record: ResidencyRecord | None = None
             candidates: list[ResidencyRecord] = []
             paused_engines: list[object] = []
+            destructive_handoff: PrimaryHandoffLease | None = None
+            destructive_primary = False
+            destructive_replacement = False
+            projection: ReplacementProjection | None = None
             try:
                 if replace_group is not None:
                     if replace_mode == "reject":
-                        # Reject is a non-destructive preflight: close admission
-                        # only after proving the old assistant is already idle,
-                        # so a busy rejection cannot evict unrelated residents.
+                        # Preserve the established busy-before-capacity
+                        # contract without evicting anything: the zero-timeout
+                        # pause closes admission while the projection is read.
                         (
                             candidates,
                             paused_engines,
@@ -613,11 +657,38 @@ class ResidentModelManager:
                             replace_group, replace_mode
                         )
                     else:
-                        # Wait/abort may drain or terminate live traffic. Merely
-                        # identify the protected group here; do not mutate the
-                        # healthy assistant until the replacement has actually
-                        # materialized and passed its modality contract.
-                        candidates = self._replacement_candidates_locked(replace_group)
+                        candidates = self._replacement_candidates_locked(
+                            replace_group,
+                            replace_mode=replace_mode,
+                        )
+                    projection = self._replacement_projection_locked(
+                        estimate,
+                        candidates,
+                        memory_policy,
+                    )
+                    if projection.reason == "role_capacity_insufficient_after_eviction":
+                        raise ResidentModelCapacityError(
+                            "resident model memory ceiling exceeded after projected "
+                            "assistant replacement",
+                            replacement_projection=projection,
+                        )
+                    destructive_replacement = projection.strategy == "evict_first"
+                    if destructive_replacement:
+                        if replace_mode != "reject":
+                            (
+                                candidates,
+                                paused_engines,
+                            ) = await self._quiesce_replacement_group_locked(
+                                replace_group, replace_mode
+                            )
+                        (
+                            destructive_handoff,
+                            destructive_primary,
+                        ) = await self._evict_replacement_before_load_locked(
+                            candidates,
+                            replace_group,
+                        )
+                        paused_engines = []
                 await self._evict_for_locked(
                     estimate,
                     exclude={model_name, *(item.model_id for item in candidates)},
@@ -640,9 +711,14 @@ class ResidentModelManager:
                     last_used_at=now,
                     pinned=pin,
                     performance=performance,
+                    replacement_projection=projection,
                 )
                 group = _effective_replace_group(record.entry, replace_group)
-                if replace_group is not None and replace_mode != "reject":
+                if destructive_replacement:
+                    record.primary = destructive_primary
+                    if destructive_primary:
+                        record.pinned = True
+                elif replace_group is not None and replace_mode != "reject":
                     (
                         candidates,
                         paused_engines,
@@ -657,9 +733,11 @@ class ResidentModelManager:
                 # Keep the replacement private until the old inference engines
                 # have reached the policy boundary. Publication only makes the
                 # already-quiesced replacement visible to residency readers.
-                self.registry.add(entry)
+                self.registry.add(entry, is_default=record.primary)
                 self._index_record(record)
                 self.loads_total += 1
+                if destructive_primary and self._on_primary_changed is not None:
+                    self._on_primary_changed(entry)
                 await self._evict_for_locked(
                     0,
                     exclude={
@@ -667,7 +745,10 @@ class ResidentModelManager:
                         *(item.model_id for item in candidates),
                     },
                 )
-                if group is not None:
+                if destructive_handoff is not None:
+                    destructive_handoff.commit(entry)
+                    destructive_handoff = None
+                if group is not None and not destructive_replacement:
                     await self._commit_group_replacement_locked(
                         record, group, candidates
                     )
@@ -694,9 +775,86 @@ class ResidentModelManager:
                                 await result
                         _release_allocator_cache()
                 finally:
-                    await self._resume_engines(paused_engines)
+                    if destructive_handoff is not None:
+                        destructive_handoff.commit(None)
+                    if not destructive_replacement:
+                        await self._resume_engines(paused_engines)
                 raise
             return record
+
+    def _replacement_projection_locked(
+        self,
+        incoming_bytes: int,
+        candidates: list[ResidencyRecord],
+        memory_policy: str,
+    ) -> ReplacementProjection:
+        """Choose rollback-safe or destructive admission before mutation."""
+
+        current = self._accounted_usage()
+        limit = self.memory_limit_bytes
+        keep_projected = current + incoming_bytes
+        releasable = tuple(
+            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
+            for record in candidates
+        )
+        evict_projected = (
+            max(0, current - sum(size for _, size in releasable)) + incoming_bytes
+        )
+        if limit <= 0 or keep_projected <= limit:
+            return ReplacementProjection(
+                strategy="keep_then_commit",
+                reason="keep_both_fits",
+                models_to_free=releasable,
+                current_bytes=current,
+                requested_bytes=incoming_bytes,
+                projected_bytes=evict_projected,
+                limit_bytes=limit,
+            )
+        if memory_policy == "evict_first_if_needed" and evict_projected <= limit:
+            return ReplacementProjection(
+                strategy="evict_first",
+                reason="role_capacity_evict_first_required",
+                models_to_free=releasable,
+                current_bytes=current,
+                requested_bytes=incoming_bytes,
+                projected_bytes=evict_projected,
+                limit_bytes=limit,
+            )
+        return ReplacementProjection(
+            strategy="reject",
+            reason="role_capacity_insufficient_after_eviction",
+            models_to_free=releasable,
+            current_bytes=current,
+            requested_bytes=incoming_bytes,
+            projected_bytes=evict_projected,
+            limit_bytes=limit,
+        )
+
+    async def _evict_replacement_before_load_locked(
+        self,
+        candidates: list[ResidencyRecord],
+        group: str,
+    ) -> tuple[PrimaryHandoffLease | None, bool]:
+        """Destructively retire a quiesced group while holding audio ownership."""
+
+        old_primary = next((record for record in candidates if record.primary), None)
+        handoff = None
+        if old_primary is not None and self._on_primary_handoff is not None:
+            handoff = self._on_primary_handoff(old_primary.entry)
+        try:
+            if old_primary is not None:
+                if self._on_primary_changed is not None:
+                    self._on_primary_changed(None)
+                self.registry.clear_default()
+            for record in candidates:
+                record.primary = False
+                record.pinned = False
+                await self._evict_locked(record, reason=f"replace_{group}_evict_first")
+        except BaseException:
+            if handoff is not None:
+                handoff.commit(None)
+            raise
+        return handoff, old_primary is not None
 
     async def _reload_locked(
         self,
@@ -1218,6 +1376,11 @@ class ResidentModelManager:
                     "idle_seconds": max(0.0, now - record.last_used_at),
                     "performance": (
                         record.performance.payload() if record.performance else None
+                    ),
+                    "replacement_projection": (
+                        record.replacement_projection.payload()
+                        if record.replacement_projection
+                        else None
                     ),
                 }
             )

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -409,6 +409,10 @@ class ResidentModelManager:
         self.idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
         self._clock = clock
         self._memory_reader = memory_reader
+        # Residency is configured before startup loading. Preserve the process
+        # baseline so the protected startup model receives an attributable
+        # footprint instead of treating Python/server memory as releasable.
+        self._baseline_memory_bytes = self._read_memory()
         self._on_primary_handoff = on_primary_handoff
         self._on_primary_changed = on_primary_changed
         self._records: dict[str, ResidencyRecord] = {}
@@ -451,10 +455,10 @@ class ResidentModelManager:
             estimated_bytes=max(
                 1, estimated_bytes or estimate_model_bytes(entry.model_name)
             ),
-            # Process footprint is exposed separately as the authoritative
-            # total. Charging it to the primary row would make that one model
-            # appear to own Python, uvicorn, Metal caches, and every secondary.
-            measured_bytes=0,
+            measured_bytes=max(
+                0,
+                self._read_memory() - self._baseline_memory_bytes,
+            ),
             loaded_at=now,
             last_used_at=now,
             pinned=True,
@@ -822,80 +826,92 @@ class ResidentModelManager:
     ) -> ReplacementProjection:
         """Choose rollback-safe or destructive admission before mutation."""
 
-        current = self._accounted_usage()
+        measured = self._read_memory()
+        reserved = sum(
+            max(record.estimated_bytes, record.measured_bytes)
+            for record in self._records.values()
+            if record.state == "resident"
+        )
+        current = max(measured, reserved)
         limit = self.memory_limit_bytes
-        keep_projected = current + incoming_bytes
-        replacement_releasable = tuple(
-            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
-            for record in candidates
-        )
         replacement_ids = {record.model_id for record in candidates}
-        idle_releasable = tuple(
-            (record.model_id, max(record.estimated_bytes, record.measured_bytes))
-            for record in self._eviction_candidates_locked(replacement_ids)
-        )
-        replacement_bytes = sum(size for _, size in replacement_releasable)
-        evict_projected = max(0, current - replacement_bytes) + incoming_bytes
+        idle_candidates = self._eviction_candidates_locked(replacement_ids)
+
+        def payload(records: list[ResidencyRecord]) -> tuple[tuple[str, int], ...]:
+            return tuple(
+                (
+                    record.model_id,
+                    max(record.estimated_bytes, record.measured_bytes),
+                )
+                for record in records
+            )
+
+        def projected(records: list[ResidencyRecord]) -> int:
+            released_measured = sum(record.measured_bytes for record in records)
+            released_reserved = sum(
+                max(record.estimated_bytes, record.measured_bytes) for record in records
+            )
+            remaining = max(
+                max(0, measured - released_measured),
+                max(0, reserved - released_reserved),
+            )
+            return remaining + incoming_bytes
+
+        keep_projected = current + incoming_bytes
+        evict_projected = projected(candidates)
         if limit <= 0 or keep_projected <= limit:
             return ReplacementProjection(
                 strategy="keep_then_commit",
                 reason="keep_both_fits",
-                models_to_free=replacement_releasable,
+                models_to_free=payload(candidates),
                 current_bytes=current,
                 requested_bytes=incoming_bytes,
                 projected_bytes=evict_projected,
                 limit_bytes=limit,
             )
         if memory_policy == "evict_first_if_needed":
-            selected = list(replacement_releasable)
-            for item in idle_releasable:
+            selected = list(candidates)
+            for record in idle_candidates:
                 if evict_projected <= limit:
                     break
-                selected.append(item)
-                evict_projected = max(0, evict_projected - item[1])
+                selected.append(record)
+                evict_projected = projected(selected)
             if evict_projected <= limit:
                 return ReplacementProjection(
                     strategy="evict_first",
                     reason="role_capacity_evict_first_required",
-                    models_to_free=tuple(selected),
+                    models_to_free=payload(selected),
                     current_bytes=current,
                     requested_bytes=incoming_bytes,
                     projected_bytes=evict_projected,
                     limit_bytes=limit,
                 )
         else:
-            selected_idle: list[tuple[str, int]] = []
+            selected_idle: list[ResidencyRecord] = []
             keep_after_lru = keep_projected
-            for item in idle_releasable:
+            for record in idle_candidates:
                 if keep_after_lru <= limit:
                     break
-                selected_idle.append(item)
-                keep_after_lru = max(0, keep_after_lru - item[1])
+                selected_idle.append(record)
+                keep_after_lru = projected(selected_idle)
             if keep_after_lru <= limit:
                 return ReplacementProjection(
                     strategy="keep_then_commit",
                     reason="keep_both_fits",
-                    models_to_free=tuple(selected_idle) + replacement_releasable,
+                    models_to_free=payload(selected_idle + candidates),
                     current_bytes=current,
                     requested_bytes=incoming_bytes,
-                    projected_bytes=max(0, keep_after_lru - replacement_bytes),
+                    projected_bytes=projected(selected_idle + candidates),
                     limit_bytes=limit,
                 )
-        all_releasable = replacement_releasable + idle_releasable
-        projected_after_all = (
-            max(
-                0,
-                current - sum(size for _, size in all_releasable),
-            )
-            + incoming_bytes
-        )
+        all_releasable = candidates + idle_candidates
         return ReplacementProjection(
             strategy="reject",
             reason="role_capacity_insufficient_after_eviction",
-            models_to_free=all_releasable,
+            models_to_free=payload(all_releasable),
             current_bytes=current,
             requested_bytes=incoming_bytes,
-            projected_bytes=projected_after_all,
+            projected_bytes=projected(all_releasable),
             limit_bytes=limit,
         )
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -588,6 +588,7 @@ class ResidentModelManager:
         reload_if_changed: bool = False,
         replace_mode: str = "reject",
         memory_policy: str = "keep_then_commit",
+        resolved_group: str | None = None,
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -652,6 +653,11 @@ class ResidentModelManager:
             projection: ReplacementProjection | None = None
             try:
                 if replace_group is not None:
+                    if resolved_group is not None and resolved_group != replace_group:
+                        raise ResidentModelError(
+                            f"model {model_name!r} belongs to replacement group "
+                            f"{resolved_group!r}, not {replace_group!r}"
+                        )
                     if replace_mode == "reject":
                         # Preserve the established busy-before-capacity
                         # contract without evicting anything: the zero-timeout
@@ -670,7 +676,11 @@ class ResidentModelManager:
                     projection = self._replacement_projection_locked(
                         estimate,
                         candidates,
-                        memory_policy,
+                        (
+                            memory_policy
+                            if resolved_group == replace_group
+                            else "keep_then_commit"
+                        ),
                     )
                     if projection.reason == "role_capacity_insufficient_after_eviction":
                         raise ResidentModelCapacityError(

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -787,6 +787,10 @@ class ResidentModelManager:
                         destructive_primary_publish_attempted
                         and self._on_primary_changed is not None
                     ):
+                        # Removing the rejected target may auto-promote an
+                        # unrelated secondary. A failed primary publication
+                        # has no valid default until a later load succeeds.
+                        self.registry.clear_default()
                         try:
                             self._on_primary_changed(None)
                         except BaseException:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -647,6 +647,7 @@ class ResidentModelManager:
             paused_engines: list[object] = []
             destructive_handoff: PrimaryHandoffLease | None = None
             destructive_primary = False
+            destructive_primary_publish_attempted = False
             destructive_replacement = False
             projection: ReplacementProjection | None = None
             try:
@@ -743,6 +744,7 @@ class ResidentModelManager:
                 self._index_record(record)
                 self.loads_total += 1
                 if destructive_primary and self._on_primary_changed is not None:
+                    destructive_primary_publish_attempted = True
                     self._on_primary_changed(entry)
                 await self._evict_for_locked(
                     0,
@@ -781,6 +783,16 @@ class ResidentModelManager:
                                 await result
                         _release_allocator_cache()
                 finally:
+                    if (
+                        destructive_primary_publish_attempted
+                        and self._on_primary_changed is not None
+                    ):
+                        try:
+                            self._on_primary_changed(None)
+                        except BaseException:
+                            logger.exception(
+                                "Failed to clear rejected replacement primary"
+                            )
                     if destructive_handoff is not None:
                         destructive_handoff.commit(None)
                     if not destructive_replacement:


### PR DESCRIPTION
## Intention

Let an explicit Desktop assistant replacement proceed when the selected model fits only after the old assistant is released, while keeping memory and routing truth exact.

Closes #2439.

## Scope

- Add the explicit `memory_policy` load contract (`keep_then_commit` or `evict_first_if_needed`); the Desktop-facing route defaults to the latter.
- Preserve the rollback-capable load-then-commit transaction when old and new assistants fit together.
- When peak coexistence breaches the ceiling but the final replacement fits, close admission, hold the existing primary/audio handoff, retire the old assistant, and load the selected target.
- Reject before retirement when the target still cannot fit.
- Return `replacement_projection` on successful residency rows and typed HTTP 507 responses, including strategy, reason, models freed, and current/requested/projected/limit bytes.

## Non-goals

- No UI, scheduler/cache, audio-lane, estimator, or general eviction redesign.
- No over-ceiling force mode and no second dry-run response shape.
- No change to replacement drain/abort semantics outside memory admission.

## Contract

- `keep_both_fits`: the existing rollback path remains unchanged.
- `role_capacity_evict_first_required`: old assistant retirement is intentionally destructive; a later loader failure reports no primary rather than claiming rollback.
- `role_capacity_insufficient_after_eviction`: HTTP 507 occurs before model retirement.

## Verification

- `tests/test_resident_models.py` + `tests/test_audio_model_worker.py`: 98 passed.
- Changed-lines coverage: 100% against `origin/main`.
- Ruff, format, compile, and diff checks: green.
- Targeted mypy: no diagnostics in the two changed production modules (the local repository-wide budget runner is dependency-skewed outside this diff).

### Validation environment note

Exact head `a0f12886e3fafecf89aeef63c86da7b14054526e`: Codex R9 LGTM; lint passed; targeted tests 76 passed; full unit suite 19,123 passed (110 skipped); changed-line coverage 138/138 (100%). The stress matrix was environment-blocked before model execution because its fixed port 8451 is occupied by the protected operator serve; the shared serve was not interrupted. Atlas accepted this environment-only blocker for the train.