### PR TITLE
ci: keep unpromoted full gates pending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,9 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     permissions:
+      actions: read
       contents: read
+      pull-requests: read
       statuses: write
     steps:
       - name: Start an internal PR merge status pending
@@ -723,9 +725,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
+          LIVE_PR_JSON="$RUNNER_TEMP/live-pr.json"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "$LIVE_PR_JSON"
+          LIVE_STATE=$(jq -r '.state' "$LIVE_PR_JSON")
+          LIVE_BASE_REF=$(jq -r '.base.ref' "$LIVE_PR_JSON")
+          LIVE_HEAD_SHA=$(jq -r '.head.sha' "$LIVE_PR_JSON")
+          LIVE_FULL_CI=$(jq -r 'any(.labels[]; .name == "full-ci")' "$LIVE_PR_JSON")
+
+          RUNS_JSON="$RUNNER_TEMP/ci-runs.json"
+          gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" > "$RUNS_JSON"
+          LATEST_RUN_ID=$(jq -r '[.workflow_runs[]] | if length > 0 then max_by(.id).id else "" end' "$RUNS_JSON")
+          if [ "$LIVE_STATE" != open ] || [ "$LIVE_BASE_REF" != main ] || \
+             [ "$LIVE_HEAD_SHA" != "$HEAD_SHA" ] || [ "$LIVE_FULL_CI" != true ] || \
+             [ "$LATEST_RUN_ID" != "$RUN_ID" ]; then
+            echo "Not settling stale or unpromoted engine evidence (state=$LIVE_STATE base=$LIVE_BASE_REF live=$LIVE_HEAD_SHA run_head=$HEAD_SHA full_ci=$LIVE_FULL_CI latest_run=${LATEST_RUN_ID:-missing} run_id=$RUN_ID)."
+            exit 0
+          fi
+
           jq -n \
             --arg target_url "$RUN_URL" \
             '{state: "success", context: "tests", description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,7 +643,26 @@ jobs:
       - l1-smoke
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
+      statuses: write
     steps:
+      - name: Start an internal PR merge status pending
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.outputs.engine == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg target_url "$RUN_URL" \
+            '{state: "pending", context: "tests", description: "Evaluating the required engine merge gate", target_url: $target_url}' \
+            | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null
+
       - name: Check test results
         run: |
           if [ "${{ needs.changes.result }}" != success ]; then
@@ -674,8 +693,8 @@ jobs:
           fi
           if [ "${{ github.event_name }}" = "pull_request" ] \
             && [ "${{ needs.changes.outputs.full_gate }}" != "true" ]; then
-            echo "Engine PR gate passed; apply the full-ci label when this PR is ready to merge"
-            exit 1
+            echo "Engine PR checks passed; the required tests status remains pending until the full-ci label is applied"
+            exit 0
           fi
           if [ "${{ needs.test-matrix.result }}" != "success" ]; then
             echo "Unit tests failed"
@@ -694,3 +713,20 @@ jobs:
             echo "Small-model tool-loop contract failed"
             exit 1
           fi
+
+      - name: Settle a successful internal full-CI status
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.outputs.engine == 'true' &&
+          needs.changes.outputs.full_gate == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg target_url "$RUN_URL" \
+            '{state: "success", context: "tests", description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \
+            | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null

--- a/.github/workflows/full-ci-label-gate.yml
+++ b/.github/workflows/full-ci-label-gate.yml
@@ -188,8 +188,14 @@ jobs:
           fi
 
           case "$RUN_NAME" in
-            CI) CONTEXT=tests ;;
-            "rapid-mac CI") CONTEXT=desktop-tests ;;
+            CI)
+              CONTEXT=tests
+              WORKFLOW_FILE=ci.yml
+              ;;
+            "rapid-mac CI")
+              CONTEXT=desktop-tests
+              WORKFLOW_FILE=rapid-mac-ci.yml
+              ;;
             *)
               echo "::error::Unexpected source workflow: $RUN_NAME" >&2
               exit 1
@@ -205,6 +211,14 @@ jobs:
           if [ "$PR_STATE" != open ] || [ "$BASE_REF" != main ] || \
              [ "$LIVE_HEAD_SHA" != "$RUN_SHA" ] || [ "$FULL_CI" != true ]; then
             echo "Not settling stale or unpromoted evidence (PR=$PR_NUMBER state=$PR_STATE base=$BASE_REF live=$LIVE_HEAD_SHA run=$RUN_SHA full_ci=$FULL_CI)."
+            exit 0
+          fi
+
+          RUNS_JSON="$RUNNER_TEMP/source-runs.json"
+          gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${RUN_SHA}&event=pull_request&per_page=100" > "$RUNS_JSON"
+          LATEST_RUN_ID=$(jq -r '[.workflow_runs[]] | if length > 0 then max_by(.id).id else "" end' "$RUNS_JSON")
+          if [ "$LATEST_RUN_ID" != "$RUN_ID" ]; then
+            echo "Not settling superseded $RUN_NAME evidence (latest_run=${LATEST_RUN_ID:-missing} completed_run=$RUN_ID)."
             exit 0
           fi
 

