### PR TITLE
ci: add auto-release dry run

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,7 +5,7 @@ name: Auto-release on version bump
 # gate passes on the self-hosted Apple-Silicon runner (the Studio). The existing
 # ``publish.yml`` then publishes to PyPI on the ``release: published`` event.
 #
-# Flow:  detect (hosted)  →  tier1-agent-gate (self-hosted Studio)  →  release
+# Flow: detect (hosted) → Tier-1 + Desktop candidate gates → release-prep → release
 # The release job ``needs`` the gate, so a version bump cannot tag or publish
 # unless the five Tier-1 agents (Claude Code / Codex / Hermes / Aider /
 # DeepSeek Harness) re-verify
@@ -28,12 +28,17 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      dry_run:
+        description: "Run detect + Tier-1 + signed Desktop candidate gates at the selected branch/tag ref; no tag, Release, updater, or protected environment. Mutually exclusive with force_version and retry_version."
+        type: boolean
+        required: false
+        default: false
       force_version:
-        description: "EMERGENCY only: release this exact version WITHOUT the Tier-1 gate (use when the Studio runner is down). Must equal pyproject.toml. Leave blank otherwise. Mutually exclusive with retry_version."
+        description: "EMERGENCY only: release this exact version WITHOUT the Tier-1 gate (use when the Studio runner is down). Must equal pyproject.toml. Leave blank otherwise. Mutually exclusive with dry_run and retry_version."
         required: false
         default: ""
       retry_version:
-        description: "NORMAL retry: re-run the full release at the CURRENT main head for this version (use when a release stalled because main advanced past the validated candidate). Must equal pyproject.toml, run on main, and bypass NOTHING (Tier-1 + signed candidate + evidence + approval all re-run). Mutually exclusive with force_version."
+        description: "NORMAL retry: re-run the full release at the CURRENT main head for this version (use when a release stalled because main advanced past the validated candidate). Must equal pyproject.toml, run on main, and bypass NOTHING (Tier-1 + signed candidate + evidence + approval all re-run). Mutually exclusive with force_version and dry_run."
         required: false
         default: ""
       reason:
@@ -53,6 +58,7 @@ jobs:
       should_release: ${{ steps.detect.outputs.should_release }}
       version: ${{ steps.detect.outputs.version }}
       force: ${{ steps.detect.outputs.force }}
