### PR TITLE
test: make the hermetic HF fixture network-off by default (#2518)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,7 @@ jobs:
             tests/test_music_engine.py \
             tests/test_audio_model_worker.py \
             tests/test_server_load_model_order.py \
+            tests/test_hermetic_network_off.py \
             tests/test_routing_groups_0131.py \
             tests/test_ready_banner_timing.py \
             tests/test_api_validation_bundle.py \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Pytest configuration and shared fixtures."""
 
+import ipaddress
+import os
+import socket
+import sys
+
 import pytest
 
 # Environment variables that point at the host's real, machine-specific HF
@@ -12,11 +17,157 @@ import pytest
 # explicitly opt in. See the ``_hermetic_hf_and_config_dirs`` fixture.
 #
 # ``HF_HUB_OFFLINE`` is deliberately NOT listed here: it is a network-access
-# toggle, not a cache-location knob, and ``tests/test_cli_offline_serve.py``
-# exercises it exhaustively with its own ``monkeypatch`` calls. Touching it
-# here would fight those tests. A test that needs offline semantics sets it
-# itself.
+# toggle, not a cache-location knob. It is handled separately by the
+# network-off half of the same fixture (``_install_hf_offline``), and tests
+# such as ``tests/test_cli_offline_serve.py`` that exercise both values still
+# win because a test-body ``monkeypatch`` call runs after the autouse fixture.
 _HF_CACHE_ENV_VARS = ("HF_HOME", "HF_HUB_CACHE", "TRANSFORMERS_CACHE")
+
+# Marker that opts a test back INTO network access (#2518). Every other test
+# runs network-off: the Hugging Face hub is pinned offline and any socket
+# connect to a non-loopback address fails immediately. ``real_hf_cache`` alone
+# does NOT grant network access — a test that needs both marks both.
+_NETWORK_OPT_IN_MARKER = "requires_network"
+
+
+class HermeticNetworkAccessError(RuntimeError):
+    """A hermetic (non-``requires_network``) test tried to reach the network.
+
+    Deliberately NOT an ``OSError`` subclass: ``urllib3``/``httpcore``/
+    ``asyncio`` retry or translate socket ``OSError``s, which would turn the
+    guard into a slow, mislabelled ``ConnectionError``. A ``RuntimeError``
+    passes straight through to the test with the offending address in it.
+    """
+
+
+def _is_local_address(address) -> bool:
+    """True for loopback / unspecified IPs, ``localhost`` and AF_UNIX paths.
+
+    Loopback is allowed because the unit suite legitimately starts in-process
+    servers and connects to them; everything else is off-box by definition.
+    """
+    if not isinstance(address, tuple) or not address:
+        # AF_UNIX path (str/bytes) or an exotic family — local IPC.
+        return True
+    host = address[0]
+    if isinstance(host, bytes):
+        host = host.decode("ascii", "replace")
+    if not isinstance(host, str):
+        return True
+    if host == "" or host.lower().rstrip(".") == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host.split("%", 1)[0])
+    except ValueError:
+        return False  # any other hostname resolves off-box
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip.is_loopback or ip.is_unspecified
+
+
+def _install_network_guard(monkeypatch, nodeid: str) -> None:
+    """Fail fast on any non-loopback ``socket.connect`` for the current test.
+
+    Same shape as pytest-socket's ``--allow-hosts=127.0.0.1`` mode, kept
+    in-tree so the no-MLX CI lane needs no extra plugin. Patching the class
+    attribute covers plain sockets, ``ssl.SSLSocket`` (it calls
+    ``super().connect``), ``socket.create_connection`` (urllib / urllib3 /
+    httpcore) and asyncio's ``sock_connect`` — i.e. every HTTP client the
+    product uses, including the model mirror's ``urllib`` round-trips.
+    """
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+
+    def _refuse(address) -> None:
+        where = (
+            f"{address[0]}:{address[1]}"
+            if isinstance(address, tuple) and len(address) >= 2
+            else repr(address)
+        )
+        raise HermeticNetworkAccessError(
+            f"{nodeid} attempted a network connection to {where}. Unit tests "
+            "are network-off by default (tests/conftest.py, #2518): stub the "
+            "download / HTTP call, or mark the test "
+            f"@pytest.mark.{_NETWORK_OPT_IN_MARKER} if it genuinely needs the "
+            "network."
+        )
+
+    def _guarded_connect(self, address):
+        if not _is_local_address(address):
+            _refuse(address)
+        return real_connect(self, address)
+
+    def _guarded_connect_ex(self, address):
+        if not _is_local_address(address):
+            _refuse(address)
+        return real_connect_ex(self, address)
+
+    _guarded_connect._hermetic_network_guard = True
+    _guarded_connect_ex._hermetic_network_guard = True
+    monkeypatch.setattr(socket.socket, "connect", _guarded_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", _guarded_connect_ex)
+
+
+def _hf_offline_from_env() -> bool:
+    """``huggingface_hub.constants._is_true`` semantics for the offline switches."""
+    raw = os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")
+    return raw is not None and raw.lower() in {"1", "on", "yes", "true"}
+
+
+def _reset_hf_sessions() -> None:
+    """Drop huggingface_hub's cached HTTP session(s), if the hub is loaded.
+
+    huggingface_hub < 1.0 binds its ``OfflineAdapter`` when a (per-thread,
+    cached) ``requests`` session is created, so flipping the offline constant
+    only takes effect on a fresh session. 1.x checks the constant on every
+    request instead and has no ``reset_sessions``; nothing to do there.
+    """
+    hf_http = sys.modules.get("huggingface_hub.utils._http")
+    reset = getattr(hf_http, "reset_sessions", None)
+    if reset is not None:
+        reset()
+
+
+def _install_hf_offline(monkeypatch, request) -> None:
+    """Pin the Hugging Face hub offline for the current test.
+
+    Two layers, because ``huggingface_hub.constants`` snapshots
+    ``HF_HUB_OFFLINE`` from the environment ONCE at import time (see
+    ``scripts/kv_quant_quality_gate.py::_enable_hf_offline`` for the same
+    fix in the product tooling):
+
+    * ``HF_HUB_OFFLINE=1`` in the environment — read by the product's own
+      offline switch (``cli._offline_hub_mode_active``) and by a hub imported
+      for the first time during the test.
+    * ``huggingface_hub.constants.HF_HUB_OFFLINE = True`` when the hub is
+      already imported — ``is_offline_mode()`` reads it at request time, so
+      every hub HTTP call raises ``OfflineModeIsEnabled`` and
+      ``snapshot_download`` / ``hf_hub_download`` of an uncached repo raise
+      ``LocalEntryNotFoundError`` immediately instead of downloading.
+    """
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    hf_constants = sys.modules.get("huggingface_hub.constants")
+    if hf_constants is not None and hasattr(hf_constants, "HF_HUB_OFFLINE"):
+        monkeypatch.setattr(hf_constants, "HF_HUB_OFFLINE", True)
+    _reset_hf_sessions()
+    # Run before ``monkeypatch`` undoes the constant, so no offline-bound
+    # session (hub < 1.0) outlives this test.
+    request.addfinalizer(_reset_hf_sessions)
+
+
+def _sync_hf_offline_with_env(monkeypatch) -> None:
+    """For ``requires_network`` tests: make the hub constant mirror the env.
+
+    A previous hermetic test may have been the first to import the hub while
+    ``HF_HUB_OFFLINE=1`` was set, freezing the constant to ``True`` for the
+    whole session. Re-derive it from the (unpatched) environment so an opted-in
+    test sees the host's real offline setting.
+    """
+    hf_constants = sys.modules.get("huggingface_hub.constants")
+    if hf_constants is not None and hasattr(hf_constants, "HF_HUB_OFFLINE"):
+        monkeypatch.setattr(hf_constants, "HF_HUB_OFFLINE", _hf_offline_from_env())
+    _reset_hf_sessions()
+
 
 # RAPID_MLX_* env vars that name a config/data directory on the real host.
 # Isolating them alongside the HF cache keeps state that lives in the user's
@@ -51,28 +202,53 @@ def _hermetic_hf_and_config_dirs(tmp_path, monkeypatch, request):
     and a fresh Linux CI runner with none now run every non-opted-in test
     against the same empty cache.
 
-    Opt-out: mark a test ``@pytest.mark.real_hf_cache`` (registered below) when
-    it genuinely needs the host's real cache. A handful of integration tests
-    legitimately probe the real cache (e.g. scan the repo index for a real
-    ``models--*`` layout, or load real weights for a tokenizer/grammar file) —
-    those must be marked so they keep working on a host with a real cache
-    (Studio). Every OTHER test — including one that used to read the real cache
+    Network-off by default (#2518): an empty per-test cache turned every
+    latent ``load_model`` / ``snapshot_download`` into a real download — on
+    hosted CI that pulled ``Qwen3.5-9B-4bit`` once per leaking test and kept
+    the no-MLX lane busy for ~20 min. So the same fixture also pins the
+    Hugging Face hub offline (``HF_HUB_OFFLINE=1`` plus the already-imported
+    ``huggingface_hub.constants.HF_HUB_OFFLINE``) and fails any non-loopback
+    ``socket.connect`` immediately with ``HermeticNetworkAccessError`` naming
+    the test and the address. See ``_install_hf_offline`` /
+    ``_install_network_guard``.
+
+    Opt-ins (registered below, both must be reviewed):
+      * ``@pytest.mark.real_hf_cache`` — use the host's real cache. A handful
+        of integration tests legitimately probe it (scan the repo index for a
+        real ``models--*`` layout, load real weights for a tokenizer/grammar
+        file). It does NOT grant network access: a cached checkpoint loads
+        fine offline, and an uncached one fails fast instead of downloading.
+      * ``@pytest.mark.requires_network`` — disarm the network guard. Nothing
+        in the unit suite needs it today; a test that genuinely does must
+        say so here rather than depend on the runner's connectivity.
+    Every OTHER test — including one that used to read the real cache
     (``test_doctor_env_health.py::test_huge_hf_cache_marks_warn``, made hermetic
     by mocking ``_hf_cache_dir`` / ``_dir_size_gb``) — is hermetic by default.
-    Opting a test in must be reviewed: it re-introduces host-state dependence
-    for that one test.
 
     Compatibility:
       * Tests that already manipulate these vars via ``monkeypatch`` in their
         own body simply override this fixture (test-body calls win; ``tmp_path``
-        and the autouse fixture's values are torn down together).
+        and the autouse fixture's values are torn down together). That includes
+        ``HF_HUB_OFFLINE``: ``tests/test_cli_offline_serve.py`` sets it to
+        ``"1"`` / ``""`` per test to drive the product's offline switch either
+        way, and a test that mocks the downloader and wants the product's
+        ONLINE path simply ``delenv``s it — the socket guard still stands.
       * The existing ``scheduler_config_stub`` fixture (NOT autouse) and the
         ``_reset_global_parser_state_after_each_test`` autouse fixture are
         unaffected — they never read HF / RAPID_MLX dirs.
       * Legacy ``HUGGINGFACE_HUB_CACHE`` (pre-``HF_HUB_CACHE`` spelling) is left
         alone; no codebase reader uses it and ``test_release_check_random.py``
         toggles it itself.
+      * Loopback / AF_UNIX sockets stay open: in-process test servers, uvicorn
+        on ``127.0.0.1``, asyncio self-pipes and ``HF_ENDPOINT=http://127.0.0.1``
+        stubs all keep working.
     """
+    if request.node.get_closest_marker(_NETWORK_OPT_IN_MARKER) is not None:
+        _sync_hf_offline_with_env(monkeypatch)
+    else:
+        _install_hf_offline(monkeypatch, request)
+        _install_network_guard(monkeypatch, request.node.nodeid)
+
     if request.node.get_closest_marker("real_hf_cache"):
         yield
         return
@@ -111,8 +287,6 @@ def _hermetic_hf_and_config_dirs(tmp_path, monkeypatch, request):
     # same temp layout. Guard by ``sys.modules.get`` because ``mock_hf_env`` /
     # network markers import hub lazily and ``huggingface_hub`` may not be
     # loaded yet for a given test.
-    import sys
-
     for modname in (
         "huggingface_hub",
         "huggingface_hub.constants",
@@ -130,6 +304,25 @@ def _hermetic_hf_and_config_dirs(tmp_path, monkeypatch, request):
                 monkeypatch.setattr(mod, attr, val)
 
     yield
+
+
+@pytest.fixture
+def hub_online_env(monkeypatch):
+    """Simulate the product's ONLINE hub mode for a test that mocks the fetch.
+
+    The hermetic default exports ``HF_HUB_OFFLINE=1``, which the product's own
+    switch (``cli._offline_hub_mode_active``) honours: ``_ensure_model_downloaded``
+    and the ``chat`` / ``/model`` gates then refuse an uncached model up front
+    instead of walking the download path. A test that asserts on that path
+    (disk gate called, resolved sha pinned, confirm prompt shown, ...) with the
+    downloader stubbed requests this fixture so it keeps testing what it says.
+
+    The network guard is NOT disarmed: the hub constant stays offline and
+    non-loopback sockets still fail fast, so every real fetch must be stubbed.
+    Use ``@pytest.mark.requires_network`` for genuine network access instead.
+    """
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
 
 
 _SCRIPT_ONLY_MODULES = {"regression_suite.py"}
@@ -274,9 +467,18 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "real_hf_cache: opt a test into using the host's real HF cache, "
-        "bypassing the hermetic autouse ``_hermetic_hf_and_config_dirs`` "
-        "fixture. Use only when a test genuinely needs the real cache; "
+        "bypassing the cache redirection of the hermetic autouse "
+        "``_hermetic_hf_and_config_dirs`` fixture (the network guard still "
+        "applies). Use only when a test genuinely needs the real cache; "
         "review every use. See that fixture's docstring.",
+    )
+    config.addinivalue_line(
+        "markers",
+        f"{_NETWORK_OPT_IN_MARKER}: opt a test into real network access, "
+        "disarming the network-off guard of the hermetic autouse "
+        "``_hermetic_hf_and_config_dirs`` fixture (HF_HUB_OFFLINE + "
+        "non-loopback socket refusal, #2518). Use only for a genuine "
+        "integration test; review every use.",
     )
 
 

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -151,7 +151,7 @@ def test_chat_disable_prefix_cache_flag_is_registered():
     assert captured[0].disable_prefix_cache is True
 
 
-def test_chat_no_model_defaults_to_qwen35_4b():
+def test_chat_no_model_defaults_to_qwen35_4b(hub_online_env):
     """`rapid-mlx chat` (no model) on a COLD cache routes chat_command with
     the first-run starter (qwen3.5-4b-4bit).
 
@@ -1600,7 +1600,7 @@ def test_stream_chat_response_aborts_on_repetition(monkeypatch):
     assert "repeating" in buf.getvalue() or "repetition" in buf.getvalue()
 
 
-def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
+def test_ensure_model_downloaded_calls_disk_check(monkeypatch, hub_online_env):
     """`_ensure_model_downloaded` must gate on `_check_disk_space` so a
     user without room for a 20 GB model fails fast with a clear error
     instead of a 90 % partial download."""
@@ -1635,7 +1635,9 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     ]
 
 
-def test_ensure_model_downloaded_aborts_when_the_hub_wont_answer(monkeypatch):
+def test_ensure_model_downloaded_aborts_when_the_hub_wont_answer(
+    monkeypatch, hub_online_env
+):
     """An unreachable Hub must abort the pre-download, not fall through to it.
 
     ``snapshot_download``'s own revision lookup has no deadline — huggingface_hub
@@ -1674,7 +1676,9 @@ def test_ensure_model_downloaded_aborts_when_the_hub_wont_answer(monkeypatch):
     assert downloaded == []  # never entered the unbounded download
 
 
-def test_ensure_model_downloaded_pins_resolved_sha_and_records_main_ref(monkeypatch):
+def test_ensure_model_downloaded_pins_resolved_sha_and_records_main_ref(
+    monkeypatch, hub_online_env
+):
     """The bounded probe result must replace, not precede, an unbounded lookup."""
     from types import SimpleNamespace
 
@@ -2010,7 +2014,9 @@ def test_chat_switch_download_abort_reports_reason_above(monkeypatch, capsys):
     assert "previous server still running" in out
 
 
-def test_chat_switch_confirm_cancel_keeps_old_server(monkeypatch, capsys):
+def test_chat_switch_confirm_cancel_keeps_old_server(
+    monkeypatch, capsys, hub_online_env
+):
     """When the /model switch's confirm prompt is declined (``confirm_or_abort``
     raises SystemExit, i.e. the user said no), chat_command prints "Model
     switch cancelled" and keeps the previous server untouched."""

--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -369,7 +369,7 @@ def _run_main_gate_probe(
     return confirm, state["dispatched"]
 
 
-def test_autoselected_starter_uses_standard_download_gate():
+def test_autoselected_starter_uses_standard_download_gate(hub_online_env):
     # Regression guard: the auto-selected starter must NOT special-case the
     # download gate. The starter is an unpinned Hugging Face repo whose
     # declared size we must actually verify — never assume — before waiving
@@ -387,7 +387,9 @@ def test_autoselected_starter_uses_standard_download_gate():
     assert dispatched is True  # and the run still reaches dispatch
 
 
-def test_autoselected_starter_still_runs_disk_gate_in_prefetch(monkeypatch):
+def test_autoselected_starter_still_runs_disk_gate_in_prefetch(
+    monkeypatch, hub_online_env
+):
     # Belt-and-braces: the download-prep path always runs the DISK-SPACE gate
     # before pulling. ``_ensure_model_downloaded`` calls ``_check_disk_space``
     # (under the spinner) so a full disk still aborts cleanly regardless of the
@@ -406,7 +408,7 @@ def test_autoselected_starter_still_runs_disk_gate_in_prefetch(monkeypatch):
     assert called["disk"] is True
 
 
-def test_explicit_uncached_model_still_confirms():
+def test_explicit_uncached_model_still_confirms(hub_online_env):
     # Control: an explicitly-typed, uncached model DOES hit the confirm gate.
     confirm, _dispatched = _run_main_gate_probe(["chat", "qwen3.5-9b-4bit"])
     assert confirm.called is True

--- a/tests/test_hermetic_network_off.py
+++ b/tests/test_hermetic_network_off.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression for #2518 — the hermetic unit fixture is network-off by default.
+
+``tests/conftest.py::_hermetic_hf_and_config_dirs`` used to redirect the HF
+cache to an empty per-test directory but left network access open, so any
+unit test that reached ``server.load_model`` with a real repo id quietly
+downloaded ``mlx-community/Qwen3.5-9B-4bit`` into ``tmp_path`` — once per
+test — and kept the hosted no-MLX lane busy for ~20 minutes (CI run
+33084172753, ``test_server_load_model_order.py``). These tests pin the guard
+itself: the hub is offline, an uncached ``snapshot_download`` fails
+immediately without touching the Hub, a non-loopback socket connect is
+refused with the offending test named, loopback keeps working, and the exact
+prefetch that leaked can no longer download anything.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from pathlib import Path
+
+import pytest
+
+FAKE_REPO = "rapid-mlx-tests/does-not-exist-2518"
+LEAKED_REPO = "mlx-community/Qwen3.5-9B-4bit"
+# TEST-NET-1 (RFC 5737) is never routable, so a leak could not succeed here
+# anyway — but the guard must refuse BEFORE any syscall, which the timing
+# assertions pin.
+OFF_BOX = ("192.0.2.1", 443)
+
+
+def _guard_armed() -> bool:
+    return bool(getattr(socket.socket.connect, "_hermetic_network_guard", False))
+
+
+def _hub_cache_entry(repo_id: str) -> Path:
+    return Path(os.environ["HF_HUB_CACHE"]) / f"models--{repo_id.replace('/', '--')}"
+
+
+def test_default_fixture_pins_hub_offline_and_arms_socket_guard():
+    hf_constants = pytest.importorskip("huggingface_hub.constants")
+    assert os.environ.get("HF_HUB_OFFLINE") == "1"
+    assert hf_constants.is_offline_mode() is True
+    assert _guard_armed()
+    assert getattr(socket.socket.connect_ex, "_hermetic_network_guard", False)
+
+
+def test_snapshot_download_of_uncached_repo_fails_fast_offline():
+    hub = pytest.importorskip("huggingface_hub")
+    from huggingface_hub.utils import LocalEntryNotFoundError
+
+    started = time.monotonic()
+    with pytest.raises(LocalEntryNotFoundError) as excinfo:
+        hub.snapshot_download(FAKE_REPO)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5.0, (
+        f"offline refusal took {elapsed:.1f}s — did it hit the network?"
+    )
+    assert "outgoing traffic has been disabled" in str(excinfo.value)
+    assert not _hub_cache_entry(FAKE_REPO).exists()
+
+
+def test_non_loopback_connect_is_refused_immediately(request):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        started = time.monotonic()
+        with pytest.raises(RuntimeError, match=r"192\.0\.2\.1:443") as excinfo:
+            sock.connect(OFF_BOX)
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert type(excinfo.value).__name__ == "HermeticNetworkAccessError"
+    message = str(excinfo.value)
+    # Names the offending test and the reviewable opt-in.
+    assert request.node.nodeid in message
+    assert "requires_network" in message
+    # Not an OSError: HTTP clients must not retry/translate it into a slow
+    # ConnectionError.
+    assert not isinstance(excinfo.value, OSError)
+
+
+def test_connect_ex_is_guarded_too():
+    with (
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock,
+        pytest.raises(RuntimeError, match=r"192\.0\.2\.1:443"),
+    ):
+        sock.connect_ex(OFF_BOX)
+
+
+def test_hostname_destinations_are_refused_before_dns():
+    """A hostname that is not ``localhost`` is off-box: refuse without resolving."""
+    with (
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock,
+        pytest.raises(RuntimeError, match=r"huggingface\.co:443"),
+    ):
+        sock.connect(("huggingface.co", 443))
+
+
+def test_loopback_sockets_still_work():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        with socket.create_connection(("127.0.0.1", port), timeout=5) as client:
+            conn, _ = server.accept()
+            conn.close()
+            assert client.getpeername()[0] == "127.0.0.1"
+
+
+def test_leaked_prefetch_cannot_download_under_default_fixture(capsys):
+    """The exact call that leaked: ``server._ensure_routing_config`` on an
+    uncached repo id. It must fail fast (the product's own offline refusal or
+    the hub's offline error, whichever fires first) and leave no cache entry —
+    no ``config.json``, no shards."""
+    server = pytest.importorskip("vllm_mlx.server")
+
+    started = time.monotonic()
+    with pytest.raises((SystemExit, RuntimeError)):
+        server._ensure_routing_config(LEAKED_REPO)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 10.0, f"prefetch took {elapsed:.1f}s — did it start a download?"
+    assert not _hub_cache_entry(LEAKED_REPO).exists()
+    out = capsys.readouterr()
+    assert "offline" in (out.out + out.err).lower()
+
+
+@pytest.mark.real_hf_cache
+def test_real_hf_cache_alone_does_not_grant_network():
+    hf_constants = pytest.importorskip("huggingface_hub.constants")
+    assert os.environ.get("HF_HUB_OFFLINE") == "1"
+    assert hf_constants.is_offline_mode() is True
+    assert _guard_armed()
+
+
+@pytest.mark.requires_network
+def test_requires_network_marker_disarms_the_guard():
+    assert not _guard_armed()
+    assert not getattr(socket.socket.connect_ex, "_hermetic_network_guard", False)
+    # The hub constant mirrors the host's real environment again (a developer
+    # may legitimately run the suite under HF_HUB_OFFLINE=1, so only equality
+    # with the env is asserted, never "online").
+    hf_constants = pytest.importorskip("huggingface_hub.constants")
+    raw = os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE")
+    expected = raw is not None and raw.lower() in {"1", "on", "yes", "true"}
+    assert hf_constants.is_offline_mode() is expected

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -82,6 +82,10 @@ def test_load_model_enables_native_tool_format_when_parser_supports_it(monkeypat
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
+    # #2518: the repo id is a label for the stub engine, not a checkpoint to
+    # fetch — skip the config prefetch so the empty hermetic cache never turns
+    # this into a real download.
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit")
 
@@ -111,6 +115,8 @@ def test_load_model_tracks_explicit_served_model_name(monkeypatch, served, expec
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
     monkeypatch.setattr(server, "_served_model_name_set", not expected, raising=False)
+    # #2518: no config prefetch — the repo id is a label for the stub engine.
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit", served_model_name=served)
 
@@ -464,6 +470,8 @@ def test_load_model_infers_programmatic_max_tokens_explicit(monkeypatch):
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
+    # #2518: no config prefetch — the repo id is a label for the stub engine.
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit")
     cfg = get_config()
@@ -507,6 +515,10 @@ def test_load_model_mtp_kwarg_translates_to_scheduler_config(
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
+    # #2518: no config prefetch — the repo id is a label for the stub engine.
+    # (``scheduler_config_stub`` shims ``mlx`` on the no-MLX lane, so the
+    # ``importorskip`` above does NOT skip this test there.)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
 
     with pytest.warns(DeprecationWarning, match="load_model\\(mtp=True\\)"):
         server.load_model("mlx-community/Qwen3.5-9B-4bit", mtp=True)
@@ -607,6 +619,9 @@ def test_load_model_response_cache_reconfigure_failure_forces_disabled(monkeypat
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
+
+    # #2518: no config prefetch — the repo id is a label for the stub engine.
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
 
     # load_model must NOT raise (best-effort), but must force the cache safe.
     server.load_model("mlx-community/Qwen3.5-9B-4bit")

--- a/tests/test_streaming_detokenizer.py
+++ b/tests/test_streaming_detokenizer.py
@@ -8,6 +8,13 @@ from mlx_lm.tokenizer_utils import (
 )
 from transformers import AutoTokenizer
 
+# Every test here goes through one of the three fixtures below, which
+# legitimately fetch/load ``mlx-community/Qwen3-0.6B-8bit`` into the empty
+# per-test cache. Reviewed opt-in (#2518, PR #2525): the hermetic default pins
+# the Hub offline and refuses non-loopback sockets, which would fail these
+# fixtures at setup on the Apple lane.
+pytestmark = pytest.mark.requires_network
+
 
 class TestStreamingDetokenizer:
     """Test streaming detokenizer correctness."""


### PR DESCRIPTION
## Why

Closes #2518.

The autouse fixture `tests/conftest.py::_hermetic_hf_and_config_dirs` redirects the Hugging Face cache to an empty per-test `tmp_path`, but it left network access open. Any unit test that reaches `server.load_model(...)` with a real repo id therefore runs the real config prefetch (`server._ensure_routing_config` -> `cli._ensure_model_downloaded` -> mirror round-trips + `snapshot_download`) against an empty cache and downloads `mlx-community/Qwen3.5-9B-4bit` into the pytest temp tree, once per test.

On hosted CI this is what kept the `test-matrix` no-MLX jobs of PR #2436 in the unit step for ~20 minutes (run 33084172753, job 98559274759, Python 3.12; the three matrix jobs took 18m32s / 24m53s / 26m07s and eventually passed because the download succeeded). Test-to-test timestamps in that log show the leak, all in `tests/test_server_load_model_order.py`:

| test | wall time in CI |
| --- | --- |
| `test_load_model_enables_native_tool_format_when_parser_supports_it` | 8m00s |
| `test_load_model_tracks_explicit_served_model_name[studio-assistant-True]` | 3m52s |
| `test_load_model_tracks_explicit_served_model_name[None-False]` | 1m32s |
| `test_load_model_infers_programmatic_max_tokens_explicit` | 2m42s |
| `test_load_model_mtp_kwarg_translates_to_scheduler_config` | 3m56s |
| `test_load_model_response_cache_reconfigure_failure_forces_disabled` | 1m58s |

(The `mtp_kwarg` one runs on the no-MLX lane despite its `pytest.importorskip("mlx")` because `scheduler_config_stub` shims `mlx` into `sys.modules` first.)

Reproduced locally without network: with `HF_HUB_OFFLINE` unset, `HF_ENDPOINT=http://127.0.0.1:9` (closed port) and the mirror disabled, the same six tests fail in 2.5 s with `httpcore ... connect_tcp.started host='127.0.0.1' port=9` in the captured log, i.e. they were about to fetch the 9B checkpoint.

## What

Test harness only; no engine code changes.

- `tests/conftest.py`: the default hermetic path is now network-off.
  - `HF_HUB_OFFLINE=1` via `monkeypatch.setenv` (the product's own offline switch, `cli._offline_hub_mode_active`, and any hub imported during the test honour it), plus `huggingface_hub.constants.HF_HUB_OFFLINE = True` when the hub is already imported (the constant is snapshotted at import; same fix as `scripts/kv_quant_quality_gate.py::_enable_hf_offline`). Every hub HTTP call now raises `OfflineModeIsEnabled`; `snapshot_download` / `hf_hub_download` of an uncached repo raise `LocalEntryNotFoundError` immediately. Cached sessions are reset for huggingface_hub < 1.0 (which binds its `OfflineAdapter` at session creation).
  - A fail-fast socket guard (pytest-socket's `--allow-hosts=127.0.0.1` shape, kept in-tree so the no-MLX lane needs no plugin): `socket.socket.connect` / `connect_ex` raise `HermeticNetworkAccessError(RuntimeError)` for any non-loopback destination, naming the test nodeid, the `host:port`, and the opt-in marker. Loopback, unspecified and AF_UNIX addresses stay open, so in-process servers, uvicorn on 127.0.0.1 and asyncio self-pipes keep working. It is deliberately not an `OSError`, so urllib3/httpcore/asyncio cannot retry or translate it into a slow `ConnectionError`.
  - New marker `requires_network` (registered in `pytest_configure`) is the only way back to real network access; it re-derives the hub constant from the real environment. `real_hf_cache` keeps its meaning (use the host cache) but no longer implies network: a cached checkpoint loads fine offline, an uncached one fails fast instead of downloading. Nothing in the suite needs `requires_network` today.
  - New fixture `hub_online_env` (clears `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` only; the hub constant and socket guard stay armed) for tests that assert on the product's ONLINE download path with the fetch stubbed. With `HF_HUB_OFFLINE=1` exported, the product's own switch (`cli._offline_hub_mode_active`) makes `_ensure_model_downloaded` and the `chat` / `/model` gates refuse an uncached model up front (`_refuse_offline_uncached` -> `SystemExit(1)`), which is the correct product behaviour but not what those tests test.
- `tests/test_server_load_model_order.py`: the six leaking tests stub `server._ensure_routing_config` (the same seam their sibling tests already use) — the repo id is only a label for the `_StubEngine`, not a checkpoint to fetch.
- `tests/test_cli_chat.py` (5 tests) and `tests/test_first_run_guide.py` (3 tests) request `hub_online_env`: 7 of them started failing with the product's offline refusal under the new default (`test_chat_no_model_defaults_to_qwen35_4b`, `test_ensure_model_downloaded_calls_disk_check`, `test_ensure_model_downloaded_pins_resolved_sha_and_records_main_ref`, `test_chat_switch_confirm_cancel_keeps_old_server`, `test_autoselected_starter_uses_standard_download_gate`, `test_autoselected_starter_still_runs_disk_gate_in_prefetch`, `test_explicit_uncached_model_still_confirms`); the eighth, `test_ensure_model_downloaded_aborts_when_the_hub_wont_answer`, kept passing but for the wrong reason (offline refusal instead of the bounded-probe abort it asserts), so it opts in too. An audit run that logged every test in which `_offline_hub_mode_active()` returned True confirmed no other rostered test's outcome depends on the new default: 13 hits in 11 tests, all of which set the switch themselves (`test_cli_chat.py::test_chat_switch_refuses_offline_uncached_before_confirm`, nine in `test_cli_offline_serve.py`) or are the new regression test.
- `tests/test_hermetic_network_off.py` (new, 9 tests): the hub is offline and the guard armed by default; `snapshot_download` of a fake repo raises `LocalEntryNotFoundError` in well under a second and creates no `models--*` entry; a connect to `192.0.2.1:443` and to `huggingface.co:443` is refused before any syscall/DNS with the test named in the message; `connect_ex` is guarded; loopback still connects; the exact leaked call `server._ensure_routing_config("mlx-community/Qwen3.5-9B-4bit")` fails fast under the default fixture and leaves no cache entry; `real_hf_cache` alone keeps the guard armed; `requires_network` disarms it.
- `.github/workflows/ci.yml`: one line adds the new file to the `test-matrix` roster so the protection is exercised on the lane that hung.

## Scope / Non-goals

- No product model-loading behaviour changes; `vllm_mlx/` is untouched.
- The guard only intercepts `socket.connect`/`connect_ex`; DNS lookups and UDP `sendto` are not blocked (the hub hook fires before DNS for all `huggingface_hub` traffic; the mirror's `urllib` calls hit the connect guard). Product code that swallows a broad `except Exception` around a network call would hide the guard's error, as with pytest-socket; `_ensure_routing_config` chains it as `__cause__`, so it stays visible there.
- Not addressed: making `_ensure_routing_config` itself cheaper, the Apple-Silicon lane roster, or `pytest-timeout` for the unit step.

## Verification

Local venv mirroring the CI job (`/opt/homebrew/bin/python3.12 -m venv`, `pip install -e . --no-deps`, `pip install -r config/requirements-ci-linux.txt`; huggingface_hub 1.29.0, pytest 9.1.1, no MLX). "blocked env" = `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` unset, `HF_ENDPOINT=http://127.0.0.1:9`, `RAPID_MLX_MODEL_MIRROR=` (mirror opt-out), so any leak fails fast instead of downloading.

- Before the fix, blocked env: `pytest tests/test_server_load_model_order.py -k test_load_model_` -> 6 failed, 6 passed, 13 deselected in 2.54s (the six tests above; `--log-level=DEBUG` shows `connect_tcp.started host='127.0.0.1' port=9`).
- Before the fix, blocked env, the full `test-matrix` "Run unit tests (no MLX required)" command from `ci.yml` (both pytest invocations, identical args): 6 failed, 6218 passed, 21 skipped, 27 deselected in 122.71s + 86 passed in 14.56s. The only failures were the six leaking tests, so every other rostered test was already offline-clean.
- After the fix, blocked env: `pytest tests/test_hermetic_network_off.py tests/test_server_load_model_order.py` -> 34 passed in 0.91s.
- After the fix, plain host env (nothing set; the fixture alone has to block): same command -> 34 passed in 1.71s.
- After the fix, blocked env, the same full `test-matrix` command: 6233 passed, 21 skipped, 27 deselected in 113.83s + 86 passed in 15.72s (0 failures; 6218 + 6 previously failing + 9 new = 6233). The same command with the audit plugin enabled: 6233 passed, 21 skipped, 27 deselected + 86 passed.
- After rebasing onto `2a9ed0f1` (the `train_gates.sh` drift test landed meanwhile; its parser reads `ci.yml` itself, so the roster addition self-syncs): `pytest tests/test_train_gates_matches_ci.py tests/test_hermetic_network_off.py tests/test_server_load_model_order.py` -> 52 passed in 1.65s.
- `ruff check tests/conftest.py tests/test_hermetic_network_off.py tests/test_server_load_model_order.py` -> All checks passed; `ruff format --check` -> 3 files already formatted; `git diff --check` clean.
- Not run here: the Apple-Silicon lane (no MLX allowed on this host for this task); it runs the same autouse fixture, and its `real_hf_cache` tests load cached weights, which works offline.
