### PR TITLE
fix(engine): SSOT frozensets for serving_lane_reason + contract roster (#2515)

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1372,6 +1372,52 @@ class TestResolveServingLane:
         )
 
 
+class TestServingLaneDecisionValidation:
+    """The SSOT membership checks on ``ServingLaneDecision`` fail fast."""
+
+    def test_unknown_reason_is_rejected(self):
+        from vllm_mlx.api.utils import ServingLaneDecision
+
+        with pytest.raises(ValueError, match="unknown serving_lane_reason"):
+            ServingLaneDecision(False, "operator_forced_text")
+
+    def test_auto_text_fallback_with_non_downgrade_reason_is_rejected(self):
+        from vllm_mlx.api.utils import ServingLaneDecision
+
+        # A vision-lane reason is not a silent downgrade, so pairing it with
+        # auto_text_fallback=True must fail (it would reach the generic copy).
+        with pytest.raises(
+            ValueError, match="cannot be paired with auto_text_fallback"
+        ):
+            ServingLaneDecision(True, "vision_supported", auto_text_fallback=True)
+
+    def test_auto_text_fallback_with_downgrade_reason_is_accepted(self):
+        from vllm_mlx.api.utils import ServingLaneDecision
+
+        decision = ServingLaneDecision(
+            False, "vision_memory_insufficient", auto_text_fallback=True
+        )
+        assert decision.reason == "vision_memory_insufficient"
+        assert decision.auto_text_fallback is True
+
+    def test_ssot_members_are_all_constructible(self):
+        from vllm_mlx.api.utils import (
+            AUTO_TEXT_FALLBACK_REASONS,
+            SERVING_LANE_REASONS,
+            ServingLaneDecision,
+        )
+
+        # Every reason the SSOT names must be a valid construction — this would
+        # catch the set drifting from what the decision function emits. Every
+        # auto-fallback reason must also pass the flag.
+        for reason in SERVING_LANE_REASONS:
+            ServingLaneDecision(False, reason)
+        for reason in AUTO_TEXT_FALLBACK_REASONS:
+            ServingLaneDecision(False, reason, auto_text_fallback=True)
+        # Auto-fallback members are a strict subset of all reasons.
+        assert AUTO_TEXT_FALLBACK_REASONS <= SERVING_LANE_REASONS
+
+
 class TestExtractMultimodalContent:
     """Tests for extract_multimodal_content function."""
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1386,10 +1386,22 @@ class TestServingLaneDecisionValidation:
 
         # A vision-lane reason is not a silent downgrade, so pairing it with
         # auto_text_fallback=True must fail (it would reach the generic copy).
-        with pytest.raises(
-            ValueError, match="cannot be paired with auto_text_fallback"
-        ):
+        with pytest.raises(ValueError, match="requires auto_text_fallback=False"):
             ServingLaneDecision(True, "vision_supported", auto_text_fallback=True)
+
+    def test_downgrade_reason_without_auto_text_fallback_is_rejected(self):
+        from vllm_mlx.api.utils import ServingLaneDecision
+
+        with pytest.raises(ValueError, match="requires auto_text_fallback=True"):
+            ServingLaneDecision(False, "vision_memory_insufficient")
+
+    def test_reason_must_match_selected_lane(self):
+        from vllm_mlx.api.utils import ServingLaneDecision
+
+        with pytest.raises(ValueError, match="requires is_mllm=True"):
+            ServingLaneDecision(False, "vision_supported")
+        with pytest.raises(ValueError, match="requires is_mllm=False"):
+            ServingLaneDecision(True, "text_checkpoint")
 
     def test_auto_text_fallback_with_downgrade_reason_is_accepted(self):
         from vllm_mlx.api.utils import ServingLaneDecision
@@ -1404,6 +1416,7 @@ class TestServingLaneDecisionValidation:
         from vllm_mlx.api.utils import (
             AUTO_TEXT_FALLBACK_REASONS,
             SERVING_LANE_REASONS,
+            VISION_SERVING_LANE_REASONS,
             ServingLaneDecision,
         )
 
@@ -1411,11 +1424,15 @@ class TestServingLaneDecisionValidation:
         # catch the set drifting from what the decision function emits. Every
         # auto-fallback reason must also pass the flag.
         for reason in SERVING_LANE_REASONS:
-            ServingLaneDecision(False, reason)
-        for reason in AUTO_TEXT_FALLBACK_REASONS:
-            ServingLaneDecision(False, reason, auto_text_fallback=True)
+            ServingLaneDecision(
+                reason in VISION_SERVING_LANE_REASONS,
+                reason,
+                auto_text_fallback=reason in AUTO_TEXT_FALLBACK_REASONS,
+            )
         # Auto-fallback members are a strict subset of all reasons.
         assert AUTO_TEXT_FALLBACK_REASONS <= SERVING_LANE_REASONS
+        assert VISION_SERVING_LANE_REASONS <= SERVING_LANE_REASONS
+        assert not (AUTO_TEXT_FALLBACK_REASONS & VISION_SERVING_LANE_REASONS)
 
 
 class TestExtractMultimodalContent:

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -20,6 +20,14 @@ from vllm_mlx.output_collector import RequestOutputCollector  # noqa: E402
 from vllm_mlx.scheduler import BackpressureError, Scheduler  # noqa: E402
 
 
+def test_engine_rejects_unknown_serving_lane_reason():
+    with pytest.raises(ValueError, match="unknown serving_lane_reason"):
+        BatchedEngine(
+            "fake/text-checkpoint",
+            serving_lane_reason="vision_weight_unavailable",
+        )
+
+
 @pytest.mark.asyncio
 async def test_missing_vision_weights_update_live_lane_reason(monkeypatch):
     from vllm_mlx.models import mllm as mllm_mod

--- a/tests/test_engine_lifecycle.py
+++ b/tests/test_engine_lifecycle.py
@@ -28,9 +28,27 @@ def test_engine_rejects_unknown_serving_lane_reason():
         )
 
 
+@pytest.mark.parametrize(
+    ("engine_kwargs", "reason"),
+    [
+        ({"force_text": True}, "vision_supported"),
+        ({"force_mllm": True}, "text_checkpoint"),
+    ],
+)
+def test_engine_rejects_reason_for_the_wrong_effective_lane(engine_kwargs, reason):
+    with pytest.raises(ValueError, match="requires is_mllm"):
+        BatchedEngine(
+            "fake/checkpoint",
+            serving_lane_reason=reason,
+            **engine_kwargs,
+        )
+
+
 @pytest.mark.asyncio
 async def test_missing_vision_weights_update_live_lane_reason(monkeypatch):
     from vllm_mlx.models import mllm as mllm_mod
+
+    monkeypatch.setattr("vllm_mlx.engine.batched.is_mllm_model", lambda _: True)
 
     class FakeTextOnlyMLLM:
         def __init__(self, model_name, trust_remote_code=True):
@@ -46,7 +64,6 @@ async def test_missing_vision_weights_update_live_lane_reason(monkeypatch):
         "fake/text-only-vision-checkpoint",
         serving_lane_reason="vision_supported",
     )
-    engine._is_mllm = True
 
     async def start_llm():
         return None

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -106,10 +106,14 @@ def _decision_reasons() -> dict[str, tuple[bool, bool]]:
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
-            if (
-                not isinstance(node.func, ast.Name)
-                or node.func.id != "ServingLaneDecision"
-            ):
+            constructor_name = (
+                node.func.id
+                if isinstance(node.func, ast.Name)
+                else node.func.attr
+                if isinstance(node.func, ast.Attribute)
+                else None
+            )
+            if constructor_name != "ServingLaneDecision":
                 continue
             lane_node = _call_argument(node, 0, "is_mllm")
             reason_node = _call_argument(node, 1, "reason")