+      dry_run: ${{ steps.detect.outputs.dry_run }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -66,13 +72,36 @@ jobs:
           # explicitly — keep the pattern).
           GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
           FORCE_VERSION: ${{ github.event.inputs.force_version }}
           RETRY_VERSION: ${{ github.event.inputs.retry_version }}
           REASON: ${{ github.event.inputs.reason }}
           ACTOR: ${{ github.actor }}
         run: |
-          # --- Manual workflow_dispatch (emergency force OR normal retry) --
+          # --- Manual workflow_dispatch (dry-run, emergency force, or retry) --
           if [ "$EVENT" = "workflow_dispatch" ]; then
+            # A dry run exercises the two real pre-publication gates on the
+            # selected branch/tag ref. It is deliberately not a release route.
+            if [ "$DRY_RUN" = "true" ]; then
+              if [ -n "$FORCE_VERSION" ] || [ -n "$RETRY_VERSION" ]; then
+                echo "❌ dry_run cannot be combined with force_version or retry_version." >&2
+                exit 1
+              fi
+              VERSION=$(grep -m1 '^version *=' pyproject.toml | awk -F'"' '{print $2}')
+              python3 scripts/release_version.py validate "$VERSION" >/dev/null
+              echo "🧪 DRY RUN requested by @$ACTOR at exact source $GITHUB_SHA (v$VERSION)"
+              echo "    ref: $GITHUB_REF"
+              echo "    Tier-1 and signed Desktop candidate gates will run."
+              echo "    release-prep/release are disabled: no tag, Release, updater, or protected environment."
+              {
+                echo "version=$VERSION"
+                echo "should_release=true"
+                echo "force=false"
+                echo "dry_run=true"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             # force_version and retry_version are mutually exclusive routes.
             if [ -n "$FORCE_VERSION" ] && [ -n "$RETRY_VERSION" ]; then
               echo "❌ force_version and retry_version are mutually exclusive; provide at most one." >&2
@@ -80,8 +109,11 @@ jobs:
             fi
             if [ -z "$FORCE_VERSION" ] && [ -z "$RETRY_VERSION" ]; then
               echo "workflow_dispatch with neither force_version nor retry_version — nothing to do."
-              echo "should_release=false" >> "$GITHUB_OUTPUT"
-              echo "force=false" >> "$GITHUB_OUTPUT"
+              {
+                echo "should_release=false"
+                echo "force=false"
+                echo "dry_run=false"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -135,24 +167,36 @@ jobs:
                 --json isDraft -q .isDraft 2>/dev/null || echo "missing")
               if [ "$RELEASE_DRAFT" = "false" ]; then
                 echo "Release v$VERSION already exists — nothing to do (idempotent)"
-                echo "should_release=false" >> "$GITHUB_OUTPUT"
-                echo "force=false" >> "$GITHUB_OUTPUT"
+                {
+                  echo "should_release=false"
+                  echo "force=false"
+                  echo "dry_run=false"
+                } >> "$GITHUB_OUTPUT"
                 exit 0
               fi
               echo "Tag v$VERSION exists without a published Release — will recover"
-              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-              echo "should_release=true" >> "$GITHUB_OUTPUT"
-              echo "force=$FORCE_BOOL" >> "$GITHUB_OUTPUT"
+              {
+                echo "version=$VERSION"
+                echo "should_release=true"
+                echo "force=$FORCE_BOOL"
+                echo "dry_run=false"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            echo "force=$FORCE_BOOL" >> "$GITHUB_OUTPUT"
+            {
+              echo "version=$VERSION"
+              echo "should_release=true"
+              echo "force=$FORCE_BOOL"
+              echo "dry_run=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # --- Normal push path -------------------------------------------
-          echo "force=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "force=false"
+            echo "dry_run=false"
+          } >> "$GITHUB_OUTPUT"
           SUBJECT=$(git log -1 --pretty=%s)
           echo "subject: $SUBJECT"
 
@@ -186,8 +230,10 @@ jobs:
             exit 0
           fi
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "should_release=true"
+          } >> "$GITHUB_OUTPUT"
           echo "✓ Detected version bump → v$VERSION (pyproject matches, release missing)"
 
   # 2) The gate. Runs on the self-hosted Apple-Silicon runner (the Studio) —
@@ -432,6 +478,53 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # A dry run deliberately ends here: after both real pre-publication gates,
+  # before release-prep, the protected rapid-mac-tag environment, or any tag /
+  # Release / updater write. Keep a final fail-closed job so the run conclusion
+  # and summary state both gate results and the exact source identity.
+  dry-run-summary:
+    needs: [detect, tier1-agent-gate, desktop-candidate-gate]
+    if: >-
+      always()
+      && needs.detect.result == 'success'
+      && needs.detect.outputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify both dry-run gates and report the zero-publication boundary
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+          TIER1_RESULT: ${{ needs.tier1-agent-gate.result }}
+          DESKTOP_RESULT: ${{ needs.desktop-candidate-gate.result }}
+          ACCEPTED_SHA: ${{ needs.desktop-candidate-gate.outputs.accepted_sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Auto-release dry run"
+            echo ""
+            echo "Version: ${VERSION}"
+            echo "Selected ref: ${SOURCE_REF}"
+            echo "Exact source SHA: ${SOURCE_SHA}"
+            echo "Tier-1 gate: ${TIER1_RESULT}"
+            echo "Desktop candidate gate: ${DESKTOP_RESULT}"
+            echo "Accepted Desktop SHA: ${ACCEPTED_SHA:-<none>}"
+            echo ""
+            echo "No tag, GitHub Release, updater pointer, or protected environment was created."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$TIER1_RESULT" != "success" ] || [ "$DESKTOP_RESULT" != "success" ]; then
+            echo "::error::dry run requires both pre-publication gates to succeed (Tier-1=$TIER1_RESULT, Desktop=$DESKTOP_RESULT)." >&2
+            exit 1
+          fi
+          if [ "$ACCEPTED_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Desktop candidate accepted $ACCEPTED_SHA, expected selected source $SOURCE_SHA." >&2
+            exit 1
+          fi
+          echo "::notice::dry run passed at exact source $SOURCE_SHA; publication jobs remain disabled."
+
   # 3) Tag + GitHub Release. Runs when the gate passed OR this is a forced
   #    (gate-bypassed) release, AND the desktop candidate gate accepted the
   #    exact commit. ``!cancelled()`` lets the ``if`` evaluate even though the
@@ -448,6 +541,7 @@ jobs:
       !cancelled()
       && needs.detect.result == 'success'
       && needs.detect.outputs.should_release == 'true'
+      && needs.detect.outputs.dry_run != 'true'
       && (needs.detect.outputs.force == 'true' || needs.tier1-agent-gate.result == 'success')
       && needs.desktop-candidate-gate.result == 'success'
     runs-on: ubuntu-latest
@@ -661,6 +755,7 @@ jobs:
       !cancelled()
       && needs.detect.result == 'success'
       && needs.detect.outputs.should_release == 'true'
+      && needs.detect.outputs.dry_run != 'true'
       && (needs.detect.outputs.force == 'true' || needs.tier1-agent-gate.result == 'success')
       && needs.desktop-candidate-gate.result == 'success'
       && needs.release-prep.result == 'success'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,12 +12,14 @@ extended operational guide, `docs/development/releasing.md`, defers to it.
 
 ## TL;DR — cut a release
 
-1. Bump `version` in `pyproject.toml` to `X.Y.Z`.
-2. In the same PR, `git mv docs/release-notes/unreleased.md
+1. Run the non-publishing auto-release dry run on the intended bump parent and
+   record its exact green run URL (procedure below).
+2. Bump `version` in `pyproject.toml` to `X.Y.Z`.
+3. In the same PR, `git mv docs/release-notes/unreleased.md
    docs/release-notes/vX.Y.Z.md` (optional — see "Release notes" below).
-3. Open a PR whose commit subject is exactly `chore: bump version to X.Y.Z`
+4. Open a PR whose commit subject is exactly `chore: bump version to X.Y.Z`
    (GitHub's `(#N)` squash suffix is fine), and merge it to `main`.
-4. Merging starts the pipeline. After the Desktop candidate validates the
+5. Merging starts the pipeline. After the Desktop candidate validates the
    exact commit, the live main head and release-blocker evidence are gathered,
    and the protected `rapid-mac-tag` deployment requests approval, a **reviewer
    inspects the exact SHA / main-head / blocker evidence** shown there and
@@ -28,6 +30,47 @@ There is **no separate manual tag or publish command** — no button, no
 hand-run script. The reviewer's approval at the protected environment gate is
 the **only manual transaction step** a release requires; everything else is
 automated.
+
+## Pre-bump auto-release dry run (no publication)
+
+`auto-release.yml` has a maintainer-only `workflow_dispatch` dry-run route that
+executes its real `detect`, `tier1-agent-gate`, and signed
+`desktop-candidate-gate` jobs at the selected branch or tag ref. It then stops:
+`release-prep` and `release` are explicitly skipped, the `rapid-mac-tag`
+environment is never requested, and no tag, GitHub Release, PyPI event, or
+updater pointer is created.
+
+Run it on the exact ref whose head you intend to validate:
+
+```bash
+DRY_RUN_REF=main  # or the pushed branch containing an auto-release change
+DRY_RUN_SHA="$(gh api \
+  "repos/raullenchai/Rapid-MLX/git/ref/heads/$DRY_RUN_REF" --jq .object.sha)"
+
+gh workflow run auto-release.yml -R raullenchai/Rapid-MLX --ref "$DRY_RUN_REF" -f dry_run=true
+
+DRY_RUN_ID="$(gh run list -R raullenchai/Rapid-MLX \
+  --workflow auto-release.yml --event workflow_dispatch \
+  --commit "$DRY_RUN_SHA" --limit 1 --json databaseId --jq '.[0].databaseId')"
+test -n "$DRY_RUN_ID"
+test "$(gh run view "$DRY_RUN_ID" -R raullenchai/Rapid-MLX \
+  --json headSha --jq .headSha)" = "$DRY_RUN_SHA"
+gh run watch "$DRY_RUN_ID" -R raullenchai/Rapid-MLX --exit-status
+gh run view "$DRY_RUN_ID" -R raullenchai/Rapid-MLX
+```
+
+The final `dry-run-summary` job must be green, bind the accepted Desktop SHA to
+`DRY_RUN_SHA`, and report that both publication jobs were skipped with no
+protected environment or release mutation. A failed or mismatched run is not
+evidence; fix the gate or ref selection and run it once on the corrected exact
+head.
+
+Every PR that changes `.github/workflows/auto-release.yml` or a script/action
+invoked by `tier1-agent-gate` or `desktop-candidate-gate` must link a green
+exact-head dry-run URL in its PR body. Before opening the version-bump PR, run
+the same dry run on the intended bump parent (`main` at that moment) and include
+its URL + full `headSha` in the bump PR evidence. This exercises gate changes
+before the bump commit can activate the publishing route.
 
 ## Desktop (Rapid-MLX Desktop) RC tags — validated before claimed
 
@@ -150,6 +193,12 @@ The two gates run **in parallel** (they share nothing — different runners,
 different checks) and `release-prep` `needs` BOTH, so **a canonical normal
 release cannot tag or publish unless *both* pass**: the Tier-1 engine gate and
 the signed Desktop candidate at the exact commit.
+
+For `workflow_dispatch` with `dry_run=true`, detect intentionally sets the gate
+route active with `force=false`; the same two gates run, then
+`dry-run-summary` records their exact-SHA result while `release-prep` and
+`release` remain skipped. This is pre-release evidence only and cannot request
+the production environment or publish.
 
 Exact invariant: canonical normal releases require the Tier-1 gate; the audited
 **emergency dispatch may bypass only the Tier-1 gate** (see below); the signed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,13 +45,21 @@ Run it on the exact ref whose head you intend to validate:
 ```bash
 DRY_RUN_REF=main  # or the pushed branch containing an auto-release change
 DRY_RUN_SHA="$(gh api \
-  "repos/raullenchai/Rapid-MLX/git/ref/heads/$DRY_RUN_REF" --jq .object.sha)"
+  "repos/raullenchai/Rapid-MLX/commits/$DRY_RUN_REF" --jq .sha)"
+DRY_RUN_DISPATCHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 gh workflow run auto-release.yml -R raullenchai/Rapid-MLX --ref "$DRY_RUN_REF" -f dry_run=true
 
-DRY_RUN_ID="$(gh run list -R raullenchai/Rapid-MLX \
-  --workflow auto-release.yml --event workflow_dispatch \
-  --commit "$DRY_RUN_SHA" --limit 1 --json databaseId --jq '.[0].databaseId')"
+DRY_RUN_ID=
+for _ in {1..30}; do
+  DRY_RUN_ID="$(gh run list -R raullenchai/Rapid-MLX \
+    --workflow auto-release.yml --event workflow_dispatch \
+    --commit "$DRY_RUN_SHA" --created ">=$DRY_RUN_DISPATCHED_AT" \
+    --limit 10 --json databaseId,createdAt \
+    --jq 'sort_by(.createdAt) | last | .databaseId // empty')"
+  test -z "$DRY_RUN_ID" || break
+  sleep 2
+done
 test -n "$DRY_RUN_ID"
 test "$(gh run view "$DRY_RUN_ID" -R raullenchai/Rapid-MLX \
   --json headSha --jq .headSha)" = "$DRY_RUN_SHA"
@@ -59,7 +67,9 @@ gh run watch "$DRY_RUN_ID" -R raullenchai/Rapid-MLX --exit-status
 gh run view "$DRY_RUN_ID" -R raullenchai/Rapid-MLX
 ```
 
-The final `dry-run-summary` job must be green, bind the accepted Desktop SHA to
+The timestamp-bounded lookup ensures `DRY_RUN_ID` belongs to this dispatch,
+rather than reusing an older run at the same SHA. The final `dry-run-summary`
+job must be green, bind the accepted Desktop SHA to
 `DRY_RUN_SHA`, and report that both publication jobs were skipped with no
 protected environment or release mutation. A failed or mismatched run is not
 evidence; fix the gate or ref selection and run it once on the corrected exact

--- a/tests/release/test_auto_release_dry_run.sh
+++ b/tests/release/test_auto_release_dry_run.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Offline contract for auto-release's maintainer-dispatched dry-run lane.
+# The lane must exercise the two real pre-publication gates at the selected
+# ref's exact SHA while making release-prep, the protected environment, tags,
+# Releases, and updater publication unreachable.
+# shellcheck disable=SC2016  # Assertions intentionally match literal ${{ }} / shell text.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+WORKFLOW="$REPO_ROOT/.github/workflows/auto-release.yml"
+RELEASE_DOC="$REPO_ROOT/RELEASE.md"
+PROJECT_VERSION=$(awk -F'"' '/^version *=/ { print $2; exit }' "$REPO_ROOT/pyproject.toml")
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+contains() {
+  if grep -qF -- "$2" <<<"$1"; then
+    ok "$3"
+  else
+    bad "$3"
+    printf '        want: %s\n' "$2"
+  fi
+}
+lacks() {
+  if grep -qF -- "$2" <<<"$1"; then
+    bad "$3"
+    printf '        reject: %s\n' "$2"
+  else
+    ok "$3"
+  fi
+}
+
+echo "== 1. workflow_dispatch exposes a typed, non-publishing dry_run input =="
+INPUTS=$(sed -n '/^  workflow_dispatch:/,/^permissions:/p' "$WORKFLOW")
+DRY_INPUT=$(sed -n '/^      dry_run:$/,/^      force_version:$/p' "$WORKFLOW")
+contains "$INPUTS" "dry_run:" "workflow_dispatch exposes dry_run"
+contains "$DRY_INPUT" "type: boolean" "dry_run preserves GitHub's Boolean input type"
+contains "$DRY_INPUT" "default: false" "normal dispatches do not become dry runs implicitly"
+contains "$DRY_INPUT" "no tag, Release, updater, or protected environment" \
+  "the input advertises its zero-publication boundary"
+
+echo "== 2. detect routes dry_run through the real gates without a release route =="
+DETECT_HEAD=$(sed -n '/^  detect:$/,/^    steps:/p' "$WORKFLOW")
+DRY_ROUTE=$(sed -n '/if \[ "$DRY_RUN" = "true" \]; then/,/# force_version and retry_version/p' "$WORKFLOW")
+contains "$DETECT_HEAD" 'dry_run: ${{ steps.detect.outputs.dry_run }}' \
+  "detect exports dry_run for every downstream job"
+contains "$(sed -n '/^  detect:$/,/^  # 2)/p' "$WORKFLOW")" \
+  'DRY_RUN: ${{ inputs.dry_run }}' \
+  "detect consumes the typed inputs context"
+contains "$DRY_ROUTE" 'if [ "$DRY_RUN" = "true" ]' \
+  "manual detection has an explicit dry-run route"
+contains "$DRY_ROUTE" 'dry_run cannot be combined with force_version or retry_version' \
+  "dry-run and publishing dispatch routes are mutually exclusive"
+contains "$DRY_ROUTE" 'echo "should_release=true"' \
+  "dry-run reaches both existing pre-publication gates"
+contains "$DRY_ROUTE" 'echo "force=false"' \
+  "dry-run never activates the Tier-1 emergency bypass"
+contains "$DRY_ROUTE" 'echo "dry_run=true"' \
+  "dry-run identity is explicit rather than inferred downstream"
+
+DETECT_SCRIPT=$(awk '
+  /- name: Detect version bump \(or forced release\)/ { found = 1 }
+  found && $0 == "        run: |" { in_run = 1; next }
+  in_run && /^  # 2\)/ { exit }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW")
+DRY_OUTPUT="$TMP_DIR/dry-output"
+if (
+  cd "$REPO_ROOT"
+  EVENT=workflow_dispatch \
+  DRY_RUN=true \
+  FORCE_VERSION='' \
+  RETRY_VERSION='' \
+  REASON='' \
+  ACTOR=offline-contract \
+  GITHUB_SHA=0123456789abcdef0123456789abcdef01234567 \
+  GITHUB_REF=refs/heads/test-dry-run \
+  GITHUB_OUTPUT="$DRY_OUTPUT" \
+  bash -c "$DETECT_SCRIPT"
+); then
+  if grep -qxF "version=$PROJECT_VERSION" "$DRY_OUTPUT" \
+    && grep -qxF 'should_release=true' "$DRY_OUTPUT" \
+    && grep -qxF 'force=false' "$DRY_OUTPUT" \
+    && grep -qxF 'dry_run=true' "$DRY_OUTPUT"; then
+    ok "extracted detect script routes dry_run=true to both non-forced gates"
+  else
+    bad "extracted detect script routes dry_run=true to both non-forced gates"
+    sed 's/^/        output: /' "$DRY_OUTPUT"
+  fi
+else
+  bad "extracted detect script routes dry_run=true to both non-forced gates"
+fi
+
+MIXED_OUTPUT="$TMP_DIR/mixed-output"
+if (
+  cd "$REPO_ROOT"
+  EVENT=workflow_dispatch \
+  DRY_RUN=true \
+  FORCE_VERSION="$PROJECT_VERSION" \
+  RETRY_VERSION='' \
+  REASON='' \
+  ACTOR=offline-contract \
+  GITHUB_SHA=0123456789abcdef0123456789abcdef01234567 \
+  GITHUB_REF=refs/heads/test-dry-run \
+  GITHUB_OUTPUT="$MIXED_OUTPUT" \
+  bash -c "$DETECT_SCRIPT" >/dev/null 2>&1
+); then
+  bad "extracted detect script rejects dry_run plus a publishing input"
+else
+  ok "extracted detect script rejects dry_run plus a publishing input"
+fi
+
+echo "== 3. both production jobs are unreachable in dry-run mode =="
+PREP_IF=$(sed -n '/^  release-prep:$/,/runs-on:/p' "$WORKFLOW")
+RELEASE_IF=$(sed -n '/^  release:$/,/runs-on:/p' "$WORKFLOW")
+contains "$PREP_IF" "needs.detect.outputs.dry_run != 'true'" \
+  "dry-run skips release-prep before any publication evidence path"
+contains "$RELEASE_IF" "needs.detect.outputs.dry_run != 'true'" \
+  "dry-run skips the environment-gated release job"
+
+echo "== 4. the final dry-run summary fails closed on either gate =="
+SUMMARY=$(sed -n '/^  dry-run-summary:$/,/^  # 3)/p' "$WORKFLOW")
+contains "$SUMMARY" "needs: [detect, tier1-agent-gate, desktop-candidate-gate]" \
+  "summary waits for both real gates"
+contains "$SUMMARY" "needs.tier1-agent-gate.result" \
+  "summary consumes the Tier-1 result"
+contains "$SUMMARY" "needs.desktop-candidate-gate.result" \
+  "summary consumes the Desktop candidate result"
+contains "$SUMMARY" 'if [ "$TIER1_RESULT" != "success" ] || [ "$DESKTOP_RESULT" != "success" ]' \
+  "summary fails unless both gates succeeded"
+contains "$SUMMARY" 'if [ "$ACCEPTED_SHA" != "$SOURCE_SHA" ]' \
+  "summary binds the accepted Desktop candidate to the run SHA"
+contains "$SUMMARY" "No tag, GitHub Release, updater pointer, or protected environment was created." \
+  "run summary states the observable zero-publication result"
+lacks "$SUMMARY" "environment:" "dry-run summary has no protected environment"
+lacks "$SUMMARY" "tag_desktop_app.sh" "dry-run summary cannot claim the Desktop tag"
+lacks "$SUMMARY" "create_release.sh" "dry-run summary cannot create the engine release"
+
+echo "== 5. operator docs require exact-head evidence before release changes =="
+contains "$(cat "$RELEASE_DOC")" \
+  'gh workflow run auto-release.yml -R raullenchai/Rapid-MLX --ref "$DRY_RUN_REF" -f dry_run=true' \
+  "runbook uses the documented workflow_dispatch ref + Boolean input"
+contains "$(cat "$RELEASE_DOC")" \
+  "Every PR that changes \`.github/workflows/auto-release.yml\`" \
+  "release workflow PRs must link a green dry-run URL"
+contains "$(cat "$RELEASE_DOC")" \
+  "Before opening the version-bump PR" \
+  "the intended bump parent is dry-run before the bump PR opens"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/release/test_auto_release_dry_run.sh
+++ b/tests/release/test_auto_release_dry_run.sh
@@ -147,6 +147,21 @@ contains "$(cat "$RELEASE_DOC")" \
   'gh workflow run auto-release.yml -R raullenchai/Rapid-MLX --ref "$DRY_RUN_REF" -f dry_run=true' \
   "runbook uses the documented workflow_dispatch ref + Boolean input"
 contains "$(cat "$RELEASE_DOC")" \
+  '"repos/raullenchai/Rapid-MLX/commits/$DRY_RUN_REF" --jq .sha' \
+  "runbook resolves branch, tag, and SHA refs through the generic commit endpoint"
+lacks "$(cat "$RELEASE_DOC")" \
+  'git/ref/heads/$DRY_RUN_REF' \
+  "runbook does not resolve selectable refs through a branch-only endpoint"
+contains "$(cat "$RELEASE_DOC")" \
+  'DRY_RUN_DISPATCHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"' \
+  "runbook records an unambiguous lower bound before dispatch"
+contains "$(cat "$RELEASE_DOC")" \
+  '--created ">=$DRY_RUN_DISPATCHED_AT"' \
+  "run discovery cannot select an older run at the same SHA"
+contains "$(cat "$RELEASE_DOC")" \
+  'for _ in {1..30}; do' \
+  "runbook waits for the newly dispatched run to become visible"
+contains "$(cat "$RELEASE_DOC")" \
   "Every PR that changes \`.github/workflows/auto-release.yml\`" \
   "release workflow PRs must link a green dry-run URL"
 contains "$(cat "$RELEASE_DOC")" \

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -279,7 +279,7 @@ echo "== 6b. candidate gate runs IN PARALLEL with the Tier-1 gate (dependency) =
 # ONLY — it starts at the same time as tier1 — while release-prep still `needs`
 # BOTH and requires BOTH before the tag can be claimed. Parallelism must not let
 # a release skip either gate.
-CAND_NEEDS=$(sed -n '/^  desktop-candidate-gate:/,/^  # 3)/p' "$AUTO_RELEASE")
+CAND_NEEDS=$(sed -n '/^  desktop-candidate-gate:/,/^  dry-run-summary:/p' "$AUTO_RELEASE")
 contains "$CAND_NEEDS" "needs: detect" \
   "desktop-candidate-gate needs only detect (starts in parallel with tier1)"
 lacks "$CAND_NEEDS" "tier1-agent-gate" \


### PR DESCRIPTION
## Why

The Tier-1 and signed Desktop release gates currently receive their first end-to-end exercise only after a version bump reaches `main`. A gate configuration problem can therefore block the release path after the release commit lands.

This adds a dispatchable, fail-closed dry-run route so release operators and workflow-changing PRs can exercise both gates at an exact ref without creating tags, releases, updater artifacts, or a protected-environment review.

Closes #2492.

## What changed

- Add a typed `workflow_dispatch` boolean input, `dry_run`, mutually exclusive with `force` and `retry_failed_release`.
- Route dry runs through version detection, `tier1-agent-gate`, and `desktop-candidate-gate` at the dispatched SHA.
- Add an always-run summary that verifies both gates passed and the accepted Desktop candidate SHA equals the dispatched SHA.
- Explicitly exclude dry runs from `release-prep`, `release`, and the `rapid-mac-tag` environment.
- Document the exact-head operator procedure and required dry-run evidence for release-path changes and bump preflight.
- Add executable workflow-contract coverage and update the candidate-only promotion boundary for the new summary job.

## Scope and non-goals

This PR only adds dry-run orchestration, documentation, and contract tests. It does not alter production push/tag routing, signing/notarization steps, publication behavior, release assets, model selection, or gate contents.

## Acceptance criteria

- A dispatch on the PR's exact head runs detect + Tier-1 + signed Desktop candidate gates.
- The summary records the requested ref, exact SHA, gate results, and accepted Desktop SHA.
- No tag, GitHub Release, updater artifact, or protected-environment review is created.
- Existing production promotion contracts remain green.

## Verification

Exact head: `2b09a8e0ef08f8895280989ff7e602da6ada4b8d`

1. Dry-run contract: 32/32 assertions passed.
2. Release promotion contract: 87/87 assertions passed.
3. Release regression bundle: Desktop tag 55/55, engine release 49/49, release notes 63/63, subject routing 6/6.
4. Workflow integrity: no new actionlint findings; all 14 workflows pass action pinning; YAML boundary check confirms the summary has no environment and production release retains `rapid-mac-tag`.
5. Focused Python and hygiene: 31 pytest cases passed; new shell test passes ShellCheck and `bash -n`; `git diff --check` and secret review passed.

Exact-head dry-run: [run 33047129086](https://github.com/raullenchai/Rapid-MLX/actions/runs/33047129086) — GREEN.

- `detect`, `tier1-agent-gate`, `desktop-candidate-gate`, and `dry-run-summary`: success.
- Accepted Desktop SHA: `2b09a8e0ef08f8895280989ff7e602da6ada4b8d` (matches the dispatched head).
- `release-prep` and `release`: skipped; pending deployments and deployments at the dry-run SHA: none.
- Post-run audit: existing release tag SHAs and publish times unchanged; production appcast SHA-256 unchanged (`bda74f2664328e3d955541116a84af32aebe0b78af2d8c689435a9978170cb51`).