### PR TITLE
ci(release): preflight pinned sidecar snapshots

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -291,7 +291,8 @@ jobs:
       - name: Preflight immutable sidecar smoke snapshots
         id: sidecar-pins
         run: |
-          python3 apps/rapid-mac/scripts/check-sidecar-smoke-cache.py \
+          /opt/homebrew/opt/python@3.12/bin/python3.12 \
+            apps/rapid-mac/scripts/check-sidecar-smoke-cache.py \
             --manifest apps/rapid-mac/scripts/sidecar-smoke-models.json \
             --github-output "$GITHUB_OUTPUT"
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -288,6 +288,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      - name: Preflight immutable sidecar smoke snapshots
+        id: sidecar-pins
+        run: |
+          python3 apps/rapid-mac/scripts/check-sidecar-smoke-cache.py \
+            --manifest apps/rapid-mac/scripts/sidecar-smoke-models.json \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Re-verify Tier-1 agents against the release source
         env:
           VERSION: ${{ needs.detect.outputs.version }}
@@ -307,10 +314,10 @@ jobs:
           # real image gate below. The Studio runner is intentionally the only
           # release host with model weights; offline resolution makes cache
           # drift or eviction fail closed instead of silently downloading.
-          SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit
-          SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53
-          SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit
-          SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2
+          SIDECAR_VISION_SMOKE_MODEL: ${{ steps.sidecar-pins.outputs.qwen_model }}
+          SIDECAR_VISION_SMOKE_REVISION: ${{ steps.sidecar-pins.outputs.qwen_revision }}
+          SIDECAR_GEMMA_SMOKE_MODEL: ${{ steps.sidecar-pins.outputs.gemma_model }}
+          SIDECAR_GEMMA_SMOKE_REVISION: ${{ steps.sidecar-pins.outputs.gemma_revision }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
             tests/test_release_baselines.py \
             tests/test_sidecar_distribution_constraints.py \
             tests/test_sidecar_vision_smoke.py \
+            tests/test_sidecar_smoke_cache_preflight.py \
             tests/test_validate_release_subject.py \
             tests/test_check_release_notes.py \
             tests/test_check_gha_pinning.py \

--- a/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
+++ b/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fail fast when an immutable release sidecar snapshot is not cached.
+
+The release gate is intentionally offline.  This preflight mirrors the cache
+coordinate used by ``huggingface_hub.snapshot_download(..., revision=<sha>,
+local_files_only=True)`` without importing or loading model code.  It runs
+before the release venv, agent smoke, sidecar build, or any model load.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+_REVISION = re.compile(r"[0-9a-f]{40}")
+_KEY = re.compile(r"[a-z][a-z0-9_]*")
+_REPOSITORY = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?"
+)
+
+
+class PreflightError(Exception):
+    """The pin manifest or local cache cannot satisfy the offline gate."""
+
+
+def default_cache_root() -> Path:
+    if value := os.environ.get("HF_HUB_CACHE"):
+        return Path(value).expanduser()
+    if value := os.environ.get("HF_HOME"):
+        return Path(value).expanduser() / "hub"
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+    return cache_home / "huggingface" / "hub"
+
+
+def load_pins(path: Path) -> dict[str, tuple[str, str]]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(f"cannot read pin manifest {path}: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema") != 1:
+        raise PreflightError("sidecar pin manifest must be an object with schema 1")
+    models = payload.get("models")
+    if not isinstance(models, dict) or set(models) != {"qwen", "gemma"}:
+        raise PreflightError("sidecar pin manifest must define exactly qwen and gemma")
+
+    result: dict[str, tuple[str, str]] = {}
+    for key, entry in models.items():
+        if not _KEY.fullmatch(key) or not isinstance(entry, dict):
+            raise PreflightError(f"invalid sidecar pin entry {key!r}")
+        repository = entry.get("repository")
+        revision = entry.get("revision")
+        if not isinstance(repository, str) or not _REPOSITORY.fullmatch(repository):
+            raise PreflightError(f"{key}.repository must be an owner/name ID")
+        if not isinstance(revision, str) or not _REVISION.fullmatch(revision):
+            raise PreflightError(f"{key}.revision must be a full lowercase commit SHA")
+        result[key] = (repository, revision)
+    return result
+
+
+def snapshot_path(cache_root: Path, repository: str, revision: str) -> Path:
+    return (
+        cache_root / f"models--{repository.replace('/', '--')}" / "snapshots" / revision
+    )
+
+
+def missing_pins(
+    pins: dict[str, tuple[str, str]], cache_root: Path
+) -> list[tuple[str, str]]:
+    missing: list[tuple[str, str]] = []
+    for repository, revision in pins.values():
+        snapshot = snapshot_path(cache_root, repository, revision)
+        try:
+            # Cached snapshots contain symlinks into blobs. Following them here
+            # catches empty snapshots and snapshots whose blobs were evicted,
+            # without opening or loading any model files.
+            populated = snapshot.is_dir() and any(
+                candidate.is_file() for candidate in snapshot.rglob("*")
+            )
+        except OSError:
+            populated = False
+        if not populated:
+            missing.append((repository, revision))
+    return missing
+
+
+def write_outputs(path: Path, pins: dict[str, tuple[str, str]]) -> None:
+    lines: list[str] = []
+    for key, (repository, revision) in pins.items():
+        lines.extend((f"{key}_model={repository}", f"{key}_revision={revision}"))
+    with path.open("a") as output:
+        output.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--cache-root", type=Path, default=None)
+    parser.add_argument("--github-output", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        pins = load_pins(args.manifest)
+    except PreflightError as exc:
+        print(f"sidecar cache preflight: FAIL: {exc}", file=sys.stderr)
+        return 2
+
+    cache_root = (args.cache_root or default_cache_root()).expanduser()
+    missing = missing_pins(pins, cache_root)
+    if missing:
+        print(
+            f"sidecar cache preflight: FAIL: {len(missing)} immutable snapshot(s) "
+            f"missing from {cache_root}",
+            file=sys.stderr,
+        )
+        for repository, revision in missing:
+            print(f"  - {repository}@{revision}", file=sys.stderr)
+            print(
+                '    restore: python3 -c "from huggingface_hub import '
+                f"snapshot_download; snapshot_download('{repository}', "
+                f"revision='{revision}')\"",
+                file=sys.stderr,
+            )
+        print(
+            "No download was attempted; release gate remains offline.", file=sys.stderr
+        )
+        return 1
+
+    if args.github_output is not None:
+        write_outputs(args.github_output, pins)
+    print(
+        f"sidecar cache preflight: PASS: {len(pins)} pinned snapshots in {cache_root}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
+++ b/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
@@ -15,7 +15,7 @@ import json
 import os
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 _REVISION = re.compile(r"[0-9a-f]{40}")
 _KEY = re.compile(r"[a-z][a-z0-9_]*")
@@ -38,7 +38,7 @@ def default_cache_root() -> Path:
     return cache_home / "huggingface" / "hub"
 
 
-def load_pins(path: Path) -> dict[str, tuple[str, str]]:
+def load_pins(path: Path) -> dict[str, tuple[str, str, tuple[str, ...]]]:
     try:
         payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
@@ -49,17 +49,35 @@ def load_pins(path: Path) -> dict[str, tuple[str, str]]:
     if not isinstance(models, dict) or set(models) != {"qwen", "gemma"}:
         raise PreflightError("sidecar pin manifest must define exactly qwen and gemma")
 
-    result: dict[str, tuple[str, str]] = {}
+    result: dict[str, tuple[str, str, tuple[str, ...]]] = {}
     for key, entry in models.items():
         if not _KEY.fullmatch(key) or not isinstance(entry, dict):
             raise PreflightError(f"invalid sidecar pin entry {key!r}")
         repository = entry.get("repository")
         revision = entry.get("revision")
+        files = entry.get("files")
         if not isinstance(repository, str) or not _REPOSITORY.fullmatch(repository):
             raise PreflightError(f"{key}.repository must be an owner/name ID")
         if not isinstance(revision, str) or not _REVISION.fullmatch(revision):
             raise PreflightError(f"{key}.revision must be a full lowercase commit SHA")
-        result[key] = (repository, revision)
+        if (
+            not isinstance(files, list)
+            or not files
+            or not all(isinstance(file, str) for file in files)
+            or len(files) != len(set(files))
+        ):
+            raise PreflightError(f"{key}.files must be a non-empty unique string list")
+        for file in files:
+            file_path = PurePosixPath(file)
+            if (
+                file_path.is_absolute()
+                or not file_path.parts
+                or any(part in {"", ".", ".."} for part in file_path.parts)
+                or "\\" in file
+                or "\n" in file
+            ):
+                raise PreflightError(f"{key}.files contains an unsafe path {file!r}")
+        result[key] = (repository, revision, tuple(files))
     return result
 
 
@@ -70,28 +88,31 @@ def snapshot_path(cache_root: Path, repository: str, revision: str) -> Path:
 
 
 def missing_pins(
-    pins: dict[str, tuple[str, str]], cache_root: Path
-) -> list[tuple[str, str]]:
-    missing: list[tuple[str, str]] = []
-    for repository, revision in pins.values():
+    pins: dict[str, tuple[str, str, tuple[str, ...]]], cache_root: Path
+) -> list[tuple[str, str, tuple[str, ...]]]:
+    missing: list[tuple[str, str, tuple[str, ...]]] = []
+    for repository, revision, files in pins.values():
         snapshot = snapshot_path(cache_root, repository, revision)
-        try:
-            # Cached snapshots contain symlinks into blobs. Following them here
-            # catches empty snapshots and snapshots whose blobs were evicted,
-            # without opening or loading any model files.
-            populated = snapshot.is_dir() and any(
-                candidate.is_file() for candidate in snapshot.rglob("*")
-            )
-        except OSError:
-            populated = False
-        if not populated:
-            missing.append((repository, revision))
+        missing_files: list[str] = []
+        for file in files:
+            try:
+                # is_file follows the cache's blob symlinks. It catches both
+                # absent entries and evicted blobs without opening model data.
+                present = snapshot.is_dir() and (snapshot / file).is_file()
+            except OSError:
+                present = False
+            if not present:
+                missing_files.append(file)
+        if missing_files:
+            missing.append((repository, revision, tuple(missing_files)))
     return missing
 
 
-def write_outputs(path: Path, pins: dict[str, tuple[str, str]]) -> None:
+def write_outputs(
+    path: Path, pins: dict[str, tuple[str, str, tuple[str, ...]]]
+) -> None:
     lines: list[str] = []
-    for key, (repository, revision) in pins.items():
+    for key, (repository, revision, _) in pins.items():
         lines.extend((f"{key}_model={repository}", f"{key}_revision={revision}"))
     with path.open("a") as output:
         output.write("\n".join(lines) + "\n")
@@ -118,8 +139,10 @@ def main(argv: list[str] | None = None) -> int:
             f"missing from {cache_root}",
             file=sys.stderr,
         )