@@ -173,6 +177,27 @@ _VALIDATED_REASON_PASSTHROUGHS = frozenset(
     }
 )
 
+# Constructor/response keyword forwarding sites whose values have already
+# crossed ``ServingLaneDecision`` or ``BatchedEngine`` validation. Any new
+# dynamic keyword emission fails closed until its exact source is audited.
+_VALIDATED_REASON_KEYWORD_PASSTHROUGHS = frozenset(
+    {
+        ("server.py", "BatchedEngine", "_serving_lane_reason"),
+        ("server.py", "BatchedEngine", "serving_lane_reason"),
+        (
+            "routes/chat.py",
+            "e.openai_detail",
+            "getattr(engine, 'serving_lane_reason', None)",
+        ),
+        (
+            "routes/responses.py",
+            "e.openai_detail",
+            "getattr(engine, 'serving_lane_reason', None)",
+        ),
+        ("routes/models.py", "ModelInfo", "serving_lane_reason"),
+    }
+)
+
 
 def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
     """Static reason values assigned to reason fields anywhere in the engine tree."""
@@ -232,6 +257,57 @@ def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
     return found
 
 
+def _keyword_reason_values() -> set[str]:
+    """Static values passed through any ``serving_lane_reason=`` keyword."""
+    found: set[str] = set()
+    seen_passthroughs: set[tuple[str, str, str]] = set()
+    for path in ENGINE.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        constants = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "serving_lane_reason":
+                    continue
+                value = keyword.value
+                if isinstance(value, ast.Constant) and value.value is None:
+                    continue
+                if (
+                    isinstance(value, ast.Constant) and isinstance(value.value, str)
+                ) or (isinstance(value, ast.Name) and value.id in constants):
+                    found.add(
+                        _string_value(
+                            value,
+                            constants,
+                            context=(
+                                f"serving_lane_reason keyword at {path}:{node.lineno}"
+                            ),
+                        )
+                    )
+                    continue
+                relative_path = path.relative_to(ENGINE).as_posix()
+                passthrough = (
+                    relative_path,
+                    ast.unparse(node.func),
+                    ast.unparse(value),
+                )
+                assert passthrough in _VALIDATED_REASON_KEYWORD_PASSTHROUGHS, (
+                    "unvalidated dynamic serving_lane_reason keyword: "
+                    f"{passthrough}. Route the value through the shared "
+                    "invariant, then add only that exact pass-through here."
+                )
+                seen_passthroughs.add(passthrough)
+    assert seen_passthroughs == _VALIDATED_REASON_KEYWORD_PASSTHROUGHS, (
+        "validated serving_lane_reason keyword roster drifted:\n"
+        f"missing: "
+        f"{sorted(_VALIDATED_REASON_KEYWORD_PASSTHROUGHS - seen_passthroughs)}\n"
+        f"unexpected: "
+        f"{sorted(seen_passthroughs - _VALIDATED_REASON_KEYWORD_PASSTHROUGHS)}"
+    )
+    return found
+
+
 @pytest.mark.parametrize(
     "source",
     [
@@ -251,6 +327,50 @@ def test_dynamic_reason_assignment_scanner_fails_closed(
         _literal_assignments()
 
 
+def test_qualified_decision_constructor_is_scanned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "qualified.py").write_text(
+        'decision = api.ServingLaneDecision(False, "qualified_reason")\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+
+    assert _decision_reasons() == {"qualified_reason": (False, False)}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ('"literal_reason"', {"literal_reason"}),
+        ("local_reason", None),
+    ],
+)
+def test_reason_keyword_scanner_is_exhaustive_and_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    expected: set[str] | None,
+):
+    (tmp_path / "keyword.py").write_text(
+        f"response = Response(serving_lane_reason={value})\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+    monkeypatch.setitem(
+        globals(),
+        "_VALIDATED_REASON_KEYWORD_PASSTHROUGHS",
+        frozenset(),
+    )
+
+    if expected is None:
+        with pytest.raises(AssertionError, match="unvalidated dynamic"):
+            _keyword_reason_values()
+    else:
+        assert _keyword_reason_values() == expected
+
+
 def _engine_reasons() -> dict[str, bool]:
     """``{reason: auto_text_fallback}`` across the whole engine tree.
 
@@ -264,6 +384,12 @@ def _engine_reasons() -> dict[str, bool]:
     # video-gen modalities and passes it straight through. Those models have
     # no vision lane to lose, so the generic copy is not misleading for them.
     for reason in _literal_assignments():
+        reasons.setdefault(reason, False)
+    # Response/model constructors can emit the field without assigning it to
+    # a named target first. Include every static keyword literal in the same
+    # exhaustive engine roster; audited dynamic forwarding sites add no new
+    # value of their own.
+    for reason in _keyword_reason_values():
         reasons.setdefault(reason, False)
     # An assignment to the instance attribute is the engine downgrading
     # itself mid-load: after a failed vision load its own warning calls this

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -35,6 +35,8 @@ import ast
 import re
 from pathlib import Path
 
+import pytest
+
 from vllm_mlx.api.utils import (
     AUTO_TEXT_FALLBACK_REASONS,
     SERVING_LANE_REASONS,
@@ -132,18 +134,50 @@ def _decision_reasons() -> dict[str, tuple[bool, bool]]:
     return found
 
 
-def _assignment_target(target: ast.expr) -> str | None:
+def _assignment_targets(target: ast.expr) -> list[str]:
     if isinstance(target, ast.Name):
-        return target.id
+        return [target.id]
     if isinstance(target, ast.Attribute):
         owner = ast.unparse(target.value)
-        return f"{owner}.{target.attr}"
-    return None
+        return [f"{owner}.{target.attr}"]
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return [name for item in target.elts for name in _assignment_targets(item)]
+    return []
+
+
+# Dynamic assignments are allowed only when their exact source has already
+# crossed a validated boundary. Keeping this roster exact makes the scanner
+# fail closed on a new local variable, attribute, call, or destructuring site.
+_VALIDATED_REASON_PASSTHROUGHS = frozenset(
+    {
+        (
+            "engine/batched.py",
+            "self._serving_lane_reason",
+            "serving_lane_reason",
+        ),
+        (
+            "server.py",
+            "_serving_lane_reason",
+            "_serving_checkpoint.lane_reason",
+        ),
+        (
+            "server.py",
+            "serving_lane_reason",
+            "serving_checkpoint.lane_reason",
+        ),
+        (
+            "routes/models.py",
+            "serving_lane_reason",
+            "_served_lane_fields(model_id)",
+        ),
+    }
+)
 
 
 def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
     """Static reason values assigned to reason fields anywhere in the engine tree."""
     found: set[str] = set()
+    seen_passthroughs: set[tuple[str, str, str]] = set()
     for path in ENGINE.rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         constants = _module_string_constants(tree)
@@ -151,12 +185,11 @@ def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
             if not isinstance(node, (ast.Assign, ast.AnnAssign)):
                 continue
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-            names = [_assignment_target(target) for target in targets]
+            names = [name for target in targets for name in _assignment_targets(target)]
             selected = [
                 name
                 for name in names
-                if name is not None
-                and (
+                if (
                     name == exact_target
                     if exact_target is not None
                     else name.endswith("serving_lane_reason")
@@ -169,10 +202,19 @@ def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
                 # Optional response/schema fields are initialized empty; they
                 # are not reason emitters.
                 continue
-            if isinstance(value, ast.Name) and value.id not in constants:
-                # Runtime pass-through from an already validated decision/profile.
-                continue
-            if isinstance(value, ast.Attribute) and value.attr == "lane_reason":
+            if not (
+                isinstance(value, ast.Constant) and isinstance(value.value, str)
+            ) and not (isinstance(value, ast.Name) and value.id in constants):
+                relative_path = path.relative_to(ENGINE).as_posix()
+                source = ast.unparse(value)
+                passthroughs = {(relative_path, name, source) for name in selected}
+                unknown = passthroughs - _VALIDATED_REASON_PASSTHROUGHS
+                assert not unknown, (
+                    "unvalidated dynamic serving-lane reason assignment(s): "
+                    f"{sorted(unknown)}. Route the value through the shared "
+                    "invariant, then add only that exact pass-through here."
+                )
+                seen_passthroughs.update(passthroughs)
                 continue
             found.add(
                 _string_value(
@@ -181,7 +223,32 @@ def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
                     context=f"reason assignment at {path}:{node.lineno}",
                 )
             )
+    if exact_target is None:
+        assert seen_passthroughs == _VALIDATED_REASON_PASSTHROUGHS, (
+            "validated serving-lane pass-through roster drifted:\n"
+            f"missing: {sorted(_VALIDATED_REASON_PASSTHROUGHS - seen_passthroughs)}\n"
+            f"unexpected: {sorted(seen_passthroughs - _VALIDATED_REASON_PASSTHROUGHS)}"
+        )
     return found
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def assign(self, local_reason):\n    self._serving_lane_reason = local_reason\n",
+        "def assign():\n    lane, serving_lane_reason = resolve()\n",
+    ],
+)
+def test_dynamic_reason_assignment_scanner_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    (tmp_path / "dynamic.py").write_text(source, encoding="utf-8")
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+
+    with pytest.raises(AssertionError, match="unvalidated dynamic"):
+        _literal_assignments()
 
 
 def _engine_reasons() -> dict[str, bool]:

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -4,8 +4,8 @@
 The engine reports *why* a model is serving text-only in
 ``serving_lane_reason``; the Desktop app turns that into the sentence a user
 reads when the photo button is disabled. Nothing connects the two sides — the
-engine emits bare string literals from three files, the app matches them in a
-Swift ``switch`` — so they drifted:
+engine emits bare string literals, the app matches them in a Swift ``switch`` —
+so they drifted:
 
 * the app matched ``operator_forced_text``, which the engine has never emitted
   (it emits ``text_lane_forced``), leaving that copy permanently unreachable;
@@ -16,13 +16,17 @@ Swift ``switch`` — so they drifted:
 Both survived because the Swift fixtures asserting this area used the ghost
 strings too, so the tests agreed with the app instead of with the engine.
 
-This test is the thing that would have caught it. It parses the reason
-literals out of the engine and the ``case`` labels out of the Swift source and
-compares them. A text comparison is the only mechanism available (one side is
-Python, the other Swift, and the engine has no enum) — which is precisely why
-the drift went unnoticed.
+The engine now has a single source of truth: ``SERVING_LANE_REASONS`` /
+``AUTO_TEXT_FALLBACK_REASONS`` in ``vllm_mlx/api/utils.py``, enforced at
+construction time by ``ServingLaneDecision.__post_init__``. This test imports
+that SSOT and, rather than trusting it to be right, re-scans the whole engine
+tree for the literals actually emitted and proves the SSOT is both complete (no
+emitted reason can fall outside it) and exactly matches the Swift ``case``
+labels the user actually reads.
 
-mlx-free: pure parsing, no engine import, runs on the Linux CI leg.
+mlx-free: the ``vllm_mlx.api.utils`` import chain pulls in no MLX (verified —
+the Linux CI leg runs this with no MLX installed), and reason collection is
+pure text parsing.
 """
 
 from __future__ import annotations
