### PR TITLE
perf(qwen4): vectorize long-context QSA mask construction

### DIFF
--- a/docs/benchmarks/qwen38-flash-next-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-m3-ultra.md
@@ -187,6 +187,62 @@ fallback means the run does not establish token-level schema enforcement.
 | 8,192 (8,156) | 24.246 s | 336.4 | 37.38 | 12.85 GiB | 17.6 GB |
 | 32,768 (32,732) | 107.244 s | 305.2 | 32.58 | 12.87 GiB | 24.1 GB |
 
+## QSA prefill follow-up
+
+A follow-up candidate for 0.13.2 removes host synchronization from the QSA
+selection-mask builder. The attention math, top-k selection, 2,048-token
+budget, compressed-index cache, and dense SDPA input remain unchanged. The
+implementation constructs the selected block and tail-token indices as MLX
+arrays and scatters them into the existing mask in one device-side operation,
+instead of iterating over every query in Python and converting each row of
+selected blocks to a host list.
+
+The candidate was measured on the same machine, artifact revision,
+quantization, prompt builder, cache-clear procedure, and 3-run/256-decode-token
+methodology as the 0.13.1 table above. It used MLX 0.32.2, MLX-LM 0.31.3, and
+Transformers 5.12.1. The server ran from candidate commit
+`dfcacbb2d80a3a423433d7e8054b9e966cc1b9dc`; the baseline is the published
+0.13.1 quiet-window result.
+
+```bash
+HF_HUB_OFFLINE=1 /private/tmp/rapid-flash-pypi-0131/bin/python \
+  -m vllm_mlx.cli serve \
+  /path/to/dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --served-model-name qwen3.8-flash-next-4bit \
+  --host 127.0.0.1 --port 8464
+
+/private/tmp/rapid-flash-pypi-0131/bin/python \
+  .orca/flash-next-eval/benchmark.py \
+  --url http://127.0.0.1:8464/v1 \
+  --model qwen3.8-flash-next-4bit \
+  --tokenizer-path /path/to/dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --server-pid SERVER_PID \
+  --label qsa-vectorized-dfcacbb2 \
+  --rapid-sha dfcacbb2d80a3a423433d7e8054b9e966cc1b9dc \
+  --artifact-revision dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --output /private/tmp/flash-next-qsa-vectorized-benchmark.json
+```
+
+| Target (reported) | 0.13.1 TTFT | Candidate TTFT | TTFT speedup | 0.13.1 prefill | Candidate prefill | Candidate decode | MLX active |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 128 (92) | 0.380 s | 0.385 s | 0.99x | 241.8 tok/s | 238.9 tok/s | 25.62 tok/s | 103.1 GB |
+| 2,048 (2,012) | 3.274 s | 3.346 s | 0.98x | 614.6 tok/s | 601.4 tok/s | 24.17 tok/s | 103.1 GB |
+| 8,192 (8,156) | 37.984 s | 13.689 s | **2.77x** | 214.7 tok/s | **595.8 tok/s** | 23.25 tok/s | 103.4 GB |
+| 32,768 (32,732) | 186.201 s | 62.851 s | **2.96x** | 175.8 tok/s | **520.8 tok/s** | 21.52 tok/s | 104.7 GB |
+
+The optimization activates only after the QSA budget boundary, so the 128 and
+2K rows are unchanged code paths; their small differences are run-to-run
+noise. Five deterministic user-path checks were byte-identical to the 0.13.1
+baseline: short exact text, strict JSON, a forced tool call, 8K needle recall,
+and 32K needle recall. The two long-context answers remained `MANGO-4827` and
+`ZEPHYR-9135`.
+
+A compact gather experiment was also rejected. Gathering approximately 2,051
+K/V tokens separately for each query lowered the synthetic 8K layer's peak
+allocation but made it 1.8x slower because MLX had to materialize the gathered
+rows. A future direct sparse-attention kernel can consume the compact indices
+without that copy; the rejected gather path is not included in the candidate.
+
 ## Interpretation
 
 Flash-Next reached the first visible token sooner at the 128- and 2K-target

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -619,6 +619,28 @@ def test_qsa_attention_uses_reference_dense_path_below_sparse_budget(monkeypatch
     assert cache[0].offset == cache[1].offset == 5
 
 
+def test_qsa_vectorized_mask_preserves_budget_tail_and_causality():
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    selected = QSAIndexer(args)(
+        mx.zeros((1, 65, args.hidden_size)),
+        QSAIndexCache(compress_ratio=2),
+        physical_kv_length=65,
+    )
+    assert selected is not None
+    mx.eval(selected)
+    mask = np.array(selected[0, 0])
+
+    expected_counts = []
+    for position in range(65):
+        complete = (position + 1) // 2
+        tail = position + 1 - complete * 2
+        expected_counts.append(min(complete, 4) * 2 + tail)
+    np.testing.assert_array_equal(mask.sum(axis=-1), expected_counts)
+    assert mask[0, 0]
+    assert mask[-1, -1]
+    assert not np.any(np.triu(mask, k=1))
+
+
 def test_qsa_batch_prefill_builds_mask_before_kv_update(monkeypatch):
     args = _args(indexer_budget=8, indexer_compress_ratio=2)
     attention = QSAAttention(args)

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -575,6 +575,28 @@ def apply_qwen4_exp_rope(
     return output
 
 
+@dataclass(frozen=True)
+class _QSASelection:
+    """Compact per-query physical KV indices produced by the QSA indexer."""
+
+    token_indices: mx.array
+    valid: mx.array
+    physical_kv_length: int
+
+    def dense_mask(self) -> mx.array:
+        """Materialize the reference mask for unsupported sparse consumers."""
+        batch, length, _ = self.token_indices.shape
+        # Invalid compact slots share a sentinel column so they cannot clear a
+        # real token when put_along_axis sees duplicate indices.
+        sentinel = self.physical_kv_length
+        indices = mx.where(self.valid, self.token_indices, sentinel)
+        selected = mx.zeros(
+            (batch, length, self.physical_kv_length + 1), dtype=mx.bool_
+        )
+        selected = mx.put_along_axis(selected, indices, self.valid, axis=-1)
+        return selected[:, None, :, : self.physical_kv_length]
+
+
 class QSAIndexer(nn.Module):
     """Weight-bearing QSA selector backed by raw-ring/compressed-key state."""
 
@@ -647,12 +669,13 @@ class QSAIndexer(nn.Module):
         # (MIT), without its O(B*L*topk*K) token-mask materialization.
         if physical_kv_length // self.compress_ratio <= self.block_topk:
             return None
-        selected = mx.zeros((batch, length, physical_kv_length), dtype=mx.bool_)
         left_padding = (
             [0] * batch
             if cache.left_padding is None
             else [int(value) for value in cache.left_padding.tolist()]
         )
+        compact_indices = []
+        compact_valid = []
         for batch_index in range(batch):
             input_start, valid_length = valid_spans[batch_index]
             available_blocks = cache._compressed_counts[batch_index]
@@ -677,34 +700,68 @@ class QSAIndexer(nn.Module):
                 scores = mx.where(valid_blocks, scores, -mx.inf)
                 selected_blocks = mx.argpartition(
                     scores, kth=-self.block_topk, axis=-1
-                )[..., -self.block_topk :]
-            for query_index in range(input_start, input_start + valid_length):
-                logical_position = offsets[batch_index] + query_index - input_start
-                complete_blocks = (logical_position + 1) // self.compress_ratio
-                token_indices: list[int] = []
-                if complete_blocks:
-                    if complete_blocks <= self.block_topk:
-                        blocks = list(range(complete_blocks))
-                    else:
-                        if selected_blocks is None:
-                            raise RuntimeError(
-                                "QSA sparse selection was not materialized"
-                            )
-                        blocks = [
-                            int(value)
-                            for value in selected_blocks[query_index].tolist()
-                        ]
-                    for block in blocks:
-                        start = block * self.compress_ratio
-                        token_indices.extend(range(start, start + self.compress_ratio))
-                tail_start = complete_blocks * self.compress_ratio
-                token_indices.extend(range(tail_start, logical_position + 1))
-                if token_indices:
-                    physical_indices = [
-                        left_padding[batch_index] + index for index in token_indices
-                    ]
-                    selected[batch_index, query_index, physical_indices] = True
-        return selected[:, None, :, :]
+                )[..., -self.block_topk :].astype(mx.int32)
+            query_indices = mx.arange(length, dtype=mx.int32)
+            logical_positions = offsets[batch_index] + query_indices - input_start
+            complete_counts = mx.maximum(
+                (logical_positions + 1) // self.compress_ratio, 0
+            )
+            if selected_blocks is None:
+                max_complete = (
+                    offsets[batch_index] + valid_length
+                ) // self.compress_ratio
+                if max_complete > self.block_topk:
+                    raise RuntimeError("QSA sparse selection was not materialized")
+                selected_blocks = mx.broadcast_to(
+                    mx.arange(self.block_topk, dtype=mx.int32)[None, :],
+                    (length, self.block_topk),
+                )
+
+            dense_blocks = mx.broadcast_to(
+                mx.arange(self.block_topk, dtype=mx.int32)[None, :],
+                (length, self.block_topk),
+            )
+            blocks = mx.where(
+                complete_counts[:, None] > self.block_topk,
+                selected_blocks,
+                dense_blocks,
+            )
+            block_valid = mx.arange(self.block_topk)[None, :] < mx.minimum(
+                complete_counts[:, None], self.block_topk
+            )
+            block_tokens = (
+                blocks[:, :, None] * self.compress_ratio
+                + mx.arange(self.compress_ratio, dtype=mx.int32)[None, None, :]
+            ).reshape(length, self.token_budget)
+            block_token_valid = mx.broadcast_to(
+                block_valid[:, :, None],
+                (length, self.block_topk, self.compress_ratio),
+            ).reshape(length, self.token_budget)
+
+            tail_start = complete_counts * self.compress_ratio
+            tail_counts = logical_positions + 1 - tail_start
+            tail_offsets = mx.arange(self.compress_ratio, dtype=mx.int32)[None, :]
+            tail_tokens = tail_start[:, None] + tail_offsets
+            tail_valid = tail_offsets < tail_counts[:, None]
+
+            query_valid = (query_indices >= input_start) & (
+                query_indices < input_start + valid_length
+            )
+            indices = mx.concatenate([block_tokens, tail_tokens], axis=-1)
+            valid = mx.concatenate([block_token_valid, tail_valid], axis=-1)
+            valid = valid & query_valid[:, None]
+            indices = mx.clip(
+                indices + left_padding[batch_index], 0, physical_kv_length - 1
+            )
+            compact_indices.append(indices)
+            compact_valid.append(valid)
+
+        selection = _QSASelection(
+            token_indices=mx.stack(compact_indices),
+            valid=mx.stack(compact_valid),
+            physical_kv_length=physical_kv_length,
+        )
+        return selection.dense_mask()
 
 
 class QSAAttention(nn.Module):


### PR DESCRIPTION
## Why

Qwen3.8 Flash-Next long-context prefill crossed a severe host-side cliff above its 2,048-token QSA budget. Each query row converted device top-k indices to a Python list, expanded blocks token by token, and mutated a dense mask from Python. On the released 0.13.1 path this limited the 8K and 32K prefill rates to 214.7 and 175.8 tok/s on the 256 GB M3 Ultra test machine.

## What

- Keep QSA scoring and top-k selection on MLX arrays.
- Expand selected blocks and incomplete tail tokens with broadcasted array operations.
- Scatter the compact indices into the existing dense attention mask in one device-side operation.
- Preserve the ordinary causal SDPA path at and below the configured QSA budget.
- Add regression coverage for per-position budget, tail-token, and causal-mask semantics.
- Record the exact full-model before/after evidence and the rejected compact-gather experiment.

## Design precedent

Established sparse-attention serving designs keep top-k selection device-resident and pass compact indices to a dedicated consumer instead of synchronizing each query through the host. The current MLX attention primitive still consumes the existing dense mask, so this change adopts the safe first half of that design: vectorized device-side index expansion and scatter with no attention-math change. A compact K/V gather fallback was measured and rejected because materializing per-query rows made the 8K layer 1.8x slower; a future direct sparse kernel can consume the same compact index shape without that copy.

## Scope / Non-goals

Scope is the vendored Qwen4-Exp QSA mask builder, focused tests, and reproducible benchmark documentation. Non-goals are changes to QSA scoring, top-k membership, the 2,048-token budget, cache lifecycle, attention kernels, MoE routing/fusion, MTP, dependencies, release metadata, and other model families.

## Verification

- `69 passed, 2 skipped`: Qwen4-Exp vendored/reference/artifact-parity test set (optional external parity gates skipped by their existing environment guards).
- `329 passed`: model auto-config and hybrid-cache CLI tests.
- Ruff check and format check passed; compileall and diff check passed.
- Five user-path outputs were byte-identical to the 0.13.1 baseline: exact text, strict JSON, forced tool call, 8K needle, and 32K needle.
- Same-box, same-artifact, 3-run medians: 8K prefill 214.7 → 595.8 tok/s (2.77x TTFT speedup); 32K 175.8 → 520.8 tok/s (2.96x TTFT speedup).
- MLX active memory remained approximately 103–105 GB.

## Behaviour delta

For Qwen4-Exp prompts above the QSA budget, mask construction now stays in MLX array operations instead of synchronizing every query row through Python. Selected tokens and generated outputs are unchanged; only long-context prefill performance changes. Prompts at or below the budget retain the previous causal SDPA path.
