### PR TITLE
ci(release): promote exact pre-tag desktop artifacts

### DIFF
--- a/.github/actions/desktop-releasable/action.yml
+++ b/.github/actions/desktop-releasable/action.yml
@@ -2,10 +2,10 @@ name: Desktop releasable candidate
 description: >-
   Build, sign, notarise and DMG-validate the rapid-mac desktop app at an exact
   commit while producing and verifying a Desktop release manifest. This is the
-  SINGLE shared build+validate contract used by BOTH the pre-tag candidate gate
-  (auto-release.yml) and the tag-triggered publishing lane (rapid-mac-release.yml),
-  so the two lanes can never drift apart. It NEVER creates a tag, release, updater
-  pointer, or any public asset — publishing stays entirely with the caller.
+  shared build+validate contract used by the pre-tag candidate gate and by
+  standalone tag/manual builds. Auto-release promotes the candidate's exact
+  bytes instead of invoking this action again. It NEVER creates a tag, release,
+  updater pointer, or public asset — publishing stays with the caller.
 
 inputs:
   checkout_path:
@@ -39,21 +39,21 @@ inputs:
     default: 'false'
   publish_sparkle:
     description: >-
-      'true' only for the tagged publishing lane, which builds the Sparkle ZIP +
-      appcast (needs the SPARKLE_ED_PRIVATE_KEY and the previous rapid-mac tag).
+      'true' for a releasable candidate or tagged standalone build that must
+      produce the Sparkle ZIP + appcast (needs SPARKLE_ED_PRIVATE_KEY).
     required: false
     default: 'false'
   release_notes_file:
     description: >-
-      Absolute path to the staged release-notes markdown (tagged lane only),
+      Absolute path to the staged release-notes markdown (Sparkle lane only),
       embedded into the Sparkle appcast so the release body and the updater
-      carry identical notes. Empty for the candidate lane.
+      carry identical notes. Empty only when Sparkle publication is disabled.
     required: false
     default: ''
   sparkle_cdn_base:
     description: >-
       CDN base URL (https://dl.rapidmlx.com) for the Signed Sparkle ZIP +
-      appcast download prefix. Tagged lane only.
+      appcast download prefix. Sparkle lane only.
     required: false
     default: ''
   previous_stable_tag:
@@ -266,9 +266,8 @@ runs:
       # strictly exceed the build of EVERY prior rapid-mac release INCLUDING RCs
       # (rc2 must beat rc1; a stable must beat its latest rc), so an already-
       # installed app never rejects the update. Runs in BOTH the candidate and
-      # tagged lanes whenever a prior release exists — INDEPENDENT of Sparkle
-      # publication — so the candidate validates it BEFORE the immutable tag,
-      # not only in the post-tag publishing run.
+      # standalone-build lanes whenever a prior release exists — INDEPENDENT of Sparkle
+      # publication — so the candidate validates it BEFORE the immutable tag.
       if: inputs.signed == 'true' && inputs.previous_release_tag != ''
       env:
         TAG: ${{ inputs.app_tag }}
@@ -378,8 +377,8 @@ runs:
         bash scripts/dmg.sh
 
     - name: Bundle size delta gate (block if DMG grew > cap vs previous rapid-mac release)
-      # Runs in BOTH the candidate and tagged lanes so the DMG size-delta is a
-      # real pre-tag gate, not just a publish-time check. Only skipped when there
+      # Runs in BOTH the candidate and standalone-build lanes, so DMG size delta
+      # remains a real pre-tag gate. Only skipped when there
       # is no previous release baseline. DELTA_COMPARED tells the manifest whether
       # a comparison actually happened so no lane claims dmg-size-delta it skipped.
       if: inputs.previous_stable_tag != ''

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -384,9 +384,9 @@ jobs:
     permissions:
       contents: read
     env:
-      # The candidate must be the REAL signed, notarised lane. Derived identically
-      # to the tagged lane's SIGNED, so a candidate accepted here is the exact
-      # product the tag lane is expected to reproduce. auto-release.yml runs on
+      # The candidate must be the REAL signed, notarised lane. Its exact bytes
+      # become the tagged release, so accepting an ad-hoc candidate is forbidden.
+      # auto-release.yml runs on
       # push to main / workflow_dispatch (never pull_request), so these secrets
       # are available here.
       SIGNED: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 != '' && secrets.MACOS_DEVID_CERT_PASSWORD != '' && secrets.AC_API_KEY_P8_BASE64 != '' && secrets.AC_API_KEY_ID != '' && secrets.AC_API_ISSUER_ID != '' }}
@@ -427,6 +427,24 @@ jobs:
           echo "previous_release_tag=${PREV_RELEASE:-}" >> "$GITHUB_OUTPUT"
           echo "::notice::DMG size-delta baseline: ${PREV_STABLE:-<none>}; Sparkle monotonic predecessor: ${PREV_RELEASE:-<none>}"
 
+      - name: Stage Desktop release notes for the exact candidate
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/release-notes.md"
+          awk -v needle="## [${VERSION}]" '
+            {
+              if (index($0, needle) == 1) { in_section = 1; print; next }
+              if (in_section && /^## /) { exit }
+              if (in_section) { print }
+            }
+          ' apps/rapid-mac/CHANGELOG.md > "$OUT"
+          [[ -s "$OUT" ]] || {
+            echo "::error::apps/rapid-mac/CHANGELOG.md has no ## [${VERSION}] section"
+            exit 1
+          }
+
       - uses: ./.github/actions/desktop-releasable
         id: releasable
         with:
@@ -436,7 +454,11 @@ jobs:
           app_tag: rapid-mac-v${{ needs.detect.outputs.version }}
           signed: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 != '' && secrets.MACOS_DEVID_CERT_PASSWORD != '' && secrets.AC_API_KEY_P8_BASE64 != '' && secrets.AC_API_KEY_ID != '' && secrets.AC_API_ISSUER_ID != '' }}
           require_signed: 'true'
-          publish_sparkle: 'false'
+          # Build the canonical Sparkle bytes here too. The protected tagged
+          # lane promotes this exact signed/notarised bundle; it never rebuilds.
+          publish_sparkle: 'true'
+          release_notes_file: ${{ runner.temp }}/release-notes.md
+          sparkle_cdn_base: ${{ vars.RAPID_MAC_DIST_CDN_BASE }}
           previous_stable_tag: ${{ steps.prev.outputs.previous_stable_tag }}
           previous_release_tag: ${{ steps.prev.outputs.previous_release_tag }}
           MACOS_DEVID_CERT_P12_BASE64: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 }}
