### PR TITLE
fix(mac): avoid launch-time keychain identity stalls

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -267,8 +267,20 @@ struct SystemKeychain: KeychainStoring {
 
     private static func isDeveloperIDApplication(_ code: SecStaticCode) -> Bool {
         guard let requirement = developerIDApplicationCodeRequirement() else { return false }
-        return SecStaticCodeCheckValidity(code, [], requirement) == errSecSuccess
+        return SecStaticCodeCheckValidity(
+            code,
+            developerIDApplicationValidationFlags,
+            requirement
+        ) == errSecSuccess
     }
+
+    /// The namespace decision only needs to establish that the signing
+    /// certificate satisfies the Developer ID Application requirement. Do not
+    /// revalidate the executable or every sealed app resource here: this runs
+    /// while the app constructs its settings model, before the first window.
+    static let developerIDApplicationValidationFlags = SecCSFlags(
+        rawValue: kSecCSDoNotValidateResources | kSecCSDoNotValidateExecutable
+    )
 
     static func developerIDApplicationRequirementCompiles() -> Bool {
         developerIDApplicationCodeRequirement() != nil

--- a/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
@@ -28,7 +28,6 @@ struct DeferredTelemetryConsentBanner: View {
 
             Button("No thanks", role: .cancel) { consent.decline() }
                 .buttonStyle(.bordered)
-                .keyboardShortcut(.cancelAction)
                 .accessibilityIdentifier("TelemetryConsent.PostValue.Decline")
 
             Button("Share") { consent.share() }

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -70,7 +70,9 @@ struct DeferredTelemetryConsentWiringTests {
             #expect(banner.contains("TelemetryConsent.PostValue\(identifier == "Banner" ? "" : ".")\(identifier)"))
         }
         #expect(!banner.contains(".isModal"))
-        #expect(banner.contains(".keyboardShortcut(.cancelAction)"))
+        #expect(banner.contains("Button(\"No thanks\", role: .cancel) { consent.decline() }"))
+        #expect(!banner.contains(".keyboardShortcut(.cancelAction)"),
+                "Escape belongs to the active app interaction; only an explicit click may decline")
         #expect(!banner.contains("@FocusState"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import Testing
 @testable import Rapid
 
@@ -100,6 +101,14 @@ struct SettingsWebSearchKeyDraftTests {
     @Test("Developer ID Application uses a valid system code requirement")
     func developerIDRequirementCompiles() {
         #expect(SystemKeychain.developerIDApplicationRequirementCompiles())
+    }
+
+    @Test("Developer ID namespace detection never revalidates the app bundle")
+    func developerIDNamespaceCheckSkipsSealedResourcesAndExecutable() {
+        let flags = SystemKeychain.developerIDApplicationValidationFlags
+
+        #expect(flags.contains(SecCSFlags(rawValue: kSecCSDoNotValidateResources)))
+        #expect(flags.contains(SecCSFlags(rawValue: kSecCSDoNotValidateExecutable)))
     }
 
     @Test("Explicit save recovers from an inaccessible current-identity item")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1312,9 +1312,14 @@ flow_fresh_install() {
     wait_identifier TelemetryConsent.PostValueBanner "$OUT/post-value-consent-visible.json"
     assert_tree_text "$OUT/post-value-consent-visible.json" "Hello"
     baseline fresh-install.post-value-consent "$OUT/post-value-consent-visible.json"
-    # Exercise the native cancel shortcut rather than only the button action:
-    # closing this invitation is a durable decline and must never re-prompt.
+    # The invitation is part of the main window, not a modal. Escape belongs
+    # to the active app interaction and must never answer a permanent privacy
+    # choice on the user's behalf.
     "$AX_DRIVER" key "$APP_PID" escape > "$OUT/post-value-consent-escape.json"
+    wait_identifier TelemetryConsent.PostValueBanner "$OUT/post-value-consent-after-escape.json"
+    press "$OUT/post-value-consent-after-escape.json" \
+        TelemetryConsent.PostValue.Decline \
+        "$OUT/post-value-consent-explicit-decline.json"
     for _ in {1..40}; do
         see_main "$OUT/post-value-consent-declined.json"
         if ! jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.PostValueBanner")' \
@@ -1325,7 +1330,7 @@ flow_fresh_install() {
     done
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.PostValueBanner")' \
         "$OUT/post-value-consent-declined.json" >/dev/null; then
-        die "Escape did not dismiss the telemetry invitation"
+        die "explicit No thanks did not dismiss the telemetry invitation"
     fi
     relaunch_persona
     wait_identifier rapid.chat.compose "$OUT/post-value-consent-relaunch.json"

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -64,7 +64,7 @@ def test_ax_dump_omits_non_finite_numbers_before_json_serialization():
     assert "origin.x.isFinite" in bounds and "extent.height.isFinite" in bounds
 
 
-def test_ax_escape_posts_a_real_key_to_the_target_process():
+def test_ax_escape_posts_a_real_key_without_answering_nonmodal_consent():
     source = DRIVER.read_text()
     key = source.split('if command == "key" {', 1)[1].split("\n}", 1)[0]
     assert 'wanted == "escape"' in key
@@ -76,7 +76,14 @@ def test_ax_escape_posts_a_real_key_to_the_target_process():
         HARNESS.read_text().split("flow_fresh_install() {", 1)[1].split("\n}", 1)[0]
     )
     assert '"$AX_DRIVER" key "$APP_PID" escape' in fresh_install
-    assert "Escape did not dismiss the telemetry invitation" in fresh_install
+    assert (
+        "wait_identifier TelemetryConsent.PostValueBanner"
+        ' "$OUT/post-value-consent-after-escape.json"'
+    ) in fresh_install
+    assert "TelemetryConsent.PostValue.Decline" in fresh_install
+    assert (
+        "explicit No thanks did not dismiss the telemetry invitation" in fresh_install
+    )
     assert "dismissed telemetry invitation returned after relaunch" in fresh_install
 
 


### PR DESCRIPTION
## Why

Requested by the maintainer during 0.13.1 dogfood. The Keychain namespace identity check ran before the first window and revalidated every sealed resource in the release-shaped app bundle. Separately, the non-modal post-value telemetry invitation bound Escape to a permanent decline, so unrelated keyboard cancellation could silently answer the privacy choice.

## What

- Validate only the Developer ID certificate requirement for namespace selection; skip executable and sealed-resource revalidation.
- Preserve the existing release/development namespace and migration behavior.
- Keep **No thanks** as an explicit button, but remove the non-modal Escape shortcut.
- Pin both contracts in focused Swift tests.

## Scope / non-goals

Desktop-only. No Keychain service or migration changes, no telemetry collection/privacy changes, no consent redesign, and no unrelated launch work.

## Evidence

- Focused Keychain + deferred-consent suites: 24/24 passed.
- Release-shaped 473 MB app identity check: new validation flags <1 ms; full sealed-resource validation 455 ms on a warm cache.
- Full Desktop suite and release build in progress.
- Codex capped at two rounds.