--- a/.github/workflows/full-ci-label-gate.yml
+++ b/.github/workflows/full-ci-label-gate.yml
@@ -1,0 +1,226 @@
+name: Full CI label gate
+
+# Keep the required tests / desktop-tests contexts pending until a product PR
+# is promoted with the full-ci label. pull_request_target is deliberate: this
+# metadata-only workflow must be able to publish statuses for fork PRs, whose
+# pull_request GITHUB_TOKEN is read-only. It checks out only the trusted base
+# policy and never executes code from the PR head.
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Open PR number to re-evaluate (operator rehearsal/recovery)"
+        required: true
+        type: number
+  workflow_run:
+    workflows: [CI, rapid-mac CI]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: full-ci-label-gate-${{ github.event.pull_request.number || inputs.pr_number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  # Every invocation reads live PR metadata. Serializing them prevents a label
+  # event from cancelling the completion hook that turns pending into success.
+  cancel-in-progress: false
+
+jobs:
+  publish-required-statuses:
+    if: github.event_name != 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve the live PR and fail closed first
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          PR_JSON="$RUNNER_TEMP/pr.json"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"
+
+          PR_STATE=$(jq -r '.state' "$PR_JSON")
+          BASE_REF=$(jq -r '.base.ref' "$PR_JSON")
+          BASE_SHA=$(jq -r '.base.sha' "$PR_JSON")
+          HEAD_SHA=$(jq -r '.head.sha' "$PR_JSON")
+          FULL_CI=$(jq -r 'any(.labels[]; .name == "full-ci")' "$PR_JSON")
+          if [ "$PR_STATE" != open ] || [ "$BASE_REF" != main ] || \
+             ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || \
+             ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::PR #$PR_NUMBER must be open, target main, and expose exact base/head SHAs (state=$PR_STATE base=$BASE_REF base_sha=$BASE_SHA head=$HEAD_SHA)." >&2
+            exit 1
+          fi
+
+          post_status() {
+            local context=$1 state=$2 description=$3
+            jq -n \
+              --arg state "$state" \
+              --arg context "$context" \
+              --arg description "$description" \
+              --arg target_url "$RUN_URL" \
+              '{state: $state, context: $context, description: $description, target_url: $target_url}' \
+              | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null
+          }
+
+          # Publish pending before any classifier work. A checkout, API, or
+          # policy failure after this point leaves both required contexts
+          # blocked instead of reusing stale success from an earlier label.
+          post_status tests pending "Evaluating whether this PR needs the full-ci label"
+          post_status desktop-tests pending "Evaluating whether this PR needs the full-ci label"
+
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo "full_ci=$FULL_CI"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out the trusted policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # pull_request_target runs in the base repository. Pin the checkout
+          # explicitly so no future default change can execute a fork's head.
+          ref: ${{ steps.pr.outputs.base_sha }}
+
+      - name: Classify changed paths from GitHub metadata
+        id: policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PATHS="$RUNNER_TEMP/changed-paths"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > "$PATHS"
+          python3 scripts/classify_ci_changes.py \
+            --paths-file "$PATHS" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish the label requirement
+        env:
+          DESKTOP: ${{ steps.policy.outputs.desktop }}
+          ENGINE: ${{ steps.policy.outputs.engine }}
+          FULL_CI: ${{ steps.pr.outputs.full_ci }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          post_status() {
+            local context=$1 state=$2 description=$3
+            jq -n \
+              --arg state "$state" \
+              --arg context "$context" \
+              --arg description "$description" \
+              --arg target_url "$RUN_URL" \
+              '{state: $state, context: $context, description: $description, target_url: $target_url}' \
+              | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null
+          }
+
+          # Refuse to settle a policy result if a synchronize or label event
+          # raced this invocation after its initial live snapshot.
+          LIVE_PR_JSON="$RUNNER_TEMP/live-pr.json"
+          gh api "repos/${REPO}/pulls/${{ steps.pr.outputs.pr_number }}" > "$LIVE_PR_JSON"
+          LIVE_STATE=$(jq -r '.state' "$LIVE_PR_JSON")
+          LIVE_BASE_REF=$(jq -r '.base.ref' "$LIVE_PR_JSON")
+          LIVE_HEAD_SHA=$(jq -r '.head.sha' "$LIVE_PR_JSON")
+          LIVE_FULL_CI=$(jq -r 'any(.labels[]; .name == "full-ci")' "$LIVE_PR_JSON")
+          if [ "$LIVE_STATE" != open ] || [ "$LIVE_BASE_REF" != main ] || \
+             [ "$LIVE_HEAD_SHA" != "$HEAD_SHA" ] || [ "$LIVE_FULL_CI" != "$FULL_CI" ]; then
+            echo "::error::PR metadata changed during evaluation; leaving the captured head pending for the next event." >&2
+            exit 1
+          fi
+
+          if [ "$ENGINE" = true ]; then
+            if [ "$FULL_CI" = true ]; then
+              DESCRIPTION="Waiting for the required engine full-CI run"
+            else
+              DESCRIPTION="Apply the full-ci label to run the required engine merge gate"
+            fi
+            post_status tests pending "$DESCRIPTION"
+            echo "$DESCRIPTION"
+          else
+            post_status tests success "Engine full-ci gate not applicable to this PR"
+          fi
+
+          if [ "$DESKTOP" = true ]; then
+            if [ "$FULL_CI" = true ]; then
+              DESCRIPTION="Waiting for the required Desktop full-CI run"
+            else
+              DESCRIPTION="Apply the full-ci label to run the required Desktop merge gate"
+            fi
+            post_status desktop-tests pending "$DESCRIPTION"
+            echo "$DESCRIPTION"
+          else
+            post_status desktop-tests success "Desktop full-ci gate not applicable to this PR"
+          fi
+
+  settle-completed-gate:
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Settle an exact-head full-CI status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Completed workflow is not associated with a pull request; nothing to settle."
+            exit 0
+          fi
+
+          case "$RUN_NAME" in
+            CI) CONTEXT=tests ;;
+            "rapid-mac CI") CONTEXT=desktop-tests ;;
+            *)
+              echo "::error::Unexpected source workflow: $RUN_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          PR_JSON="$RUNNER_TEMP/pr.json"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"
+          PR_STATE=$(jq -r '.state' "$PR_JSON")
+          BASE_REF=$(jq -r '.base.ref' "$PR_JSON")
+          LIVE_HEAD_SHA=$(jq -r '.head.sha' "$PR_JSON")
+          FULL_CI=$(jq -r 'any(.labels[]; .name == "full-ci")' "$PR_JSON")
+          if [ "$PR_STATE" != open ] || [ "$BASE_REF" != main ] || \
+             [ "$LIVE_HEAD_SHA" != "$RUN_SHA" ] || [ "$FULL_CI" != true ]; then
+            echo "Not settling stale or unpromoted evidence (PR=$PR_NUMBER state=$PR_STATE base=$BASE_REF live=$LIVE_HEAD_SHA run=$RUN_SHA full_ci=$FULL_CI)."
+            exit 0
+          fi
+
+          JOB_PAGES="$RUNNER_TEMP/jobs.json"
+          gh api --paginate --slurp \
+            "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" > "$JOB_PAGES"
+          JOB_CONCLUSION=$(jq -r --arg context "$CONTEXT" \
+            '[.[] | .jobs[] | select(.name == $context)] | if length == 1 then .[0].conclusion else "" end' \
+            "$JOB_PAGES")
+          if [ "$WORKFLOW_CONCLUSION" != success ] || [ "$JOB_CONCLUSION" != success ]; then
+            echo "The exact-head $RUN_NAME run did not pass its $CONTEXT aggregate (workflow=$WORKFLOW_CONCLUSION job=${JOB_CONCLUSION:-missing}); leaving status pending."
+            exit 0
+          fi
+
+          jq -n \
+            --arg context "$CONTEXT" \
+            --arg target_url "$RUN_URL" \
+            '{state: "success", context: $context, description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \
+            | gh api --method POST "repos/${REPO}/statuses/${RUN_SHA}" --input - >/dev/null

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -773,7 +773,26 @@ jobs:
       - gui-golden-flows
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
+      - name: Start an internal PR merge status pending
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.outputs.desktop == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg target_url "$RUN_URL" \
+            '{state: "pending", context: "desktop-tests", description: "Evaluating the required Desktop merge gate", target_url: $target_url}' \
+            | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null
+
       - name: Check desktop results
         env:
           DESKTOP_EXPECTED: ${{ needs.changes.outputs.desktop }}
