### PR TITLE
fix(mac): bound image attachment count and aggregate bytes (#2456)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -25,15 +25,52 @@ struct ChatAttachmentDraft: Equatable {
     var hasAttachments: Bool { !images.isEmpty || !files.isEmpty }
     var isImportingFiles: Bool { fileImportID != nil || imageImportID != nil }
 
-    mutating func appendImage(_ image: ChatImageAttachment, sourceURL: URL? = nil) {
+    /// Appends a single image only when it fits the per-message image budget
+    /// (count and combined bytes). Returns `false` (and appends nothing) when
+    /// the budget is already exhausted, so a caller can surface a notice. This
+    /// is the draft-level companion to ``ChatImageAttachment/importCandidates``:
+    /// the pre-read gate bounds the picker/drop, and this bounds the direct
+    /// paste path and any late import completion.
+    @discardableResult
+    mutating func appendImage(
+        _ image: ChatImageAttachment,
+        sourceURL: URL? = nil
+    ) -> Bool {
+        guard Self.canAppend(image, to: images) else { return false }
         images.append(image)
         if let sourceURL { sourcePaths[image.id] = Self.attachmentKey(for: sourceURL) }
+        return true
     }
 
+    /// Appends each imported image that still fits the per-message image budget,
+    /// preserving order and source identity, and returns how many were rejected
+    /// for exceeding it. Mirrors how file imports apply their fitted budget;
+    /// the existing, already-fitted images always precede the imported ones, so
+    /// the shared gate keeps only the imported subset that still fits.
+    @discardableResult
     mutating func appendImages(
         _ imported: [(attachment: ChatImageAttachment, sourceURL: URL)]
-    ) {
-        for item in imported { appendImage(item.attachment, sourceURL: item.sourceURL) }
+    ) -> Int {
+        let fitted = ChatImageAttachment.fittedForMessage(
+            images + imported.map(\.attachment)
+        )
+        let kept = imported.filter { attachment, _ in
+            fitted.contains { $0.id == attachment.id }
+        }
+        for item in kept {
+            images.append(item.attachment)
+            sourcePaths[item.attachment.id] = Self.attachmentKey(for: item.sourceURL)
+        }
+        return imported.count - kept.count
+    }
+
+    private static func canAppend(
+        _ image: ChatImageAttachment,
+        to images: [ChatImageAttachment]
+    ) -> Bool {
+        guard images.count < ChatImageAttachment.maxImagesPerMessage else { return false }
+        let existingBytes = images.reduce(0) { $0 + $1.data.count }
+        return existingBytes + image.data.count <= ChatImageAttachment.maxCombinedImageBytes
     }
 
     mutating func beginImageImport() -> UUID? {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -92,12 +92,27 @@ struct ChatAttachmentDraft: Equatable {
         notice: String?
     ) -> Bool {
         guard imageImportID == id else { return false }
-        appendImages(imported)
-        if let notice {
-            if let current = self.notice, current != notice {
-                self.notice = "\(current) \(notice)"
+        let combinedCount = images.count + imported.count
+        let budgetRejectedCount = appendImages(imported)
+        var mergedNotice = notice
+        if budgetRejectedCount > 0 {
+            // The on-disk pre-read estimate can differ from the normalized
+            // PNG/JPEG payload. This is the authoritative post-normalization
+            // gate, so its late rejection must be visible rather than silently
+            // dropping an image that the picker initially admitted.
+            let limit: ChatImageAttachment.ImageBudgetLimit =
+                combinedCount > ChatImageAttachment.maxImagesPerMessage ? .count : .bytes
+            let budgetNotice = ChatImageAttachment.budgetNotice(
+                rejectedCount: budgetRejectedCount,
+                limit: limit
+            )
+            mergedNotice = mergedNotice.map { "\(budgetNotice) \($0)" } ?? budgetNotice
+        }
+        if let mergedNotice {
+            if let current = self.notice, current != mergedNotice {
+                self.notice = "\(current) \(mergedNotice)"
             } else {
-                self.notice = notice
+                self.notice = mergedNotice
             }
         }
         imageImportID = nil

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatAttachmentDraft.swift
@@ -69,8 +69,9 @@ struct ChatAttachmentDraft: Equatable {
         to images: [ChatImageAttachment]
     ) -> Bool {
         guard images.count < ChatImageAttachment.maxImagesPerMessage else { return false }
-        let existingBytes = images.reduce(0) { $0 + $1.data.count }
-        return existingBytes + image.data.count <= ChatImageAttachment.maxCombinedImageBytes
+        let existingBytes = images.reduce(0) { $0 + $1.encodedDataURLByteCount }
+        return existingBytes + image.encodedDataURLByteCount
+            <= ChatImageAttachment.maxCombinedEncodedImageBytes
     }
 
     mutating func beginImageImport() -> UUID? {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -4,6 +4,15 @@ import UniformTypeIdentifiers
 
 struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable {
     static let maxBytes = 20 * 1024 * 1024
+    /// Per-message image budget, mirroring the document attachment budget
+    /// (``ChatFileAttachment/maxAttachmentsPerMessage`` and friends). The
+    /// per-file 20 MB cap is not enough on its own: a multi-select or drop can
+    /// present dozens of individually valid images, and decoding every one and
+    /// base64-encoding the whole set into a single request would freeze or
+    /// exhaust the Desktop process. `maxImagesPerMessage` bounds the count and
+    /// `maxCombinedImageBytes` bounds the aggregate encoded bytes.
+    static let maxImagesPerMessage = 4
+    static let maxCombinedImageBytes = 20 * 1024 * 1024
     /// Keep image preprocessing below the embedded engine's per-request
     /// vision-token budget. A 2048 × 1536 image is roughly 4K vision tokens
     /// on the recommended model, leaving useful margin below its 8K cap.
@@ -29,6 +38,51 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
             max(1, Int((Double(width) * scale).rounded())),
             max(1, Int((Double(height) * scale).rounded()))
         )
+    }
+
+    /// Bound work before reading any selected image. The per-file 20 MB cap
+    /// is enforced at read time; this pre-read gate stops the count and the
+    /// aggregate bytes from growing unbounded across a multi-select/drop, which
+    /// would otherwise decode and retain every image and base64 them all into a
+    /// single request. Accepted order matches the selection; each candidate's
+    /// on-disk file size is the pre-read estimate for the aggregate byte gate.
+    static func importCandidates(
+        _ urls: [URL],
+        existingCount: Int,
+        existingBytes: Int
+    ) -> (accepted: [URL], rejectedCount: Int) {
+        var accepted: [URL] = []
+        var remainingCount = max(0, maxImagesPerMessage - max(0, existingCount))
+        var remainingBytes = max(0, maxCombinedImageBytes - max(0, existingBytes))
+        for url in urls {
+            guard remainingCount > 0 else { break }
+            let size = (
+                try? url.resourceValues(forKeys: [.fileSizeKey])
+            )?.fileSize ?? 0
+            guard size <= remainingBytes else { continue }
+            accepted.append(url)
+            remainingCount -= 1
+            remainingBytes -= size
+        }
+        return (accepted, max(0, urls.count - accepted.count))
+    }
+
+    /// Returns the ordered subset that fits the per-message image budget (count
+    /// and combined bytes). Images cannot be truncated the way document text is
+    /// (``ChatFileAttachment/fittedForMessage(_:)``), so an image that does not
+    /// fit is dropped rather than reduced.
+    static func fittedForMessage(
+        _ attachments: [ChatImageAttachment]
+    ) -> [ChatImageAttachment] {
+        var result: [ChatImageAttachment] = []
+        var remainingBytes = maxCombinedImageBytes
+        for attachment in attachments {
+            guard result.count < maxImagesPerMessage,
+                  attachment.data.count <= remainingBytes else { continue }
+            result.append(attachment)
+            remainingBytes -= attachment.data.count
+        }
+        return result
     }
 
     let id: UUID

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -10,9 +10,41 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
     /// present dozens of individually valid images, and decoding every one and
     /// base64-encoding the whole set into a single request would freeze or
     /// exhaust the Desktop process. `maxImagesPerMessage` bounds the count and
-    /// `maxCombinedImageBytes` bounds the aggregate encoded bytes.
+    /// ``maxCombinedEncodedImageBytes`` bounds the aggregate **encoded** bytes.
     static let maxImagesPerMessage = 4
-    static let maxCombinedImageBytes = 20 * 1024 * 1024
+    /// Combined budget for the images in one message, measured in exact
+    /// encoded `data:<mime>;base64,…` byte counts, not raw `Data.count`.
+    /// Each image travels over the wire as a base64 data URL, so raw bytes
+    /// under-count the request by ~4/3 and can deterministically blow past the
+    /// engine's 8 MiB request-body cap with a 413. This budget stays below
+    /// that cap while leaving dedicated room for text, history, tools, and
+    /// JSON framing. **Value under review: Pixel (product).**
+    static let maxCombinedEncodedImageBytes = 6 * 1024 * 1024
+
+    /// A human-readable form of ``maxCombinedEncodedImageBytes`` for notices.
+    static var formattedCombinedImageBudget: String {
+        let bytes = maxCombinedEncodedImageBytes
+        let mb = Double(bytes) / Double(1024 * 1024)
+        if mb == mb.rounded() { return "\(Int(mb)) MB" }
+        return String(format: "%.1f MB", mb)
+    }
+
+    /// Why ``importCandidates(_:existingCount:existingBytes:)`` dropped a
+    /// candidate. Kept distinct so a notice can tell the user whether the
+    /// count or the combined-byte budget was the binding limit.
+    enum ImageBudgetLimit {
+        case count
+        case bytes
+    }
+
+    /// Exact number of bytes a `data:<mime>;base64,<payload>` URL occupies for
+    /// `rawBytes` of payload, without materialising the base64 string.
+    /// `"data:"` + `<mime>` + `";base64,"` + base64(data); base64 of `n` bytes
+    /// is `4 * ceil(n / 3)` and the integer `(n + 2) / 3 * 4` avoids floats.
+    static func encodedDataURLByteCount(mimeType: String, rawBytes: Int) -> Int {
+        let base64 = ((rawBytes + 2) / 3) * 4
+        return 5 + mimeType.utf8.count + 8 + base64
+    }
     /// Keep image preprocessing below the embedded engine's per-request
     /// vision-token budget. A 2048 × 1536 image is roughly 4K vision tokens
     /// on the recommended model, leaving useful margin below its 8K cap.
@@ -45,26 +77,37 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
     /// aggregate bytes from growing unbounded across a multi-select/drop, which
     /// would otherwise decode and retain every image and base64 them all into a
     /// single request. Accepted order matches the selection; each candidate's
-    /// on-disk file size is the pre-read estimate for the aggregate byte gate.
+    /// on-disk file size is the pre-read estimate for the aggregate byte gate,
+    /// charged at the encoded data-URL rate. The exact post-decode gate
+    /// (``ChatImageAttachment/fittedForMessage(_:)``) is authoritative and is
+    /// also applied at the wire, so a small pre-read skew cannot admit an
+    /// over-budget request.
     static func importCandidates(
         _ urls: [URL],
         existingCount: Int,
         existingBytes: Int
-    ) -> (accepted: [URL], rejectedCount: Int) {
+    ) -> (accepted: [URL], rejectedCount: Int, limit: ImageBudgetLimit) {
         var accepted: [URL] = []
         var remainingCount = max(0, maxImagesPerMessage - max(0, existingCount))
-        var remainingBytes = max(0, maxCombinedImageBytes - max(0, existingBytes))
+        var remainingBytes = max(0, maxCombinedEncodedImageBytes - max(0, existingBytes))
+        var limit: ImageBudgetLimit = .count
         for url in urls {
             guard remainingCount > 0 else { break }
             let size = (
                 try? url.resourceValues(forKeys: [.fileSizeKey])
             )?.fileSize ?? 0
-            guard size <= remainingBytes else { continue }
+            // MIME is unknown before read; its prefix differs by one byte, which
+            // is immaterial at this pre-read stage.
+            let estimatedEncoded = encodedDataURLByteCount(mimeType: "image/jpeg", rawBytes: size)
+            guard estimatedEncoded <= remainingBytes else {
+                limit = .bytes
+                continue
+            }
             accepted.append(url)
             remainingCount -= 1
-            remainingBytes -= size
+            remainingBytes -= estimatedEncoded
         }
-        return (accepted, max(0, urls.count - accepted.count))
+        return (accepted, max(0, urls.count - accepted.count), limit)
     }
 
     /// Returns the ordered subset that fits the per-message image budget (count
@@ -75,12 +118,12 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
         _ attachments: [ChatImageAttachment]
     ) -> [ChatImageAttachment] {
         var result: [ChatImageAttachment] = []
-        var remainingBytes = maxCombinedImageBytes
+        var remainingBytes = maxCombinedEncodedImageBytes
         for attachment in attachments {
             guard result.count < maxImagesPerMessage,
-                  attachment.data.count <= remainingBytes else { continue }
+                  attachment.encodedDataURLByteCount <= remainingBytes else { continue }
             result.append(attachment)
-            remainingBytes -= attachment.data.count
+            remainingBytes -= attachment.encodedDataURLByteCount
         }
         return result
     }
@@ -235,6 +278,12 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
     }
 
     var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }
+
+    /// Exact number of bytes this attachment's `dataURL` occupies on the wire,
+    /// without materialising `dataURL` just to measure it.
+    var encodedDataURLByteCount: Int {
+        Self.encodedDataURLByteCount(mimeType: mimeType, rawBytes: data.count)
+    }
 
     enum ValidationError: LocalizedError {
         case tooLarge, tooManyPixels, unsupportedType, animatedGIF

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -29,6 +29,25 @@ struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable
         return String(format: "%.1f MB", mb)
     }
 
+    /// User-facing explanation for attachments rejected by the per-message
+    /// image budget. Keeping this copy beside the limits lets both the pre-read
+    /// picker gate and the authoritative post-normalization gate report the
+    /// same count and binding reason.
+    static func budgetNotice(
+        rejectedCount: Int = 0,
+        limit: ImageBudgetLimit = .count
+    ) -> String {
+        let budget = formattedCombinedImageBudget
+        let base = "Attach up to \(maxImagesPerMessage) images or \(budget) of images per message."
+        guard rejectedCount > 0 else { return base }
+        let reason: String = switch limit {
+        case .count: "too many images"
+        case .bytes: "their combined size exceeds the \(budget) budget"
+        }
+        let plural = rejectedCount == 1 ? "image was" : "images were"
+        return "\(base) \(rejectedCount) \(plural) not added — \(reason)."
+    }
+
     /// Why ``importCandidates(_:existingCount:existingBytes:)`` dropped a
     /// candidate. Kept distinct so a notice can tell the user whether the
     /// count or the combined-byte budget was the binding limit.

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -944,14 +944,22 @@ enum Wire {
         init(from message: ChatMessage, includeImages: Bool = true) {
             self.role = message.role.rawValue
             let modelContent = message.modelContent
-            if message.imageAttachments.isEmpty || !includeImages {
+            // Defense in depth: re-apply the per-message image budget at the
+            // wire, so a restored or pre-limit message can never resend more
+            // encoded image bytes than the request body can carry (413). Normal
+            // in-app sends were already fitted at the draft, making this a
+            // no-op for them.
+            let images = includeImages
+                ? ChatImageAttachment.fittedForMessage(message.imageAttachments)
+                : []
+            if images.isEmpty {
                 self.content = .text(modelContent)
             } else {
                 var parts: [ContentPart] = []
                 if !modelContent.isEmpty {
                     parts.append(.init(type: "text", text: modelContent, image_url: nil))
                 }
-                parts.append(contentsOf: message.imageAttachments.map {
+                parts.append(contentsOf: images.map {
                     .init(type: "image_url", text: nil, image_url: .init(url: $0.dataURL))
                 })
                 self.content = .parts(parts)

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1027,13 +1027,17 @@ struct ChatView: View {
     /// ``addFileURLs(_:)`` gates documents.
     @discardableResult
     private func addImageURLs(_ urls: [URL]) -> Bool {
+        let existing = attachmentDraft.images
         let selection = ChatImageAttachment.importCandidates(
             urls,
-            existingCount: attachmentDraft.images.count,
-            existingBytes: attachmentDraft.images.reduce(0) { $0 + $1.data.count }
+            existingCount: existing.count,
+            existingBytes: existing.reduce(0) { $0 + $1.encodedDataURLByteCount }
         )
         guard !selection.accepted.isEmpty else {
-            attachmentDraft.notice = imageBudgetNotice
+            attachmentDraft.notice = imageBudgetNotice(
+                rejectedCount: selection.rejectedCount,
+                limit: selection.limit
+            )
             return false
         }
         guard let importRequest = attachmentDrafts.beginImageImport(
@@ -1043,9 +1047,18 @@ struct ChatView: View {
             let outcome = await Task.detached(priority: .userInitiated) {
                 Self.loadImageAttachments(selection.accepted)
             }.value
-            let notice = selection.rejectedCount > 0
-                ? imageBudgetNotice
-                : outcome.rejection
+            // Merge distinct reasons instead of replacing one with the other: a
+            // batch can drop candidates at the pre-read budget gate AND contain
+            // an invalid / oversize-20 MB file discovered at decode time. The
+            // notice keeps both, and names how many and why.
+            var notice = outcome.rejection
+            if selection.rejectedCount > 0 {
+                let budget = imageBudgetNotice(
+                    rejectedCount: selection.rejectedCount,
+                    limit: selection.limit
+                )
+                notice = notice.map { "\(budget) \($0)" } ?? budget
+            }
             attachmentDrafts.finishImageImport(
                 request: importRequest,
                 outcome.accepted,
@@ -1055,8 +1068,22 @@ struct ChatView: View {
         return true
     }
 
-    private var imageBudgetNotice: String {
-        "Attach up to \(ChatImageAttachment.maxImagesPerMessage) images or 20 MB of images per message."
+    /// Notice for the per-message image budget. Names the rejected count and
+    /// which budget (count vs combined bytes) was the binding limit; the
+    /// paste path, which has no count detail, uses the base message only.
+    private func imageBudgetNotice(
+        rejectedCount: Int = 0,
+        limit: ChatImageAttachment.ImageBudgetLimit = .count
+    ) -> String {
+        let budget = ChatImageAttachment.formattedCombinedImageBudget
+        let base = "Attach up to \(ChatImageAttachment.maxImagesPerMessage) images or \(budget) of images per message."
+        guard rejectedCount > 0 else { return base }
+        let reason: String = switch limit {
+        case .count: "too many images"
+        case .bytes: "their combined size exceeds the \(budget) budget"
+        }
+        let plural = rejectedCount == 1 ? "image was" : "images were"
+        return "\(base) \(rejectedCount) \(plural) not added — \(reason)."
     }
 
     @discardableResult
@@ -1177,7 +1204,7 @@ struct ChatView: View {
                 if attachmentDraft.appendImage(pasted) {
                     attachmentDraft.notice = nil
                 } else {
-                    attachmentDraft.notice = imageBudgetNotice
+                    attachmentDraft.notice = imageBudgetNotice()
                 }
             } catch { attachmentDraft.notice = error.localizedDescription }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1021,22 +1021,42 @@ struct ChatView: View {
     /// phone capture, so keep it off the main actor. The conversation-keyed
     /// generation contract mirrors document imports: a late result cannot land
     /// in whichever conversation happens to be visible by then.
+    ///
+    /// The picker/drop counts against a per-message image budget (count and
+    /// combined bytes), gated here before any decode work, exactly like
+    /// ``addFileURLs(_:)`` gates documents.
     @discardableResult
     private func addImageURLs(_ urls: [URL]) -> Bool {
+        let selection = ChatImageAttachment.importCandidates(
+            urls,
+            existingCount: attachmentDraft.images.count,
+            existingBytes: attachmentDraft.images.reduce(0) { $0 + $1.data.count }
+        )
+        guard !selection.accepted.isEmpty else {
+            attachmentDraft.notice = imageBudgetNotice
+            return false
+        }
         guard let importRequest = attachmentDrafts.beginImageImport(
             conversationID: viewModel.activeConversationID
         ) else { return false }
         Task { @MainActor in
             let outcome = await Task.detached(priority: .userInitiated) {
-                Self.loadImageAttachments(urls)
+                Self.loadImageAttachments(selection.accepted)
             }.value
+            let notice = selection.rejectedCount > 0
+                ? imageBudgetNotice
+                : outcome.rejection
             attachmentDrafts.finishImageImport(
                 request: importRequest,
                 outcome.accepted,
-                notice: outcome.rejection
+                notice: notice
             )
         }
         return true
+    }
+
+    private var imageBudgetNotice: String {
+        "Attach up to \(ChatImageAttachment.maxImagesPerMessage) images or 20 MB of images per message."
     }
 
     @discardableResult
@@ -1149,10 +1169,16 @@ struct ChatView: View {
                 return true
             }
             do {
-                attachmentDraft.appendImage(try ChatImageAttachment(
+                let pasted = try ChatImageAttachment(
                     filename: "Pasted image.png", mimeType: "image/png", data: png
-                ))
-                attachmentDraft.notice = nil
+                )
+                // The draft's own budget gate rejects a paste that would exceed
+                // the per-message image count or combined-byte budget.
+                if attachmentDraft.appendImage(pasted) {
+                    attachmentDraft.notice = nil
+                } else {
+                    attachmentDraft.notice = imageBudgetNotice
+                }
             } catch { attachmentDraft.notice = error.localizedDescription }
         }
         return true

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1034,7 +1034,7 @@ struct ChatView: View {
             existingBytes: existing.reduce(0) { $0 + $1.encodedDataURLByteCount }
         )
         guard !selection.accepted.isEmpty else {
-            attachmentDraft.notice = imageBudgetNotice(
+            attachmentDraft.notice = ChatImageAttachment.budgetNotice(
                 rejectedCount: selection.rejectedCount,
                 limit: selection.limit
             )
@@ -1053,7 +1053,7 @@ struct ChatView: View {
             // notice keeps both, and names how many and why.
             var notice = outcome.rejection
             if selection.rejectedCount > 0 {
-                let budget = imageBudgetNotice(
+                let budget = ChatImageAttachment.budgetNotice(
                     rejectedCount: selection.rejectedCount,
                     limit: selection.limit
                 )
@@ -1066,24 +1066,6 @@ struct ChatView: View {
             )
         }
         return true
-    }
-
-    /// Notice for the per-message image budget. Names the rejected count and
-    /// which budget (count vs combined bytes) was the binding limit; the
-    /// paste path, which has no count detail, uses the base message only.
-    private func imageBudgetNotice(
-        rejectedCount: Int = 0,
-        limit: ChatImageAttachment.ImageBudgetLimit = .count
-    ) -> String {
-        let budget = ChatImageAttachment.formattedCombinedImageBudget
-        let base = "Attach up to \(ChatImageAttachment.maxImagesPerMessage) images or \(budget) of images per message."
-        guard rejectedCount > 0 else { return base }
-        let reason: String = switch limit {
-        case .count: "too many images"
-        case .bytes: "their combined size exceeds the \(budget) budget"
-        }
-        let plural = rejectedCount == 1 ? "image was" : "images were"
-        return "\(base) \(rejectedCount) \(plural) not added — \(reason)."
     }
 
     @discardableResult
@@ -1204,7 +1186,7 @@ struct ChatView: View {
                 if attachmentDraft.appendImage(pasted) {
                     attachmentDraft.notice = nil
                 } else {
-                    attachmentDraft.notice = imageBudgetNotice()
+                    attachmentDraft.notice = ChatImageAttachment.budgetNotice()
                 }
             } catch { attachmentDraft.notice = error.localizedDescription }
         }

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -274,6 +274,172 @@ struct ChatAttachmentDraftTests {
         #expect(draft.images == [second])
     }
 
+    @Test("appendImage enforces the per-message image count and byte budget")
+    func appendImageEnforcesImageBudget() throws {
+        var draft = ChatAttachmentDraft()
+        // Fill the count slot.
+        for index in 0..<ChatImageAttachment.maxImagesPerMessage {
+            let appended = draft.appendImage(try makeImage(name: "\(index).png"))
+            #expect(appended)
+        }
+        // Count budget exhausted: a fitted image is rejected.
+        let countRejected = draft.appendImage(try makeImage(name: "overflow.png"))
+        #expect(!countRejected)
+        #expect(draft.images.count == ChatImageAttachment.maxImagesPerMessage)
+
+        // Byte budget exhausted: each image is individually under the per-file
+        // 20 MB cap, but two that together exceed the 20 MB aggregate cannot
+        // both be appended.
+        var byteDraft = ChatAttachmentDraft()
+        let large = try makeImage(name: "big.png", bytes: 20 * 1024 * 1024 - 1)
+        let largeAccepted = byteDraft.appendImage(large)
+        #expect(largeAccepted)
+        let another = try makeImage(name: "another.png", bytes: 20 * 1024 * 1024 - 1)
+        let byteRejected = byteDraft.appendImage(another)
+        #expect(!byteRejected)
+        #expect(byteDraft.images == [large])
+    }
+
+    @Test("appendImages keeps only the batch that fits and reports the rejected count")
+    func appendImagesGatesMixedBatch() throws {
+        var draft = ChatAttachmentDraft()
+        // The first image alone fits; together the pair exceeds 20 MB aggregate,
+        // so the second is dropped and counted as rejected.
+        let first = try makeImage(name: "first.png", bytes: 12 * 1024 * 1024)
+        let second = try makeImage(name: "second.png", bytes: 12 * 1024 * 1024)
+
+        let rejectedCount = draft.appendImages([
+            (first, URL(fileURLWithPath: "/tmp/first.png")),
+            (second, URL(fileURLWithPath: "/tmp/second.png")),
+        ])
+        #expect(rejectedCount == 1)
+        #expect(draft.images == [first])
+        #expect(draft.sourcePaths.count == 1)
+        #expect(draft.sourcePaths[first.id] != nil)
+        #expect(draft.sourcePaths[second.id] == nil)
+    }
+
+    @Test("duplicate paths are filtered before the budget gate so they consume budget once")
+    func duplicatesAreDedupedBeforeBudgetGate() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-dedup-budget-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Six references to one path. Dedup must collapse them to a single
+        // candidate so the 4-slot count budget is charged once, not six times.
+        let file = root.appendingPathComponent("photo.png")
+        try Data(repeating: 0, count: 100).write(to: file)
+        let batch = Array(repeating: file, count: 6)
+
+        // What addAttachmentURLs does first: dedup the batch.
+        let (fresh, duplicates) = ChatAttachmentDraft.withoutAlreadyAttached(
+            batch, attached: []
+        )
+        #expect(fresh == [file])
+        #expect(duplicates == 5)
+
+        // Then the image budget gate sees only the single fresh path and accepts
+        // it (and, having been deduped, it is charged once).
+        let selection = ChatImageAttachment.importCandidates(
+            fresh, existingCount: 0, existingBytes: 0
+        )
+        #expect(selection.accepted == [file])
+        #expect(selection.rejectedCount == 0)
+
+        // If dedup had NOT run first, the raw six would consume four slots:
+        // prove the gate alone would have under-promised.
+        let withoutDedup = ChatImageAttachment.importCandidates(
+            batch, existingCount: 0, existingBytes: 0
+        )
+        #expect(withoutDedup.rejectedCount > 0)
+    }
+
+    @Test("a submission (the wire request) never exceeds the accepted, bounded image set")
+    func submissionStaysWithinImageBudget() throws {
+        var draft = ChatAttachmentDraft()
+        // Push far more images than the budget admits; the draft gate holds the
+        // count, and takeSubmission snapshots only what fits. The request is
+        // built from this snapshot, so it is bounded by construction.
+        for index in 0..<ChatImageAttachment.maxImagesPerMessage + 5 {
+            _ = draft.appendImage(try makeImage(name: "\(index).png"))
+        }
+        let submission = draft.takeSubmission()
+        #expect(submission.images.count == ChatImageAttachment.maxImagesPerMessage)
+        #expect(submission.images.reduce(0) { $0 + $1.data.count }
+            <= ChatImageAttachment.maxCombinedImageBytes)
+    }
+
+    @Test("a deleted conversation cannot be resurrected by a late image import")
+    func deletedConversationRejectsImageCompletion() throws {
+        let deletedConversation = UUID()
+        let survivingConversation = UUID()
+        var store = ChatAttachmentDraftStore()
+        let startedImport = store.beginImageImport(conversationID: deletedConversation)
+        let importID = try #require(startedImport)
+
+        let late = try makeImage(name: "late.png")
+        store.retainDrafts(for: [survivingConversation])
+        let accepted = store.finishImageImport(
+            request: importID,
+            [(late, URL(fileURLWithPath: "/tmp/late.png"))],
+            notice: nil
+        )
+
+        #expect(!accepted)
+        #expect(!store[deletedConversation].hasAttachments)
+        #expect(!store[deletedConversation].isImportingFiles)
+    }
+
+    @Test("switching conversations mid-image-import cannot land images in the visible draft")
+    func imageImportCannotResurrectAcrossConversations() throws {
+        let conversationA = UUID()
+        let conversationB = UUID()
+        let late = try makeImage(name: "late.png")
+        var store = ChatAttachmentDraftStore()
+
+        let startedA = store.beginImageImport(conversationID: conversationA)
+        let importA = try #require(startedA)
+        // Switch to B after import A started.
+        store.beginImageImport(conversationID: conversationB)
+
+        let accepted = store.finishImageImport(
+            request: importA,
+            [(late, URL(fileURLWithPath: "/tmp/late.png"))],
+            notice: nil
+        )
+
+        #expect(accepted)
+        #expect(store[conversationA].images == [late])
+        #expect(store[conversationB].images.isEmpty)
+    }
+
+    @Test("ChatView gates images before importing and keeps dedup upstream")
+    func imageBudgetWiringIntoChatView() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/Rapid/UI/ChatView.swift"),
+            encoding: .utf8
+        )
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(source)
+
+        // The pre-read budget gate runs before any beginImageImport/read work.
+        let gated = stripped.contains(
+            "letselection=ChatImageAttachment.importCandidates(urls,existingCount:attachmentDraft.images.count,existingBytes:attachmentDraft.images.reduce(0){$0+$1.data.count})"
+        )
+        #expect(gated, "addImageURLs no longer gates image candidates before import.")
+        #expect(stripped.contains(
+            "Self.loadImageAttachments(selection.accepted)"
+        ), "addImageURLs must load only the budgeted candidates, not the whole selection.")
+        #expect(stripped.contains(
+            "attachmentDraft.filteringAlreadyAttached(urls)"
+        ), "Dedup must remain the first step so duplicates never reach the budget gate twice.")
+    }
+
     @Test("ChatView writes async completion through the originating conversation key")
     func lifecycleIsWiredIntoChatView() throws {
         let source = try String(
@@ -297,11 +463,11 @@ struct ChatAttachmentDraftTests {
         #expect(stripped.contains(".onChange(of:viewModel.conversations.map(\\.id)){_,_inpruneAttachmentDrafts()}"))
     }
 
-    private func makeImage(name: String) throws -> ChatImageAttachment {
+    private func makeImage(name: String, bytes: Int = 4) throws -> ChatImageAttachment {
         try ChatImageAttachment(
             filename: name,
             mimeType: "image/png",
-            data: Data([0x89, 0x50, 0x4E, 0x47])
+            data: Data(repeating: 0x47, count: bytes)
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -323,6 +323,31 @@ struct ChatAttachmentDraftTests {
         #expect(draft.sourcePaths[second.id] == nil)
     }
 
+    @Test("post-normalization budget rejection reports its count and reason")
+    func finishImageImportReportsLateBudgetRejection() throws {
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        let almostHalf = rawBytesForEncoded(Int(budget * 6 / 10))
+        let first = try makeImage(name: "first.png", bytes: almostHalf)
+        let second = try makeImage(name: "second.png", bytes: almostHalf)
+        var draft = ChatAttachmentDraft()
+        let startedImportID = draft.beginImageImport()
+        let importID = try #require(startedImportID)
+
+        let accepted = draft.finishImageImport(
+            id: importID,
+            [
+                (first, URL(fileURLWithPath: "/tmp/first.png")),
+                (second, URL(fileURLWithPath: "/tmp/second.png")),
+            ],
+            notice: nil
+        )
+
+        #expect(accepted)
+        #expect(draft.images == [first])
+        #expect(draft.notice?.contains("1 image was not added") == true)
+        #expect(draft.notice?.contains("combined size exceeds") == true)
+    }
+
     @Test("duplicate paths are filtered before the budget gate so they consume budget once")
     func duplicatesAreDedupedBeforeBudgetGate() throws {
         let root = FileManager.default.temporaryDirectory

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -287,14 +287,16 @@ struct ChatAttachmentDraftTests {
         #expect(!countRejected)
         #expect(draft.images.count == ChatImageAttachment.maxImagesPerMessage)
 
-        // Byte budget exhausted: each image is individually under the per-file
-        // 20 MB cap, but two that together exceed the 20 MB aggregate cannot
-        // both be appended.
+        // Byte budget exhausted (measured in exact encoded data-URL bytes):
+        // each image individually fits the combined budget, but two that
+        // together exceed it cannot both be appended.
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        let almostHalf = rawBytesForEncoded(Int(budget * 6 / 10))
         var byteDraft = ChatAttachmentDraft()
-        let large = try makeImage(name: "big.png", bytes: 20 * 1024 * 1024 - 1)
+        let large = try makeImage(name: "big.png", bytes: almostHalf)
         let largeAccepted = byteDraft.appendImage(large)
         #expect(largeAccepted)
-        let another = try makeImage(name: "another.png", bytes: 20 * 1024 * 1024 - 1)
+        let another = try makeImage(name: "another.png", bytes: almostHalf)
         let byteRejected = byteDraft.appendImage(another)
         #expect(!byteRejected)
         #expect(byteDraft.images == [large])
@@ -303,10 +305,12 @@ struct ChatAttachmentDraftTests {
     @Test("appendImages keeps only the batch that fits and reports the rejected count")
     func appendImagesGatesMixedBatch() throws {
         var draft = ChatAttachmentDraft()
-        // The first image alone fits; together the pair exceeds 20 MB aggregate,
-        // so the second is dropped and counted as rejected.
-        let first = try makeImage(name: "first.png", bytes: 12 * 1024 * 1024)
-        let second = try makeImage(name: "second.png", bytes: 12 * 1024 * 1024)
+        // The first image alone fits the encoded byte budget; together the pair
+        // exceeds it, so the second is dropped and counted as rejected.
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        let almostHalf = rawBytesForEncoded(Int(budget * 6 / 10))
+        let first = try makeImage(name: "first.png", bytes: almostHalf)
+        let second = try makeImage(name: "second.png", bytes: almostHalf)
 
         let rejectedCount = draft.appendImages([
             (first, URL(fileURLWithPath: "/tmp/first.png")),
@@ -366,8 +370,8 @@ struct ChatAttachmentDraftTests {
         }
         let submission = draft.takeSubmission()
         #expect(submission.images.count == ChatImageAttachment.maxImagesPerMessage)
-        #expect(submission.images.reduce(0) { $0 + $1.data.count }
-            <= ChatImageAttachment.maxCombinedImageBytes)
+        #expect(submission.images.reduce(0) { $0 + $1.encodedDataURLByteCount }
+            <= ChatImageAttachment.maxCombinedEncodedImageBytes)
     }
 
     @Test("a deleted conversation cannot be resurrected by a late image import")
@@ -427,9 +431,11 @@ struct ChatAttachmentDraftTests {
         let stripped = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(source)
 
-        // The pre-read budget gate runs before any beginImageImport/read work.
+        // The pre-read budget gate runs before any beginImageImport/read work,
+        // charging existing images at their encoded wire form so the incoming
+        // batch and the already-attached set speak the same byte budget.
         let gated = stripped.contains(
-            "letselection=ChatImageAttachment.importCandidates(urls,existingCount:attachmentDraft.images.count,existingBytes:attachmentDraft.images.reduce(0){$0+$1.data.count})"
+            "letselection=ChatImageAttachment.importCandidates(urls,existingCount:existing.count,existingBytes:existing.reduce(0){$0+$1.encodedDataURLByteCount})"
         )
         #expect(gated, "addImageURLs no longer gates image candidates before import.")
         #expect(stripped.contains(
@@ -469,6 +475,14 @@ struct ChatAttachmentDraftTests {
             mimeType: "image/png",
             data: Data(repeating: 0x47, count: bytes)
         )
+    }
+
+    /// A raw byte count whose encoded data-URL size is *at most* `encoded`, so
+    /// a test can express "this image encodes to ~60 % of the message budget"
+    /// without hard-coding base64 expansion.
+    private func rawBytesForEncoded(_ encoded: Int) -> Int {
+        let prefix = ChatImageAttachment.encodedDataURLByteCount(mimeType: "image/png", rawBytes: 0)
+        return ((encoded - prefix) / 4) * 3
     }
 
     private func makeFile(name: String, text: String) throws -> ChatFileAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -475,12 +475,22 @@ struct ChatImageAttachmentTests {
         }
     }
 
+    /// A raw byte count whose encoded data-URL size is *at most* `encoded`.
+    /// Lets a test express "this file encodes to the image budget" without
+    /// hard-coding base64 expansion in every assertion.
+    private func rawCountForEncoded(_ encoded: Int, mimeType: String = "image/png") -> Int {
+        let prefix = ChatImageAttachment.encodedDataURLByteCount(mimeType: mimeType, rawBytes: 0)
+        let base64 = max(0, encoded - prefix)
+        return (base64 / 4) * 3
+    }
+
     @Test("importCandidates enforces the count and aggregate-byte boundaries")
     func importCandidatesBoundaries() throws {
         let root = try tempDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
 
-        // Count boundary: 6 files, 4-slot budget => 4 accepted, 2 rejected.
+        // Count boundary: 6 files, 4-slot budget => 4 accepted, 2 rejected,
+        // and the binding limit is the count, not bytes.
         let six = try materialize([
             ("a.png", 100), ("b.png", 100), ("c.png", 100),
             ("d.png", 100), ("e.png", 100), ("f.png", 100),
@@ -490,32 +500,38 @@ struct ChatImageAttachmentTests {
         )
         #expect(countSelection.accepted == Array(six.prefix(ChatImageAttachment.maxImagesPerMessage)))
         #expect(countSelection.rejectedCount == 6 - ChatImageAttachment.maxImagesPerMessage)
+        #expect(countSelection.limit == .count)
 
-        // Aggregate-byte boundary: an image over the remaining aggregate budget
-        // is skipped (its per-file 20 MB check still happens at read time), while
-        // a following image that fits is still admitted.
-        let max = ChatImageAttachment.maxCombinedImageBytes
-        let half = max / 2
+        // Aggregate-byte boundary: an image whose *encoded* form is over the
+        // remaining budget is skipped (its per-file 20 MB check still happens
+        // at read time), while a following image that fits is still admitted,
+        // and the binding limit is bytes.
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        // one raw byte more than encodes to the full budget -> encoded > budget
+        let bigRaw = rawCountForEncoded(budget) + 1
+        let halfRaw = rawCountForEncoded(budget / 2)
         let big = try materialize([
-            ("big.png", max + 1), ("small.png", 100),
+            ("big.png", bigRaw), ("small.png", 100),
         ], in: root)
         let bigSelection = ChatImageAttachment.importCandidates(
             big, existingCount: 0, existingBytes: 0
         )
         #expect(bigSelection.accepted == [big[1]])
         #expect(bigSelection.rejectedCount == 1)
+        #expect(bigSelection.limit == .bytes)
 
         let thirds = try materialize([
-            ("one.png", half), ("two.png", half), ("three.png", 100),
+            ("one.png", halfRaw), ("two.png", halfRaw), ("three.png", 100),
         ], in: root)
         let thirdsSelection = ChatImageAttachment.importCandidates(
             thirds, existingCount: 0, existingBytes: 0
         )
-        // half+half fits exactly (== budget), the third is over.
+        // Two encoded-half-budget images fit; the third's encoded bytes push
+        // the set over the combined budget.
         #expect(thirdsSelection.accepted == Array(thirds.prefix(2)))
         #expect(thirdsSelection.rejectedCount == 1)
 
-        // Existing budget/bytes are honored.
+        // Existing budget/count are honored: no count slots remain.
         let withExisting = ChatImageAttachment.importCandidates(
             [thirds[2]], existingCount: 4, existingBytes: 0
         )
@@ -527,11 +543,12 @@ struct ChatImageAttachmentTests {
     func importCandidatesMixedBatch() throws {
         let root = try tempDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
-        let max = ChatImageAttachment.maxCombinedImageBytes
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        let oversizeRaw = rawCountForEncoded(budget) + 1
         // First fits, second is over the aggregate budget, third fits again
         // only if the second was skipped and bytes remain.
         let urls = try materialize([
-            ("keep.png", 10), ("oversize.png", max), ("keep2.png", 10),
+            ("keep.png", 10), ("oversize.png", oversizeRaw), ("keep2.png", 10),
         ], in: root)
         let selection = ChatImageAttachment.importCandidates(
             urls, existingCount: 0, existingBytes: 0
@@ -547,7 +564,9 @@ struct ChatImageAttachmentTests {
         )
         let big = try ChatImageAttachment(
             filename: "b.png", mimeType: "image/png",
-            data: Data(repeating: 2, count: ChatImageAttachment.maxCombinedImageBytes)
+            data: Data(repeating: 2, count: rawCountForEncoded(
+                ChatImageAttachment.maxCombinedEncodedImageBytes
+            ))
         )
         let many = try ChatImageAttachment(
             filename: "c.png", mimeType: "image/png", data: Data(repeating: 3, count: 10)
@@ -594,6 +613,75 @@ struct ChatImageAttachmentTests {
         for rejectedImage in rejected {
             #expect(!wire.contains(rejectedImage.data.base64EncodedString()))
         }
+    }
+
+    @Test("wire construction inherently bounds an over-limit message (restore/upgrade path)")
+    func wireConstructionBoundsOverLimitMessage() throws {
+        // An upgraded or restored profile can carry a message that predates the
+        // budget, with more images than the wire may carry. Wire.Message.init
+        // must re-apply the budget itself, not trust the message to be pre-fit.
+        // First, more images than the count cap.
+        let tooMany = try (0..<ChatImageAttachment.maxImagesPerMessage + 5).map {
+            try ChatImageAttachment(
+                filename: "\($0).png", mimeType: "image/png",
+                data: Data(repeating: UInt8(64 + $0), count: 10)
+            )
+        }
+        let countMessage = ChatMessage(
+            role: .user, content: "Describe", imageAttachments: tooMany
+        )
+        let countWire = String(
+            decoding: try JSONEncoder().encode(
+                ChatStreamClient.Request(
+                    alias: "qwen3.5-9b-4bit",
+                    messages: [countMessage]
+                ).messages
+            ),
+            as: UTF8.self
+        )
+        let expectedKeep = ChatImageAttachment.fittedForMessage(tooMany)
+        #expect(expectedKeep.count == ChatImageAttachment.maxImagesPerMessage)
+        for kept in expectedKeep {
+            #expect(countWire.contains(kept.data.base64EncodedString()))
+        }
+        for dropped in tooMany.dropFirst(ChatImageAttachment.maxImagesPerMessage) {
+            #expect(!countWire.contains(dropped.data.base64EncodedString()))
+        }
+
+        // Second, fewer images whose combined *encoded* bytes exceed the wire
+        // budget. A message with several near-budget images must have all but
+        // the fitting subset stripped at the wire, even though each is under
+        // the 20 MB per-file cap. Distinct byte payloads keep each base64
+        // encoding unique so the wire reveals exactly which image survived.
+        let budget = ChatImageAttachment.maxCombinedEncodedImageBytes
+        let heavyRaw = rawCountForEncoded(budget / 2) + 1  // encodes to > budget/2
+        let heavies = try (0..<3).map {
+            try ChatImageAttachment(
+                filename: "heavy\($0).png", mimeType: "image/png",
+                data: Data(repeating: UInt8(7 + $0), count: heavyRaw)
+            )
+        }
+        // Two of these cannot co-fit (each is > half the encoded budget).
+        #expect(ChatImageAttachment.fittedForMessage(heavies).count == 1)
+        let heavyMessage = ChatMessage(
+            role: .user,
+            content: "Describe",
+            imageAttachments: heavies
+        )
+        let heavyWire = String(
+            decoding: try JSONEncoder().encode(
+                ChatStreamClient.Request(
+                    alias: "qwen3.5-9b-4bit",
+                    messages: [heavyMessage]
+                ).messages
+            ),
+            as: UTF8.self
+        )
+        // The wired message carries only the one image that fits, not all three
+        // the over-limit message held.
+        #expect(heavyWire.contains(heavies[0].data.base64EncodedString()))
+        #expect(!heavyWire.contains(heavies[1].data.base64EncodedString()))
+        #expect(!heavyWire.contains(heavies[2].data.base64EncodedString()))
     }
 
     private static func writeSolidImage(

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -458,6 +458,144 @@ struct ChatImageAttachmentTests {
         }
     }
 
+    private func tempDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-img-budget-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// Creates real files with the given byte sizes so
+    /// `importCandidates` (which reads `fileSizeKey`) sees real sizes.
+    private func materialize(_ files: [(name: String, size: Int)], in root: URL) throws -> [URL] {
+        try files.map { entry in
+            let url = root.appendingPathComponent(entry.name)
+            try Data(repeating: 0, count: entry.size).write(to: url)
+            return url
+        }
+    }
+
+    @Test("importCandidates enforces the count and aggregate-byte boundaries")
+    func importCandidatesBoundaries() throws {
+        let root = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Count boundary: 6 files, 4-slot budget => 4 accepted, 2 rejected.
+        let six = try materialize([
+            ("a.png", 100), ("b.png", 100), ("c.png", 100),
+            ("d.png", 100), ("e.png", 100), ("f.png", 100),
+        ], in: root)
+        let countSelection = ChatImageAttachment.importCandidates(
+            six, existingCount: 0, existingBytes: 0
+        )
+        #expect(countSelection.accepted == Array(six.prefix(ChatImageAttachment.maxImagesPerMessage)))
+        #expect(countSelection.rejectedCount == 6 - ChatImageAttachment.maxImagesPerMessage)
+
+        // Aggregate-byte boundary: an image over the remaining aggregate budget
+        // is skipped (its per-file 20 MB check still happens at read time), while
+        // a following image that fits is still admitted.
+        let max = ChatImageAttachment.maxCombinedImageBytes
+        let half = max / 2
+        let big = try materialize([
+            ("big.png", max + 1), ("small.png", 100),
+        ], in: root)
+        let bigSelection = ChatImageAttachment.importCandidates(
+            big, existingCount: 0, existingBytes: 0
+        )
+        #expect(bigSelection.accepted == [big[1]])
+        #expect(bigSelection.rejectedCount == 1)
+
+        let thirds = try materialize([
+            ("one.png", half), ("two.png", half), ("three.png", 100),
+        ], in: root)
+        let thirdsSelection = ChatImageAttachment.importCandidates(
+            thirds, existingCount: 0, existingBytes: 0
+        )
+        // half+half fits exactly (== budget), the third is over.
+        #expect(thirdsSelection.accepted == Array(thirds.prefix(2)))
+        #expect(thirdsSelection.rejectedCount == 1)
+
+        // Existing budget/bytes are honored.
+        let withExisting = ChatImageAttachment.importCandidates(
+            [thirds[2]], existingCount: 4, existingBytes: 0
+        )
+        #expect(withExisting.accepted.isEmpty)
+        #expect(withExisting.rejectedCount == 1)
+    }
+
+    @Test("importCandidates admits a mixed accepted/rejected batch in selection order")
+    func importCandidatesMixedBatch() throws {
+        let root = try tempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let max = ChatImageAttachment.maxCombinedImageBytes
+        // First fits, second is over the aggregate budget, third fits again
+        // only if the second was skipped and bytes remain.
+        let urls = try materialize([
+            ("keep.png", 10), ("oversize.png", max), ("keep2.png", 10),
+        ], in: root)
+        let selection = ChatImageAttachment.importCandidates(
+            urls, existingCount: 0, existingBytes: 0
+        )
+        #expect(selection.accepted == [urls[0], urls[2]])
+        #expect(selection.rejectedCount == 1)
+    }
+
+    @Test("fittedForMessage caps count and keeps only images that fit the combined budget")
+    func fittedForMessageBoundaries() throws {
+        let small = try ChatImageAttachment(
+            filename: "a.png", mimeType: "image/png", data: Data(repeating: 1, count: 10)
+        )
+        let big = try ChatImageAttachment(
+            filename: "b.png", mimeType: "image/png",
+            data: Data(repeating: 2, count: ChatImageAttachment.maxCombinedImageBytes)
+        )
+        let many = try ChatImageAttachment(
+            filename: "c.png", mimeType: "image/png", data: Data(repeating: 3, count: 10)
+        )
+        // A single image that fills the whole budget leaves room for nothing else.
+        #expect(ChatImageAttachment.fittedForMessage([big, small, many]) == [big])
+        // When the big image is not first, it cannot coexist with the two small
+        // images that already used some budget; the small ones are kept.
+        #expect(ChatImageAttachment.fittedForMessage([small, big, many]) == [small, many])
+        // Count cap: 6 small images fit bytes but not count.
+        let sixSmall = try (0..<6).map {
+            try ChatImageAttachment(
+                filename: "\($0).png", mimeType: "image/png", data: Data(repeating: 1, count: 10)
+            )
+        }
+        #expect(ChatImageAttachment.fittedForMessage(sixSmall).count
+            == ChatImageAttachment.maxImagesPerMessage)
+    }
+
+    @Test("wire request never exceeds the accepted, bounded image set")
+    func wireRequestStaysWithinImageBudget() throws {
+        // Distinct byte payloads keep each base64 encoding unique so the wire
+        // can be checked for exactly which images were admitted.
+        let many = try (0..<ChatImageAttachment.maxImagesPerMessage + 5).map { index in
+            try ChatImageAttachment(
+                filename: "\(index).png",
+                mimeType: "image/png",
+                data: Data(repeating: UInt8(64 + index), count: 10)
+            )
+        }
+        let admitted = ChatImageAttachment.fittedForMessage(many)
+        #expect(admitted.count == ChatImageAttachment.maxImagesPerMessage)
+        let request = ChatStreamClient.Request(
+            alias: "qwen3.5-9b-4bit",
+            messages: [
+                ChatMessage(role: .user, content: "Describe", imageAttachments: admitted)
+            ]
+        )
+        let wire = String(decoding: try JSONEncoder().encode(request.messages), as: UTF8.self)
+        for attachment in admitted {
+            #expect(wire.contains(attachment.data.base64EncodedString()))
+        }
+        let rejected = Array(many.dropFirst(ChatImageAttachment.maxImagesPerMessage))
+        for rejectedImage in rejected {
+            #expect(!wire.contains(rejectedImage.data.base64EncodedString()))
+        }
+    }
+
     private static func writeSolidImage(
         to url: URL,
         width: Int,


### PR DESCRIPTION
Fixes #2456

## Why

Image attachments had only a 20 MB per-file limit. Multi-select, paste, and drop could therefore retain and base64-encode an unbounded set into one request, freezing the Desktop app or deterministically exceeding the engine's 8 MiB request-body cap.

## What

- Limit one message to four images and exactly 6 MiB of encoded `data:<mime>;base64,...` bytes; the 20 MB per-file validation remains unchanged.
- Gate picker/drop candidates before decoding, then reapply the authoritative budget after normalization and again at wire construction for restored legacy messages.
- Keep selection order and source identity while rejecting only the images that do not fit.
- Report the rejected count and whether count or encoded bytes was the binding limit, including late post-normalization rejection; preserve mixed decode/budget reasons in one notice.
- Add count, encoded-byte, mixed-batch, duplicate, conversation-race, late-normalization, restored-message, and wire-boundary regression coverage.

The 6 MiB image envelope leaves at least 2 MiB below the server's 8 MiB body cap for text, history, tool payloads, and JSON framing. `ChatStreamClient.Request` includes image payloads from only the selected relevant image turn, so history cannot multiply that envelope.

## Scope / Non-goals

- No server-cap, model-capability, vision-token, lane-selection, or image-normalization changes.
- No change to the 20 MB per-file validation.
- No unrelated engine or CLI changes.

## Design precedent

The implementation reuses Rapid-MLX's existing document-attachment pattern: a cheap pre-read admission gate, an authoritative normalized-data fit, a defensive wire-boundary fit, and one conversation-owned draft. It adapts that established mechanism to non-truncatable image payloads instead of introducing a second attachment lifecycle.

## Verification

- `swift build --package-path apps/rapid-mac --build-tests`
- `swift test --package-path apps/rapid-mac --filter Attachment` — 76 tests across 7 suites passed before the final focused update.
- `swift test --package-path apps/rapid-mac --filter ChatAttachmentDraftTests` — 21 passed.
- `swift test --package-path apps/rapid-mac --filter ChatImageAttachmentTests` — 26 passed.
- `git diff --check origin/main...HEAD`
- Independent Codex review is being rerun on this exact head; required CI and PR validation must be green before merge.

## Behaviour delta

Picker, paste, or drop now keeps at most four images whose combined encoded data URLs fit within 6 MiB. Excess images are not sent, and the composer explains how many were rejected and whether count or encoded size caused the rejection.
