### PR TITLE
fix(routing): keep qwen4_exp/flash-next on text lane; honor spec_decode + text-diffusion group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,12 @@ jobs:
             tests/test_server.py \
             tests/test_paged_cache.py \
             tests/test_mllm_continuous_batching.py \
+            tests/test_mllm_batch_generator.py \
+            tests/test_mllm_penalty_passthrough.py \
+            tests/test_guided.py \
+            tests/test_chat_streaming_guided.py \
+            tests/test_anthropic_output_config.py \
+            tests/test_response_format_json_schema_strict.py \
             tests/test_mllm_cache.py \
             tests/test_memory_cache.py \
             tests/test_optimizations.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
             tests/test_music_engine.py \
             tests/test_audio_model_worker.py \
             tests/test_server_load_model_order.py \
+            tests/test_routing_groups_0131.py \
             tests/test_ready_banner_timing.py \
             tests/test_api_validation_bundle.py \
             tests/test_aliases_contract.py \
@@ -482,6 +483,7 @@ jobs:
             tests/test_suffix_decoding.py \
             tests/test_qwen4_exp_artifact_parity.py \
             tests/test_qwen4_exp_reference_parity.py \
+            tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
             -v --tb=short \
             -m "not slow" \

--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -639,6 +639,20 @@ async def test_mllm_output_schema_fails_closed_when_schema_is_unusable(monkeypat
     assert chat_kwargs == {}
 
 
+@pytest.mark.asyncio
+async def test_output_schema_ignores_engines_without_mllm_capability():
+    from vllm_mlx.routes import anthropic as anthropic_route
+
+    request = SimpleNamespace(response_format=object(), tools=[])
+    chat_kwargs = {}
+
+    await anthropic_route._attach_mllm_schema_processor(
+        SimpleNamespace(tokenizer="tok"), request, chat_kwargs
+    )
+
+    assert chat_kwargs == {}
+
+
 def test_mllm_streaming_schema_disables_reasoning_classification(
     monkeypatch, anthropic_client
 ):

--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -619,3 +619,73 @@ async def test_mllm_output_schema_does_not_replace_tool_grammar(monkeypatch):
     await anthropic_route._attach_mllm_schema_processor(engine, request, chat_kwargs)
 
     assert chat_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_mllm_output_schema_fails_closed_when_schema_is_unusable(monkeypatch):
+    from vllm_mlx.routes import anthropic as anthropic_route
+
+    monkeypatch.setattr(
+        anthropic_route,
+        "extract_json_schema_for_guided",
+        lambda _response_format: None,
+    )
+    request = SimpleNamespace(response_format=object(), tools=[])
+    engine = SimpleNamespace(is_mllm=True, tokenizer="tok")
+    chat_kwargs = {}
+
+    await anthropic_route._attach_mllm_schema_processor(engine, request, chat_kwargs)
+
+    assert chat_kwargs == {}
+
+
+def test_mllm_streaming_schema_disables_reasoning_classification(
+    monkeypatch, anthropic_client
+):
+    """The Anthropic streaming path treats schema bytes as answer content."""
+    from vllm_mlx.api import guided
+
+    marker = object()
+    monkeypatch.setattr(
+        guided,
+        "build_json_schema_logits_processor",
+        lambda *_args: marker,
+    )
+
+    async def _stream_chat(engine, messages, **kwargs):
+        engine.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        yield _GenerationOutput(
+            text='{"name":"alice"}',
+            raw_text='{"name":"alice"}',
+            new_text='{"name":"alice"}',
+            tokens=[1],
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+    engine = anthropic_client.engine
+    engine.is_mllm = True
+    engine.tokenizer.chat_template = "<think>"
+    engine.stream_chat = types.MethodType(_stream_chat, engine)
+
+    response = anthropic_client.client.post(
+        "/v1/messages",
+        json=_payload(
+            stream=True,
+            output_config={
+                "format": {
+                    "type": "json_schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                }
+            },
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    assert engine.calls[0].kwargs["grammar_logits_processor"] is marker
+    assert engine.calls[0].kwargs["enable_thinking"] is False
+    assert '"type": "thinking"' not in response.text

--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -591,7 +591,7 @@ async def test_mllm_output_schema_attaches_request_local_processor(monkeypatch):
             marker if tokenizer == "tok" and actual_schema == schema else None
         ),
     )
-    request = SimpleNamespace(response_format=object())
+    request = SimpleNamespace(response_format=object(), tools=[])
     engine = SimpleNamespace(is_mllm=True, tokenizer="tok")
     chat_kwargs = {}
 
@@ -599,3 +599,23 @@ async def test_mllm_output_schema_attaches_request_local_processor(monkeypatch):
 
     assert chat_kwargs["grammar_logits_processor"] is marker
     assert chat_kwargs["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_mllm_output_schema_does_not_replace_tool_grammar(monkeypatch):
+    """Combined tools/schema requests retain the existing tool-call contract."""
+    from vllm_mlx.api import guided
+    from vllm_mlx.routes import anthropic as anthropic_route
+
+    monkeypatch.setattr(
+        guided,
+        "build_json_schema_logits_processor",
+        lambda *_args: pytest.fail("whole-response schema must not replace tools"),
+    )
+    request = SimpleNamespace(response_format=object(), tools=[object()])
+    engine = SimpleNamespace(is_mllm=True, tokenizer="tok")
+    chat_kwargs = {}
+
+    await anthropic_route._attach_mllm_schema_processor(engine, request, chat_kwargs)
+
+    assert chat_kwargs == {}

--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -20,6 +20,7 @@ The route-level tests reuse the lightweight-engine fixture pattern from
 engine, which keeps CI hermetic.
 """
 
+import contextvars
 import json
 import sys
 import types
@@ -326,6 +327,7 @@ class _RecordingEngine:
     """
 
     preserve_native_tool_format = False
+    is_mllm = False
 
     def __init__(self):
         self.calls: list[SimpleNamespace] = []
@@ -350,8 +352,14 @@ def _install_lightweight_engine_modules(monkeypatch):
     base_mod.BaseEngine = _BaseEngine
     base_mod.GenerationOutput = _GenerationOutput
 
+    batched_mod = types.ModuleType("vllm_mlx.engine.batched")
+    batched_mod._admission_engine_context = contextvars.ContextVar(
+        "test_admission_engine", default=None
+    )
+
     monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
     monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.batched", batched_mod)
 
 
 _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
@@ -359,6 +367,7 @@ _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
     "vllm_mlx.config.server_config",
     "vllm_mlx.engine",
     "vllm_mlx.engine.base",
+    "vllm_mlx.engine.batched",
     "vllm_mlx.middleware.auth",
     "vllm_mlx.service.helpers",
     "vllm_mlx.routes.anthropic",
@@ -560,3 +569,33 @@ class TestRouteOutputConfigSurface:
             "output_config.effort leaked into engine chat kwargs — "
             "this field belongs to Pick 1 (concurrent PR)."
         )
+
+
+@pytest.mark.asyncio
+async def test_mllm_output_schema_attaches_request_local_processor(monkeypatch):
+    """Claude-shaped structured output is constrained on the MLLM lane."""
+    from vllm_mlx.api import guided
+    from vllm_mlx.routes import anthropic as anthropic_route
+
+    marker = object()
+    schema = {"type": "object", "properties": {"title": {"type": "string"}}}
+    monkeypatch.setattr(
+        anthropic_route,
+        "extract_json_schema_for_guided",
+        lambda _response_format: schema,
+    )
+    monkeypatch.setattr(
+        guided,
+        "build_json_schema_logits_processor",
+        lambda tokenizer, actual_schema: (
+            marker if tokenizer == "tok" and actual_schema == schema else None
+        ),
+    )
+    request = SimpleNamespace(response_format=object())
+    engine = SimpleNamespace(is_mllm=True, tokenizer="tok")
+    chat_kwargs = {}
+
+    await anthropic_route._attach_mllm_schema_processor(engine, request, chat_kwargs)
+
+    assert chat_kwargs["grammar_logits_processor"] is marker
+    assert chat_kwargs["enable_thinking"] is False

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -225,6 +225,45 @@ def test_streaming_json_schema_routes_through_guided_generation():
     assert "".join(content_parts) == _GUIDED_OUTPUT
 
 
+def test_mllm_streaming_schema_stays_on_scheduler_with_request_processor(
+    monkeypatch,
+):
+    """Vision-capable serving keeps its lane and constrains decode in place."""
+    from vllm_mlx.api import guided
+
+    marker = object()
+    monkeypatch.setattr(
+        guided,
+        "build_json_schema_logits_processor",
+        lambda _tokenizer, schema: marker if schema == _SCHEMA else None,
+    )
+    engine = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
+    engine.is_mllm = True
+    engine.supports_guided_generation = False
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "stream": True,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "pick a color"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "Pick", "schema": _SCHEMA},
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert engine.guided_calls == []
+    assert len(engine.stream_calls) == 1
+    assert engine.stream_calls[0]["kwargs"]["grammar_logits_processor"] is marker
+    assert engine.stream_calls[0]["kwargs"]["enable_thinking"] is False
+    assert "data: [DONE]" in resp.text
+
+
 def test_streaming_guided_no_duplicate_usage_when_include_usage_true():
     """When ``stream_options.include_usage`` is True, usage must appear
     ONLY in the dedicated usage chunk, NOT in the finish chunk too —

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -237,6 +237,13 @@ def test_mllm_streaming_schema_stays_on_scheduler_with_request_processor(
         "build_json_schema_logits_processor",
         lambda _tokenizer, schema: marker if schema == _SCHEMA else None,
     )
+    from vllm_mlx.routes import chat as chat_route
+
+    monkeypatch.setattr(
+        chat_route,
+        "_build_reasoning_budget_processor",
+        lambda *_args, **_kwargs: object(),
+    )
     engine = _GuidedEngine(guided_text=_GUIDED_OUTPUT)
     engine.is_mllm = True
     engine.supports_guided_generation = False
@@ -260,6 +267,7 @@ def test_mllm_streaming_schema_stays_on_scheduler_with_request_processor(
     assert engine.guided_calls == []
     assert len(engine.stream_calls) == 1
     assert engine.stream_calls[0]["kwargs"]["grammar_logits_processor"] is marker
+    assert "reasoning_budget_logits_processor" not in engine.stream_calls[0]["kwargs"]
     assert engine.stream_calls[0]["kwargs"]["enable_thinking"] is False
     assert "data: [DONE]" in resp.text
 

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -35,6 +35,40 @@ requires_guided = pytest.mark.skipif(
 )
 
 
+@requires_guided
+def test_scheduler_json_schema_processor_forces_eos_after_complete_value():
+    """A complete JSON value terminates instead of admitting whitespace forever."""
+    import math
+
+    import mlx.core as mx
+
+    from vllm_mlx.api.guided import build_json_schema_logits_processor
+
+    tokenizer = _build_byte_level_fast_tokenizer()
+    processor = build_json_schema_logits_processor(
+        tokenizer,
+        {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+            "additionalProperties": False,
+        },
+    )
+    assert processor is not None
+
+    prompt = tokenizer.encode("title:", add_special_tokens=False)
+    processor(prompt, mx.zeros((1, len(tokenizer))))
+    generated = tokenizer.encode('{"title":"OK"}', add_special_tokens=False)
+    masked = processor(prompt + generated, mx.zeros((1, len(tokenizer))))
+    row = masked[0].tolist()
+    eos_id = tokenizer.eos_token_id
+
+    assert math.isfinite(row[eos_id])
+    assert all(
+        not math.isfinite(value) for idx, value in enumerate(row) if idx != eos_id
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fake MLX model + tokenizer helpers (for the decode-loop tests)
 # ---------------------------------------------------------------------------

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -55,6 +55,7 @@ def test_scheduler_json_schema_processor_forces_eos_after_complete_value():
         },
     )
     assert processor is not None
+    processor._stop_ids = (-1, tokenizer.eos_token_id)
 
     prompt = tokenizer.encode("title:", add_special_tokens=False)
     processor(prompt, mx.zeros((1, len(tokenizer))))
@@ -64,6 +65,7 @@ def test_scheduler_json_schema_processor_forces_eos_after_complete_value():
     eos_id = tokenizer.eos_token_id
 
     assert math.isfinite(row[eos_id])
+    assert not math.isfinite(row[-1])
     assert all(
         not math.isfinite(value) for idx, value in enumerate(row) if idx != eos_id
     )

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -35,6 +35,27 @@ requires_guided = pytest.mark.skipif(
 )
 
 
+def test_scheduler_json_schema_processor_returns_none_without_backend(monkeypatch):
+    from vllm_mlx.api import guided
+
+    monkeypatch.setattr(guided, "HAS_LLGUIDANCE", False)
+    assert guided.build_json_schema_logits_processor(object(), {}) is None
+
+
+@requires_guided
+def test_scheduler_json_schema_processor_fails_closed(monkeypatch):
+    from vllm_mlx.api import guided, tool_grammar
+
+    monkeypatch.setattr(tool_grammar, "get_lltokenizer", lambda _tokenizer: None)
+    assert guided.build_json_schema_logits_processor(object(), {}) is None
+
+    def _raise(_tokenizer):
+        raise RuntimeError("bad tokenizer")
+
+    monkeypatch.setattr(tool_grammar, "get_lltokenizer", _raise)
+    assert guided.build_json_schema_logits_processor(object(), {}) is None
+
+
 @requires_guided
 def test_scheduler_json_schema_processor_forces_eos_after_complete_value():
     """A complete JSON value terminates instead of admitting whitespace forever."""

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -788,6 +788,42 @@ def test_step_request_processor_sees_compute_ahead_token(monkeypatch):
     assert int(sampled.item()) == 2
 
 
+def test_prefill_first_token_uses_request_logits_processor(monkeypatch):
+    """A request constraint owns token zero, not only steady-state decode."""
+    from mlx_lm.models import cache as cache_module
+
+    class _Cache:
+        def merge(self, _caches):
+            return self
+
+    monkeypatch.setattr(cache_module, "make_prompt_cache", lambda _model: [_Cache()])
+    monkeypatch.setattr(
+        "vllm_mlx.mllm_batch_generator.first_incompatible_mllm_cache_type",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.mllm_batch_generator.make_sampler",
+        lambda **_kwargs: lambda logprobs: mx.argmax(logprobs, axis=-1),
+    )
+
+    model = _RecordingModel()
+    gen = _make_generator(model)
+    gen._preprocess_request = lambda _request: None
+    gen._run_vision_encoding = lambda _request, cache: mx.zeros((1, 1, 4))
+    request = _make_request(pixel_values=None)
+
+    def _force_token_two(_token_ids, logits):
+        constrained = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+        constrained[..., 2] = 0
+        return constrained
+
+    request.logits_processors = [_force_token_two]
+
+    batch = gen._process_prompts([request])
+
+    assert int(batch.y.item()) == 2
+
+
 def test_step_caches_shared_sampler_across_calls(monkeypatch):
     """Repeated steps with the same (temp, top_p) reuse the cached sampler."""
     make_sampler_calls = []

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -766,7 +766,6 @@ def test_step_request_processor_sees_compute_ahead_token(monkeypatch):
     )
     gen = _make_step_stub_generator()
     request = _make_sampling_request(0, 0.0, 1.0)
-    request.output_tokens = [9]
     request.logits_processors = [constraint]
 
     sampled, _ = MLLMBatchGenerator._step(
@@ -775,8 +774,17 @@ def test_step_request_processor_sees_compute_ahead_token(monkeypatch):
         cache=[],
         requests=[request],
     )
+    history_id = id(request.logits_processor_tokens)
+    MLLMBatchGenerator._step(
+        gen,
+        mx.array([[4]], dtype=mx.uint32),
+        cache=[],
+        requests=[request],
+    )
 
-    assert histories == [[9, 3]]
+    assert histories == [[3], [3, 4]]
+    assert request.logits_processor_tokens == [3, 4]
+    assert id(request.logits_processor_tokens) == history_id
     assert int(sampled.item()) == 2
 
 

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -745,6 +745,41 @@ def test_step_homogeneous_requests_call_shared_sampler_once(monkeypatch):
     assert sampled.shape == (4,)
 
 
+def test_step_request_processor_sees_compute_ahead_token(monkeypatch):
+    """Constraints see the token already fed into the decode step.
+
+    ``request.output_tokens`` trails ``input_tokens`` by one token in the
+    MLLM compute-ahead pipeline.  Omitting that current token desynchronizes an
+    incremental grammar after its first generated token and makes it fail open.
+    """
+    histories = []
+
+    def constraint(token_ids, logits):
+        histories.append(list(token_ids))
+        constrained = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+        constrained[..., 2] = 0
+        return constrained
+
+    monkeypatch.setattr(
+        "vllm_mlx.mllm_batch_generator.make_sampler",
+        lambda **_kwargs: lambda logprobs: mx.argmax(logprobs, axis=-1),
+    )
+    gen = _make_step_stub_generator()
+    request = _make_sampling_request(0, 0.0, 1.0)
+    request.output_tokens = [9]
+    request.logits_processors = [constraint]
+
+    sampled, _ = MLLMBatchGenerator._step(
+        gen,
+        mx.array([[3]], dtype=mx.uint32),
+        cache=[],
+        requests=[request],
+    )
+
+    assert histories == [[9, 3]]
+    assert int(sampled.item()) == 2
+
+
 def test_step_caches_shared_sampler_across_calls(monkeypatch):
     """Repeated steps with the same (temp, top_p) reuse the cached sampler."""
     make_sampler_calls = []

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -669,6 +669,16 @@ class TestMLLMEosContract:
 
         assert scheduler.stop_tokens == {11, 12, 13}
 
+    def test_boolean_model_eos_is_not_a_token_id(self):
+        from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+        processor = SimpleNamespace(tokenizer=SimpleNamespace(eos_token_id=11))
+        model = SimpleNamespace(config=SimpleNamespace(eos_token_id=True))
+
+        scheduler = MLLMScheduler(model, processor, MLLMSchedulerConfig())
+
+        assert scheduler.stop_tokens == {11}
+
     def test_request_logits_processor_reaches_batch_generator(self):
         """Structured-output state stays request-local through admission."""
         from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -16,6 +16,7 @@ Test Cases:
 import base64
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -631,6 +632,60 @@ class TestVideoFpsForwarding:
         batch_req = bg.unprocessed_requests[0]
         assert batch_req.video_fps == 3.0
         assert batch_req.video_max_frames == 24
+
+
+@_skip_no_mlx_lm
+class TestMLLMEosContract:
+    """The MLLM generator must honor the loaded model's EOS contract."""
+
+    def test_model_config_eos_reaches_batch_generator(self):
+        """A processor/model EOS mismatch must still terminate generation.
+
+        Qwen3.5's processor tokenizer uses ``<|im_end|>`` while the loaded
+        multimodal model resolves ``<|endoftext|>`` as its model EOS.  The
+        latter is the token emitted by the affected title-generation path.
+        """
+        from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+        tokenizer = SimpleNamespace(eos_token_id=248046)
+        processor = SimpleNamespace(tokenizer=tokenizer)
+        model = SimpleNamespace(config=SimpleNamespace(eos_token_id=248044))
+
+        scheduler = MLLMScheduler(model, processor, MLLMSchedulerConfig())
+        scheduler._ensure_batch_generator()
+
+        assert scheduler.stop_tokens == {248044, 248046}
+        assert scheduler.batch_generator is not None
+        assert scheduler.batch_generator.stop_tokens == {248044, 248046}
+
+    def test_nested_text_config_eos_is_a_supported_fallback(self):
+        """Raw config-shaped MLLM models may retain EOS under text_config."""
+        from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+        processor = SimpleNamespace(tokenizer=SimpleNamespace(eos_token_id=11))
+        model = SimpleNamespace(config={"text_config": {"eos_token_id": [12, 13]}})
+
+        scheduler = MLLMScheduler(model, processor, MLLMSchedulerConfig())
+
+        assert scheduler.stop_tokens == {11, 12, 13}
+
+    def test_request_logits_processor_reaches_batch_generator(self):
+        """Structured-output state stays request-local through admission."""
+        from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+        constraint = MagicMock()
+        processor = SimpleNamespace(tokenizer=SimpleNamespace(eos_token_id=7))
+        model = SimpleNamespace(config=SimpleNamespace(eos_token_id=7))
+        scheduler = MLLMScheduler(model, processor, MLLMSchedulerConfig())
+
+        scheduler.add_request(prompt="title", logits_processors=[constraint])
+        scheduler._schedule_waiting()
+
+        assert scheduler.batch_generator is not None
+        assert scheduler.batch_generator.active_batch is None
+        assert scheduler.batch_generator.unprocessed_requests[0].logits_processors == [
+            constraint
+        ]
 
 
 @_skip_no_mlx_lm

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -24,6 +24,7 @@ This module pins behaviour at three layers:
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -273,3 +274,23 @@ async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
     async for _ in engine.stream_generate(prompt="hi", max_tokens=8):
         pass
     assert captured["logits_processors"] == []
+
+    async def _fake_generate(**kw):
+        captured.update(kw)
+        return SimpleNamespace(
+            output_text="ok",
+            output_token_ids=[1],
+            prompt_tokens=1,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+    engine._mllm_scheduler.generate = _fake_generate
+    await engine.generate(
+        prompt="hi",
+        max_tokens=8,
+        grammar_logits_processor=grammar,
+        reasoning_budget_logits_processor=budget,
+        suppressed_tokens_logits_processor=suppression,
+    )
+    assert captured["logits_processors"] == [grammar, budget, suppression]

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -248,6 +248,9 @@ async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
 
     engine._mllm_scheduler.add_request_async = _fake_add
     engine._mllm_scheduler.stream_outputs = _empty_stream
+    grammar = object()
+    budget = object()
+    suppression = object()
 
     async for _ in engine.stream_generate(
         prompt="hi",
@@ -255,9 +258,13 @@ async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
         repetition_penalty=1.7,
         presence_penalty=0.3,
         frequency_penalty=0.4,
+        grammar_logits_processor=grammar,
+        reasoning_budget_logits_processor=budget,
+        suppressed_tokens_logits_processor=suppression,
     ):
         pass
 
     assert captured["repetition_penalty"] == 1.7
     assert captured["presence_penalty"] == 0.3
     assert captured["frequency_penalty"] == 0.4
+    assert captured["logits_processors"] == [grammar, budget, suppression]

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -268,3 +268,8 @@ async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
     assert captured["presence_penalty"] == 0.3
     assert captured["frequency_penalty"] == 0.4
     assert captured["logits_processors"] == [grammar, budget, suppression]
+
+    captured.clear()
+    async for _ in engine.stream_generate(prompt="hi", max_tokens=8):
+        pass
+    assert captured["logits_processors"] == []

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -414,12 +414,19 @@ def test_strict_true_guided_unavailable_returns_422_on_violation_non_streaming()
 def test_strict_mllm_processor_fail_open_still_validates_response(monkeypatch):
     """A request-local matcher failure cannot weaken ``strict=true``."""
     from vllm_mlx.api import guided
+    from vllm_mlx.routes import chat as chat_route
 
     marker = object()
+    budget = object()
     monkeypatch.setattr(
         guided,
         "build_json_schema_logits_processor",
         lambda _tokenizer, _schema: marker,
+    )
+    monkeypatch.setattr(
+        chat_route,
+        "_build_reasoning_budget_processor",
+        lambda *_args, **_kwargs: budget,
     )
     engine = _Engine(supports_guided=False, chat_text=_INVALID_PAYLOAD_OUT_OF_RANGE)
     engine.is_mllm = True
@@ -431,7 +438,9 @@ def test_strict_mllm_processor_fail_open_still_validates_response(monkeypatch):
     assert resp.json()["error"]["code"] == "json_schema_violation"
     assert len(engine.chat_calls) == 2
     assert engine.chat_calls[0]["kwargs"]["grammar_logits_processor"] is marker
+    assert engine.chat_calls[0]["kwargs"]["reasoning_budget_logits_processor"] is budget
     assert "grammar_logits_processor" not in engine.chat_calls[1]["kwargs"]
+    assert "reasoning_budget_logits_processor" not in engine.chat_calls[1]["kwargs"]
 
 
 def test_strict_true_guided_unavailable_returns_200_when_initial_output_valid():

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -411,6 +411,28 @@ def test_strict_true_guided_unavailable_returns_422_on_violation_non_streaming()
     assert snap["strict_repairs_succeeded_total"] == 0
 
 
+def test_strict_mllm_processor_fail_open_still_validates_response(monkeypatch):
+    """A request-local matcher failure cannot weaken ``strict=true``."""
+    from vllm_mlx.api import guided
+
+    marker = object()
+    monkeypatch.setattr(
+        guided,
+        "build_json_schema_logits_processor",
+        lambda _tokenizer, _schema: marker,
+    )
+    engine = _Engine(supports_guided=False, chat_text=_INVALID_PAYLOAD_OUT_OF_RANGE)
+    engine.is_mllm = True
+    client = _make_client(engine)
+
+    resp = client.post("/v1/chat/completions", json=_payload(strict=True))
+
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "json_schema_violation"
+    assert len(engine.chat_calls) == 2
+    assert engine.chat_calls[0]["kwargs"]["grammar_logits_processor"] is marker
+
+
 def test_strict_true_guided_unavailable_returns_200_when_initial_output_valid():
     """R12-4 happy-path — strict+no-guided + initial output valid →
     200 with the validated body (no repair retry needed)."""

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -438,7 +438,7 @@ def test_strict_mllm_processor_fail_open_still_validates_response(monkeypatch):
     assert resp.json()["error"]["code"] == "json_schema_violation"
     assert len(engine.chat_calls) == 2
     assert engine.chat_calls[0]["kwargs"]["grammar_logits_processor"] is marker
-    assert engine.chat_calls[0]["kwargs"]["reasoning_budget_logits_processor"] is budget
+    assert "reasoning_budget_logits_processor" not in engine.chat_calls[0]["kwargs"]
     assert "grammar_logits_processor" not in engine.chat_calls[1]["kwargs"]
     assert "reasoning_budget_logits_processor" not in engine.chat_calls[1]["kwargs"]
 

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -431,6 +431,7 @@ def test_strict_mllm_processor_fail_open_still_validates_response(monkeypatch):
     assert resp.json()["error"]["code"] == "json_schema_violation"
     assert len(engine.chat_calls) == 2
     assert engine.chat_calls[0]["kwargs"]["grammar_logits_processor"] is marker
+    assert "grammar_logits_processor" not in engine.chat_calls[1]["kwargs"]
 
 
 def test_strict_true_guided_unavailable_returns_200_when_initial_output_valid():

--- a/tests/test_routing_groups_0131.py
+++ b/tests/test_routing_groups_0131.py
@@ -17,7 +17,12 @@ shape returned by the alias artifact's ``config.json`` (``model_type=qwen4_exp``
 false``).
 """
 
+import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
 
 from vllm_mlx.api import utils as utils_mod
 from vllm_mlx.api.utils import (
@@ -221,3 +226,143 @@ def test_fix3_spec_decode_requested_slides_vision_capable_to_text(
     vision_only = resolve_serving_lane_decision("/local/qwen35-vision", force_mllm=True)
     assert vision_only.is_mllm is True
     assert vision_only.reason == "vision_lane_forced"
+
+
+def test_fix3_spec_decode_on_text_checkpoint_keeps_text_lane(monkeypatch):
+    monkeypatch.setattr(utils_mod, "is_mllm_model", lambda _name: False)
+
+    decision = resolve_serving_lane_decision(
+        "/local/text-checkpoint", requested_spec_decode="mtp"
+    )
+
+    assert decision.is_mllm is False
+    assert decision.reason == "text_checkpoint"
+
+
+def test_fix3_cli_helper_forwards_legacy_mtp_as_requested_spec_decode(monkeypatch):
+    from vllm_mlx import cli
+
+    seen = {}
+
+    def _resolve(_model, **kwargs):
+        seen.update(kwargs)
+        return False, True
+
+    monkeypatch.setattr(utils_mod, "resolve_serving_lane", _resolve)
+
+    assert (
+        cli._serve_will_run_on_mllm_lane(
+            SimpleNamespace(
+                model="/local/vision-checkpoint",
+                mllm=False,
+                no_mllm=False,
+                spec_decode="none",
+                enable_mtp=True,
+            )
+        )
+        is False
+    )
+    assert seen["requested_spec_decode"] == "mtp"
+
+    seen.clear()
+    assert (
+        cli._serve_will_run_on_mllm_lane(
+            SimpleNamespace(
+                model="/local/vision-checkpoint",
+                mllm=False,
+                no_mllm=False,
+                spec_decode="none",
+                enable_mtp=False,
+                force_spec_decode=True,
+            )
+        )
+        is False
+    )
+    assert seen["requested_spec_decode"] == "auto"
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [("--enable-mtp", "mtp"), ("--force-spec-decode", "auto")],
+)
+def test_fix3_cli_serve_forwards_parsed_spec_decode_to_lane_contract(
+    monkeypatch, flag, expected
+):
+    from vllm_mlx import cli
+
+    class _StopAtPFlashError(Exception):
+        pass
+
+    seen = []
+
+    def _resolve(_model, **kwargs):
+        seen.append(kwargs)
+        return False, True
+
+    def _stop(*_args, **_kwargs):
+        raise _StopAtPFlashError
+
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(utils_mod, "resolve_serving_lane", _resolve)
+    monkeypatch.setattr("vllm_mlx.pflash.resolve_pflash_config", _stop)
+    monkeypatch.setattr(
+        "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "serve",
+            "qwen3.5-4b-4bit",
+            flag,
+        ],
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(_StopAtPFlashError):
+        cli.main()
+
+    assert seen
+    assert all(call["requested_spec_decode"] == expected for call in seen)
+
+
+def test_fix3_standalone_server_forwards_parsed_mtp_to_lane_contract(monkeypatch):
+    from vllm_mlx import cli, server
+
+    seen = []
+
+    def _resolve(_model, **kwargs):
+        seen.append(kwargs)
+        return False, True
+
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(server, "resolve_serving_lane", _resolve)
+    monkeypatch.setattr(server, "load_model", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
+    monkeypatch.setattr("uvicorn.run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vllm_mlx.server",
+            "--model",
+            "qwen3.5-4b-4bit",
+            "--force-spec-decode",
+        ],
+    )
+
+    with mock.patch.object(server, "register_audio_routes_if_enabled"):
+        server.main()
+
+    assert seen
+    assert seen[0]["requested_spec_decode"] == "auto"

--- a/tests/test_routing_groups_0131.py
+++ b/tests/test_routing_groups_0131.py
@@ -19,7 +19,7 @@ false``).
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -69,6 +69,18 @@ def _metadata(config: dict, snapshot_dir: Path) -> ModelMetadata:
         snapshot_dir=snapshot_dir,
         is_local=False,
     )
+
+
+def _install_scheduler_stub(monkeypatch) -> None:
+    """Let the public serve entry points run in the Linux no-MLX lane."""
+    scheduler = ModuleType("vllm_mlx.scheduler")
+
+    class SchedulerConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    scheduler.SchedulerConfig = SchedulerConfig
+    monkeypatch.setitem(sys.modules, "vllm_mlx.scheduler", scheduler)
 
 
 def test_fix1_unaliased_qwen4_exp_vendored_goes_text_lane(monkeypatch, tmp_path):
@@ -303,6 +315,7 @@ def test_fix3_cli_serve_forwards_parsed_spec_decode_to_lane_contract(
         raise _StopAtPFlashError
 
     monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+    _install_scheduler_stub(monkeypatch)
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
     monkeypatch.setattr(utils_mod, "resolve_serving_lane", _resolve)
@@ -332,7 +345,12 @@ def test_fix3_cli_serve_forwards_parsed_spec_decode_to_lane_contract(
 def test_fix3_standalone_server_forwards_parsed_mtp_to_lane_contract(monkeypatch):
     from vllm_mlx import cli, server
 
+    class _StopAtPFlashError(Exception):
+        pass
+
     seen = []
+
+    _install_scheduler_stub(monkeypatch)
 
     def _resolve(_model, **kwargs):
         seen.append(kwargs)
@@ -341,6 +359,10 @@ def test_fix3_standalone_server_forwards_parsed_mtp_to_lane_contract(monkeypatch
     monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
     monkeypatch.setattr(server, "resolve_serving_lane", _resolve)
     monkeypatch.setattr(server, "load_model", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "vllm_mlx.pflash.resolve_pflash_config",
+        lambda *_a, **_kw: (_ for _ in ()).throw(_StopAtPFlashError()),
+    )
     monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
     monkeypatch.setattr("uvicorn.run", lambda *_a, **_kw: None)
     monkeypatch.setattr(
@@ -361,7 +383,10 @@ def test_fix3_standalone_server_forwards_parsed_mtp_to_lane_contract(monkeypatch
         ],
     )
 
-    with mock.patch.object(server, "register_audio_routes_if_enabled"):
+    with (
+        mock.patch.object(server, "register_audio_routes_if_enabled"),
+        pytest.raises(_StopAtPFlashError),
+    ):
         server.main()
 
     assert seen

--- a/tests/test_routing_groups_0131.py
+++ b/tests/test_routing_groups_0131.py
@@ -1,0 +1,223 @@
+"""Routing-group fixes for 0.13.1 (fix/0131-routing-groups).
+
+FIX 1 — ``qwen4_exp`` (Qwen3.8-Flash-Next) visual-config checkpoints must stay
+on the vendored TEXT lane rather than the mlx-vlm MLLM lane, both when served
+through a curated ``is_text_only`` alias and when served from an unaliased
+local path (via ``_VENDORED_TEXT_FALLBACK_MODEL_TYPES``).
+
+FIX 3 — a requested speculative decoder (``requested_spec_decode != none``) must
+slide a vision-capable checkpoint back onto the text lane (reason
+``text_lane_speculative_decode``) instead of silently being dropped by the MLLM
+lane, which never consumes ``scheduler_config.spec_decode``.
+
+These tests fake the installed mlx-vlm version to >= 0.6.16 (the Desktop sidecar
+pin) and assert the resulting lane decision for the Qwen3.8-Flash-Next config
+shape returned by the alias artifact's ``config.json`` (``model_type=qwen4_exp``,
+``vision_config`` present, ``image_token_id`` present, ``language_model_only==
+false``).
+"""
+
+from pathlib import Path
+
+from vllm_mlx.api import utils as utils_mod
+from vllm_mlx.api.utils import (
+    _VENDORED_TEXT_FALLBACK_MODEL_TYPES,
+    mllm_arch_unsupported_but_text_vendored,
+    resolve_serving_lane_decision,
+)
+from vllm_mlx.model_metadata import ModelMetadata
+from vllm_mlx.model_profile import ModelProfile
+
+
+def _flash_next_config() -> dict:
+    """The exact config shape the Qwen3.8-Flash-Next-4bit checkpoint ships."""
+    return {
+        "architectures": ["Qwen4ExpForConditionalGeneration"],
+        "model_type": "qwen4_exp",
+        "vision_config": {"hidden_size": 1024},
+        "image_token_id": 248056,
+        "language_model_only": False,
+    }
+
+
+def _fake_mlx_vlm_ge_016(monkeypatch):
+    """Fake the installed mlx-vlm as a recent version that can drive the
+    vision arch — i.e. the scenario where the alias would otherwise be routed
+    into the mlx-vlm MLLM lane (Desktop sidecar pins mlx-vlm 0.6.16)."""
+    import importlib.metadata as md
+
+    _orig_version = md.version
+    monkeypatch.setattr(
+        md,
+        "version",
+        lambda name: "0.6.17" if name == "mlx-vlm" else _orig_version(name),
+    )
+    # Ensure the MLLM runtime is "supported" under the faked version so the
+    # only thing keeping the model off the MLLM lane is our fix.
+    monkeypatch.setattr(utils_mod, "mllm_hybrid_runtime_supported", lambda: True)
+
+
+def _metadata(config: dict, snapshot_dir: Path) -> ModelMetadata:
+    return ModelMetadata(
+        config=config,
+        chat_template=None,
+        snapshot_dir=snapshot_dir,
+        is_local=False,
+    )
+
+
+def test_fix1_unaliased_qwen4_exp_vendored_goes_text_lane(monkeypatch, tmp_path):
+    """FIX 1: an UNALIASED local qwen4_exp checkpoint (no curated alias profile)
+    whose vision config + real vision weights would otherwise route to MLLM must
+    stay on the vendored text lane once ``qwen4_exp`` is in
+    ``_VENDORED_TEXT_FALLBACK_MODEL_TYPES``."""
+    _fake_mlx_vlm_ge_016(monkeypatch)
+    assert "qwen4_exp" in _VENDORED_TEXT_FALLBACK_MODEL_TYPES
+
+    # No curated alias for this raw path.
+    monkeypatch.setattr(utils_mod, "resolve_profile", lambda name: None)
+    monkeypatch.setattr(
+        utils_mod,
+        "read_model_metadata",
+        lambda name: _metadata(_flash_next_config(), tmp_path),
+    )
+    # Positive multimodal weight evidence — the vendored-text refire is what
+    # must pull it back to the text lane, not an inconclusive verdict.
+    monkeypatch.setattr(
+        utils_mod,
+        "checkpoint_has_multimodal_weights",
+        lambda snapshot, config: True,
+    )
+
+    # Without the fix the raw mllm model check is True and mlx-vlm has no
+    # qwen4_exp package, so the vendored fallback must fire.
+    assert mllm_arch_unsupported_but_text_vendored("/some/local/qwen4_exp") is True
+    decision = resolve_serving_lane_decision("/some/local/qwen4_exp")
+    assert decision.is_mllm is False
+    assert decision.auto_text_fallback is True
+    assert decision.reason == "vision_architecture_unavailable"
+
+
+def test_fix1_curated_text_alias_goes_text_lane(monkeypatch, tmp_path):
+    """FIX 1: the curated qwen3.8-flash-next-4bit alias pins ``is_text_only`` so
+    it stays text even against real vision weights and a >= 0.6.16 mlx-vlm."""
+    _fake_mlx_vlm_ge_016(monkeypatch)
+    curated = ModelProfile(
+        hf_path="mlx-community/Qwen3.8-Flash-Next-4bit",
+        is_text_only=True,
+    )
+    monkeypatch.setattr(utils_mod, "resolve_profile", lambda name: curated)
+    monkeypatch.setattr(
+        utils_mod,
+        "read_model_metadata",
+        lambda name: _metadata(_flash_next_config(), tmp_path),
+    )
+    monkeypatch.setattr(
+        utils_mod,
+        "checkpoint_has_multimodal_weights",
+        lambda snapshot, config: True,
+    )
+    decision = resolve_serving_lane_decision("qwen3.8-flash-next-4bit")
+    assert decision.is_mllm is False
+    assert decision.reason == "text_checkpoint"
+
+
+def test_fix2_text_diffusion_resolves_to_assistant_replacement_group():
+    """FIX 2: a text-diffusion profile (e.g. diffusion-gemma-26b-4bit) must
+    resolve to the SAME replacement group as resident_models._replacement_group
+    derives for the text engine ("assistant"), so loading it with a chat model
+    resident does not trip the resolved_group != replace_group 409 guard."""
+    from vllm_mlx.routes.residency import _resolved_group_for_profile
+    from vllm_mlx.runtime.resident_models import ModelEntry, _replacement_group
+
+    # Request-facing profile modality → group, matching the Fix 2 mapping.
+    assert _resolved_group_for_profile("text-diffusion") == "assistant"
+    assert _resolved_group_for_profile("text") == "assistant"
+    assert _resolved_group_for_profile("vision") == "assistant"
+    assert _resolved_group_for_profile("image-gen") == "image-gen"
+    assert _resolved_group_for_profile("video-gen") == "video-gen"
+
+    # Engine-derivation parity: a text-diffusion engine is a text engine.
+    entry = ModelEntry(
+        engine=_MockEngine("text"),
+        model_name="diffusion-gemma-26b-4bit",
+        model_path="diffusion-gemma-26b-4bit",
+    )
+    assert _replacement_group(entry) == "assistant"
+
+
+class _MockEngine:
+    """Minimal engine stub for resident_models._replacement_group."""
+
+    def __init__(self, modality: str):
+        self._modality = modality
+
+    @property
+    def is_image_gen(self) -> bool:
+        return self._modality == "image-gen"
+
+    @property
+    def is_video_gen(self) -> bool:
+        return self._modality == "video-gen"
+
+    @property
+    def is_mllm(self) -> bool:
+        return self._modality == "mllm"
+
+
+def test_fix3_spec_decode_requested_slides_vision_capable_to_text(
+    monkeypatch,
+    tmp_path,
+):
+    """FIX 3: requesting MTP spec-decode on a vision-capable (non-vendored)
+    checkpoint must route to the TEXT lane (reason
+    ``text_lane_speculative_decode``) so the decoder is honoured instead of
+    silently dropped by the MLLM lane, which never consumes
+    ``scheduler_config.spec_decode``."""
+    _fake_mlx_vlm_ge_016(monkeypatch)
+    # A genuinely MLLM-routable vision-capable checkpoint (NOT the qwen4_exp
+    # vendored-fallback shape, which Fix 1 already pins to text): the Qwen3.5-4B
+    # vision-config shape used by the existing vision-evidence tests.
+    monkeypatch.setattr(utils_mod, "resolve_profile", lambda name: None)
+    monkeypatch.setattr(
+        utils_mod,
+        "read_model_metadata",
+        lambda name: _metadata(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1024},
+                "image_token_id": 248056,
+            },
+            tmp_path,
+        ),
+    )
+    monkeypatch.setattr(
+        utils_mod,
+        "checkpoint_has_multimodal_weights",
+        lambda snapshot, config: True,
+    )
+
+    # Without a spec-decode request the model is vision-capable -> MLLM lane.
+    assert resolve_serving_lane_decision("/local/qwen35-vision").is_mllm is True
+    # With a requested decoder -> forced text lane with the fix-3 reason.
+    decision = resolve_serving_lane_decision(
+        "/local/qwen35-vision", requested_spec_decode="mtp"
+    )
+    assert decision.is_mllm is False
+    assert decision.reason == "text_lane_speculative_decode"
+    assert decision.auto_text_fallback is True
+
+    # Spec-decode wins over an explicit --mllm: the MLLM lane can never honour
+    # the decoder, so forcing vision must not silently drop it.
+    with_mllm = resolve_serving_lane_decision(
+        "/local/qwen35-vision",
+        force_mllm=True,
+        requested_spec_decode="mtp",
+    )
+    assert with_mllm.is_mllm is False
+    assert with_mllm.reason == "text_lane_speculative_decode"
+
+    # An explicit --mllm WITHOUT a speculative request still forces vision.
+    vision_only = resolve_serving_lane_decision("/local/qwen35-vision", force_mllm=True)
+    assert vision_only.is_mllm is True
+    assert vision_only.reason == "vision_lane_forced"

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -293,11 +293,12 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
             {
                 "force_mllm": False,
                 "force_text": False,
+                "requested_spec_decode": "none",
             },
         ),
         (
             "publisher/model",
-            {"force_text": False},
+            {"force_text": False, "requested_spec_decode": "none"},
         ),
     ]
     assert startup_kwargs["model_name"] == runtime.engine.kwargs["model_name"]

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -380,6 +380,7 @@
     "is_hybrid": true,
     "is_hybrid_explicit": true,
     "is_moe": true,
+    "is_text_only": true,
     "supports_spec_decode": false,
     "min_memory_gb": 128,
     "experimental": true

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -25,6 +25,7 @@ Two constraint modes are supported, matching the two the OpenAI
   ``response_format={"type":"json_object"}`` mode).
 """
 
+import json
 import logging
 from typing import Any
 
@@ -625,6 +626,43 @@ class GuidedGenerator:
         except Exception:
             logger.exception("JSON object generation failed")
             return None
+
+
+def build_json_schema_logits_processor(tokenizer, json_schema: dict):
+    """Build the shared incremental JSON-schema processor for a scheduler.
+
+    Unlike :class:`GuidedGenerator`, this does not own a model or a decode
+    loop. It lets continuous-batching engines apply the same llguidance
+    grammar inside their existing per-request logits-processor pipeline.
+    """
+    if not HAS_LLGUIDANCE:
+        return None
+
+    from .tool_grammar import (
+        GrammarLogitsProcessor,
+        get_lltokenizer,
+        model_stop_token_ids,
+    )
+
+    try:
+        lltokenizer = get_lltokenizer(tokenizer)
+        if lltokenizer is None:
+            return None
+        grammar = LLMatcher.grammar_from_json_schema(
+            json.dumps(json_schema),
+            overrides={"whitespace_flexible": True},
+        )
+        processor = GrammarLogitsProcessor(
+            lltokenizer,
+            grammar,
+            tokenizer=tokenizer,
+            stop_token_ids=model_stop_token_ids(tokenizer),
+            force_stop_when_accepting=True,
+        )
+        return None if processor.is_broken() else processor
+    except Exception:
+        logger.exception("guided decode: failed to build incremental JSON processor")
+        return None
 
 
 def generate_with_schema(

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -2245,6 +2245,7 @@ class GrammarLogitsProcessor:
         think_excluded_ids: Any = None,
         tokenizer: Any = None,
         stop_token_ids: Any = None,
+        force_stop_when_accepting: bool = False,
     ):
         self._lltok = lltokenizer
         # Reuse a cached compiled-grammar TEMPLATE (deep-copied per request) so
@@ -2335,6 +2336,7 @@ class GrammarLogitsProcessor:
         )
         self._stop_ids: tuple[int, ...] = tuple(stop_ids)
         self._stop_ids_arr = None