@@ -795,8 +814,8 @@ jobs:
             exit 0
           fi
           if [ "${{ github.event_name }}" = pull_request ] && [ "$FULL_GATE" != true ]; then
-            echo "Desktop PR gate passed; apply the full-ci label when this PR is ready to merge"
-            exit 1
+            echo "Desktop PR checks passed; the required desktop-tests status remains pending until the full-ci label is applied"
+            exit 0
           fi
           for result in "$IDENTIFIERS" "$IDENTIFIER_TESTS" "$HARNESS_CONTRACTS" "$BUILD"; do
             if [ "$result" != success ]; then
@@ -814,3 +833,20 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Settle a successful internal full-CI status
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.outputs.desktop == 'true' &&
+          needs.changes.outputs.full_gate == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg target_url "$RUN_URL" \
+            '{state: "success", context: "desktop-tests", description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \
+            | gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" --input - >/dev/null

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -774,7 +774,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
+      pull-requests: read
       statuses: write
     steps:
       - name: Start an internal PR merge status pending
@@ -843,9 +845,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
+          LIVE_PR_JSON="$RUNNER_TEMP/live-pr.json"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "$LIVE_PR_JSON"
+          LIVE_STATE=$(jq -r '.state' "$LIVE_PR_JSON")
+          LIVE_BASE_REF=$(jq -r '.base.ref' "$LIVE_PR_JSON")
+          LIVE_HEAD_SHA=$(jq -r '.head.sha' "$LIVE_PR_JSON")
+          LIVE_FULL_CI=$(jq -r 'any(.labels[]; .name == "full-ci")' "$LIVE_PR_JSON")
+
+          RUNS_JSON="$RUNNER_TEMP/rapid-mac-ci-runs.json"
+          gh api "repos/${REPO}/actions/workflows/rapid-mac-ci.yml/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" > "$RUNS_JSON"
+          LATEST_RUN_ID=$(jq -r '[.workflow_runs[]] | if length > 0 then max_by(.id).id else "" end' "$RUNS_JSON")
+          if [ "$LIVE_STATE" != open ] || [ "$LIVE_BASE_REF" != main ] || \
+             [ "$LIVE_HEAD_SHA" != "$HEAD_SHA" ] || [ "$LIVE_FULL_CI" != true ] || \
+             [ "$LATEST_RUN_ID" != "$RUN_ID" ]; then
+            echo "Not settling stale or unpromoted Desktop evidence (state=$LIVE_STATE base=$LIVE_BASE_REF live=$LIVE_HEAD_SHA run_head=$HEAD_SHA full_ci=$LIVE_FULL_CI latest_run=${LATEST_RUN_ID:-missing} run_id=$RUN_ID)."
+            exit 0
+          fi
+
           jq -n \
             --arg target_url "$RUN_URL" \
             '{state: "success", context: "desktop-tests", description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -43,6 +43,12 @@ on:
     # Do not add a paths filter here. This context is eligible to be a required
     # check, and GitHub leaves path-filtered required workflows pending forever
     # when they are skipped. The job exits quickly when the version is unchanged.
