### PR TITLE
fix(mac): align onboarding admission with the curated-pick predicate so a recommended model is never a dead-end (#2505)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
@@ -288,11 +288,15 @@ enum OnboardingModelSelection {
     /// which over-states low-bit / MoE footprints (the 32 GB tier's
     /// `qwen3.8-27b-4bit` reads ~22 GB as an estimate but its measured 8K
     /// serve peak is 20.0 GB and fits). This mirrors every start path —
-    /// ``ContentView.runLaunchAutoStart``, ``ModelPickerBar.handleStartTap``,
-    /// ``CacheAwareDefault.bucketedFits`` — so `.tooBig` is only a veto when
-    /// the alias isn't THIS Mac's curated recommendation.
-    /// ``RAMBucketedDefault.isRecommendedPick`` carries the `<16 GB` floor
-    /// guard, so an 8 GB Mac's clamped-to-16 GB picks stay subject to the veto.
+    /// ``ContentView.runLaunchAutoStart``,
+    /// ``ModelPickerBar.handleStartTap``, and
+    /// ``RAMBucketedDefault/CacheAwareDefault.pick(catalog:hardware:bucketedDefault:excludedAliases:)``
+    /// — so `.tooBig` is only a veto when the alias isn't THIS Mac's curated
+    /// recommendation.
+    /// ``RAMBucketedDefault.isRecommendedPick`` only returns true for a tier
+    /// this Mac genuinely sits in (RAM ≥ the tier's floor), so a machine below
+    /// the minimum 8 GB floor is "recommended" for no tier and nothing is
+    /// exempt there — the `.tooBig` veto still applies.
     static func isAvailable(alias: String, hardware: MacHardware) -> Bool {
         if RAMBucketedDefault.isRecommendedPick(
             alias: alias, physicalRAMGB: hardware.physicalRAMGB

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
@@ -283,8 +283,23 @@ enum OnboardingModelSelection {
     /// Whether this Mac can run the alias, using the classification the model
     /// picker already disables on. Not a new compatibility claim — the same
     /// ``ModelSizing`` estimate, read in one more place.
+    ///
+    /// A curated recommendation is trusted over ``ModelSizing``'s estimate,
+    /// which over-states low-bit / MoE footprints (the 32 GB tier's
+    /// `qwen3.8-27b-4bit` reads ~22 GB as an estimate but its measured 8K
+    /// serve peak is 20.0 GB and fits). This mirrors every start path —
+    /// ``ContentView.runLaunchAutoStart``, ``ModelPickerBar.handleStartTap``,
+    /// ``CacheAwareDefault.bucketedFits`` — so `.tooBig` is only a veto when
+    /// the alias isn't THIS Mac's curated recommendation.
+    /// ``RAMBucketedDefault.isRecommendedPick`` carries the `<16 GB` floor
+    /// guard, so an 8 GB Mac's clamped-to-16 GB picks stay subject to the veto.
     static func isAvailable(alias: String, hardware: MacHardware) -> Bool {
-        ModelSizing.classify(ModelSizing.estimate(alias: alias), on: hardware) != .tooBig
+        if RAMBucketedDefault.isRecommendedPick(
+            alias: alias, physicalRAMGB: hardware.physicalRAMGB
+        ) {
+            return true
+        }
+        return ModelSizing.classify(ModelSizing.estimate(alias: alias), on: hardware) != .tooBig
     }
 
     /// Build the row set for a catalogue slice. Cached-ness comes from the

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
@@ -288,15 +288,16 @@ enum OnboardingModelSelection {
     /// which over-states low-bit / MoE footprints (the 32 GB tier's
     /// `qwen3.8-27b-4bit` reads ~22 GB as an estimate but its measured 8K
     /// serve peak is 20.0 GB and fits). This mirrors every start path —
-    /// ``ContentView.runLaunchAutoStart``,
-    /// ``ModelPickerBar.handleStartTap``, and
-    /// ``RAMBucketedDefault/CacheAwareDefault.pick(catalog:hardware:bucketedDefault:excludedAliases:)``
-    /// — so `.tooBig` is only a veto when the alias isn't THIS Mac's curated
+    /// ``ContentView.runLaunchAutoStart``, ``ModelPickerBar.handleStartTap``
+    /// and ``CacheAwareDefault`` all gate `.tooBig` on the same
+    /// ``RAMBucketedDefault.isRecommendedPick(alias:physicalRAMGB:)`` — so
+    /// `.tooBig` is only a veto when the alias isn't THIS Mac's curated
     /// recommendation.
-    /// ``RAMBucketedDefault.isRecommendedPick`` only returns true for a tier
-    /// this Mac genuinely sits in (RAM ≥ the tier's floor), so a machine below
-    /// the minimum 8 GB floor is "recommended" for no tier and nothing is
-    /// exempt there — the `.tooBig` veto still applies.
+    ///
+    /// That predicate is floor-guarded: it is true only for a tier this Mac
+    /// genuinely sits in (RAM ≥ the tier's floor). Below the lowest tier's
+    /// floor a Mac sits in no tier, so the curated picks it is shown are NOT
+    /// exempt and the `.tooBig` veto still applies to them.
     static func isAvailable(alias: String, hardware: MacHardware) -> Bool {
         if RAMBucketedDefault.isRecommendedPick(
             alias: alias, physicalRAMGB: hardware.physicalRAMGB

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
@@ -88,6 +88,68 @@ struct OnboardingWontFitReviewTests {
         .init(alias: alias, isCached: cached, isAvailable: available)
     }
 
+    /// A Mac with exactly ``ramGB`` of physical RAM, tiered by RAM alone.
+    /// The tier/band only affect ``ModelSizing`` classification; the chip
+    /// identity is irrelevant to the availability verdict under test.
+    private static func hardware(ramGB: Double) -> MacHardware {
+        MacHardware(
+            brandString: "Apple M3 Pro",
+            family: .m3,
+            tier: .pro,
+            physicalRAMBytes: UInt64(ramGB) * UInt64(1 << 30),
+            memoryBandwidthGBs: 150
+        )
+    }
+
+    // MARK: - 1b. #2505 invariant: a curated pick is never refused by its own Review
+
+    /// #2505 regression: on a 32 GB Mac the setup card recommended
+    /// ``qwen3.8-27b-4bit`` while the Download Review ("WON'T FIT")
+    /// disabled Download & start — a dead-end. The card and the Review
+    /// had drifted because ``OnboardingModelSelection.isAvailable`` (which
+    /// drives the Review's disabled primary) applied ``ModelSizing``'s raw
+    /// ``.tooBig`` veto, while every start path exempts the Mac's curated
+    /// recommendation (``RAMBucketedDefault.isRecommendedPick``), trusting
+    /// its measured footprint over the estimate. Table-driven over the
+    /// PINNED tiers so the card and Review can never disagree again.
+    @Test("Every tier's curated recommended picks pass the Review's availability admission")
+    func curatedPicksAreAdmissibleOnTheirOwnTier() {
+        for tier in RAMBucketedDefault.tiers {
+            for pick in tier.picks {
+                let hw = Self.hardware(ramGB: tier.floorGB)
+                // The card presents this as RECOMMENDED, so it is by definition
+                // this Mac's curated pick (the carve-out the card relies on)…
+                #expect(RAMBucketedDefault.isRecommendedPick(
+                    alias: pick.alias, physicalRAMGB: hw.physicalRAMGB),
+                    "\(pick.alias) should be a \(tier.floorGB) GB tier pick")
+                // …and that same pick must NOT be refused by the Download
+                // Review, or the user hits a dead-end: the card says
+                // "recommended" while Review disables Download & start.
+                #expect(OnboardingModelSelection.isAvailable(
+                    alias: pick.alias, hardware: hw),
+                    "\(pick.alias) is curated for the \(tier.floorGB) GB tier but its Review refuses Download")
+            }
+        }
+    }
+
+    /// Condition-2 guard: the `.tooBig && !isRecommendedPick` carve-out must
+    /// not leak — a genuinely-too-big alias that ISN'T this Mac's curated pick
+    /// stays inaccessible, and a pick merely SHOWN below its tier's floor (the
+    /// sub-16 GB clamp) still respects the veto. Only the in-tier curated pick
+    /// is exempt.
+    @Test("The carve-out is narrow: only the in-tier curated pick is exempt")
+    func carveOutIsNarrow() {
+        // A 70B model is never a 32 GB tier pick → still refused on 32 GB.
+        #expect(!OnboardingModelSelection.isAvailable(
+            alias: Self.tooBigAlias, hardware: Self.hardware(ramGB: 32)))
+        // An 8 GB Mac only gets the 16 GB tier's picks SHOWN; it does not sit
+        // in that tier, so they remain subject to the veto (OOM hole guard).
+        // bonsai-27b-2bit (~7.6 GB real, ~14.8 GB estimate) is a 24 GB tier
+        // pick, not an 8 GB pick → still refused on 8 GB.
+        #expect(!OnboardingModelSelection.isAvailable(
+            alias: "bonsai-27b-2bit", hardware: Self.hardware(ramGB: 8)))
+    }
+
     // MARK: - 1. The fixture is actually incompatible
 
     /// Everything below is meaningless if the alias under test happens to fit.

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
@@ -134,23 +134,27 @@ struct OnboardingWontFitReviewTests {
 
     /// Condition-2 guard: the `.tooBig && !isRecommendedPick` carve-out must
     /// not leak — a genuinely-too-big alias that ISN'T this Mac's curated pick
-    /// stays inaccessible, and a machine below the minimum tier floor (8 GB)
-    /// is recommended for no tier, so the veto applies to everything it is
-    /// shown. Only an in-tier curated pick is exempt.
+    /// stays inaccessible, and below the lowest tier's floor a Mac sits in no
+    /// tier, so the curated picks it is shown are not exempt either. Only an
+    /// in-tier curated pick is exempt. The floor is read from the pinned
+    /// ``RAMBucketedDefault.tiers`` rather than restated here.
     @Test("The carve-out is narrow: only the in-tier curated pick is exempt")
     func carveOutIsNarrow() {
         // A 70B model is never a 32 GB tier pick → still refused on 32 GB.
         #expect(!OnboardingModelSelection.isAvailable(
             alias: Self.tooBigAlias, hardware: Self.hardware(ramGB: 32)))
         // bonsai-27b-2bit (~7.6 GB real, ~14.8 GB estimate) is a 24 GB tier