+        self._force_stop_when_accepting = force_stop_when_accepting
         if self._stop_ids:
             import mlx.core as mx
 
@@ -2521,6 +2523,23 @@ class GrammarLogitsProcessor:
             if self._think_excluded_ids:
                 return self._apply_think_exclusion(logits)
             return logits
+
+        if self._force_stop_when_accepting and self._matcher.is_accepting():
+            # JSON-schema generation is one complete value, unlike the tool
+            # grammar's optional/repeated-call language. Once that value is
+            # accepted, force one of the model's real EOS tokens so the
+            # scheduler terminates deterministically instead of admitting
+            # trailing whitespace and relying on a later natural stop.
+            if self._stop_ids:
+                import mlx.core as mx
+
+                allowed = [
+                    token for token in self._stop_ids if token < logits.shape[-1]
+                ]
+                if allowed:
+                    out = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)
+                    out[..., allowed] = logits[..., allowed]
+                    return out
 
         if self._matcher.is_stopped():
             return logits

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -2534,7 +2534,7 @@ class GrammarLogitsProcessor:
                 import mlx.core as mx
 
                 allowed = [
-                    token for token in self._stop_ids if token < logits.shape[-1]
+                    token for token in self._stop_ids if 0 <= token < logits.shape[-1]
                 ]
                 if allowed:
                     out = mx.full(logits.shape, -float("inf"), dtype=logits.dtype)

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1246,7 +1246,7 @@ is_vlm_model = is_mllm_model
 # multimodal routing automatically once a dependency bump ships support —
 # no code change needed here (remove the entry when the vendored backbone
 # itself is retired).
