### PR TITLE
fix(mac): downscale large chat images before sending

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -39,6 +39,10 @@ struct ChatAttachmentDraft: Equatable {
     mutating func beginImageImport() -> UUID? {
         guard imageImportID == nil else { return nil }
         let id = UUID()
+        // A new selection supersedes an old notice. Any notice produced by
+        // that selection after async image decoding starts must survive its
+        // later completion.
+        notice = nil
         imageImportID = id
         return id
     }
@@ -51,7 +55,13 @@ struct ChatAttachmentDraft: Equatable {
     ) -> Bool {
         guard imageImportID == id else { return false }
         appendImages(imported)
-        self.notice = notice
+        if let notice {
+            if let current = self.notice, current != notice {
+                self.notice = "\(current) \(notice)"
+            } else {
+                self.notice = notice
+            }
+        }
         imageImportID = nil
         return true
     }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -4,6 +4,10 @@ import UniformTypeIdentifiers
 
 struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable {
     static let maxBytes = 20 * 1024 * 1024
+    /// Keep image preprocessing below the embedded engine's per-request
+    /// vision-token budget. A 2048 × 1536 image is roughly 4K vision tokens
+    /// on the recommended model, leaving useful margin below its 8K cap.
+    static let maxVisionLongEdge = 2_048
     /// Bounds decoded memory before ImageIO creates a full bitmap. This still
     /// admits 48 MP iPhone captures while rejecting compressed image bombs.
     static let maxPixelCount = 64_000_000
@@ -15,6 +19,16 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
             && width <= maxPixelDimension
             && height <= maxPixelDimension
             && width <= maxPixelCount / height
+    }
+
+    static func normalizedPixelSize(width: Int, height: Int) -> (width: Int, height: Int) {
+        let longEdge = max(width, height)
+        guard longEdge > maxVisionLongEdge else { return (width, height) }
+        let scale = Double(maxVisionLongEdge) / Double(longEdge)
+        return (
+            max(1, Int((Double(width) * scale).rounded())),
+            max(1, Int((Double(height) * scale).rounded()))
+        )
     }
 
     let id: UUID
@@ -41,30 +55,43 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
     init(contentsOf url: URL) throws {
         let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentTypeKey])
         guard (values.fileSize ?? 0) <= Self.maxBytes else { throw ValidationError.tooLarge }
