### PR TITLE
fix: preserve forced tool calls on MLLM lane

### DIFF
--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -163,9 +163,7 @@ def test_forced_named_tool_on_mllm_uses_prefix_not_dropped_processors(
     def _unexpected_reasoning_budget(*_args, **_kwargs):
         raise AssertionError("MLLM requests must not build logits processors")
 
-    monkeypatch.setattr(
-        chat_route, "_offload_tool_grammar_build", _unexpected_grammar
-    )
+    monkeypatch.setattr(chat_route, "_offload_tool_grammar_build", _unexpected_grammar)
     monkeypatch.setattr(
         chat_route, "_enforce_tool_grammar_bounds_or_400", _unexpected_bounds
     )
@@ -221,10 +219,13 @@ def test_forced_named_tool_on_mllm_uses_prefix_not_dropped_processors(
     )
     assert "grammar_logits_processor" not in kwargs
     assert "reasoning_budget_logits_processor" not in kwargs
-    assert sum(
-        "cannot apply logits processors" in record.getMessage()
-        for record in caplog.records
-    ) == 1
+    assert (
+        sum(
+            "cannot apply logits processors" in record.getMessage()
+            for record in caplog.records
+        )
+        == 1
+    )
 
 
 def test_chat_route_rejects_image_on_text_lane_with_typed_reason():

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -142,6 +142,86 @@ def _multipart_user_message(text: str) -> dict:
     }
 
 
+def test_forced_named_tool_on_mllm_uses_prefix_not_dropped_processors(
+    monkeypatch, caplog
+):
+    """MLLM generation must retain a real enforcement lever for forced tools.
+
+    The text route may successfully build a grammar processor, but the current
+    MLLM scheduler cannot consume it.  The route must therefore discard that
+    processor, restore the parser-derived assistant prefix, and avoid building
+    the equally unsupported reasoning-budget processor.
+    """
+    from vllm_mlx.routes import chat as chat_route
+
+    class _GrammarProcessor:
+        reasoning_gate_id = None
+
+    async def _built_grammar(*_args, **_kwargs):
+        return _GrammarProcessor()
+
+    def _unexpected_reasoning_budget(*_args, **_kwargs):
+        raise AssertionError("MLLM requests must not build logits processors")
+
+    monkeypatch.setattr(chat_route, "_offload_tool_grammar_build", _built_grammar)
+    monkeypatch.setattr(
+        chat_route,
+        "_build_reasoning_budget_processor",
+        _unexpected_reasoning_budget,
+    )
+
+    engine = _StubMLLMEngine()
+    client = _make_client(engine)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "qwen3-vl-8b-4bit"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = "hermes"
+    cfg.reasoning_parser_name = None
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-vl-8b-4bit",
+            "messages": [{"role": "user", "content": "Weather in Paris?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+            "stream": False,
+        },
+    )
+
+    # The canned stub deliberately ignores the prefix and returns prose, so the
+    # route's schema-valid synthesis guard rejects its final response.  The
+    # contract under test is the generation kwargs delivered to that stub.
+    assert response.status_code == 422, response.text
+    kwargs = engine.chat_calls[0]["kwargs"]
+    assert kwargs["forced_assistant_prefix"] == (
+        '<tool_call>\n{"name": "get_weather", "arguments": '
+    )
+    assert "grammar_logits_processor" not in kwargs
+    assert "reasoning_budget_logits_processor" not in kwargs
+    assert sum(
+        "cannot apply logits processors" in record.getMessage()
+        for record in caplog.records
+    ) == 1
+
+
 def test_chat_route_rejects_image_on_text_lane_with_typed_reason():
     engine = _StubTextFallbackEngine()
     client = _make_client(engine)

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -147,23 +147,28 @@ def test_forced_named_tool_on_mllm_uses_prefix_not_dropped_processors(
 ):
     """MLLM generation must retain a real enforcement lever for forced tools.
 
-    The text route may successfully build a grammar processor, but the current
-    MLLM scheduler cannot consume it.  The route must therefore discard that
-    processor, restore the parser-derived assistant prefix, and avoid building
-    the equally unsupported reasoning-budget processor.
+    The current MLLM scheduler cannot consume text-lane logits processors.  The
+    route must therefore avoid grammar validation/compilation, restore the
+    parser-derived assistant prefix, and avoid building the equally unsupported
+    reasoning-budget processor.
     """
     from vllm_mlx.routes import chat as chat_route
 