-_VENDORED_TEXT_FALLBACK_MODEL_TYPES = ("muse_glimmer",)
+_VENDORED_TEXT_FALLBACK_MODEL_TYPES = ("muse_glimmer", "qwen4_exp")
 
 
 def mllm_arch_unsupported_but_text_vendored(model_name: str) -> bool:
@@ -1378,10 +1378,37 @@ def resolve_serving_lane_decision(
     force_mllm: bool = False,
     force_text: bool = False,
     vision_min_memory_gb: float | None = None,
+    requested_spec_decode: str = "none",
 ) -> ServingLaneDecision:
-    """Resolve one lane contract for startup, residency, and diagnostics."""
+    """Resolve one lane contract for startup, residency, and diagnostics.
+
+    ``requested_spec_decode`` carries the operator-requested speculative
+    decoder ("none" when none). The MLLM/VLM lane ignores speculative
+    decoding entirely — ``_start_llm`` consumes ``scheduler_config.spec_decode``
+    while ``_start_mllm`` never reads it — so on a vision-capable checkpoint a
+    requested spec_decode would silently be dropped and throughput would regress
+    vs the text lane. Route such a model back onto the text lane (where the
+    requested decoder is honoured) with reason ``text_lane_speculative_decode``.
+    """
     if force_text:
         return ServingLaneDecision(False, "text_lane_forced")