-        for repository, revision in missing:
+        for repository, revision, missing_files in missing:
             print(f"  - {repository}@{revision}", file=sys.stderr)
+            for file in missing_files:
+                print(f"      missing: {file}", file=sys.stderr)
             print(
                 '    restore: python3 -c "from huggingface_hub import '
                 f"snapshot_download; snapshot_download('{repository}', "

--- a/apps/rapid-mac/scripts/sidecar-smoke-models.json
+++ b/apps/rapid-mac/scripts/sidecar-smoke-models.json
@@ -3,11 +3,39 @@
   "models": {
     "qwen": {
       "repository": "mlx-community/Qwen3.5-9B-4bit",
-      "revision": "8b2b98c00a6b4d291155e4890773ca8f769aee53"
+      "revision": "8b2b98c00a6b4d291155e4890773ca8f769aee53",
+      "files": [
+        ".gitattributes",
+        "README.md",
+        "chat_template.jinja",
+        "config.json",
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "model.safetensors.index.json",
+        "preprocessor_config.json",
+        "processor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "video_preprocessor_config.json",
+        "vocab.json"
+      ]
     },
     "gemma": {
       "repository": "mlx-community/gemma-4-e2b-it-8bit",
-      "revision": "03dcf209f3f549b4075e7191e77cf69b3d48e1b2"
+      "revision": "03dcf209f3f549b4075e7191e77cf69b3d48e1b2",
+      "files": [
+        ".gitattributes",
+        "README.md",
+        "chat_template.jinja",
+        "config.json",
+        "generation_config.json",
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "model.safetensors.index.json",
+        "processor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json"
+      ]
     }
   }
 }