-    class _GrammarProcessor:
-        reasoning_gate_id = None
+    async def _unexpected_grammar(*_args, **_kwargs):
+        raise AssertionError("MLLM requests must not compile a tool grammar")
 
-    async def _built_grammar(*_args, **_kwargs):
-        return _GrammarProcessor()
+    def _unexpected_bounds(*_args, **_kwargs):
+        raise AssertionError("MLLM requests must not enter grammar-only validation")
 
     def _unexpected_reasoning_budget(*_args, **_kwargs):
         raise AssertionError("MLLM requests must not build logits processors")
 
-    monkeypatch.setattr(chat_route, "_offload_tool_grammar_build", _built_grammar)
+    monkeypatch.setattr(
+        chat_route, "_offload_tool_grammar_build", _unexpected_grammar
+    )
+    monkeypatch.setattr(
+        chat_route, "_enforce_tool_grammar_bounds_or_400", _unexpected_bounds
+    )
     monkeypatch.setattr(
         chat_route,
         "_build_reasoning_budget_processor",

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -148,25 +148,19 @@ def test_forced_named_tool_on_mllm_uses_prefix_not_dropped_processors(
     """MLLM generation must retain a real enforcement lever for forced tools.
 
     The current MLLM scheduler cannot consume text-lane logits processors.  The
-    route must therefore avoid grammar validation/compilation, restore the
-    parser-derived assistant prefix, and avoid building the equally unsupported
-    reasoning-budget processor.
+    route must therefore avoid grammar compilation, restore the parser-derived
+    assistant prefix, and avoid building the equally unsupported reasoning-budget
+    processor.
     """
     from vllm_mlx.routes import chat as chat_route
 
     async def _unexpected_grammar(*_args, **_kwargs):
         raise AssertionError("MLLM requests must not compile a tool grammar")
 
-    def _unexpected_bounds(*_args, **_kwargs):
-        raise AssertionError("MLLM requests must not enter grammar-only validation")
-
     def _unexpected_reasoning_budget(*_args, **_kwargs):
         raise AssertionError("MLLM requests must not build logits processors")
 
     monkeypatch.setattr(chat_route, "_offload_tool_grammar_build", _unexpected_grammar)
-    monkeypatch.setattr(
-        chat_route, "_enforce_tool_grammar_bounds_or_400", _unexpected_bounds
-    )
     monkeypatch.setattr(
         chat_route,
         "_build_reasoning_budget_processor",

--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -3519,12 +3519,14 @@ def test_line1_route_threads_predicate_into_offload_build():
     # NOT on the shared default executor before admission. The route no longer runs
     # a separate pre-admission probe — it passes ``messages`` / ``resolved_thinking``
     # into the offload so the in-slot probe can render.
-    offload_pos = src.find(
-        "_offload_tool_grammar_build(\n        engine, cfg, request, messages, resolved_thinking"
-    )
+    offload_pos = src.find("_offload_tool_grammar_build(")
     assert offload_pos != -1, (
         "route must thread messages/resolved_thinking into the admission-gated build "
         "so the seed render runs in-slot (r3 #5)"
+    )
+    offload_call = src[offload_pos : offload_pos + 180]
+    assert "engine, cfg, request, messages, resolved_thinking" in offload_call, (
+        "route must pass messages/resolved_thinking to the admission-gated build"
     )
     assert "_line1_probe_seed_offloaded(" not in src, (
         "the pre-admission offloaded probe must be gone (r3 #5 DoS)"

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4328,7 +4328,13 @@ async def _create_chat_completion_impl(
     # before ``_offload_tool_grammar_build`` — the offload treats an oversized
     # schema as ineligible and returns ``None`` (silent free-form), which under
     # default-on would drop the structural guarantee the operator asked for.
-    _enforce_tool_grammar_bounds_or_400(cfg, request)
+    # The serialized MLLM scheduler cannot consume text-lane logits processors.
+    # Detect that capability boundary before schema validation / compilation so
+    # an MLLM request cannot spend CPU or occupy a shared grammar-build slot for
+    # a processor that generation would silently drop.
+    _mllm_ignores_logits_processors = bool(getattr(engine, "is_mllm", False))
+    if not _mllm_ignores_logits_processors:
+        _enforce_tool_grammar_bounds_or_400(cfg, request)
     # LINE① (#558): decide reasoning-gated forced-grammar eligibility. Engage only
     # when a thinking budget is set AND the template PREFILLS an unclosed
     # ``<think>`` (seed state "open") — the exact condition under which the coupled
@@ -4342,23 +4348,11 @@ async def _create_chat_completion_impl(
     # where a request flood could queue unbounded render work. When the gate engages
     # the build stashes the rendered prefix on the processor (``_line1_seed_prefix``)
     # and the coupled budget reuses it below (no second render).
-    _glp = await _offload_tool_grammar_build(
-        engine, cfg, request, messages, resolved_thinking
-    )
-    # The serialized MLLM scheduler does not currently accept any of the
-    # text-lane logits processors.  Keeping a processor here is worse than a
-    # no-op: it suppresses the forced-assistant-prefix fallback below even
-    # though ``BatchedEngine`` cannot forward the processor to generation.
-    # Restore the established prefix contract until MLLMScheduler grows an
-    # explicit logits-processor capability (tracked separately).
-    _mllm_ignores_logits_processors = bool(getattr(engine, "is_mllm", False))
-    if _mllm_ignores_logits_processors and _glp is not None:
-        logger.warning(
-            "MLLM %s chat request cannot apply logits processors; discarding "
-            "the tool grammar and restoring the forced-assistant-prefix fallback",
-            "streaming" if request.stream else "non-streaming",
+    _glp = None
+    if not _mllm_ignores_logits_processors:
+        _glp = await _offload_tool_grammar_build(
+            engine, cfg, request, messages, resolved_thinking
         )
-        _glp = None
     # LINE① (#558) Option B — COUPLE the generation-time thinking budget to the
     # gated grammar. ``reasoning_gate_id is not None`` means the grammar's mask is
     # held OFF until ``</think>`` (runtime token-id gate), so a budget that
@@ -4410,6 +4404,14 @@ async def _create_chat_completion_impl(
         _forced_prefix = _compute_forced_tool_prefix(cfg, request)
     if _forced_prefix:
         chat_kwargs["forced_assistant_prefix"] = _forced_prefix
+    if _mllm_ignores_logits_processors and (
+        _forced_prefix or getattr(request, "reasoning_max_tokens", None) is not None
+    ):
+        logger.warning(
+            "MLLM %s chat request cannot apply logits processors; using the "
+            "forced-assistant-prefix fallback where available",
+            "streaming" if request.stream else "non-streaming",
+        )
 
     # PFlash routing (#287): structured-output prompts are
     # prompt-integrity-sensitive — lossy compression would corrupt the

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4345,6 +4345,20 @@ async def _create_chat_completion_impl(
     _glp = await _offload_tool_grammar_build(
         engine, cfg, request, messages, resolved_thinking
     )
+    # The serialized MLLM scheduler does not currently accept any of the
+    # text-lane logits processors.  Keeping a processor here is worse than a
+    # no-op: it suppresses the forced-assistant-prefix fallback below even
+    # though ``BatchedEngine`` cannot forward the processor to generation.
+    # Restore the established prefix contract until MLLMScheduler grows an
+    # explicit logits-processor capability (tracked separately).
+    _mllm_ignores_logits_processors = bool(getattr(engine, "is_mllm", False))
+    if _mllm_ignores_logits_processors and _glp is not None:
+        logger.warning(
+            "MLLM %s chat request cannot apply logits processors; discarding "
+            "the tool grammar and restoring the forced-assistant-prefix fallback",
+            "streaming" if request.stream else "non-streaming",
+        )
+        _glp = None
     # LINE① (#558) Option B — COUPLE the generation-time thinking budget to the
     # gated grammar. ``reasoning_gate_id is not None`` means the grammar's mask is
     # held OFF until ``</think>`` (runtime token-id gate), so a budget that
@@ -4476,15 +4490,17 @@ async def _create_chat_completion_impl(
     # holds the tool grammar OFF through the ``<think>`` span, so the budget's
     # force-close of ``</think>`` lands before any tool-call token — safe despite
     # vLLM #44676 (which is the UNGATED auto/parser path this never touches).
-    _rblp = _build_reasoning_budget_processor(
-        engine,
-        request,
-        cfg,
-        messages,
-        resolved_thinking,
-        allow_tools=_line1_gate_engaged,
-        seed_prefix=(_line1_prefix if _line1_gate_engaged else _LINE1_SEED_UNSET),
-    )
+    _rblp = None
+    if not _mllm_ignores_logits_processors:
+        _rblp = _build_reasoning_budget_processor(
+            engine,
+            request,
+            cfg,
+            messages,
+            resolved_thinking,
+            allow_tools=_line1_gate_engaged,
+            seed_prefix=(_line1_prefix if _line1_gate_engaged else _LINE1_SEED_UNSET),
+        )
     if _rblp is not None:
         chat_kwargs["reasoning_budget_logits_processor"] = _rblp
     elif _line1_gate_engaged:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4329,12 +4329,13 @@ async def _create_chat_completion_impl(
     # schema as ineligible and returns ``None`` (silent free-form), which under
     # default-on would drop the structural guarantee the operator asked for.
     # The serialized MLLM scheduler cannot consume text-lane logits processors.
-    # Detect that capability boundary before schema validation / compilation so
-    # an MLLM request cannot spend CPU or occupy a shared grammar-build slot for
-    # a processor that generation would silently drop.
+    # Detect that capability boundary before compilation so an MLLM request
+    # cannot spend CPU or occupy a shared grammar-build slot for a processor
+    # that generation would silently drop. Keep the cheap schema bounds guard
+    # on every lane: it also prevents oversized client schemas from reaching
+    # prompt rendering even when constrained decoding is unavailable.
     _mllm_ignores_logits_processors = bool(getattr(engine, "is_mllm", False))
-    if not _mllm_ignores_logits_processors:
-        _enforce_tool_grammar_bounds_or_400(cfg, request)
+    _enforce_tool_grammar_bounds_or_400(cfg, request)
     # LINE① (#558): decide reasoning-gated forced-grammar eligibility. Engage only
     # when a thinking budget is set AND the template PREFILLS an unclosed
     # ``<think>`` (seed state "open") — the exact condition under which the coupled


### PR DESCRIPTION
## Why

Forced named/required tool calls can lose both enforcement levers on the MLLM serving lane: the route builds a grammar processor and suppresses its prefix fallback, while the current MLLM scheduler cannot consume that processor. The model may then return prose or an invalid fabricated call.

## Scope

- Discard an unusable tool grammar on MLLM requests and restore the existing parser-derived forced assistant prefix.
- Skip the equally unsupported reasoning-budget processor on that lane.
- Emit one warning identifying streaming vs non-streaming affected requests.
- Add a focused fake-MLLM route contract.

## Non-goals

- No MLLM scheduler redesign or generic retry.
- No model/alias heuristics.
- No changes to auto tool choice or text-lane grammar behavior.

The scheduler capability follow-up is tracked in #2468.

## Validation

- `python3.12 -m pytest -q tests/test_chat_route_vlm_image.py tests/test_grammar_processor_558.py -x` — 133 passed
- `python3.12 -m ruff check vllm_mlx/routes/chat.py tests/test_chat_route_vlm_image.py` — passed
- `git diff --check` — passed