### PR TITLE
docs: add optional contributor X-handle field to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,3 +62,13 @@ Examples:
 - [ ] If new tests touch a critical code path (parser / scheduler / security), I've spot-checked that they fail when the corresponding production line is broken (see SOP §Step 3)
 - [ ] Updated README/docs if applicable
 - [ ] No breaking changes to existing API
+
+## Author
+
+X handle (optional, external contributors): @
+
+<!--
+Leave blank if you prefer not to be credited publicly when this merges.
+This field is optional and only used to thank external contributors on
+our public project account when their PR merges. It is never required.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -65,7 +65,7 @@ Examples:
 
 ## Author
 
-X handle (optional, external contributors): @
+X handle (optional, external contributors):
 
 <!--
 Leave blank if you prefer not to be credited publicly when this merges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ effect and mask a broken production wiring path.
 4. **Self-validate your PR** (see below) — saves a round trip with maintainers
 5. Open a PR against `main` with a clear description, filling in **all required sections of the PR template** (the six-field contract — Why / Scope / Non-goals / Acceptance / Verification / Behaviour delta — plus the AI assistance disclosure)
 
+The optional `## Author` field in the template (an X handle for external contributors) is purely for crediting contributors publicly when their PR merges — leave it blank if you'd prefer not to be credited.
+
 ### Necessity & AI assistance — what we ask, why
 
 The PR template asks two questions up front: *why is this needed?* and *was AI used?* These aren't gatekeeping for the sake of it.


### PR DESCRIPTION
## Why
When a community PR merges we want to be able to credit the author on our
public X account. Right now there is no place for an external contributor
to volunteer an X handle, so the follow-up thread has to be tracked down
ad-hoc. This is a contributor-credit template change: it asks for an
**optional** X handle on the PR template so crediting is easy when it
merges — with an explicit opt-out for contributors who'd rather not be
credited.

## What
- `.github/PULL_REQUEST_TEMPLATE.md`: add a short `## Author` section at
  the end — `X handle (optional, external contributors): @` — with an
  HTML comment telling contributors "Leave blank if you prefer not to be
  credited publicly when this merges."
- `CONTRIBUTING.md`: one sentence under the pull-request workflow section
  saying the field is optional and only used to thank contributors
  publicly on merge.

## Scope / Non-goals
- Nothing else changes. No other projects are mentioned. No README /
  workflow / code / tests touched.
- The field is strictly optional and never required for merge; leaving it
  blank must not affect any gate.

## Verification
- Docs-only diff (`.github/PULL_REQUEST_TEMPLATE.md` + `CONTRIBUTING.md`).
- Confirmed the `cl_description_quality` description gate has no
  unedited-template detection — it only requires a title >= 3 words, a
  non-empty body, and one rationale signal (e.g. `## Why`), all of which
  remain present when the optional `## Author` field is left blank. The
  added section contains no `- [ ]` checkbox, so `test_plan_check` is not
  triggered either. An empty optional field does not read as an unedited
  template (#2510 context).
- Applied the `skip-version-bump` label (docs-only; no version change).