+  # A required check must also report on GitHub's synthetic merge-queue SHA.
+  # The PR event already validated any release-specific title/body contract;
+  # the queue event supplies the stable context while tests/desktop-tests
+  # validate the combined candidate tree.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: read
@@ -59,6 +65,7 @@ jobs:
 
       - name: Determine whether the version line changed
         id: verchange
+        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -304,5 +311,9 @@ jobs:
           echo "✓ Complete bump contract: one commit, synchronized notes, and exact-head pre-flight run $RUN_ID."
 
       - name: Pass — no stray version change
-        if: steps.verchange.outputs.changed != 'true'
+        if: github.event_name == 'pull_request' && steps.verchange.outputs.changed != 'true'
         run: echo "✓ Version line unchanged — nothing to guard."
+
+      - name: Pass — PR contract already validated before merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "✓ Merge-group candidate receives the stable required context; combined-tree validation belongs to tests and desktop-tests."

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -127,8 +127,9 @@ The status transition is fail closed:
 4. Only a successful exact-head full-CI aggregate may replace that selected
    lane's pending status with success. The aggregate job settles same-repository
    PRs directly; a trusted `workflow_run` completion hook settles fork PRs.
-5. A stale SHA, removed label, failed/cancelled workflow, missing aggregate job,
-   classifier failure, or metadata mismatch leaves the status pending.
+5. A stale SHA, removed label, superseded exact-head run, failed/cancelled
+   workflow, missing aggregate job, classifier failure, or metadata mismatch
+   leaves the status pending.
 
 Do not replace this with a job-level `if` condition. GitHub reports a skipped
 job as successful, which would allow a required skipped context to bypass the

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -31,11 +31,13 @@ and commands. Whole-repository Ruff and engine/Desktop version synchronization
 remain universal because Desktop support code includes Python and either side
 of the shared version contract may change.
 
-The required checks are the stable aggregate jobs `tests` and `desktop-tests`.
-They must not be renamed or hidden behind workflow-level path filters without a
-matching branch-protection migration. `tests` includes lint, type-check job
-health, the MLX dependency-bound guard on pull requests, and all selected engine
-test lanes; `desktop-tests` includes every selected Desktop lane.
+The strict required checks are the stable aggregate jobs `tests`,
+`desktop-tests`, and `version-bump-guard`. They must not be renamed or hidden
+behind workflow-level path filters without a matching branch-protection
+migration. `tests` includes lint, type-check job health, the MLX
+dependency-bound guard on pull requests, and all selected engine test lanes;
+`desktop-tests` includes every selected Desktop lane. `version-bump-guard`
+runs for every pull request, passing quickly when the version is unchanged.
 
 ### Type-error budget
 
@@ -103,15 +105,43 @@ cannot silently disappear.
 
 The label never changes lane classification. This prevents an engine-only PR
 from allocating the full Desktop gate, or a Desktop-only PR from allocating
-the full model gate. The selected product aggregate intentionally remains
-non-successful until the label is present, so branch protection cannot bypass
-its merge gate.
+the full model gate.
 