--- a/apps/rapid-mac/scripts/sidecar-smoke-models.json
+++ b/apps/rapid-mac/scripts/sidecar-smoke-models.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "models": {
+    "qwen": {
+      "repository": "mlx-community/Qwen3.5-9B-4bit",
+      "revision": "8b2b98c00a6b4d291155e4890773ca8f769aee53"
+    },
+    "gemma": {
+      "repository": "mlx-community/gemma-4-e2b-it-8bit",
+      "revision": "03dcf209f3f549b4075e7191e77cf69b3d48e1b2"
+    }
+  }
+}

--- a/tests/test_sidecar_smoke_cache_preflight.py
+++ b/tests/test_sidecar_smoke_cache_preflight.py
@@ -16,22 +16,36 @@ _SPEC.loader.exec_module(_MODULE)
 
 
 def _populate(cache: Path, repository: str, revision: str) -> None:
+    files = next(
+        files
+        for pinned_repository, pinned_revision, files in _MODULE.load_pins(
+            _MANIFEST
+        ).values()
+        if (pinned_repository, pinned_revision) == (repository, revision)
+    )
     snapshot = _MODULE.snapshot_path(cache, repository, revision)
-    snapshot.mkdir(parents=True)
-    (snapshot / "config.json").write_text("{}")
+    for file in files:
+        target = snapshot / file
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("stub")
 
 
 def test_manifest_is_the_exact_two_pin_source_of_truth() -> None:
-    assert _MODULE.load_pins(_MANIFEST) == {
-        "qwen": (
-            "mlx-community/Qwen3.5-9B-4bit",
-            "8b2b98c00a6b4d291155e4890773ca8f769aee53",
-        ),
-        "gemma": (
-            "mlx-community/gemma-4-e2b-it-8bit",
-            "03dcf209f3f549b4075e7191e77cf69b3d48e1b2",
-        ),
-    }
+    pins = _MODULE.load_pins(_MANIFEST)
+    assert pins["qwen"][:2] == (
+        "mlx-community/Qwen3.5-9B-4bit",
+        "8b2b98c00a6b4d291155e4890773ca8f769aee53",
+    )
+    assert pins["gemma"][:2] == (
+        "mlx-community/gemma-4-e2b-it-8bit",
+        "03dcf209f3f549b4075e7191e77cf69b3d48e1b2",
+    )
+    for _, _, files in pins.values():
+        assert "config.json" in files
+        assert "tokenizer.json" in files
+        assert "model.safetensors.index.json" in files
+        assert "model-00001-of-00002.safetensors" in files
+        assert "model-00002-of-00002.safetensors" in files
 
 
 def test_cache_root_matches_hugging_face_environment_precedence(
@@ -57,14 +71,14 @@ def test_one_missing_pin_fails_and_names_exact_recovery(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], missing_key: str
 ) -> None:
     pins = _MODULE.load_pins(_MANIFEST)
-    for key, (repository, revision) in pins.items():
+    for key, (repository, revision, _) in pins.items():
         if key != missing_key:
             _populate(tmp_path, repository, revision)
     assert (
         _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
     )
     error = capsys.readouterr().err
-    repository, revision = pins[missing_key]
+    repository, revision, _ = pins[missing_key]
     assert f"{repository}@{revision}" in error
     assert f"revision='{revision}'" in error
     assert "No download was attempted" in error
@@ -78,39 +92,54 @@ def test_both_missing_are_reported_together(
     )
     error = capsys.readouterr().err
     assert "2 immutable snapshot(s)" in error
-    for repository, revision in _MODULE.load_pins(_MANIFEST).values():
+    for repository, revision, _ in _MODULE.load_pins(_MANIFEST).values():
         assert f"{repository}@{revision}" in error
 
 
 def test_both_present_pass_without_reading_model_files(tmp_path: Path) -> None:
-    for repository, revision in _MODULE.load_pins(_MANIFEST).values():
+    for repository, revision, _ in _MODULE.load_pins(_MANIFEST).values():
         _populate(tmp_path, repository, revision)
     assert (
         _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 0
     )
 
 
