### PR TITLE
fix(pr_validate): reject unedited PR-template bodies in cl_description_quality (#2510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,7 @@ jobs:
             tests/test_pr_validate_merge_base.py \
             tests/test_pr_validate_diff_coverage.py \
             tests/test_pr_validate_codex.py \
+            tests/test_pr_validate_cl_description_quality.py \
             tests/test_release_baselines.py \
             tests/test_sidecar_distribution_constraints.py \
             tests/test_sidecar_vision_smoke.py \

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -209,6 +209,25 @@ def run_pipeline(
             )
             break
 
+    # ``--body-only`` exists to reproduce the description-quality verdict
+    # locally. If that single gate got SKIPPED (via
+    # ``PR_VALIDATE_SKIP_DESC=1``) the run validated nothing — a silent
+    # MERGE-SAFE here would mislead the author into thinking their body is
+    # fine. Surface it as a loud WARNING (non-blocking, the user asked for
+    # the override) rather than a clean pass.
+    if body_only:
+        desc_result = next(
+            (r for r in ctx.results if r.name == "cl_description_quality"), None
+        )
+        if desc_result is not None and desc_result.status == "skip":
+            print(
+                "  WARNING: --body-only ran but the description gate was "
+                "SKIPPED via PR_VALIDATE_SKIP_DESC=1 — this run validated "
+                "NOTHING about the body. Unset that env var and re-run to "
+                "get a real description verdict.",
+                file=sys.stderr,
+            )
+
     # Render the scorecard to stdout (so callers can pipe into PR comments).
     print(render_scorecard(ctx))
 

--- a/scripts/pr_validate/steps/cl_description_quality.py
+++ b/scripts/pr_validate/steps/cl_description_quality.py
@@ -90,6 +90,78 @@ _RATIONALE_SIGNALS = (
     re.compile(r"\bbecause\b", re.IGNORECASE),
 )
 
+# Strip HTML comments (``<!-- ... -->``) BEFORE any scoring so template
+# boilerplate / rationale hidden inside ``<!-- -->`` can't satisfy the
+# "body has rationale" rule. Issue #2510: an UNEDITED
+# ``.github/PULL_REQUEST_TEMPLATE.md`` (with ``[x]`` boxes ticked) was a
+# FALSE green because the template's ``## Why`` / ``## Scope`` headings
+# matched the rationale signals even though all the real prose sat inside
+# HTML comments.
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Markdown headings ``#``..``######``, for slicing the body into sections.
+_HEADING = re.compile(r"^(#{1,6})\s+(\S.*)$", re.MULTILINE)
+
+# The two contract headings whose sections must carry real prose. A PR
+# that uses the template but leaves ``## Why`` / ``## Scope`` empty (their
+# only content being an HTML comment) must FAIL — the whole point of issue
+# #2510. Only these two matter; optional/empty sections elsewhere (e.g. a
+# newer ``## Author`` field) are deliberately NOT gated so a legitimate PR
+# with real Why/Scope prose but an empty Author field still passes.
+_CONTRACT_HEADINGS = ("why", "scope")
+
+# Markdown furniture stripped from the front of a line before deciding
+# whether it counts as "substantive prose" — blank lines, bullet/quote
+# prefixes, and task-list checkboxes (``- [ ]`` / ``- [x]``).
+_FURNITURE = re.compile(r"^[\s>*+\-\[\]xX]*")
+
+
+def _strip_comments(body: str) -> str:
+    """Return ``body`` with every ``<!-- ... -->`` HTML comment removed.
+
+    Comment content is inert markdown that GitHub renders hidden; it must
+    not count toward "does this PR explain WHY?" — an author can leave the
+    entire template in place (all prose inside comments) and the body
+    would look well-formed while carrying zero real rationale.
+    """
+    return _HTML_COMMENT.sub("", body)
+
+
+def _sections(body: str) -> dict[str, str]:
+    """Split a body into per-heading sections keyed by lowercased heading
+    text. A section runs from its heading to the next heading at the SAME
+    or HIGHER level (a ``###`` subheading stays within its parent). Each
+    value is the section's prose (the heading line itself excluded)."""
+    matches = list(_HEADING.finditer(body))
+    sections: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        level = len(m.group(1))
+        start = m.end()
+        end = len(body)
+        for j in range(i + 1, len(matches)):
+            if len(matches[j].group(1)) <= level:
+                end = matches[j].start()
+                break
+        name = m.group(2).strip().lower()
+        sections[name] = body[start:end]
+    return sections
+
+
+def _is_substantive_prose(text: str) -> bool:
+    """True if ``text`` contains at least one real word after stripping
+    markdown furniture (bullets, quotes, checkboxes, blank lines) from each
+    line. Rejects a section whose "content" is only markdown decoration or
+    that is empty once HTML comments (the template's hiding place) are
+    removed."""
+    for line in text.splitlines():
+        stripped = _FURNITURE.sub("", line)
+        # ``[^\W\d_]`` matches any unicode letter (word char, not digit/_). A
+        # real rationale line always has at least one letter after furniture.
+        if re.search(r"[^\W\d_]", stripped):
+            return True
+    return False
+
+
 _OVERRIDE_ENV = "PR_VALIDATE_SKIP_DESC"
 
 
@@ -110,6 +182,10 @@ class CLDescriptionQualityStep(Step):
 
         title = (ctx.pr_title or "").strip()
         body = (ctx.pr_body or "").strip()
+        # Everything below scores the COMMENT-STRIPPED body so template
+        # boilerplate hidden in ``<!-- -->`` can never satisfy "body exists"
+        # or "body has rationale" (issue #2510).
+        stripped = _strip_comments(body).strip()
 
         # 1) Title check — strip a conventional-commit prefix if present
         # so "fix: bug" still trips the bad-pattern net, but
@@ -159,12 +235,14 @@ class CLDescriptionQualityStep(Step):
                     ),
                 )
 