+        guard values.contentType?.conforms(to: .image) == true,
+              let source = CGImageSourceCreateWithURL(url as CFURL, nil)
+        else { throw ValidationError.unsupportedType }
+        guard CGImageSourceGetCount(source) == 1 else { throw ValidationError.animatedGIF }
+        let sourceProperties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+            as? [CFString: Any] ?? [:]
+        guard let width = (sourceProperties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+              let height = (sourceProperties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+              Self.dimensionsFit(width: width, height: height)
+        else { throw ValidationError.tooManyPixels }
+
         let type = values.contentType
-        if type?.conforms(to: .png) == true {
+        let fitsVisionBudget = max(width, height) <= Self.maxVisionLongEdge
+        if type?.conforms(to: .png) == true, fitsVisionBudget {
             try self.init(
                 filename: url.lastPathComponent,
                 mimeType: "image/png",
                 data: Data(contentsOf: url)
             )
-        } else if type?.conforms(to: .jpeg) == true {
+        } else if type?.conforms(to: .jpeg) == true, fitsVisionBudget {
             try self.init(
                 filename: url.lastPathComponent,
                 mimeType: "image/jpeg",
                 data: Data(contentsOf: url)
             )
-        } else if type?.conforms(to: .gif) == true {
+        } else if type?.conforms(to: .gif) == true, fitsVisionBudget {
             try self.init(
                 filename: url.lastPathComponent,
                 mimeType: "image/gif",
                 data: Data(contentsOf: url)
             )
         } else {
-            guard type?.conforms(to: .image) == true else {
-                throw ValidationError.unsupportedType
-            }
-            let normalized = try Self.normalizedStaticImage(at: url)
+            let normalized = try Self.normalizedStaticImage(
+                source: source,
+                sourceProperties: sourceProperties,
+                at: url
+            )
             try self.init(
                 filename: normalized.filename,
                 mimeType: normalized.mimeType,
@@ -75,30 +102,34 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
 
     /// Normalize native still-image formats at the attachment boundary so the
     /// persisted attachment, preview, and wire request all share one truthful
-    /// MIME/byte contract. PNG/JPEG/GIF stay byte-for-byte unchanged above;
-    /// every other decodable static image becomes JPEG, or PNG when alpha must
-    /// be preserved. The ordinary initializer applies the same 20 MB wire cap
-    /// to the normalized result.
+    /// MIME/byte contract. Small PNG/JPEG/GIF files stay byte-for-byte
+    /// unchanged above. Larger or native still images become JPEG, or PNG when
+    /// alpha must be preserved. The ordinary initializer applies the same 20 MB
+    /// wire cap to the normalized result.
     private static func normalizedStaticImage(
+        source: CGImageSource,
+        sourceProperties: [CFString: Any],
         at url: URL
     ) throws -> (filename: String, mimeType: String, data: Data) {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              CGImageSourceGetCount(source) == 1
-        else { throw ValidationError.unsupportedType }
-        let sourceProperties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
-            as? [CFString: Any] ?? [:]
-        guard let width = (sourceProperties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
-              let height = (sourceProperties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
-              dimensionsFit(width: width, height: height)
-        else { throw ValidationError.tooManyPixels }
-        guard let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        let thumbnailOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxVisionLongEdge,
+            kCGImageSourceShouldCacheImmediately: true,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            thumbnailOptions as CFDictionary
+        ) else {
             throw ValidationError.unsupportedType
         }
 
-        let preservesAlpha: Bool = switch image.alphaInfo {
-        case .none, .noneSkipFirst, .noneSkipLast: false
-        case .premultipliedFirst, .premultipliedLast, .first, .last, .alphaOnly: true
-        @unknown default: true
+        let preservesAlpha: Bool
+        if let sourceHasAlpha = sourceProperties[kCGImagePropertyHasAlpha] as? NSNumber {
+            preservesAlpha = sourceHasAlpha.boolValue
+        } else {
+            preservesAlpha = Self.containsTransparentPixel(image)
         }
         let targetType: UTType = preservesAlpha ? .png : .jpeg
         let mimeType = preservesAlpha ? "image/png" : "image/jpeg"
@@ -111,6 +142,8 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
         ) else { throw ValidationError.unsupportedType }
 
         var properties = sourceProperties
+        // The thumbnail transform has already applied EXIF orientation.
+        properties[kCGImagePropertyOrientation] = 1
         if !preservesAlpha {
             properties[kCGImageDestinationLossyCompressionQuality] = 0.9
         }
@@ -122,6 +155,29 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
         let base = url.deletingPathExtension().lastPathComponent
         let suffix = preservesAlpha ? "png" : "jpg"
         return ("\(base).\(suffix)", mimeType, output as Data)
+    }
+
+    /// Thumbnail backing stores may carry an alpha channel for an opaque
+    /// source. Inspect the already-bounded thumbnail instead of treating the
+    /// channel's mere presence as transparency.
+    private static func containsTransparentPixel(_ image: CGImage) -> Bool {
+        switch image.alphaInfo {
+        case .none, .noneSkipFirst, .noneSkipLast: return false
+        default: break
+        }
+        let bytesPerRow = image.width * 4
+        var pixels = [UInt8](repeating: 255, count: bytesPerRow * image.height)
+        guard let context = CGContext(
+            data: &pixels,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return true }
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        return stride(from: 3, to: pixels.count, by: 4).contains { pixels[$0] < 255 }
     }
 
     var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -819,6 +819,7 @@ enum ChatStreamError: LocalizedError {
            message.localizedCaseInsensitiveContains("exceeds the per-batch cap") {
             return "That image is too large for this model. Try an image no larger than 2,048 pixels on its longest side."
         }
+        guard envelope.error.code == "image_input_unsupported" else { return nil }
         return message
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -800,21 +800,25 @@ enum ChatStreamError: LocalizedError {
         }
     }
 
-    /// Only the typed image-rejection contract is safe, user-facing copy.
-    /// Other structured 4xx/5xx envelopes may contain operational details and
-    /// must continue through the normal actionable-error diagnosis.
+    /// A typed client-side rejection on an image-bearing request is terminal
+    /// for that attachment. The caller uses this only when the request owns an
+    /// image turn, so later plain-text turns can omit the rejected payload.
     var attachmentFailureMessage: String? {
         guard case .httpStatus(let code, let body) = self,
-              (400..<600).contains(code),
+              (400..<500).contains(code),
               let data = body.data(using: .utf8),
               let envelope = try? JSONDecoder().decode(Wire.ErrorEnvelope.self, from: data),
               envelope.error.type == "invalid_request_error",
-              envelope.error.code == "image_input_unsupported",
               let message = envelope.error.message?.trimmingCharacters(
                 in: .whitespacesAndNewlines
               ),
               !message.isEmpty
         else { return nil }
+
+        if message.localizedCaseInsensitiveContains("vision-request prompt tokens"),
+           message.localizedCaseInsensitiveContains("exceeds the per-batch cap") {
+            return "That image is too large for this model. Try an image no larger than 2,048 pixels on its longest side."
+        }
         return message
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -31,6 +31,28 @@ struct ChatAttachmentDraftTests {
         #expect(draft.sourcePaths.count == 1)
     }
 
+    @Test("async image completion preserves a rejection from the same mixed selection")
+    func mixedSelectionNoticeSurvivesImageCompletion() throws {
+        let conversationID = UUID()
+        var store = ChatAttachmentDraftStore()
+        store[conversationID].notice = "Old notice"
+        let startedRequest = store.beginImageImport(conversationID: conversationID)
+        let request = try #require(startedRequest)
+        #expect(store[conversationID].notice == nil)
+
+        store[conversationID].notice = "That file type isn't supported."
+        let image = try makeImage(name: "accepted.png")
+        let accepted = store.finishImageImport(
+            request: request,
+            [(image, URL(fileURLWithPath: "/tmp/accepted.png"))],
+            notice: nil
+        )
+
+        #expect(accepted)
+        #expect(store[conversationID].images == [image])
+        #expect(store[conversationID].notice == "That file type isn't supported.")
+    }
+
     @Test("consume atomically clears attachments, identity, notice, and import state")
     func consumeClearsEveryTransientField() throws {
         let image = try makeImage(name: "first.png")

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import ImageIO
 import Testing
@@ -13,6 +14,41 @@ struct ChatImageAttachmentTests {
         #expect(!ChatImageAttachment.dimensionsFit(width: 8_001, height: 8_000))
         #expect(!ChatImageAttachment.dimensionsFit(width: 20_000, height: 1))
         #expect(!ChatImageAttachment.dimensionsFit(width: 0, height: 4_000))
+    }
+
+    @Test("vision-bound dimensions preserve aspect ratio with a 2048-pixel long edge")
+    func visionDimensionBudget() {
+        #expect(ChatImageAttachment.normalizedPixelSize(width: 5_000, height: 4_000) == (2_048, 1_638))
+        #expect(ChatImageAttachment.normalizedPixelSize(width: 3_840, height: 2_160) == (2_048, 1_152))
+        #expect(ChatImageAttachment.normalizedPixelSize(width: 140, height: 140) == (140, 140))
+    }
+
+    @Test("large JPEG is normalized at the attachment boundary while a small PNG stays unchanged")
+    func largeStandardImageNormalizes() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-image-normalization-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jpeg = root.appendingPathComponent("photo.jpg")
+        try Self.writeSolidImage(to: jpeg, width: 5_000, height: 4_000, type: .jpeg)
+        let normalized = try ChatImageAttachment(contentsOf: jpeg)
+        let normalizedSource = try #require(
+            CGImageSourceCreateWithData(normalized.data as CFData, nil)
+        )
+        let normalizedProperties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(normalizedSource, 0, nil) as? [CFString: Any]
+        )
+        #expect((normalizedProperties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue == 2_048)
+        #expect((normalizedProperties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue == 1_638)
+
+        let png = root.appendingPathComponent("small.png")
+        try Self.writeSolidImage(to: png, width: 140, height: 140, type: .png)
+        let originalPNG = try Data(contentsOf: png)
+        let unchanged = try ChatImageAttachment(contentsOf: png)
+        #expect(unchanged.filename == "small.png")
+        #expect(unchanged.mimeType == "image/png")
+        #expect(unchanged.data == originalPNG)
     }
 
     @Test("real HEIC fixture normalizes to truthful JPEG attachment bytes")
@@ -420,5 +456,35 @@ struct ChatImageAttachmentTests {
         #expect(throws: ChatImageAttachment.ValidationError.self) {
             try ChatImageAttachment(filename: "x.webp", mimeType: "image/webp", data: Data())
         }
+    }
+
+    private static func writeSolidImage(
+        to url: URL,
+        width: Int,
+        height: Int,
+        type: UTType
+    ) throws {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(red: 0.9, green: 0.4, blue: 0.1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = try #require(context.makeImage())
+        let output = NSMutableData()
+        let destination = try #require(CGImageDestinationCreateWithData(
+            output,
+            type.identifier as CFString,
+            1,
+            nil
+        ))
+        CGImageDestinationAddImage(destination, image, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        try (output as Data).write(to: url)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
@@ -70,6 +70,10 @@ struct HumanizeErrorTests {
     @Test("Unrelated structured server failures remain private diagnostics")
     func structuredServerFailureReasonStaysPrivate() {
         #expect(ChatStreamError.httpStatus(
+            400,
+            #"{"error":{"message":"Context length exceeded","type":"invalid_request_error","code":"context_length_exceeded"}}"#
+        ).attachmentFailureMessage == nil)
+        #expect(ChatStreamError.httpStatus(
             500,
             #"{"error":{"message":"Internal server error"}}"#
         ).attachmentFailureMessage == nil)

--- a/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/HumanizeErrorTests.swift
@@ -55,6 +55,18 @@ struct HumanizeErrorTests {
         #expect(!ChatViewModel.humanize(error).contains("image input"))
     }
 
+    @Test("Vision token-cap rejection becomes actionable terminal image copy")
+    func visionTokenCapBecomesAttachmentRejection() {
+        let body = #"{"error":{"message":"Vision-request prompt tokens (16329) exceeds the per-batch cap (8192 = vision token budget 8192 × 1 vision request(s)). For image inputs, downscale the image.","type":"invalid_request_error","code":null}}"#
+        let message = ChatStreamError.httpStatus(400, body).attachmentFailureMessage
+        #expect(
+            message
+                == "That image is too large for this model. Try an image no larger than 2,048 pixels on its longest side."
+        )
+        #expect(message?.contains("tokens") == false)
+        #expect(message?.contains("8192") == false)
+    }
+
     @Test("Unrelated structured server failures remain private diagnostics")
     func structuredServerFailureReasonStaysPrivate() {
         #expect(ChatStreamError.httpStatus(


### PR DESCRIPTION
## Why

Requested by the maintainer during 0.13.1 dogfood. High-resolution JPEGs and screenshots exceeded the embedded vision token budget, returned a typed HTTP 400, and remained eligible on later turns so the conversation kept resending the rejected image.

## What

- Normalize still-image attachments to a maximum 2,048-pixel long edge while preserving orientation, color, and transparency.
- Preserve the existing 20 MB encoded-byte limit and 64 MP / 16,384-pixel predecode bounds.
- Treat typed image-bearing 4xx invalid-request responses as terminal attachment rejection, surface a bounded actionable reason, and omit the rejected image from later text turns.
- Keep small PNG/JPEG/GIF attachments byte-for-byte unchanged.

Restacked onto the train-6c base, which already contains the prerequisite image normalization work; this branch now carries only the image-budget and terminal-rejection delta.

## Non-goals

- Engine or server changes
- Video or Live Photo support
- Changing the existing encoded-size and decompression-bomb limits

## Verification

- Restack range-diff: all three scoped commits patch-equivalent
- Focused Swift: 54/54 passed
- Release-shaped app build: passed (75.54 s)
- `git diff --check`: passed

## Acceptance

- 5,000×4,000 becomes 2,048×1,638
- 3,840×2,160 becomes 2,048×1,152
- Small PNG remains unchanged
- Typed vision-budget 400 marks the image rejected; existing follow-up contract sends no rejected image