@@ -30,15 +34,17 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from vllm_mlx.api.utils import (
+    AUTO_TEXT_FALLBACK_REASONS,
+    SERVING_LANE_REASONS,
+)
+
 REPO = Path(__file__).resolve().parents[1]
 
-# The engine has no single source of truth for these values: the decision
-# function emits most of them, but startup seeds one and the engine rewrites
-# another after a failed vision load. Scan the tree rather than naming files,
-# so a reason introduced in a fourth module cannot slip past this contract.
+# Scan the whole engine tree rather than naming files, so a reason introduced
+# in a fourth module (or a literal seeded outside the decision function) cannot
+# slip past this contract.
 ENGINE = REPO / "vllm_mlx"
-LANE_DECISIONS = ENGINE / "api/utils.py"
-BATCHED = ENGINE / "engine/batched.py"
 
 PROFILE_SWIFT = REPO / "apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift"
 
@@ -60,18 +66,19 @@ def _balanced_call(text: str, open_paren: int) -> str:
     raise AssertionError(f"unbalanced ServingLaneDecision call at offset {open_paren}")
 
 
-def _engine_decisions() -> dict[str, bool]:
-    """``{reason: auto_text_fallback}`` for every ``ServingLaneDecision``."""
-    text = LANE_DECISIONS.read_text()
+def _decision_reasons() -> dict[str, bool]:
+    """``{reason: auto_text_fallback}`` for every ``ServingLaneDecision`` in the tree."""
     found: dict[str, bool] = {}
-    for match in re.finditer(r"ServingLaneDecision\(", text):
-        call = _balanced_call(text, match.end() - 1)
-        reason = re.search(r'"([^"]+)"', call)
-        assert reason, f"ServingLaneDecision without a literal reason: {call!r}"
-        auto_fallback = bool(AUTO_FALLBACK_RE.search(call))
-        # A reason emitted from several call sites is auto-fallback if ANY of
-        # them sets the flag — the user can reach the copy through that path.
-        found[reason.group(1)] = found.get(reason.group(1), False) or auto_fallback
+    for path in ENGINE.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"ServingLaneDecision\(", text):
+            call = _balanced_call(text, match.end() - 1)
+            reason = re.search(r'"([^"]+)"', call)
+            assert reason, f"ServingLaneDecision without a literal reason: {call!r}"
+            auto_fallback = bool(AUTO_FALLBACK_RE.search(call))
+            # A reason emitted from several call sites is auto-fallback if ANY of
+            # them sets the flag — the user can reach the copy through that path.
+            found[reason.group(1)] = found.get(reason.group(1), False) or auto_fallback
     assert found, "no ServingLaneDecision constructions found — parser is stale"
     return found
 
@@ -86,14 +93,14 @@ def _literal_assignments(attribute: str) -> set[str]:
 
 
 def _engine_reasons() -> dict[str, bool]:
