### PR TITLE
ci: reject duplicate pytest roster entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,6 @@ jobs:
             tests/test_version_sync.py \
             tests/test_pull_variant_selection.py \
             tests/test_share_cli.py \
-            tests/test_cli_models.py \
             tests/test_doctor_env_health.py \
             tests/test_train_gates_matches_ci.py \
             -v --tb=short \

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -8,7 +8,9 @@ engine-only or Desktop-only PR into an all-product run.
 
 import json
 import os
+import shlex
 import subprocess
+from collections import Counter
 from pathlib import Path
 
 import yaml
@@ -28,6 +30,45 @@ def _step_run(workflow: Path, job: str, step_name: str) -> str:
 
 def _job(workflow: Path, job: str) -> dict[str, object]:
     return yaml.safe_load(workflow.read_text())["jobs"][job]
+
+
+def _pytest_invocations(workflow: Path) -> list[tuple[str, list[str]]]:
+    """Return explicit test nodes from each workflow ``pytest`` command."""
+    jobs = yaml.safe_load(workflow.read_text())["jobs"]
+    invocations: list[tuple[str, list[str]]] = []
+    for job_name, job in jobs.items():
+        for step in job.get("steps", []):
+            run = str(step.get("run", "")).replace("\\\n", " ")
+            for line in run.splitlines():
+                command = line.strip()
+                if not command.startswith("pytest "):
+                    continue
+                tokens = shlex.split(command)
+                explicit_nodes = [
+                    token
+                    for token in tokens[1:]
+                    if token.startswith("tests/") and ".py" in token
+                ]
+                invocations.append(
+                    (f"{workflow.name}:{job_name}:{step.get('name')}", explicit_nodes)
+                )
+    return invocations
+
+
+def test_workflow_pytest_invocations_do_not_repeat_explicit_test_nodes():
+    invocations = [
+        invocation
+        for workflow in (ENGINE_WORKFLOW, DESKTOP_WORKFLOW)
+        for invocation in _pytest_invocations(workflow)
+    ]
+    assert invocations, "no workflow pytest invocations parsed — contract is stale"
+
+    duplicates: list[str] = []
+    for location, nodes in invocations:
+        repeated = sorted(node for node, count in Counter(nodes).items() if count > 1)
+        duplicates.extend(f"{location}: {node}" for node in repeated)
+
+    assert not duplicates, "duplicate explicit pytest nodes:\n" + "\n".join(duplicates)
 
 
 def _workflow_strings(workflow: Path) -> dict[str, object]:

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -13,6 +13,7 @@ import subprocess
 from collections import Counter
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -32,8 +33,35 @@ def _job(workflow: Path, job: str) -> dict[str, object]:
     return yaml.safe_load(workflow.read_text())["jobs"][job]
 
 
+def _explicit_pytest_nodes(command: str) -> list[str] | None:
+    """Return explicit test nodes, rejecting an unrecognised pytest launcher."""
+    tokens = shlex.split(command)
+    explicit_nodes = [
+        token for token in tokens if token.startswith("tests/") and ".py" in token
+    ]
+    if not explicit_nodes:
+        return None
+
+    if tokens[0] == "pytest":
+        argument_offset = 1
+    elif (
+        len(tokens) >= 3
+        and Path(tokens[0]).name.startswith("python")
+        and tokens[1:3] == ["-m", "pytest"]
+    ):
+        argument_offset = 3
+    else:
+        raise AssertionError(f"unsupported pytest command form: {command}")
+
+    return [
+        token
+        for token in tokens[argument_offset:]
+        if token.startswith("tests/") and ".py" in token
+    ]
+
+
 def _pytest_invocations(workflow: Path) -> list[tuple[str, list[str]]]:
-    """Return explicit test nodes from each workflow ``pytest`` command."""
+    """Return explicit test nodes from each recognised workflow pytest command."""
     jobs = yaml.safe_load(workflow.read_text())["jobs"]
     invocations: list[tuple[str, list[str]]] = []
     for job_name, job in jobs.items():
@@ -41,34 +69,54 @@ def _pytest_invocations(workflow: Path) -> list[tuple[str, list[str]]]:
             run = str(step.get("run", "")).replace("\\\n", " ")
             for line in run.splitlines():
                 command = line.strip()
-                if not command.startswith("pytest "):
+                explicit_nodes = _explicit_pytest_nodes(command)
+                if explicit_nodes is None:
                     continue
