### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0</string>
+	<string>0.13.1</string>
 	<key>CFBundleVersion</key>
-	<string>165</string>
+	<string>166</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.0"
+version = "0.13.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Ship the completed 0.13.1 fixes and experimental model lane through the
canonical release path, preserving exact source-to-artifact identity across
the engine package and signed/notarized Desktop app.

User-facing highlights:

- Photos work in chat on the recommended vision model.
- Speech to Text arms itself and remains available while users switch chat
  models.
- First-run and model-switch memory guidance reflects what will actually remain
  resident after replacement.
- MTP assistants keep working when another model loads.
- Qwen3.8-Flash-Next has an experimental CLI/API text lane for Macs with at
  least 128 GB of unified memory.
- Structured client requests terminate normally on the vision lane, and common
  HEIC and high-resolution photo attachments are handled without poisoning the
  conversation after a typed rejection.
- Model loading, API validation, and command-line setup are more reliable.

## Scope

- Set engine and Desktop version to `0.13.1`.
- Increment the Desktop build once from the live pre-bump value (`165` to
  `166`).
- Build on the curated release notes landed at exact post-train-6d main SHA
  `3e0bc307d2f4c217306a8377b2395ac9018f7fc3`.

## Non-goals

- No product or model behavior changes.
- No manual tag, emergency bypass, updater rewrite, or credential change.
- No product fix, model artifact upload, or release-workflow redesign.
- This PR does not merge itself, create tags, or publish artifacts.

## Acceptance

- Version/build sync and Release pre-flight pass.
- PR validation, required checks, and full CI are green on the exact zero-behind
  head.
- Both release tags, signed/notarized DMG, engine distributions, hashes, and
  updater evidence all bind to the same accepted release source SHA after the
  protected release transaction.
- Per the 04:14Z human release decision, release-candidate dogfood is waived;
  the exact `c730e45f3d90358e88768be3f836151d50ca0193` integrity build completed
  signed, notarized, stapled, and Gatekeeper-accepted without tagging or
  publication.