-    """``{reason: needs_dedicated_copy}`` across the whole engine tree.
+    """``{reason: auto_text_fallback}`` across the whole engine tree.
 
     The flag answers "can a vision-capable model reach the user with this
     reason while serving text-only", which is what makes the generic copy
     wrong. ``ServingLaneDecision`` records that as ``auto_text_fallback``;
     assignments outside it have to be classified here.
     """
-    reasons = _engine_decisions()
+    reasons = _decision_reasons()
     # Plain assignments seed the field — startup does this for image-gen /
     # video-gen modalities and passes it straight through. Those models have
     # no vision lane to lose, so the generic copy is not misleading for them.
@@ -138,6 +145,52 @@ def _swift_case_labels() -> set[str]:
     return labels
 
 
+def test_ssot_is_the_exhaustive_set_of_emitted_reasons():
+    """The SSOT must both contain every reason the engine emits and not be dead.
+
+    This is the mechanism-level check behind the issue: a stray ``serving_lane_reason``
+    literal introduced anywhere in the engine (now or later) fails the ``<=`` half, and
+    a stale SSOT entry that the engine stopped emitting fails the ``>=`` half. Either
+    half means engine and copy have been allowed to drift again.
+    """
+    emitted = set(_engine_reasons())
+    assert set(SERVING_LANE_REASONS) == emitted, (
+        f"SERVING_LANE_REASONS and the engine tree disagree:\n"
+        f"  in SSOT but never emitted by the engine: "
+        f"{sorted(set(SERVING_LANE_REASONS) - emitted) or 'none'}\n"
+        f"  emitted by the engine but missing from SSOT: "
+        f"{sorted(emitted - set(SERVING_LANE_REASONS)) or 'none'}\n"
+        f"Emitted (from tree scan): {sorted(emitted)}"
+    )
+
+
+def test_auto_text_fallback_ssot_matches_the_tree():
+    """``AUTO_TEXT_FALLBACK_REASONS`` must exactly describe the decision function's flag.
+
+    ``auto_text_fallback=True`` is a field on ``ServingLaneDecision``, so its
+    authoritative enumeration is the set of ``ServingLaneDecision`` call sites
+    that pass the flag (compared against the imported SSOT). ``__post_init__``
+    enforces membership, so a reason that gains or loses the flag without the
+    SSOT following is a construction-time error — this test is the belt that
+    shows both stayed in lockstep.
+
+    (This is deliberately distinct from the wider "silent downgrade" copy set —
+    ``vision_weights_unavailable`` is a mid-load rewrite that never passes
+    through ``ServingLaneDecision``, so it is not an ``AUTO_TEXT_FALLBACK``
+    member even though it still needs dedicated copy; see
+    ``test_every_silent_downgrade_has_dedicated_copy``.)
+    """
+    decision_auto = {r for r, is_auto in _decision_reasons().items() if is_auto}
+    assert decision_auto, "no auto_text_fallback decisions parsed — parser is stale"
+    assert set(AUTO_TEXT_FALLBACK_REASONS) == decision_auto, (
+        f"AUTO_TEXT_FALLBACK_REASONS and the ServingLaneDecision call sites disagree:\n"
+        f"  flagged by SSOT but no decision call site uses it: "
+        f"{sorted(set(AUTO_TEXT_FALLBACK_REASONS) - decision_auto) or 'none'}\n"
+        f"  decision call site flags it but SSOT misses it: "
+        f"{sorted(decision_auto - set(AUTO_TEXT_FALLBACK_REASONS)) or 'none'}"
+    )
+
+
 def test_desktop_matches_only_reasons_the_engine_emits():
     """No ghost cases.
 
@@ -154,17 +207,20 @@ def test_desktop_matches_only_reasons_the_engine_emits():
     )
 
 
-def test_every_auto_text_fallback_reason_has_dedicated_copy():
+def test_every_silent_downgrade_has_dedicated_copy():
     """Silent downgrades must not fall through to the generic sentence.
 
-    ``auto_text_fallback`` means the checkpoint IS vision-capable but its
-    vision lane was not admitted. The default arm tells the user to pick a
-    vision-capable model, which is the model they are already running — so
-    every one of these reasons needs copy naming the real cause.
+    A silent downgrade means the checkpoint IS vision-capable but its vision
+    lane was not admitted — recorded either as ``auto_text_fallback=True`` on a
+    ``ServingLaneDecision`` or as the mid-load ``vision_weights_unavailable``
+    rewrite (which never passes through the dataclass). The default arm tells
+    the user to pick a vision-capable model, which is the model they are already
+    running — so every silent downgrade needs copy naming the real cause. We use
+    the full tree-derived downgrade set so both mechanisms are covered.
     """