-The workflows also subscribe to GitHub's `merge_group` event. After the
-repository becomes eligible for GitHub merge queues, every queue candidate will
-automatically receive the same full coverage against its synthetic candidate
-commit. This validates the combined state that will actually reach `main`,
-rather than repeatedly validating each PR against an obsolete base.
+### Pending, not failing, before promotion
+
+An unpromoted product PR is a waiting release candidate, not a test failure.
+The aggregate Action check therefore passes after its inexpensive PR checks,
+while `.github/workflows/full-ci-label-gate.yml` publishes a same-name pending
+commit status for each selected product lane. GitHub requires both a check run
+and a commit status when they share a required name, so the pending status keeps
+the merge blocked without showing a false red failure.
+
+The status transition is fail closed:
+
+1. A trusted `pull_request_target` workflow reads the live PR and immediately
+   posts pending `tests` and `desktop-tests` statuses before classification.
+2. It checks out only the base revision of the policy and classifies filenames
+   obtained from the GitHub API. It never checks out or executes the PR head.
+3. An unselected lane becomes successful immediately. A selected lane remains
+   pending both before and after the `full-ci` label is applied.
+4. Only a successful exact-head full-CI aggregate may replace that selected
+   lane's pending status with success. The aggregate job settles same-repository
+   PRs directly; a trusted `workflow_run` completion hook settles fork PRs.
+5. A stale SHA, removed label, failed/cancelled workflow, missing aggregate job,
+   classifier failure, or metadata mismatch leaves the status pending.
+
+Do not replace this with a job-level `if` condition. GitHub reports a skipped
+job as successful, which would allow a required skipped context to bypass the
+promotion gate. Do not publish success when the label is observed: doing so
+would briefly reuse old exact-SHA check evidence during label churn.
+
+All three required workflows subscribe to GitHub's `merge_group` event. Every
+queue candidate will therefore receive `tests`, `desktop-tests`, and
+`version-bump-guard` on its synthetic candidate commit. Product workflows run
+full combined-tree coverage for merge groups. The version guard emits its
+stable context because the individual PR contract was already validated before
+queue entry. This validates the state that will actually reach `main`, rather
+than repeatedly validating each PR against an obsolete base.
 
 Pushes to `main` retain the full engine coverage as a post-merge signal.
 
@@ -146,17 +176,56 @@ organization, or private repositories owned by an Enterprise Cloud
 organization. Rapid-MLX is a public repository owned by a personal account, so
 the queue cannot be enabled until ownership moves to an organization.
 
-After that eligibility change, and after the workflows containing
-`merge_group` support are present on `main`:
+The current `main` protection is strict and requires three GitHub Actions
+contexts from app id `15368`: `tests`, `desktop-tests`, and
+`version-bump-guard`. There are no repository rulesets. Keep that protection
+unchanged until the owner enables a queue.
 
-1. Require `tests` and `desktop-tests` for `main`.
-2. Require branches to be up to date through the merge queue, rather than
-   asking authors or agents to rebase every open PR after each merge.
-3. Use squash as the merge method and start with a small queue batch. Increase
-   batching only after observing queue latency and failure isolation.
+After ownership moves to an eligible organization and these workflows are on
+the default branch, the owner should enable **Require merge queue** in the
+existing non-wildcard `main` branch-protection rule and configure:
 
-Do not enable the queue before the workflow trigger reaches `main`: otherwise
-GitHub creates a merge-group commit whose required checks never start.
+- merge queue required and squash as the allowed merge method;
+- required status checks `tests`, `desktop-tests`, and `version-bump-guard`;
+- the existing strict status-check policy retained; the queue candidate
+  provides the up-to-date combined tree without repeated author rebases;
+- build concurrency `1` initially;
+- merge only non-failing entries enabled;
+- status-check timeout `60 minutes`;
+- minimum and maximum merge group size `1`, with a `0` minute minimum wait.
+
+After five consecutive green merge groups, increase maximum group size to `3`
+and use a `5` minute wait to amortize busy integration trains. Keep concurrency
+at `1` until failure attribution and runner capacity are demonstrated at that
+batch size.
+
+Before changing `main`, rehearse on a scratch target branch in an eligible
+organization-owned repository:
+
+1. Create the scratch branch from the intended `main` SHA and temporarily add
+   that branch to all three workflows' event filters in the sandbox only.
+2. Apply the exact required contexts and queue settings above to the scratch
+   branch.
+3. Queue one documentation-only PR and one harmless cross-cutting workflow PR.
+   Confirm all three contexts appear on both synthetic merge-group SHAs, and
+   confirm the cross-cutting PR runs both product lanes.
+4. Queue two PRs concurrently. Confirm strict protection groups or restacks
+   them without direct pushes, and that deliberately failing the second PR
+   removes only its group.
+5. Remove the sandbox changes and record run URLs before applying the settings
+   to `main`.
+
+A hosted scratch rehearsal cannot be performed in the current personal-account
+repository because GitHub does not expose merge queues there. Local event
+fixtures and workflow contract tests verify the `merge_group` wiring now; the
+organization-owned scratch rehearsal above remains a hard prerequisite to the
+owner's production configuration change.
+
+Do not enable the queue before every required workflow trigger reaches `main`:
+otherwise GitHub creates a merge-group commit whose required check remains
+`Expected` forever. Treat an indefinitely expected
+`version-bump-guard` as a trigger defect and stop; never bypass the required
+context.
 
 ## Rollback
 

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -62,7 +62,11 @@ def test_changed_lines_gate_unions_linux_and_apple_coverage() -> None:
 
     aggregate_needs = set(jobs["tests"]["needs"])
     assert "changed-lines-coverage" in aggregate_needs
