### PR TITLE
test(mac): bound dictation busy-waits by time, not yield count (#2537)

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -420,7 +420,7 @@ struct DictationTests {
         #expect(hotkeyStartCount == 0)
 
         warmupContinuation?.resume(returning: true)
-        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        await waitUntil { controller.phase == .idle }
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1)
     }
@@ -462,7 +462,7 @@ struct DictationTests {
         #expect(hotkeyStopCount == 0)
 
         controller.serverStateDidChange(.ready(alias: "qwen3.5-4b-4bit"))
-        for _ in 0..<40 where controller.phase != .idle { await Task.yield() }
+        await waitUntil { controller.phase == .idle }
 
         #expect(controller.phase == .idle)
         #expect(controller.isHotkeyArmed)
@@ -504,7 +504,7 @@ struct DictationTests {
         while warmupContinuation == nil { await Task.yield() }
         #expect(controller.phase == .preparingModel)
         warmupContinuation?.resume(returning: true)
-        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        await waitUntil { controller.phase == .idle }
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1)
     }
@@ -564,7 +564,7 @@ struct DictationTests {
         #expect(hotkeyStartCount == 0)
 
         warmupContinuation?.resume(returning: true)
-        for _ in 0..<20 where controller.phase != .idle { await Task.yield() }
+        await waitUntil { controller.phase == .idle }
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1)
     }
@@ -670,7 +670,7 @@ struct DictationTests {
 
         await controller.bootstrap(deferModelPreparation: true)
         controller.modelAlias = "another-speech-input"
-        for _ in 0..<40 where controller.phase != .idle { await Task.yield() }
+        await waitUntil { controller.phase == .idle }
 
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1, "the enabled feature keeps one event-tap registration")
@@ -975,6 +975,23 @@ struct DictationTests {
         #expect(starts == 2)
         secondContinuation?.resume(returning: true)
         await firstEnable.value
+    }
+
+    /// Yields until `condition` holds or a short wall-clock deadline passes.
+    ///
+    /// The readiness/prewarm hand-off is scheduled on the main actor, so a wait
+    /// must bound by time, not by a fixed number of scheduler yields: a
+    /// `for _ in 0..<20 where … { await Task.yield() }` poll flakes when the
+    /// parallel suite on a loaded runner doesn't re-enter the actor within the
+    /// finite yield budget (issue #2537).
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition(), clock.now < deadline { await Task.yield() }
     }
 
     @MainActor


### PR DESCRIPTION
Fixes #2537

## Why

The desktop `build` job (2970-test Swift suite) flakes intermittently on the dictation readiness/prewarm hand-off. Under parallel-suite runner load, `completed chat-model switch re-prepares enabled dictation before Ready` fails in 0.001 s: a `for _ in 0..<20 where controller.phase != .idle { await Task.yield() }` poll exhausts its fixed scheduler-yield budget before the main-actor warmup `CheckedContinuation` resume re-enters, leaving the phase at `.preparingModel` and `hotkeyStartCount` at 0. A fixed-iteration poll is a symptom-level wait: 20 (or 40) yields is not a real time bound.

## What

- Add a `@MainActor` `waitUntil(_:timeout:)` helper that yields until a condition holds or a 1 s wall-clock `ContinuousClock` deadline passes.
- Replace the five `where controller.phase != .idle` condition-poll sites (was `0..<20` ×3 and `0..<40` ×2) with `await waitUntil { controller.phase == .idle }`.

Semantics unchanged — each site still asserts `.idle` afterwards; the wait is now bounded by time instead of an arbitrary yield count, so it is load-independent.

## Scope / Non-goals

- Test-hardening only in `apps/rapid-mac/Tests/RapidTests/DictationTests.swift`; zero product, engine, or CI code.
- The `for _ in 0..<N { await Task.yield() }` `settle` windows with no condition (lines ~717, ~970) are intentionally untouched: they assert that an effect has NOT happened during a window, which a positive `waitUntil` would invert. Not part of the observed flake.

## Design precedent

Modelled on how Swift concurrency tests uniformly bound async waits: poll on the actor with a wall-clock deadline (`ContinuousClock`/`Duration`) rather than a fixed iteration budget, so a loaded scheduler cannot starve the wait. The same async-timing hardening class as this desk's earlier desktop-suite work (#2480/#2481).

## Verification

- The failing test always passed when the suite was not under load; the fix replaces its only unbounded wait, so there is no path that returns before the transition or raves against the deadline.
- `for _ in 0..<N`-with-condition polls eliminated at all five sites (`git grep 'for _ in 0..<[0-9]* where' apps/rapid-mac/Tests/RapidTests/DictationTests.swift` → empty).
- Desktop `build` job runs the full 2970-test suite on CI; this PR's CI result is the verification (the previously-flaky test, now deadline-bounded, must be green on the new head).

## Behaviour delta

None — test-only change; no product or user-visible behavior change.