-        // pick, not an 8 GB pick → on an 8 GB Mac it is not recommended and
-        // stays subject to the (real) veto.
+        // pick, not a lowest-tier pick → on a lowest-tier Mac it is not
+        // recommended and stays subject to the (real) veto.
+        let lowestTier = RAMBucketedDefault.tiers[0]
         #expect(!OnboardingModelSelection.isAvailable(
-            alias: "bonsai-27b-2bit", hardware: Self.hardware(ramGB: 8)))
-        // Below the minimum 8 GB floor a Mac sits in no tier, so even the
-        // smallest shown pick is not "recommended" and the veto applies.
+            alias: "bonsai-27b-2bit",
+            hardware: Self.hardware(ramGB: lowestTier.floorGB)))
+        // Below the lowest tier's floor a Mac sits in no tier, so even that
+        // tier's own smart pick is not "recommended" and the veto applies.
         #expect(!OnboardingModelSelection.isAvailable(
-            alias: "lfm2.5-2.6b-4bit", hardware: Self.hardware(ramGB: 6)))
+            alias: lowestTier.primary.alias,
+            hardware: Self.hardware(ramGB: lowestTier.floorGB - 2)))
     }
 
     // MARK: - 1. The fixture is actually incompatible

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingWontFitReviewTests.swift
@@ -134,20 +134,23 @@ struct OnboardingWontFitReviewTests {
 
     /// Condition-2 guard: the `.tooBig && !isRecommendedPick` carve-out must
     /// not leak — a genuinely-too-big alias that ISN'T this Mac's curated pick
-    /// stays inaccessible, and a pick merely SHOWN below its tier's floor (the
-    /// sub-16 GB clamp) still respects the veto. Only the in-tier curated pick
-    /// is exempt.
+    /// stays inaccessible, and a machine below the minimum tier floor (8 GB)
+    /// is recommended for no tier, so the veto applies to everything it is
+    /// shown. Only an in-tier curated pick is exempt.
     @Test("The carve-out is narrow: only the in-tier curated pick is exempt")
     func carveOutIsNarrow() {
         // A 70B model is never a 32 GB tier pick → still refused on 32 GB.
         #expect(!OnboardingModelSelection.isAvailable(
             alias: Self.tooBigAlias, hardware: Self.hardware(ramGB: 32)))