-                tokens = shlex.split(command)
-                explicit_nodes = [
-                    token
-                    for token in tokens[1:]
-                    if token.startswith("tests/") and ".py" in token
-                ]
                 invocations.append(
                     (f"{workflow.name}:{job_name}:{step.get('name')}", explicit_nodes)
                 )
     return invocations
 
 
-def test_workflow_pytest_invocations_do_not_repeat_explicit_test_nodes():
-    invocations = [
-        invocation
-        for workflow in (ENGINE_WORKFLOW, DESKTOP_WORKFLOW)
-        for invocation in _pytest_invocations(workflow)
-    ]
-    assert invocations, "no workflow pytest invocations parsed — contract is stale"
-
+def _assert_no_duplicate_explicit_test_nodes(
+    invocations: list[tuple[str, list[str]]],
+) -> None:
     duplicates: list[str] = []
     for location, nodes in invocations:
         repeated = sorted(node for node, count in Counter(nodes).items() if count > 1)
         duplicates.extend(f"{location}: {node}" for node in repeated)
 
     assert not duplicates, "duplicate explicit pytest nodes:\n" + "\n".join(duplicates)
+
+
+def test_pytest_command_parser_supports_workflow_launchers():
+    node = "tests/test_cli_models.py"
+    assert _explicit_pytest_nodes(f"pytest {node} -q") == [node]
+    assert _explicit_pytest_nodes(f"python -m pytest {node} -q") == [node]
+    assert _explicit_pytest_nodes(f"python3.12 -m pytest {node} -q") == [node]
+
+
+def test_pytest_command_parser_rejects_unknown_launcher_with_explicit_nodes():
+    with pytest.raises(AssertionError, match="unsupported pytest command form"):
+        _explicit_pytest_nodes("uv run pytest tests/test_cli_models.py -q")
+
+
+def test_duplicate_explicit_test_nodes_are_rejected():
+    node = "tests/test_cli_models.py"
+    with pytest.raises(AssertionError, match=node):
+        _assert_no_duplicate_explicit_test_nodes([("ci.yml:tests", [node, node])])
+
+
+def test_workflow_pytest_invocations_do_not_repeat_explicit_test_nodes():
+    invocations: list[tuple[str, list[str]]] = []
+    for workflow in (ENGINE_WORKFLOW, DESKTOP_WORKFLOW):
+        workflow_invocations = _pytest_invocations(workflow)
+        assert workflow_invocations, (
+            f"no explicit workflow pytest invocations parsed from {workflow.name}"
+        )
+        invocations.extend(workflow_invocations)
+
+    _assert_no_duplicate_explicit_test_nodes(invocations)
 
 
 def _workflow_strings(workflow: Path) -> dict[str, object]:


### PR DESCRIPTION
## Why

The Linux no-MLX workflow listed the same CLI models test file twice in one pytest command. Pytest therefore collected and executed it twice, wasting hosted time and making the explicit roster harder to audit.

Fixes #2458.

## What

- Remove the second tests/test_cli_models.py entry from the Linux no-MLX roster.
- Add a workflow contract that parses every explicit pytest invocation in the engine and Desktop workflows and rejects repeated test nodes within the same command.

## Scope / Non-goals

Scope is limited to the duplicate roster entry and its regression contract. This does not add or remove test coverage, change CI lane classification, alter job dependencies, or modify product code.

## Design precedent

I reviewed the repository existing workflow-contract tests and kept the guard beside those tests. The implementation follows the existing pattern of parsing checked-in workflow commands as data and failing closed when the expected command shape disappears. I rejected a one-off assertion that counts only this filename because it would allow the same class of duplication to recur elsewhere.

## Acceptance

Each explicit test node appears at most once per pytest invocation. The existing test may still appear in a different invocation when process isolation is intentional.

## Verification

- python3.12 -m pytest -q tests/test_ci_lane_promotion.py tests/test_classify_ci_changes.py tests/test_train_gates_matches_ci.py tests/test_check_gha_pinning.py — 87 passed.
- python3.12 -m ruff check tests/test_ci_lane_promotion.py — passed.
- python3.12 -m ruff format --check tests/test_ci_lane_promotion.py — passed.
- Exact roster audit reports one tests/test_cli_models.py entry.
- git diff --check — passed.

## AI assistance disclosure

Codex implemented the two-file change and reviewed the workflow parser against every current pytest invocation. The focused workflow contracts, lint, formatting, exact roster audit, and diff check above verify the result.

By submitting this PR I confirm I can explain the intent, risk, and behavior of every change in this PR.