-    aggregate_run = jobs["tests"]["steps"][0]["run"]
+    aggregate_run = next(
+        step["run"]
+        for step in jobs["tests"]["steps"]
+        if step.get("name") == "Check test results"
+    )
     assert "needs.changed-lines-coverage.result" in aggregate_run
 
     # Non-engine PRs return before inspecting the intentionally skipped union

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -6,6 +6,9 @@ restore the expensive behavior where applying ``full-ci`` changed an
 engine-only or Desktop-only PR into an all-product run.
 """
 
+import json
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -107,6 +110,127 @@ def test_internal_product_aggregates_own_pending_to_success_transition():
         assert f'context: "{context}"' in settle["run"]
         assert 'state: "success"' in settle["run"]
 
+        permissions = _job(workflow, job_name)["permissions"]
+        assert permissions == {
+            "actions": "read",
+            "contents": "read",
+            "pull-requests": "read",
+            "statuses": "write",
+        }
+
+
+def _execute_internal_settlement(
+    tmp_path: Path,
+    *,
+    workflow: Path,
+    job_name: str,
+    full_ci: bool,
+    latest_run_id: int,
+) -> str | None:
+    run = _step_run(workflow, job_name, "Settle a successful internal full-CI status")
+    mock_bin = tmp_path / "bin"
+    mock_bin.mkdir()
+    mock_gh = mock_bin / "gh"
+    mock_gh.write_text(
+        """#!/bin/bash
+set -euo pipefail
+case "$*" in
+  "api repos/test/repo/pulls/7") cat "$MOCK_PR_JSON" ;;
+  *"/actions/workflows/"*"/runs?"*) cat "$MOCK_RUNS_JSON" ;;
+  *"--method POST"*) cat > "$MOCK_POST" ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 91 ;;
+esac
+"""
+    )
+    mock_gh.chmod(0o755)
+
+    head_sha = "a" * 40
+    pr_json = tmp_path / "pr.json"
+    pr_json.write_text(
+        json.dumps(
+            {
+                "state": "open",
+                "base": {"ref": "main"},
+                "head": {"sha": head_sha},
+                "labels": [{"name": "full-ci"}] if full_ci else [],
+            }
+        )
+    )
+    runs_json = tmp_path / "runs.json"
+    runs_json.write_text(json.dumps({"workflow_runs": [{"id": latest_run_id}]}))
+    post = tmp_path / "post.json"
+    env = os.environ | {
+        "GH_TOKEN": "test-token",
+        "HEAD_SHA": head_sha,
+        "MOCK_POST": str(post),
+        "MOCK_PR_JSON": str(pr_json),
+        "MOCK_RUNS_JSON": str(runs_json),
+        "PATH": f"{mock_bin}:{os.environ['PATH']}",
+        "PR_NUMBER": "7",
+        "REPO": "test/repo",
+        "RUN_ID": "100",
+        "RUN_URL": "https://example.invalid/run/100",
+        "RUNNER_TEMP": str(tmp_path),
+    }
+    subprocess.run(["bash", "-c", run], check=True, env=env, capture_output=True)
+    return post.read_text() if post.exists() else None
+
+
+def test_internal_settlement_rejects_removed_label_and_superseded_run(tmp_path):
+    for index, (workflow, job_name) in enumerate(
+        (
+            (ENGINE_WORKFLOW, "tests"),
+            (DESKTOP_WORKFLOW, "desktop-tests"),
+        )
+    ):
+        removed = tmp_path / f"removed-{index}"
+        removed.mkdir()
+        assert (
+            _execute_internal_settlement(
+                removed,
+                workflow=workflow,
+                job_name=job_name,
+                full_ci=False,
+                latest_run_id=100,
+            )
+            is None
+        )
+
+        superseded = tmp_path / f"superseded-{index}"
+        superseded.mkdir()
+        assert (
+            _execute_internal_settlement(
+                superseded,
+                workflow=workflow,
+                job_name=job_name,
+                full_ci=True,
+                latest_run_id=101,
+            )
+            is None
+        )
+
+
+def test_internal_settlement_accepts_live_label_on_latest_exact_head(tmp_path):
+    for index, (workflow, job_name, context) in enumerate(
+        (
+            (ENGINE_WORKFLOW, "tests", "tests"),
+            (DESKTOP_WORKFLOW, "desktop-tests", "desktop-tests"),
+        )
+    ):
+        lane = tmp_path / f"valid-{index}"
+        lane.mkdir()
+        posted = _execute_internal_settlement(
+            lane,
+            workflow=workflow,
+            job_name=job_name,
+            full_ci=True,
+            latest_run_id=100,
+        )
+        assert posted is not None
+        payload = json.loads(posted)
+        assert payload["state"] == "success"
+        assert payload["context"] == context
+
 
 def test_metadata_gate_is_trusted_fail_closed_and_never_executes_pr_head():
     workflow = _workflow_strings(LABEL_GATE_WORKFLOW)
@@ -156,6 +280,8 @@ def test_metadata_gate_settles_only_live_exact_head_successful_full_ci():
     assert 'FULL_CI" != true' in run
     assert 'WORKFLOW_CONCLUSION" != success' in run
     assert 'JOB_CONCLUSION" != success' in run
+    assert 'LATEST_RUN_ID" != "$RUN_ID' in run
+    assert "actions/workflows/${WORKFLOW_FILE}/runs" in run
     assert "actions/runs/${RUN_ID}/jobs" in run
     assert 'state: "success"' in run
     assert "statuses/${RUN_SHA}" in run

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -13,6 +13,8 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 ENGINE_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+LABEL_GATE_WORKFLOW = ROOT / ".github/workflows/full-ci-label-gate.yml"
+VERSION_WORKFLOW = ROOT / ".github/workflows/version-check.yml"
 
 
 def _step_run(workflow: Path, job: str, step_name: str) -> str:
@@ -23,6 +25,11 @@ def _step_run(workflow: Path, job: str, step_name: str) -> str:
 
 def _job(workflow: Path, job: str) -> dict[str, object]:
     return yaml.safe_load(workflow.read_text())["jobs"][job]
+
+
+def _workflow_strings(workflow: Path) -> dict[str, object]:
+    """Keep ``on`` as a string instead of YAML 1.1's boolean True."""
+    return yaml.load(workflow.read_text(), Loader=yaml.BaseLoader)
 
 
 def test_engine_full_ci_still_classifies_the_pr_diff():