-        // An 8 GB Mac only gets the 16 GB tier's picks SHOWN; it does not sit
-        // in that tier, so they remain subject to the veto (OOM hole guard).
         // bonsai-27b-2bit (~7.6 GB real, ~14.8 GB estimate) is a 24 GB tier
-        // pick, not an 8 GB pick → still refused on 8 GB.
+        // pick, not an 8 GB pick → on an 8 GB Mac it is not recommended and
+        // stays subject to the (real) veto.
         #expect(!OnboardingModelSelection.isAvailable(
             alias: "bonsai-27b-2bit", hardware: Self.hardware(ramGB: 8)))
+        // Below the minimum 8 GB floor a Mac sits in no tier, so even the
+        // smallest shown pick is not "recommended" and the veto applies.
+        #expect(!OnboardingModelSelection.isAvailable(
+            alias: "lfm2.5-2.6b-4bit", hardware: Self.hardware(ramGB: 6)))
     }
 
     // MARK: - 1. The fixture is actually incompatible

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -353,15 +353,26 @@ struct Step2ModelSelectionBehaviorTests {
         #expect(review.title == OnboardingModelSelection.Verb.downloadAndStart)
     }
 
-    /// Availability is the classification the model picker already disables on
-    /// — not a new claim invented for onboarding.
-    @Test("Availability comes from ModelSizing.classify, not from onboarding")
-    func availabilityUsesTheExistingDecision() {
+    /// Availability reuses the classification the model picker already disables
+    /// on — not a new claim invented for onboarding — plus the ONE established
+    /// carve-out the rest of the app already applies: a Mac's curated
+    /// recommendation (``RAMBucketedDefault.isRecommendedPick``) is trusted over
+    /// ``ModelSizing``'s estimate, which over-states low-bit / MoE footprints.
+    /// So ``isAvailable`` ⇔ ``!tooBig || isRecommendedPick`` — a model is only
+    /// unavailable when it is BOTH too big (per the estimate) AND not a curated
+    /// pick — exactly the predicate every start path uses (#2505 aligned
+    /// onboarding to it).
+    @Test("Availability is the picker predicate on top of a narrow curated-pick carve-out")
+    func availabilityUsesThePickerPredicate() {
         let hardware = MacHardware.detect()
         for alias in ["qwen3.5-4b-4bit", "lfm2.5-1b-4bit", "qwen3-0.6b-4bit"] {
-            let expected = ModelSizing.classify(
+            let tooBig = ModelSizing.classify(
                 ModelSizing.estimate(alias: alias), on: hardware
-            ) != .tooBig
+            ) == .tooBig
+            let carvedOut = RAMBucketedDefault.isRecommendedPick(
+                alias: alias, physicalRAMGB: hardware.physicalRAMGB
+            )
+            let expected = !tooBig || carvedOut
             #expect(OnboardingModelSelection.isAvailable(alias: alias, hardware: hardware) == expected)
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -362,19 +362,28 @@ struct Step2ModelSelectionBehaviorTests {
     /// unavailable when it is BOTH too big (per the estimate) AND not a curated
     /// pick — exactly the predicate every start path uses (#2505 aligned
     /// onboarding to it).
+    ///
+    /// A fixed 32 GB fixture rather than the host, so the verdict is
+    /// deterministic and exercises the carve-out: on 32 GB the curated
+    /// `qwen3.8-27b-4bit` is `.tooBig` by ``ModelSizing``'s estimate yet MUST
+    /// be available (the exact #2505 dead-end it fixes).
     @Test("Availability is the picker predicate on top of a narrow curated-pick carve-out")
     func availabilityUsesThePickerPredicate() {
-        let hardware = MacHardware.detect()
-        for alias in ["qwen3.5-4b-4bit", "lfm2.5-1b-4bit", "qwen3-0.6b-4bit"] {
-            let tooBig = ModelSizing.classify(
-                ModelSizing.estimate(alias: alias), on: hardware
-            ) == .tooBig
-            let carvedOut = RAMBucketedDefault.isRecommendedPick(
-                alias: alias, physicalRAMGB: hardware.physicalRAMGB
-            )
-            let expected = !tooBig || carvedOut
-            #expect(OnboardingModelSelection.isAvailable(alias: alias, hardware: hardware) == expected)
-        }
+        let hw = MacHardware(
+            brandString: "Apple M2 Pro",
+            family: .m2,
+            tier: .pro,
+            physicalRAMBytes: 32 * UInt64(1 << 30),
+            memoryBandwidthGBs: 200
+        )
+        // #2505: the 32 GB curated pick is tooBig by estimate but available.
+        #expect(ModelSizing.classify(
+            ModelSizing.estimate(alias: "qwen3.8-27b-4bit"), on: hw) == .tooBig)
+        #expect(OnboardingModelSelection.isAvailable(alias: "qwen3.8-27b-4bit", hardware: hw))
+        // A too-big NON-pick stays unavailable (no carve-out).
+        #expect(!OnboardingModelSelection.isAvailable(alias: "llama3.1-70b-4bit", hardware: hw))
+        // A fitting non-pick is available as usual.
+        #expect(OnboardingModelSelection.isAvailable(alias: "qwen3.5-4b-4bit", hardware: hw))
     }
 
     @Test("Cached-ness is read from the catalogue, never from copy or grouping")


### PR DESCRIPTION
Closes #2505 (P0). On a 32 GB Mac the setup card recommended `qwen3.8-27b-4bit`
while its Download Review disabled Download & start — a dead-end the user
cannot proceed past.

## Root cause
Two surfaces disagreed for 32 GB:
- The **setup card** (tier table, AA-Index #2055) recommends `qwen3.8-27b-4bit`
  (measured ~8K serve peak **20.0 GB**).
- The **Download Review** admission (`OnboardingModelSelection.isAvailable`)
  applied `ModelSizing`'s raw `.tooBig` veto (`estimate` 22.05 GB → `.tooBig`
  against the 19.2 GB 75%-of-usable ceiling) → **Download & start disabled**.

Every other start path already unifies on **`.tooBig && !isRecommendedPick`**
(“a recommended pick trusts the curated measured footprint and is NEVER
rejected when the estimate over-states it”): `ContentView.runLaunchAutoStart`,
`ModelPickerBar.handleStartTap`, the switch gate, `CacheAwareDefault`.
Onboarding was the **one** surface that applied the raw veto — that's the bug
(and it would dead-end any recommended pick the estimate over-states, e.g. the
24 GB `bonsai-27b-2bit` which estimates ~14.8 GB but fits 16 GB real).

## Fix (SSOT, not a table edit)
`OnboardingModelSelection.isAvailable` now mirrors the established predicate:
`.tooBig` is a veto only when the alias **isn't** this Mac's curated
recommendation (`RAMBucketedDefault.isRecommendedPick(alias:physicalRAMGB:)`,
which is true only for a tier this Mac genuinely sits in — RAM ≥ the tier's
floor — so below the lowest tier's floor a Mac is recommended for no tier and
the curated picks it is shown are not exempt). No tier-table change, no
AA-Index policy change, no user-visible recommendation change.

## Behaviour delta
Only the 32 GB `qwen3.8-27b-4bit` and 24 GB `bonsai-27b-2bit` curated picks
flip from refused to admissible in onboarding (the two picks whose estimate
over-states their measured footprint past the 75 % ceiling); everything else
is unchanged, and the load-time memory confirmation still applies.

- **Before:** on a 32 GB Mac, the setup card says “RECOMMENDED FOR YOUR 32 GB
  MAC” but the Download Review reports “This model cannot run on this Mac” and
  disables Download & start → user cannot proceed.
- **After:** the curated 32 GB pick passes admission; its Download Review shows
  Download & start **enabled**. Non-recommended models that are genuinely
  `.tooBig` (e.g. a 70B on 32 GB) remain disabled exactly as before.
- No change to the recommendation tier table, the banner, or which model is
  offered. The only code-path change is the admission predicate alignment.

## Test (table-driven invariant — first #2497 case)
`OnboardingWontFitReviewTests.curatedPicksAreAdmissibleOnTheirOwnTier` iterates
the pinned tiers and asserts every curated primary+alt pick passes `isAvailable`
at its floor — so the Review can never again contradict the setup card — plus
`carveOutIsNarrow`, which pins the carve-out to in-tier picks only (a 70B
non-pick on 32 GB, a 24 GB pick on the lowest tier, and the lowest tier's own
smart pick just below that tier's floor all stay refused; the floor is read
from `RAMBucketedDefault.tiers`, not restated). `Step2ModelSelectionBehaviorTests`
now uses a fixed 32 GB fixture: `qwen3.8-27b-4bit` is `.tooBig` by estimate yet
available, `llama3.1-70b-4bit` stays unavailable, `qwen3.5-4b-4bit` is available.

## Condition-1 evidence
Measured on the 32 GB Mac mini (M2 Pro) while the author's desk was offline —
raw numbers in
https://github.com/raullenchai/Rapid-MLX/pull/2512#issuecomment-5439468865.
**Verdict: ACCEPTABLE.** `qwen3.8-27b-4bit` on a fresh `rapid-mlx==0.13.1`
install keeps `memory_pressure` **normal** both idle and with +4 GiB of busy app
memory, shows **zero swap growth**, decodes at **11.5–12.0 tok/s**, TTFT
**0.8–1.5 s**. Caveats: thin headroom under load, prefill ~62 tok/s, and this
is CLI-side evidence — GUI before/after screenshots of the setup card / Review
sheet and the onboarding→download→first-chat journey to be added by the author
when their desk is back.

## Atlas review-item fixes
- Floor wording: the doc comment and `carveOutIsNarrow` describe the guard
  generically (below the lowest tier's floor the curated picks are not exempt)
  instead of naming a clamp value; the test derives the floor and pick from
  `RAMBucketedDefault.tiers`.
- Replaced the host-dependent availability spec in `Step2ModelSelectionBehaviorTests`
  (used `MacHardware.detect()`, never exercised the carve-out) with the fixed
  32 GB fixture above.
- Doc link now names the actual predicate,
  `RAMBucketedDefault.isRecommendedPick(alias:physicalRAMGB:)` (`bucketedFits`
  is a local inside `CacheAwareDefault.pick`, not a linkable member).

## Follow-up (not in this PR)
- #2513 — the two-footprints inconsistency (`ModelSizing.estimate` 22.05 GB vs the
  curated measured 20.0 GB for qwen3.8-27b-4bit) is tracked separately so the
  admission math and the recommendation stay honest.
- `RAMBucketedDefault.swift` still carries pre-existing "sub-16 GB clamp"
  wording in its own comments (`tier(forPhysicalRAMGB:)`, `isRecommendedPick`);
  out of scope for this one-file product change.


Co-Authored-By: Claude <noreply@anthropic.com>