+    # A requested speculative decoder is only honoured by the text lane
+    # (``_start_llm`` consumes ``scheduler_config.spec_decode``; ``_start_mllm``
+    # never reads it).  Give it the same precedence as force_text — above
+    # ``force_mllm`` — so ``--mllm`` + spec-decode still keeps the decoder on
+    # the text lane rather than silently dropping it, exactly as ``force_text``
+    # already outranks ``force_mllm`` here.  ``None`` is treated as "none".
+    if requested_spec_decode not in (None, "none"):
+        if not is_mllm_model(model_name):
+            logger.info(
+                "Speculative decode requested (spec_decode=%r) on a text "
+                "checkpoint — text lane already selected; decoder honoured.",
+                requested_spec_decode,
+            )
+            return ServingLaneDecision(False, "text_checkpoint")
+        return ServingLaneDecision(
+            False, "text_lane_speculative_decode", auto_text_fallback=True
+        )
     if force_mllm:
         return ServingLaneDecision(True, "vision_lane_forced")
     if not is_mllm_model(model_name):
@@ -1420,7 +1447,11 @@ def resolve_serving_lane_decision(
 
 
 def resolve_serving_lane(
-    model_name: str, *, force_mllm: bool = False, force_text: bool = False
+    model_name: str,
+    *,
+    force_mllm: bool = False,
+    force_text: bool = False,
+    requested_spec_decode: str = "none",
 ) -> tuple[bool, bool]:
     """Decide the FINAL serving lane for a model, resolving the automatic
     hybrid→text-only fallback up front so every consumer (PFlash defaulting,
@@ -1454,7 +1485,10 @@ def resolve_serving_lane(
     engine (#352 dogfood P1-②).
     """
     decision = resolve_serving_lane_decision(
-        model_name, force_mllm=force_mllm, force_text=force_text
+        model_name,
+        force_mllm=force_mllm,
+        force_text=force_text,
+        requested_spec_decode=requested_spec_decode,
     )
     return decision.is_mllm, decision.auto_text_fallback
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2818,6 +2818,8 @@ def _serve_will_run_on_mllm_lane(args) -> bool:
     requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
     if requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
         requested_spec_decode = "mtp"
+    elif requested_spec_decode == "none" and getattr(args, "force_spec_decode", False):
+        requested_spec_decode = "auto"
     is_mllm_lane, _auto_text_fallback = resolve_serving_lane(
         args.model,
         force_mllm=getattr(args, "mllm", False),
@@ -3310,8 +3312,10 @@ def serve_command(args):
     # exactly as an explicit ``--text-only`` run would be (#352 dogfood P1-②).
     if not args.enable_dflash:
         _requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
-        if _requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
-            _requested_spec_decode = "mtp"
+        if _requested_spec_decode == "none" and getattr(
+            args, "force_spec_decode", False
+        ):
+            _requested_spec_decode = "auto"
         _serve_is_mllm, _ = resolve_serving_lane(
             args.model,
             force_mllm=getattr(args, "mllm", False),

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2815,10 +2815,14 @@ def _serve_will_run_on_mllm_lane(args) -> bool:
     """
     from .api.utils import resolve_serving_lane
 
+    requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
+    if requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
+        requested_spec_decode = "mtp"
     is_mllm_lane, _auto_text_fallback = resolve_serving_lane(
         args.model,
         force_mllm=getattr(args, "mllm", False),
         force_text=getattr(args, "no_mllm", False),
+        requested_spec_decode=requested_spec_decode,
     )
     return is_mllm_lane
 
@@ -3305,10 +3309,14 @@ def serve_command(args):
     # that auto-downgrades to the text-only lane is PFlash-capable there,
     # exactly as an explicit ``--text-only`` run would be (#352 dogfood P1-②).
     if not args.enable_dflash:
+        _requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
+        if _requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
+            _requested_spec_decode = "mtp"
         _serve_is_mllm, _ = resolve_serving_lane(
             args.model,
             force_mllm=getattr(args, "mllm", False),
             force_text=getattr(args, "no_mllm", False),
+            requested_spec_decode=_requested_spec_decode,
         )
         # Resolve BOTH per-alias PFlash defaults (mode + keep_ratio, e.g.
         # bonsai-27b-2bit → always @ 0.50) and build the config in one shared

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2120,15 +2120,15 @@ class BatchedEngine(BaseEngine):
                 for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
                 if k in kwargs
             }
-            _mllm_logits_processors = [
-                processor
-                for processor in (
-                    kwargs.pop("grammar_logits_processor", None),
-                    kwargs.pop("reasoning_budget_logits_processor", None),
-                    kwargs.pop("suppressed_tokens_logits_processor", None),
-                )
-                if processor is not None
-            ]
+            _mllm_logits_processors = []
+            for processor_key in (
+                "grammar_logits_processor",
+                "reasoning_budget_logits_processor",
+                "suppressed_tokens_logits_processor",
+            ):
+                processor = kwargs.pop(processor_key, None)
+                if processor is not None:
+                    _mllm_logits_processors.append(processor)
             try:
                 output = await self._mllm_scheduler.generate(
                     prompt=prompt,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2120,6 +2120,15 @@ class BatchedEngine(BaseEngine):
                 for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
                 if k in kwargs
             }
+            _mllm_logits_processors = [
+                processor
+                for processor in (
+                    kwargs.pop("grammar_logits_processor", None),
+                    kwargs.pop("reasoning_budget_logits_processor", None),
+                    kwargs.pop("suppressed_tokens_logits_processor", None),
+                )
+                if processor is not None
+            ]
             try:
                 output = await self._mllm_scheduler.generate(
                     prompt=prompt,
@@ -2133,6 +2142,7 @@ class BatchedEngine(BaseEngine):
                     video_max_frames=kwargs.pop("video_max_frames", None),
                     lifecycle_admission_token=admission_token,
                     on_request_committed=request_committed,
+                    logits_processors=_mllm_logits_processors,
                     **_mllm_penalty_kwargs,
                 )
             except BaseException:
@@ -2372,6 +2382,15 @@ class BatchedEngine(BaseEngine):
                 for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
                 if k in kwargs
             }
+            _mllm_logits_processors = [
+                processor
+                for processor in (
+                    kwargs.pop("grammar_logits_processor", None),
+                    kwargs.pop("reasoning_budget_logits_processor", None),
+                    kwargs.pop("suppressed_tokens_logits_processor", None),
+                )
+                if processor is not None
+            ]
             try:
                 request_id = await self._mllm_scheduler.add_request_async(
                     request_id=request_id,
@@ -2386,6 +2405,7 @@ class BatchedEngine(BaseEngine):
                     video_max_frames=kwargs.pop("video_max_frames", None),
                     lifecycle_admission_token=admission_token,
                     on_request_committed=commit_admission,
+                    logits_processors=_mllm_logits_processors,
                     **_mllm_penalty_kwargs,
                 )
             except BaseException:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -304,6 +304,7 @@ class MLLMBatchRequest:
     # token suppression).  These use the same ``(token_ids, logits)``
     # contract as the text scheduler and are owned by this request.
     logits_processors: list[Callable] = field(default_factory=list)
+    logits_processor_tokens: list[int] = field(default_factory=list)
     video_fps: float | None = None  # Caller-specified video FPS
     video_max_frames: int | None = None  # Caller-specified max video frames
 
@@ -550,7 +551,7 @@ def _apply_request_logits_processors(
     token_ids: list[int] | None = None,
 ) -> mx.array:
     """Apply request-owned processors using its cumulative output tokens."""
-    history = req.output_tokens if token_ids is None else token_ids
+    history = req.logits_processor_tokens if token_ids is None else token_ids
     for processor in req.logits_processors:
         row_logits = processor(history, row_logits)
     return row_logits
@@ -1539,16 +1540,22 @@ class MLLMBatchGenerator:
             and len(requests) == logits.shape[0]
             and any(request.logits_processors for request in requests)
         ):
+            # Materialize the current token batch once, then keep each
+            # processor's cumulative host history incrementally. Rebuilding
+            # ``[*output_tokens, current.item()]`` per request would copy the
+            # full sequence on every step (quadratic over a long response) and
+            # synchronize the device once per active request.
+            current_tokens = input_tokens[:, -1].tolist()
+            for request, token in zip(requests, current_tokens):
+                if request.logits_processors:
+                    request.logits_processor_tokens.append(int(token))
             logits = mx.concatenate(
                 [
                     (
                         _apply_request_logits_processors(
                             request,
                             logits[i : i + 1],
-                            [
-                                *request.output_tokens,
-                                int(input_tokens[i, -1].item()),
-                            ],
+                            request.logits_processor_tokens,
                         )
                         if request.logits_processors
                         else logits[i : i + 1]

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -300,6 +300,10 @@ class MLLMBatchRequest:
     repetition_penalty: float = 1.0
     presence_penalty: float = 0.0
     frequency_penalty: float = 0.0
+    # Per-request decode processors (structured output, reasoning budget,
+    # token suppression).  These use the same ``(token_ids, logits)``
+    # contract as the text scheduler and are owned by this request.
+    logits_processors: list[Callable] = field(default_factory=list)
     video_fps: float | None = None  # Caller-specified video FPS
     video_max_frames: int | None = None  # Caller-specified max video frames
 
@@ -537,6 +541,18 @@ def _maybe_apply_penalty_processors(
     tokens = req.output_tokens
     for processor in cached[1]:
         row_logits = processor(tokens, row_logits)
+    return row_logits
+
+
+def _apply_request_logits_processors(
+    req: MLLMBatchRequest,
+    row_logits: mx.array,
+    token_ids: list[int] | None = None,
+) -> mx.array:
+    """Apply request-owned processors using its cumulative output tokens."""
+    history = req.output_tokens if token_ids is None else token_ids
+    for processor in req.logits_processors:
+        row_logits = processor(history, row_logits)
     return row_logits
 
 
@@ -1378,6 +1394,12 @@ class MLLMBatchGenerator:
 
                 # Extract last token logits and sample with per-request params
                 last_logits = logits[:, -1, :]
+                # Request-local constraints must own token zero as well as
+                # steady-state decode. Applying them only in ``_step`` lets an
+                # invalid first token escape during prefill; the grammar then
+                # sees an already-committed token it never allowed and must
+                # drop the constraint.
+                last_logits = _apply_request_logits_processors(req, last_logits)
                 logprobs = last_logits - mx.logsumexp(
                     last_logits, axis=-1, keepdims=True
                 )
@@ -1511,6 +1533,30 @@ class MLLMBatchGenerator:
                     _maybe_apply_penalty_processors(req, logits[i : i + 1])
                 )
             logits = mx.concatenate(processed_rows, axis=0)
+
+        if (
+            requests
+            and len(requests) == logits.shape[0]
+            and any(request.logits_processors for request in requests)
+        ):
+            logits = mx.concatenate(
+                [
+                    (
+                        _apply_request_logits_processors(
+                            request,
+                            logits[i : i + 1],
+                            [
+                                *request.output_tokens,
+                                int(input_tokens[i, -1].item()),
+                            ],
+                        )
+                        if request.logits_processors
+                        else logits[i : i + 1]
+                    )
+                    for i, request in enumerate(requests)
+                ],
+                axis=0,
+            )
 
         # Sample per-request with correct temperature/top_p.
         # Fast path: when all requests in the batch share (temp, top_p),

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -157,6 +157,7 @@ class MLLMRequest:
     num_prompt_tokens: int = 0
     num_output_tokens: int = 0
     lifecycle_admission_token: str | None = None
+    logits_processors: list[Callable] = field(default_factory=list)
 
 
 def _find_stop_match_in_new_window(
@@ -430,7 +431,11 @@ class MLLMScheduler:
         """Get stop token IDs from tokenizer.
 
         Mirrors ``Scheduler._get_stop_tokens`` — see that docstring
-        for the rationale behind each of the four sources.
+        for the rationale behind the tokenizer sources.  Multimodal
+        loaders also expose the resolved model EOS on ``model.config``;
+        that value can differ from the processor tokenizer's primary EOS
+        (Qwen3.5 is one such checkpoint), so it must participate in the
+        same union used by the batch generator.
         """
         from .utils.tokenizer import RAPID_EXTRA_EOS_ATTR
 
@@ -464,6 +469,31 @@ class MLLMScheduler:
         extras = getattr(tokenizer, RAPID_EXTRA_EOS_ATTR, None)
         if extras:
             stop_tokens.update(extras)
+
+        # Source 5: the loaded model configuration.  mlx-vlm resolves
+        # architecture-specific/nested ``text_config.eos_token_id`` onto
+        # the live model config.  Keep the nested read as a fail-closed
+        # fallback for config shapes that do not perform that resolution.
+        def _config_value(config: Any, name: str) -> Any:
+            if isinstance(config, dict):
+                return config.get(name)
+            return getattr(config, name, None)
+
+        def _add_ids(value: Any) -> None:
+            if isinstance(value, bool):
+                return
+            if isinstance(value, int):
+                stop_tokens.add(value)
+            elif isinstance(value, (list, set, tuple)):
+                stop_tokens.update(
+                    item
+                    for item in value
+                    if isinstance(item, int) and not isinstance(item, bool)
+                )
+
+        _add_ids(_config_value(self.model_config, "eos_token_id"))
+        text_config = _config_value(self.model_config, "text_config")
+        _add_ids(_config_value(text_config, "eos_token_id"))
 
         return stop_tokens
 
@@ -570,6 +600,7 @@ class MLLMScheduler:
         repetition_penalty = _pop_penalty("repetition_penalty", 1.0)
         presence_penalty = _pop_penalty("presence_penalty", 0.0)
         frequency_penalty = _pop_penalty("frequency_penalty", 0.0)
+        logits_processors = list(kwargs.pop("logits_processors", ()) or ())
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -589,6 +620,7 @@ class MLLMScheduler:
             video_fps=video_fps,
             video_max_frames=video_max_frames,
             lifecycle_admission_token=kwargs.pop("lifecycle_admission_token", None),
+            logits_processors=logits_processors,
         )
 
         # D-M01-2X (0.8.2 dogfood, codex r10 BLOCKING follow-up):
@@ -870,6 +902,7 @@ class MLLMScheduler:
                 repetition_penalty=request.sampling_params.repetition_penalty,
                 presence_penalty=request.sampling_params.presence_penalty,
                 frequency_penalty=request.sampling_params.frequency_penalty,
+                logits_processors=request.logits_processors,
                 video_fps=request.video_fps,
                 video_max_frames=request.video_max_frames,
             )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -491,8 +491,9 @@ class MLLMScheduler:
                     if isinstance(item, int) and not isinstance(item, bool)
                 )
 
-        _add_ids(_config_value(self.model_config, "eos_token_id"))
-        text_config = _config_value(self.model_config, "text_config")
+        model_config = getattr(self, "model_config", None)
+        _add_ids(_config_value(model_config, "eos_token_id"))
+        text_config = _config_value(model_config, "text_config")
         _add_ids(_config_value(text_config, "eos_token_id"))
 
         return stop_tokens

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -24,7 +24,10 @@ from ..api.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
-from ..api.tool_calling import convert_tools_for_template
+from ..api.tool_calling import (
+    convert_tools_for_template,
+    extract_json_schema_for_guided,
+)
 from ..api.utils import (
     StreamingThinkRouter,
     StreamingToolCallFilter,
@@ -99,6 +102,28 @@ def _resolved_sampling_kwargs(openai_request) -> dict:
     }
     out.update(build_extended_sampling_kwargs(openai_request))
     return out
+
+
+async def _attach_mllm_schema_processor(engine, openai_request, chat_kwargs) -> None:
+    """Keep Anthropic structured output on the MLLM scheduler decode path."""
+    if not engine.is_mllm or openai_request.response_format is None:
+        return
+    schema = extract_json_schema_for_guided(openai_request.response_format)
+    if not schema:
+        return
+    from ..api.guided import build_json_schema_logits_processor
+
+    processor = await asyncio.to_thread(
+        build_json_schema_logits_processor,
+        engine.tokenizer,
+        schema,
+    )
+    if processor is not None:
+        chat_kwargs["grammar_logits_processor"] = processor
+        # This grammar owns the complete assistant payload from token zero;
+        # a reasoning preamble is outside its language. Keep prompt rendering
+        # and response classification aligned with that decode contract.
+        chat_kwargs["enable_thinking"] = False
 
 
 logger = logging.getLogger(__name__)
@@ -839,6 +864,7 @@ async def create_anthropic_message(
         )
         if effective_thinking is not None:
             chat_kwargs["enable_thinking"] = effective_thinking
+        await _attach_mllm_schema_processor(engine, openai_request, chat_kwargs)
 
         start_time = time.perf_counter()
         timeout = cfg.default_timeout
@@ -1612,6 +1638,8 @@ async def _stream_anthropic_messages(
     resolved_thinking = _resolve_enable_thinking(openai_request)
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
+    await _attach_mllm_schema_processor(engine, openai_request, chat_kwargs)
+    _schema_constrained = "grammar_logits_processor" in chat_kwargs
 
     # Issue #702: per-request alias-level reasoning capability gate.
     # When the served alias declares ``reasoning_parser: null`` in
@@ -1905,6 +1933,11 @@ async def _stream_anthropic_messages(
         unconditional=cfg.reasoning_parser_name == "deepseek_r1_distill",
         tools_requested=bool(chat_kwargs.get("tools")),
     )
+    if _schema_constrained:
+        # The grammar owns token zero and cannot admit a reasoning preamble;
+        # classify its JSON bytes as answer content rather than opening a
+        # phantom thinking block that terminal reconciliation would duplicate.
+        _starts_thinking = False
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
     # D-ANTHRO-TOOL-USAGE F5: seed the running counter with the
     # pre-message_start estimate so the terminal ``message_delta`` is
@@ -2030,6 +2063,8 @@ async def _stream_anthropic_messages(
     # blocks on literal ``<think>`` tags in the raw stream (and is
     # itself gated by ``_gate_thinking_pieces`` below).
     if not _reasoning_enabled:
+        reasoning_parser = None
+    if _schema_constrained:
         reasoning_parser = None
     if reasoning_parser:
         configure_request = getattr(reasoning_parser, "configure_request", None)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -106,7 +106,11 @@ def _resolved_sampling_kwargs(openai_request) -> dict:
 
 async def _attach_mllm_schema_processor(engine, openai_request, chat_kwargs) -> None:
     """Keep Anthropic structured output on the MLLM scheduler decode path."""
-    if not engine.is_mllm or openai_request.response_format is None:
+    if (
+        not engine.is_mllm
+        or openai_request.response_format is None
+        or openai_request.tools
+    ):
         return
     schema = extract_json_schema_for_guided(openai_request.response_format)
     if not schema:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -107,7 +107,7 @@ def _resolved_sampling_kwargs(openai_request) -> dict:
 async def _attach_mllm_schema_processor(engine, openai_request, chat_kwargs) -> None:
     """Keep Anthropic structured output on the MLLM scheduler decode path."""
     if (
-        not engine.is_mllm
+        not getattr(engine, "is_mllm", False)
         or openai_request.response_format is None
         or openai_request.tools
     ):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5443,6 +5443,14 @@ async def _create_chat_completion_impl(
                 "tool_choice",
                 "logprobs",
                 "top_logprobs",
+                # Decode processors are request-local and stateful. Reusing
+                # the first attempt's matcher/cursor would constrain the
+                # repair as a continuation of the abandoned document rather
+                # than a fresh JSON value. The repair prompt plus post-check
+                # are the established unconstrained second-attempt contract.
+                "grammar_logits_processor",
+                "reasoning_budget_logits_processor",
+                "suppressed_tokens_logits_processor",
             ):
                 repair_kwargs.pop(_k, None)
             # H-06 #267b: re-check the context-length gate AGAINST the

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4887,7 +4887,20 @@ async def _create_chat_completion_impl(
                 # so operators see uniform traffic shape across the
                 # guided / postgen-validation / disabled arms.
                 incr_strict_request()
-                if not use_guided and _mllm_schema_processor is None:
+                if _mllm_schema_processor is not None and strict_enforcement_active:
+                    # The request-local matcher intentionally fails open if a
+                    # committed token desynchronizes it. Strict mode therefore
+                    # keeps the existing post-generation validator as a second
+                    # line of enforcement; a fail-open can preserve liveness,
+                    # but it cannot turn invalid JSON into a successful strict
+                    # response.
+                    use_strict_postgen_validation = True
+                    logger.info(
+                        "Strict json_schema mode on the MLLM lane — engaging "
+                        "request-local constrained decoding plus post-generate "
+                        "validation."
+                    )
+                elif not use_guided and _mllm_schema_processor is None:
                     # R12-4: pre-R12-4 this branch raised 400
                     # ``guided_extra_required``. That broke
                     # pydantic-ai end-to-end (Astrid r3) — every

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5443,16 +5443,22 @@ async def _create_chat_completion_impl(
                 "tool_choice",
                 "logprobs",
                 "top_logprobs",
-                # Decode processors are request-local and stateful. Reusing
-                # the first attempt's matcher/cursor would constrain the
-                # repair as a continuation of the abandoned document rather
-                # than a fresh JSON value. The repair prompt plus post-check
-                # are the established unconstrained second-attempt contract.
+                # The schema matcher is request-local and stateful. Reusing
+                # its cursor would constrain the repair as a continuation of
+                # the abandoned document rather than a fresh JSON value. The
+                # repair prompt plus post-check are the established
+                # unconstrained second-attempt contract.
                 "grammar_logits_processor",
-                "reasoning_budget_logits_processor",
-                "suppressed_tokens_logits_processor",
             ):
                 repair_kwargs.pop(_k, None)
+            if engine.is_mllm and "grammar_logits_processor" in chat_kwargs:
+                # A whole-response schema grammar owns token zero on MLLM and
+                # explicitly rendered the first attempt with thinking off.
+                # Its reasoning processor (if one was prepared before that
+                # decision) is stateful and inapplicable to the fresh repair.
+                # Other engines keep their pre-existing reasoning budget, and
+                # token suppression remains intact on every lane.
+                repair_kwargs.pop("reasoning_budget_logits_processor", None)
             # H-06 #267b: re-check the context-length gate AGAINST the
             # POST-BUILD repair prompt. ``build_repair_messages`` builds a
             # strictly larger prompt than the initial request (prepended

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4868,6 +4868,11 @@ async def _create_chat_completion_impl(
                 )
                 if _mllm_schema_processor is not None:
                     chat_kwargs["grammar_logits_processor"] = _mllm_schema_processor
+                    # The schema grammar owns token zero, so the request cannot
+                    # also carry a processor that forces a ``</think>`` token
+                    # after a reasoning budget.  That token is outside the JSON
+                    # grammar and would make the constraint fail open.
+                    chat_kwargs.pop("reasoning_budget_logits_processor", None)
                     # The schema grammar owns the complete assistant payload
                     # from token zero, so it cannot admit a reasoning preamble.
                     # Keep prompt rendering and output classification aligned.

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4853,6 +4853,26 @@ async def _create_chat_completion_impl(
     if response_format and not request.tools:
         json_schema = extract_json_schema_for_guided(response_format)
         if json_schema:
+            # MLLM continuous batching owns its decode loop, so the legacy
+            # model-owning ``GuidedGenerator`` cannot be used without routing
+            # the request away from the vision-capable lane. Build the same
+            # llguidance grammar as a request-local logits processor instead.
+            _mllm_schema_processor = None
+            if engine.is_mllm:
+                from ..api.guided import build_json_schema_logits_processor
+
+                _mllm_schema_processor = await asyncio.to_thread(
+                    build_json_schema_logits_processor,
+                    engine.tokenizer,
+                    json_schema,
+                )
+                if _mllm_schema_processor is not None:
+                    chat_kwargs["grammar_logits_processor"] = _mllm_schema_processor
+                    # The schema grammar owns the complete assistant payload
+                    # from token zero, so it cannot admit a reasoning preamble.
+                    # Keep prompt rendering and output classification aligned.
+                    chat_kwargs["enable_thinking"] = False
+
             # ``supports_guided_generation`` and ``generate_with_schema``
             # are on the BaseEngine contract — defaults are False /
             # NotImplementedError, so engines without guided decoding
@@ -4867,7 +4887,7 @@ async def _create_chat_completion_impl(
                 # so operators see uniform traffic shape across the
                 # guided / postgen-validation / disabled arms.
                 incr_strict_request()
-                if not use_guided:
+                if not use_guided and _mllm_schema_processor is None:
                     # R12-4: pre-R12-4 this branch raised 400
                     # ``guided_extra_required``. That broke
                     # pydantic-ai end-to-end (Astrid r3) — every
@@ -4907,7 +4927,7 @@ async def _create_chat_completion_impl(
                         "Using guided generation for JSON schema "
                         "enforcement (strict=true)"
                     )
-            elif use_guided:
+            elif use_guided or _mllm_schema_processor is not None:
                 logger.info("Using guided generation for JSON schema enforcement")
             else:
                 # Surface the silent-degradation case: client asked for

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -110,6 +110,21 @@ async def model_residency():
     return snapshot
 
 
+def _resolved_group_for_profile(modality: str) -> str:
+    """Map a request-facing profile modality to its lifecycle replacement group.
+
+    Mirrors ``resident_models._replacement_group`` (assistant for text, mllm,
+    vision, and text-diffusion): a diffusion-gemma-26b checkpoint runs as a text
+    engine whose lifecycle group is "assistant", so the request-facing profile
+    modality ("text-diffusion") must resolve to the same group or the
+    ``resolved_group != replace_group`` guard raises a spurious 409 when the
+    Desktop picks it with a chat model resident.  Kept in one place so both the
+    request FIX path here and the engine-derived group stay in parity
+    (#0131-routing-groups Fix 2).
+    """
+    return "assistant" if modality in {"text", "vision", "text-diffusion"} else modality
+
+
 @router.post("/v1/models/load")
 async def load_resident_model(request: ModelLoadRequest):
     """Load a model into the current process, evicting idle LRU entries first."""
@@ -135,11 +150,7 @@ async def load_resident_model(request: ModelLoadRequest):
         profile = path_profile if request.model_path else model_profile
         resolved_group = None
         if profile is not None:
-            resolved_group = (
-                "assistant"
-                if profile.modality in {"text", "vision"}
-                else profile.modality
-            )
+            resolved_group = _resolved_group_for_profile(profile.modality)
         if (
             performance is not None
             and profile is not None

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3449,8 +3449,10 @@ Examples:
     if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
         _ensure_routing_config(args.model)
     _srv_requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
-    if _srv_requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
-        _srv_requested_spec_decode = "mtp"
+    if _srv_requested_spec_decode == "none" and getattr(
+        args, "force_spec_decode", False
+    ):
+        _srv_requested_spec_decode = "auto"
     _srv_is_mllm, _ = resolve_serving_lane(
         args.model,
         force_mllm=_srv_force_mllm,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1735,6 +1735,7 @@ def _resolve_serving_checkpoint(
     *,
     force_mllm: bool = False,
     force_text: bool = False,
+    requested_spec_decode: str = "none",
 ) -> _ServingCheckpoint:
     """Resolve alias, local checkpoint, and serving lane as one contract.
 
@@ -1764,6 +1765,7 @@ def _resolve_serving_checkpoint(
         vision_min_memory_gb=(
             profile.vision_min_memory_gb if profile is not None else None
         ),
+        requested_spec_decode=requested_spec_decode,
     )
     return _ServingCheckpoint(
         model_path=model_path,
@@ -2078,6 +2080,11 @@ def load_model(
             model_name,
             force_mllm=force_mllm,
             force_text=force_text,
+            requested_spec_decode=(
+                getattr(scheduler_config, "spec_decode", "none")
+                if scheduler_config is not None
+                else "none"
+            ),
         )
         _engine_model_path = _serving_checkpoint.load_path
         _auto_text_fallback = _serving_checkpoint.auto_text_fallback
@@ -2395,6 +2402,9 @@ async def _load_dynamic_resident_model(
         serving_checkpoint = _resolve_serving_checkpoint(
             resolved_path,
             force_text=profile_force_text,
+            # Residency loads carry no spec-decode request; keep the lane
+            # contract identical to startup (whose default is also "none").
+            requested_spec_decode="none",
         )
         resolved_path = serving_checkpoint.model_path
         load_path = serving_checkpoint.load_path
@@ -3438,10 +3448,14 @@ Examples:
     _srv_force_text = getattr(args, "no_mllm", False)
     if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
         _ensure_routing_config(args.model)
+    _srv_requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
+    if _srv_requested_spec_decode == "none" and getattr(args, "enable_mtp", False):
+        _srv_requested_spec_decode = "mtp"
     _srv_is_mllm, _ = resolve_serving_lane(
         args.model,
         force_mllm=_srv_force_mllm,
         force_text=_srv_force_text,
+        requested_spec_decode=_srv_requested_spec_decode,
     )
     # Resolve mode AND per-alias keep_ratio through the single shared helper —
     # the same call ``cli.py`` uses for ``serve``/``bench``. Going through


### PR DESCRIPTION
## Routing-group fixes for 0.13.1 (train-6c)

Release-blocker fix PR. Base: train-6b head `e838fb62` (origin/main `aaf2e010` does not yet contain #2457 / the `qwen3.8-flash-next-4bit` alias). **Echo to rebase onto the final train-6c merge.**

### FIX 1 (P0) — qwen3.8-flash-next-4bit no longer routes to the mlx-vlm MLLM lane
The alias checkpoint declares `model_type=qwen4_exp` + `vision_config` + `image_token_id` + `language_model_only=false`, so with mlx-vlm ≥ 0.6.16 (Desktop sidecar pins 0.6.16; pyproject allows <0.7) `is_mllm_model` returns True and the MLLM engine is chosen — but mlx_vlm has **no `qwen4_exp` model package** → load fails after a 98 GiB download.
- Added `"is_text_only": true` to the `qwen3.8-flash-next-4bit` alias (Bonsai-27B pattern).
- Added `"qwen4_exp"` to `_VENDORED_TEXT_FALLBACK_MODEL_TYPES` so an **unaliased local path** of this config also stays on the vendored text lane.

### FIX 3 (P1) — requested spec_decode is no longer silently dropped on the MLLM lane
`_start_llm` consumes `scheduler_config.spec_decode`; `_start_mllm` never reads it. `resolve_serving_lane_decision` now takes `requested_spec_decode` and, when `!= none` on a vision-capable checkpoint, forces the **text lane** (reason `text_lane_speculative_decode`, `auto_text_fallback=true`) so MTP/etc. keeps working. Threaded through `resolve_serving_lane`, `_resolve_serving_checkpoint` (startup + residency parity), and `_serve_will_run_on_mllm_lane`.

### FIX 2 (P1) — residency no longer 409s on text-diffusion models
`resolved_group` (routes/residency.py) mapped `text-diffusion` → `"text-diffusion"` while `_replacement_group` (runtime/resident_models.py) derives `"assistant"` for the text engine → the `resolved_group != replace_group` guard raised HTTP 409 when the Desktop picks diffusion-gemma-26b-4bit with a chat model resident. Extracted `_resolved_group_for_profile` deriving `"assistant"` for text/vision/text-diffusion (parity with `_replacement_group`).

### Tests
- New `tests/test_routing_groups_0131.py` — routing tests for all three fixes (fakes mlx-vlm ≥ 0.6.16; does **not** monkeypatch `is_mllm_model`).
- Updated `test_server_load_model_order.py` call-contract for the new `requested_spec_decode` kwarg.
- Verified locally: test_aliases_contract (2933), test_api_utils (163), test_no_mllm_flag (44), test_resident_models (72), test_server_load_model_order (25), test_routes (138+), test_modality_field, disk-stream + pflash wiring — all green.

Non-goals (per Atlas): no other routing, no suffix decoding, no scheduler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