@@ -55,6 +62,118 @@ def test_non_desktop_change_exits_before_full_ci_requirement():
     no_lane = run.index('if [ "$DESKTOP_EXPECTED" != true ]')
     promotion = run.index('if [ "${{ github.event_name }}" = pull_request ]')
     assert classifier_gate < no_lane < promotion
+
+
+def test_unpromoted_product_aggregates_pass_without_publishing_success():
+    for workflow, job_name, result_step in (
+        (ENGINE_WORKFLOW, "tests", "Check test results"),
+        (DESKTOP_WORKFLOW, "desktop-tests", "Check desktop results"),
+    ):
+        run = _step_run(workflow, job_name, result_step)
+        promotion = run.index("full_gate" if job_name == "tests" else "FULL_GATE")
+        unpromoted_branch = run[promotion : run.index("fi", promotion) + 2]
+        assert "status remains pending" in unpromoted_branch
+        assert "exit 0" in unpromoted_branch
+        assert "exit 1" not in unpromoted_branch
+
+
+def test_internal_product_aggregates_own_pending_to_success_transition():
+    for workflow, job_name, lane, context in (
+        (ENGINE_WORKFLOW, "tests", "engine", "tests"),
+        (DESKTOP_WORKFLOW, "desktop-tests", "desktop", "desktop-tests"),
+    ):
+        steps = _job(workflow, job_name)["steps"]
+        pending = next(
+            step
+            for step in steps
+            if step.get("name") == "Start an internal PR merge status pending"
+        )
+        settle = next(
+            step
+            for step in steps
+            if step.get("name") == "Settle a successful internal full-CI status"
+        )
+
+        pending_condition = str(pending["if"])
+        assert f"needs.changes.outputs.{lane} == 'true'" in pending_condition
+        assert "head.repo.full_name == github.repository" in pending_condition
+        assert "full_gate" not in pending_condition
+        assert f'context: "{context}"' in pending["run"]
+        assert 'state: "pending"' in pending["run"]
+
+        settle_condition = str(settle["if"])
+        assert "needs.changes.outputs.full_gate == 'true'" in settle_condition
+        assert "head.repo.full_name == github.repository" in settle_condition
+        assert f'context: "{context}"' in settle["run"]
+        assert 'state: "success"' in settle["run"]
+
+
+def test_metadata_gate_is_trusted_fail_closed_and_never_executes_pr_head():
+    workflow = _workflow_strings(LABEL_GATE_WORKFLOW)
+    triggers = workflow["on"]
+    assert "pull_request_target" in triggers
+    assert "workflow_dispatch" in triggers
+    assert "workflow_run" in triggers
+    assert "pull_request" not in triggers
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+        "statuses": "write",
+    }
+
+    job = workflow["jobs"]["publish-required-statuses"]
+    steps = job["steps"]
+    assert steps[0]["name"] == "Resolve the live PR and fail closed first"
+    resolve = steps[0]["run"]
+    assert 'gh api "repos/${REPO}/pulls/${PR_NUMBER}"' in resolve
+    assert "post_status tests pending" in resolve
+    assert "post_status desktop-tests pending" in resolve
+    assert "PR_STATE" in resolve and "BASE_REF" in resolve and "HEAD_SHA" in resolve
+
+    checkout = steps[1]
+    assert checkout["name"] == "Check out the trusted policy"
+    assert checkout["with"]["ref"] == "${{ steps.pr.outputs.base_sha }}"
+    workflow_text = LABEL_GATE_WORKFLOW.read_text()
+    assert "pull_request.head.sha" not in checkout["with"]["ref"]
+    assert "github.event.pull_request.title" not in workflow_text
+    assert "github.event.pull_request.body" not in workflow_text
+
+    classify = steps[2]["run"]
+    assert "pulls/${PR_NUMBER}/files" in classify
+    assert "scripts/classify_ci_changes.py" in classify
+
+    publish = steps[3]["run"]
+    assert 'LIVE_HEAD_SHA" != "$HEAD_SHA' in publish
+    assert 'LIVE_FULL_CI" != "$FULL_CI' in publish
+
+
+def test_metadata_gate_settles_only_live_exact_head_successful_full_ci():
+    workflow = _workflow_strings(LABEL_GATE_WORKFLOW)
+    settle = workflow["jobs"]["settle-completed-gate"]
+    assert settle["if"] == "github.event_name == 'workflow_run'"
+    run = settle["steps"][0]["run"]
+    assert 'LIVE_HEAD_SHA" != "$RUN_SHA' in run
+    assert 'FULL_CI" != true' in run
+    assert 'WORKFLOW_CONCLUSION" != success' in run
+    assert 'JOB_CONCLUSION" != success' in run
+    assert "actions/runs/${RUN_ID}/jobs" in run
+    assert 'state: "success"' in run
+    assert "statuses/${RUN_SHA}" in run
+
+
+def test_all_strict_required_workflows_emit_on_merge_group():
+    for workflow in (ENGINE_WORKFLOW, DESKTOP_WORKFLOW, VERSION_WORKFLOW):
+        triggers = _workflow_strings(workflow)["on"]
+        assert triggers["merge_group"]["types"] == ["checks_requested"]
+
+    version = _workflow_strings(VERSION_WORKFLOW)
+    guard = version["jobs"]["version-bump-guard"]
+    queue_step = next(
+        step
+        for step in guard["steps"]
+        if step.get("name") == "Pass — PR contract already validated before merge queue"
+    )
+    assert queue_step["if"] == "github.event_name == 'merge_group'"
 
 
 def test_gui_golden_job_requires_both_desktop_lane_and_full_promotion():