-    auto_fallback = {r for r, is_auto in _engine_reasons().items() if is_auto}
-    assert auto_fallback, "no auto_text_fallback reasons parsed — parser is stale"
-    uncovered = auto_fallback - _swift_case_labels()
+    silent_downgrades = {r for r, is_auto in _engine_reasons().items() if is_auto}
+    assert silent_downgrades, "no silent-downgrade reasons parsed — parser is stale"
+    uncovered = silent_downgrades - _swift_case_labels()
     assert not uncovered, (
         f"these reasons downgrade a vision-capable model to text but have no "
         f"dedicated copy in ServerModelProfile.swift: {sorted(uncovered)}. They "
@@ -183,7 +239,7 @@ def test_text_lane_forced_reason_has_dedicated_copy():
     way the checkpoint looks vision-capable while photos are refused, which is
     exactly when the generic copy is at its most confusing.
     """
-    assert "text_lane_forced" in _engine_reasons(), (
+    assert "text_lane_forced" in SERVING_LANE_REASONS, (
         "the engine no longer emits text_lane_forced; update this test and the "
         "Swift case together"
     )

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -210,6 +210,17 @@ _VALIDATED_REASON_KEYWORD_PASSTHROUGHS = frozenset(
     }
 )
 
+# Dictionary-literal forwarding sites whose values come from a live engine
+# that already validated its serving-lane reason at construction/ingestion.
+_VALIDATED_REASON_DICT_PASSTHROUGHS = frozenset(
+    {
+        (
+            "runtime/resident_models.py",
+            "getattr(engine, 'serving_lane_reason', None)",
+        ),
+    }
+)
+
 
 def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
     """Static reason values assigned to reason fields anywhere in the engine tree."""
@@ -320,6 +331,66 @@ def _keyword_reason_values() -> set[str]:
     return found
 
 
+def _dict_reason_values() -> set[str]:
+    """Static values emitted under a dictionary ``serving_lane_reason`` key."""
+    found: set[str] = set()
+    seen_passthroughs: set[tuple[str, str]] = set()
+    for path in ENGINE.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        constants = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Dict):
+                items = zip(node.keys, node.values, strict=True)
+            elif isinstance(node, ast.DictComp):
+                items = ((node.key, node.value),)
+            else:
+                continue
+            for key, value in items:
+                key_name = (
+                    key.value
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                    else constants.get(key.id)
+                    if isinstance(key, ast.Name)
+                    else None
+                )
+                if key_name != "serving_lane_reason":
+                    continue
+                if isinstance(value, ast.Constant) and value.value is None:
+                    continue
+                if (
+                    isinstance(value, ast.Constant) and isinstance(value.value, str)
+                ) or (isinstance(value, ast.Name) and value.id in constants):
+                    found.add(
+                        _string_value(
+                            value,
+                            constants,
+                            context=(
+                                f"serving_lane_reason dict value at "
+                                f"{path}:{node.lineno}"
+                            ),
+                        )
+                    )
+                    continue
+                passthrough = (
+                    path.relative_to(ENGINE).as_posix(),
+                    ast.unparse(value),
+                )
+                assert passthrough in _VALIDATED_REASON_DICT_PASSTHROUGHS, (
+                    "unvalidated dynamic serving_lane_reason dictionary value: "
+                    f"{passthrough}. Route the value through the shared "
+                    "invariant, then add only that exact pass-through here."
+                )
+                seen_passthroughs.add(passthrough)
+    assert seen_passthroughs == _VALIDATED_REASON_DICT_PASSTHROUGHS, (
+        "validated serving_lane_reason dictionary roster drifted:\n"
+        f"missing: "
+        f"{sorted(_VALIDATED_REASON_DICT_PASSTHROUGHS - seen_passthroughs)}\n"
+        f"unexpected: "
+        f"{sorted(seen_passthroughs - _VALIDATED_REASON_DICT_PASSTHROUGHS)}"
+    )
+    return found
+
+
 @pytest.mark.parametrize(
     "source",
     [
@@ -339,13 +410,25 @@ def test_dynamic_reason_assignment_scanner_fails_closed(
         _literal_assignments()
 
 
-def test_subscript_reason_assignment_reaches_exhaustive_ssot_check(
+@pytest.mark.parametrize(
+    "emission",
+    [
+        'payload["serving_lane_reason"] = "unknown_reason"',
+        'payload = {"serving_lane_reason": "unknown_reason"}',
+        ('payload = {"serving_lane_reason": "unknown_reason" for _ in range(1)}'),
+        (
+            'REASON_FIELD = "serving_lane_reason"\n'
+            'payload = {REASON_FIELD: "unknown_reason"}'
+        ),
+    ],
+)
+def test_literal_reason_emission_reaches_exhaustive_ssot_check(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    emission: str,
 ):
-    (tmp_path / "subscript.py").write_text(
-        'decision = ServingLaneDecision(False, "text_checkpoint")\n'
-        'payload["serving_lane_reason"] = "unknown_reason"\n',
+    (tmp_path / "emission.py").write_text(
+        f'decision = ServingLaneDecision(False, "text_checkpoint")\n{emission}\n',
         encoding="utf-8",
     )
     monkeypatch.setitem(globals(), "ENGINE", tmp_path)
@@ -355,9 +438,33 @@ def test_subscript_reason_assignment_reaches_exhaustive_ssot_check(
         "_VALIDATED_REASON_KEYWORD_PASSTHROUGHS",
         frozenset(),
     )
+    monkeypatch.setitem(
+        globals(),
+        "_VALIDATED_REASON_DICT_PASSTHROUGHS",
+        frozenset(),
+    )
 
     with pytest.raises(AssertionError, match="unknown_reason"):
         _assert_ssot_matches_engine()
+
+
+def test_dynamic_dict_reason_scanner_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "dict_value.py").write_text(
+        'payload = {"serving_lane_reason": local_reason}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+    monkeypatch.setitem(
+        globals(),
+        "_VALIDATED_REASON_DICT_PASSTHROUGHS",
+        frozenset(),
+    )
+
+    with pytest.raises(AssertionError, match="unvalidated dynamic"):
+        _dict_reason_values()
 
 
 def test_qualified_decision_constructor_is_scanned(
@@ -423,6 +530,11 @@ def _engine_reasons() -> dict[str, bool]:
     # exhaustive engine roster; audited dynamic forwarding sites add no new
     # value of their own.
     for reason in _keyword_reason_values():
+        reasons.setdefault(reason, False)
+    # Response dictionaries can emit the field without an assignment target
+    # or call keyword. Scan their literal keys separately; audited dynamic
+    # forwarding contributes no new reason value of its own.
+    for reason in _dict_reason_values():
         reasons.setdefault(reason, False)
     # An assignment to the instance attribute is the engine downgrading
     # itself mid-load: after a failed vision load its own warning calls this

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -144,6 +144,13 @@ def _assignment_targets(target: ast.expr) -> list[str]:
     if isinstance(target, ast.Attribute):
         owner = ast.unparse(target.value)
         return [f"{owner}.{target.attr}"]
+    if (
+        isinstance(target, ast.Subscript)
+        and isinstance(target.slice, ast.Constant)
+        and isinstance(target.slice.value, str)
+    ):
+        owner = ast.unparse(target.value)
+        return [f"{owner}.{target.slice.value}"]
     if isinstance(target, (ast.List, ast.Tuple)):
         return [name for item in target.elts for name in _assignment_targets(item)]
     return []
@@ -154,6 +161,11 @@ def _assignment_targets(target: ast.expr) -> list[str]:
 # fail closed on a new local variable, attribute, call, or destructuring site.
 _VALIDATED_REASON_PASSTHROUGHS = frozenset(
     {
+        (
+            "api/utils.py",
+            "error.serving_lane_reason",
+            "serving_lane_reason",
+        ),
         (
             "engine/batched.py",
             "self._serving_lane_reason",
@@ -327,6 +339,27 @@ def test_dynamic_reason_assignment_scanner_fails_closed(
         _literal_assignments()
 
 
+def test_subscript_reason_assignment_reaches_exhaustive_ssot_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "subscript.py").write_text(
+        'decision = ServingLaneDecision(False, "text_checkpoint")\n'
+        'payload["serving_lane_reason"] = "unknown_reason"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+    monkeypatch.setitem(globals(), "_VALIDATED_REASON_PASSTHROUGHS", frozenset())
+    monkeypatch.setitem(
+        globals(),
+        "_VALIDATED_REASON_KEYWORD_PASSTHROUGHS",
+        frozenset(),
+    )
+
+    with pytest.raises(AssertionError, match="unknown_reason"):
+        _assert_ssot_matches_engine()
+
+
 def test_qualified_decision_constructor_is_scanned(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -430,14 +463,7 @@ def _swift_case_labels() -> set[str]:
     return labels
 
 
-def test_ssot_is_the_exhaustive_set_of_emitted_reasons():
-    """The SSOT must both contain every reason the engine emits and not be dead.
-
-    This is the mechanism-level check behind the issue: a stray ``serving_lane_reason``
-    literal introduced anywhere in the engine (now or later) fails the ``<=`` half, and
-    a stale SSOT entry that the engine stopped emitting fails the ``>=`` half. Either
-    half means engine and copy have been allowed to drift again.
-    """
+def _assert_ssot_matches_engine() -> None:
     emitted = set(_engine_reasons())
     assert set(SERVING_LANE_REASONS) == emitted, (
         f"SERVING_LANE_REASONS and the engine tree disagree:\n"
@@ -447,6 +473,17 @@ def test_ssot_is_the_exhaustive_set_of_emitted_reasons():
         f"{sorted(emitted - set(SERVING_LANE_REASONS)) or 'none'}\n"
         f"Emitted (from tree scan): {sorted(emitted)}"
     )
+
+
+def test_ssot_is_the_exhaustive_set_of_emitted_reasons():
+    """The SSOT must both contain every reason the engine emits and not be dead.
+
+    This is the mechanism-level check behind the issue: a stray ``serving_lane_reason``
+    literal introduced anywhere in the engine (now or later) fails the ``<=`` half, and
+    a stale SSOT entry that the engine stopped emitting fails the ``>=`` half. Either
+    half means engine and copy have been allowed to drift again.
+    """
+    _assert_ssot_matches_engine()
 
 
 def test_auto_text_fallback_ssot_matches_the_tree():

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -31,12 +31,14 @@ pure text parsing.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
 from vllm_mlx.api.utils import (
     AUTO_TEXT_FALLBACK_REASONS,
     SERVING_LANE_REASONS,
+    VISION_SERVING_LANE_REASONS,
 )
 
 REPO = Path(__file__).resolve().parents[1]
@@ -48,47 +50,137 @@ ENGINE = REPO / "vllm_mlx"
 
 PROFILE_SWIFT = REPO / "apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift"
 
-# ``ServingLaneDecision(False, "x", auto_text_fallback=True)`` — tolerant of
-# line breaks and spacing, strict about the keyword actually being True.
-AUTO_FALLBACK_RE = re.compile(r"auto_text_fallback\s*=\s*True")
+
+def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+    """Top-level string constants available to reason emitters in one module."""
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = value.value
+    return constants
 
 
-def _balanced_call(text: str, open_paren: int) -> str:
-    """Source of the call whose ``(`` sits at ``open_paren``."""
-    depth = 0
-    for i in range(open_paren, len(text)):
-        if text[i] == "(":
-            depth += 1
-        elif text[i] == ")":
-            depth -= 1
-            if depth == 0:
-                return text[open_paren : i + 1]
-    raise AssertionError(f"unbalanced ServingLaneDecision call at offset {open_paren}")
+def _string_value(node: ast.expr, constants: dict[str, str], *, context: str) -> str:
+    """Resolve a string literal or a module-level string constant, else fail loud."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in constants:
+        return constants[node.id]
+    raise AssertionError(
+        f"{context} must use a string literal or module-level string constant; "
+        f"AST scanner cannot validate {ast.unparse(node)!r}"
+    )
 
 
-def _decision_reasons() -> dict[str, bool]:
-    """``{reason: auto_text_fallback}`` for every ``ServingLaneDecision`` in the tree."""
-    found: dict[str, bool] = {}
+def _bool_value(node: ast.expr, *, context: str) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    raise AssertionError(
+        f"{context} must use a bool literal; AST scanner cannot validate "
+        f"{ast.unparse(node)!r}"
+    )
+
+
+def _call_argument(call: ast.Call, position: int, keyword: str) -> ast.expr | None:
+    for item in call.keywords:
+        if item.arg == keyword:
+            return item.value
+    return call.args[position] if len(call.args) > position else None
+
+
+def _decision_reasons() -> dict[str, tuple[bool, bool]]:
+    """``{reason: (is_mllm, auto_fallback)}`` for every decision construction."""
+    found: dict[str, tuple[bool, bool]] = {}
     for path in ENGINE.rglob("*.py"):
-        text = path.read_text(encoding="utf-8")
-        for match in re.finditer(r"ServingLaneDecision\(", text):
-            call = _balanced_call(text, match.end() - 1)
-            reason = re.search(r'"([^"]+)"', call)
-            assert reason, f"ServingLaneDecision without a literal reason: {call!r}"
-            auto_fallback = bool(AUTO_FALLBACK_RE.search(call))
-            # A reason emitted from several call sites is auto-fallback if ANY of
-            # them sets the flag — the user can reach the copy through that path.
-            found[reason.group(1)] = found.get(reason.group(1), False) or auto_fallback
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        constants = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if (
+                not isinstance(node.func, ast.Name)
+                or node.func.id != "ServingLaneDecision"
+            ):
+                continue
+            lane_node = _call_argument(node, 0, "is_mllm")
+            reason_node = _call_argument(node, 1, "reason")
+            auto_node = _call_argument(node, 2, "auto_text_fallback")
+            assert lane_node is not None and reason_node is not None, (
+                f"ServingLaneDecision at {path}:{node.lineno} omits lane or reason"
+            )
+            context = f"ServingLaneDecision at {path}:{node.lineno}"
+            reason = _string_value(reason_node, constants, context=context)
+            classification = (
+                _bool_value(lane_node, context=context),
+                _bool_value(auto_node, context=context)
+                if auto_node is not None
+                else False,
+            )
+            previous = found.setdefault(reason, classification)
+            assert previous == classification, (
+                f"{reason!r} has conflicting lane/fallback classifications: "
+                f"{previous} and {classification}"
+            )
     assert found, "no ServingLaneDecision constructions found — parser is stale"
     return found
 
 
-def _literal_assignments(attribute: str) -> set[str]:
-    """Reason strings assigned to ``attribute`` anywhere in the engine tree."""
-    pattern = re.compile(rf'{re.escape(attribute)}\s*=\s*"([^"]+)"')
+def _assignment_target(target: ast.expr) -> str | None:
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        owner = ast.unparse(target.value)
+        return f"{owner}.{target.attr}"
+    return None
+
+
+def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
+    """Static reason values assigned to reason fields anywhere in the engine tree."""
     found: set[str] = set()
     for path in ENGINE.rglob("*.py"):
-        found.update(pattern.findall(path.read_text(encoding="utf-8")))
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        constants = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            names = [_assignment_target(target) for target in targets]
+            selected = [
+                name
+                for name in names
+                if name is not None
+                and (
+                    name == exact_target
+                    if exact_target is not None
+                    else name.endswith("serving_lane_reason")
+                )
+            ]
+            if not selected:
+                continue
+            value = node.value
+            if isinstance(value, ast.Constant) and value.value is None:
+                # Optional response/schema fields are initialized empty; they
+                # are not reason emitters.
+                continue
+            if isinstance(value, ast.Name) and value.id not in constants:
+                # Runtime pass-through from an already validated decision/profile.
+                continue
+            if isinstance(value, ast.Attribute) and value.attr == "lane_reason":
+                continue
+            found.add(
+                _string_value(
+                    value,
+                    constants,
+                    context=f"reason assignment at {path}:{node.lineno}",
+                )
+            )
     return found
 
 
@@ -100,11 +192,11 @@ def _engine_reasons() -> dict[str, bool]:
     wrong. ``ServingLaneDecision`` records that as ``auto_text_fallback``;
     assignments outside it have to be classified here.
     """
-    reasons = _decision_reasons()
+    reasons = {reason: auto for reason, (_, auto) in _decision_reasons().items()}
     # Plain assignments seed the field — startup does this for image-gen /
     # video-gen modalities and passes it straight through. Those models have
     # no vision lane to lose, so the generic copy is not misleading for them.
-    for reason in _literal_assignments("serving_lane_reason"):
+    for reason in _literal_assignments():
         reasons.setdefault(reason, False)
     # An assignment to the instance attribute is the engine downgrading
     # itself mid-load: after a failed vision load its own warning calls this
@@ -112,7 +204,7 @@ def _engine_reasons() -> dict[str, bool]:
     # Same silent downgrade the flag marks elsewhere, but it never passes
     # through ServingLaneDecision, so there is no flag to read. Runs after the
     # loop above, whose broader pattern also matches these lines.
-    for reason in _literal_assignments("self._serving_lane_reason"):
+    for reason in _literal_assignments(exact_target="self._serving_lane_reason"):
         reasons[reason] = True
     return reasons
 
@@ -180,7 +272,9 @@ def test_auto_text_fallback_ssot_matches_the_tree():
     member even though it still needs dedicated copy; see
     ``test_every_silent_downgrade_has_dedicated_copy``.)
     """
-    decision_auto = {r for r, is_auto in _decision_reasons().items() if is_auto}
+    decision_auto = {
+        reason for reason, (_, is_auto) in _decision_reasons().items() if is_auto
+    }
     assert decision_auto, "no auto_text_fallback decisions parsed — parser is stale"
     assert set(AUTO_TEXT_FALLBACK_REASONS) == decision_auto, (
         f"AUTO_TEXT_FALLBACK_REASONS and the ServingLaneDecision call sites disagree:\n"
@@ -188,6 +282,19 @@ def test_auto_text_fallback_ssot_matches_the_tree():
         f"{sorted(set(AUTO_TEXT_FALLBACK_REASONS) - decision_auto) or 'none'}\n"
         f"  decision call site flags it but SSOT misses it: "
         f"{sorted(decision_auto - set(AUTO_TEXT_FALLBACK_REASONS)) or 'none'}"
+    )
+
+
+def test_vision_lane_reason_ssot_matches_the_tree():
+    decision_vision = {
+        reason for reason, (is_mllm, _) in _decision_reasons().items() if is_mllm
+    }
+    assert set(VISION_SERVING_LANE_REASONS) == decision_vision, (
+        "VISION_SERVING_LANE_REASONS and decision call sites disagree:\n"
+        f"  in SSOT but no vision decision emits it: "
+        f"{sorted(set(VISION_SERVING_LANE_REASONS) - decision_vision) or 'none'}\n"
+        f"  emitted on vision lane but absent from SSOT: "
+        f"{sorted(decision_vision - set(VISION_SERVING_LANE_REASONS)) or 'none'}"
     )
 
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1407,6 +1407,19 @@ AUTO_TEXT_FALLBACK_REASONS = frozenset(
     }
 )
 
+# Reasons that select the multimodal lane. Every other reason in the complete
+# roster describes a text lane (including mid-load and non-LLM fallbacks).
+# Keeping this classification explicit lets ``ServingLaneDecision`` reject a
+# reason/boolean pairing that would otherwise make downstream engine selection
+# disagree with the diagnostic sent to clients.
+VISION_SERVING_LANE_REASONS = frozenset(
+    {
+        "vision_lane_forced",
+        "vision_hybrid_runtime_supported",
+        "vision_supported",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ServingLaneDecision:
@@ -1423,12 +1436,21 @@ class ServingLaneDecision:
                 f"{sorted(SERVING_LANE_REASONS)}. Add it to SERVING_LANE_REASONS "
                 f"and the Desktop copy contract if it is genuinely engine-emitted."
             )
-        if self.auto_text_fallback and self.reason not in AUTO_TEXT_FALLBACK_REASONS:
+        expected_auto_fallback = self.reason in AUTO_TEXT_FALLBACK_REASONS
+        if self.auto_text_fallback != expected_auto_fallback:
             raise ValueError(
-                f"{self.reason!r} cannot be paired with auto_text_fallback=True: "
-                f"only {sorted(AUTO_TEXT_FALLBACK_REASONS)} downgrade a "
-                f"vision-capable model to the text lane. Add a dedicated Desktop "
-                f"copy case if this is genuinely a silent vision-lane downgrade."
+                f"{self.reason!r} requires auto_text_fallback="
+                f"{expected_auto_fallback}, got {self.auto_text_fallback}: only "
+                f"{sorted(AUTO_TEXT_FALLBACK_REASONS)} downgrade a vision-capable "
+                f"model to the text lane. Update the reason roster and dedicated "
+                f"Desktop copy together if that classification changes."
+            )
+        expected_mllm = self.reason in VISION_SERVING_LANE_REASONS
+        if self.is_mllm != expected_mllm:
+            raise ValueError(
+                f"{self.reason!r} requires is_mllm={expected_mllm}, got "
+                f"{self.is_mllm}: vision-lane reasons are "
+                f"{sorted(VISION_SERVING_LANE_REASONS)}"
             )
 
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1421,6 +1421,37 @@ VISION_SERVING_LANE_REASONS = frozenset(
 )
 
 
+def validate_serving_lane_reason(
+    reason: str,
+    *,
+    is_mllm: bool,
+    auto_text_fallback: bool | None = None,
+) -> None:
+    """Validate a serving-lane reason against its effective lane metadata."""
+    if reason not in SERVING_LANE_REASONS:
+        raise ValueError(
+            f"unknown serving_lane_reason {reason!r}: must be one of "
+            f"{sorted(SERVING_LANE_REASONS)}. Add it to SERVING_LANE_REASONS "
+            f"and the Desktop copy contract if it is genuinely engine-emitted."
+        )
+    if auto_text_fallback is not None:
+        expected_auto_fallback = reason in AUTO_TEXT_FALLBACK_REASONS
+        if auto_text_fallback != expected_auto_fallback:
+            raise ValueError(
+                f"{reason!r} requires auto_text_fallback="
+                f"{expected_auto_fallback}, got {auto_text_fallback}: only "
+                f"{sorted(AUTO_TEXT_FALLBACK_REASONS)} downgrade a vision-capable "
+                f"model to the text lane. Update the reason roster and dedicated "
+                f"Desktop copy together if that classification changes."
+            )
+    expected_mllm = reason in VISION_SERVING_LANE_REASONS
+    if is_mllm != expected_mllm:
+        raise ValueError(
+            f"{reason!r} requires is_mllm={expected_mllm}, got {is_mllm}: "
+            f"vision-lane reasons are {sorted(VISION_SERVING_LANE_REASONS)}"
+        )
+
+
 @dataclass(frozen=True)
 class ServingLaneDecision:
     """Metadata-derived serving lane and stable machine-readable reason."""
@@ -1430,28 +1461,11 @@ class ServingLaneDecision:
     auto_text_fallback: bool = False
 
     def __post_init__(self) -> None:
-        if self.reason not in SERVING_LANE_REASONS:
-            raise ValueError(
-                f"unknown serving_lane_reason {self.reason!r}: must be one of "
-                f"{sorted(SERVING_LANE_REASONS)}. Add it to SERVING_LANE_REASONS "
-                f"and the Desktop copy contract if it is genuinely engine-emitted."
-            )
-        expected_auto_fallback = self.reason in AUTO_TEXT_FALLBACK_REASONS
-        if self.auto_text_fallback != expected_auto_fallback:
-            raise ValueError(
-                f"{self.reason!r} requires auto_text_fallback="
-                f"{expected_auto_fallback}, got {self.auto_text_fallback}: only "
-                f"{sorted(AUTO_TEXT_FALLBACK_REASONS)} downgrade a vision-capable "
-                f"model to the text lane. Update the reason roster and dedicated "
-                f"Desktop copy together if that classification changes."
-            )
-        expected_mllm = self.reason in VISION_SERVING_LANE_REASONS
-        if self.is_mllm != expected_mllm:
-            raise ValueError(
-                f"{self.reason!r} requires is_mllm={expected_mllm}, got "
-                f"{self.is_mllm}: vision-lane reasons are "
-                f"{sorted(VISION_SERVING_LANE_REASONS)}"
-            )
+        validate_serving_lane_reason(
+            self.reason,
+            is_mllm=self.is_mllm,
+            auto_text_fallback=self.auto_text_fallback,
+        )
 
 
 def resolve_serving_lane_decision(

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1363,6 +1363,51 @@ def mllm_backbone_is_hybrid(model_name: str) -> bool:
     return mllm_backbone_cache_mode(model_name) is not None
 
 
+# Single source of truth for the machine-readable ``serving_lane_reason``
+# strings the engine emits. Every emitting site — ``resolve_serving_lane_decision``
+# below, the startup seed in ``server.py``, and the post-load rewrite in
+# ``engine/batched.py`` — must emit a value that lives in this set. Keeping it
+# here (next to the decision function) instead of inlining literals at each site
+# is what lets ``ServingLaneDecision`` fail fast on a stray or renamed reason
+# and lets the Desktop copy contract test enumerate the values authoritatively.
+SERVING_LANE_REASONS = frozenset(
+    {
+        # resolve_serving_lane_decision — text lane
+        "text_lane_forced",
+        "text_checkpoint",
+        "text_lane_speculative_decode",
+        # resolve_serving_lane_decision — vision lane
+        "vision_lane_forced",
+        "vision_architecture_unavailable",
+        "vision_hybrid_cache_unsupported",
+        "vision_hybrid_runtime_supported",
+        "vision_hybrid_runtime_unsupported",
+        "vision_memory_insufficient",
+        "vision_supported",
+        # engine/batched.py — post-load rewrite after a failed vision load
+        "vision_weights_unavailable",
+        # server.py — startup seed for modalities with no vision lane
+        "not_applicable",
+    }
+)
+
+# The subset of ``SERVING_LANE_REASONS`` the engine pairs with
+# ``auto_text_fallback=True``: a checkpoint that LOOKS vision-capable but was
+# downgraded to the text lane during resolution. These are exactly the reasons
+# a vision-capable model can reach the user with while serving text-only, so
+# they are the ones the Desktop copy must give dedicated, cause-naming copy to
+# (never the generic "pick a vision-capable model" sentence).
+AUTO_TEXT_FALLBACK_REASONS = frozenset(
+    {
+        "text_lane_speculative_decode",
+        "vision_architecture_unavailable",
+        "vision_hybrid_cache_unsupported",
+        "vision_hybrid_runtime_unsupported",
+        "vision_memory_insufficient",
+    }
+)
+
+
 @dataclass(frozen=True)
 class ServingLaneDecision:
     """Metadata-derived serving lane and stable machine-readable reason."""
@@ -1370,6 +1415,21 @@ class ServingLaneDecision:
     is_mllm: bool
     reason: str
     auto_text_fallback: bool = False
+
+    def __post_init__(self) -> None:
+        if self.reason not in SERVING_LANE_REASONS:
+            raise ValueError(
+                f"unknown serving_lane_reason {self.reason!r}: must be one of "
+                f"{sorted(SERVING_LANE_REASONS)}. Add it to SERVING_LANE_REASONS "
+                f"and the Desktop copy contract if it is genuinely engine-emitted."
+            )
+        if self.auto_text_fallback and self.reason not in AUTO_TEXT_FALLBACK_REASONS:
+            raise ValueError(
+                f"{self.reason!r} cannot be paired with auto_text_fallback=True: "
+                f"only {sorted(AUTO_TEXT_FALLBACK_REASONS)} downgrade a "
+                f"vision-capable model to the text lane. Add a dedicated Desktop "
+                f"copy case if this is genuinely a silent vision-lane downgrade."
+            )
 
 
 def resolve_serving_lane_decision(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -25,7 +25,12 @@ from dataclasses import replace
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
-from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
+from ..api.utils import (
+    SERVING_LANE_REASONS,
+    clean_output_text,
+    extract_multimodal_content,
+    is_mllm_model,
+)
 from ..output_router import Channel, OutputRouter
 from ..utils.chat_template import apply_chat_template as shared_apply_chat_template
 from .base import BaseEngine, GenerationOutput
@@ -870,6 +875,14 @@ class BatchedEngine(BaseEngine):
         # demand for the vision lane, so a missing vision tower must hard-fail
         # for that operator rather than silently degrade behind their back.
         self._force_mllm = force_mllm
+        if (
+            serving_lane_reason is not None
+            and serving_lane_reason not in SERVING_LANE_REASONS
+        ):
+            raise ValueError(
+                f"unknown serving_lane_reason {serving_lane_reason!r}: must be "
+                f"one of {sorted(SERVING_LANE_REASONS)}"
+            )
         self._serving_lane_reason = serving_lane_reason
         if force_text:
             # User explicitly opted out of MLLM routing. Skip the probe

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -26,10 +26,10 @@ from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import (
-    SERVING_LANE_REASONS,
     clean_output_text,
     extract_multimodal_content,
     is_mllm_model,
+    validate_serving_lane_reason,
 )
 from ..output_router import Channel, OutputRouter
 from ..utils.chat_template import apply_chat_template as shared_apply_chat_template
@@ -875,15 +875,6 @@ class BatchedEngine(BaseEngine):
         # demand for the vision lane, so a missing vision tower must hard-fail
         # for that operator rather than silently degrade behind their back.
         self._force_mllm = force_mllm
-        if (
-            serving_lane_reason is not None
-            and serving_lane_reason not in SERVING_LANE_REASONS
-        ):
-            raise ValueError(
-                f"unknown serving_lane_reason {serving_lane_reason!r}: must be "
-                f"one of {sorted(SERVING_LANE_REASONS)}"
-            )
-        self._serving_lane_reason = serving_lane_reason
         if force_text:
             # User explicitly opted out of MLLM routing. Skip the probe
             # entirely so a False from auto-detection can't be overridden
@@ -891,6 +882,12 @@ class BatchedEngine(BaseEngine):
             self._is_mllm = False
         else:
             self._is_mllm = force_mllm or is_mllm_model(model_name)
+        if serving_lane_reason is not None:
+            validate_serving_lane_reason(
+                serving_lane_reason,
+                is_mllm=self._is_mllm,
+            )
+        self._serving_lane_reason = serving_lane_reason
         self._tool_logits_processor_factory = None
 
         self._model = None

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2091,6 +2091,9 @@ def load_model(
         _serving_lane_reason = _serving_checkpoint.lane_reason
     if _auto_text_fallback:
         fallback_detail = {
+            "text_lane_speculative_decode": (
+                "the requested speculative decoder is not honored by its vision lane"
+            ),
             "vision_hybrid_runtime_unsupported": (
                 "the installed vision runtime does not support its hybrid "
                 "language backbone"


### PR DESCRIPTION
## Why

The engine emits a dozen `serving_lane_reason` strings from three files (`vllm_mlx/api/utils.py` decision sites, `server.py` startup seed, `engine/batched.py` post-load rewrite) with **no single source of truth**. The Desktop app turns these into user-facing sentences via a Swift `switch` in `ServerModelProfile.swift`; with no SSOT the two sides drifted for months (`operator_forced_text` ghost case, `vision_memory_insufficient` missing copy). Follow-up to the #2514 review: make the set authoritative so a stray or renamed reason fails fast, and give the cross-language contract test a real SSOT to verify against.

## What

- **`vllm_mlx/api/utils.py`** — define the authoritative `SERVING_LANE_REASONS`, `AUTO_TEXT_FALLBACK_REASONS`, and `VISION_SERVING_LANE_REASONS` frozensets plus one shared `validate_serving_lane_reason` invariant. `ServingLaneDecision` validates membership, auto-fallback classification, and effective lane through that helper.
- **`vllm_mlx/engine/batched.py`** — validate every non-null ingested reason against the already-resolved effective text/vision lane through the same helper.
- **`tests/test_serving_lane_reason_contract.py`** — scan the complete engine tree for emitted literals; require exact SSOT, fallback, vision-lane, and Swift-copy coverage.
- **`tests/test_api_utils.py`** — exercise decision membership, fallback, and lane-pairing failures.
- **`tests/test_engine_lifecycle.py`** — reject unknown reasons and both contradictory text/vision lane pairings while preserving automatic missing-vision fallback.
- **`vllm_mlx/server.py`** — make the speculative-decode downgrade log name its real cause.

## Scope / Non-goals

- Engine-side reason SSOT and validation only. **No Swift copy changes**; the existing Desktop copy remains the contract target.
- No routing-policy redesign, public enum, version bump, or `pyproject.toml` change.
- Startup and post-load reason rewrites remain direct assignments because they do not carry auto-fallback metadata; the exhaustive tree scan covers those emitters, while BatchedEngine constructor ingestion uses the shared lane invariant.

## Verification

- `pytest tests/test_serving_lane_reason_contract.py tests/test_api_utils.py tests/test_engine_lifecycle.py` — 240 passed.
- `ruff check` + `ruff format --check` — clean on all six changed files.
- The contract import remains MLX-free and runs unchanged on Linux CI.
- Exact-head `pr_validate` follows converged independent review.

## Behaviour delta

- Unknown reasons, invalid auto-fallback classifications, and reasons contradicting the effective text/vision lane now fail at their ingestion boundary instead of publishing inconsistent diagnostics.
- The startup speculative-decode downgrade log now names the real cause rather than a hybrid-cache fallback.

## Design precedent

**Audit (every emitting site; all 12 reasons):**
- `vllm_mlx/api/utils.py` `resolve_serving_lane_decision` (lines 1394–1446): `text_lane_forced` (1394), `text_checkpoint` (1408, 1415), `text_lane_speculative_decode` (1410, auto-fallback), `vision_lane_forced` (1413), `vision_architecture_unavailable` (1418, auto-fallback), `vision_hybrid_cache_unsupported` (1424, auto-fallback), `vision_memory_insufficient` (1440, auto-fallback), `vision_hybrid_runtime_supported` (1442), `vision_hybrid_runtime_unsupported` (1444, auto-fallback), `vision_supported` (1446).
- `vllm_mlx/server.py` startup seed (2077 / 2400): `not_applicable`.
- `vllm_mlx/engine/batched.py` post-load rewrite (1432): `vision_weights_unavailable`.

**Adopted:** the frozenset SSOT plus one shared invariant used by both decision construction and live-engine ingestion; the exhaustive scanner recognizes qualified decision constructors, assignments, and every `serving_lane_reason=` keyword emission, failing closed on unaudited dynamic forwarding so every direct emitter and Desktop case remain synchronized.

**Rejected:**
- A full enum/type-grid abstraction layer — more machinery than the two sets need; the issue asked for exactly the frozensets.
- Swift copy changes — the Desktop copy is already correct (incl. the `vision_memory_insufficient` physical-RAM case that must never say "free up memory"); changing it would be out of scope and risk regressing the UX the constraint protects.
- Wrapping startup and post-load direct assignments in `ServingLaneDecision` — those sites do not own auto-fallback metadata. They remain covered by the exhaustive scanner; constructor ingestion validates lane consistency through the shared helper.

Fixes #2515
Part of #2499

🤖 Generated with [Claude Code](https://claude.com/claude-code)



