### PR TITLE
train: departure 2026-08-28 0040Z (#2534, #2437, #2409)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,18 +160,14 @@ jobs:
             bash "$t"
           done
 
-      # Parser microbench — catches order-of-magnitude (>12x) regressions in
-      # tool-call extraction. Pure Python (parsers don't import mlx). The gate
-      # is a RELATIVE budget (parser μs/call vs a SAME-RUN calibration
-      # baseline, × REGRESSION_LIMIT), so shared-runner speed no longer flakes
-      # it (#2344): calibration and the parser bench run back-to-back on the
-      # same hardware, so uniform runner-speed changes cancel and the verdict is
-      # ε ≤ 12×. Interleaved rounds and a median reject isolated scheduler
-      # pauses without weakening sustained-regression detection.
-      # Running WITHOUT `--report` makes this an ENFORCED gate: the script
-      # exits nonzero when any parser exceeds its relative budget, reddening
-      # the PR, so a "still correct, 10x slower" perf regression can't merge —
-      # the exact failure this bench exists to catch.
+      # Parser microbench — reports order-of-magnitude (>12x) regressions in
+      # tool-call extraction. Pure Python (parsers don't import mlx). The
+      # relative budget scales parser μs/call by a same-run control workload;
+      # interleaved rounds and a median reduce uniform machine-speed noise and
+      # isolated scheduler pauses. Different operations do not necessarily
+      # scale together across hosted architectures, so this shared-runner lane
+      # is intentionally ADVISORY (#2344). The serial M3 release check runs the
+      # same script without `--report` and remains the enforced timing gate.
       #
       # PYTHONPATH=. so `from vllm_mlx.tool_parsers...` resolves
       # without installing the package — pytest auto-adds rootdir but
@@ -182,7 +178,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           pip install pydantic transformers jsonschema openai-harmony
-          python scripts/microbench_parsers.py
+          python scripts/microbench_parsers.py --report
 
   mlx-bound-guard:
     # #1248 — a change to an mlx / mlx-lm / mlx-vlm version bound can re-open the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,17 @@ jobs:
             bash "$t"
           done
 
-      # Parser microbench — catches >10x regressions in tool-call
-      # extraction. Pure Python (parsers don't import mlx). The gate is a
-      # RELATIVE budget (parser cost vs a same-run calibration baseline),
-      # so shared-runner speed no longer flakes it (#2344). This step runs
-      # `--report` (advisory) so a slow shared runner can never red a PR on
-      # timing noise — the numbers print for visibility, and the hard gate
-      # is reserved for a dedicated-M3 / maintainer check.
+      # Parser microbench — catches order-of-magnitude (>12x) regressions in
+      # tool-call extraction. Pure Python (parsers don't import mlx). The gate
+      # is a RELATIVE budget (parser μs/call vs a SAME-RUN calibration
+      # baseline, × REGRESSION_LIMIT), so shared-runner speed no longer flakes
+      # it (#2344): calibration and the parser bench run back-to-back on the
+      # same hardware, so runner speed cancels and the verdict is ε ≤ 12× — an
+      # order-of-magnitude regression check immune to shared-hardware variance.
+      # Running WITHOUT `--report` makes this an ENFORCED gate: the script
+      # exits nonzero when any parser exceeds its relative budget, reddening
+      # the PR, so a "still correct, 10x slower" perf regression can't merge —
+      # the exact failure this bench exists to catch.
       #
       # PYTHONPATH=. so `from vllm_mlx.tool_parsers...` resolves
       # without installing the package — pytest auto-adds rootdir but
@@ -177,7 +181,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           pip install pydantic transformers jsonschema openai-harmony
-          python scripts/microbench_parsers.py --report
+          python scripts/microbench_parsers.py
 
   mlx-bound-guard:
     # #1248 — a change to an mlx / mlx-lm / mlx-vlm version bound can re-open the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       # without installing the package — pytest auto-adds rootdir but
       # bare `python` doesn't, and we don't want a full `pip install -e .`
       # here just for the parser module.
-      - name: Parser microbench (advisory)
+      - name: Parser microbench
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,9 @@ jobs:
       # is a RELATIVE budget (parser μs/call vs a SAME-RUN calibration
       # baseline, × REGRESSION_LIMIT), so shared-runner speed no longer flakes
       # it (#2344): calibration and the parser bench run back-to-back on the
-      # same hardware, so runner speed cancels and the verdict is ε ≤ 12× — an
-      # order-of-magnitude regression check immune to shared-hardware variance.
+      # same hardware, so uniform runner-speed changes cancel and the verdict is
+      # ε ≤ 12×. Interleaved rounds and a median reject isolated scheduler
+      # pauses without weakening sustained-regression detection.
       # Running WITHOUT `--report` makes this an ENFORCED gate: the script
       # exits nonzero when any parser exceeds its relative budget, reddening
       # the PR, so a "still correct, 10x slower" perf regression can't merge —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,20 +161,23 @@ jobs:
           done
 
       # Parser microbench — catches >10x regressions in tool-call
-      # extraction. Pure Python (parsers don't import mlx); thresholds
-      # are intentionally generous (3-5x measured M3 numbers) to
-      # absorb ubuntu-latest's shared-hardware variance.
+      # extraction. Pure Python (parsers don't import mlx). The gate is a
+      # RELATIVE budget (parser cost vs a same-run calibration baseline),
+      # so shared-runner speed no longer flakes it (#2344). This step runs
+      # `--report` (advisory) so a slow shared runner can never red a PR on
+      # timing noise — the numbers print for visibility, and the hard gate
+      # is reserved for a dedicated-M3 / maintainer check.
       #
       # PYTHONPATH=. so `from vllm_mlx.tool_parsers...` resolves
       # without installing the package — pytest auto-adds rootdir but
       # bare `python` doesn't, and we don't want a full `pip install -e .`
       # here just for the parser module.
-      - name: Parser microbench
+      - name: Parser microbench (advisory)
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           pip install pydantic transformers jsonschema openai-harmony
-          python scripts/microbench_parsers.py
+          python scripts/microbench_parsers.py --report
 
   mlx-bound-guard:
     # #1248 — a change to an mlx / mlx-lm / mlx-vlm version bound can re-open the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             full_gate="$FULL_CI"
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
             if [ "$full_gate" = true ]; then
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             else
               echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             fi
@@ -66,7 +66,7 @@ jobs:
               echo 'desktop=true'
               echo 'docs_only=false'
               echo 'full_gate=true'
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}'
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}'
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -570,13 +570,17 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # Two GOLDEN models run coherence + the engine contract. The remaining 4B
+    # GOLDEN models run coherence + the engine contract. The Qwen3.5-9B is the
+    # largest lane (#2419: top-telemetry cover) at ~6GB 4-bit — at the ~7GB edge,
+    # so it is coherence + engine-contract and watched for OOM flakes. The
+    # remaining 4B
     # aliases run contract-only: forcing a zero-argument call factors model
     # competence out while still covering multi-turn replay, streaming channel
     # routing, and native-marker leaks (#1677).
-    # Each model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB
-    # model comfortably. A 3-4B model is fine for a coherence/parser gate — it
-    # is not a chat-quality eval, which stays on the 35B L2 tier.
+    # Each model runs on its own runner (parallel) so lanes do not share RAM.
+    # The 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
+    # Bonsai-27B) are 15-38GB and exceed this free runner's ~7GB budget — they stay
+    # on the self-hosted 35B Studio (L2) tier, not on L1.
     #
     # Gemma3 is multimodal but this contract is text/tool-only, so the smoke
     # script forces ``--no-mllm`` and exercises its LM backbone without pulling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             full_gate="$FULL_CI"
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"
             if [ "$full_gate" = true ]; then
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}' >> "$GITHUB_OUTPUT"
             else
               echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"}]}' >> "$GITHUB_OUTPUT"
             fi
@@ -66,7 +66,7 @@ jobs:
               echo 'desktop=true'
               echo 'docs_only=false'
               echo 'full_gate=true'
-              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"},{"model":"qwen3.5-9b-4bit","contract_only":"0"}]}'
+              echo 'l1_matrix={"include":[{"model":"qwen3.5-4b-4bit","contract_only":"0"},{"model":"llama3-3b-4bit","contract_only":"0"},{"model":"gemma3-4b-qat-4bit","contract_only":"1"},{"model":"qwen3-4b-instruct-2507-4bit","contract_only":"1"},{"model":"qwen3-4b-thinking-2507-4bit","contract_only":"1"}]}'
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -570,17 +570,18 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # GOLDEN models run coherence + the engine contract. The Qwen3.5-9B is the
-    # largest lane (#2419: top-telemetry cover) at ~6GB 4-bit — at the ~7GB edge,
-    # so it is coherence + engine-contract and watched for OOM flakes. The
-    # remaining 4B
+    # GOLDEN models run coherence + the engine contract. The 4B
     # aliases run contract-only: forcing a zero-argument call factors model
     # competence out while still covering multi-turn replay, streaming channel
     # routing, and native-marker leaks (#1677).
     # Each model runs on its own runner (parallel) so lanes do not share RAM.
-    # The 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
-    # Bonsai-27B) are 15-38GB and exceed this free runner's ~7GB budget — they stay
-    # on the self-hosted 35B Studio (L2) tier, not on L1.
+    # The Qwen3.5-9B (#2419 top-telemetry cover) was tried here and relocated off
+    # L1: its runtime footprint is ~8.7 GB (vllm_mlx/model_recommendations.json,
+    # SSOT — bucketed at the 18 GB floor) vs this runner's ~7 GB, and the
+    # coherence serve OOMs (server unreachable, 503) under the gate. It, like the
+    # 26-35B top-telemetry lanes (Qwen3.6-35B-A3B, Qwen3.8/3.6-27B, Gemma-4-26B,
+    # Bonsai-27B, 15-38GB), exceeds this free runner's ~7GB budget — they stay on
+    # the self-hosted 35B Studio tier-1 gate (L2), not on L1.
     #
     # Gemma3 is multimodal but this contract is text/tool-only, so the smoke
     # script forces ``--no-mllm`` and exercises its LM backbone without pulling

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,10 @@ markers =
     slow: marks tests as slow (require model loading, deselect with '-m "not slow"')
     integration: marks tests as integration tests (require running server)
     needle: PFlash needle-in-haystack quality gate (#287) — requires PFLASH_NEEDLE_MODEL and a real model load; skipped by default.
+    requires_mlx: marks tests that import or otherwise need mlx; auto-skipped by
+        tests/conftest.py when mlx is unavailable (the no-MLX CI leg). It is NOT
+        in the addopts `-m` default exclusion, so a local dev run still executes
+        these tests when mlx is installed.
 
 # Default options
 addopts =

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -141,6 +141,11 @@ class BenchResult:
     us_per_call: float
     iters: int
     threshold_us: float
+    # Runner speedup (vs the M3 reference) measured on the VERDICT round — the
+    # pair whose numbers are reported, so the printed threshold always matches
+    # the printed speedup (Codex #2409 NIT: the old display-only global
+    # calibrate-then-print could disagree with the actual verdict).
+    speedup: float
     passed: bool
 
 
@@ -197,12 +202,36 @@ def _measure_runner_speedup() -> float:
     speed this run). Returns the ratio (≈ 1 on an M3, larger on slower
     shared runners), floored at ``_RUNNER_SPEEDUP_FLOOR`` (0.5) so a
     suspiciously fast measurement can't compress the effective threshold