@@ -445,6 +467,7 @@ jobs:
           AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
           AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
           AC_API_KEY_P8_BASE64: ${{ secrets.AC_API_KEY_P8_BASE64 }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
           SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
 
       - name: Accept the desktop candidate (bind evidence to the full SHA)
@@ -476,13 +499,34 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "signed=${SIGNED}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload desktop candidate DMG + manifest
+      - name: Stage exact pre-tag Desktop candidate bundle
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          BUNDLE="$RUNNER_TEMP/desktop-pre-tag-candidate"
+          mkdir -p "$BUNDLE/sparkle"
+          cp apps/rapid-mac/build/rapid-mlx-desktop.dmg "$BUNDLE/"
+          cp apps/rapid-mac/build/rapid-mlx-desktop.manifest.json "$BUNDLE/"
+          cp "$RUNNER_TEMP/release-notes.md" "$BUNDLE/release-notes.md"
+          cp apps/rapid-mac/build/sparkle/appcast.xml "$BUNDLE/sparkle/"
+          cp apps/rapid-mac/build/sparkle/*.zip "$BUNDLE/sparkle/"
+          python3 scripts/desktop_promotion.py create \
+            --bundle "$BUNDLE" \
+            --output "$BUNDLE/desktop-promotion-manifest.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow .github/workflows/auto-release.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --source-sha "$GITHUB_SHA" \
+            --version "$VERSION" \
+            --app-tag "rapid-mac-v${VERSION}"
+
+      - name: Upload SHA-labelled pre-tag Desktop candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: rapid-mlx-desktop-dmg
-          path: |
-            apps/rapid-mac/build/rapid-mlx-desktop.dmg
-            apps/rapid-mac/build/rapid-mlx-desktop.manifest.json
+          name: rapid-mlx-desktop-pre-tag-candidate-${{ github.sha }}
+          path: ${{ runner.temp }}/desktop-pre-tag-candidate
           if-no-files-found: error
           retention-days: 7
 
@@ -563,7 +607,6 @@ jobs:
       accepted_sha: ${{ steps.accepted.outputs.accepted_sha }}
       main_sha: ${{ steps.mainhead.outputs.main_sha }}
       open_ids: ${{ steps.blockers.outputs.open_ids }}
-      have_pat: ${{ steps.appcheck.outputs.have_pat }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -581,12 +624,6 @@ jobs:
         id: appcheck
         env:
           VERSION: ${{ needs.detect.outputs.version }}
-          # Presence only — the value never enters the log. The app tag has to
-          # be created by a real user or the DMG workflow never fires (see the
-          # tag step in release-tag), so whether we hold a PAT decides whether
-          # this release can cut the app half at all. Deciding it HERE before
-          # anything is published is what makes the skip recoverable.
-          HAVE_PAT: ${{ secrets.RELEASE_PAT != '' }}
         run: |
           set -euo pipefail
           if ! grep -qE "^## \[${VERSION//./\\.}\]" apps/rapid-mac/CHANGELOG.md; then
@@ -594,18 +631,6 @@ jobs:
             exit 1
           fi
           echo "apps/rapid-mac/CHANGELOG.md has a [${VERSION}] section."
-
-          # Fail HERE, before anything is published, because there is no good
-          # answer later. Skipping the app tag would leave a green run with only
-          # the engine released, and a re-run then sees the published engine
-          # Release, sets should_release=false and never reaches the app step —
-          # the version would be permanently engine-only. Failing now costs
-          # nothing: set the secret and re-run, and the whole release proceeds.
-          if [ "$HAVE_PAT" != "true" ]; then
-            echo "::error::RELEASE_PAT is not set. The app tag has to be created by a real user — a ref written with the default GITHUB_TOKEN triggers no workflow, so no DMG would ever be built for ${VERSION}. Nothing has been published yet: add the RELEASE_PAT secret and re-run this workflow."
-            exit 1
-          fi
-          echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes
         id: changelog
@@ -776,8 +801,8 @@ jobs:
     environment: rapid-mac-tag
     permissions:
       contents: write
-      # read the live ``rapid-mac-tag`` environment protection below.
-      actions: read
+      # Read protection and explicitly dispatch the exact promotion workflow.
+      actions: write
       # The pre-tag re-query re-reads the live open ``release-blocker`` issue set
       # immediately before the immutable tag is claimed (TOCTOU guard).
       issues: read
@@ -888,8 +913,9 @@ jobs:
       # flow rather than stranding a version as engine-only forever.
       - name: Tag the desktop app at the exact validated SHA
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          HAVE_PAT: ${{ needs.release-prep.outputs.have_pat }}
+          # Intentional default token: its tag event cannot recursively trigger
+          # another build. The next step performs one exact explicit dispatch.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.detect.outputs.version }}
           RELEASE_SHA: ${{ needs.release-prep.outputs.release_sha }}
           # The SHA the candidate gate validated and release-prep printed for
@@ -899,12 +925,26 @@ jobs:
           set -euo pipefail
           bash scripts/tag_desktop_app.sh
 
+      - name: Dispatch exact Desktop candidate promotion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TAG: rapid-mac-v${{ needs.detect.outputs.version }}
+          ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }}
+          PRODUCER_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh workflow run rapid-mac-release.yml \
+            --ref "$APP_TAG" \
+            -f "promote_run_id=$PRODUCER_RUN_ID" \
+            -f "promote_sha=$ACCEPTED_SHA"
+          echo "::notice::dispatched exact Desktop promotion from auto-release run ${PRODUCER_RUN_ID} at ${ACCEPTED_SHA}"
+
       # An existing same-SHA tag is an idempotent success for the tag claim, but
       # it does not prove the Desktop workflow ever completed. Wait for the exact
       # tagged workflow run and its published non-empty DMG before exposing the
       # engine release. API/auth/malformed/mismatch/failure/timeout all fail
-      # closed. Recovery is an explicit rerun/dispatch at this immutable tag;
-      # this gate never moves/deletes a tag or starts a workflow itself.
+      # closed. Recovery reruns the exact failed promotion; this gate never
+      # moves/deletes a tag or broadens the producer identity.
       - name: Wait for exact Desktop tagged publication
         timeout-minutes: 360
         env:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -926,18 +926,28 @@ jobs:
           bash scripts/tag_desktop_app.sh
 
       - name: Dispatch exact Desktop candidate promotion
+        id: desktop_dispatch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           APP_TAG: rapid-mac-v${{ needs.detect.outputs.version }}
           ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }}
           PRODUCER_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          gh workflow run rapid-mac-release.yml \
-            --ref "$APP_TAG" \
-            -f "promote_run_id=$PRODUCER_RUN_ID" \
-            -f "promote_sha=$ACCEPTED_SHA"
-          echo "::notice::dispatched exact Desktop promotion from auto-release run ${PRODUCER_RUN_ID} at ${ACCEPTED_SHA}"
+          PAYLOAD="$(jq -nc \
+            --arg ref "$APP_TAG" \
+            --arg run_id "$PRODUCER_RUN_ID" \
+            --arg sha "$ACCEPTED_SHA" \
+            '{ref: $ref, inputs: {promote_run_id: $run_id, promote_sha: $sha}}')"
+          RESPONSE="$(gh api \
+            --method POST \
+            --header 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/${REPO}/actions/workflows/rapid-mac-release.yml/dispatches" \
+            --input - <<<"$PAYLOAD")"
+          DESKTOP_RUN_ID="$(jq -er '.workflow_run_id | select(type == "number" and . > 0)' <<<"$RESPONSE")"
+          echo "desktop_run_id=$DESKTOP_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "::notice::dispatched exact Desktop promotion run ${DESKTOP_RUN_ID} from auto-release run ${PRODUCER_RUN_ID} at ${ACCEPTED_SHA}"
 
       # An existing same-SHA tag is an idempotent success for the tag claim, but
       # it does not prove the Desktop workflow ever completed. Wait for the exact
@@ -951,12 +961,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_TAG: rapid-mac-v${{ needs.detect.outputs.version }}
           ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }}
+          EXPECTED_RUN_ID: ${{ steps.desktop_dispatch.outputs.desktop_run_id }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           python3 scripts/check_desktop_publish.py \
             --app-tag "$APP_TAG" \
             --accepted-sha "$ACCEPTED_SHA" \
+            --expected-run-id "$EXPECTED_RUN_ID" \
             --repo "$REPO" \
             --workflow rapid-mac-release.yml \
             --deadline-min 350 \

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -394,17 +394,6 @@ jobs:
               raise SystemExit("producer run identity mismatch: " + ", ".join(failed))
           print(run["run_attempt"])
           PY
-          RUN_ATTEMPT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["run_attempt"])' "$RUN_JSON")"
-          JOBS="$RUNNER_TEMP/producer-jobs.json"
-          gh api "repos/${REPO}/actions/runs/${PROMOTE_RUN_ID}/jobs?filter=latest&per_page=100" > "$JOBS"
-          python3 - "$JOBS" <<'PY'
-          import json, pathlib, sys
-          jobs = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("jobs")
-          matches = [j for j in jobs or [] if j.get("name") == "desktop-candidate-gate"]
-          if len(matches) != 1 or matches[0].get("conclusion") != "success":
-              raise SystemExit("producer desktop-candidate-gate is not exactly one successful job")
-          PY
-          echo "run_attempt=$RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#rapid-mac-v}" >> "$GITHUB_OUTPUT"
 
       - name: Download exact SHA-labelled pre-tag candidate
@@ -418,14 +407,34 @@ jobs:
 
       - name: Verify provenance, signing, notarization, and tag binding
         env:
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
           PROMOTE_RUN_ID: ${{ inputs.promote_run_id }}
           PROMOTE_SHA: ${{ inputs.promote_sha }}
-          RUN_ATTEMPT: ${{ steps.producer.outputs.run_attempt }}
           VERSION: ${{ steps.producer.outputs.version }}
         run: |
           set -euo pipefail
+          RUN_ATTEMPT="$(python3 - <<'PY'
+          import json
+          manifest = json.load(open("candidate/desktop-promotion-manifest.json"))
+          attempt = (manifest.get("producer") or {}).get("run_attempt")
+          if type(attempt) is not int or attempt < 1:
+              raise SystemExit("candidate manifest has no positive producer run_attempt")
+          print(attempt)
+          PY
+          )"
+          JOBS="$RUNNER_TEMP/producer-jobs.json"
+          gh api \
+            "repos/${REPO}/actions/runs/${PROMOTE_RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100" \
+            > "$JOBS"
+          python3 - "$JOBS" <<'PY'
+          import json, pathlib, sys
+          jobs = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("jobs")
+          matches = [j for j in jobs or [] if j.get("name") == "desktop-candidate-gate"]
+          if len(matches) != 1 or matches[0].get("conclusion") != "success":
+              raise SystemExit("artifact-producing desktop-candidate-gate attempt is not exactly one successful job")
+          PY
           python3 scripts/desktop_promotion.py verify \
             --bundle candidate \
             --manifest candidate/desktop-promotion-manifest.json \

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -4,12 +4,14 @@
 # private desktop repo's release.yml. It builds apps/rapid-mac/ (the
 # SwiftUI app + its bundled rapid-mlx sidecar), signs it with a Developer
 # ID identity, notarises + staples both the .app and the .dmg, and
-# attaches the DMG to the GitHub Release for the tag.
+# attaches the DMG to the GitHub Release for the tag. Auto-release dispatches
+# this workflow with a producer run/SHA to promote its exact pre-tag bytes;
+# standalone tag pushes and input-free manual dispatches retain the build path.
 #
 # Trigger: pushing a ``rapid-mac-v*`` tag. The ``rapid-mac-v`` prefix keeps
 # app releases from colliding with the engine's own ``v*`` release tags in
-# this same monorepo. A manual workflow_dispatch does the same build but
-# only uploads a workflow artifact (no GitHub Release), so signing can be
+# this same monorepo. An input-free manual workflow_dispatch does the same build
+# but only uploads a workflow artifact (no GitHub Release), so signing can be
 # dry-run without cutting a tag.
 #
 # ── Required GitHub Actions secrets (Settings → Secrets and variables →
@@ -61,6 +63,15 @@ on:
     tags:
       - "rapid-mac-v*"
   workflow_dispatch:
+    inputs:
+      promote_run_id:
+        description: Exact auto-release run that produced the pre-tag candidate bundle.
+        required: false
+        type: string
+      promote_sha:
+        description: Exact 40-character source SHA bound into that candidate bundle.
+        required: false
+        type: string
 
 permissions:
   contents: write   # attach the .dmg to the GitHub Release
@@ -68,6 +79,11 @@ permissions:
 
 jobs:
   build:
+    # Standalone tag pushes and input-free manual dry runs retain the complete
+    # build path. Auto-release supplies both promotion inputs and skips rebuild.
+    if: >-
+      github.event_name != 'workflow_dispatch'
+      || (inputs.promote_run_id == '' && inputs.promote_sha == '')
     runs-on: macos-15   # default Xcode 16 → Swift 6.0 (Package.swift tools 6.0)
     timeout-minutes: 120
     outputs:
@@ -225,10 +241,9 @@ jobs:
 
       - name: Build + sign + notarise + DMG-validate (shared contract)
         id: releasable
-        # #2301: the tag-triggered lane runs the EXACT same signed/notarised/
-        # DMG-validated gate as the pre-tag candidate lane, via the single
-        # desktop-releasable composite action, so the two can never drift. It
-        # produces + verifies the Desktop manifest and creates no pointer.
+        # Standalone tag pushes and input-free dry runs use the shared build
+        # contract. Auto-release promotion skips this job and re-verifies the
+        # already-built candidate in promote-candidate below.
         uses: ./.github/actions/desktop-releasable
         with:
           checkout_path: ${{ github.workspace }}
@@ -318,6 +333,182 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  promote-candidate:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      && inputs.promote_run_id != ''
+      && inputs.promote_sha != ''
+    runs-on: macos-15
+    timeout-minutes: 45
+    outputs:
+      signed: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify exact tag and producer run identity
+        id: producer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          PROMOTE_RUN_ID: ${{ inputs.promote_run_id }}
+          PROMOTE_SHA: ${{ inputs.promote_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$PROMOTE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::promote_run_id must be a positive integer"
+            exit 1
+          }
+          [[ "$PROMOTE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::promote_sha must be a full lowercase commit SHA"
+            exit 1
+          }
+          [[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?$ ]] || {
+            echo "::error::promotion must be dispatched at a rapid-mac-v* tag"
+            exit 1
+          }
+          source scripts/resolve_github_tag.sh
+          TAG_SHA="$(resolve_github_tag_commit "$TAG")"
+          [[ "$TAG_SHA" == "$PROMOTE_SHA" && "$GITHUB_SHA" == "$PROMOTE_SHA" ]] || {
+            echo "::error::tag=${TAG_SHA}, checkout=${GITHUB_SHA}, requested=${PROMOTE_SHA}; refusing cross-SHA promotion"
+            exit 1
+          }
+
+          RUN_JSON="$RUNNER_TEMP/producer-run.json"
+          gh api "repos/${REPO}/actions/runs/${PROMOTE_RUN_ID}" > "$RUN_JSON"
+          python3 - "$RUN_JSON" "$REPO" "$PROMOTE_SHA" <<'PY'
+          import json, pathlib, sys
+          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          expected_repo, expected_sha = sys.argv[2:]
+          checks = {
+              "repository": (run.get("repository") or {}).get("full_name") == expected_repo,
+              "workflow": run.get("path") == ".github/workflows/auto-release.yml",
+              "source": run.get("head_sha") == expected_sha,
+              "event": run.get("event") in {"push", "workflow_dispatch"},
+              "attempt": type(run.get("run_attempt")) is int and run["run_attempt"] > 0,
+          }
+          failed = [name for name, ok in checks.items() if not ok]
+          if failed:
+              raise SystemExit("producer run identity mismatch: " + ", ".join(failed))
+          print(run["run_attempt"])
+          PY
+          RUN_ATTEMPT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["run_attempt"])' "$RUN_JSON")"
+          JOBS="$RUNNER_TEMP/producer-jobs.json"
+          gh api "repos/${REPO}/actions/runs/${PROMOTE_RUN_ID}/jobs?filter=latest&per_page=100" > "$JOBS"
+          python3 - "$JOBS" <<'PY'
+          import json, pathlib, sys
+          jobs = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("jobs")
+          matches = [j for j in jobs or [] if j.get("name") == "desktop-candidate-gate"]
+          if len(matches) != 1 or matches[0].get("conclusion") != "success":
+              raise SystemExit("producer desktop-candidate-gate is not exactly one successful job")
+          PY
+          echo "run_attempt=$RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#rapid-mac-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download exact SHA-labelled pre-tag candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mlx-desktop-pre-tag-candidate-${{ inputs.promote_sha }}
+          path: candidate
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.promote_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify provenance, signing, notarization, and tag binding
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          PROMOTE_RUN_ID: ${{ inputs.promote_run_id }}
+          PROMOTE_SHA: ${{ inputs.promote_sha }}
+          RUN_ATTEMPT: ${{ steps.producer.outputs.run_attempt }}
+          VERSION: ${{ steps.producer.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 scripts/desktop_promotion.py verify \
+            --bundle candidate \
+            --manifest candidate/desktop-promotion-manifest.json \
+            --repository "$REPO" \
+            --workflow .github/workflows/auto-release.yml \
+            --run-id "$PROMOTE_RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --source-sha "$PROMOTE_SHA" \
+            --version "$VERSION" \
+            --app-tag "$TAG"
+
+          PROJ="apps/rapid-mac"
+          mkdir -p "$PROJ/build"
+          cp candidate/rapid-mlx-desktop.dmg "$PROJ/build/rapid-mlx-desktop.dmg"
+          cp candidate/rapid-mlx-desktop.manifest.json "$PROJ/build/rapid-mlx-desktop.manifest.json"
+          MOUNT="$RUNNER_TEMP/promoted-dmg"
+          mkdir -p "$MOUNT"
+          hdiutil attach candidate/rapid-mlx-desktop.dmg -nobrowse -readonly -mountpoint "$MOUNT"
+          trap 'hdiutil detach "$MOUNT" -quiet || hdiutil detach "$MOUNT" -force -quiet || true' EXIT
+          ditto "$MOUNT/Rapid-MLX Desktop.app" "$PROJ/build/Rapid-MLX Desktop.app"
+          hdiutil detach "$MOUNT" -quiet
+          trap - EXIT
+          python3 scripts/desktop_manifest.py verify \
+            --app-dir "$PROJ" \
+            --dmg candidate/rapid-mlx-desktop.dmg \
+            --manifest candidate/rapid-mlx-desktop.manifest.json
+          bash "$PROJ/scripts/validate-dmg.sh" candidate/rapid-mlx-desktop.dmg
+          xcrun stapler validate candidate/rapid-mlx-desktop.dmg
+          spctl --assess --type open --context context:primary-signature --verbose=2 \
+            candidate/rapid-mlx-desktop.dmg
+
+      - name: Promote exact DMG + manifest bytes into this run
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mlx-desktop-dmg
+          path: |
+            candidate/rapid-mlx-desktop.dmg
+            candidate/rapid-mlx-desktop.manifest.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Promote exact release-note bytes into this run
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-release-notes
+          path: candidate/release-notes.md
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Promote exact Sparkle bytes into this run
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-sparkle-update
+          path: |
+            candidate/sparkle/*.zip
+            candidate/sparkle/appcast.xml
+          if-no-files-found: error
+          retention-days: 7
+
+  desktop-ready:
+    needs: [build, promote-candidate]
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      signed: ${{ steps.mode.outputs.signed }}
+    steps:
+      - name: Require exactly one successful Desktop source lane
+        id: mode
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          PROMOTE_RESULT: ${{ needs.promote-candidate.result }}
+          BUILD_SIGNED: ${{ needs.build.outputs.signed }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_RESULT" == "success" && "$PROMOTE_RESULT" == "skipped" ]]; then
+            echo "signed=$BUILD_SIGNED" >> "$GITHUB_OUTPUT"
+          elif [[ "$BUILD_RESULT" == "skipped" && "$PROMOTE_RESULT" == "success" ]]; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::expected exactly one successful Desktop source lane; build=$BUILD_RESULT promotion=$PROMOTE_RESULT"
+            exit 1
+          fi
+
   # ─────────────────────────────────────────────────────────────────────
   # REQUIRED FOR TAGS: mirror the notarised DMG and update the static fallback.
   #
@@ -334,7 +525,7 @@ jobs:
   #   * The manifest is uploaded last, after the immutable DMG, so clients can
   #     never observe a release whose artifact is not available yet.
   mirror-dist:
-    needs: build
+    needs: desktop-ready
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/')
@@ -352,7 +543,7 @@ jobs:
           path: notes
 
       - name: Download the signed Sparkle update
-        if: needs.build.outputs.signed == 'true'
+        if: needs.desktop-ready.outputs.signed == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: rapid-mac-sparkle-update
@@ -403,7 +594,7 @@ jobs:
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
-          if [[ "${{ needs.build.outputs.signed }}" == "true" ]]; then
+          if [[ "${{ needs.desktop-ready.outputs.signed }}" == "true" ]]; then
             SPARKLE_ZIP="$(find sparkle -maxdepth 1 -type f -name '*.zip' -print -quit)"
             [[ -n "$SPARKLE_ZIP" && -f "$SPARKLE_ZIP" ]] || {
               echo "::error::missing signed Sparkle ZIP"
@@ -457,7 +648,7 @@ jobs:
           if-no-files-found: error
 
       - name: Stage Sparkle appcast for serialized publication
-        if: needs.build.outputs.signed == 'true'
+        if: needs.desktop-ready.outputs.signed == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rapid-mac-sparkle-appcast
@@ -468,7 +659,7 @@ jobs:
   # serialized here. Turnstyle queues every run (unlike native concurrency,
   # which keeps only one pending run and can drop an intermediate tag).
   publish-updater-fallback:
-    needs: [build, mirror-dist]
+    needs: [desktop-ready, mirror-dist]
     runs-on: ubuntu-latest
     # Includes the turnstyle queue plus final updater/Release publication.
     timeout-minutes: 120
@@ -505,7 +696,7 @@ jobs:
           path: notes
 
       - name: Download staged Sparkle appcast
-        if: needs.build.outputs.signed == 'true'
+        if: needs.desktop-ready.outputs.signed == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: rapid-mac-sparkle-appcast
@@ -615,7 +806,7 @@ jobs:
             --file dist/latest.json --content-type application/json \
             --cache-control "no-cache, must-revalidate" --remote
 
-          if [[ "${{ needs.build.outputs.signed }}" == "true" ]]; then
+          if [[ "${{ needs.desktop-ready.outputs.signed }}" == "true" ]]; then
             [[ -s sparkle/appcast.xml ]] || { echo "::error::missing appcast.xml"; exit 1; }
             npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/appcast.xml" \
               --file sparkle/appcast.xml --content-type application/xml \
@@ -667,7 +858,7 @@ jobs:
           # ``GH_REPO`` lets gh resolve the repo without a working tree.
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-          SIGNED: ${{ needs.build.outputs.signed }}
+          SIGNED: ${{ needs.desktop-ready.outputs.signed }}
         run: |
           set -euo pipefail
           VERSION="${TAG#rapid-mac-v}"

--- a/scripts/check_desktop_publish.py
+++ b/scripts/check_desktop_publish.py
@@ -16,7 +16,8 @@ all of the following hold:
   2. An EXACT `rapid-mac-release.yml` run reaches SUCCESS within the deadline. A
      run is exact when its ref/branch is the tag, its head_sha equals
      ``accepted_sha``, and its event is the tag push (or an explicit
-     ``workflow_dispatch`` at the tag ref — a recovery we never create here).
+     ``workflow_dispatch`` at the tag ref. Auto-release creates that dispatch
+     with the exact pre-tag producer run and accepted SHA).
      Poll policy: prefer any exact success; keep waiting while an exact run is
      active (queued/in_progress); fail only when no exact run is active and a
      failed one remains.
@@ -29,9 +30,9 @@ all of the following hold:
      deadline.
 
 If the tag exists but no successful exact run/release is reached, the diagnostic
-directs recovery to: rerun the failed exact workflow, or dispatch
-``rapid-mac-release.yml`` at ``--ref <tag>``, then re-run auto-release. It never
-moves or deletes the tag, and it never auto-dispatches or broadens publication.
+directs recovery to rerun that exact promotion or rerun auto-release, whose
+dispatch supplies both required ``promote_run_id`` and ``promote_sha`` inputs.
+This helper never moves/deletes a tag or broadens publication.
 
 All logic is exercised with raw ``gh`` output (never text/regex on structured
 fields) and a deadline + sleep that are injectable, so the poll behaviour is
@@ -181,7 +182,8 @@ def _qualifying_runs(
     Uses the official workflow-runs API filtered by ``branch == app_tag``, then
     requires, in Python: ``head_branch == app_tag`` (exact ref), ``head_sha ==
     accepted_sha`` (exact candidate), and ``event`` in {push, workflow_dispatch}
-    (push is the expected trigger; dispatch-at-tag is an explicit recovery).
+    (push is the standalone tag path; dispatch-at-tag is the auto-release
+    build-once promotion path).
     API discontinuity (call fails, malformed JSON) fails immediately here.
     """
     runs_json = _run(
@@ -477,17 +479,18 @@ def verify(
             raise PublishGateError(
                 f"{app_tag}: rapid-mac-release.yml run(s) on the tag ref completed "
                 f"without success and no exact run is active. The tagged Desktop "
-                "publish failed. Recovery: re-run the failed exact workflow run, or "
-                f"dispatch rapid-mac-release.yml at --ref {app_tag}, then re-run "
-                "auto-release. Do NOT move or delete the tag."
+                "publish failed. Recovery: re-run the failed exact promotion, or "
+                "re-run auto-release so it dispatches rapid-mac-release.yml with "
+                "the exact promote_run_id and promote_sha. Do NOT move or delete "
+                "the tag."
             )
         if time.monotonic() >= deadline:
             raise PublishGateError(
                 f"{app_tag}: no successful, exact rapid-mac-release.yml run on the tag "
                 "ref within the deadline. The tagged Desktop publish did not "
-                "complete. Recovery: re-run the failed exact workflow, or dispatch "
-                f"rapid-mac-release.yml at --ref {app_tag}, then re-run auto-release. "
-                "Do NOT move or delete the tag."
+                "complete. Recovery: re-run the failed exact promotion, or re-run "
+                "auto-release so it supplies the exact promote_run_id and "
+                "promote_sha. Do NOT move or delete the tag."
             )
         time.sleep(sleep_sec)
 
@@ -515,8 +518,8 @@ def verify(
             f"{app_tag}: the run succeeded but no published (non-draft) GitHub "
             "Release with an uploaded non-zero rapid-mlx-desktop.dmg asset exists. "
             "The Desktop artifact was not published; the engine must not release. "
-            "Recovery: re-run the failed exact workflow, or dispatch "
-            f"rapid-mac-release.yml at --ref {app_tag}, then re-run auto-release."
+            "Recovery: re-run the failed exact promotion, or re-run auto-release "
+            "so it supplies the exact promote_run_id and promote_sha."
         )
     release_digest, release_size = release_identity
     if (release_digest, release_size) != (run_digest, run_size):

--- a/scripts/check_desktop_publish.py
+++ b/scripts/check_desktop_publish.py
@@ -13,11 +13,10 @@ all of the following hold:
   1. ``app_tag`` is a valid release version (via the shared release_version
      parser) and the tag resolves (peeling annotated objects) to exactly
      ``accepted_sha`` — the SHA the candidate lane validated.
-  2. An EXACT `rapid-mac-release.yml` run reaches SUCCESS within the deadline. A
-     run is exact when its ref/branch is the tag, its head_sha equals
-     ``accepted_sha``, and its event is the tag push (or an explicit
-     ``workflow_dispatch`` at the tag ref. Auto-release creates that dispatch
-     with the exact pre-tag producer run and accepted SHA).
+  2. The EXACT `rapid-mac-release.yml` run ID returned by auto-release's
+     ``workflow_dispatch`` reaches SUCCESS within the deadline. Its ref/branch
+     must be the tag, its head_sha must equal ``accepted_sha``, and its event
+     must be ``workflow_dispatch``. A concurrent manual/tag run cannot qualify.
      Poll policy: prefer any exact success; keep waiting while an exact run is
      active (queued/in_progress); fail only when no exact run is active and a
      failed one remains.
@@ -175,15 +174,19 @@ def _resolve_tag(gh: str, repo: str, app_tag: str) -> str:
 
 
 def _qualifying_runs(
-    gh: str, repo: str, workflow: str, app_tag: str, accepted_sha: str
+    gh: str,
+    repo: str,
+    workflow: str,
+    app_tag: str,
+    accepted_sha: str,
+    expected_run_id: int,
 ) -> list[dict]:
     """List rapid-mac-release.yml runs; return those BOUND exactly to this tag+candidate.
 
     Uses the official workflow-runs API filtered by ``branch == app_tag``, then
-    requires, in Python: ``head_branch == app_tag`` (exact ref), ``head_sha ==
-    accepted_sha`` (exact candidate), and ``event`` in {push, workflow_dispatch}
-    (push is the standalone tag path; dispatch-at-tag is the auto-release
-    build-once promotion path).
+    requires, in Python: the exact run ID returned by the dispatch,
+    ``head_branch == app_tag``, ``head_sha == accepted_sha``, and event
+    ``workflow_dispatch``. Tag pushes and other manual dispatches are ignored.
     API discontinuity (call fails, malformed JSON) fails immediately here.
     """
     runs_json = _run(
@@ -210,7 +213,6 @@ def _qualifying_runs(
         ) from exc
     if not isinstance(runs, list):
         raise PublishGateError("workflow-runs API did not return an array")
-    allowed_events = {"push", "workflow_dispatch"}
     bound = []
     for r in runs:
         if not isinstance(r, dict):
@@ -235,9 +237,10 @@ def _qualifying_runs(
                 f"workflow-runs API returned malformed record: {r!r}"
             )
         if (
-            head_branch == app_tag
+            run_id == expected_run_id
+            and head_branch == app_tag
             and head_sha == accepted_sha
-            and event in allowed_events
+            and event == "workflow_dispatch"
         ):
             bound.append(
                 {
@@ -423,6 +426,7 @@ def verify(
     *,
     app_tag: str,
     accepted_sha: str,
+    expected_run_id: int,
     repo: str,
     workflow: str,
     gh: str,
@@ -432,6 +436,8 @@ def verify(
     """Return evidence lines or raise PublishGateError."""
     _assert_app_tag(app_tag)
     _assert_sha(accepted_sha)
+    if type(expected_run_id) is not int or expected_run_id < 1:
+        raise PublishGateError("expected-run-id must be a positive integer")
 
     evidence: list[str] = []
 
@@ -445,14 +451,14 @@ def verify(
         )
     evidence.append(f"tag {app_tag} resolves to validated candidate {accepted_sha}")
 
-    # 2) Poll the exact rapid-mac-release.yml run(s) bound to app_tag+accepted_sha.
-    #    Prefer any exact success; wait while an exact run is active; fail only
-    #    when no exact run is active and a failed one remains. API discontinuities
-    #    are fatal immediately (raised by _qualifying_runs/_run).
+    # 2) Poll only the exact run ID returned by the dispatch. A concurrent
+    #    input-free manual dispatch or tag-push rebuild cannot satisfy this gate.
     deadline = time.monotonic() + deadline_sec
     success_run = None
     while True:
-        bound = _qualifying_runs(gh, repo, workflow, app_tag, accepted_sha)
+        bound = _qualifying_runs(
+            gh, repo, workflow, app_tag, accepted_sha, expected_run_id
+        )
         completed = [r for r in bound if r.get("status") == "completed"]
         active = [
             r
@@ -460,9 +466,8 @@ def verify(
             if r.get("status") in ("queued", "in_progress", "waiting", "pending")
         ]
 
-        # Once the set settles, its newest exact run is authoritative. A newer
-        # failed rerun invalidates an older success; otherwise engine/Desktop
-        # identity could be certified from stale publication evidence.
+        # A rerun preserves its workflow run ID, so its latest state remains
+        # bound to the same dispatch without accepting any neighboring run.
         if bound and not active:
             newest = max(bound, key=lambda run: run["databaseId"])
             if (
@@ -550,6 +555,7 @@ def _parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--app-tag", required=True)
     p.add_argument("--accepted-sha", required=True)
+    p.add_argument("--expected-run-id", type=int, required=True)
     p.add_argument("--repo", required=True)
     p.add_argument("--workflow", default="rapid-mac-release.yml")
     p.add_argument("--gh", default="gh")
@@ -564,6 +570,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence = verify(
             app_tag=args.app_tag,
             accepted_sha=args.accepted_sha,
+            expected_run_id=args.expected_run_id,
             repo=args.repo,
             workflow=args.workflow,
             gh=args.gh,

--- a/scripts/desktop_promotion.py
+++ b/scripts/desktop_promotion.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Create and verify provenance for an exact pre-tag Desktop release bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import xml.etree.ElementTree as ET
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    from release_version import parse_version
+except ModuleNotFoundError:
+    from scripts.release_version import parse_version
+
+SCHEMA = 1
+LIFECYCLE_STAGE = "pre-tag-candidate"
+DMG = "rapid-mlx-desktop.dmg"
+DESKTOP_MANIFEST = "rapid-mlx-desktop.manifest.json"
+NOTES = "release-notes.md"
+APPCAST = "sparkle/appcast.xml"
+PROMOTION_MANIFEST = "desktop-promotion-manifest.json"
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha(value: str, label: str = "source SHA") -> str:
+    if len(value) != 40 or any(ch not in "0123456789abcdef" for ch in value):
+        raise ValueError(f"{label} must be a 40-character lowercase Git commit SHA")
+    return value
+
+
+def _positive(value: int, label: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _safe_relative(value: str) -> str:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or value != path.as_posix():
+        raise ValueError(f"unsafe promotion payload path: {value!r}")
+    return value
+
+
+def _regular_file(bundle: Path, relative: str) -> Path:
+    relative = _safe_relative(relative)
+    path = bundle / relative
+    if (
+        any(parent.is_symlink() for parent in [path, *list(path.parents)[:2]])
+        or not path.is_file()
+    ):
+        raise ValueError(f"promotion payload is missing a regular file: {relative}")
+    return path
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _payload_paths(bundle: Path) -> list[str]:
+    sparkle = bundle / "sparkle"
+    zips = sorted(
+        path for path in sparkle.glob("*.zip") if path.is_file() and not path.is_symlink()
+    )
+    if len(zips) != 1:
+        raise ValueError(
+            f"promotion bundle must contain exactly one regular sparkle/*.zip; found {len(zips)}"
+        )
+    paths = [DMG, DESKTOP_MANIFEST, NOTES, APPCAST, f"sparkle/{zips[0].name}"]
+    for relative in paths:
+        _regular_file(bundle, relative)
+    actual = {
+        path.relative_to(bundle).as_posix()
+        for path in bundle.rglob("*")
+        if path.is_file() or path.is_symlink()
+    }
+    allowed = {*paths, PROMOTION_MANIFEST}
+    unexpected = actual - allowed
+    if unexpected:
+        raise ValueError(
+            "promotion bundle contains unrecorded payload: " + ", ".join(sorted(unexpected))
+        )
+    if (bundle / NOTES).stat().st_size == 0:
+        raise ValueError("promotion release notes must not be empty")
+    return paths
+
+
+def _verify_desktop_manifest(
+    bundle: Path, *, source_sha: str, version: str, app_tag: str
+) -> None:
+    manifest = _load_json(bundle / DESKTOP_MANIFEST, "Desktop manifest")
+    if manifest.get("source_sha") != source_sha:
+        raise ValueError("Desktop manifest source SHA does not match promotion source")
+    if manifest.get("version") != version or manifest.get("app_tag") != app_tag:
+        raise ValueError("Desktop manifest version/tag does not match promotion identity")
+    if manifest.get("signed") is not True:
+        raise ValueError("Desktop manifest is not a signed release candidate")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) != 1:
+        raise ValueError("Desktop manifest must contain exactly one DMG artifact")
+    item = artifacts[0]
+    dmg = _regular_file(bundle, DMG)
+    if not isinstance(item, dict) or item.get("filename") != DMG:
+        raise ValueError("Desktop manifest does not name the canonical DMG")
+    if item.get("size") != dmg.stat().st_size or item.get("sha256") != _sha256(dmg):
+        raise ValueError("Desktop manifest does not match the canonical DMG bytes")
+
+
+def _verify_appcast(bundle: Path, *, version: str, zip_relative: str) -> None:
+    appcast = _regular_file(bundle, APPCAST)
+    try:
+        root = ET.parse(appcast).getroot()
+    except (OSError, ET.ParseError) as exc:
+        raise ValueError(f"cannot parse Sparkle appcast: {exc}") from exc
+    enclosures = root.findall(".//enclosure")
+    if len(enclosures) != 1:
+        raise ValueError(f"Sparkle appcast must contain exactly one enclosure; found {len(enclosures)}")
+    enclosure = enclosures[0]
+    zip_path = _regular_file(bundle, zip_relative)
+    url = enclosure.get("url", "")
+    if url.rsplit("/", 1)[-1] != zip_path.name:
+        raise ValueError("Sparkle enclosure URL does not name the promoted ZIP")
+    if enclosure.get("length") != str(zip_path.stat().st_size):
+        raise ValueError("Sparkle enclosure length does not match the promoted ZIP")
+    if enclosure.get(f"{{{SPARKLE_NS}}}shortVersionString") != version:
+        raise ValueError("Sparkle short version does not match the promotion version")
+    build = enclosure.get(f"{{{SPARKLE_NS}}}version", "")
+    if not build.isdigit() or int(build) < 1:
+        raise ValueError("Sparkle enclosure has no valid numeric bundle build")
+    if not enclosure.get(f"{{{SPARKLE_NS}}}edSignature"):
+        raise ValueError("Sparkle enclosure has no EdDSA signature")
+
+
+def create_manifest(
+    *,
+    bundle: Path,
+    repository: str,
+    workflow: str,
+    run_id: int,
+    run_attempt: int,
+    source_sha: str,
+    version: str,
+    app_tag: str,
+) -> dict[str, Any]:
+    _sha(source_sha)
+    parse_version(version)
+    if app_tag != f"rapid-mac-v{version}":
+        raise ValueError("promotion tag does not match version")
+    if repository.count("/") != 1 or repository.startswith("/") or repository.endswith("/"):
+        raise ValueError("repository must be an owner/name identifier")
+    if workflow != ".github/workflows/auto-release.yml":
+        raise ValueError("promotion producer must be auto-release.yml")
+    paths = _payload_paths(bundle)
+    _verify_desktop_manifest(
+        bundle, source_sha=source_sha, version=version, app_tag=app_tag
+    )
+    zip_relative = next(path for path in paths if path.endswith(".zip"))
+    _verify_appcast(bundle, version=version, zip_relative=zip_relative)
+    return {
+        "schema": SCHEMA,
+        "lifecycle_stage": LIFECYCLE_STAGE,
+        "release": {"version": version, "app_tag": app_tag},
+        "producer": {
+            "repository": repository,
+            "workflow": workflow,
+            "run_id": _positive(run_id, "run id"),
+            "run_attempt": _positive(run_attempt, "run attempt"),
+            "source_sha": source_sha,
+        },
+        "artifacts": [
+            {
+                "path": relative,
+                "sha256": _sha256(_regular_file(bundle, relative)),
+                "size": _regular_file(bundle, relative).stat().st_size,
+            }
+            for relative in paths
+        ],
+    }
+
+
+def verify_manifest(
+    *,
+    bundle: Path,
+    manifest_path: Path,
+    repository: str,
+    workflow: str,
+    run_id: int,
+    run_attempt: int,
+    source_sha: str,
+    version: str,
+    app_tag: str,
+) -> dict[str, Any]:
+    parse_version(version)
+    if app_tag != f"rapid-mac-v{version}":
+        raise ValueError("expected promotion tag does not match version")
+    canonical_manifest = _regular_file(bundle, PROMOTION_MANIFEST)
+    if manifest_path.absolute() != canonical_manifest.absolute():
+        raise ValueError("promotion manifest must be the canonical file inside the bundle")
+    manifest = _load_json(canonical_manifest, "promotion manifest")
+    if manifest.get("schema") != SCHEMA:
+        raise ValueError("promotion manifest has an unknown schema")
+    if manifest.get("lifecycle_stage") != LIFECYCLE_STAGE:
+        raise ValueError("promotion manifest has an unexpected lifecycle stage")
+    release = manifest.get("release")
+    producer = manifest.get("producer")
+    if not isinstance(release, dict) or release != {"version": version, "app_tag": app_tag}:
+        raise ValueError("promotion manifest release identity does not match expected tag/version")
+    if not isinstance(producer, dict):
+        raise ValueError("promotion manifest producer must be an object")
+    expected = {
+        "repository": repository,
+        "workflow": workflow,
+        "run_id": _positive(run_id, "expected run id"),
+        "run_attempt": _positive(run_attempt, "expected run attempt"),
+        "source_sha": _sha(source_sha, "expected source SHA"),
+    }
+    for key, value in expected.items():
+        if producer.get(key) != value:
+            raise ValueError(f"promotion producer {key} does not match the requested run")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("promotion manifest artifacts must be an array")
+    paths = _payload_paths(bundle)
+    if len(artifacts) != len(paths):
+        raise ValueError("promotion manifest artifact roster is incomplete")
+    recorded: dict[str, dict[str, Any]] = {}
+    for item in artifacts:
+        if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+            raise ValueError("promotion manifest contains a malformed artifact")
+        relative = _safe_relative(item["path"])
+        if relative in recorded:
+            raise ValueError(f"promotion manifest repeats artifact path {relative}")
+        recorded[relative] = item
+    if set(recorded) != set(paths):
+        raise ValueError("promotion manifest artifact roster does not match the bundle")
+    for relative in paths:
+        path = _regular_file(bundle, relative)
+        item = recorded[relative]
+        if item.get("size") != path.stat().st_size or item.get("sha256") != _sha256(path):
+            raise ValueError(f"promotion artifact bytes do not match manifest: {relative}")
+
+    _verify_desktop_manifest(
+        bundle, source_sha=source_sha, version=version, app_tag=app_tag
+    )
+    _verify_appcast(
+        bundle,
+        version=version,
+        zip_relative=next(path for path in paths if path.endswith(".zip")),
+    )
+    return manifest
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--bundle", type=Path, required=True)
+    common.add_argument("--repository", required=True)
+    common.add_argument("--workflow", default=".github/workflows/auto-release.yml")
+    common.add_argument("--run-id", type=int, required=True)
+    common.add_argument("--source-sha", required=True)
+    common.add_argument("--version", required=True)
+    common.add_argument("--app-tag", required=True)
+    create = sub.add_parser("create", parents=[common])
+    create.add_argument("--run-attempt", type=int, required=True)
+    create.add_argument("--output", type=Path, required=True)
+    verify = sub.add_parser("verify", parents=[common])
+    verify.add_argument("--run-attempt", type=int, required=True)
+    verify.add_argument("--manifest", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            manifest = create_manifest(
+                bundle=args.bundle,
+                repository=args.repository,
+                workflow=args.workflow,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+                source_sha=args.source_sha,
+                version=args.version,
+                app_tag=args.app_tag,
+            )
+            args.output.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        else:
+            verify_manifest(
+                bundle=args.bundle,
+                manifest_path=args.manifest,
+                repository=args.repository,
+                workflow=args.workflow,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+                source_sha=args.source_sha,
+                version=args.version,
+                app_tag=args.app_tag,
+            )
+    except (OSError, ValueError) as exc:
+        print(f"desktop promotion: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/desktop_promotion.py
+++ b/scripts/desktop_promotion.py
@@ -79,7 +79,9 @@ def _load_json(path: Path, label: str) -> dict[str, Any]:
 def _payload_paths(bundle: Path) -> list[str]:
     sparkle = bundle / "sparkle"
     zips = sorted(
-        path for path in sparkle.glob("*.zip") if path.is_file() and not path.is_symlink()
+        path
+        for path in sparkle.glob("*.zip")
+        if path.is_file() and not path.is_symlink()
     )
     if len(zips) != 1:
         raise ValueError(
@@ -97,7 +99,8 @@ def _payload_paths(bundle: Path) -> list[str]:
     unexpected = actual - allowed
     if unexpected:
         raise ValueError(
-            "promotion bundle contains unrecorded payload: " + ", ".join(sorted(unexpected))
+            "promotion bundle contains unrecorded payload: "
+            + ", ".join(sorted(unexpected))
         )
     if (bundle / NOTES).stat().st_size == 0:
         raise ValueError("promotion release notes must not be empty")
@@ -111,7 +114,9 @@ def _verify_desktop_manifest(
     if manifest.get("source_sha") != source_sha:
         raise ValueError("Desktop manifest source SHA does not match promotion source")
     if manifest.get("version") != version or manifest.get("app_tag") != app_tag:
-        raise ValueError("Desktop manifest version/tag does not match promotion identity")
+        raise ValueError(
+            "Desktop manifest version/tag does not match promotion identity"
+        )
     if manifest.get("signed") is not True:
         raise ValueError("Desktop manifest is not a signed release candidate")
     artifacts = manifest.get("artifacts")
@@ -133,7 +138,9 @@ def _verify_appcast(bundle: Path, *, version: str, zip_relative: str) -> None:
         raise ValueError(f"cannot parse Sparkle appcast: {exc}") from exc
     enclosures = root.findall(".//enclosure")
     if len(enclosures) != 1:
-        raise ValueError(f"Sparkle appcast must contain exactly one enclosure; found {len(enclosures)}")
+        raise ValueError(
+            f"Sparkle appcast must contain exactly one enclosure; found {len(enclosures)}"
+        )
     enclosure = enclosures[0]
     zip_path = _regular_file(bundle, zip_relative)
     url = enclosure.get("url", "")
@@ -165,7 +172,11 @@ def create_manifest(
     parse_version(version)
     if app_tag != f"rapid-mac-v{version}":
         raise ValueError("promotion tag does not match version")
-    if repository.count("/") != 1 or repository.startswith("/") or repository.endswith("/"):
+    if (
+        repository.count("/") != 1
+        or repository.startswith("/")
+        or repository.endswith("/")
+    ):
         raise ValueError("repository must be an owner/name identifier")
     if workflow != ".github/workflows/auto-release.yml":
         raise ValueError("promotion producer must be auto-release.yml")
@@ -214,7 +225,9 @@ def verify_manifest(
         raise ValueError("expected promotion tag does not match version")
     canonical_manifest = _regular_file(bundle, PROMOTION_MANIFEST)
     if manifest_path.absolute() != canonical_manifest.absolute():
-        raise ValueError("promotion manifest must be the canonical file inside the bundle")
+        raise ValueError(
+            "promotion manifest must be the canonical file inside the bundle"
+        )
     manifest = _load_json(canonical_manifest, "promotion manifest")
     if manifest.get("schema") != SCHEMA:
         raise ValueError("promotion manifest has an unknown schema")
@@ -222,8 +235,13 @@ def verify_manifest(
         raise ValueError("promotion manifest has an unexpected lifecycle stage")
     release = manifest.get("release")
     producer = manifest.get("producer")
-    if not isinstance(release, dict) or release != {"version": version, "app_tag": app_tag}:
-        raise ValueError("promotion manifest release identity does not match expected tag/version")
+    if not isinstance(release, dict) or release != {
+        "version": version,
+        "app_tag": app_tag,
+    }:
+        raise ValueError(
+            "promotion manifest release identity does not match expected tag/version"
+        )
     if not isinstance(producer, dict):
         raise ValueError("promotion manifest producer must be an object")
     expected = {
@@ -235,7 +253,9 @@ def verify_manifest(
     }
     for key, value in expected.items():
         if producer.get(key) != value:
-            raise ValueError(f"promotion producer {key} does not match the requested run")
+            raise ValueError(
+                f"promotion producer {key} does not match the requested run"
+            )
     artifacts = manifest.get("artifacts")
     if not isinstance(artifacts, list):
         raise ValueError("promotion manifest artifacts must be an array")
@@ -255,8 +275,12 @@ def verify_manifest(
     for relative in paths:
         path = _regular_file(bundle, relative)
         item = recorded[relative]
-        if item.get("size") != path.stat().st_size or item.get("sha256") != _sha256(path):
-            raise ValueError(f"promotion artifact bytes do not match manifest: {relative}")
+        if item.get("size") != path.stat().st_size or item.get("sha256") != _sha256(
+            path
+        ):
+            raise ValueError(
+                f"promotion artifact bytes do not match manifest: {relative}"
+            )
 
     _verify_desktop_manifest(
         bundle, source_sha=source_sha, version=version, app_tag=app_tag

--- a/scripts/tag_desktop_app.sh
+++ b/scripts/tag_desktop_app.sh
@@ -9,21 +9,18 @@
 # ``rapid-mac-vX.Y.Z`` tag was a manual step somebody had to remember, and
 # for four releases nobody did.
 #
-# Creating ``refs/tags/rapid-mac-v$VERSION`` hands off to
-# .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
-# and attaches the DMG.
+# Creating ``refs/tags/rapid-mac-v$VERSION`` records the immutable release
+# identity. The caller explicitly dispatches .github/workflows/rapid-mac-release.yml
+# with the pre-tag producer run and SHA, so that workflow promotes the already
+# signed/notarised bytes instead of rebuilding them.
 #
 # WHY THE API AND NOT ``git push``
 # --------------------------------
-# actions/checkout persists the default ``GITHUB_TOKEN`` as the credential
-# for ``origin``, and GitHub suppresses workflow runs caused by pushes
-# authenticated with ``GITHUB_TOKEN`` (its anti-loop guard). A ``git push``
-# of this tag would therefore succeed, the step would go green, and NO app
-# build, signing, notarisation or DMG would ever happen — the silent
-# half-release this whole change exists to prevent. Going through
-# ``gh api`` uses ``GH_TOKEN``, which the workflow sets to the RELEASE_PAT
-# user; a ref created by a real user does fire ``push``. This is the same
-# reason create_release.sh runs under the PAT.
+# The API makes the tag claim atomic and token-independent. Auto-release uses
+# its default ``GITHUB_TOKEN`` intentionally: GitHub suppresses the resulting
+# push-triggered workflow, then the caller issues one explicit workflow_dispatch
+# carrying the exact producer run and source SHA. That avoids a duplicate build
+# while preserving standalone PAT/manual tag pushes as a supported rebuild path.
 #
 # Idempotency is a POST, not a pre-check: ``POST /git/refs`` fails 422 when
 # the ref already exists, so the claim is atomic. Only on that failure do we
@@ -34,21 +31,6 @@
 # rapid-mac tags are annotated). Same tree → done. Different tree → refuse:
 # moving a published tag would ship one version's notes against another's
 # build.
-#
-# WHY A MISSING PAT IS FATAL RATHER THAN A FALLBACK
-# -------------------------------------------------
-# Creating the tag under GITHUB_TOKEN would be worse than not creating it. The
-# ref would exist and this step would go green, but the run it should have
-# triggered is suppressed — and the recovery (restore the secret, re-run) then
-# finds a tag that already points at the right commit and exits 0 without
-# emitting any event. The app could never be built for that version again
-# without hand-deleting a published tag.
-#
-# Skipping quietly is no better: the run ends green with only the engine
-# released, and a re-run sees the published engine Release, decides there is
-# nothing to release, and never reaches this step again. So this refuses to
-# run at all. In the workflow the same condition is checked BEFORE anything is
-# published, which is what makes "set the secret and re-run" an actual fix.
 #
 # Required environment:
 #   VERSION            X.Y.Z — the version the engine just released
@@ -61,13 +43,8 @@
 #                      validated. This is what stops an RC tag from preceding its
 #                      validated artifact commit (#2301).
 #   GITHUB_REPOSITORY  owner/repo
-#   GH_TOKEN           consumed by ``gh`` (RELEASE_PAT in the workflow)
+#   GH_TOKEN           consumed by ``gh`` (GITHUB_TOKEN in auto-release)
 # Optional:
-#   HAVE_PAT           "true" when GH_TOKEN is the RELEASE_PAT. Anything else,
-#                      INCLUDING the empty string, refuses to tag (see above).
-#                      Only a genuinely unset value defaults to true, for a
-#                      hand-run — an empty one means a workflow expression
-#                      evaluated to nothing, which must not read as consent.
 #   GH                 path to the gh binary (tests point this at a mock)
 #
 # Exit status: 0 tag created or already correct, 1 anything else.
@@ -79,7 +56,6 @@ set -euo pipefail
 : "${ACCEPTED_SHA:?tag_desktop_app.sh: ACCEPTED_SHA is required — a desktop tag can only be claimed at the SHA a candidate build validated}"
 : "${GITHUB_REPOSITORY:?tag_desktop_app.sh: GITHUB_REPOSITORY is required}"
 GH_BIN="${GH:-gh}"
-HAVE_PAT="${HAVE_PAT-true}"
 
 # Both SHAs must be full 40-character commits. Comparing short SHAs would let a
 # collision or a truncation mistake read as the same commit, and a human must be
@@ -113,12 +89,6 @@ fi
 
 APP_TAG="rapid-mac-v${VERSION}"
 
-if [ "$HAVE_PAT" != "true" ]; then
-  echo "::error::refusing to create ${APP_TAG}: RELEASE_PAT is not available, and a tag written with the default GITHUB_TOKEN triggers no workflow — no DMG would ever be built, and the tag's existence would then block every retry." >&2
-  echo "   Set the RELEASE_PAT secret and run again." >&2
-  exit 1
-fi
-
 # Print the exact identity being claimed BEFORE the irreversible POST, so the
 # run log and the environment-approval audit both carry the full commit that a
 # candidate build validated — never a branch name or short SHA.
@@ -127,7 +97,7 @@ echo "Claiming $APP_TAG at validated candidate SHA $RELEASE_SHA"
 
 if "$GH_BIN" api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
     -f "ref=refs/tags/$APP_TAG" -f "sha=$RELEASE_SHA" >/dev/null 2>&1; then
-  echo "Created $APP_TAG at $RELEASE_SHA → rapid-mac-release.yml"
+  echo "Created $APP_TAG at $RELEASE_SHA; caller must dispatch rapid-mac-release.yml with the exact candidate run"
   exit 0
 fi
 

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -146,12 +146,14 @@ contains "$TAGSTEP" 'ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }
   "tag step claims at the pre-approval accepted SHA"
 contains "$TAGSTEP" 'scripts/tag_desktop_app.sh' "tag step invokes the tagged script"
 lacks "$TAGSTEP" "git push" "tag step never git pushes"
-contains "$TAGSTEP" 'gh workflow run rapid-mac-release.yml' \
+contains "$TAGSTEP" 'actions/workflows/rapid-mac-release.yml/dispatches' \
   "tag claim is followed by an explicit Desktop promotion dispatch"
-contains "$TAGSTEP" '-f "promote_run_id=$PRODUCER_RUN_ID"' \
+contains "$TAGSTEP" 'promote_run_id: $run_id' \
   "promotion dispatch carries the exact producer run"
-contains "$TAGSTEP" '-f "promote_sha=$ACCEPTED_SHA"' \
+contains "$TAGSTEP" 'promote_sha: $sha' \
   "promotion dispatch carries the accepted source SHA"
+contains "$TAGSTEP" 'desktop_run_id=$DESKTOP_RUN_ID' \
+  "promotion dispatch records the exact child run ID"
 
 CANDIDATE=$(sed -n '/name: Stage exact pre-tag Desktop candidate bundle/,/^  dry-run-summary:/p' "$AUTO_RELEASE")
 contains "$CANDIDATE" 'desktop_promotion.py create' \
@@ -166,6 +168,10 @@ contains "$PROMOTE" 'run-id: ${{ inputs.promote_run_id }}' \
   "publisher downloads from the exact producer run"
 contains "$PROMOTE" 'desktop_promotion.py verify' \
   "publisher verifies every promoted byte and producer identity"
+contains "$PROMOTE" 'manifest.get("producer")' \
+  "publisher reads the artifact-producing attempt from the downloaded manifest"
+contains "$PROMOTE" '/attempts/${RUN_ATTEMPT}/jobs' \
+  "publisher verifies the candidate job from the artifact-producing attempt"
 contains "$PROMOTE" 'desktop_manifest.py verify' \
   "publisher re-verifies the DMG manifest against its extracted app"
 contains "$PROMOTE" 'xcrun stapler validate' \
@@ -189,6 +195,10 @@ contains "$PUBLISH_WAIT" 'APP_TAG: rapid-mac-v${{ needs.detect.outputs.version }
   "publication wait binds the exact Desktop tag"
 contains "$PUBLISH_WAIT" 'ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }}' \
   "publication wait binds the validated candidate SHA"
+contains "$PUBLISH_WAIT" 'EXPECTED_RUN_ID: ${{ steps.desktop_dispatch.outputs.desktop_run_id }}' \
+  "publication wait binds the exact dispatched child run"
+contains "$PUBLISH_WAIT" '--expected-run-id "$EXPECTED_RUN_ID"' \
+  "publication helper receives that exact child run ID"
 contains "$PUBLISH_WAIT" '--workflow rapid-mac-release.yml' \
   "publication wait binds the expected Desktop workflow"
 contains "$PUBLISH_WAIT" 'timeout-minutes: 360' \

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -146,6 +146,38 @@ contains "$TAGSTEP" 'ACCEPTED_SHA: ${{ needs.release-prep.outputs.accepted_sha }
   "tag step claims at the pre-approval accepted SHA"
 contains "$TAGSTEP" 'scripts/tag_desktop_app.sh' "tag step invokes the tagged script"
 lacks "$TAGSTEP" "git push" "tag step never git pushes"
+contains "$TAGSTEP" 'gh workflow run rapid-mac-release.yml' \
+  "tag claim is followed by an explicit Desktop promotion dispatch"
+contains "$TAGSTEP" '-f "promote_run_id=$PRODUCER_RUN_ID"' \
+  "promotion dispatch carries the exact producer run"
+contains "$TAGSTEP" '-f "promote_sha=$ACCEPTED_SHA"' \
+  "promotion dispatch carries the accepted source SHA"
+
+CANDIDATE=$(sed -n '/name: Stage exact pre-tag Desktop candidate bundle/,/^  dry-run-summary:/p' "$AUTO_RELEASE")
+contains "$CANDIDATE" 'desktop_promotion.py create' \
+  "candidate creates cryptographic promotion provenance"
+contains "$CANDIDATE" 'rapid-mlx-desktop-pre-tag-candidate-${{ github.sha }}' \
+  "candidate artifact name exposes lifecycle stage and full source SHA"
+contains "$CANDIDATE" 'apps/rapid-mac/build/sparkle/appcast.xml' \
+  "candidate stages the exact signed Sparkle appcast"
+
+PROMOTE=$(sed -n '/^  promote-candidate:/,/^  desktop-ready:/p' "$RAPID_RELEASE")
+contains "$PROMOTE" 'run-id: ${{ inputs.promote_run_id }}' \
+  "publisher downloads from the exact producer run"
+contains "$PROMOTE" 'desktop_promotion.py verify' \
+  "publisher verifies every promoted byte and producer identity"
+contains "$PROMOTE" 'desktop_manifest.py verify' \
+  "publisher re-verifies the DMG manifest against its extracted app"
+contains "$PROMOTE" 'xcrun stapler validate' \
+  "publisher re-validates the notarization ticket"
+contains "$PROMOTE" 'spctl --assess' \
+  "publisher re-validates Gatekeeper acceptance"
+contains "$PROMOTE" 'name: rapid-mlx-desktop-dmg' \
+  "publisher exposes exact bytes under the canonical downstream artifact name"
+lacks "$PROMOTE" 'desktop-releasable' \
+  "promotion lane never invokes the build action"
+lacks "$PROMOTE" 'notarize.sh' \
+  "promotion lane never re-notarizes or repacks"
 
 # A same-SHA tag claim may no-op after a prior failed/missed Desktop workflow.
 # The engine must therefore wait for exact tagged Desktop publication evidence,
@@ -201,20 +233,22 @@ else
 fi
 
 RESOLVER_USES=$(grep -c 'resolve_github_tag_commit "$TAG"' "$RAPID_RELEASE")
-[[ "$RESOLVER_USES" == 2 ]] \
-  && ok "both tagged-lane tag checks use the bounded recursive resolver" \
-  || bad "both tagged-lane tag checks use the bounded recursive resolver (got $RESOLVER_USES)"
+[[ "$RESOLVER_USES" == 3 ]] \
+  && ok "promotion plus both publication checks use the bounded recursive resolver" \
+  || bad "promotion plus both publication checks use the bounded recursive resolver (got $RESOLVER_USES)"
 lacks "$RAPID_RELEASE" 'git/refs/tags/${TAG}' \
   "tagged lane has no remaining one-level tag resolver"
 
-BUILD_TIMEOUT=$(sed -n '/^  build:/,/^  mirror-dist:/p' "$RAPID_RELEASE" | awk '/timeout-minutes:/ {print $2; exit}')
-MIRROR_TIMEOUT=$(sed -n '/^  mirror-dist:/,/^  publish-updater-fallback:/p' "$RAPID_RELEASE" | awk '/timeout-minutes:/ {print $2; exit}')
-PUBLISH_TIMEOUT=$(sed -n '/^  publish-updater-fallback:/,$p' "$RAPID_RELEASE" | awk '/timeout-minutes:/ {print $2; exit}')
-if [[ "$BUILD_TIMEOUT" == 120 && "$MIRROR_TIMEOUT" == 30 && "$PUBLISH_TIMEOUT" == 120 \
+BUILD_TIMEOUT=$(awk '/^  build:/{job=1} job && /timeout-minutes:/{print $2; exit}' "$RAPID_RELEASE")
+PROMOTE_TIMEOUT=$(awk '/^  promote-candidate:/{job=1} job && /timeout-minutes:/{print $2; exit}' "$RAPID_RELEASE")
+MIRROR_TIMEOUT=$(awk '/^  mirror-dist:/{job=1} job && /timeout-minutes:/{print $2; exit}' "$RAPID_RELEASE")
+PUBLISH_TIMEOUT=$(awk '/^  publish-updater-fallback:/{job=1} job && /timeout-minutes:/{print $2; exit}' "$RAPID_RELEASE")
+if [[ "$BUILD_TIMEOUT" == 120 && "$PROMOTE_TIMEOUT" == 45 \
+      && "$MIRROR_TIMEOUT" == 30 && "$PUBLISH_TIMEOUT" == 120 \
       && $((BUILD_TIMEOUT + MIRROR_TIMEOUT + PUBLISH_TIMEOUT)) -lt 350 ]]; then
-  ok "parent poll covers child build, mirror, turnstyle and publication budgets"
+  ok "parent poll covers the slower Desktop source, mirror, turnstyle and publication budgets"
 else
-  bad "parent poll covers child build, mirror, turnstyle and publication budgets"
+  bad "parent poll covers the slower Desktop source, mirror, turnstyle and publication budgets"
 fi
 
 # ---------------------------------------------------------------------------
@@ -330,9 +364,10 @@ echo "== 7. release job re-verifies LIVE environment protection before claim =="
 # when the tag is claimed. The release job live-fetches the environment +
 # deployment-branch-policies and runs the SAME check_release_environment.py —
 # positioned BEFORE the pre-tag blocker/main re-queries and any tag write — and
-# carries the actions:read permission the environments read-back needs.
+# carries actions:write for the environment read-back plus exact dispatch.
 RELJOB=$(sed -n '/^  release:$/,/^name: Auto-release on version bump/p' "$AUTO_RELEASE")
-contains "$RELJOB" 'actions: read' "release job has actions:read (environments read-back)"
+contains "$RELJOB" 'actions: write' \
+  "release job has actions:write for environment read-back plus exact dispatch"
 RE_ENV=$(sed -n '/Verify live rapid-mac-tag environment protection/,/Download the release evidence/p' "$AUTO_RELEASE")
 contains "$RE_ENV" 'repos/${REPO}/environments/${ENV_NAME}' \
   "release job live-fetches the rapid-mac-tag environment"

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -227,14 +227,16 @@ lacks "$APP_STEP" "TAG_APPROVED" \
 lacks "$APP_STEP" "git push" "app tag step does not git push the tag"
 
 DISPATCH_STEP=$(sed -n '/name: Dispatch exact Desktop candidate promotion/,/name: Wait for exact Desktop/p' "$WORKFLOW")
-contains "$DISPATCH_STEP" 'gh workflow run rapid-mac-release.yml' \
-  "auto-release explicitly dispatches the Desktop publisher"
-contains "$DISPATCH_STEP" '--ref "$APP_TAG"' \
+contains "$DISPATCH_STEP" 'actions/workflows/rapid-mac-release.yml/dispatches' \
+  "auto-release explicitly dispatches the Desktop publisher through the API"
+contains "$DISPATCH_STEP" '--arg ref "$APP_TAG"' \
   "dispatch is bound to the immutable Desktop tag"
-contains "$DISPATCH_STEP" '-f "promote_run_id=$PRODUCER_RUN_ID"' \
+contains "$DISPATCH_STEP" 'promote_run_id: $run_id' \
   "dispatch passes the exact producer run"
-contains "$DISPATCH_STEP" '-f "promote_sha=$ACCEPTED_SHA"' \
+contains "$DISPATCH_STEP" 'promote_sha: $sha' \
   "dispatch passes the exact accepted SHA"
+contains "$DISPATCH_STEP" '.workflow_run_id' \
+  "dispatch captures the exact child run ID returned by GitHub"
 
 # Everything that can refuse the app half has to happen BEFORE the engine
 # Release is published. Publishing is the irreversible step: once the Release

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -206,35 +206,14 @@ OUT=$(CHAIN_LEN=99 run taken_chain "$SHA_GOOD") && RC=0 || RC=$?
                      || bad "refuses a chain deeper than the peel bound"
 
 # ==========================================================================
-echo "== 6c. no PAT: refuse to run at all =="
-# ==========================================================================
-# A tag written with GITHUB_TOKEN fires no workflow AND blocks every retry: the
-# re-run finds it already at the right commit and exits green, so the DMG can
-# never be built for that version without hand-deleting a published tag.
-# Skipping quietly is no better — the run would end green with only the engine
-# released, and the next re-run sees the published engine Release and decides
-# there is nothing left to release. So this fails, and the workflow asks the
-# same question before anything irreversible happens.
-#
-# The EMPTY case is the one that bites in production: a workflow expression
-# that evaluates to nothing would otherwise hit the "unset means a human is
-# running this" default and recreate the dead-tag failure.
-for BAD_PAT in false ""; do
-  OUT=$(HAVE_PAT="$BAD_PAT" run free "") && RC=0 || RC=$?
-  [ "${RC:-0}" -ne 0 ] && ok "non-zero with HAVE_PAT='$BAD_PAT'" || bad "non-zero with HAVE_PAT='$BAD_PAT'"
-  lacks "$(cat "$TMP/calls")" "git/refs" "creates NO tag with HAVE_PAT='$BAD_PAT'"
-  contains "$OUT" "RELEASE_PAT is not available" "says which secret is missing (HAVE_PAT='$BAD_PAT')"
-done
-
-# ==========================================================================
 echo "== 7. workflow wiring =="
 # ==========================================================================
-# The app tag MUST be created through the API under the PAT. A ``git push``
-# uses the credential actions/checkout persisted (GITHUB_TOKEN), and GitHub
-# suppresses workflow runs caused by GITHUB_TOKEN pushes — the step would go
-# green with no app build, signing, notarisation or DMG.
+# The app tag is created through the atomic API under GITHUB_TOKEN. GitHub
+# suppresses that token's push event, so auto-release must explicitly dispatch
+# the exact already-built candidate immediately afterwards.
 APP_STEP=$(sed -n '/Tag the desktop app at the exact validated SHA/,/^      - name:/p' "$WORKFLOW")
-contains "$APP_STEP" "secrets.RELEASE_PAT" "app tag step runs under the PAT"
+contains "$APP_STEP" 'GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}' \
+  "app tag step intentionally uses the recursion-safe default token"
 contains "$APP_STEP" "scripts/tag_desktop_app.sh" "app tag step calls the tested script"
 contains "$APP_STEP" "ACCEPTED_SHA: \${{ needs.release-prep.outputs.accepted_sha }}" \
   "app tag step is bound to the pre-approval accepted SHA"
@@ -246,26 +225,16 @@ contains "$APP_STEP" "ACCEPTED_SHA: \${{ needs.release-prep.outputs.accepted_sha
 lacks "$APP_STEP" "TAG_APPROVED" \
   "app tag step does not self-assert a meaningless approval boolean"
 lacks "$APP_STEP" "git push" "app tag step does not git push the tag"
-# Finding RELEASE_PAT in the env is not enough — the step falls back to
-# GITHUB_TOKEN, so it must also be TOLD whether the token it got can trigger a
-# workflow. Without this wiring the script's own guard defaults to "true" and
-# the fallback silently creates a dead tag. The pre-approval job derives it and
-# passes it to the environment-gated release job the same way the old in-job
-# appcheck did.
-contains "$APP_STEP" "HAVE_PAT: \${{ needs.release-prep.outputs.have_pat }}" \
-  "app tag step is told whether the PAT is actually present"
-# Assert the EXACT expression and the EXACT guard. A bare "have_pat=" check
-# passed even when the published value was empty — which the script's
-# "unset means a human" default then read as consent, recreating the very
-# dead-tag failure this wiring exists to prevent. Pin what is written, not
-# that something is.
-PREFLIGHT=$(sed -n '/Pre-check the desktop app CHANGELOG/,/Build release notes/p' "$WORKFLOW")
-contains "$PREFLIGHT" "HAVE_PAT: \${{ secrets.RELEASE_PAT != '' }}" \
-  "pre-flight derives have_pat from the secret's presence"
-contains "$PREFLIGHT" 'echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"' \
-  "pre-flight publishes that value verbatim, not a literal"
-contains "$PREFLIGHT" 'if [ "$HAVE_PAT" != "true" ]; then' \
-  "pre-flight refuses before anything is published"
+
+DISPATCH_STEP=$(sed -n '/name: Dispatch exact Desktop candidate promotion/,/name: Wait for exact Desktop/p' "$WORKFLOW")
+contains "$DISPATCH_STEP" 'gh workflow run rapid-mac-release.yml' \
+  "auto-release explicitly dispatches the Desktop publisher"
+contains "$DISPATCH_STEP" '--ref "$APP_TAG"' \
+  "dispatch is bound to the immutable Desktop tag"
+contains "$DISPATCH_STEP" '-f "promote_run_id=$PRODUCER_RUN_ID"' \
+  "dispatch passes the exact producer run"
+contains "$DISPATCH_STEP" '-f "promote_sha=$ACCEPTED_SHA"' \
+  "dispatch passes the exact accepted SHA"
 
 # Everything that can refuse the app half has to happen BEFORE the engine
 # Release is published. Publishing is the irreversible step: once the Release

--- a/tests/test_check_desktop_publish.py
+++ b/tests/test_check_desktop_publish.py
@@ -164,7 +164,7 @@ def _run_record(
     *,
     status="completed",
     conclusion="success",
-    event="push",
+    event="workflow_dispatch",
     head_sha=ACCEPTED,
     head_branch="rapid-mac-v0.13.0-rc2",
 ):
@@ -204,10 +204,19 @@ def _asset(
     return a
 
 
-def _verify(gate, gh, state, *, deadline_sec=0.05, sleep_sec=0.0):
+def _verify(
+    gate,
+    gh,
+    state,
+    *,
+    expected_run_id=1,
+    deadline_sec=0.05,
+    sleep_sec=0.0,
+):
     return gate.verify(
         app_tag="rapid-mac-v0.13.0-rc2",
         accepted_sha=ACCEPTED,
+        expected_run_id=expected_run_id,
         repo="raullenchai/Rapid-MLX",
         workflow="rapid-mac-release.yml",
         gh=str(gh),
@@ -237,20 +246,20 @@ def test_older_failure_plus_active_rerun_waits_then_succeeds(gate, tmp_path):
         echo "$((n + 1))" > "{state}/count"
         if [[ "$n" == "0" ]]; then
           echo '['
-          echo '  {{"id": 10, "event": "push", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "failure"}},'
-          echo '  {{"id": 11, "event": "push", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "in_progress", "conclusion": null}}'
+          echo '  {{"id": 10, "event": "workflow_dispatch", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "failure"}},'
+          echo '  {{"id": 11, "event": "workflow_dispatch", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "in_progress", "conclusion": null}}'
           echo ']'
         else
           echo '['
-          echo '  {{"id": 10, "event": "push", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "failure"}},'
-          echo '  {{"id": 11, "event": "push", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "success"}}'
+          echo '  {{"id": 10, "event": "workflow_dispatch", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "failure"}},'
+          echo '  {{"id": 11, "event": "workflow_dispatch", "head_sha": "{ACCEPTED}", "head_branch": "rapid-mac-v0.13.0-rc2", "status": "completed", "conclusion": "success"}}'
           echo ']'
         fi
         """
     )
     _write(state, "runs.sh", runs_script)
     _write(state, "release.json", _release_with(_asset()))
-    evidence = _verify(gate, gh, state, deadline_sec=10)
+    evidence = _verify(gate, gh, state, expected_run_id=11, deadline_sec=10)
     assert any("run 11 succeeded" in e for e in evidence)
 
 
@@ -262,7 +271,7 @@ def test_old_failure_plus_success_prefers_success(gate, tmp_path):
         _runs_with(_run_record(10, conclusion="failure"), _run_record(11)),
     )
     _write(state, "release.json", _release_with(_asset()))
-    evidence = _verify(gate, gh, state)
+    evidence = _verify(gate, gh, state, expected_run_id=11)
     assert any("run 11 succeeded" in e for e in evidence)
 
 
@@ -275,7 +284,7 @@ def test_newer_failed_rerun_invalidates_older_success(gate, tmp_path):
     )
     _write(state, "release.json", _release_with(_asset()))
     with pytest.raises(gate.PublishGateError, match="completed without success"):
-        _verify(gate, gh, state)
+        _verify(gate, gh, state, expected_run_id=11)
 
 
 def test_success_waits_for_active_exact_rerun_then_uses_newest(gate, tmp_path):
@@ -294,7 +303,7 @@ def test_success_waits_for_active_exact_rerun_then_uses_newest(gate, tmp_path):
     )
     _write(state, "runs.sh", runs_script)
     _write(state, "release.json", _release_with(_asset()))
-    evidence = _verify(gate, gh, state, deadline_sec=10)
+    evidence = _verify(gate, gh, state, expected_run_id=11, deadline_sec=10)
     assert any("run 11 succeeded" in e for e in evidence)
     assert (state / "count").read_text().strip() == "2"
 
@@ -311,7 +320,7 @@ def test_delayed_tag_run_appearance_is_polled_to_success(gate, tmp_path):
     )
     _write(state, "runs.sh", runs_script)
     _write(state, "release.json", _release_with(_asset()))
-    evidence = _verify(gate, gh, state, deadline_sec=10)
+    evidence = _verify(gate, gh, state, expected_run_id=12, deadline_sec=10)
     assert any("run 12 succeeded" in e for e in evidence)
     assert (state / "count").read_text().strip() == "4"
 
@@ -320,7 +329,7 @@ def test_only_failed_no_active_fails_closed(gate, tmp_path):
     gh, state = _mock_state(tmp_path)
     _write(state, "runs.sh", _runs_with(_run_record(10, conclusion="failure")))
     with pytest.raises(gate.PublishGateError, match="completed without success"):
-        _verify(gate, gh, state, deadline_sec=0.05)
+        _verify(gate, gh, state, expected_run_id=10, deadline_sec=0.05)
 
 
 def test_still_in_progress_times_out(gate, tmp_path):
@@ -332,7 +341,14 @@ def test_still_in_progress_times_out(gate, tmp_path):
         _runs_with(_run_record(10, status="in_progress", conclusion=None)),
     )
     with pytest.raises(gate.PublishGateError, match="within the deadline"):
-        _verify(gate, gh, state, deadline_sec=0.05, sleep_sec=0.0)
+        _verify(
+            gate,
+            gh,
+            state,
+            expected_run_id=10,
+            deadline_sec=0.05,
+            sleep_sec=0.0,
+        )
 
 
 def test_api_failure_fails_immediately(gate, tmp_path):
@@ -352,14 +368,14 @@ def test_wrong_head_branch_is_not_exact(gate, tmp_path):
     )
     # Resolution still says ACCEPTED (ref.json) but no exact run -> timeout/fail.
     with pytest.raises(gate.PublishGateError):
-        _verify(gate, gh, state, deadline_sec=0.05)
+        _verify(gate, gh, state, expected_run_id=9, deadline_sec=0.05)
 
 
 def test_wrong_head_sha_is_not_exact(gate, tmp_path):
     gh, state = _mock_state(tmp_path)
     _write(state, "runs.sh", _runs_with(_run_record(9, head_sha=OTHER)))
     with pytest.raises(gate.PublishGateError):
-        _verify(gate, gh, state, deadline_sec=0.05)
+        _verify(gate, gh, state, expected_run_id=9, deadline_sec=0.05)
 
 
 def test_exact_tag_workflow_dispatch_recovery_is_accepted(gate, tmp_path):
@@ -370,15 +386,37 @@ def test_exact_tag_workflow_dispatch_recovery_is_accepted(gate, tmp_path):
         _runs_with(_run_record(12, event="workflow_dispatch")),
     )
     _write(state, "release.json", _release_with(_asset()))
-    evidence = _verify(gate, gh, state)
+    evidence = _verify(gate, gh, state, expected_run_id=12)
     assert any("event workflow_dispatch" in line for line in evidence)
+
+
+def test_concurrent_manual_success_cannot_replace_failed_dispatched_run(gate, tmp_path):
+    gh, state = _mock_state(tmp_path)
+    _write(
+        state,
+        "runs.sh",
+        _runs_with(
+            _run_record(77, conclusion="failure"),
+            _run_record(88, conclusion="success"),
+        ),
+    )
+    _write(state, "release.json", _release_with(_asset()))
+    with pytest.raises(gate.PublishGateError, match="completed without success"):
+        _verify(gate, gh, state, expected_run_id=77)
+
+
+def test_push_run_with_dispatched_id_is_not_accepted(gate, tmp_path):
+    gh, state = _mock_state(tmp_path)
+    _write(state, "runs.sh", _runs_with(_run_record(91, event="push")))
+    with pytest.raises(gate.PublishGateError, match="within the deadline"):
+        _verify(gate, gh, state, expected_run_id=91, deadline_sec=0.05)
 
 
 def test_unrelated_event_is_not_exact(gate, tmp_path):
     gh, state = _mock_state(tmp_path)
     _write(state, "runs.sh", _runs_with(_run_record(13, event="pull_request")))
     with pytest.raises(gate.PublishGateError, match="within the deadline"):
-        _verify(gate, gh, state, deadline_sec=0.05)
+        _verify(gate, gh, state, expected_run_id=13, deadline_sec=0.05)
 
 
 def test_malformed_workflow_run_fails_immediately(gate, tmp_path):
@@ -387,7 +425,7 @@ def test_malformed_workflow_run_fails_immediately(gate, tmp_path):
     del malformed["status"]
     _write(state, "runs.sh", _runs_with(malformed))
     with pytest.raises(gate.PublishGateError, match="malformed record"):
-        _verify(gate, gh, state, deadline_sec=10)
+        _verify(gate, gh, state, expected_run_id=14, deadline_sec=10)
 
 
 def test_draft_release_fails(gate, tmp_path):
@@ -548,6 +586,7 @@ def test_invalid_app_tag_fails(gate, tmp_path):
         gate.verify(
             app_tag="rapid-mac-v0.13",
             accepted_sha=ACCEPTED,
+            expected_run_id=1,
             repo="raullenchai/Rapid-MLX",
             workflow="rapid-mac-release.yml",
             gh=str(gh),

--- a/tests/test_desktop_promotion.py
+++ b/tests/test_desktop_promotion.py
@@ -32,7 +32,9 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
                     {
                         "filename": dmg.name,
                         "size": dmg.stat().st_size,
-                        "sha256": __import__("hashlib").sha256(dmg.read_bytes()).hexdigest(),
+                        "sha256": __import__("hashlib")
+                        .sha256(dmg.read_bytes())
+                        .hexdigest(),
                     }
                 ],
             }

--- a/tests/test_desktop_promotion.py
+++ b/tests/test_desktop_promotion.py
@@ -1,0 +1,162 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.desktop_promotion import create_manifest, verify_manifest
+
+SHA = "a" * 40
+VERSION = "0.13.2"
+TAG = f"rapid-mac-v{VERSION}"
+REPO = "raullenchai/Rapid-MLX"
+WORKFLOW = ".github/workflows/auto-release.yml"
+
+
+def _bundle(tmp_path: Path) -> tuple[Path, Path]:
+    bundle = tmp_path / "candidate"
+    sparkle = bundle / "sparkle"
+    sparkle.mkdir(parents=True)
+    dmg = bundle / "rapid-mlx-desktop.dmg"
+    dmg.write_bytes(b"signed notarized dmg")
+    zip_path = sparkle / "Rapid-MLX-Desktop-0.13.2.zip"
+    zip_path.write_bytes(b"signed sparkle zip")
+    (bundle / "release-notes.md").write_text("## [0.13.2]\n")
+    (bundle / "rapid-mlx-desktop.manifest.json").write_text(
+        json.dumps(
+            {
+                "source_sha": SHA,
+                "version": VERSION,
+                "app_tag": TAG,
+                "signed": True,
+                "artifacts": [
+                    {
+                        "filename": dmg.name,
+                        "size": dmg.stat().st_size,
+                        "sha256": __import__("hashlib").sha256(dmg.read_bytes()).hexdigest(),
+                    }
+                ],
+            }
+        )
+    )
+    (sparkle / "appcast.xml").write_text(
+        f'''<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><enclosure url="https://dl.rapidmlx.com/{zip_path.name}" length="{zip_path.stat().st_size}" sparkle:version="132" sparkle:shortVersionString="{VERSION}" sparkle:edSignature="signature" /></item></channel></rss>'''
+    )
+    manifest = bundle / "desktop-promotion-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            create_manifest(
+                bundle=bundle,
+                repository=REPO,
+                workflow=WORKFLOW,
+                run_id=123,
+                run_attempt=2,
+                source_sha=SHA,
+                version=VERSION,
+                app_tag=TAG,
+            )
+        )
+    )
+    return bundle, manifest
+
+
+def _verify(bundle: Path, manifest: Path):
+    return verify_manifest(
+        bundle=bundle,
+        manifest_path=manifest,
+        repository=REPO,
+        workflow=WORKFLOW,
+        run_id=123,
+        run_attempt=2,
+        source_sha=SHA,
+        version=VERSION,
+        app_tag=TAG,
+    )
+
+
+def test_exact_bundle_round_trip(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    assert _verify(bundle, manifest)["producer"]["run_attempt"] == 2
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "rapid-mlx-desktop.dmg",
+        "rapid-mlx-desktop.manifest.json",
+        "release-notes.md",
+        "sparkle/appcast.xml",
+        "sparkle/Rapid-MLX-Desktop-0.13.2.zip",
+    ],
+)
+def test_mutated_payload_is_rejected(tmp_path: Path, relative: str):
+    bundle, manifest = _bundle(tmp_path)
+    with (bundle / relative).open("ab") as handle:
+        handle.write(b"mutation")
+    with pytest.raises(ValueError, match="does not match|bytes"):
+        _verify(bundle, manifest)
+
+
+def test_wrong_exact_run_is_rejected(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    with pytest.raises(ValueError, match="run_id"):
+        verify_manifest(
+            bundle=bundle,
+            manifest_path=manifest,
+            repository=REPO,
+            workflow=WORKFLOW,
+            run_id=124,
+            run_attempt=2,
+            source_sha=SHA,
+            version=VERSION,
+            app_tag=TAG,
+        )
+
+
+def test_missing_or_extra_zip_is_rejected(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    (bundle / "sparkle/extra.zip").write_bytes(b"extra")
+    with pytest.raises(ValueError, match="exactly one"):
+        _verify(bundle, manifest)
+
+
+def test_unrecorded_payload_is_rejected(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    (bundle / "surprise.txt").write_text("not in the signed roster")
+    with pytest.raises(ValueError, match="unrecorded payload"):
+        _verify(bundle, manifest)
+
+
+def test_unsafe_manifest_path_is_rejected(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    data = json.loads(manifest.read_text())
+    data["artifacts"][0]["path"] = "../rapid-mlx-desktop.dmg"
+    manifest.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="unsafe"):
+        _verify(bundle, manifest)
+
+
+def test_symlinked_promotion_manifest_is_rejected(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    outside = tmp_path / "outside.json"
+    manifest.rename(outside)
+    manifest.symlink_to(outside)
+    with pytest.raises(ValueError, match="regular file"):
+        _verify(bundle, manifest)
+
+
+def test_appcast_identity_is_rejected_even_if_manifest_is_rehashed(tmp_path: Path):
+    bundle, manifest = _bundle(tmp_path)
+    appcast = bundle / "sparkle/appcast.xml"
+    appcast.write_text(
+        appcast.read_text().replace(
+            f'sparkle:shortVersionString="{VERSION}"',
+            'sparkle:shortVersionString="0.13.3"',
+        )
+    )
+    data = json.loads(manifest.read_text())
+    item = next(x for x in data["artifacts"] if x["path"] == "sparkle/appcast.xml")
+    item["size"] = appcast.stat().st_size
+    item["sha256"] = __import__("hashlib").sha256(appcast.read_bytes()).hexdigest()
+    manifest.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="short version"):
+        _verify(bundle, manifest)

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
+AUTO_RELEASE = ROOT / ".github/workflows/auto-release.yml"
 DESKTOP_WORKFLOW = ROOT / ".github/workflows/rapid-mac-release.yml"
 DESKTOP_RELEASABLE = ROOT / ".github/actions/desktop-releasable/action.yml"
 PREFLIGHT_WORKFLOW = ROOT / ".github/workflows/release-preflight.yml"
@@ -32,6 +33,40 @@ def test_desktop_raw_bundle_headroom_does_not_weaken_dmg_growth_gate():
     assert 'BUNDLE_SIZE_DELTA_CAP_MB: "50"' in workflow
     assert 'CAP_MB="${BUNDLE_SIZE_CAP_MB:-550}"' in shared_action
     assert 'DELTA_CAP_MB="${BUNDLE_SIZE_DELTA_CAP_MB:-50}"' in shared_action
+
+
+def test_auto_release_stages_one_sha_labelled_complete_desktop_bundle():
+    workflow = AUTO_RELEASE.read_text(encoding="utf-8")
+    candidate = _step(workflow, "Stage exact pre-tag Desktop candidate bundle")
+    upload = _step(workflow, "Upload SHA-labelled pre-tag Desktop candidate")
+    assert "desktop_promotion.py create" in candidate
+    assert "rapid-mlx-desktop.dmg" in candidate
+    assert "rapid-mlx-desktop.manifest.json" in candidate
+    assert "release-notes.md" in candidate
+    assert "sparkle/appcast.xml" in candidate
+    assert "sparkle/*.zip" in candidate
+    assert "rapid-mlx-desktop-pre-tag-candidate-${{ github.sha }}" in upload
+
+
+def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
+    workflow = yaml.load(DESKTOP_WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert set(inputs) == {"promote_run_id", "promote_sha"}
+    jobs = workflow["jobs"]
+    assert "github.event_name != 'workflow_dispatch'" in jobs["build"]["if"]
+    assert "inputs.promote_run_id == ''" in jobs["build"]["if"]
+    assert "inputs.promote_sha == ''" in jobs["build"]["if"]
+    assert "github.event_name == 'workflow_dispatch'" in jobs["promote-candidate"]["if"]
+    assert jobs["promote-candidate"]["if"] == (
+        "github.event_name == 'workflow_dispatch' "
+        "&& inputs.promote_run_id != '' && inputs.promote_sha != ''"
+    )
+    assert jobs["desktop-ready"]["needs"] == ["build", "promote-candidate"]
+    assert jobs["mirror-dist"]["needs"] == "desktop-ready"
+    assert jobs["publish-updater-fallback"]["needs"] == [
+        "desktop-ready",
+        "mirror-dist",
+    ]
 
 
 def test_release_preflight_is_dispatch_only_and_exact_head_bound():


### PR DESCRIPTION
## Why

The protected auto-release currently validates one signed/notarized Desktop candidate before the tag, then rebuilds a second DMG after the tag. That makes the approved evidence describe different bytes from the shipped artifact.

Closes #2451.

## What

- Build the signed DMG, Sparkle ZIP/appcast, and release notes once in the pre-tag candidate gate.
- Record an exact lifecycle label plus SHA-256/size provenance for every payload file, producer run/attempt, source SHA, version, and intended tag.
- Claim the protected tag with the default workflow token, then explicitly dispatch the tagged publisher with the exact producer run and accepted SHA; capture GitHub’s returned child workflow run ID.
- Verify that exact child run, the artifact-producing attempt, tag/checkout/source identity, every payload hash, Desktop manifest, Sparkle identity, notarization ticket, Gatekeeper verdict, and DMG presentation before re-uploading the unchanged bytes under canonical downstream artifact names.
- Preserve standalone tag-push builds and input-free manual signing dry runs.

## Scope / Non-goals

This changes Desktop release orchestration and its offline contracts only. It does not change semver, CFBundleVersion, Sparkle ordering, signing/notarization requirements, release authorization, updater ordering, or candidate/tester identity from #2450.

## Verification

- All 10 `tests/release/test_*.sh` contracts pass.
- 70 focused pytest cases pass across promotion provenance, workflow routing, publication evidence, and Desktop manifests.
- Ruff passes on changed Python.
- Workflow-expression validation passes for all 15 workflows.
- All 15 workflows use SHA-pinned actions.
- actionlint introduces no new findings (the configured Studio label and two existing SC2129 style findings remain).
- `git diff --check` passes.
- Independent Codex review round 1 findings were both fixed and dispositioned on the PR.

A live auto-release dry run is intentionally not dispatched while Studio is reserved for the human qwen3.8-flash run; hosted PR checks remain in scope.

## Behaviour delta

Normal auto-release publication now promotes the exact pre-tag signed/notarized bytes instead of rebuilding them. Standalone tag pushes still perform a full build, and input-free manual dispatch remains a non-publishing dry run.