### PR TITLE
fix(mac): bound hung Desktop test suite to 2 min + upload sample artifact (#2488)

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -252,8 +252,26 @@ jobs:
       #
       # The real fix is to stop blocking threads inside async tests; until
       # then, do not drop this flag.
+      #
+      # #2488: wrapped by scripts/desktop-test-timeout.sh so a hung suite
+      # (per-suite .timeLimit(.minutes(2)) on the hang-prone suites) or a hung
+      # whole run (per-run deadline + /usr/bin/sample + ps + vm_stat artifact)
+      # fails fast with a readable reason instead of burning the job timeout.
       - name: swift test
-        run: swift test --no-parallel
+        run: ./scripts/desktop-test-timeout.sh
+
+      # #2488: upload the hang-sample artifact (stack + system state) so the
+      # cause of a hung/failed desktop-test run is inspectable from the CI log
+      # without re-running. `if-no-files-found: ignore` keeps healthy runs from
+      # failing on an empty artifact dir.
+      - name: Upload Desktop test hang sample
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: desktop-test-hang-sample-${{ github.sha }}
+          path: apps/rapid-mac/build/desktop-hang-artifacts
+          if-no-files-found: ignore
+          retention-days: 1
 
       # Kept alongside `swift test` rather than folded into it: this script
       # runs without the test target, so it stays usable while bisecting a

--- a/apps/rapid-mac/Package.swift
+++ b/apps/rapid-mac/Package.swift
@@ -96,6 +96,32 @@ let package = Package(
             name: "SwiftMathVendorTests",
             dependencies: ["SwiftMath"],
             path: "Vendor/SwiftMath/Tests"
+        ),
+        // #2488: the Desktop test-suite hang watchdog.
+        //
+        // ``RapidDesktopTestWatchdog`` is a small library holding the pure,
+        // seam-injectable hang-watchdog logic (deadline math, artifact path,
+        // sample invocation) that the CI wrapper
+        // (``scripts/desktop-test-timeout.sh``) uses to convert a hung
+        // `swift test` run into a fast, readable failure with a sampled stack
+        // artifact. Its decision logic is unit-tested in
+        // ``RapidDesktopTestWatchdogTests`` with fake clock / process / sample
+        // seams. It deliberately does NOT ship in the `.app` (the ``Rapid``
+        // executable target does not depend on it) — it is a CI/test-runner
+        // concern only.
+        .target(
+            name: "RapidDesktopTestWatchdog",
+            path: "Sources/RapidDesktopTestWatchdog"
+        ),
+        .executableTarget(
+            name: "RapidDesktopTestWatchdogRun",
+            dependencies: ["RapidDesktopTestWatchdog"],
+            path: "Sources/RapidDesktopTestWatchdogRun"
+        ),
+        .testTarget(
+            name: "RapidDesktopTestWatchdogTests",
+            dependencies: ["RapidDesktopTestWatchdog"],
+            path: "Tests/RapidDesktopTestWatchdogTests"
         )
         // NOTE (2026-08-05): the RapidTests target is BACK in the manifest,
         // above. It had been excluded on the reasoning that the strip

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/ProcessAlive.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/ProcessAlive.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Real-host process-liveness probe. A PID can be detected as
+/// "not alive" even while it is technically a zombie; for our purpose
+/// (is the run still making progress?) a live-or-zombie distinction is
+/// handled by treating only an explicit "no such PID" as dead.
+public enum ProcessAlive {
+
+    /// True if a process with `pid` exists right now.
+    ///
+    /// Uses `kill(pid, 0)` (the standard "does this pid exist" probe), which
+    /// requires no child relationship and triggers no signal delivery. A
+    /// ``errno`` of ``ESRCH`` (no such process) → false; permission-denied
+    /// (``EPERM``) still means the process exists → true.
+    public static func isAlive(pid: pid_t) -> Bool {
+        guard pid > 1 else { return false }
+        if kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/SampleInvocation.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/SampleInvocation.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Real-host sampler: captures a hung process's stack with `/usr/bin/sample`
+/// plus a snapshot of process state (`ps`) and memory pressure (`vm_stat`),
+/// all written into a single `.txt` artifact for CI to upload.
+///
+/// The invocation pattern mirrors the existing in-process
+/// `CIHangWatchdog.sample(pid:)` (Tests/RapidTests/Support/CIHangWatchdog.swift)
+/// so a developer who has read one recognizes the other; the addition here is
+/// that the whole set is redirected into a named artifact file rather than
+/// `/dev/stdout`, plus `ps`/`vm_stat` give the RAM/memory-pressure context that
+/// lets a reader tell a "stuck waiting on memory" hang from a pure deadlock.
+public enum SampleInvocation {
+
+    /// Capture the stack + system state for `pid` into `artifactURL`.
+    public static func capture(
+        pid: pid_t,
+        config: WatchdogConfig = WatchdogConfig(),
+        artifactURL: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: artifactURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // Fresh materialize the artifact (FileHandle(forWritingTo:) alone
+        // fails when the file doesn't yet exist), then write the sections.
+        if !FileManager.default.fileExists(atPath: artifactURL.path) {
+            try Data().write(to: artifactURL)
+        }
+        let handle = try FileHandle(forWritingTo: artifactURL)
+        try handle.truncate(atOffset: 0)
+        try handle.seek(toOffset: 0)
+        try writeSections(into: handle, pid: pid, config: config)
+        try handle.close()
+    }
+
+    private static func writeSections(into handle: FileHandle, pid: pid_t, config: WatchdogConfig) throws {
+        func write(_ s: String) throws {
+            try handle.write(contentsOf: Data(s.utf8))
+        }
+
+        try write("Rapid Desktop test-suite hang capture\n")
+        try write("captured at: \(Date())\n")
+        try write("wrapped PID: \(pid)\n")
+        try write("sample duration: \(config.sampleDurationSeconds)s\n\n")
+
+        // Process state + RAM context first, so a reader sees memory pressure
+        // even if the stack sample below is truncated.
+        try write("===== ps -p \(pid) -o pid,ppid,state,%cpu,%mem,rss,etime,comm =====\n")
+        try write(shellOutput("/bin/ps", ["-p", String(pid), "-o", "pid,ppid,state,%cpu,%mem,rss,etime,comm"]))
+        try write("\n===== vm_stat =====\n")
+        try write(shellOutput("/usr/bin/vm_stat", []))
+        try write("\n===== memory pressure -Q =====\n")
+        try write(shellOutput("/usr/bin/memory_pressure", ["-Q"]))
+
+        // The stack capture proper.
+        try write("\n===== /usr/bin/sample \(pid) \(config.sampleDurationSeconds) -file ... =====\n")
+        try write(streamingSample(pid: pid, seconds: config.sampleDurationSeconds))
+        try write("===== end capture \(pid) =====\n")
+    }
+
+    /// `/usr/bin/sample` streams to stdout; capture it into the artifact.
+    private static func streamingSample(pid: pid_t, seconds: Int) -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = [String(pid), String(seconds)]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            return "<sample failed: \(error)>"
+        }
+    }
+
+    /// Run a command and return its combined stdout (best-effort, non-fatal).
+    private static func shellOutput(_ executable: String, _ args: [String]) -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            return "<'\(executable)' failed: \(error)>"
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/Watchdog.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/Watchdog.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Configuration for the Desktop test-suite hang watchdog.
+///
+/// The whole purpose of this component is to convert a hung `swift test`
+/// run — which today can stall a train for the full job timeout (20 minutes,
+/// once 45) with no usable diagnostic — into a fast, readable failure with a
+/// sampled stack artifact. Two complementary mechanisms exist:
+///
+///  * Swift Testing's per-suite `.timeLimit(.minutes(2))` trait (added to the
+///    specific hang-prone suites, `TestTimeouts.hangProne`) fails the suite
+///    quickly and names the suite.
+///  * This watchdog is the *whole-run* backstop: it enforces a per-run
+///    deadline on the `swift test` process and, on expiry, samples the hung
+///    process's stacks so we know WHERE it hung even when no per-suite limit
+///    was in place.
+public struct WatchdogConfig: Sendable {
+    /// Deadline for the wrapped run, measured from when the watchdog starts
+    /// watching. This is the whole-run backstop, not the per-suite 2-minute
+    /// limit — it must sit above the healthy serialized `swift test` duration
+    /// so a healthy run is never expired.
+    public var deadline: Duration
+    /// Seconds for each `/usr/bin/sample` capture. 1 is plenty to get a stack.
+    public var sampleDurationSeconds: Int
+    /// Directory the sample + system-state artifact is written into.
+    public var artifactDir: URL
+    /// Path prefix for the artifact basename.
+    public var artifactName: String
+
+    public init(
+        deadline: Duration = .seconds(300),
+        sampleDurationSeconds: Int = 1,
+        artifactDir: URL = URL(fileURLWithPath: "/tmp/desktop-hang-artifacts"),
+        artifactName: String = "desktop-hang"
+    ) {
+        self.deadline = deadline
+        self.sampleDurationSeconds = sampleDurationSeconds
+        self.artifactDir = artifactDir
+        self.artifactName = artifactName
+    }
+}
+
+/// A process-survival test + the hooks that let a unit test fake the world.
+///
+/// Everything that touches the real host (wall clock, whether a PID is still
+/// alive, launching `/usr/bin/sample` and the system-state probes) is
+/// injected here as a closure, so the decision logic in ``HangWatchdog`` is
+/// pure and unit-testable without any real process, clock, or sampler.
+public struct WatchdogSeams: Sendable {
+    /// Returns the current wall-clock instant. Injected clock seam.
+    public var now: @Sendable () -> Date
+    /// True while the wrapped process is still alive. Injected process seam.
+    public var wrappedProcessIsAlive: @Sendable () -> Bool
+    /// Perform the stack + system-state capture for the (hung) process and
+    /// write it into the artifact at `artifactURL`. Injected sample seam.
+    public var capture: @Sendable (pid_t, URL) throws -> Void
+
+    public static let live = WatchdogSeams(
+        now: { Date() },
+        wrappedProcessIsAlive: { fatalError("live seam used without a PID; use makeLive(pid:)") },
+        capture: { pid, url in try SampleInvocation.capture(pid: pid, artifactURL: url) }
+    )
+
+    /// Build the live seams pinned to a specific wrapped PID.
+    public static func makeLive(pid: pid_t, config: WatchdogConfig) -> WatchdogSeams {
+        WatchdogSeams(
+            now: { Date() },
+            wrappedProcessIsAlive: { ProcessAlive.isAlive(pid: pid) },
+            capture: { capturedPID, url in
+                try SampleInvocation.capture(
+                    pid: capturedPID,
+                    config: config,
+                    artifactURL: url
+                )
+            }
+        )
+    }
+}
+
+/// Outcome of a watchdog watch.
+public enum WatchdogResult: Equatable, Sendable {
+    /// The wrapped process exited before the deadline elapsed.
+    case completed
+    /// The deadline elapsed while the wrapped process was still running; a
+    /// sample artifact was captured and (optionally) the run was killed.
+    case hung(artifactURL: URL, reason: String)
+}
+
+/// The hang watchdog: pure decision logic over injected seams.
+///
+/// `run` watches a wrapped process (identified only through the injected
+/// `wrappedProcessIsAlive` seam) until either it exits (returns
+/// ``WatchdogResult/completed``) or the deadline passes while it is still
+/// alive (returns ``WatchdogResult/hung`` after capturing the sample).
+///
+/// The deadline math and the artifact-path construction are pure and unit
+/// tested with a fake clock and fake process; the real capture is delegated
+/// to ``SampleInvocation``.
+public struct HangWatchdog {
+    public let config: WatchdogConfig
+    public let seams: WatchdogSeams
+
+    public init(config: WatchdogConfig = WatchdogConfig(), seams: WatchdogSeams) {
+        self.config = config
+        self.seams = seams
+    }
+
+    /// The artifact URL for a given PID and clock instant (pure; testable).
+    public func artifactURL(pid: pid_t, at date: Date) -> URL {
+        let stamp = String(Int64(date.timeIntervalSince1970))
+        let name = "\(config.artifactName)-\(pid)-\(stamp).txt"
+        return config.artifactDir.appendingPathComponent(name)
+    }
+
+    /// Whether the deadline has elapsed given a start offset and the current
+    /// wall clock (pure; testable).
+    public func isExpired(startedAt start: Date, now nowDate: Date) -> Bool {
+        nowDate.timeIntervalSince(start) >= config.deadline.toSeconds
+    }
+
+    /// Watch the wrapped process until it exits or the deadline is exceeded.
+    ///
+    /// - Parameter pid: the wrapped PID, used for the artifact name + capture.
+    /// - Returns: ``WatchdogResult/completed`` if the process exited before
+    ///   the deadline, else ``WatchdogResult/hung`` with the captured artifact.
+    public func run(watchedPID pid: pid_t) -> WatchdogResult {
+        let start = seams.now()
+        let pollInterval: TimeInterval = 0.25
+
+        while true {
+            if !seams.wrappedProcessIsAlive() {
+                return .completed
+            }
+            if isExpired(startedAt: start, now: seams.now()) {
+                let url = artifactURL(pid: pid, at: seams.now())
+                do {
+                    try seams.capture(pid, url)
+                } catch {
+                    return .hung(
+                        artifactURL: url,
+                        reason: "deadline (\(config.deadline.toSeconds)s) exceeded; sample capture failed: \(error)"
+                    )
+                }
+                return .hung(
+                    artifactURL: url,
+                    reason: "deadline (\(config.deadline.toSeconds)s) exceeded; see sample artifact \(url.path)"
+                )
+            }
+            Thread.sleep(forTimeInterval: pollInterval)
+        }
+    }
+}
+
+// MARK: - Duration helpers
+
+extension Duration {
+    /// Whole seconds represented by this duration (truncated).
+    fileprivate var toSeconds: TimeInterval {
+        let components = self.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdogRun/main.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdogRun/main.swift
@@ -1,0 +1,54 @@
+import Foundation
+import RapidDesktopTestWatchdog
+
+/// CLI entry for the Desktop test-suite hang watchdog, launched by
+/// `scripts/desktop-test-timeout.sh`. It watches a wrapped process and, when
+/// the run outlives the deadline while still alive, captures the stack +
+/// system-state artifact and exits non-zero so the CI wrapper fails fast.
+///
+/// Usage:
+///   RapidDesktopTestWatchdogRun <pid> <deadline-seconds> <artifact-dir> [artifact-name]
+///
+/// Exit codes:
+///   0  the wrapped process exited before the deadline (healthy run / normal fail)
+///   1  the deadline elapsed while the wrapped process was still alive (hang)
+///   2  usage / argument error
+
+let args = CommandLine.arguments
+
+func usage() -> Never {
+    FileHandle.standardError.write(Data(
+        "usage: RapidDesktopTestWatchdogRun <pid> <deadline-seconds> <artifact-dir> [artifact-name]\n".utf8))
+    exit(2)
+}
+
+guard args.count >= 4, let pid = pid_t(args[1]), let deadlineSeconds = Int(args[2]) else {
+    usage()
+}
+
+let artifactDir = URL(fileURLWithPath: args[3])
+let artifactName = args.count >= 5 ? args[4] : "desktop-hang"
+
+let config = WatchdogConfig(
+    deadline: .seconds(deadlineSeconds),
+    sampleDurationSeconds: 1,
+    artifactDir: artifactDir,
+    artifactName: artifactName
+)
+
+let watchdog = HangWatchdog(
+    config: config,
+    seams: .makeLive(pid: pid, config: config)
+)
+
+let result = watchdog.run(watchedPID: pid)
+
+switch result {
+case .completed:
+    exit(0)
+case .hung(let artifactURL, let reason):
+    let message = "::error::Rapid desktop-test watchdog: \(reason)\n"
+        + "sample artifact: \(artifactURL.path)\n"
+    FileHandle.standardError.write(Data(message.utf8))
+    exit(1)
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/Locked.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/Locked.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A tiny lock-protected mutable box so `@Sendable` test closures (the seams
+/// require `@Sendable`) can safely capture and mutate shared state in Swift 6
+/// strict-concurrency mode.
+final class Locked<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Value
+
+    init(_ value: Value) {
+        _value = value
+    }
+
+    /// Read or mutate the boxed value under the lock.
+    func withLock<T>(_ body: (inout Value) -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&_value)
+    }
+
+    var value: Value {
+        withLock { $0 }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/SampleInvocationTests.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/SampleInvocationTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import RapidDesktopTestWatchdog
+
+/// Verifies the real-host sampler (`/usr/bin/sample` + `ps`/`vm_stat`) writes
+/// a non-trivial `.txt` artifact for a live process. Uses a short-lived
+/// `sleep` child as the sample target — a real process the OS sampler can
+/// capture — so no test hangs even if `sample` stalls.
+@Suite("SampleInvocation — live capture")
+struct SampleInvocationTests {
+
+    @Test("capture writes a non-empty artifact with sample + ps + vm_stat sections")
+    func capturesLiveProcess() throws {
+        // Spawn a real child so there is a genuine PID to sample.
+        let sleeper = Process()
+        sleeper.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        sleeper.arguments = ["10"]
+        try sleeper.run()
+        defer { kill(sleeper.processIdentifier, SIGKILL) }
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wd-test-\(UUID().uuidString)")
+        let config = WatchdogConfig(
+            deadline: .seconds(60),
+            sampleDurationSeconds: 1,
+            artifactDir: dir,
+            artifactName: "desktop-hang"
+        )
+        let url = dir.appendingPathComponent("desktop-hang-\(sleeper.processIdentifier)-test.txt")
+
+        try SampleInvocation.capture(pid: sleeper.processIdentifier, config: config, artifactURL: url)
+
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(text.contains("Rapid Desktop test-suite hang capture"))
+        #expect(text.contains("===== ps -p"))
+        #expect(text.contains("===== vm_stat ====="))
+        #expect(text.contains("===== /usr/bin/sample"))
+        #expect(text.contains("sleep"))   // the sampled stack names the process
+        #expect(text.count > 200)         // genuinely captured content, not a stub
+    }
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/WatchdogTests.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/WatchdogTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import RapidDesktopTestWatchdog
+
+/// Unit tests for the hang-watchdog decision logic, driven entirely through
+/// injected seams (fake clock, fake process-survival, fake sample capture) so
+/// no real `/usr/bin/sample`, process, or wall clock is touched.
+@Suite("HangWatchdog — deadline math + seams")
+struct WatchdogDecisionTests {
+
+    // MARK: - Deadline math (pure)
+
+    @Test("isExpired is false before the deadline")
+    func notExpiredBeforeDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(120))
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date(timeIntervalSince1970: 100) }))
+        let start = Date(timeIntervalSince1970: 0)
+        // 60s elapsed < 120s deadline.
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 60)) == false)
+    }
+
+    @Test("isExpired is true at and past the deadline")
+    func expiredAtAndPastDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(120))
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date() }))
+        let start = Date(timeIntervalSince1970: 0)
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 120)) == true)
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 300)) == true)
+    }
+
+    // MARK: - Artifact path (pure)
+
+    @Test("artifact URL embeds pid, name prefix, timestamp and .txt suffix")
+    func artifactPathShape() {
+        let cfg = WatchdogConfig(
+            artifactDir: URL(fileURLWithPath: "/tmp/hang", isDirectory: true),
+            artifactName: "desktop-hang"
+        )
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date(timeIntervalSince1970: 12345) }))
+        let url = wd.artifactURL(pid: 4242, at: Date(timeIntervalSince1970: 12345))
+        #expect(url.path == "/tmp/hang/desktop-hang-4242-12345.txt")
+    }
+
+    // MARK: - run() outcomes via fake seams
+
+    @Test("run returns completed when the wrapped process exits before deadline")
+    func completesWhenProcessExitsFirst() {
+        let cfg = WatchdogConfig(deadline: .seconds(60))
+        let wd = HangWatchdog(
+            config: cfg,
+            seams: .fake(
+                now: { Date() },
+                wrappedAlive: { false },   // already gone
+                capture: { pid, url in
+                    Issue.record("capture must not run when the process is already gone")
+                }
+            )
+        )
+        #expect(wd.run(watchedPID: 100) == .completed)
+    }
+
+    @Test("run returns hung + writes artifact when the process outlives the deadline")
+    func hangsAndCapturesOnDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(2), artifactDir: URL(fileURLWithPath: "/tmp/x"))
+        let captured = Locked<(pid: pid_t, url: URL)?>(nil)
+        let calls = Locked(0)
+        let wd = HangWatchdog(
+            config: cfg,
+            seams: WatchdogSeams(
+                now: {
+                    let n = calls.withLock { c -> Int in
+                        c += 1
+                        return c
+                    }
+                    // First call is the start instant (t=0); every later poll
+                    // is t=60s, already past the 2s deadline, while the process
+                    // stays alive — so the watchdog must expire and capture.
+                    return Date(timeIntervalSince1970: n == 1 ? 0 : 60)
+                },
+                wrappedProcessIsAlive: { true },
+                capture: { pid, url in captured.withLock { $0 = (pid, url) } }
+            )
+        )
+        let result = wd.run(watchedPID: 77)
+        guard case .hung(let url, let reason) = result else {
+            Issue.record("expected .hung, got \(result)")
+            return
+        }
+        let got = captured.value
+        #expect(got?.pid == 77)
+        #expect(url == got?.url)
+        #expect(url.path == "/tmp/x/desktop-hang-77-60.txt")
+        #expect(reason.contains("deadline"))
+    }
+}
+
+extension WatchdogSeams {
+    /// Convenience fake-seams constructor for tests.
+    static func fake(
+        now: @escaping @Sendable () -> Date = { Date() },
+        wrappedAlive: @escaping @Sendable () -> Bool = { true },
+        capture: @escaping @Sendable (pid_t, URL) throws -> Void = { _, _ in }
+    ) -> WatchdogSeams {
+        WatchdogSeams(now: now, wrappedProcessIsAlive: wrappedAlive, capture: capture)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
@@ -14,7 +14,7 @@ import Testing
 /// macOS reads 5 base sizes off an icns (16, 32, 128, 256, 512) and
 /// each has a `@2x` retina pair, so 10 representations total. We
 /// assert all 10 are present and decode to a non-empty PNG payload.
-@Suite("AppIcon.icns subimage coverage")
+@Suite("AppIcon.icns subimage coverage", TestTimeouts.hangProne)
 struct AppIconBundleTests {
     /// Locate the shipped icns by walking up from the test bundle
     /// to the repo root, since `swift test` doesn't expose Resources/

--- a/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-@Suite("DMG presentation scripts")
+@Suite("DMG presentation scripts", TestTimeouts.hangProne)
 struct DMGPresentationScriptTests {
     @Test("Validator preserves legacy compatibility and detaches by device")
     func validatorCompatibilityAndCleanup() throws {

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -260,7 +260,7 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
 /// can never fire and no responder is needed: the suite asserts the resident
 /// rejection/load behaviour on fixtures, not on the host's real RAM.
 @MainActor
-@Suite("Resident-load rejection feedback", .serialized)
+@Suite("Resident-load rejection feedback", .serialized, TestTimeouts.hangProne)
 struct ResidentLoadFeedbackTests {
     @Test("Resident admission publishes alias-scoped working state immediately", .timeLimit(.minutes(1)))
     func publishesResidentLoadInFlightState() async {

--- a/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
@@ -22,7 +22,7 @@ import Testing
 ///
 /// Pattern mirrors ``ToolUseCapabilitySourceGuardTests`` (PR #343):
 /// strip comments/whitespace, then assert canonical substrings.
-@Suite("Sidecar shim cwd-hijack hardening (#361)")
+@Suite("Sidecar shim cwd-hijack hardening (#361)", TestTimeouts.hangProne)
 struct SidecarShimHardeningTests {
 
     /// Repository root, derived from ``#filePath`` so the test runs

--- a/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
@@ -29,7 +29,7 @@ import Testing
 /// can't quietly delete any one of them. The bug class is too
 /// expensive (100% slim-DMG install failure rate; only caught by
 /// release-day dogfood) to rely on a single point of defence.
-@Suite("Sidecar version SemVer gate (#411) — four-layer regression pins")
+@Suite("Sidecar version SemVer gate (#411) — four-layer regression pins", TestTimeouts.hangProne)
 struct SidecarVersionGateTests {
 
     private static var sourceRoot: URL {

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestTimeouts.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestTimeouts.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+
+/// Shared time-limit traits for hang-prone Desktop test suites (#2488).
+///
+/// A suite that spawns a real engine process, or that waits on RAM/clock and
+/// could stall the serialised `swift test --no-parallel` pool, should declare
+/// it by adding the shared trait constant to its `@Suite` attribute — one line
+/// per suite:
+///
+/// ```swift
+/// @Suite("...", .timeLimit(.minutes(2)))
+/// ```
+/// becomes:
+/// ```swift
+/// @Suite("...", TestTimeouts.hangProne)
+/// ```
+///
+/// This is deliberately a *suite-level* limit (Swift Testing's `.timeLimit`
+/// is recursive over a suite's contained tests), so a single stuck `@Test`
+/// trips the whole suite at 2 minutes instead of stalling the serialised run
+/// until the CI job timeout. The complementary whole-run backstop lives in
+/// `scripts/desktop-test-timeout.sh`.
+///
+/// Only `.minutes(_:)` (integer) is available on the installed toolchain —
+/// `.seconds`/`.milliseconds` are marked unavailable — so 2 minutes is the
+/// finest granularity the trait allows.
+enum TestTimeouts {
+    /// 2-minute time limit applied to hang-prone suites.
+    static let hangProne: any SuiteTrait = .timeLimit(.minutes(2))
+}

--- a/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
@@ -23,7 +23,7 @@ import Testing
 /// vendored SwiftMath notice exists in-tree, `THIRD_PARTY.md` points at the
 /// shipped `Contents/Resources/Licenses/` location, and `build.sh` actually
 /// invokes the staging script.
-@Suite("Third-party license staging")
+@Suite("Third-party license staging", TestTimeouts.hangProne)
 struct ThirdPartyLicenseStagingTests {
     /// Repository root, derived from this file's own compile-time location:
     /// `<root>/apps/rapid-mac/Tests/RapidTests/<this file>`.

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -4,6 +4,15 @@ import XCTest
 
 @MainActor
 final class ChatAttachmentJourneyTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // #2488: bound each XCUI journey to 2 minutes so a hung UI test (the
+        // #2481 ledger hang) fails fast instead of stalling the XCUITest run.
+        // This is the XCUITest-target analog of the Swift Testing
+        // `TestTimeouts.hangProne` suite trait.
+        executionTimeAllowance = 120
+    }
+
     func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {
         continueAfterFailure = false
         let harness = try RapidUITestHarness(

--- a/apps/rapid-mac/scripts/desktop-test-timeout.sh
+++ b/apps/rapid-mac/scripts/desktop-test-timeout.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Desktop test-suite hang backstop.
+#
+# Wraps `swift test --no-parallel` so a hung suite can never burn the whole
+# job timeout (20 minutes, once 45) with no diagnostic. Two complementary
+# mechanisms (see #2488):
+#
+#   1. Per-suite `.timeLimit(.minutes(2))` (TestTimeouts.hangProne) applied to
+#      the hang-prone suites fails those suites in 2 minutes and names them.
+#   2. THIS script is the whole-run safety net: it enforces a per-run deadline
+#      on the swift-test process and, on expiry, hands the hung process to the
+#      RapidDesktopTestWatchdogRun watchdog which samples its stacks (plus
+#      `ps` / `vm_stat` / `memory_pressure`) into a `.txt` artifact, then we
+#      kill the hung process and exit non-zero with a readable reason.
+#
+# The per-run deadline must sit ABOVE the healthy serialized run so a healthy
+# suite never expires (per-suite .timeLimit provides the real 2-minute
+# guarantee); override with RAPID_DESKTOP_DEADLINE_MINUTES if a host runs the
+# suite slower/faster.
+#
+# Artifacts are written to RAPID_DESKTOP_HANG_ARTIFACT_DIR (default
+# build/desktop-hang-artifacts, match CI's upload step path if you move it).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-8}"
+ARTIFACT_DIR="${RAPID_DESKTOP_HANG_ARTIFACT_DIR:-"$ROOT/build/desktop-hang-artifacts"}"
+
+# Locate (and if needed build) the watchdog executable BEFORE launching
+# `swift test`, so we never contends with the running test for the SwiftPM
+# `.build` lock. Prefer RAPID_WATCHDOG_BIN (CI can pass a prebuilt path); fall
+# back to `swift build --product`.
+WATCHDOG_BIN="${RAPID_WATCHDOG_BIN:-}"
+if [[ -n "$WATCHDOG_BIN" && ! -x "$WATCHDOG_BIN" ]]; then
+    echo "error: RAPID_WATCHDOG_BIN not executable: $WATCHDOG_BIN" >&2
+    WATCHDOG_BIN=""
+fi
+if [[ -z "$WATCHDOG_BIN" ]] && swift build --product RapidDesktopTestWatchdogRun >/dev/null 2>&1; then
+    WATCHDOG_BIN="$ROOT/.build/debug/RapidDesktopTestWatchdogRun"
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+# --- Launch `swift test` in the background, remember its PID ---------------
+swift test --no-parallel &
+TEST_PID=$!
+
+# --- Watchdog: fail fast if the run outlives the deadline while still alive --
+hang_detected=0
+if [[ -n "$WATCHDOG_BIN" && -x "$WATCHDOG_BIN" ]]; then
+    deadline_seconds=$(( DEADLINE_MINUTES * 60 ))
+    if "$WATCHDOG_BIN" "$TEST_PID" "$deadline_seconds" "$ARTIFACT_DIR" \
+        > "$ARTIFACT_DIR/watchdog.stdout" 2> "$ARTIFACT_DIR/watchdog.stderr"; then
+        # Watchdog exited 0 => the wrapped process exited before the deadline.
+        :
+    else
+        hang_detected=1
+    fi
+else
+    # No watchdog binary: fall back to a plain `wait` (no fast-fail guarantee,
+    # but the job's own timeout-minutes still bounds the burn).
+    echo "warning: RapidDesktopTestWatchdogRun not built; running without hang backstop" >&2
+fi
+
+# --- Reap the test process; on hang, kill it so nothing is orphaned ---------
+if [[ $hang_detected -eq 1 ]]; then
+    echo "::error::Desktop test suite exceeded ${DEADLINE_MINUTES} min hard deadline; killing hung process $TEST_PID" >&2
+    kill -9 "$TEST_PID" 2>/dev/null || true
+    # Also kill any swift-testing/xctest children that outlived the kill.
+    pkill -9 -P "$TEST_PID" 2>/dev/null || true
+    # Surface the artifact path the watchdog wrote.
+    if [[ -d "$ARTIFACT_DIR" ]]; then
+        echo "hang sample artifact(s) under: $ARTIFACT_DIR" >&2
+        ls -1 "$ARTIFACT_DIR" >&2 || true
+    fi
+    wait "$TEST_PID" 2>/dev/null || true
+    exit 124   # matches timeout(1)'s kill exit code convention
+fi
+
+# Normal path: propagate the test process's own exit code.
+set +e
+wait "$TEST_PID"
+TEST_EXIT=$?
+set -e
+# Avoid stale hang artifacts confusing the upload step on a healthy run.
+if [[ -d "$ARTIFACT_DIR" && -n "${ARTIFACT_DIR}" && "${ARTIFACT_DIR}" != "/" ]]; then
+    # Keep the dir (CI `if-no-files-found: ignore` needs a stable path) but
+    # clear it so an empty upload shows no false hang.
+    rm -rf -- "${ARTIFACT_DIR:?}"/* 2>/dev/null || true
+fi
+exit "$TEST_EXIT"

--- a/apps/rapid-mac/scripts/desktop-test-timeout.sh
+++ b/apps/rapid-mac/scripts/desktop-test-timeout.sh
@@ -16,7 +16,10 @@
 # The per-run deadline must sit ABOVE the healthy serialized run so a healthy
 # suite never expires (per-suite .timeLimit provides the real 2-minute
 # guarantee); override with RAPID_DESKTOP_DEADLINE_MINUTES if a host runs the
-# suite slower/faster.
+# suite slower/faster. Default 15 min: generously above any healthy serialized
+# run while still 5 min below the job's 20-min timeout AND producing a sample
+# artifact (which a plain job timeout never does). The suite-level .timeLimit
+# is what actually delivers the 2-minute fail-fast for the hang-prone suites.
 #
 # Artifacts are written to RAPID_DESKTOP_HANG_ARTIFACT_DIR (default
 # build/desktop-hang-artifacts, match CI's upload step path if you move it).
@@ -25,7 +28,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-8}"
+DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-15}"
 ARTIFACT_DIR="${RAPID_DESKTOP_HANG_ARTIFACT_DIR:-"$ROOT/build/desktop-hang-artifacts"}"
 
 # Locate (and if needed build) the watchdog executable BEFORE launching

--- a/scripts/train_gates_parser.py
+++ b/scripts/train_gates_parser.py
@@ -261,16 +261,27 @@ def parse_diff_cover_invocation() -> dict[str, Any]:
 
 
 def parse_swift_test_invocation() -> dict[str, Any]:
-    """Parse the Desktop ``swift test`` invocation from rapid-mac-ci.yml."""
+    """Parse the Desktop ``swift test`` invocation from rapid-mac-ci.yml.
+
+    Since #2488 the hosted Desktop gate wraps ``swift test --no-parallel`` in
+    ``scripts/desktop-test-timeout.sh`` (per-run hang deadline + sample
+    artifact). The authoritative invocation is now that wrapper; the legacy
+    bare ``swift test --no-parallel`` remains accepted so an unpinned checkout
+    (or a pre-#2488 branch) doesn't drift-fail. ``train_gates.sh`` Gate 5 runs
+    the real ``swift test --no-parallel`` itself; this parser's value only
+    feeds the deterministic gates-hash.
+    """
+    desktop_wrapper = "./scripts/desktop-test-timeout.sh"
     parsed = yaml.safe_load(MAC_CI_WORKFLOW.read_text())
     for job in parsed["jobs"].values():
         for step in job.get("steps", []):
             if isinstance(step, dict) and step.get("name") == "swift test":
                 run = step["run"].strip()
-                if run != "swift test --no-parallel":
+                if run not in (desktop_wrapper, "swift test --no-parallel"):
                     raise _drift(
                         f"Desktop swift test drifted: expected "
-                        f"'swift test --no-parallel', found {run!r}"
+                        f"{desktop_wrapper!r} or 'swift test --no-parallel', "
+                        f"found {run!r}"
                     )
                 return {"cmd": run}
     raise _drift("could not find the Desktop 'swift test' step")

--- a/tests/test_train_gates_matches_ci.py
+++ b/tests/test_train_gates_matches_ci.py
@@ -342,9 +342,19 @@ def test_train_gates_refuses_base_equal_to_head() -> None:
 # Desktop swift test (Gate 5)
 # ---------------------------------------------------------------------------
 def test_swift_test_invocation_matches_workflow() -> None:
+    # Since #2488 the hosted Desktop gate wraps `swift test --no-parallel` in
+    # ``scripts/desktop-test-timeout.sh``. The parser must reflect THAT as the
+    # authoritative desktop-test invocation (it feeds the gates-hash).
     parsed = parse_swift_test_invocation()
-    assert parsed == {"cmd": "swift test --no-parallel"}
-    assert "swift test --no-parallel" in MAC_CI
+    assert parsed in (
+        {"cmd": "swift test --no-parallel"},
+        {"cmd": "./scripts/desktop-test-timeout.sh"},
+    )
+    hosted = MAC_CI
+    assert (
+        "swift test --no-parallel" in hosted
+        or "./scripts/desktop-test-timeout.sh" in hosted
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2488 (Atlas, ds0732 desk).

## Problem
A hung Desktop test suite (`swift test --no-parallel` in rapid-mac-ci.yml)
could stall the train for the full 20-minute job (once 45) with **no usable
diagnostic** — the documented incident deadlocked every `@MainActor` test
("1,416 tests started, ZERO finished").

## Two complementary mechanisms

1. **Per-suite `.timeLimit(.minutes(2))`** Swift Testing trait on the
   hang-prone suites, via a shared `TestTimeouts.hangProne` constant (one line
   per new hang-prone suite), so a stuck test fails in 2 minutes and names the
   suite. Applied to: ResidentLoadFeedback (#2480 ledger) and the
   subprocess-spawning suites (`proc.waitUntilExit`: ThirdPartyLicense,
   SidecarVersionGate, SidecarShimHardening, AppIconBundle, DMGPresentation).
   The XCUITest analog — ChatAttachmentJourney (#2481) — sets
   `executionTimeAllowance = 120` in `setUp`.

2. **Whole-run backstop**: `scripts/desktop-test-timeout.sh` wraps
   `swift test --no-parallel`, enforces a per-run deadline (default 15 min,
   `RAPID_DESKTOP_DEADLINE_MINUTES` override, above the healthy run / below
   the job timeout). On expiry it hands the hung process to the new
   `RapidDesktopTestWatchdogRun` executable, which samples stacks plus
   `ps`/`vm_stat`/`memory_pressure` into a `.txt` artifact, then kills the run
   so the job fails fast with a readable reason. CI uploads that artifact.

## Testability (seams)
The watchdog decision logic lives in a new **non-shipping** SPM library
(`RapidDesktopTestWatchdog`) with injectable clock/process/sample seams and is
unit-tested with a fake clock + fake process (deadline math, artifact path,
sample invocation, completed-vs-hung outcome). The live `/usr/bin/sample`
capture is verified against a real child process in `SampleInvocationTests`.

## Scope / non-goals
- Only `apps/rapid-mac` test targets + a CI upload step. No re-enabling of
  #2480 suites, no gate-roster changes, no engine code.

## Coordination
- `train_gates_parser.parse_swift_test_invocation` + its drift test pinned the
  bare `swift test --no-parallel`; updated both to accept the #2488 wrapper as
  the authoritative Desktop-test invocation (legacy command still accepted for
  pre-#2488 checkouts). `tests/test_train_gates_matches_ci.py`: 18/18 green.

## Verification
- Watchdog unit tests: 6/6 pass.
- Drift test: 18/18 pass.
- Hang backstop proven end-to-end against a real hung subprocess: 9.7 KB
  artifact with `ps`/`vm_stat`/`memory_pressure`/`sample` sections, and the
  process is killed so the job fails fast.
- PR-only demo: a deliberately hanging test tripped the watchdog and produced
  the artifact; the demo test is removed before this final head.