-        # 2) Body must exist
-        if not body:
+        # 2) Body must exist. Scored on the comment-stripped body: a body
+        # whose only content is ``<!-- … -->`` is effectively empty (issue
+        # #2510) — the template's skeleton must not read as a real body.
+        if not stripped:
             return StepResult(
                 name=self.name,
                 status="fail",
-                summary="PR body is empty",
+                summary="PR body is empty (or only HTML comments)",
                 details=(
                     "Every PR needs a body explaining the WHY: what problem "
                     "is being solved and why this approach. "
@@ -188,13 +266,49 @@ class CLDescriptionQualityStep(Step):
                 ),
             )
 
-        # 3) Body must contain a rationale signal
+        # 3) Body must explain WHY.
+        #
+        # 3a) If the author used the ``## Why`` / ``## Scope`` contract
+        # headings, those sections must carry real prose — NOT just the
+        # heading. An UNEDITED template has all its prose inside HTML
+        # comments, so after comment-strip ``## Why`` is immediately
+        # followed by ``## Scope`` with nothing in between → empty → FAIL.
+        # Only these two headings are gated; optional/empty sections
+        # elsewhere (e.g. a newer ``## Author`` field) never false-fail a
+        # PR that has real Why/Scope prose.
+        sections = _sections(stripped)
+        for heading in _CONTRACT_HEADINGS:
+            if heading in sections and not _is_substantive_prose(sections[heading]):
+                return StepResult(
+                    name=self.name,
+                    status="fail",
+                    summary=f"`## {heading.title()}` section is empty (unfilled template)",
+                    details=(
+                        f"The PR has a `## {heading.title()}` heading but that "
+                        "section carries no prose — its only content is an "
+                        "HTML comment or markdown furniture. The template's "
+                        "comment blocks are guide rails, not a filled-in "
+                        "answer.\n\n"
+                        f"Rewrite the `## {heading.title()}` section with the "
+                        "actual rationale (issue #2510): what problem is "
+                        "being solved and why this approach.\n\n"
+                        f"Current section (after removing `<!-- -->` "
+                        f"comments):\n```\n{sections[heading].strip() or '(empty)'}\n```"
+                    ),
+                )
+
+        # 3b) Body must carry a rationale signal. Evaluated on the
+        # comment-stripped body so comment-only prose (e.g. a lone
+        # ``<!-- because … -->``) never satisfies the check. This keeps the
+        # lenient paths intact for PRs that DON'T use the template headings
+        # — an inline ``Why:`` line, a ``Closes #N`` link, or a because-
+        # clause, and the ``## Why`` heading itself for template users.
         for pattern in _RATIONALE_SIGNALS:
-            if pattern.search(body):
+            if pattern.search(stripped):
                 return StepResult(
                     name=self.name,
                     status="pass",
-                    summary=f"title OK + body has rationale ({len(body)} chars)",
+                    summary=f"title OK + body has rationale ({len(stripped)} chars)",
                 )
 
         return StepResult(
@@ -202,7 +316,7 @@ class CLDescriptionQualityStep(Step):
             status="fail",
             summary="PR body has no rationale signal (no 'why', no 'closes #', no 'because')",
             details=(
-                f"Body is {len(body)} chars but contains no recognizable "
+                f"Body is {len(stripped)} chars but contains no recognizable "
                 "rationale signal. Add one of:\n"
                 "- A heading like `## Why`, `## Rationale`, `## Motivation`, "
                 "or `## Background`.\n"

--- a/tests/test_pr_validate_cl_description_quality.py
+++ b/tests/test_pr_validate_cl_description_quality.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``CLDescriptionQualityStep`` — the PR description-quality gate.
+
+Issue #2510: an UNEDITED ``.github/PULL_REQUEST_TEMPLATE.md`` (with the
+``[x]`` checklist boxes ticked) was a FALSE green — the template's
+``## Why`` / ``## Scope`` headings matched the rationale-signal regex even
+though every word of real prose sat inside ``<!-- … -->`` HTML comments.
+The fix: strip HTML comments before scoring and require substantive prose
+under the ``## Why`` / ``## Scope`` contract headings.
+
+These are pure-CPU tests: no MLX, no network. The raw template file on disk
+is the fixture for the false-green regression test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.cl_description_quality import (
+    CLDescriptionQualityStep,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TEMPLATE = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+
+
+def _ctx(body: str, title: str = "feat: describe a scoped real change") -> Context:
+    """Context shell with a good title and the given body — everything the
+    step reads apart from ``ctx.pr_title`` / ``ctx.pr_body`` is defaulted."""
+    ctx = Context(pr_number=999, repo="x/y")
+    ctx.pr_title = title
+    ctx.pr_body = body
+    return ctx
+
+
+def _run(body: str, title: str = "feat: describe a scoped real change"):
+    return CLDescriptionQualityStep().run(_ctx(body, title=title))
+
+
+def test_raw_template_fails():
+    """The core #2510 regression: the RAW, UNEDITED template (prose all
+    inside ``<!-- -->`` comments, boxes ticked) must FAIL — its ``## Why`` /
+    ``## Scope`` sections are empty once comments are stripped."""
+    body = _TEMPLATE.read_text()
+    assert "## Why" in body, "test fixture sanity: template has a ## Why section"
+    result = _run(body)
+    assert result.status == "fail"
+    assert "empty" in result.summary
+
+
+def test_why_section_empty_fails_even_with_box_ticked():
+    """A body that left ``## Why`` as an empty comment-fence fails even when
+    a later ``## Checklist`` box is ``[x]`` — the template skeleton alone is
+    not a rationale."""
+    body = (
+        "## Why\n\n"
+        "<!-- fill me in -->\n\n"
+        "## Scope\n"
+        "rewrote the cache invalidation path.\n\n"
+        "## Checklist\n"
+        "- [x] lint\n"
+    )
+    result = _run(body)
+    assert result.status == "fail"
+    assert "## Why" in result.summary or "Why" in result.summary
+
+
+def test_scope_section_empty_fails():
+    """The ``## Scope`` heading is also a contract heading — an empty (or
+    comment-only) Scope fails alongside a filled Why."""
+    body = (
+        "## Why\n"
+        "fixes #123 (parser drops tool_call deltas)\n\n"
+        "## Scope\n"
+        "<!-- what changed goes here -->\n"
+    )
+    result = _run(body)
+    assert result.status == "fail"
+    assert "## Scope" in result.summary
+
+
+def test_real_pr_with_why_and_scope_passes():
+    """A genuine PR with real prose under both contract headings passes."""
+    body = (
+        "## Why\n"
+        "fixes #123 (parser drops tool_call deltas)\n\n"
+        "## Scope\n"
+        "- rewrote the grammar edge for nested tool calls.\n\n"
+        "## Non-goals\n- no server change.\n\n"
+        "## Verification\n- [x] pytest tests/\n"
+    )
+    result = _run(body)
+    assert result.status == "pass"
+
+
+def test_comment_only_prose_does_not_satisfy_rationale():
+    """A body whose ONLY content is an HTML comment carries no rationale —
+    it must fail as effectively empty (issue #2510)."""
+    body = "<!-- This reverts a bad commit because it caused a crash -->"
+    result = _run(body, title="fix: revert a bad commit to stop a crash")
+    assert result.status == "fail"
+    assert "empty" in result.summary
+
+
+def test_why_prose_without_scope_heading_passes():
+    """A partial-template PR (Why filled, no Scope heading) still passes —
+    we only gate headings that are actually present."""
+    body = "## Why\nfixes #123 (parser drops tool_call deltas)\n"
+    result = _run(body)
+    assert result.status == "pass"
+
+
+def test_author_section_empty_does_not_false_fail():
+    """Compatibility with the OPTIONAL ``## Author`` section (PR #2532): a
+    legitimate PR with real Why/Scope prose but an EMPTY Author field still
+    passes — only Why/Scope prose is gated."""
+    body = (
+        "## Why\n"
+        "restores N% TPS regression on model M\n\n"
+        "## Author\n"
+        "(empty)\n\n"
+        "## Scope\n"
+        "- rebuilt the attention kernel.\n\n"
+        "## Checklist\n- [x] lint\n"
+    )
+    result = _run(body)
+    assert result.status == "pass"
+
+
+def test_reason_why_line_without_heading_passes():
+    """The lenient non-template path is preserved: an inline ``**Why:**``
+    line (no ``## Why`` heading) is still a rationale signal."""
+    body = "**Why:** the flake only shows under residency load.\n"
+    result = _run(body)
+    assert result.status == "pass"
+
+
+def test_no_rationale_fails():
+    """A body with real words but no rationale signal (no why heading, no
+    issue link, no because, no Why: line) fails."""
+    body = "This change touches the scheduler module and is small.\n"
+    result = _run(body)
+    assert result.status == "fail"
+    assert "no rationale" in result.summary

--- a/tests/test_pr_validate_runner.py
+++ b/tests/test_pr_validate_runner.py
@@ -379,6 +379,29 @@ class TestBodyOnly:
         assert rc == 0  # template body → desc gate passes
         assert "## [cl_description_quality]" in captured.err
 
+    def test_body_only_with_skip_desc_warns_not_silent_pass(
+        self, repo_root_cwd, capsys, monkeypatch
+    ):
+        """``--body-only`` + ``PR_VALIDATE_SKIP_DESC=1`` must WARN rather
+        than silently report MERGE-SAFE. In body-only mode the description
+        gate is the ONLY check; if the override skips it, the run validated
+        nothing and a clean verdict would mislead the author (issue #2510)."""
+        monkeypatch.setenv("PR_VALIDATE_SKIP_DESC", "1")
+        self._stub_fetch(
+            monkeypatch,
+            title="feat: some perfectly good title",
+            body="## Why\nfixes #123 (a real rationale)\n## Scope\n- real",
+        )
+        rc = run_pipeline(pr_number=999, body_only=True)
+        captured = capsys.readouterr()
+        # Skip is neutral → non-blocking exit code still 0 (user asked for
+        # the override), but the run must NOT be a silent pass: a loud
+        # warning tells the author nothing about the body was validated.
+        assert rc == 0
+        assert "WARNING" in captured.err
+        assert "PR_VALIDATE_SKIP_DESC" in captured.err
+        assert "validated" in captured.err
+
 
 class TestBaseOverrideValidation:
     def test_bad_base_sha_fails_fast_with_clear_message(self, repo_root_cwd, capsys):


### PR DESCRIPTION
## Why

`scripts/pr_validate/steps/cl_description_quality.py` currently PASSES on heading / rationale-SIGNAL presence only. An unedited `.github/PULL_REQUEST_TEMPLATE.md` (with the `[x]` checklist boxes ticked) is a **FALSE green**: the template's `## Why` / `## Scope` headings match `_RATIONALE_SIGNALS` even though every word of real prose sits inside `<!-- … -->` HTML comments. Empirically verified in the issue: raw template + ticked boxes → `cl_description_quality` PASS, `test_plan_check` PASS.

This weakens the whole merge-readiness gate: a PR body that never says WHY (only the template skeleton, left untouched) is treated as well-described. The description-quality step exists precisely to catch that — with the headings matching the rationale regex, it could not.

## What

- **Strip HTML comments before scoring** (`_strip_comments`): comment-only prose can no longer satisfy the "body exists" or "has rationale" rules. A body whose only content is `<!-- … -->` is effectively empty and FAILS.
- **Require substantive prose under the `## Why` / `## Scope` contract headings** when present (`_sections` + `_is_substantive_prose`). After comment-strip an unedited template has `## Why` immediately followed by `## Scope` with nothing between → empty → FAIL. Only these two headings are gated.
- **Preserve the lenient non-template paths**: `Closes #N` / `Fixes #N` issue links, inline `Why:` lines, and `because`-clauses still satisfy the rationale check for PRs that don't use the template headings.
- **`--body-only` + `PR_VALIDATE_SKIP_DESC=1` now WARNs** instead of silently reporting MERGE-SAFE: in body-only mode the description gate is the ONLY check, so a skip means the run validated nothing.
- New test file `tests/test_pr_validate_cl_description_quality.py` feeds the **RAW template file on disk** and expects FAIL, plus the prose/comment/Author-path cases. Registered in the ci.yml changed-lines coverage list.

## Scope / Non-goals

- Scope: `cl_description_quality` step logic + the body-only runner warning + tests + ci.yml test registration.
- Non-goals: no change to `fetch.py` / merge-base resolution (untouched); no change to `test_plan_check` (already correctly passes the template); no change to the six-field contract headings themselves.
- The `test_plan_check` step intentionally still passes an unedited template — this PR is specifically about the missing-rationale FALSE green, not checkbox discipline.

## Verification

- `pytest tests/test_pr_validate_*.py` → **329 passed** (includes all 9 new step-level tests, the new runner body-only warning test, and the existing merge-base / runner / test_plan_check suites).
- `ruff check` + `ruff format --check` on changed Python files → clean.
- `mypy` on changed `scripts/pr_validate` files → no new errors (the one `runner.py:140` typing nit is pre-existing at HEAD; `scripts/pr_validate` is outside the mypy shrink-only budget gate).
- Manual trace of the RAW template: stripped body shows `## Why ⏎ ## Scope` with no prose → FAIL "`## Why` section is empty (unfilled template)".

## Behaviour delta

- **Default behavior of the description gate changes**: an unedited (comment-only) PR template body now FAILS `cl_description_quality` instead of passing. A real PR with prose under `## Why` / `## Scope` is unaffected and still passes.
- `--body-only` with `PR_VALIDATE_SKIP_DESC=1` now emits a loud WARNING to stderr instead of a silent clean verdict.

## Design precedent

**What I looked at:** the existing step's rationale signals (`_RATIONALE_SIGNALS`) and its Google eng-practices rationale; the adjacent `test_plan_check` step/tests for the step-under-test idiom; `test_pr_validate_runner.py`'s `TestBodyOnly` for the body-only pipeline idiom; `test_pr_validate_merge_base.py` for the pure-CPU, no-network test style.

**What I adopted:** no new abstraction layer — three small module-level helpers (`_strip_comments`, `_sections`, `_is_substantive_prose`) matched to the existing step's style; the same ``_ctx(...)`` context-shell test helper idiom as `test_pr_validate_test_plan_check.py`; the `TestBodyOnly` stub-fetch + real-step runner pattern for the warning test.

**What I rejected and why:** (a) gating *every* heading — the PR #2532 `## Author` field shows a template can gain optional/empty sections; gating only `## Why`/`## Scope` keeps the gate precise (issue requirement). (b) Requiring the rationale to live specifically in the `## Why` section — that would break the long-standing leniency where an issue link / `Why:` line / `because`-clause suffices for non-template PRs. The prose check is layered in *before* (not instead of) that lenient fallback. (c) Treating a skipped desc-gate in body-only as a hard FAIL — the user explicitly asked for the override via env var, so the right contract is a loud WARNING, not an unrequested block.

Part of #2499. Fixes #2510.