-def test_broken_snapshot_symlink_fails_closed(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize(
+    ("damaged_file", "broken_link"),
+    [
+        ("model-00002-of-00002.safetensors", True),
+        ("tokenizer.json", False),
+    ],
+)
+def test_partial_snapshot_fails_closed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    damaged_file: str,
+    broken_link: bool,
 ) -> None:
     pins = _MODULE.load_pins(_MANIFEST)
-    for key, (repository, revision) in pins.items():
+    for key, (repository, revision, _) in pins.items():
         if key == "qwen":
+            _populate(tmp_path, repository, revision)
             snapshot = _MODULE.snapshot_path(tmp_path, repository, revision)
-            snapshot.mkdir(parents=True)
-            (snapshot / "config.json").symlink_to(tmp_path / "missing-blob")
+            damaged_path = snapshot / damaged_file
+            damaged_path.unlink()
+            if broken_link:
+                damaged_path.symlink_to(tmp_path / "missing-blob")
         else:
             _populate(tmp_path, repository, revision)
 
     assert (
         _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
     )
-    assert f"{pins['qwen'][0]}@{pins['qwen'][1]}" in capsys.readouterr().err
+    error = capsys.readouterr().err
+    assert f"{pins['qwen'][0]}@{pins['qwen'][1]}" in error
+    assert f"missing: {damaged_file}" in error
 
 
 def test_present_pins_emit_workflow_outputs(tmp_path: Path) -> None:
     pins = _MODULE.load_pins(_MANIFEST)
