### PR TITLE
ci(release): identify Desktop candidate artifacts

### DIFF
--- a/.github/actions/desktop-releasable/action.yml
+++ b/.github/actions/desktop-releasable/action.yml
@@ -24,6 +24,13 @@ inputs:
   app_tag:
     description: The intended immutable tag, rapid-mac-v<release_version>.
     required: true
+  candidate_identity:
+    description: >-
+      Optional candidate-only display identity, candidate-<8 lowercase hex>.
+      It is embedded as a separate Info.plist field and never changes the
+      numeric CFBundleVersion or the Sparkle release version.
+    required: false
+    default: ''
   signed:
     description: >-
       'true' when the Developer ID + notary secrets are all present (the real
@@ -205,6 +212,7 @@ runs:
         # Developer-ID-signed installation because code-signing continuity
         # validation correctly rejects it.
         SPARKLE_PUBLIC_ED_KEY: ${{ inputs.signed == 'true' && inputs.SPARKLE_PUBLIC_ED_KEY || '' }}
+        RAPID_CANDIDATE_IDENTITY: ${{ inputs.candidate_identity }}
         SIGNED: ${{ inputs.signed }}
       shell: bash
       run: |

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -205,6 +205,7 @@ jobs:
              && [[ "$REF_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?$ ]]; then
             APP_VERSION="$REF_VERSION"
             IS_TAG="true"
+            CANDIDATE_IDENTITY=""
           else
             # Manual workflow_dispatch dry-run on a branch: there is no tag to
             # derive the version from, so read the version the build will
@@ -214,6 +215,7 @@ jobs:
             # dry-run and validates the real tree under development. Nothing is
             # published or tagged (#2301).
             IS_TAG="false"
+            CANDIDATE_IDENTITY="candidate-${GITHUB_SHA:0:8}"
             SOURCE_PLIST="apps/rapid-mac/Resources/Info.plist"
             APP_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$SOURCE_PLIST")"
             [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?$ ]] || {
@@ -233,11 +235,14 @@ jobs:
             | python3 scripts/release_version.py preceding "${APP_VERSION}")"
           PREV_RELEASE="$(git tag -l 'rapid-mac-v*' --sort=v:refname \
             | python3 scripts/release_version.py preceding-release "${APP_VERSION}")"
-          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "is_tag=$IS_TAG" >> "$GITHUB_OUTPUT"
-          echo "app_tag=rapid-mac-v$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "previous_stable_tag=${PREV_STABLE:-}" >> "$GITHUB_OUTPUT"
-          echo "previous_release_tag=${PREV_RELEASE:-}" >> "$GITHUB_OUTPUT"
+          {
+            echo "app_version=$APP_VERSION"
+            echo "is_tag=$IS_TAG"
+            echo "app_tag=rapid-mac-v$APP_VERSION"
+            echo "candidate_identity=$CANDIDATE_IDENTITY"
+            echo "previous_stable_tag=${PREV_STABLE:-}"
+            echo "previous_release_tag=${PREV_RELEASE:-}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build + sign + notarise + DMG-validate (shared contract)
         id: releasable
@@ -253,6 +258,7 @@ jobs:
           # branch workflow_dispatch dry-run it is a SYNTHETIC rapid-mac-v<version>
           # used only to bind the manifest — never claimed/tagged.
           app_tag: ${{ steps.appmeta.outputs.app_tag }}
+          candidate_identity: ${{ steps.appmeta.outputs.candidate_identity }}
           signed: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 != '' && secrets.MACOS_DEVID_CERT_PASSWORD != '' && secrets.AC_API_KEY_P8_BASE64 != '' && secrets.AC_API_KEY_ID != '' && secrets.AC_API_ISSUER_ID != '' }}
           # A REAL rapid-mac-v* tag run must be SIGNED (this is a user-facing
           # release satisfying the approved evidence): use require_signed=true so
@@ -313,6 +319,30 @@ jobs:
           path: |
             apps/rapid-mac/build/rapid-mlx-desktop.dmg
             apps/rapid-mac/build/rapid-mlx-desktop.manifest.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Stage candidate-labelled tester DMG
+        if: steps.appmeta.outputs.is_tag != 'true'
+        env:
+          CANDIDATE_IDENTITY: ${{ steps.appmeta.outputs.candidate_identity }}
+        run: |
+          set -euo pipefail
+          cd apps/rapid-mac/build
+          SOURCE="rapid-mlx-desktop.dmg"
+          TARGET="rapid-mlx-desktop-${CANDIDATE_IDENTITY}.dmg"
+          [[ "$CANDIDATE_IDENTITY" =~ ^candidate-[0-9a-f]{8}$ ]]
+          [[ -s "$SOURCE" ]]
+          cp "$SOURCE" "$TARGET"
+          cmp -s "$SOURCE" "$TARGET"
+          echo "CANDIDATE_DMG=$PWD/$TARGET" >> "$GITHUB_ENV"
+
+      - name: Upload candidate-labelled tester DMG
+        if: steps.appmeta.outputs.is_tag != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mlx-desktop-${{ steps.appmeta.outputs.candidate_identity }}
+          path: ${{ env.CANDIDATE_DMG }}
           if-no-files-found: error
           retention-days: 7
 

--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -51,6 +51,7 @@ enum AboutPanel {
         let view = AboutView(
             version: bundleShortVersion(),
             build: bundleBuildNumber(),
+            candidateIdentity: bundleCandidateIdentity(),
             engine: engineIdentity(resolution: server.binaryResolution),
             website: website,
             repoURL: repoURL,
@@ -100,6 +101,31 @@ enum AboutPanel {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String
     }
 
+    static func bundleCandidateIdentity() -> String? {
+        guard let identity = Bundle.main.infoDictionary?["RapidCandidateIdentity"] as? String,
+              !identity.isEmpty else {
+            return nil
+        }
+        return identity
+    }
+
+    static func versionLine(
+        version: String,
+        build: String?,
+        candidateIdentity: String?
+    ) -> String {
+        var line: String
+        if let build, !build.isEmpty, build != version {
+            line = "Version \(version) (\(build))"
+        } else {
+            line = "Version \(version)"
+        }
+        if let candidateIdentity, !candidateIdentity.isEmpty {
+            line += " · \(candidateIdentity)"
+        }
+        return line
+    }
+
     /// Describe the binary the server will actually spawn, rather than the
     /// sidecar merely shipped inside this app bundle. A runtime override can
     /// legitimately win version selection; surfacing that fact prevents a
@@ -121,16 +147,18 @@ enum AboutPanel {
 private struct AboutView: View {
     let version: String
     let build: String?
+    let candidateIdentity: String?
     let engine: AboutPanel.EngineIdentity?
     let website: String
     let repoURL: String
     let privacyURL: String
 
     private var versionLine: String {
-        if let build, !build.isEmpty, build != version {
-            return "Version \(version) (\(build))"
-        }
-        return "Version \(version)"
+        AboutPanel.versionLine(
+            version: version,
+            build: build,
+            candidateIdentity: candidateIdentity
+        )
     }
 
     var body: some View {

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import Rapid
+
+@Suite("About candidate identity")
+struct AboutPanelCandidateIdentityTests {
+    @Test("release build keeps the stable version line")
+    func releaseVersionLine() {
+        #expect(
+            AboutPanel.versionLine(
+                version: "0.13.1",
+                build: "166",
+                candidateIdentity: nil
+            ) == "Version 0.13.1 (166)"
+        )
+    }
+
+    @Test("candidate build exposes its exact source identity")
+    func candidateVersionLine() {
+        #expect(
+            AboutPanel.versionLine(
+                version: "0.13.1",
+                build: "166",
+                candidateIdentity: "candidate-a6b820cf"
+            ) == "Version 0.13.1 (166) · candidate-a6b820cf"
+        )
+    }
+}

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -41,6 +41,18 @@ cp "$ROOT/.build/$CONFIG/Rapid" "$CONTENTS/MacOS/Rapid"
 cp "$ROOT/Resources/Info.plist" "$CONTENTS/Info.plist"
 cp "$ROOT/Resources/AppIcon.icns" "$CONTENTS/Resources/AppIcon.icns"
 
+# Candidate builds keep the release/Sparkle version fields byte-for-byte
+# identical to source. A separate, validated identity lets About and tester
+# filenames expose the exact source without making CFBundleVersion non-numeric.
+if [[ -n "${RAPID_CANDIDATE_IDENTITY:-}" ]]; then
+    if [[ ! "$RAPID_CANDIDATE_IDENTITY" =~ ^candidate-[0-9a-f]{8}$ ]]; then
+        echo "ERR: RAPID_CANDIDATE_IDENTITY must be candidate-<8 lowercase hex>" >&2
+        exit 1
+    fi
+    plutil -insert RapidCandidateIdentity -string "$RAPID_CANDIDATE_IDENTITY" \
+        "$CONTENTS/Info.plist"
+fi
+
 # SwiftPM links Sparkle dynamically but this app is assembled by hand rather
 # than by Xcode, so its normal "Embed & Sign" phase does not run for us. Copy
 # the complete framework (including symlinks and installer helpers), then add

--- a/tests/test_candidate_build_identity.py
+++ b/tests/test_candidate_build_identity.py
@@ -39,12 +39,20 @@ def test_candidate_tester_dmg_is_additive_and_dispatch_only() -> None:
     assert 'cmp -s "$SOURCE" "$TARGET"' in stage["run"]
     assert "candidate_identity" in candidate["with"]["name"]
 
+    # The exact pre-tag promotion path added by #2451 never enters this build
+    # job, so it cannot acquire a tester-only identity or renamed artifact.
+    assert "inputs.promote_run_id == ''" in build["if"]
+    assert "inputs.promote_sha == ''" in build["if"]
+    promotion_names = {step.get("name") for step in jobs["promote-candidate"]["steps"]}
+    assert "Stage candidate-labelled tester DMG" not in promotion_names
+    assert "Upload candidate-labelled tester DMG" not in promotion_names
+
 
 def test_build_script_validates_and_embeds_separate_candidate_key() -> None:
     text = BUILD.read_text()
 
     assert "^candidate-[0-9a-f]{8}$" in text
     assert "plutil -insert RapidCandidateIdentity" in text
-    candidate_block = text[text.index('if [[ -n "${RAPID_CANDIDATE_IDENTITY') :]
-    assert "CFBundleVersion" not in candidate_block.split("fi", 1)[0]
-    assert "CFBundleShortVersionString" not in candidate_block.split("fi", 1)[0]
+    for version_key in ("CFBundleVersion", "CFBundleShortVersionString"):
+        assert f"plutil -insert {version_key}" not in text
+        assert f"plutil -replace {version_key}" not in text

--- a/tests/test_candidate_build_identity.py
+++ b/tests/test_candidate_build_identity.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "rapid-mac-release.yml"
+ACTION = ROOT / ".github" / "actions" / "desktop-releasable" / "action.yml"
+BUILD = ROOT / "apps" / "rapid-mac" / "scripts" / "build.sh"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def test_dispatch_candidate_identity_is_sha_bound_and_separate_from_versions() -> None:
+    text = WORKFLOW.read_text()
+    action = yaml.safe_load(ACTION.read_text())
+
+    assert 'CANDIDATE_IDENTITY="candidate-${GITHUB_SHA:0:8}"' in text
+    assert 'CANDIDATE_IDENTITY=""' in text
+    assert "candidate_identity" in action["inputs"]
+    assert action["inputs"]["candidate_identity"]["default"] == ""
+    assert "RAPID_CANDIDATE_IDENTITY" in ACTION.read_text()
+
+
+def test_candidate_tester_dmg_is_additive_and_dispatch_only() -> None:
+    jobs = _workflow()["jobs"]
+    build = jobs["build"]
+    by_name = {step.get("name"): step for step in build["steps"]}
+
+    canonical = by_name["Upload workflow artifact (DMG + manifest)"]
+    stage = by_name["Stage candidate-labelled tester DMG"]
+    candidate = by_name["Upload candidate-labelled tester DMG"]
+
+    assert "rapid-mlx-desktop.dmg" in canonical["with"]["path"]
+    assert stage["if"] == "steps.appmeta.outputs.is_tag != 'true'"
+    assert candidate["if"] == "steps.appmeta.outputs.is_tag != 'true'"
+    assert "rapid-mlx-desktop-${CANDIDATE_IDENTITY}.dmg" in stage["run"]
+    assert 'cmp -s "$SOURCE" "$TARGET"' in stage["run"]
+    assert "candidate_identity" in candidate["with"]["name"]
+
+
+def test_build_script_validates_and_embeds_separate_candidate_key() -> None:
+    text = BUILD.read_text()
+
+    assert "^candidate-[0-9a-f]{8}$" in text
+    assert "plutil -insert RapidCandidateIdentity" in text
+    candidate_block = text[text.index('if [[ -n "${RAPID_CANDIDATE_IDENTITY') :]
+    assert "CFBundleVersion" not in candidate_block.split("fi", 1)[0]
+    assert "CFBundleShortVersionString" not in candidate_block.split("fi", 1)[0]


### PR DESCRIPTION
## Why

An input-free Desktop workflow dispatch is the artifact a tester downloads before a release, but today both its About panel and downloadable DMG use the stable version identity. Two candidates built from different commits therefore look identical. The exact pre-tag promotion path landed separately and must remain byte-for-byte unchanged.

## What

- Derive candidate-<8-char source SHA> only inside the standalone build lane used by an input-free workflow dispatch.
- Pass that value through the shared releasable action into a separate RapidCandidateIdentity Info.plist key before signing.
- Show the candidate identity next to Version and Build in About.
- Upload an additive SHA-labelled DMG whose bytes match the canonical candidate DMG.

## Design precedent

Mature build systems keep the product version stable and carry source revision in separate build metadata. Tester artifacts likewise add channel or revision identity to the filename without changing updater ordering. This adapts that pattern to the native bundle: the candidate key is injected before signing, while CFBundleVersion, CFBundleShortVersionString, Sparkle metadata, the canonical DMG, and release tags keep their existing semantics.

## Scope

The change is limited to input-free workflow-dispatch candidate builds and About display. Tag builds and the protected exact pre-tag promotion path do not enter the candidate-labelled steps.

Non-goals:

- no semantic or numeric version change;
- no signing, notarization, publication, appcast, or promotion behavior change;
- no replacement or mutation of the canonical DMG and manifest;
- no product behavior outside About.

## Verification

- Focused Python workflow/action contracts: 3 passed.
- Focused Swift About tests: 2 passed.
- actionlint, YAML parse, Ruff check/format, Bash syntax, and diff checks pass.
- Release-shaped app build at candidate-f62f4a93 preserved version 0.13.1 and build 166, embedded the separate candidate key, and passed deep strict code-sign verification.
- Hosted exact-head candidate run [33128133726](https://github.com/raullenchai/Rapid-MLX/actions/runs/33128133726) passed build, signing, notarization, DMG validation, and desktop-ready; promote, mirror, and publish jobs were skipped.
- Canonical and candidate-labelled DMGs are byte-identical: 187,524,875 bytes, SHA-256 `16bfa60770813ca1946b0c9b2e2c9b235a7a7513896bfacd92e03ac8c215bc15`.
- The mounted app reports version 0.13.1, build 166, and `candidate-2fb2b131`; stapler, deep strict codesign, and Gatekeeper assessment pass.

Fixes #2535