### PR DESCRIPTION
## Why

Unlabeled product PRs currently turn the required `tests` or `desktop-tests`
facade red even when their ordinary PR checks pass. That makes an intentional
“waiting for full-CI promotion” state indistinguishable from a regression and
caused repeated train churn during 0.13.1.

## What

- Represent a selected-but-unpromoted product lane as a pending same-name
  commit status while its aggregate Action check passes.
- Keep the status pending after `full-ci` is applied until the exact-head
  aggregate genuinely succeeds.
- Cover fork PRs with trusted metadata-only `pull_request_target` /
  `workflow_run` handling that never checks out contributor code.
- Add `merge_group` support to the third strict context,
  `version-bump-guard`, alongside the existing product workflows.
- Document the exact current protection contract and the owner-only
  merge-queue rollout/rehearsal settings.

## Scope and non-goals

This changes CI state representation and documents a future owner-applied queue
configuration. It does not mutate branch protection, enable a merge queue, skip
any product validation, change lane classification, tag, publish, or run model
workloads.

GitHub does not expose merge queues to this public personal-account repository.
The operations note therefore records that a hosted scratch queue run is not
technically possible here and makes an organization-owned scratch rehearsal a
hard prerequisite before production enablement.

## Security

The write-capable metadata workflow reads the live PR through GitHub's API,
posts pending before classification, checks out only the exact base SHA, and
never consumes contributor-controlled title/body or executes the PR head.
Success settlement requires a still-open `main` PR, unchanged exact head, live
`full-ci` label, successful source workflow, and successful matching aggregate
job.

## Verification

Five local gates on the implementation, repeated after review and after the
final rebase onto `main@2a9ed0f1` (exact head `507d9f66`):

1. 94 focused workflow/release/classifier/immutable-pin Python contracts; the
   final roster includes executable label-removal and superseded-run races.
2. 16 release-preflight shell contracts and the supported Python 3.12 routing
   contracts.
3. `actionlint`, workflow-expression audit, immutable-action-pin audit, and
   BaseLoader parse for all touched workflows.
4. Ruff lint and format checks.
5. Diff/secrets/trusted-checkout review plus live branch-protection audit:
   strict `tests`, `desktop-tests`, and `version-bump-guard`, all GitHub Actions
   app id 15368.

Post-rebase integration contracts, including the newly landed train-gate drift
suite: 39 passed.

Exact-head required CI:

- Engine: https://github.com/raullenchai/Rapid-MLX/actions/runs/33089233144
- Desktop: https://github.com/raullenchai/Rapid-MLX/actions/runs/33089233093
- Version bump guard: https://github.com/raullenchai/Rapid-MLX/actions/runs/33089233234

The pre-rebase desktop run hit the known flaky
`ChatAttachmentJourneyTests.testDragPasteAndRemovalPreserveWireIdentity`
(#2481). Its single diagnosed failed-job rerun passed; no repeat retry was
performed. The final rebased exact-head desktop run passed independently.

Closes #2490