-    for repository, revision in pins.values():
+    for repository, revision, _ in pins.values():
         _populate(tmp_path, repository, revision)
     output = tmp_path / "github-output"
     assert (
@@ -150,6 +179,15 @@ def test_repository_cannot_inject_a_workflow_output(tmp_path: Path) -> None:
         _MODULE.load_pins(manifest)
 
 
+def test_manifest_file_paths_cannot_escape_the_snapshot(tmp_path: Path) -> None:
+    payload = json.loads(_MANIFEST.read_text())
+    payload["models"]["gemma"]["files"].append("../outside")
+    manifest = tmp_path / "pins.json"
+    manifest.write_text(json.dumps(payload))
+    with pytest.raises(_MODULE.PreflightError, match="unsafe path"):
+        _MODULE.load_pins(manifest)
+
+
 def test_workflow_preflight_precedes_every_expensive_command() -> None:
     workflow = (_ROOT / ".github/workflows/auto-release.yml").read_text()
     preflight = workflow.index("check-sidecar-smoke-cache.py")
@@ -161,3 +199,7 @@ def test_workflow_preflight_precedes_every_expensive_command() -> None:
         assert preflight < workflow.index(expensive)
     assert "steps.sidecar-pins.outputs.qwen_model" in workflow
     assert "steps.sidecar-pins.outputs.gemma_revision" in workflow
+    assert (
+        "/opt/homebrew/opt/python@3.12/bin/python3.12 \\\n"
+        "            apps/rapid-mac/scripts/check-sidecar-smoke-cache.py" in workflow
+    )

--- a/tests/test_sidecar_smoke_cache_preflight.py
+++ b/tests/test_sidecar_smoke_cache_preflight.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parents[1]
+_SCRIPT = _ROOT / "apps/rapid-mac/scripts/check-sidecar-smoke-cache.py"
+_MANIFEST = _ROOT / "apps/rapid-mac/scripts/sidecar-smoke-models.json"
+_SPEC = importlib.util.spec_from_file_location("sidecar_cache_preflight", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _populate(cache: Path, repository: str, revision: str) -> None:
+    snapshot = _MODULE.snapshot_path(cache, repository, revision)
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+
+
+def test_manifest_is_the_exact_two_pin_source_of_truth() -> None:
+    assert _MODULE.load_pins(_MANIFEST) == {
+        "qwen": (
+            "mlx-community/Qwen3.5-9B-4bit",
+            "8b2b98c00a6b4d291155e4890773ca8f769aee53",
+        ),
+        "gemma": (
+            "mlx-community/gemma-4-e2b-it-8bit",
+            "03dcf209f3f549b4075e7191e77cf69b3d48e1b2",
+        ),
+    }
+
+
+def test_cache_root_matches_hugging_face_environment_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_cache = tmp_path / "explicit-hub"
+    hf_home = tmp_path / "hf-home"
+    xdg_cache = tmp_path / "xdg-cache"
+    monkeypatch.setenv("HF_HUB_CACHE", str(hub_cache))
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_cache))
+    assert _MODULE.default_cache_root() == hub_cache
+
+    monkeypatch.delenv("HF_HUB_CACHE")
+    assert _MODULE.default_cache_root() == hf_home / "hub"
+
+    monkeypatch.delenv("HF_HOME")
+    assert _MODULE.default_cache_root() == xdg_cache / "huggingface" / "hub"
+
+
+@pytest.mark.parametrize("missing_key", ["qwen", "gemma"])
+def test_one_missing_pin_fails_and_names_exact_recovery(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], missing_key: str
+) -> None:
+    pins = _MODULE.load_pins(_MANIFEST)
+    for key, (repository, revision) in pins.items():
+        if key != missing_key:
+            _populate(tmp_path, repository, revision)
+    assert (
+        _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
+    )
+    error = capsys.readouterr().err
+    repository, revision = pins[missing_key]
+    assert f"{repository}@{revision}" in error
+    assert f"revision='{revision}'" in error
+    assert "No download was attempted" in error
+
+
+def test_both_missing_are_reported_together(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
+    )
+    error = capsys.readouterr().err
+    assert "2 immutable snapshot(s)" in error
+    for repository, revision in _MODULE.load_pins(_MANIFEST).values():
+        assert f"{repository}@{revision}" in error
+
+
+def test_both_present_pass_without_reading_model_files(tmp_path: Path) -> None:
+    for repository, revision in _MODULE.load_pins(_MANIFEST).values():
+        _populate(tmp_path, repository, revision)
+    assert (
+        _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 0
+    )
+
+
+def test_broken_snapshot_symlink_fails_closed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pins = _MODULE.load_pins(_MANIFEST)
+    for key, (repository, revision) in pins.items():
+        if key == "qwen":
+            snapshot = _MODULE.snapshot_path(tmp_path, repository, revision)
+            snapshot.mkdir(parents=True)
+            (snapshot / "config.json").symlink_to(tmp_path / "missing-blob")
+        else:
+            _populate(tmp_path, repository, revision)
+
+    assert (
+        _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
+    )
+    assert f"{pins['qwen'][0]}@{pins['qwen'][1]}" in capsys.readouterr().err
+
+
+def test_present_pins_emit_workflow_outputs(tmp_path: Path) -> None:
+    pins = _MODULE.load_pins(_MANIFEST)
+    for repository, revision in pins.values():
+        _populate(tmp_path, repository, revision)
+    output = tmp_path / "github-output"
+    assert (
+        _MODULE.main(
+            [
+                "--manifest",
+                str(_MANIFEST),
+                "--cache-root",
+                str(tmp_path),
+                "--github-output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    assert output.read_text().splitlines() == [
+        f"qwen_model={pins['qwen'][0]}",
+        f"qwen_revision={pins['qwen'][1]}",
+        f"gemma_model={pins['gemma'][0]}",
+        f"gemma_revision={pins['gemma'][1]}",
+    ]
+
+
+def test_malformed_manifest_fails_closed(tmp_path: Path) -> None:
+    manifest = tmp_path / "pins.json"
+    manifest.write_text(json.dumps({"schema": 1, "models": {}}))
+    with pytest.raises(_MODULE.PreflightError, match="exactly qwen and gemma"):
+        _MODULE.load_pins(manifest)
+
+
+def test_repository_cannot_inject_a_workflow_output(tmp_path: Path) -> None:
+    payload = json.loads(_MANIFEST.read_text())
+    payload["models"]["qwen"]["repository"] = "owner/model\nevil=value"
+    manifest = tmp_path / "pins.json"
+    manifest.write_text(json.dumps(payload))
+    with pytest.raises(_MODULE.PreflightError, match="owner/name"):
+        _MODULE.load_pins(manifest)
+
+
+def test_workflow_preflight_precedes_every_expensive_command() -> None:
+    workflow = (_ROOT / ".github/workflows/auto-release.yml").read_text()
+    preflight = workflow.index("check-sidecar-smoke-cache.py")
+    for expensive in (
+        "/opt/homebrew/opt/python@3.12/bin/python3.12 -m venv",
+        "tests/integrations/agent_smoke.sh",
+        "apps/rapid-mac/scripts/build-sidecar.sh",
+    ):
+        assert preflight < workflow.index(expensive)
+    assert "steps.sidecar-pins.outputs.qwen_model" in workflow
+    assert "steps.sidecar-pins.outputs.gemma_revision" in workflow

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import socket
 from pathlib import Path
 
@@ -32,16 +33,18 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
     assert "timeout-minutes: 165" in workflow
-    assert "SIDECAR_VISION_SMOKE_MODEL: mlx-community/Qwen3.5-9B-4bit" in workflow
-    assert (
-        "SIDECAR_VISION_SMOKE_REVISION: 8b2b98c00a6b4d291155e4890773ca8f769aee53"
-        in workflow
+    manifest = json.loads(
+        (
+            Path(__file__).parents[1]
+            / "apps/rapid-mac/scripts/sidecar-smoke-models.json"
+        ).read_text()
     )
-    assert "SIDECAR_GEMMA_SMOKE_MODEL: mlx-community/gemma-4-e2b-it-8bit" in workflow
+    assert manifest["models"]["qwen"]["repository"] == "mlx-community/Qwen3.5-9B-4bit"
     assert (
-        "SIDECAR_GEMMA_SMOKE_REVISION: 03dcf209f3f549b4075e7191e77cf69b3d48e1b2"
-        in workflow
+        manifest["models"]["gemma"]["repository"] == "mlx-community/gemma-4-e2b-it-8bit"
     )
+    assert "steps.sidecar-pins.outputs.qwen_model" in workflow
+    assert "steps.sidecar-pins.outputs.gemma_revision" in workflow
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
     assert '"$SIDE/python/bin/python3.12"' in workflow
     assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow


### PR DESCRIPTION
## Why

The 0.13.1 release gate spent several minutes on Tier-1 work before discovering that an immutable sidecar smoke snapshot was absent from the Studio cache. Release operators need a fast, deterministic failure before any environment setup, sidecar build, or model load.

Closes #2484.

## What

- Add one versioned manifest for the exact Qwen and Gemma sidecar smoke repositories, commit revisions, and complete immutable file rosters.
- Add a standard-library-only, cache-only preflight that follows Hugging Face cache environment precedence, rejects malformed pins, detects missing files and broken cache blob links, aggregates all missing pins/files, and prints revision-pinned recovery commands without downloading.
- Run the preflight immediately after checkout with the release host Python 3.12, and feed its validated pins into both mandatory offline image smokes.
- Add focused unit and workflow-ordering coverage to the required `tests` job.

## Scope / Non-goals

This PR only adds release-gate pin ownership and fail-fast validation. It does not download models, load weights, run GUI/AX dogfood, alter release publication, clean disk state, or implement the deferred host-hygiene policy from #2498.

## Verification

- `python3 -m pytest -q tests/test_sidecar_smoke_cache_preflight.py tests/test_sidecar_vision_smoke.py` (22 passed on Python 3.9.6)
- `/opt/homebrew/opt/python@3.12/bin/python3.12 -m py_compile apps/rapid-mac/scripts/check-sidecar-smoke-cache.py`
- `python3 -m ruff check apps/rapid-mac/scripts/check-sidecar-smoke-cache.py tests/test_sidecar_smoke_cache_preflight.py tests/test_sidecar_vision_smoke.py`
- `python3 -m ruff format --check apps/rapid-mac/scripts/check-sidecar-smoke-cache.py tests/test_sidecar_smoke_cache_preflight.py tests/test_sidecar_vision_smoke.py`
- `python3 scripts/check_gha_pinning.py`
- `actionlint` on the two touched workflows, excluding two pre-existing diagnostics (the registered Studio runner label and SC2129 in an unrelated release step)
- `git diff --check`

## Behaviour delta

Before: an absent or partially evicted pinned sidecar snapshot surfaced only when the late offline vision smoke attempted resolution.

After: the release job fails immediately after checkout, lists every missing immutable repository/revision pair and file plus its recovery command, and only then allows the existing Tier-1 work to begin.