-    below the reference budget. ``main`` calls this fresh for EACH parser so
-    a runner that becomes busy mid-run still reflects the local speed.
+    below the reference budget. ``bench_one`` calls this fresh for EACH
+    round (right before each parser segment) so a runner that becomes busy
+    mid-run still normalizes the parser it is about to time (issue #2344 #2).
     """
     per_op = min(_run_calibration() for _ in range(_CAL_REPS))
     speedup = per_op / _CAL_REF_US_PER_ITER
     return max(speedup, _RUNNER_SPEEDUP_FLOOR)
+
+
+def _median_verdict(
+    pairs: list[tuple[float, float]], base_us: float
+) -> tuple[float, float, int]:
+    """Robust (MEDIAN) ε across interleaved ``(parser_us, speedup)`` rounds.
+
+    Returns ``(eps, verdict_speedup, verdict_index)``. Median, not max
+    (Codex #2409): ``max`` lets ONE round where the runner descheduled during
+    the parser segment (but not the adjacent calibration — the back-to-back
+    interleave) dominate an already-noisy ratio and false-fail the now-
+    ENFORCED gate, amplifying the original shared-runner flake. A genuine
+    regression is slow in EVERY round → every ε is high → the median still
+    fails it; a single transient spike lifts only one round, which the median
+    ignores. ``verdict_index`` points at the median-ε round so the caller can
+    report the pair that PRODUCED the verdict (printed numbers always agree
+    with pass/fail).
+    """
+    per_round_eps = [us / (base_us * speedup) for us, speedup in pairs]
+    idx = sorted(range(len(pairs)), key=lambda i: per_round_eps[i])[
+        len(pairs) // 2
+    ]
+    return per_round_eps[idx], pairs[idx][1], idx
 
 
 def bench_one(
@@ -225,10 +254,15 @@ def bench_one(
 
     To be robust to load changing mid-run, calibration and the parser bench
     are INTERLEAVED: each round times the calibration then the parser
-    immediately after, and the verdict uses the worst (max) ε over all
-    rounds. A regressed parser is slow in every round, so it fails; a
-    transiently-idle parser adjacent to a busy calibration reads as FAST
-    relative to that busy baseline (low ε), so it does not false-fail.
+    immediately after, and the verdict uses the MEDIAN ε across rounds (a
+    robust aggregate, not the max). A regressed parser is slow in every
+    round, so every ε is high and the median still fails it; a single round
+    where the runner descheduled during the parser segment (but not the
+    adjacent calibration) inflates only that one ε, which the median ignores
+    — so the now-ENFORCED CI gate does not false-fail on one transient
+    shared-runner pause (Codex #2409). A transiently-idle parser adjacent to
+    a busy calibration reads as FAST relative to that busy baseline (low ε),
+    so it does not false-fail either.
 
     ``runner_speedup`` overrides the calibration when provided (unit tests);
     when ``None`` (production), each round's speedup is measured live.
@@ -260,23 +294,20 @@ def bench_one(
         pairs.append((us, speedup))
     total_ms = (time.perf_counter() - t_total0) * 1000
     iters_executed = sum(per_round)
-    # Worst-case ε across all paired rounds (max(parser_us / (base × speedup))).
-    # The reported us_per_call and threshold come from the SAME pair that
-    # produced the verdict (the max-ε pair), so the printed numbers always
-    # agree with pass/fail (issue #2344 review).
-    worst_pair_idx = max(
-        range(len(pairs)), key=lambda i: pairs[i][0] / (base_us * pairs[i][1])
-    )
-    worst_us, worst_speedup = pairs[worst_pair_idx]
-    eps = worst_us / (base_us * worst_speedup)
-    threshold_us = base_us * REGRESSION_LIMIT * worst_speedup
-    us_per_call = worst_us
+    # Verdict = MEDIAN ε across all paired rounds (robust aggregate), not the
+    # max — see ``_median_verdict`` (Codex #2409). The reported us_per_call and
+    # threshold come from the SAME pair that produced the verdict (the
+    # median-ε round), so the printed numbers always agree with pass/fail.
+    eps, verdict_speedup, median_idx = _median_verdict(pairs, base_us)
+    threshold_us = base_us * REGRESSION_LIMIT * verdict_speedup
+    us_per_call = pairs[median_idx][0]
     return BenchResult(
         name=name,
         total_ms=total_ms,
         us_per_call=us_per_call,
         iters=iters_executed,
         threshold_us=threshold_us,
+        speedup=verdict_speedup,
         passed=eps <= REGRESSION_LIMIT,
     )
 
@@ -301,18 +332,14 @@ def main(argv: list[str] | None = None) -> int:
         print("FAIL: no parsers loaded — import path broken", file=sys.stderr)
         return 1
 
-    # Calibrate runner speed fresh for EACH parser, immediately before its
-    # bench, so a runner that becomes busy mid-run still normalizes the
-    # parser it is about to time (issue #2344 #2). Relative budget, not an
-    # absolute wall-clock ceiling.
-    first_speedup = _measure_runner_speedup()
-
-    print(
-        f"Parser microbench × {args.iters} iters/parser "
-        f"(runner speedup vs M3 ref: {first_speedup:.2f}×)"
-    )
-    print(f"{'parser':<12}{'us/call':>12}{'threshold':>14}{'verdict':>10}")
-    print("-" * 48)
+    # NOTE (Codex #2409 NIT): no display-only upfront calibration. Each
+    # verdict carries the speedup of its own verdict round (see BenchResult),
+    # so the printed speedup ALWAYS describes the reported threshold. Pre-
+    # measuring a global "runner speedup" solely to print a headline cost
+    # ~100k extra regex ops AND could disagree with the actual verdict.
+    print(f"Parser microbench × {args.iters} iters/parser")
+    print(f"{'parser':<12}{'us/call':>12}{'speedup':>10}{'threshold':>14}{'verdict':>10}")
+    print("-" * 58)
 
     results: list[BenchResult] = []
     for name, fn in parsers.items():
@@ -325,7 +352,10 @@ def main(argv: list[str] | None = None) -> int:
         r = bench_one(name, fn, sample, args.iters)
         results.append(r)
         verdict = "OK" if r.passed else "FAIL"
-        print(f"{r.name:<12}{r.us_per_call:>12.2f}{r.threshold_us:>14.2f}{verdict:>10}")
+        print(
+            f"{r.name:<12}{r.us_per_call:>12.2f}{r.speedup:>10.2f}"
+            f"{r.threshold_us:>14.2f}{verdict:>10}"
+        )
 
     failed = [r for r in results if not r.passed]
     print()

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -237,20 +237,29 @@ def bench_one(
     # Interleave calibration and parser timing across rounds; with a tiny
     # ``iters`` (unit tests) a single round suffices.
     rounds = _CAL_REPS if iters >= _CAL_REPS else 1
-    per_round = max(1, iters // rounds)
+    # Distribute ``iters`` across rounds so the full count is actually run:
+    # the first ``iters % rounds`` rounds get one extra call, and every round
+    # runs at least one. Accounting is exact — ``sum(n_per_round) == iters``
+    # and the reported ``iters`` equals what was executed (issue #2344 review).
+    per_round = [
+        max(1, iters // rounds + (1 if i < iters % rounds else 0))
+        for i in range(rounds)
+    ]
     pairs: list[tuple[float, float]] = []
     t_total0 = time.perf_counter()
-    for _ in range(rounds):
+    for i in range(rounds):
         speedup = (
             _measure_runner_speedup() if runner_speedup is None else runner_speedup
         )
+        n = per_round[i]
         t0 = time.perf_counter()
-        for _ in range(per_round):
+        for _ in range(n):
             fn(sample)
         dt = time.perf_counter() - t0
-        us = (dt / per_round) * 1_000_000
+        us = (dt / n) * 1_000_000
         pairs.append((us, speedup))
     total_ms = (time.perf_counter() - t_total0) * 1000
+    iters_executed = sum(per_round)
     # Worst-case ε across all paired rounds (max(parser_us / (base × speedup))).
     eps = max(us / (base_us * speedup) for us, speedup in pairs)
     last_speedup = pairs[-1][1]
@@ -260,7 +269,7 @@ def bench_one(
         name=name,
         total_ms=total_ms,
         us_per_call=us_per_call,
-        iters=iters,
+        iters=iters_executed,
         threshold_us=threshold_us,
         passed=eps <= REGRESSION_LIMIT,
     )

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -211,34 +211,58 @@ def bench_one(
     sample: str,
     iters: int,
     *,
-    runner_speedup: float = 1.0,
+    runner_speedup: float | None = None,
 ) -> BenchResult:
     """Run ``fn(sample)`` ``iters`` times, return timing + verdict.
 
-    The effective threshold is the parser's M3 base scaled by the same-run
-    runner speedup and the relative regression limit (see module constants):
-    ``BASE_US[name] × REGRESSION_LIMIT × runner_speedup``. With
-    ``runner_speedup`` measured in the same process, the verdict is a
-    relative-budget regression check that does not flake on shared-runner
-    speed variance (#2344).
+    Relative-budget gate (issue #2344): the parser's M3 base scaled by the
+    same-run runner speedup and the regression limit,
+    ``threshold = BASE_US[name] × REGRESSION_LIMIT × speedup``. Because both
+    the parser measurement and the calibration baseline scale with the same
+    runner speed, the verdict reduces to ``ε ≤ REGRESSION_LIMIT`` — a
+    runner-speed-INDEPENDENT order-of-magnitude regression check that does
+    not flake on shared-hosted-runner variance.
 
-    Uses ``perf_counter`` rather than ``time.time()`` for the
-    monotonic+high-resolution guarantees the bench needs.
+    To be robust to load changing mid-run, calibration and the parser bench
+    are INTERLEAVED: each round times the calibration then the parser
+    immediately after, and the verdict uses the worst (max) ε over all
+    rounds. A regressed parser is slow in every round, so it fails; a
+    transiently-idle parser adjacent to a busy calibration reads as FAST
+    relative to that busy baseline (low ε), so it does not false-fail.
+
+    ``runner_speedup`` overrides the calibration when provided (unit tests);
+    when ``None`` (production), each round's speedup is measured live.
     """
     base_us = BASE_US.get(name, 5.0)
-    threshold_us = base_us * REGRESSION_LIMIT * runner_speedup
-    t0 = time.perf_counter()
-    for _ in range(iters):
-        fn(sample)
-    dt = time.perf_counter() - t0
-    us_per_call = (dt / iters) * 1_000_000
+    # Interleave calibration and parser timing across rounds; with a tiny
+    # ``iters`` (unit tests) a single round suffices.
+    rounds = _CAL_REPS if iters >= _CAL_REPS else 1
+    per_round = max(1, iters // rounds)
+    pairs: list[tuple[float, float]] = []
+    t_total0 = time.perf_counter()
+    for _ in range(rounds):
+        speedup = (
+            _measure_runner_speedup() if runner_speedup is None else runner_speedup
+        )
+        t0 = time.perf_counter()
+        for _ in range(per_round):
+            fn(sample)
+        dt = time.perf_counter() - t0
+        us = (dt / per_round) * 1_000_000
+        pairs.append((us, speedup))
+    total_ms = (time.perf_counter() - t_total0) * 1000
+    # Worst-case ε across all paired rounds (max(parser_us / (base × speedup))).
+    eps = max(us / (base_us * speedup) for us, speedup in pairs)
+    last_speedup = pairs[-1][1]
+    threshold_us = base_us * REGRESSION_LIMIT * last_speedup
+    us_per_call = pairs[0][0]
     return BenchResult(
         name=name,
-        total_ms=dt * 1000,
+        total_ms=total_ms,
         us_per_call=us_per_call,
         iters=iters,
         threshold_us=threshold_us,
-        passed=us_per_call <= threshold_us,
+        passed=eps <= REGRESSION_LIMIT,
     )
 
 
@@ -281,8 +305,9 @@ def main(argv: list[str] | None = None) -> int:
         if not sample:
             print(f"  [skip] {name}: no sample wired", file=sys.stderr)
             continue
-        speedup = _measure_runner_speedup()
-        r = bench_one(name, fn, sample, args.iters, runner_speedup=speedup)
+        # bench_one interleaves calibration with the parser bench itself
+        # (issue #2344 #2); no explicit upfront speedup here.
+        r = bench_one(name, fn, sample, args.iters)
         results.append(r)
         verdict = "OK" if r.passed else "FAIL"
         print(f"{r.name:<12}{r.us_per_call:>12.2f}{r.threshold_us:>14.2f}{verdict:>10}")

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -34,25 +34,70 @@ parser over threshold.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
-# Threshold: microseconds-per-call. Set 8-10x what's been measured on
-# M3 + buffer for GitHub Actions ubuntu-latest shared-runner variance.
-# Empirically a shared Linux runner measures ~5x M3 baseline at p50 and
-# spikes near 6x at p100 (observed 30.28 μs/call vs 5.5 μs M3 on
-# hermes during the 2026-06-07 flake); aim for ~10x M3 so the gate
-# stays a real regression check, not a noise canary. If a parser
-# EXCEEDS its threshold, we want a hard signal; this is much looser
-# than a "perf regression" check would be.
-THRESHOLDS_US_PER_CALL: dict[str, float] = {
-    "hermes": 80.0,  # measured ~5.5 μs on M3, ~30 μs on ubuntu-latest
-    "minimax": 120.0,  # complex regex, larger budget
-    "glm47": 80.0,  # similar shape to hermes
-    "harmony": 160.0,  # multi-channel protocol, heavier
+# ---------------------------------------------------------------------------
+# Relative threshold budget (issue #2344).
+#
+# Historical design: an ABSOLUTE μs/call ceiling per parser, hand-tuned to
+# M3 with slack for shared runners. That flakes on hosted runners — the whole
+# runner slows down and an unchanged parser trips an absolute wall-clock gate
+# (glm47 90.15 μs vs an 80 μs gate on a busy ubuntu-latest job, 1.13×, no
+# parser change). Mature perf gates avoid absolute wall-clock on shared
+# hardware by comparing against a SAME-RUN baseline / relative budget.
+#
+# New design — a relative budget that cancels runner speed:
+#
+#   parser_us_per_call  ≈  BASE_US[name] × speedup × ε
+#   effective_threshold  =  BASE_US[name] × REGRESSION_LIMIT × speedup
+#
+# where ``speedup`` is how much slower THIS runner is than the reference M3,
+# measured from the calibration workload in the same run. Because the
+# calibration and the parser benches run back-to-back on the same hardware,
+# ``speedup`` scales both sides and cancels, leaving the gate as exactly
+# ``ε ≤ REGRESSION_LIMIT`` — an order-of-magnitude regression check that is
+# (near-)immune to shared-runner speed variance. (Note ``_CAL_REF_US_PER_ITER``
+# cancels too, so its precise value only affects the printed μs scale, not the
+# verdict.)
+# ---------------------------------------------------------------------------
+
+# Intrinsic per-parser cost on the reference M3, μs/call (from the historical
+# notes: hermes ~5.5 μs, glm47 similar shape, minimax/harmony heavier).
+BASE_US: dict[str, float] = {
+    "hermes": 5.5,
+    "minimax": 8.0,
+    "glm47": 5.5,
+    "harmony": 11.0,
 }
+
+# The relative gate: a parser may be at most this many × its own calibrated
+# baseline before the bench goes red. 12× keeps the documented "order of
+# magnitude" bar with a little headroom so a borderline run doesn't flake.
+REGRESSION_LIMIT: float = 12.0
+
+# Calibration workload: cheap, pure-string (no mlx), representative of a
+# parser's hot path (regex locating tool-call markers in a parser-shaped
+# string). Every parser shares ONE calibration so the per-parser base only
+# carries intrinsic-cost differences, not runner-variance.
+_CAL_STRING = (
+    "<tool_call>get_weather\n"
+    "<arg_key>city</arg_key>\n<arg_value>San Francisco</arg_value>\n"
+    "</tool_call>"
+)
+_CAL_PATTERN = re.compile(r"<tool_call>.*?</tool_call>", re.S)
+_CAL_ITERS: int = 20_000
+_CAL_REPS: int = 5
+# Reference cost of one calibration op on the M3 (cancels in the ratio; here
+# just to report a meaningful μs scale). Set to a plausible M3 value.
+_CAL_REF_US_PER_ITER: float = 0.45
+
+# Floor so a suspiciously-fast calibration can't compress the effective
+# threshold below the reference machine's own budget (guards the signal).
+_RUNNER_SPEEDUP_FLOOR: float = 0.5
 
 # Realistic sample inputs for each parser. Each represents a single
 # tool call the parser should successfully extract — not edge cases,
@@ -129,15 +174,51 @@ def _build_parsers() -> dict[str, Callable[[str], object]]:
     return parsers
 
 
+def _run_calibration() -> float:
+    """Time one pass of the calibration workload, return μs per op."""
+    t0 = time.perf_counter()
+    for _ in range(_CAL_ITERS):
+        _CAL_PATTERN.search(_CAL_STRING)
+    dt = time.perf_counter() - t0
+    return (dt / _CAL_ITERS) * 1_000_000
+
+
+def _measure_runner_speedup() -> float:
+    """How much slower this runner is than the reference M3 (ratio >= 1).
+
+    Times the calibration workload a few times and takes the MIN so a
+    transient slow stretch during calibration can't over-relax the gate
+    (issue #2344: the whole point is to normalize the runner's *typical*
+    speed this run). Floored so a curious measurement can't compress the
+    effective threshold below the reference budget.
+    """
+    per_op = min(_run_calibration() for _ in range(_CAL_REPS))
+    speedup = per_op / _CAL_REF_US_PER_ITER
+    return max(speedup, _RUNNER_SPEEDUP_FLOOR)
+
+
 def bench_one(
-    name: str, fn: Callable[[str], object], sample: str, iters: int
+    name: str,
+    fn: Callable[[str], object],
+    sample: str,
+    iters: int,
+    *,
+    runner_speedup: float = 1.0,
 ) -> BenchResult:
     """Run ``fn(sample)`` ``iters`` times, return timing + verdict.
+
+    The effective threshold is the parser's M3 base scaled by the same-run
+    runner speedup and the relative regression limit (see module constants):
+    ``BASE_US[name] × REGRESSION_LIMIT × runner_speedup``. With
+    ``runner_speedup`` measured in the same process, the verdict is a
+    relative-budget regression check that does not flake on shared-runner
+    speed variance (#2344).
 
     Uses ``perf_counter`` rather than ``time.time()`` for the
     monotonic+high-resolution guarantees the bench needs.
     """
-    threshold_us = THRESHOLDS_US_PER_CALL.get(name, 100.0)
+    base_us = BASE_US.get(name, 5.0)
+    threshold_us = base_us * REGRESSION_LIMIT * runner_speedup
     t0 = time.perf_counter()
     for _ in range(iters):
         fn(sample)
@@ -173,7 +254,15 @@ def main(argv: list[str] | None = None) -> int:
         print("FAIL: no parsers loaded — import path broken", file=sys.stderr)
         return 1
 
-    print(f"Parser microbench × {args.iters} iters/parser")
+    # Calibrate runner speed once so every parser's effective threshold
+    # shares the same same-run baseline (issue #2344: relative budget, not
+    # absolute wall-clock on shared hardware).
+    runner_speedup = _measure_runner_speedup()
+
+    print(
+        f"Parser microbench × {args.iters} iters/parser "
+        f"(runner speedup vs M3 ref: {runner_speedup:.2f}×)"
+    )
     print(f"{'parser':<12}{'us/call':>12}{'threshold':>14}{'verdict':>10}")
     print("-" * 48)
 
@@ -183,7 +272,7 @@ def main(argv: list[str] | None = None) -> int:
         if not sample:
             print(f"  [skip] {name}: no sample wired", file=sys.stderr)
             continue
-        r = bench_one(name, fn, sample, args.iters)
+        r = bench_one(name, fn, sample, args.iters, runner_speedup=runner_speedup)
         results.append(r)
         verdict = "OK" if r.passed else "FAIL"
         print(f"{r.name:<12}{r.us_per_call:>12.2f}{r.threshold_us:>14.2f}{verdict:>10}")
@@ -209,8 +298,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     print(
         "\nIf this is a legitimate algorithm change (e.g. moving from "
-        "regex to AST), bump the threshold in `scripts/microbench_parsers.py` "
-        "with a comment citing the PR + the new baseline measurement.",
+        "regex to AST), adjust `BASE_US` / `REGRESSION_LIMIT` in "
+        "`scripts/microbench_parsers.py` with a comment citing the PR + the "
+        "new baseline measurement.",
         file=sys.stderr,
     )
     return 1

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -91,9 +91,14 @@ _CAL_STRING = (
 _CAL_PATTERN = re.compile(r"<tool_call>.*?</tool_call>", re.S)
 _CAL_ITERS: int = 20_000
 _CAL_REPS: int = 5
-# Reference cost of one calibration op on the M3 (cancels in the ratio; here
-# just to report a meaningful μs scale). Set to a plausible M3 value.
-_CAL_REF_US_PER_ITER: float = 0.45
+# Reference cost of one calibration op, MEASURED on the same reference M3
+# used for ``BASE_US`` (warmed, 100k iters, 9 reps → 0.476 μs/op; set to
+# 0.48). Because both ``BASE_US`` and this reference are measured on the same
+# M3, their ratio is the parser's intrinsic cost expressed in calibration-ops
+# — so on any runner the gate reduces to ε ≤ REGRESSION_LIMIT regardless of
+# that runner's speed (#2344). This is a real measurement, not a knob to
+# relax the gate.
+_CAL_REF_US_PER_ITER: float = 0.48
 
 # Floor so a suspiciously-fast calibration can't compress the effective
 # threshold below the reference machine's own budget (guards the signal).
@@ -184,13 +189,16 @@ def _run_calibration() -> float:
 
 
 def _measure_runner_speedup() -> float:
-    """How much slower this runner is than the reference M3 (ratio >= 1).
+    """How much slower this runner is than the reference M3, right now.
 
     Times the calibration workload a few times and takes the MIN so a
     transient slow stretch during calibration can't over-relax the gate
     (issue #2344: the whole point is to normalize the runner's *typical*
-    speed this run). Floored so a curious measurement can't compress the
-    effective threshold below the reference budget.
+    speed this run). Returns the ratio (≈ 1 on an M3, larger on slower
+    shared runners), floored at ``_RUNNER_SPEEDUP_FLOOR`` (0.5) so a
+    suspiciously fast measurement can't compress the effective threshold
+    below the reference budget. ``main`` calls this fresh for EACH parser so
+    a runner that becomes busy mid-run still reflects the local speed.
     """
     per_op = min(_run_calibration() for _ in range(_CAL_REPS))
     speedup = per_op / _CAL_REF_US_PER_ITER
@@ -254,14 +262,15 @@ def main(argv: list[str] | None = None) -> int:
         print("FAIL: no parsers loaded — import path broken", file=sys.stderr)
         return 1
 
-    # Calibrate runner speed once so every parser's effective threshold
-    # shares the same same-run baseline (issue #2344: relative budget, not
-    # absolute wall-clock on shared hardware).
-    runner_speedup = _measure_runner_speedup()
+    # Calibrate runner speed fresh for EACH parser, immediately before its
+    # bench, so a runner that becomes busy mid-run still normalizes the
+    # parser it is about to time (issue #2344 #2). Relative budget, not an
+    # absolute wall-clock ceiling.
+    first_speedup = _measure_runner_speedup()
 
     print(
         f"Parser microbench × {args.iters} iters/parser "
-        f"(runner speedup vs M3 ref: {runner_speedup:.2f}×)"
+        f"(runner speedup vs M3 ref: {first_speedup:.2f}×)"
     )
     print(f"{'parser':<12}{'us/call':>12}{'threshold':>14}{'verdict':>10}")
     print("-" * 48)
@@ -272,7 +281,8 @@ def main(argv: list[str] | None = None) -> int:
         if not sample:
             print(f"  [skip] {name}: no sample wired", file=sys.stderr)
             continue
-        r = bench_one(name, fn, sample, args.iters, runner_speedup=runner_speedup)
+        speedup = _measure_runner_speedup()
+        r = bench_one(name, fn, sample, args.iters, runner_speedup=speedup)
         results.append(r)
         verdict = "OK" if r.passed else "FAIL"
         print(f"{r.name:<12}{r.us_per_call:>12.2f}{r.threshold_us:>14.2f}{verdict:>10}")

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -261,10 +261,16 @@ def bench_one(
     total_ms = (time.perf_counter() - t_total0) * 1000
     iters_executed = sum(per_round)
     # Worst-case ε across all paired rounds (max(parser_us / (base × speedup))).
-    eps = max(us / (base_us * speedup) for us, speedup in pairs)
-    last_speedup = pairs[-1][1]
-    threshold_us = base_us * REGRESSION_LIMIT * last_speedup
-    us_per_call = pairs[0][0]
+    # The reported us_per_call and threshold come from the SAME pair that
+    # produced the verdict (the max-ε pair), so the printed numbers always
+    # agree with pass/fail (issue #2344 review).
+    worst_pair_idx = max(
+        range(len(pairs)), key=lambda i: pairs[i][0] / (base_us * pairs[i][1])
+    )
+    worst_us, worst_speedup = pairs[worst_pair_idx]
+    eps = worst_us / (base_us * worst_speedup)
+    threshold_us = base_us * REGRESSION_LIMIT * worst_speedup
+    us_per_call = worst_us
     return BenchResult(
         name=name,
         total_ms=total_ms,

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -228,9 +228,7 @@ def _median_verdict(
     with pass/fail).
     """
     per_round_eps = [us / (base_us * speedup) for us, speedup in pairs]
-    idx = sorted(range(len(pairs)), key=lambda i: per_round_eps[i])[
-        len(pairs) // 2
-    ]
+    idx = sorted(range(len(pairs)), key=lambda i: per_round_eps[i])[len(pairs) // 2]
     return per_round_eps[idx], pairs[idx][1], idx
 
 
@@ -267,7 +265,17 @@ def bench_one(
     ``runner_speedup`` overrides the calibration when provided (unit tests);
     when ``None`` (production), each round's speedup is measured live.
     """
-    base_us = BASE_US.get(name, 5.0)
+    # Every parser the bench knows about must carry an explicit ``BASE_US``
+    # entry; silently defaulting an unknown name to a magic 5.0 would mask a
+    # wiring mistake (new parser added to the loop but forgotten in BASE_US)
+    # behind an arbitrary threshold (Codex #2409 NIT).
+    if name not in BASE_US:
+        raise KeyError(
+            f"no BASE_US baseline for parser {name!r}; every parser in "
+            f"_build_parsers() must have an explicit μs/call baseline "
+            f"(see BASE_US in scripts/microbench_parsers.py)"
+        )
+    base_us = BASE_US[name]
     # Interleave calibration and parser timing across rounds; with a tiny
     # ``iters`` (unit tests) a single round suffices.
     rounds = _CAL_REPS if iters >= _CAL_REPS else 1
@@ -338,7 +346,9 @@ def main(argv: list[str] | None = None) -> int:
     # measuring a global "runner speedup" solely to print a headline cost
     # ~100k extra regex ops AND could disagree with the actual verdict.
     print(f"Parser microbench × {args.iters} iters/parser")
-    print(f"{'parser':<12}{'us/call':>12}{'speedup':>10}{'threshold':>14}{'verdict':>10}")
+    print(
+        f"{'parser':<12}{'us/call':>12}{'speedup':>10}{'threshold':>14}{'verdict':>10}"
+    )
     print("-" * 58)
 
     results: list[BenchResult] = []

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -51,20 +51,20 @@ from dataclasses import dataclass
 # parser change). Mature perf gates avoid absolute wall-clock on shared
 # hardware by comparing against a SAME-RUN baseline / relative budget.
 #
-# New design — a relative budget that cancels runner speed:
+# New design — a relative budget that normalizes runner speed:
 #
 #   parser_us_per_call  ≈  BASE_US[name] × runner_factor × ε
 #   effective_threshold  =  BASE_US[name] × REGRESSION_LIMIT × runner_factor
 #
 # where ``runner_factor`` is how much slower THIS runner is than the reference M3,
-# measured from the calibration workload in the same run. Because the
-# calibration and the parser benches run back-to-back on the same hardware,
-# ``runner_factor`` scales both sides and cancels, leaving the gate as exactly
-# ``ε ≤ REGRESSION_LIMIT`` — an order-of-magnitude regression check that
-# normalizes uniform runner-speed variance. Interleaved rounds plus a median
-# handle isolated scheduling pauses. (Note ``_CAL_REF_US_PER_ITER``
-# cancels too, so its precise value only affects the printed μs scale, not the
-# verdict.)
+# measured from the calibration workload in the same run. When calibration and
+# parser costs scale together, ``runner_factor`` scales both sides and cancels,
+# leaving ``ε ≤ REGRESSION_LIMIT``. Interleaved rounds plus a median handle
+# isolated scheduling pauses. Regex calibration cannot model every parser
+# operation across architectures, so hosted CI uses ``--report``; the enforced
+# verdict runs serially on the stable M3 release host. (Note
+# ``_CAL_REF_US_PER_ITER`` cancels when both workloads scale together, so its
+# precise value only affects the printed μs scale, not that verdict.)
 # ---------------------------------------------------------------------------
 
 # Intrinsic per-parser cost on the reference M3, μs/call (from the historical
@@ -249,7 +249,9 @@ def bench_one(
     ``threshold = BASE_US[name] × REGRESSION_LIMIT × runner_factor``. Because both
     the parser measurement and the calibration baseline scale with the same
     runner speed, the verdict reduces to ``ε ≤ REGRESSION_LIMIT`` — a
-    runner-speed-normalized order-of-magnitude regression check.
+    runner-speed-normalized order-of-magnitude regression check when the
+    control and parser costs scale together. Hosted CI therefore reports this
+    value without enforcing it; the stable M3 release lane enforces it.
 
     To be robust to load changing mid-run, calibration and the parser bench
     are INTERLEAVED: each round times the calibration then the parser
@@ -258,8 +260,8 @@ def bench_one(
     round, so every ε is high and the median still fails it; a single round
     where the runner descheduled during the parser segment (but not the
     adjacent calibration) inflates only that one ε, which the median ignores
-    — so the now-ENFORCED CI gate does not false-fail on one transient
-    shared-runner pause (Codex #2409). A transiently-idle parser adjacent to
+    — so the aggregate does not false-fail on one transient shared-runner
+    pause (Codex #2409). A transiently-idle parser adjacent to
     a busy calibration reads as FAST relative to that busy baseline (low ε),
     so it does not false-fail either.
 
@@ -354,8 +356,8 @@ def main(argv: list[str] | None = None) -> int:
     for name, fn in parsers.items():
         sample = SAMPLES.get(name, "")
         if not sample:
-            print(f"  [skip] {name}: no sample wired", file=sys.stderr)
-            continue
+            print(f"FAIL: {name}: no sample wired", file=sys.stderr)
+            return 1
         # bench_one interleaves calibration with the parser bench itself
         # (issue #2344 #2); no explicit upfront factor here.
         r = bench_one(name, fn, sample, args.iters)

--- a/scripts/microbench_parsers.py
+++ b/scripts/microbench_parsers.py
@@ -9,11 +9,12 @@ but won't catch "still correct, 10x slower" — which has shipped twice
 historically (regex rebuilding in a hot path, AST walk where a string
 search worked).
 
-The bench is intentionally generous on absolute numbers — ubuntu-
-latest is shared hardware, perf varies by ±50% run to run. The point
-is to catch *order-of-magnitude* regressions, not fine-grained perf
-tracking. For real perf measurement use a M3 + a stable baseline; see
-`docs/development/releasing.md` §"Pre-release validation gauntlet".
+The bench uses a same-run machine factor and a generous relative budget
+because ubuntu-latest is shared hardware and performance varies between
+runs. The point is to catch *order-of-magnitude* regressions, not
+fine-grained perf tracking. For real perf measurement use a M3 + a
+stable baseline; see `docs/development/releasing.md` §"Pre-release
+validation gauntlet".
 
 Per parser:
 
@@ -52,15 +53,16 @@ from dataclasses import dataclass
 #
 # New design — a relative budget that cancels runner speed:
 #
-#   parser_us_per_call  ≈  BASE_US[name] × speedup × ε
-#   effective_threshold  =  BASE_US[name] × REGRESSION_LIMIT × speedup
+#   parser_us_per_call  ≈  BASE_US[name] × runner_factor × ε
+#   effective_threshold  =  BASE_US[name] × REGRESSION_LIMIT × runner_factor
 #
-# where ``speedup`` is how much slower THIS runner is than the reference M3,
+# where ``runner_factor`` is how much slower THIS runner is than the reference M3,
 # measured from the calibration workload in the same run. Because the
 # calibration and the parser benches run back-to-back on the same hardware,
-# ``speedup`` scales both sides and cancels, leaving the gate as exactly
-# ``ε ≤ REGRESSION_LIMIT`` — an order-of-magnitude regression check that is
-# (near-)immune to shared-runner speed variance. (Note ``_CAL_REF_US_PER_ITER``
+# ``runner_factor`` scales both sides and cancels, leaving the gate as exactly
+# ``ε ≤ REGRESSION_LIMIT`` — an order-of-magnitude regression check that
+# normalizes uniform runner-speed variance. Interleaved rounds plus a median
+# handle isolated scheduling pauses. (Note ``_CAL_REF_US_PER_ITER``
 # cancels too, so its precise value only affects the printed μs scale, not the
 # verdict.)
 # ---------------------------------------------------------------------------
@@ -102,7 +104,7 @@ _CAL_REF_US_PER_ITER: float = 0.48
 
 # Floor so a suspiciously-fast calibration can't compress the effective
 # threshold below the reference machine's own budget (guards the signal).
-_RUNNER_SPEEDUP_FLOOR: float = 0.5
+_RUNNER_FACTOR_FLOOR: float = 0.5
 
 # Realistic sample inputs for each parser. Each represents a single
 # tool call the parser should successfully extract — not edge cases,
@@ -141,11 +143,11 @@ class BenchResult:
     us_per_call: float
     iters: int
     threshold_us: float
-    # Runner speedup (vs the M3 reference) measured on the VERDICT round — the
+    # Runner slowdown factor (vs the M3 reference) on the VERDICT round — the
     # pair whose numbers are reported, so the printed threshold always matches
-    # the printed speedup (Codex #2409 NIT: the old display-only global
+    # the printed factor (Codex #2409 NIT: the old display-only global
     # calibrate-then-print could disagree with the actual verdict).
-    speedup: float
+    runner_factor: float
     passed: bool
 
 
@@ -193,30 +195,30 @@ def _run_calibration() -> float:
     return (dt / _CAL_ITERS) * 1_000_000
 
 
-def _measure_runner_speedup() -> float:
+def _measure_runner_factor() -> float:
     """How much slower this runner is than the reference M3, right now.
 
     Times the calibration workload a few times and takes the MIN so a
     transient slow stretch during calibration can't over-relax the gate
     (issue #2344: the whole point is to normalize the runner's *typical*
     speed this run). Returns the ratio (≈ 1 on an M3, larger on slower
-    shared runners), floored at ``_RUNNER_SPEEDUP_FLOOR`` (0.5) so a
+    shared runners), floored at ``_RUNNER_FACTOR_FLOOR`` (0.5) so a
     suspiciously fast measurement can't compress the effective threshold
     below the reference budget. ``bench_one`` calls this fresh for EACH
     round (right before each parser segment) so a runner that becomes busy
     mid-run still normalizes the parser it is about to time (issue #2344 #2).
     """
     per_op = min(_run_calibration() for _ in range(_CAL_REPS))
-    speedup = per_op / _CAL_REF_US_PER_ITER
-    return max(speedup, _RUNNER_SPEEDUP_FLOOR)
+    runner_factor = per_op / _CAL_REF_US_PER_ITER
+    return max(runner_factor, _RUNNER_FACTOR_FLOOR)
 
 
 def _median_verdict(
     pairs: list[tuple[float, float]], base_us: float
 ) -> tuple[float, float, int]:
-    """Robust (MEDIAN) ε across interleaved ``(parser_us, speedup)`` rounds.
+    """Robust (MEDIAN) ε across interleaved ``(parser_us, runner_factor)`` rounds.
 
-    Returns ``(eps, verdict_speedup, verdict_index)``. Median, not max
+    Returns ``(eps, verdict_factor, verdict_index)``. Median, not max
     (Codex #2409): ``max`` lets ONE round where the runner descheduled during
     the parser segment (but not the adjacent calibration — the back-to-back
     interleave) dominate an already-noisy ratio and false-fail the now-
@@ -227,7 +229,7 @@ def _median_verdict(
     report the pair that PRODUCED the verdict (printed numbers always agree
     with pass/fail).
     """
-    per_round_eps = [us / (base_us * speedup) for us, speedup in pairs]
+    per_round_eps = [us / (base_us * runner_factor) for us, runner_factor in pairs]
     idx = sorted(range(len(pairs)), key=lambda i: per_round_eps[i])[len(pairs) // 2]
     return per_round_eps[idx], pairs[idx][1], idx
 
@@ -238,17 +240,16 @@ def bench_one(
     sample: str,
     iters: int,
     *,
-    runner_speedup: float | None = None,
+    runner_factor: float | None = None,
 ) -> BenchResult:
     """Run ``fn(sample)`` ``iters`` times, return timing + verdict.
 
     Relative-budget gate (issue #2344): the parser's M3 base scaled by the
-    same-run runner speedup and the regression limit,
-    ``threshold = BASE_US[name] × REGRESSION_LIMIT × speedup``. Because both
+    same-run runner factor and the regression limit,
+    ``threshold = BASE_US[name] × REGRESSION_LIMIT × runner_factor``. Because both
     the parser measurement and the calibration baseline scale with the same
     runner speed, the verdict reduces to ``ε ≤ REGRESSION_LIMIT`` — a
-    runner-speed-INDEPENDENT order-of-magnitude regression check that does
-    not flake on shared-hosted-runner variance.
+    runner-speed-normalized order-of-magnitude regression check.
 
     To be robust to load changing mid-run, calibration and the parser bench
     are INTERLEAVED: each round times the calibration then the parser
@@ -262,8 +263,8 @@ def bench_one(
     a busy calibration reads as FAST relative to that busy baseline (low ε),
     so it does not false-fail either.
 
-    ``runner_speedup`` overrides the calibration when provided (unit tests);
-    when ``None`` (production), each round's speedup is measured live.
+    ``runner_factor`` overrides the calibration when provided (unit tests);
+    when ``None`` (production), each round's factor is measured live.
     """
     # Every parser the bench knows about must carry an explicit ``BASE_US``
     # entry; silently defaulting an unknown name to a magic 5.0 would mask a
@@ -290,24 +291,22 @@ def bench_one(
     pairs: list[tuple[float, float]] = []
     t_total0 = time.perf_counter()
     for i in range(rounds):
-        speedup = (
-            _measure_runner_speedup() if runner_speedup is None else runner_speedup
-        )
+        factor = _measure_runner_factor() if runner_factor is None else runner_factor
         n = per_round[i]
         t0 = time.perf_counter()
         for _ in range(n):
             fn(sample)
         dt = time.perf_counter() - t0
         us = (dt / n) * 1_000_000
-        pairs.append((us, speedup))
+        pairs.append((us, factor))
     total_ms = (time.perf_counter() - t_total0) * 1000
     iters_executed = sum(per_round)
     # Verdict = MEDIAN ε across all paired rounds (robust aggregate), not the
     # max — see ``_median_verdict`` (Codex #2409). The reported us_per_call and
     # threshold come from the SAME pair that produced the verdict (the
     # median-ε round), so the printed numbers always agree with pass/fail.
-    eps, verdict_speedup, median_idx = _median_verdict(pairs, base_us)
-    threshold_us = base_us * REGRESSION_LIMIT * verdict_speedup
+    eps, verdict_factor, median_idx = _median_verdict(pairs, base_us)
+    threshold_us = base_us * REGRESSION_LIMIT * verdict_factor
     us_per_call = pairs[median_idx][0]
     return BenchResult(
         name=name,
@@ -315,7 +314,7 @@ def bench_one(
         us_per_call=us_per_call,
         iters=iters_executed,
         threshold_us=threshold_us,
-        speedup=verdict_speedup,
+        runner_factor=verdict_factor,
         passed=eps <= REGRESSION_LIMIT,
     )
 
@@ -341,13 +340,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     # NOTE (Codex #2409 NIT): no display-only upfront calibration. Each
-    # verdict carries the speedup of its own verdict round (see BenchResult),
-    # so the printed speedup ALWAYS describes the reported threshold. Pre-
-    # measuring a global "runner speedup" solely to print a headline cost
+    # verdict carries the factor of its own verdict round (see BenchResult),
+    # so the printed factor ALWAYS describes the reported threshold. Pre-
+    # measuring a global runner factor solely to print a headline cost
     # ~100k extra regex ops AND could disagree with the actual verdict.
     print(f"Parser microbench × {args.iters} iters/parser")
     print(
-        f"{'parser':<12}{'us/call':>12}{'speedup':>10}{'threshold':>14}{'verdict':>10}"
+        f"{'parser':<12}{'us/call':>12}{'runner':>10}{'threshold':>14}{'verdict':>10}"
     )
     print("-" * 58)
 
@@ -358,12 +357,12 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  [skip] {name}: no sample wired", file=sys.stderr)
             continue
         # bench_one interleaves calibration with the parser bench itself
-        # (issue #2344 #2); no explicit upfront speedup here.
+        # (issue #2344 #2); no explicit upfront factor here.
         r = bench_one(name, fn, sample, args.iters)
         results.append(r)
         verdict = "OK" if r.passed else "FAIL"
         print(
-            f"{r.name:<12}{r.us_per_call:>12.2f}{r.speedup:>10.2f}"
+            f"{r.name:<12}{r.us_per_call:>12.2f}{r.runner_factor:>10.2f}"
             f"{r.threshold_us:>14.2f}{verdict:>10}"
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,26 @@
 
 import pytest
 
+# One-time, session-scoped availability probe for the Apple-only ``mlx``
+# runtime. This is the ONLY place conftest imports it (and even then under
+# try/except); nothing else here should import mlx at module scope, because
+# this file is loaded by the no-MLX Linux CI leg where mlx is absent by design.
+#
+# We probe once up front and remember the result in a module global rather than
+# re-importing mlx per collection/modifyitems call — importing is comparatively
+# expensive and the answer cannot change mid-run. The ``except Exception`` (not
+# just ``ImportError``) also swallows a version that imports but fails at
+# import time (e.g. an unsupported ABI), treating it the same as absent: a test
+# that needs mlx cannot run there anyway. See the ``requires_mlx`` marker
+# documentation in pytest.ini and the auto-skip in ``pytest_collection_modifyitems``
+# below for how this flips the no-MLX leg onto the marker mechanism.
+try:
+    import mlx  # noqa: F401  (probe only)
+
+    HAS_MLX = True
+except Exception:  # noqa: BLE001 - mlx is optional; absent/failing == unavailable
+    HAS_MLX = False
+
 # Environment variables that point at the host's real, machine-specific HF
 # cache. Every non-opted-in test gets these redirected to a fresh ``tmp_path``
 # so a developer machine's real ``~/.cache/huggingface`` (possibly hundreds of
@@ -278,6 +298,14 @@ def pytest_configure(config):
         "fixture. Use only when a test genuinely needs the real cache; "
         "review every use. See that fixture's docstring.",
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_mlx: mark a test that imports or otherwise needs mlx; it is "
+        "auto-skipped on the no-MLX CI leg (see HAS_MLX in this module and the "
+        "auto-skip in ``pytest_collection_modifyitems``). Deliberately NOT in "
+        "the addopts ``-m`` default, so local dev still runs these when mlx is "
+        "present.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -306,6 +334,31 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if item.path.name in _SCRIPT_ONLY_MODULES:
             item.add_marker(skip_script_only)
+
+    # The ``requires_mlx`` auto-skip: on a host where mlx is missing (the
+    # Linux no-MLX CI leg), any test marked ``requires_mlx`` is skipped. This
+    # is what lets a CI step run the whole suite and have mlx-bound tests drop
+    # out on their own instead of being hand-curated into an exclusion roster.
+    #
+    # Guard on ``not HAS_MLX`` so a dev machine WITH mlx (i.e. the current
+    # host, or the Apple leg) runs these tests normally — the marker only bites
+    # when mlx genuinely cannot be imported. We run this in
+    # ``pytest_collection_modifyitems`` rather than an autouse fixture so the
+    # collection-time marker is seen regardless of how a test is parametrized
+    # or discovered, and the skip reason reads ``requires mlx``.
+    #
+    # NOTE: this skip only rescues tests/modules that COLLECT successfully.
+    # A module that does an unguarded top-level ``import mlx`` fails at
+    # collection time (before modifyitems), which a marker cannot prevent — that
+    # is exactly the shape the contract test tests/test_no_mlx_marker_contract.py
+    # polices on the no-MLX leg.
+    if not HAS_MLX:
+        skip_no_mlx = pytest.mark.skip(
+            reason="requires mlx (not installed on this host)"
+        )
+        for item in items:
+            if "requires_mlx" in item.keywords:
+                item.add_marker(skip_no_mlx)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -72,32 +72,78 @@ def test_unknown_parser_gets_default_threshold(mb):
 # ---------- sample / parser wiring -----------------------------------
 
 
-def test_each_threshold_has_a_sample(mb):
-    """Every parser in THRESHOLDS_US_PER_CALL must have a SAMPLES entry.
+def test_each_base_us_has_a_sample(mb):
+    """Every parser in BASE_US must have a SAMPLES entry.
     Otherwise the bench silently skips it without complaining, which
     would let a regression slip through unbenched."""
-    missing = sorted(set(mb.THRESHOLDS_US_PER_CALL) - set(mb.SAMPLES))
+    missing = sorted(set(mb.BASE_US) - set(mb.SAMPLES))
     assert not missing, (
-        f"parsers in THRESHOLDS but missing in SAMPLES: {missing}. "
+        f"parsers in BASE_US but missing in SAMPLES: {missing}. "
         "Add a realistic sample input to SAMPLES so it actually benches."
     )
 
 
-def test_each_sample_has_a_threshold(mb):
-    """And vice versa — every SAMPLES entry should have a threshold so
+def test_each_sample_has_a_base_us(mb):
+    """And vice versa — every SAMPLES entry should have a base cost so
     the gate is enforced, not just a printed timing."""
-    missing = sorted(set(mb.SAMPLES) - set(mb.THRESHOLDS_US_PER_CALL))
+    missing = sorted(set(mb.SAMPLES) - set(mb.BASE_US))
     assert not missing, (
-        f"parsers in SAMPLES but missing in THRESHOLDS: {missing}. "
-        "Either add a threshold or remove from SAMPLES."
+        f"parsers in SAMPLES but missing in BASE_US: {missing}. "
+        "Either add a base cost or remove from SAMPLES."
     )
 
 
-def test_thresholds_are_positive(mb):
-    """Catch the 'paste-bug' where someone sets a threshold to 0 or
+def test_base_us_are_positive(mb):
+    """Catch the 'paste-bug' where someone sets a base cost to 0 or
     negative — that would make every measurement fail."""
-    for name, val in mb.THRESHOLDS_US_PER_CALL.items():
-        assert val > 0, f"{name}: threshold must be positive, got {val}"
+    for name, val in mb.BASE_US.items():
+        assert val > 0, f"{name}: base cost must be positive, got {val}"
+
+
+def test_regression_limit_sane(mb):
+    """The relative gate must be a positive multiple > 1 so it actually
+    catches an order-of-magnitude regression rather than being inverted
+    or a no-op."""
+    assert mb.REGRESSION_LIMIT > 1.0
+
+
+def test_slow_runner_scales_threshold_up(mb):
+    """A slower runner must produce a proportionally higher effective
+    threshold, so an unchanged parser doesn't flake (issue #2344)."""
+    base = mb.bench_one("hermes", lambda _t: None, "x", iters=10, runner_speedup=1.0)
+    slow = mb.bench_one("hermes", lambda _t: None, "x", iters=10, runner_speedup=5.0)
+    # 5x slower runner -> threshold scales in kind; the same fast callable
+    # must still pass on BOTH (relative budget, not absolute wall-clock).
+    assert slow.threshold_us > base.threshold_us
+    assert slow.passed and base.passed
+
+
+def test_relative_budget_catches_regression_across_runner_speeds(mb):
+    """The gate is a ratio (parser / calibrated baseline), so the SAME
+    relative slowdown fails regardless of how slow the runner is. This is
+    what makes the gate runner-speed-independent (#2344)."""
+
+    def slow(_t):
+        # ~1ms per call, i.e. far more than REGRESSION_LIMIT × any base.
+        import time
+
+        time.sleep(0.001)
+
+    on_m3 = mb.bench_one("hermes", slow, "x", iters=3, runner_speedup=1.0)
+    on_slow_runner = mb.bench_one("hermes", slow, "x", iters=3, runner_speedup=5.0)
+    assert not on_m3.passed
+    # On a 5x slower runner the effective threshold scales 5x too, so the
+    # ~1ms absolute slowdown is still (first-order) a hard FAIL on both.
+    assert not on_slow_runner.passed
+
+
+def test_calibration_returns_positive_finite(mb):
+    """``_measure_runner_speedup`` must return a positive, finite scalar."""
+    import math
+
+    speedup = mb._measure_runner_speedup()
+    assert math.isfinite(speedup)
+    assert speedup >= mb._RUNNER_SPEEDUP_FLOOR
 
 
 # ---------- entry point ----------------------------------------------

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -112,8 +112,8 @@ def test_regression_limit_sane(mb):
 # scales linearly with its iteration count. Because the work is CPU-bound on
 # the same hardware, a parser asked to do N ops takes ~2× the wall-time of
 # N/2 ops — and, critically, the SAME N on a 5×-slower runner takes ~5× the
-# wall-time. We pick N so the parser costs ``BASE_US * eps * speedup`` μs, so
-# its measured μs/call grows with ``runner_speedup`` exactly like the
+# wall-time. We pick N so the parser costs ``BASE_US * eps * runner_factor`` μs,
+# so its measured μs/call grows with ``runner_factor`` exactly like the
 # calibration baseline does. The verdict then reduces to ``eps <= LIMIT``
 # independent of runner speed — which is the property that kills the #2344
 # shared-runner flake.
@@ -162,21 +162,21 @@ def _prop_parser():
     return _make
 
 
-def _bench_with_cal(mb, make, eps_mult, speedup, monkeypatch):
+def _bench_with_cal(mb, make, eps_mult, runner_factor, monkeypatch):
     """Exercise ``bench_one`` through the REAL calibration path by mocking the
     runner-speed measurement (we cannot make the shared test machine 5× slower).
 
-    The parser workload is CPU-bound and sized to cost ``BASE_US*ε*speedup`` μs
+    The parser workload is CPU-bound and sized to cost ``BASE_US*ε*runner_factor`` μs
     (each μs of work is one calibration-op's worth), so it reproduces what a
-    real parser experiences on a ``speedup``× slower runner, and the mocked
-    calibration returns exactly that ``speedup``. The verdict must then depend
+    real parser experiences on a ``runner_factor``× slower runner, and the mocked
+    calibration returns exactly that factor. The verdict must then depend
     only on ``ε`` vs ``REGRESSION_LIMIT`` — proving runner-speed independence
     (#2344).
     """
     base_us = mb.BASE_US["hermes"]
     limit = mb.REGRESSION_LIMIT
-    target = base_us * limit * eps_mult * speedup
-    monkeypatch.setattr(mb, "_measure_runner_speedup", lambda: float(speedup))
+    target = base_us * limit * eps_mult * runner_factor
+    monkeypatch.setattr(mb, "_measure_runner_factor", lambda: float(runner_factor))
     return mb.bench_one("hermes", make(target), "x", iters=_CAL_MIN_ITERS_FOR_TEST)
 
 
@@ -225,9 +225,9 @@ def test_median_verdict_ignores_a_single_spiked_round(mb):
     # this run; the MEDIAN ignores the single spike and still passes.
     spike = (base * 2.0 * limit, 1.0)  # ε = 2× 12 = 24 > 12 → max would fail
     # 1 spiked + 4 healthy rounds: the median (3rd-smallest of 5) is healthy.
-    eps, speedup, idx = mb._median_verdict([normal] * 4 + [spike], base)
+    eps, runner_factor, idx = mb._median_verdict([normal] * 4 + [spike], base)
     assert idx != 4  # reports a healthy (normal) round, not the spike
-    assert speedup == 1.0
+    assert runner_factor == 1.0
     assert eps < limit and eps == pytest.approx(0.5)
     # The SAME pairs under a *max* aggregate WOULD exceed the limit — proving
     # the test is meaningful (it would go red if production reverted to max).
@@ -239,23 +239,23 @@ def test_median_verdict_ignores_a_single_spiked_round(mb):
     assert epss > limit
 
 
-def test_speedup_override_passthrough(mb, monkeypatch):
-    """The explicit ``runner_speedup`` override path still works for tests that
+def test_runner_factor_override_passthrough(mb, monkeypatch):
+    """The explicit ``runner_factor`` override path still works for tests that
     hand a scalar (backward-compat with pre-interleave unit semantics)."""
     make = _prop_parser()
     base_us = mb.BASE_US["hermes"]
-    r = mb.bench_one("hermes", make(base_us * 5.0), "x", iters=20, runner_speedup=1.0)
+    r = mb.bench_one("hermes", make(base_us * 5.0), "x", iters=20, runner_factor=1.0)
     assert r.passed
     assert r.threshold_us == pytest.approx(mb.BASE_US["hermes"] * mb.REGRESSION_LIMIT)
 
 
 def test_calibration_returns_positive_finite(mb):
-    """``_measure_runner_speedup`` must return a positive, finite scalar."""
+    """``_measure_runner_factor`` must return a positive, finite scalar."""
     import math
 
-    speedup = mb._measure_runner_speedup()
-    assert math.isfinite(speedup)
-    assert speedup >= mb._RUNNER_SPEEDUP_FLOOR
+    runner_factor = mb._measure_runner_factor()
+    assert math.isfinite(runner_factor)
+    assert runner_factor >= mb._RUNNER_FACTOR_FLOOR
 
 
 # ---------- entry point ----------------------------------------------

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -152,53 +152,63 @@ def _prop_parser():
     return _make
 
 
-def test_slow_runner_scales_threshold_up(mb):
+def _bench_with_cal(mb, make, eps_mult, speedup, monkeypatch):
+    """Exercise ``bench_one`` through the REAL calibration path by mocking the
+    runner-speed measurement (we cannot make the shared test machine 5× slower).
+
+    The parser workload is CPU-bound and sized to cost ``BASE_US*ε*speedup`` μs
+    (each μs of work is one calibration-op's worth), so it reproduces what a
+    real parser experiences on a ``speedup``× slower runner, and the mocked
+    calibration returns exactly that ``speedup``. The verdict must then depend
+    only on ``ε`` vs ``REGRESSION_LIMIT`` — proving runner-speed independence
+    (#2344).
+    """
+    base_us = mb.BASE_US["hermes"]
+    limit = mb.REGRESSION_LIMIT
+    target = base_us * limit * eps_mult * speedup
+    monkeypatch.setattr(mb, "_measure_runner_speedup", lambda: float(speedup))
+    return mb.bench_one("hermes", make(target), "x", iters=_CAL_MIN_ITERS_FOR_TEST)
+
+
+# Shared by the two speed tests: enough iters to trigger multi-round
+# interleaving but still fast.
+_CAL_MIN_ITERS_FOR_TEST = 50
+
+
+def test_slow_runner_scales_threshold_up(mb, monkeypatch):
     """A slower runner produces a proportionally higher effective threshold,
     and a speed-proportional parser keeps the SAME verdict on both (the
     relative gate does not flake on shared-runner speed, #2344)."""
     make = _prop_parser()
-    # A healthy parser at 5× hermes base (well under REGRESSION_LIMIT).
-    base_us = mb.BASE_US["hermes"]
-    on_m3 = mb.bench_one(
-        "hermes",
-        make(base_us * 5.0 * 1.0),
-        "x",
-        iters=5,
-        runner_speedup=1.0,
-    )
-    on_slow = mb.bench_one(
-        "hermes",
-        make(base_us * 5.0 * 5.0),
-        "x",
-        iters=5,
-        runner_speedup=5.0,
-    )
-    # Threshold scales with the runner; the same relative parser passes both.
+    # A healthy parser, well under REGRESSION_LIMIT (eps=0.3×LIMIT), so
+    # timing noise can't tip it over the boundary.
+    on_m3 = _bench_with_cal(mb, make, 0.3, 1.0, monkeypatch)
+    on_slow = _bench_with_cal(mb, make, 0.3, 5.0, monkeypatch)
     assert on_slow.threshold_us > on_m3.threshold_us
     assert on_m3.passed and on_slow.passed
 
 
-def test_relative_budget_catches_regression_across_runner_speeds(mb):
+def test_relative_budget_catches_regression_across_runner_speeds(mb, monkeypatch):
     """The gate is a ratio: a parser at REGRESSION_LIMIT × its base fails at
     EVERY runner speed (fast M3 and 5×-slower shared runner alike), and one
     just under the limit passes at every speed (#2344)."""
     make = _prop_parser()
+    # Under the limit (ε=0.8×LIMIT): passes on 1x and 5x runners.
+    assert _bench_with_cal(mb, make, 0.8, 1.0, monkeypatch).passed
+    assert _bench_with_cal(mb, make, 0.8, 5.0, monkeypatch).passed
+    # Over the limit (ε=1.2×LIMIT): fails on 1x and 5x runners alike.
+    assert not _bench_with_cal(mb, make, 1.2, 1.0, monkeypatch).passed
+    assert not _bench_with_cal(mb, make, 1.2, 5.0, monkeypatch).passed
+
+
+def test_speedup_override_passthrough(mb, monkeypatch):
+    """The explicit ``runner_speedup`` override path still works for tests that
+    hand a scalar (backward-compat with pre-interleave unit semantics)."""
+    make = _prop_parser()
     base_us = mb.BASE_US["hermes"]
-    limit = mb.REGRESSION_LIMIT
-
-    def bench(speedup: float, eps_mult: float):
-        # Cost scales with speedup, threshold scales with speedup too.
-        target = base_us * limit * eps_mult * speedup
-        return mb.bench_one(
-            "hermes", make(target), "x", iters=5, runner_speedup=speedup
-        )
-
-    # Under the limit: passes on 1x and 5x runners.
-    assert bench(1.0, 0.8).passed
-    assert bench(5.0, 0.8).passed
-    # Over the limit: fails on 1x and 5x runners alike.
-    assert not bench(1.0, 1.2).passed
-    assert not bench(5.0, 1.2).passed
+    r = mb.bench_one("hermes", make(base_us * 5.0), "x", iters=20, runner_speedup=1.0)
+    assert r.passed
+    assert r.threshold_us == pytest.approx(mb.BASE_US["hermes"] * mb.REGRESSION_LIMIT)
 
 
 def test_calibration_returns_positive_finite(mb):

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -114,9 +114,9 @@ def test_regression_limit_sane(mb):
 # N/2 ops — and, critically, the SAME N on a 5×-slower runner takes ~5× the
 # wall-time. We pick N so the parser costs ``BASE_US * eps * runner_factor`` μs,
 # so its measured μs/call grows with ``runner_factor`` exactly like the
-# calibration baseline does. The verdict then reduces to ``eps <= LIMIT``
-# independent of runner speed — which is the property that kills the #2344
-# shared-runner flake.
+# calibration baseline does. These tests cover the ratio math only; a separate
+# contract below records that unrelated workloads may scale independently and
+# is why hosted CI runs this benchmark in advisory mode (#2344).
 _CAL_TEXT = (
     "<tool_call>get_weather city San Francisco "
     "<arg_key>city</arg_key><arg_value>San Francisco</arg_value></tool_call>"
@@ -168,10 +168,10 @@ def _bench_with_cal(mb, make, eps_mult, runner_factor, monkeypatch):
 
     The parser workload is CPU-bound and sized to cost ``BASE_US*ε*runner_factor`` μs
     (each μs of work is one calibration-op's worth), so it reproduces what a
-    real parser experiences on a ``runner_factor``× slower runner, and the mocked
-    calibration returns exactly that factor. The verdict must then depend
-    only on ``ε`` vs ``REGRESSION_LIMIT`` — proving runner-speed independence
-    (#2344).
+    parser experiences when both workloads scale together, and the mocked
+    calibration returns exactly that factor. The verdict must then depend only
+    on ``ε`` vs ``REGRESSION_LIMIT``. This does not claim that unlike operations
+    scale together across hosted architectures; that limitation is tested below.
     """
     base_us = mb.BASE_US["hermes"]
     limit = mb.REGRESSION_LIMIT
@@ -187,8 +187,7 @@ _CAL_MIN_ITERS_FOR_TEST = 50
 
 def test_slow_runner_scales_threshold_up(mb, monkeypatch):
     """A slower runner produces a proportionally higher effective threshold,
-    and a speed-proportional parser keeps the SAME verdict on both (the
-    relative gate does not flake on shared-runner speed, #2344)."""
+    and a parser scaled by the same factor keeps the same verdict."""
     make = _prop_parser()
     # A healthy parser, well under REGRESSION_LIMIT (eps=0.3×LIMIT), so
     # timing noise can't tip it over the boundary.
@@ -198,10 +197,9 @@ def test_slow_runner_scales_threshold_up(mb, monkeypatch):
     assert on_m3.passed and on_slow.passed
 
 
-def test_relative_budget_catches_regression_across_runner_speeds(mb, monkeypatch):
-    """The gate is a ratio: a parser at REGRESSION_LIMIT × its base fails at
-    EVERY runner speed (fast M3 and 5×-slower shared runner alike), and one
-    just under the limit passes at every speed (#2344)."""
+def test_relative_budget_math_when_workloads_scale_together(mb, monkeypatch):
+    """When subject and control costs scale together, the ratio preserves the
+    pass/fail verdict across runner factors."""
     make = _prop_parser()
     # Under the limit (ε=0.8×LIMIT): passes on 1x and 5x runners.
     assert _bench_with_cal(mb, make, 0.8, 1.0, monkeypatch).passed
@@ -211,12 +209,24 @@ def test_relative_budget_catches_regression_across_runner_speeds(mb, monkeypatch
     assert not _bench_with_cal(mb, make, 1.2, 5.0, monkeypatch).passed
 
 
+def test_independent_control_cost_can_change_verdict(mb):
+    """A control workload is not a universal hardware oracle: if its cost
+    changes independently from a fixed parser cost, the ratio can change the
+    verdict. This limitation is pinned so hosted CI stays report-only."""
+    base = mb.BASE_US["hermes"]
+    fixed_parser_us = base * mb.REGRESSION_LIMIT
+    low_factor_eps, _, _ = mb._median_verdict([(fixed_parser_us, 0.5)] * 5, base)
+    high_factor_eps, _, _ = mb._median_verdict([(fixed_parser_us, 2.0)] * 5, base)
+    assert low_factor_eps > mb.REGRESSION_LIMIT
+    assert high_factor_eps < mb.REGRESSION_LIMIT
+
+
 def test_median_verdict_ignores_a_single_spiked_round(mb):
     """The gate aggregate is the MEDIAN ε, not the max: one round where the
     runner descheduled during the parser segment (ε spikes to 10×) must NOT
     fail the gate, while a genuine regression (every round over the limit)
-    still does (Codex #2409). This is what lets the now-ENFORCED CI gate run
-    on a shared runner without flaking on a single pause."""
+    still does (Codex #2409). This keeps the report stable in hosted CI and the
+    hard gate stable on the serial M3 release host."""
     base = mb.BASE_US["hermes"]
     limit = mb.REGRESSION_LIMIT
     normal = (base * 0.5, 1.0)  # ε = 0.5 — healthy within the 12× budget
@@ -278,12 +288,22 @@ def test_report_mode_returns_zero_even_with_failures(mb):
     assert rc == 0
 
 
+def test_main_fails_when_no_parsers_load(mb, monkeypatch):
+    """An empty parser registry is a broken benchmark, not a green run."""
+    monkeypatch.setattr(mb, "_build_parsers", lambda: {})
+    assert mb.main(["--iters", "1", "--report"]) == 1
+
+
+def test_main_fails_when_loaded_parser_has_no_sample(mb, monkeypatch):
+    """A newly loaded parser cannot silently escape measurement."""
+    monkeypatch.setattr(mb, "_build_parsers", lambda: {"brand_new": lambda _t: None})
+    assert mb.main(["--iters", "1", "--report"]) == 1
+
+
 def test_enforced_gate_returns_nonzero_without_report(mb, monkeypatch):
     """The ENFORCED relative-budget gate (running WITHOUT ``--report``) must
-    exit nonzero when a parser exceeds its budget — this is the hard gate the
-    ci.yml microbench step now relies on (issue #2409 Codex: `--report` was
-    neutering the promised enforced gate). ``--report`` remains the explicit,
-    intentional opt-out for an info-only run."""
+    exit nonzero when a parser exceeds its budget. The stable M3 release check
+    uses this path; hosted CI uses the explicit report-only path."""
     import time
 
     def slow(_t):
@@ -295,3 +315,12 @@ def test_enforced_gate_returns_nonzero_without_report(mb, monkeypatch):
     assert mb.main(["--iters", "5"]) == 1
     # Explicit opt-out: --report still returns 0 even with the same failure.
     assert mb.main(["--iters", "5", "--report"]) == 0
+
+
+def test_hosted_ci_is_advisory_and_m3_release_check_is_enforced():
+    """Shared hosted timing must not block a PR, while the serial M3 release
+    check retains the non-reporting hard-gate invocation."""
+    ci = (_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    release = (_REPO_ROOT / "scripts" / "release_check_m3.sh").read_text()
+    assert "python scripts/microbench_parsers.py --report" in ci
+    assert '"$PY" scripts/microbench_parsers.py\n' in release

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -123,13 +123,22 @@ _CAL_TEXT = (
 
 
 def _cpu_iter_cost_us() -> float:
-    """Measure the per-iteration μs of the CPU-bound op on THIS machine."""
+    """Measure the per-iteration μs of the FULL generated parser body on THIS
+    machine — the ``count()`` op PLUS the ``for``-loop and ``c +=`` overhead
+    that every real iteration also pays (Codex #2409). Calibrating only
+    ``_CAL_TEXT.count("x")`` and ignoring that overhead made the synthetic
+    parser slightly SLOWER than its nominal target, so a borderline
+    sub-limit case could tip over and flake the test. The body timed here is
+    textually identical to the one ``_prop_parser`` generates, so the derived
+    ``n`` lands the parser precisely on its requested μs/call.
+    """
     import time
 
     n = 30_000
     t0 = time.perf_counter()
+    c = 0
     for _ in range(n):
-        _CAL_TEXT.count("x")
+        c += _CAL_TEXT.count("x")
     dt = time.perf_counter() - t0
     return (dt / n) * 1_000_000
 
@@ -199,6 +208,27 @@ def test_relative_budget_catches_regression_across_runner_speeds(mb, monkeypatch
     # Over the limit (ε=1.2×LIMIT): fails on 1x and 5x runners alike.
     assert not _bench_with_cal(mb, make, 1.2, 1.0, monkeypatch).passed
     assert not _bench_with_cal(mb, make, 1.2, 5.0, monkeypatch).passed
+
+
+def test_median_verdict_ignores_a_single_spiked_round(mb):
+    """The gate aggregate is the MEDIAN ε, not the max: one round where the
+    runner descheduled during the parser segment (ε spikes to 10×) must NOT
+    fail the gate, while a genuine regression (every round over the limit)
+    still does (Codex #2409). This is what lets the now-ENFORCED CI gate run
+    on a shared runner without flaking on a single pause."""
+    base = mb.BASE_US["hermes"]
+    limit = mb.REGRESSION_LIMIT
+    normal = (base * 0.5, 1.0)   # ε = 0.5 — healthy across the 12× budget
+    spike = (base * 0.5 * 20.0, 1.0)  # parser 20× nominal this round → ε = 10
+    # 1 spiked + 4 healthy rounds: the median (3rd-smallest of 5) is healthy.
+    eps, speedup, idx = mb._median_verdict([normal] * 4 + [spike], base)
+    assert idx != 4  # reports a healthy (normal) round, not the spike
+    assert speedup == 1.0
+    assert eps < limit and eps == pytest.approx(0.5)
+    # All rounds genuinely slow (ε = 1.5×LIMIT): the median still fails.
+    slow = (base * 1.5 * limit, 1.0)
+    epss, _, _ = mb._median_verdict([slow] * 5, base)
+    assert epss > limit
 
 
 def test_speedup_override_passthrough(mb, monkeypatch):

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -107,34 +107,98 @@ def test_regression_limit_sane(mb):
     assert mb.REGRESSION_LIMIT > 1.0
 
 
+# The two runner-speed tests use a CPU-bound synthetic parser whose work
+# scales linearly with its iteration count. Because the work is CPU-bound on
+# the same hardware, a parser asked to do N ops takes ~2× the wall-time of
+# N/2 ops — and, critically, the SAME N on a 5×-slower runner takes ~5× the
+# wall-time. We pick N so the parser costs ``BASE_US * eps * speedup`` μs, so
+# its measured μs/call grows with ``runner_speedup`` exactly like the
+# calibration baseline does. The verdict then reduces to ``eps <= LIMIT``
+# independent of runner speed — which is the property that kills the #2344
+# shared-runner flake.
+_CAL_TEXT = (
+    "<tool_call>get_weather city San Francisco "
+    "<arg_key>city</arg_key><arg_value>San Francisco</arg_value></tool_call>"
+)
+
+
+def _cpu_iter_cost_us() -> float:
+    """Measure the per-iteration μs of the CPU-bound op on THIS machine."""
+    import time
+
+    n = 30_000
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _CAL_TEXT.count("x")
+    dt = time.perf_counter() - t0
+    return (dt / n) * 1_000_000
+
+
+def _prop_parser():
+    """A synthetic parser whose per-call wall-time ∝ its iteration count."""
+
+    def _make(us_per_call: float):
+        k = _cpu_iter_cost_us()
+        n = max(1, int(us_per_call / k))
+
+        def fn(_t):
+            c = 0
+            for _ in range(n):
+                c += _CAL_TEXT.count("x")
+            return c
+
+        return fn
+
+    return _make
+
+
 def test_slow_runner_scales_threshold_up(mb):
-    """A slower runner must produce a proportionally higher effective
-    threshold, so an unchanged parser doesn't flake (issue #2344)."""
-    base = mb.bench_one("hermes", lambda _t: None, "x", iters=10, runner_speedup=1.0)
-    slow = mb.bench_one("hermes", lambda _t: None, "x", iters=10, runner_speedup=5.0)
-    # 5x slower runner -> threshold scales in kind; the same fast callable
-    # must still pass on BOTH (relative budget, not absolute wall-clock).
-    assert slow.threshold_us > base.threshold_us
-    assert slow.passed and base.passed
+    """A slower runner produces a proportionally higher effective threshold,
+    and a speed-proportional parser keeps the SAME verdict on both (the
+    relative gate does not flake on shared-runner speed, #2344)."""
+    make = _prop_parser()
+    # A healthy parser at 5× hermes base (well under REGRESSION_LIMIT).
+    base_us = mb.BASE_US["hermes"]
+    on_m3 = mb.bench_one(
+        "hermes",
+        make(base_us * 5.0 * 1.0),
+        "x",
+        iters=5,
+        runner_speedup=1.0,
+    )
+    on_slow = mb.bench_one(
+        "hermes",
+        make(base_us * 5.0 * 5.0),
+        "x",
+        iters=5,
+        runner_speedup=5.0,
+    )
+    # Threshold scales with the runner; the same relative parser passes both.
+    assert on_slow.threshold_us > on_m3.threshold_us
+    assert on_m3.passed and on_slow.passed
 
 
 def test_relative_budget_catches_regression_across_runner_speeds(mb):
-    """The gate is a ratio (parser / calibrated baseline), so the SAME
-    relative slowdown fails regardless of how slow the runner is. This is
-    what makes the gate runner-speed-independent (#2344)."""
+    """The gate is a ratio: a parser at REGRESSION_LIMIT × its base fails at
+    EVERY runner speed (fast M3 and 5×-slower shared runner alike), and one
+    just under the limit passes at every speed (#2344)."""
+    make = _prop_parser()
+    base_us = mb.BASE_US["hermes"]
+    limit = mb.REGRESSION_LIMIT
 
-    def slow(_t):
-        # ~1ms per call, i.e. far more than REGRESSION_LIMIT × any base.
-        import time
+    def bench(speedup: float, eps_mult: float):
+        # Cost scales with speedup, threshold scales with speedup too.
+        target = base_us * limit * eps_mult * speedup
+        return mb.bench_one(
+            "hermes", make(target), "x", iters=5, runner_speedup=speedup
+        )
 
-        time.sleep(0.001)
-
-    on_m3 = mb.bench_one("hermes", slow, "x", iters=3, runner_speedup=1.0)
-    on_slow_runner = mb.bench_one("hermes", slow, "x", iters=3, runner_speedup=5.0)
-    assert not on_m3.passed
-    # On a 5x slower runner the effective threshold scales 5x too, so the
-    # ~1ms absolute slowdown is still (first-order) a hard FAIL on both.
-    assert not on_slow_runner.passed
+    # Under the limit: passes on 1x and 5x runners.
+    assert bench(1.0, 0.8).passed
+    assert bench(5.0, 0.8).passed
+    # Over the limit: fails on 1x and 5x runners alike.
+    assert not bench(1.0, 1.2).passed
+    assert not bench(5.0, 1.2).passed
 
 
 def test_calibration_returns_positive_finite(mb):

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -238,3 +238,22 @@ def test_report_mode_returns_zero_even_with_failures(mb):
     # if perf is degenerate, --report should still exit 0.
     rc = mb.main(["--iters", "1", "--report"])
     assert rc == 0
+
+
+def test_enforced_gate_returns_nonzero_without_report(mb, monkeypatch):
+    """The ENFORCED relative-budget gate (running WITHOUT ``--report``) must
+    exit nonzero when a parser exceeds its budget — this is the hard gate the
+    ci.yml microbench step now relies on (issue #2409 Codex: `--report` was
+    neutering the promised enforced gate). ``--report`` remains the explicit,
+    intentional opt-out for an info-only run."""
+    import time
+
+    def slow(_t):
+        # ~1000 µs/call — orders of magnitude over the 12× relative budget.
+        time.sleep(0.001)
+
+    monkeypatch.setattr(mb, "_build_parsers", lambda: {"hermes": slow})
+    # Enforced: a regression reddens the run (exit 1).
+    assert mb.main(["--iters", "5"]) == 1
+    # Explicit opt-out: --report still returns 0 even with the same failure.
+    assert mb.main(["--iters", "5", "--report"]) == 0

--- a/tests/test_microbench_parsers.py
+++ b/tests/test_microbench_parsers.py
@@ -61,12 +61,13 @@ def test_bench_over_threshold_fails(mb):
     assert result.us_per_call > result.threshold_us
 
 
-def test_unknown_parser_gets_default_threshold(mb):
-    """Adding a new parser without a threshold entry should still run
-    (with a generous default), not crash with KeyError."""
-    result = mb.bench_one("brand_new", lambda _t: None, "x", iters=10)
-    assert result.threshold_us > 0  # has a default
-    assert result.passed
+def test_unknown_parser_raises_missing_baseline(mb):
+    """Adding a new parser without a ``BASE_US`` entry must fail LOUDLY, not
+    silently bench against a magic default threshold (Codex #2409) — a default
+    masks the wiring mistake (a parser added to the loop but forgotten in
+    BASE_US) behind an arbitrary number."""
+    with pytest.raises(KeyError, match="no BASE_US baseline for parser 'brand_new'"):
+        mb.bench_one("brand_new", lambda _t: None, "x", iters=10)
 
 
 # ---------- sample / parser wiring -----------------------------------
@@ -218,13 +219,20 @@ def test_median_verdict_ignores_a_single_spiked_round(mb):
     on a shared runner without flaking on a single pause."""
     base = mb.BASE_US["hermes"]
     limit = mb.REGRESSION_LIMIT
-    normal = (base * 0.5, 1.0)   # ε = 0.5 — healthy across the 12× budget
-    spike = (base * 0.5 * 20.0, 1.0)  # parser 20× nominal this round → ε = 10
+    normal = (base * 0.5, 1.0)  # ε = 0.5 — healthy within the 12× budget
+    # One round the runner descheduled during the parser segment: the parser
+    # times at ε = 2.0×LIMIT (i.e. > LIMIT). A MAX-based aggregate would fail
+    # this run; the MEDIAN ignores the single spike and still passes.
+    spike = (base * 2.0 * limit, 1.0)  # ε = 2× 12 = 24 > 12 → max would fail
     # 1 spiked + 4 healthy rounds: the median (3rd-smallest of 5) is healthy.
     eps, speedup, idx = mb._median_verdict([normal] * 4 + [spike], base)
     assert idx != 4  # reports a healthy (normal) round, not the spike
     assert speedup == 1.0
     assert eps < limit and eps == pytest.approx(0.5)
+    # The SAME pairs under a *max* aggregate WOULD exceed the limit — proving
+    # the test is meaningful (it would go red if production reverted to max).
+    eps_max = max(us / (base * sp) for us, sp in [normal] * 4 + [spike])
+    assert eps_max > limit
     # All rounds genuinely slow (ε = 1.5×LIMIT): the median still fails.
     slow = (base * 1.5 * limit, 1.0)
     epss, _, _ = mb._median_verdict([slow] * 5, base)

--- a/tests/test_no_mlx_marker_contract.py
+++ b/tests/test_no_mlx_marker_contract.py
@@ -36,9 +36,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
-from scripts.train_gates_parser import CI_WORKFLOW, parse_linux_pytest_args
+from scripts.train_gates_parser import parse_linux_pytest_args
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -150,7 +148,7 @@ def _lint_one(path: Path) -> list[str]:
         problems.append(
             f"{path.name}: unguarded top-level mlx import(s) {mlx_imports}; "
             "this crashes collection on the no-MLX Linux leg. Guard with a "
-            "top-level ``pytest.importorskip(\"mlx\")`` before the import, or "
+            'top-level ``pytest.importorskip("mlx")`` before the import, or '
             "mark the module ``pytestmark = pytest.mark.requires_mlx`` "
             "(lazy imports + marker), or take it off the no-MLX roster."
         )

--- a/tests/test_no_mlx_marker_contract.py
+++ b/tests/test_no_mlx_marker_contract.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract: the no-MLX CI leg never collects a test module that crashes on
+an unguarded top-level ``import mlx``.
+
+The Linux test-matrix step ("Run unit tests (no MLX required)") runs a roster
+of tests on a host where mlx (the Apple-Silicon runtime) is NOT installed. Its
+comment demands every collected module be no-MLX-safe. Over time that roster is
+hand-edited, and a file dropped into it that does an unguarded top-level
+``import mlx`` (directly, or via ``mlx_lm`` / ``mlx_core`` / ``mlx_vlm``) makes
+the whole leg fail at collection. This test is the machine-readable tripwire
+for that exact failure mode.
+
+It is deliberately an AST scan rather than an import check: importing every
+roster file in-process to see whether it pulls mlx would itself require mlx on
+the Apple side and would run arbitrary test-module code during collection of
+THIS suite. An AST pass is pure-stdlib, runs on the no-MLX leg, and inspects
+only module-scope imports — the ones that crash collection. Imports nested
+inside function bodies cannot crash the leg at collection (they only run when
+their test runs, and such tests guard themselves), so they are intentionally
+not flagged: that keeps the contract free of false positives.
+
+The marker mechanism interacts with this as the companion piece:
+``tests/conftest.py`` auto-skips any test marked ``requires_mlx`` when mlx is
+absent. A module that imports mlx LAZILY (inside functions) and is marked
+``requires_mlx`` therefore drops out cleanly on the no-MLX leg. But a module
+with an UNGUARDED top-level ``import mlx`` fails collection *before* the
+conftest skip can run, so such a module must instead protect itself with a
+top-level ``pytest.importorskip("mlx")`` (which short-circuits collection) or
+simply not be collected on the no-MLX leg. This test enforces those rules.
+
+Pure-pytest, Linux-friendly, no MLX import (stdlib ``ast`` only).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from scripts.train_gates_parser import CI_WORKFLOW, parse_linux_pytest_args
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Any top-level import whose base module is (or begins with) one of these is a
+# no-MLX-leg import hazard. ``mlx_*`` and ``mlx_lm`` cover the MLX family; a
+# bare ``mlx`` import is the canonical case. Everything else (`transformers`,
+# `numpy`, `vllm_mlx` itself) does not require mlx at import time.
+_MLX_MODULE_PREFIXES = ("mlx", "mlx.", "mlx_lm", "mlx_core", "mlx_vlm")
+
+
+def _module_scope_mlx_imports(tree: ast.AST) -> list[str]:
+    """Return the mlx-bound names imported at MODULE scope (top level)."""
+    imports: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(_MLX_MODULE_PREFIXES):
+                    imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            if node.module.startswith(_MLX_MODULE_PREFIXES):
+                imports.append(node.module)
+    return imports
+
+
+def _has_module_scope_guard(tree: ast.AST) -> bool:
+    """True if the module self-guards at top level with importorskip('mlx').
+
+    ``pytest.importorskip("mlx")`` at module scope aborts collection cleanly
+    when mlx is absent, so a module that calls it (before any unguarded mlx
+    import) is no-MLX-leg-safe even though it references mlx. We match the
+    exact idiomatic form ``pytest.importorskip("mlx")`` at top level.
+    """
+    for node in tree.body:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            call = node.value
+            if (
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "importorskip"
+                and call.args
+                and isinstance(call.args[0], ast.Constant)
+                and call.args[0].value in ("mlx", "mlx.core")
+            ):
+                return True
+    return False
+
+
+def _has_module_scope_requires_mlx_marker(tree: ast.AST) -> bool:
+    """True if the module carries ``pytestmark = pytest.mark.requires_mlx``.
+
+    A module that marks itself ``requires_mlx`` but still does an unguarded
+    top-level ``import mlx`` will still fail COLLECTION on the no-MLX leg (the
+    conftest skip runs after collection), so this exemption is only meaningful
+    when combined with a lazy import or a self-guard. We still treat it as an
+    explicit author signal and exempt it — mirroring the "must be marked
+    requires_mlx" escape hatch the design documents — but the stronger,
+    actually-correct protection for a top-level importer is ``importorskip``.
+    """
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            value = node.value
+            if not (isinstance(target, ast.Name) and target.id == "pytestmark"):
+                continue
+            # ``pytestmark = pytest.mark.requires_mlx``
+            if isinstance(value, ast.Attribute) and value.attr == "requires_mlx":
+                return True
+            # ``pytestmark = [pytest.mark.requires_mlx]`` (a marker list)
+            if (
+                isinstance(value, ast.List)
+                and value.elts
+                and all(
+                    isinstance(e, ast.Attribute) and e.attr == "requires_mlx"
+                    for e in value.elts
+                )
+            ):
+                return True
+    return False
+
+
+def _no_mlx_leg_test_files() -> list[Path]:
+    """The concrete test paths the no-MLX CI leg actually collects.
+
+    Sourced from ci.yml via the shared parser rather than hardcoded here, so a
+    change to the roster (adding/removing a file, or collapsing a block) is
+    automatically picked up — the same single source of truth the local
+    ``train_gates.sh`` Gate 1 uses. Keeping this contract on the LEG's actual
+    surface (not the whole tests/ tree) is what makes it free of false
+    positives: the thousands of mlx-bound tests that never run on the no-MLX
+    leg are intentionally out of scope here.
+    """
+    files: list[Path] = []
+    for invocation in parse_linux_pytest_args():
+        for token in invocation["paths"]:
+            # Strip any ``::Class::test`` selector down to the file path.
+            file_part = token.split("::", 1)[0]
+            files.append(REPO_ROOT / file_part)
+    return files
+
+
+def _lint_one(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    problems: list[str] = []
+    mlx_imports = _module_scope_mlx_imports(tree)
+    if not mlx_imports:
+        return problems
+    guarded = _has_module_scope_guard(tree)
+    marked = _has_module_scope_requires_mlx_marker(tree)
+    if not (guarded or marked):
+        problems.append(
+            f"{path.name}: unguarded top-level mlx import(s) {mlx_imports}; "
+            "this crashes collection on the no-MLX Linux leg. Guard with a "
+            "top-level ``pytest.importorskip(\"mlx\")`` before the import, or "
+            "mark the module ``pytestmark = pytest.mark.requires_mlx`` "
+            "(lazy imports + marker), or take it off the no-MLX roster."
+        )
+    return problems
+
+
+def test_contract_rules_are_loaded() -> None:
+    # Guard the marker + conftest mechanism exists; if the marker were renamed
+    # or the conftest auto-skip removed, this contract still names the escape
+    # hatches consistently and should fail loudly rather than silently rot.
+    ini = (REPO_ROOT / "pytest.ini").read_text()
+    assert "requires_mlx" in ini
+    conftest = (REPO_ROOT / "tests" / "conftest.py").read_text()
+    assert "requires_mlx" in conftest
+    assert "HAS_MLX" in conftest
+    assert "pytest_collection_modifyitems" in conftest
+
+
+def test_no_mlx_leg_contract() -> None:
+    # Every file the no-MLX leg collects must be no-MLX-safe at module scope:
+    # either it imports nothing mlx-bound at top level, or it self-guards via
+    # importorskip / declares requires_mlx. A violation is a latent no-MLX-leg
+    # collection crash — this test turns it into a hard PR-time failure.
+    files = _no_mlx_leg_test_files()
+    assert files, "no-MLX leg surfaced no test files; ci.yml layout drifted"
+    problems: list[str] = []
+    for path in files:
+        assert path.is_file(), f"no-MLX leg references missing file: {path}"
+        try:
+            problems.extend(_lint_one(path))
+        except SyntaxError as exc:  # pragma: no cover - defensive
+            problems.append(f"{path}: could not parse ({exc})")
+    assert not problems, "no-MLX leg contract violations:\n" + "\n".join(problems)
+
+
+def test_contract_handles_marked_and_guarded_patterns() -> None:
+    # Meta-test: exercise the two exemption paths on tiny synthetic snippets so
+    # the AST logic is pinned (a regression in the scanner itself cannot be
+    # masked by an empty real-world roster).
+    guarded = "import pytest\npytest.importorskip('mlx')\nimport numpy as np\n"
+    tree = ast.parse(guarded)
+    assert _module_scope_mlx_imports(tree) == []
+    # Clearing: importorskip itself is not an import node; a bare mlx import
+    # after a guard is what the guard protects.
+    mixed = "import pytest\npytest.importorskip('mlx')\nimport mlx.core as mc\n"
+    tree = ast.parse(mixed)
+    assert _module_scope_mlx_imports(tree) == ["mlx.core"]
+    assert _has_module_scope_guard(tree) is True
+    assert _has_module_scope_requires_mlx_marker(tree) is False
+
+    marked = "import pytest\npytestmark = pytest.mark.requires_mlx\n"
+    tree = ast.parse(marked)
+    assert _has_module_scope_requires_mlx_marker(tree) is True
+
+    plain = "import os\n"
+    tree = ast.parse(plain)
+    assert _module_scope_mlx_imports(tree) == []
+    assert _has_module_scope_guard(tree) is False
+    assert _has_module_scope_requires_mlx_marker(tree) is False


### PR DESCRIPTION
train: departure 2026-08-28 0040Z (train/20260828-0040Z)

Boarded (in merge order):

- #2534 ci(no-mlx): requires_mlx marker + conftest auto-skip + collection contract (#2486) (Part of #2486)
- #2437 ci(l1-smoke): relocate qwen3.5-9b-4bit off hosted L1 to the Studio tier-1 gate (#2419) (Closes #2419)
- #2409 fix(ci): make parser microbench a relative regression gate (Fixes #2344)