### PR TITLE
fix(mac): automatically re-arm dictation after model lifecycle changes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -85,7 +85,6 @@ final class DictationController {
             refreshReadiness()
             if isEnabled {
                 cancelActiveSessionForModelChange()
-                hotkey.stop()
                 phase = .preparingModel
             }
             Task {
@@ -153,6 +152,7 @@ final class DictationController {
     private let testingPrewarm: (@MainActor () async -> Bool)?
     private let testingWarmup: (@MainActor () async -> Bool)?
     private let testingHotkeyStart: (@MainActor () -> Bool)?
+    private let testingHotkeyStop: (@MainActor () -> Void)?
     private let testingRecorderStart: (@MainActor () throws -> Void)?
     private let testingRecorderCancel: (@MainActor () -> Void)?
     private let testingTranscribeCancel: (@MainActor () -> Void)?
@@ -161,6 +161,10 @@ final class DictationController {
         get { captureLifecycle.ticker }
         set { captureLifecycle.ticker = newValue }
     }
+    /// The event tap belongs to the user's Enabled intent, not to whichever
+    /// model process happens to be serving. Model transitions temporarily gate
+    /// capture through ``phase`` while keeping this registration alive.
+    private(set) var isHotkeyArmed = false
     private var recordingStart: Date?
     private var capturingApp: String?
     private var level: Float = 0
@@ -209,6 +213,7 @@ final class DictationController {
         testingPrewarm: (@MainActor () async -> Bool)? = nil,
         testingWarmup: (@MainActor () async -> Bool)? = nil,
         testingHotkeyStart: (@MainActor () -> Bool)? = nil,
+        testingHotkeyStop: (@MainActor () -> Void)? = nil,
         testingRecorderStart: (@MainActor () throws -> Void)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
         testingTranscribeCancel: (@MainActor () -> Void)? = nil,
@@ -227,6 +232,7 @@ final class DictationController {
         self.testingPrewarm = testingPrewarm
         self.testingWarmup = testingWarmup
         self.testingHotkeyStart = testingHotkeyStart
+        self.testingHotkeyStop = testingHotkeyStop
         self.testingRecorderStart = testingRecorderStart
         self.testingRecorderCancel = testingRecorderCancel
         self.testingTranscribeCancel = testingTranscribeCancel
@@ -337,12 +343,10 @@ final class DictationController {
             guard alias != modelAlias || prewarmTask == nil else { break }
             cancelActiveSessionForModelChange()
             cancelModelPreparation()
-            hotkey.stop()
             phase = .preparingModel
         case .ready(let alias):
             guard alias != modelAlias || prewarmTask == nil else { break }
             cancelActiveSessionForModelChange()
-            hotkey.stop()
             phase = .preparingModel
             Task { [weak self] in
                 await self?.enable(replacingCurrentPrewarm: true)
@@ -350,10 +354,10 @@ final class DictationController {
         case .crashed, .stopped, .idle, .missing:
             cancelActiveSessionForModelChange()
             cancelModelPreparation()
-            hotkey.stop()
             // Preserve the user's Enabled intent, but publish a terminal
-            // non-ready phase. Foreground revalidation or a later server
-            // transition can retry through the existing enable path.
+            // non-ready phase. Keep the feature-owned event tap registered:
+            // foreground revalidation or a later server transition can retry
+            // the model without asking the user to arm dictation by hand.
             phase = .off
         }
     }
@@ -390,6 +394,7 @@ final class DictationController {
         if case .reject(let message, let disableIntent) = decision {
             lastError = message
             phase = .off
+            stopHotkey()
             // Missing local model/recording prerequisites make the persisted
             // intent invalid. Accessibility is different: the user already
             // expressed intent, and granting TCC later should allow re-arm.
@@ -408,7 +413,6 @@ final class DictationController {
             return
         }
         modelPreparationDeferred = false
-        hotkey.stop()
         phase = .preparingModel
         let preparingAlias = modelAlias
         let prewarmSucceeded = await prewarmModel(
@@ -444,6 +448,11 @@ final class DictationController {
 
     @discardableResult
     private func registerHotkey() -> Bool {
+        guard !isHotkeyArmed else {
+            lastError = nil
+            phase = .idle
+            return true
+        }
         guard testingHotkeyStart?() ?? hotkey.start() else {
             // macOS does not apply an Accessibility grant to an already-running
             // process, so this is the common shape right after the user flips
@@ -457,9 +466,20 @@ final class DictationController {
             return false
         }
         accessibilityNeedsRelaunch = false
+        isHotkeyArmed = true
         lastError = nil
         phase = .idle
         return true
+    }
+
+    private func stopHotkey() {
+        guard isHotkeyArmed else { return }
+        if let testingHotkeyStop {
+            testingHotkeyStop()
+        } else {
+            hotkey.stop()
+        }
+        isHotkeyArmed = false
     }
 
     func disable() {
@@ -468,7 +488,7 @@ final class DictationController {
         // seconds in its graceful-shutdown window; leaving the event tap live
         // for that window makes the hotkey appear to work even though no new
         // transcription can possibly complete.
-        hotkey.stop()
+        stopHotkey()
         transcribeTask?.cancel()
         transcribeTask = nil
         transcribeRequestID = nil
@@ -801,7 +821,6 @@ final class DictationController {
             return
         }
         guard server.isVoiceLaneReady(for: requestedAlias) else {
-            hotkey.stop()
             phase = .preparingModel
             beginRecordingTask = nil
             beginRecordingRequestID = nil

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -132,9 +132,12 @@ struct DictationView: View {
         if controller.phase == .preparingModel {
             return "Loading \(controller.modelAlias) into memory…"
         }
-        return controller.phase == .off
-            ? "Not listening — the hotkey isn't armed"
-            : "Listening — press \(controller.trigger.label) in any app"
+        if controller.phase == .off {
+            return controller.isHotkeyArmed
+                ? "Listening paused — reconnecting the speech model"
+                : "Not listening — the hotkey isn't armed"
+        }
+        return "Listening — press \(controller.trigger.label) in any app"
     }
 
     private var statusDetail: String {

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -110,12 +110,6 @@ struct DictationView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: RapidTheme.Space.md)
-            if controller.isEnabled && controller.phase == .off
-                && controller.readinessSnapshot.isReady {
-                Button("Arm now") { Task { await controller.enable() } }
-                    .buttonStyle(.rapidSecondary)
-                    .accessibilityIdentifier("Dictation.Arm")
-            }
             // Gate turning it ON, never turning it OFF, so a session whose
             // permissions lapsed can always be switched back.
             Toggle("", isOn: $controller.isEnabled)
@@ -140,7 +134,7 @@ struct DictationView: View {
         }
         return controller.phase == .off
             ? "Not listening — the hotkey isn't armed"
-            : "Ready — press \(controller.trigger.label) in any app"
+            : "Listening — press \(controller.trigger.label) in any app"
     }
 
     private var statusDetail: String {
@@ -151,6 +145,10 @@ struct DictationView: View {
         }
         if controller.phase == .preparingModel {
             return "The local model is warming up. Recording starts when it’s ready."
+        }
+        if controller.phase == .off {
+            return controller.lastError
+                ?? "Rapid will reconnect the speech model automatically."
         }
         var parts = [controller.modelAlias]
         if let latency = controller.lastLatency {
@@ -248,7 +246,10 @@ struct DictationView: View {
 
             Divider().overlay(RapidTheme.hairline)
 
-            setupRow(label: "Hotkey", done: true) {
+            setupRow(
+                label: "Hotkey",
+                done: !controller.isEnabled || controller.isHotkeyArmed
+            ) {
                 Menu {
                     Picker("", selection: $controller.trigger) {
                         ForEach(DictationHotkey.Trigger.allCases) { trigger in

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -174,6 +174,17 @@ struct AudioCatalogTests {
         #expect(!source.contains("Picker(\"\", selection: $controller.modelAlias)"))
     }
 
+    @Test("enabled dictation exposes automatic hotkey state without a manual arm control")
+    func dictationHotkeyIsAutomatic() throws {
+        let source = try String(contentsOf: Self.dictationViewURL, encoding: .utf8)
+
+        #expect(!source.contains("Arm now"))
+        #expect(!source.contains("Dictation.Arm"))
+        #expect(source.contains("controller.isHotkeyArmed"))
+        #expect(source.contains("Listening — press"))
+        #expect(source.contains("Rapid will reconnect the speech model automatically."))
+    }
+
     @Test("parser extracts audio rows and preserves subtype, family, size, and repo")
     func parsesRows() {
         let rows = ModelCatalog.parseAudioRows(Self.sample)

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -182,6 +182,7 @@ struct AudioCatalogTests {
         #expect(!source.contains("Dictation.Arm"))
         #expect(source.contains("controller.isHotkeyArmed"))
         #expect(source.contains("Listening — press"))
+        #expect(source.contains("Listening paused — reconnecting the speech model"))
         #expect(source.contains("Rapid will reconnect the speech model automatically."))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -426,6 +426,56 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("chat-model switches keep the enabled feature's event tap armed")
+    func chatModelSwitchKeepsHotkeyRegistration() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        var hotkeyStopCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            },
+            hotkeyStop: { hotkeyStopCount += 1 }
+        )
+
+        await controller.enable()
+        #expect(controller.phase == .idle)
+        #expect(controller.isHotkeyArmed)
+        #expect(hotkeyStartCount == 1)
+
+        // Whole-process replacement publishes the old child stopping before
+        // the new alias starts. That terminal-looking intermediate state was
+        // the exact RC1 vector that destroyed the tap and exposed Arm now.
+        controller.serverStateDidChange(.stopped)
+        #expect(controller.phase == .off)
+        #expect(controller.isHotkeyArmed)
+        #expect(hotkeyStopCount == 0)
+
+        controller.serverStateDidChange(.starting(alias: "qwen3.5-4b-4bit"))
+        #expect(controller.phase == .preparingModel)
+        #expect(controller.isHotkeyArmed)
+        #expect(hotkeyStopCount == 0)
+
+        controller.serverStateDidChange(.ready(alias: "qwen3.5-4b-4bit"))
+        for _ in 0..<40 where controller.phase != .idle { await Task.yield() }
+
+        #expect(controller.phase == .idle)
+        #expect(controller.isHotkeyArmed)
+        #expect(prewarmCount == 2)
+        #expect(hotkeyStartCount == 1)
+        #expect(hotkeyStopCount == 0)
+
+        controller.disable()
+        #expect(!controller.isHotkeyArmed)
+        #expect(hotkeyStopCount == 1)
+    }
+
+    @MainActor
     @Test("failed chat-model switch leaves enabled dictation retryable")
     func failedChatModelSwitchIsRetryable() async {
         var warmupContinuation: CheckedContinuation<Bool, Never>?
@@ -550,7 +600,7 @@ struct DictationTests {
 
         #expect(controller.phase == .idle)
         #expect(prewarmCount == 1)
-        #expect(hotkeyStartCount == 2)
+        #expect(hotkeyStartCount == 1, "finishing launch restore reuses the feature-owned event tap")
     }
 
     @MainActor
@@ -620,9 +670,10 @@ struct DictationTests {
 
         await controller.bootstrap(deferModelPreparation: true)
         controller.modelAlias = "another-speech-input"
-        while hotkeyStartCount < 2 { await Task.yield() }
+        for _ in 0..<40 where controller.phase != .idle { await Task.yield() }
 
         #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1, "the enabled feature keeps one event-tap registration")
         #expect(prewarmCount == 0, "a model change must not steal the starting chat process")
     }
 
@@ -931,7 +982,8 @@ struct DictationTests {
         phase: DictationController.Phase = .off,
         initiallyDeferred: Bool = false,
         prewarm: @escaping @MainActor () async -> Bool,
-        hotkeyStart: @escaping @MainActor () -> Bool
+        hotkeyStart: @escaping @MainActor () -> Bool,
+        hotkeyStop: @escaping @MainActor () -> Void = {}
     ) -> DictationController {
         let entry = ModelEntry(
             alias: "whisper-small",
@@ -958,6 +1010,7 @@ struct DictationTests {
             ),
             testingPrewarm: prewarm,
             testingHotkeyStart: hotkeyStart,
+            testingHotkeyStop: hotkeyStop,
             testingInitialModelPreparationDeferred: initiallyDeferred,
             audioCatalogLoader: { _ in [entry] }
         )

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4921,14 +4921,14 @@ flow_dictation() {
         if jq -e '.data.ui_elements[]?
                   | select(.identifier == "Dictation.Status"
                            and (((.description // .value // .label // "") | tostring)
-                                | startswith("Ready — press")))' \
+                                | startswith("Listening — press")))' \
                  "$OUT/dictation-ready.json" >/dev/null; then
             ready_seen=1; break
         fi
         sleep 0.1
     done
     [[ "$ready_seen" == 1 ]] \
-        || die "Dictation did not become Ready after model warmup"
+        || die "Dictation did not become Listening after model warmup"
 
     # The warmup request must have stayed on the conversation server. A
     # transcription-only start here is the exact silent-eviction regression.

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -48,7 +48,7 @@ def test_dictation_journey_proves_loading_before_ready():
     assert "RAPID_GUI_DICTATION_READINESS_FIXTURE=1" in flow
     assert "FAKE_AUDIO_TRANSCRIPTION_DELAY_MS=1800" in flow
     assert "Dictation never exposed model loading before readiness" in flow
-    assert "Dictation did not become Ready after model warmup" in flow
+    assert "Dictation did not become Listening after model warmup" in flow
     assert '.event == "audio_transcription"' in flow
     assert 'and (((.description // .value // .label // "") | tostring)' in flow
 


### PR DESCRIPTION
## Why

After dictation had already worked, a whole-process chat-model switch could publish an intermediate stopped state. The controller destroyed its process-wide event tap even though capture was already gated by the model-preparation phase. Recreating the tap after the switch could fail, leaving Speech to Text enabled with every prerequisite green but requiring the user to click **Arm now**.

Fixes #2442.

## What

- Make the global hotkey registration owned by the enabled feature lifecycle instead of the serving-model lifecycle.
- Preserve the registration through stopped → starting → ready model transitions while the existing phase gate suppresses capture until the speech lane is resident.
- Stop the registration only when dictation is disabled, the app terminates, or readiness is rejected.
- Remove the manual arm control; expose truthful Hotkey readiness and distinguish paused reconnection from a genuinely unarmed hotkey.
- Rename the armed state to **Listening** and update the golden-flow contract.

## Non-goals

- No engine or audio-residency policy changes.
- No memory-conflict UX or new settings.
- No polling, sleeps, timeout changes, or broad DictationController refactor.

## Exact-head local verification

Head: `1b7a559b500fab3cb06826d371016eb7e4a6df6c`

- Focused Dictation + Audio catalog contracts: 61/61 passed.
- Full Swift serial: 2,923/2,923 passed in 31.62 s.
- Full Swift parallel: 2,923/2,923 passed in 16.99 s.
- Release build: passed in 72.95 s compile / 73.34 s wall.
- GUI control, preflight, and golden-flow inventory contracts: 34/34 passed.
- Codex round 3: LGTM.
- `pr_validate`: MERGE-SAFE; full Python suite 19,149 passed, 97 skipped, 22 deselected, 6 xfailed, 1 xpassed.
- Real-host AX is unavailable because the Studio session is locked; the release gate is the hosted dictation golden-flow shard in train-6, per release coordination.
