### PR TITLE
fix(mac): tie retained chat-lane provenance to authoritative catalog generation (#2364)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -34,11 +34,16 @@ actor ModelCatalogCache {
 
     typealias Loader = @Sendable (URL, URL?) async -> [ModelEntry]
     private let loader: Loader
+    private let cacheTTL: TimeInterval
 
-    init(loader: @escaping Loader = { binary, override in
-        await ModelCatalog.load(binary: binary, hubCacheOverride: override)
-    }) {
+    init(
+        loader: @escaping Loader = { binary, override in
+            await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+        },
+        ttl: TimeInterval = ModelCatalogCache.ttl
+    ) {
         self.loader = loader
+        self.cacheTTL = ttl
     }
 
     /// Backstop for out-of-band changes (see above).
@@ -177,7 +182,7 @@ actor ModelCatalogCache {
                snapshot, binaryPath: binaryPath, generation: generation,
                overridePath: overridePath
            ) {
-            if Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl {
+            if Date().timeIntervalSince(snapshot.fetchedAt) < cacheTTL {
                 return snapshot.entries
             }
             // Same inputs, past the TTL backstop: serve the stale entries now
@@ -201,6 +206,45 @@ actor ModelCatalogCache {
             let loaded = await inFlight.task.value
             // Publish the synchronous mirror before returning to callers that
             // immediately start a model from this catalog result.
+            await finish(inFlight)
+            return loaded
+        }
+        let entry = startLoad(
+            binary: binary, override: override, binaryPath: binaryPath,
+            generation: generation, overridePath: overridePath
+        )
+        let loaded = await entry.task.value
+        await finish(entry)
+        return loaded
+    }
+
+    /// An authoritative catalog read for lifecycle decisions that must not use
+    /// the stale-while-revalidate presentation path.
+    ///
+    /// Model start uses lane/capability metadata to choose a process mode and
+    /// persist lane-owned state. A five-minute-old row is fine for keeping a
+    /// picker responsive, but it is not evidence for those mutations. Join a
+    /// matching refresh when one exists; otherwise start one and await it.
+    func freshEntries(binary: URL, generation: UInt) async -> [ModelEntry] {
+        let override = ModelsFolderPreference.validatedOverrideURL()
+        let overridePath = override?.path
+        let binaryPath = binary.path
+
+        if let snapshot,
+           snapshotMatchesInputs(
+               snapshot, binaryPath: binaryPath, generation: generation,
+               overridePath: overridePath
+           ),
+           Date().timeIntervalSince(snapshot.fetchedAt) < cacheTTL {
+            return snapshot.entries
+        }
+
+        if let inFlight,
+           inFlight.matches(
+               binaryPath: binaryPath, generation: generation,
+               overridePath: overridePath
+           ) {
+            let loaded = await inFlight.task.value
             await finish(inFlight)
             return loaded
         }
@@ -275,6 +319,6 @@ actor ModelCatalogCache {
             snapshot, binaryPath: binary.path, generation: generation,
             overridePath: ModelsFolderPreference.validatedOverrideURL()?.path
         ) else { return false }
-        return Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl
+        return Date().timeIntervalSince(snapshot.fetchedAt) < cacheTTL
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -772,12 +772,12 @@ final class ServerManager {
     /// on. It bounds the fallback's lifecycle so a record derived from an older
     /// catalog epoch is re-derived from the authoritative catalog before it may
     /// be trusted again.
-    struct CatalogProvenStart: Equatable, Sendable {
+    struct CatalogEntryHint: Equatable, Sendable {
         let entry: ModelEntry
         let generation: UInt
     }
 
-    private var catalogProvenStartEntries: [String: CatalogProvenStart] = [:]
+    private var catalogProvenStartEntries: [String: CatalogEntryHint] = [:]
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -1130,23 +1130,31 @@ final class ServerManager {
     ///
     /// ``catalog`` is the authoritative snapshot (already correctly keyed to
     /// ``generation`` by ``ModelCatalogCache``). An empty ``catalog`` carries
-    /// no authority, so nothing is dropped — a transient probe failure must not
-    /// cancel the retained proof the memory-confirmation re-entry relies on.
+    /// no row authority, so a transient probe failure preserves only proofs
+    /// already derived from this same generation. An epoch change still drops
+    /// older proofs even when the refreshed probe fails.
     /// A retained entry survives only while its alias still resolves to the
     /// chat lane in this epoch and the entry was derived from this same
     /// generation. Pure (``nonisolated``) so the lifecycle is unit-testable
     /// without a sidecar or a main-actor context.
     nonisolated static func reconcilingProvenance(
-        _ store: [String: CatalogProvenStart],
+        _ store: [String: CatalogEntryHint],
         against catalog: [ModelEntry],
         generation: UInt
-    ) -> [String: CatalogProvenStart] {
-        guard !store.isEmpty, !catalog.isEmpty else { return store }
-        return store.filter { _, record in
+    ) -> [String: CatalogEntryHint] {
+        guard !store.isEmpty else { return store }
+        let currentEpoch = store.filter { _, record in
             // A fallback derived from an earlier catalog epoch is stale by
             // definition: it must be re-derived from this authoritative
             // snapshot before it may be trusted.
-            guard record.generation == generation else { return false }
+            record.generation == generation
+        }
+        // An empty array is the catalog subprocess-failure sentinel. It cannot
+        // disprove entries from this epoch, but an epoch advance is authority
+        // in its own right: old hints must not cross it even when the refreshed
+        // subprocess fails.
+        guard !catalog.isEmpty else { return currentEpoch }
+        return currentEpoch.filter { _, record in
             // The authoritative snapshot removes the alias (no row) or
             // reclassifies its lane (no longer chat): the chat fallback must
             // not survive it.
@@ -1155,6 +1163,22 @@ final class ServerManager {
             }) else { return false }
             return current.kind == .chat
         }
+    }
+
+    /// Accept a UI catalog hint only when its source epoch is explicit and is
+    /// still the epoch being served. A bare entry cannot be relabelled with the
+    /// current generation after an await: the UI row may have come from an
+    /// older snapshot.
+    nonisolated static func validatedCatalogHint(
+        alias: String,
+        hint: CatalogEntryHint?,
+        generation: UInt
+    ) -> CatalogEntryHint? {
+        guard let hint,
+              hint.generation == generation,
+              hint.entry.alias.caseInsensitiveCompare(alias) == .orderedSame
+        else { return nil }
+        return hint
     }
 
     /// Instance wrapper over ``reconcilingProvenance`` — reconcile the retained
@@ -1174,14 +1198,14 @@ final class ServerManager {
     /// Issue #2364 test seam — seed the retained chat-lane provenance so a
     /// lifecycle test can drive reclassification invalidation without a live
     /// sidecar. Production code never calls this.
-    internal func _testSetCatalogProvenStart(_ entries: [String: CatalogProvenStart]) {
+    internal func _testSetCatalogProvenStart(_ entries: [String: CatalogEntryHint]) {
         catalogProvenStartEntries = entries
     }
 
     /// Issue #2364 test seam — observe the retained chat-lane provenance after
     /// a reconciliation, and exercise the instance reconcile against an
     /// authoritative snapshot exactly as ``start`` does.
-    internal var _testCatalogProvenStartEntries: [String: CatalogProvenStart] {
+    internal var _testCatalogProvenStartEntries: [String: CatalogEntryHint] {
         catalogProvenStartEntries
     }
 
@@ -1368,10 +1392,18 @@ final class ServerManager {
         replacementGroup: ResidentModelReplacementGroup? = nil,
         imageMode: ResidentImageMode? = nil,
         residencyEligible: Bool = true,
-        catalogEntryHint: ModelEntry? = nil
+        catalogEntryHint: CatalogEntryHint? = nil
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
+        let catalogGeneration = downloads?.cacheGeneration ?? 0
+        if let validatedHint = Self.validatedCatalogHint(
+            alias: trimmed,
+            hint: catalogEntryHint,
+            generation: catalogGeneration
+        ) {
+            catalogProvenStartEntries[trimmed.lowercased()] = validatedHint
+        }
         let requestedPerformanceFlags = perfLaunchFlagsProvider?(trimmed) ?? []
         var requestedCatalogSupportsImageInput = false
         var probedCatalogEntry: ModelEntry?
@@ -1379,7 +1411,6 @@ final class ServerManager {
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
         if child != nil, let binary = binaryPath {
-            let catalogGeneration = downloads?.cacheGeneration ?? 0
             let catalogSnapshot = await ModelCatalogCache.shared.entries(
                 binary: binary,
                 generation: catalogGeneration
@@ -1404,8 +1435,11 @@ final class ServerManager {
         let provenCatalogEntry = Self.readyCatalogEntry(
             alias: trimmed,
             probed: probedCatalogEntry,
-            hint: catalogEntryHint
+            hint: catalogProvenStartEntries[trimmed.lowercased()]?.entry
         )
+        let provenCatalogHint = provenCatalogEntry.map {
+            CatalogEntryHint(entry: $0, generation: catalogGeneration)
+        }
         let requiresImageLaneRestart = Self.requiresProcessRestartForImageCapability(
             catalogSupportsImageInput: requestedCatalogSupportsImageInput,
             userOverrides: requestedPerformanceFlags,
@@ -1681,7 +1715,7 @@ final class ServerManager {
             hfPath: hfPath,
             memoryRequestID: memoryRequestID,
             memoryAdmission: replacementMemoryAdmission,
-            catalogEntryHint: provenCatalogEntry
+            catalogEntryHint: provenCatalogHint
         )
         // ``start`` also returns without spawning when the pre-load
         // memory guard parks the load on a confirmation prompt. Reading
@@ -2110,7 +2144,7 @@ final class ServerManager {
         memoryRequestID: UUID? = nil,
         isLaunchAutoStart: Bool = false,
         memoryAdmission: MemoryAdmissionContext? = nil,
-        catalogEntryHint: ModelEntry? = nil
+        catalogEntryHint: CatalogEntryHint? = nil
     ) async {
         // Issue #278: a manual restart is the user taking over the
         // lifecycle — reset the budget at entry so a previously
@@ -2146,17 +2180,13 @@ final class ServerManager {
             )
             return
         }
-        if let hintedEntry = Self.readyCatalogEntry(
+        let startCatalogGeneration = downloads?.cacheGeneration ?? 0
+        if let validatedHint = Self.validatedCatalogHint(
             alias: trimmedAlias,
-            probed: nil,
-            hint: catalogEntryHint
+            hint: catalogEntryHint,
+            generation: startCatalogGeneration
         ) {
-            // Retain with the catalog generation the entry was derived from
-            // so a later authoritative snapshot can invalidate it (#2364).
-            catalogProvenStartEntries[trimmedAlias.lowercased()] = CatalogProvenStart(
-                entry: hintedEntry,
-                generation: downloads?.cacheGeneration ?? 0
-            )
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = validatedHint
         }
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
@@ -2318,8 +2348,7 @@ final class ServerManager {
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
             probed: probedCatalogEntry,
-            hint: catalogEntryHint
-                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]?.entry
+            hint: catalogProvenStartEntries[trimmedAlias.lowercased()]?.entry
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2297,19 +2297,22 @@ final class ServerManager {
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
         let catalogGeneration = downloads?.cacheGeneration ?? 0
-        let catalogSnapshot = await ModelCatalogCache.shared.entries(
-            binary: binary,
-            generation: catalogGeneration
-        )
         // #2364: a newer authoritative snapshot may have removed the alias or
         // reclassified it out of the chat lane between this start and the
-        // previous one. Reconcile the retained fallback against it NOW, so a
-        // stale chat classification cannot be reused when a later probe fails.
+        // previous one. Reconcile the retained fallback against that snapshot
+        // NOW — before the ready fallback is consulted below — so a stale chat
+        // classification cannot be reused when a later probe fails.
         reconcileCatalogProvenStart(
-            against: catalogSnapshot,
+            against: await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: catalogGeneration
+            ),
             generation: catalogGeneration
         )
-        let probedCatalogEntry = catalogSnapshot.first {
+        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: catalogGeneration
+        ).first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
         let catalogEntry = Self.readyCatalogEntry(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -757,10 +757,27 @@ final class ServerManager {
     /// standard defaults; lifecycle tests inject an isolated suite while still
     /// driving the real spawn/health transition.
     private let sessionDefaults: UserDefaults?
-    /// Catalog provenance supplied by UI start paths. Retained by alias so a
+    /// Catalog provenance supplied by UI start paths, tied to the authoritative
+    /// catalog generation it was derived from. Retained by alias so a
     /// memory-confirmation re-entry does not lose the proof carried by the
-    /// original Start action when a later catalog subprocess fails.
-    private var catalogProvenStartEntries: [String: ModelEntry] = [:]
+    /// original Start action when a later catalog subprocess fails — but only
+    /// while the alias still resolves to the chat lane within the generating
+    /// catalog epoch (#2364).
+    ///
+    /// A newer authoritative snapshot that removes the alias or reclassifies
+    /// its lane drops the retained entry, so a model now audio-only can never
+    /// be persisted into the chat-selection key. ``generation`` is the
+    /// ``DownloadManager`` cacheGeneration in force when the UI read the entry
+    /// from the catalog — the same identity ``ModelCatalogCache`` keys snapshots
+    /// on. It bounds the fallback's lifecycle so a record derived from an older
+    /// catalog epoch is re-derived from the authoritative catalog before it may
+    /// be trusted again.
+    struct CatalogProvenStart: Equatable, Sendable {
+        let entry: ModelEntry
+        let generation: UInt
+    }
+
+    private var catalogProvenStartEntries: [String: CatalogProvenStart] = [:]
 
     /// v0.6 audit P1 (ServerManager — silent-crash detection):
     /// once the child has reported ready, continue polling /healthz
@@ -1108,6 +1125,76 @@ final class ServerManager {
         return hint
     }
 
+    /// Drop retained catalog provenance that a newer authoritative snapshot has
+    /// removed or reclassified, or that belongs to an earlier catalog epoch.
+    ///
+    /// ``catalog`` is the authoritative snapshot (already correctly keyed to
+    /// ``generation`` by ``ModelCatalogCache``). An empty ``catalog`` carries
+    /// no authority, so nothing is dropped — a transient probe failure must not
+    /// cancel the retained proof the memory-confirmation re-entry relies on.
+    /// A retained entry survives only while its alias still resolves to the
+    /// chat lane in this epoch and the entry was derived from this same
+    /// generation. Pure (``nonisolated``) so the lifecycle is unit-testable
+    /// without a sidecar or a main-actor context.
+    nonisolated static func reconcilingProvenance(
+        _ store: [String: CatalogProvenStart],
+        against catalog: [ModelEntry],
+        generation: UInt
+    ) -> [String: CatalogProvenStart] {
+        guard !store.isEmpty, !catalog.isEmpty else { return store }
+        return store.filter { _, record in
+            // A fallback derived from an earlier catalog epoch is stale by
+            // definition: it must be re-derived from this authoritative
+            // snapshot before it may be trusted.
+            guard record.generation == generation else { return false }
+            // The authoritative snapshot removes the alias (no row) or
+            // reclassifies its lane (no longer chat): the chat fallback must
+            // not survive it.
+            guard let current = catalog.first(where: {
+                $0.alias.caseInsensitiveCompare(record.entry.alias) == .orderedSame
+            }) else { return false }
+            return current.kind == .chat
+        }
+    }
+
+    /// Instance wrapper over ``reconcilingProvenance`` — reconcile the retained
+    /// fallback against every authoritative catalog observation so a stale chat
+    /// classification cannot survive to be reused on a later failed probe.
+    private func reconcileCatalogProvenStart(
+        against catalog: [ModelEntry],
+        generation: UInt
+    ) {
+        catalogProvenStartEntries = Self.reconcilingProvenance(
+            catalogProvenStartEntries,
+            against: catalog,
+            generation: generation
+        )
+    }
+
+    /// Issue #2364 test seam — seed the retained chat-lane provenance so a
+    /// lifecycle test can drive reclassification invalidation without a live
+    /// sidecar. Production code never calls this.
+    internal func _testSetCatalogProvenStart(_ entries: [String: CatalogProvenStart]) {
+        catalogProvenStartEntries = entries
+    }
+
+    /// Issue #2364 test seam — observe the retained chat-lane provenance after
+    /// a reconciliation, and exercise the instance reconcile against an
+    /// authoritative snapshot exactly as ``start`` does.
+    internal var _testCatalogProvenStartEntries: [String: CatalogProvenStart] {
+        catalogProvenStartEntries
+    }
+
+    /// Issue #2364 test seam — run the instance reconcile against a supplied
+    /// authoritative snapshot so a test can assert the retained fallback was
+    /// invalidated without spawning a sidecar.
+    internal func _testReconcileCatalogProvenStart(
+        against catalog: [ModelEntry],
+        generation: UInt
+    ) {
+        reconcileCatalogProvenStart(against: catalog, generation: generation)
+    }
+
     /// Issue #1838 test seam — swap in a ``ServerResidencyClient`` whose
     /// transport reads from a ``URLProtocol`` stub, so a test can drive the
     /// in-process resident-load path and observe the published rejection
@@ -1292,13 +1379,21 @@ final class ServerManager {
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
         if child != nil, let binary = binaryPath {
-            let entry = await ModelCatalogCache.shared.entries(
+            let catalogGeneration = downloads?.cacheGeneration ?? 0
+            let catalogSnapshot = await ModelCatalogCache.shared.entries(
                 binary: binary,
-                generation: downloads?.cacheGeneration ?? 0
-            ).first {
+                generation: catalogGeneration
+            )
+            if Task.isCancelled || didSignalShutdown { return false }
+            // Reconcile the retained chat-lane fallback against this
+            // authoritative snapshot just like ``start`` does (#2364).
+            reconcileCatalogProvenStart(
+                against: catalogSnapshot,
+                generation: catalogGeneration
+            )
+            let entry = catalogSnapshot.first {
                 $0.alias.caseInsensitiveCompare(trimmed) == .orderedSame
             }
-            if Task.isCancelled || didSignalShutdown { return false }
             probedCatalogEntry = entry
             requestedCatalogSupportsImageInput = ModelBrandStyle.supportsImageInput(
                 forAlias: trimmed,
@@ -2056,7 +2151,12 @@ final class ServerManager {
             probed: nil,
             hint: catalogEntryHint
         ) {
-            catalogProvenStartEntries[trimmedAlias.lowercased()] = hintedEntry
+            // Retain with the catalog generation the entry was derived from
+            // so a later authoritative snapshot can invalidate it (#2364).
+            catalogProvenStartEntries[trimmedAlias.lowercased()] = CatalogProvenStart(
+                entry: hintedEntry,
+                generation: downloads?.cacheGeneration ?? 0
+            )
         }
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
@@ -2196,17 +2296,27 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
+        let catalogGeneration = downloads?.cacheGeneration ?? 0
+        let catalogSnapshot = await ModelCatalogCache.shared.entries(
             binary: binary,
-            generation: downloads?.cacheGeneration ?? 0
-        ).first {
+            generation: catalogGeneration
+        )
+        // #2364: a newer authoritative snapshot may have removed the alias or
+        // reclassified it out of the chat lane between this start and the
+        // previous one. Reconcile the retained fallback against it NOW, so a
+        // stale chat classification cannot be reused when a later probe fails.
+        reconcileCatalogProvenStart(
+            against: catalogSnapshot,
+            generation: catalogGeneration
+        )
+        let probedCatalogEntry = catalogSnapshot.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
         let catalogEntry = Self.readyCatalogEntry(
             alias: trimmedAlias,
             probed: probedCatalogEntry,
             hint: catalogEntryHint
-                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]
+                ?? catalogProvenStartEntries[trimmedAlias.lowercased()]?.entry
         )
         if Task.isCancelled || didSignalShutdown { return }
         guard !isOperating, child == nil else { return }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1154,14 +1154,18 @@ final class ServerManager {
         // in its own right: old hints must not cross it even when the refreshed
         // subprocess fails.
         guard !catalog.isEmpty else { return currentEpoch }
-        return currentEpoch.filter { _, record in
+        return currentEpoch.reduce(into: [:]) { result, pair in
+            let (key, record) = pair
             // The authoritative snapshot removes the alias (no row) or
             // reclassifies its lane (no longer chat): the chat fallback must
             // not survive it.
             guard let current = catalog.first(where: {
                 $0.alias.caseInsensitiveCompare(record.entry.alias) == .orderedSame
-            }) else { return false }
-            return current.kind == .chat
+            }), current.kind == .chat else { return }
+            // Refresh every field, not just lane membership. Capability
+            // metadata participates in process-lane selection on a later
+            // same-epoch empty probe.
+            result[key] = CatalogEntryHint(entry: current, generation: generation)
         }
     }
 
@@ -1193,6 +1197,27 @@ final class ServerManager {
             against: catalog,
             generation: generation
         )
+    }
+
+    /// Await a lifecycle-grade snapshot whose generation is still current
+    /// when the load returns. Downloads may complete while the catalog
+    /// subprocess is running; in that case retry against the new epoch instead
+    /// of applying an old snapshot to a newer on-disk model set.
+    private func stableFreshCatalogSnapshot(
+        binary: URL
+    ) async -> (entries: [ModelEntry], generation: UInt)? {
+        while !Task.isCancelled, !didSignalShutdown {
+            let generation = downloads?.cacheGeneration ?? 0
+            let entries = await ModelCatalogCache.shared.freshEntries(
+                binary: binary,
+                generation: generation
+            )
+            guard !Task.isCancelled, !didSignalShutdown else { return nil }
+            if generation == downloads?.cacheGeneration ?? 0 {
+                return (entries, generation)
+            }
+        }
+        return nil
     }
 
     /// Issue #2364 test seam — seed the retained chat-lane provenance so a
@@ -1396,7 +1421,7 @@ final class ServerManager {
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        let catalogGeneration = downloads?.cacheGeneration ?? 0
+        var catalogGeneration = downloads?.cacheGeneration ?? 0
         if let validatedHint = Self.validatedCatalogHint(
             alias: trimmed,
             hint: catalogEntryHint,
@@ -1411,11 +1436,11 @@ final class ServerManager {
         // authoritatively. This probe is needed only to decide whether an
         // already-running text-lane sidecar can accept a resident load.
         if child != nil, let binary = binaryPath {
-            let catalogSnapshot = await ModelCatalogCache.shared.entries(
-                binary: binary,
-                generation: catalogGeneration
-            )
-            if Task.isCancelled || didSignalShutdown { return false }
+            guard let observation = await stableFreshCatalogSnapshot(binary: binary) else {
+                return false
+            }
+            let catalogSnapshot = observation.entries
+            catalogGeneration = observation.generation
             // Reconcile the retained chat-lane fallback against this
             // authoritative snapshot just like ``start`` does (#2364).
             reconcileCatalogProvenStart(
@@ -2326,23 +2351,21 @@ final class ServerManager {
         // launch a visual checkpoint in its text lane. Keeping this await
         // before `isOperating = true` preserves the cancellable startup
         // contract; re-check every entry guard after actor reentrancy.
-        let catalogGeneration = downloads?.cacheGeneration ?? 0
+        guard let catalogObservation = await stableFreshCatalogSnapshot(binary: binary) else {
+            return
+        }
+        let catalogGeneration = catalogObservation.generation
         // #2364: a newer authoritative snapshot may have removed the alias or
         // reclassified it out of the chat lane between this start and the
         // previous one. Reconcile the retained fallback against that snapshot
         // NOW — before the ready fallback is consulted below — so a stale chat
         // classification cannot be reused when a later probe fails.
+        let catalogSnapshot = catalogObservation.entries
         reconcileCatalogProvenStart(
-            against: await ModelCatalogCache.shared.entries(
-                binary: binary,
-                generation: catalogGeneration
-            ),
+            against: catalogSnapshot,
             generation: catalogGeneration
         )
-        let probedCatalogEntry = await ModelCatalogCache.shared.entries(
-            binary: binary,
-            generation: catalogGeneration
-        ).first {
+        let probedCatalogEntry = catalogSnapshot.first {
             $0.alias.caseInsensitiveCompare(trimmedAlias) == .orderedSame
         }
         let catalogEntry = Self.readyCatalogEntry(

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -787,6 +787,12 @@ struct ContentView: View {
     private func startModel(_ target: String) {
         let catalogEntry = catalogEntries.first(where: { $0.alias == target })
         let hfPath = catalogEntry?.hfRepo
+        let catalogEntryHint = catalogEntry.map {
+            ServerManager.CatalogEntryHint(
+                entry: $0,
+                generation: catalogGeneration
+            )
+        }
         // ``ensureServing`` via the shared helper, NOT ``server.start``: start is
         // cold-start only and no-ops while a different model (e.g. an Images
         // checkpoint) is resident, silently dropping the switch (#1739).
@@ -796,12 +802,7 @@ struct ContentView: View {
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: catalogEntry.map {
-                    ServerManager.CatalogEntryHint(
-                        entry: $0,
-                        generation: catalogGeneration
-                    )
-                }
+                catalogEntryHint: catalogEntryHint
             )
         }
     }
@@ -827,18 +828,19 @@ struct ContentView: View {
             isCached: entry?.cached == true
         ) else { return }
         let hfPath = entry?.hfRepo
+        let catalogEntryHint = entry.map {
+            ServerManager.CatalogEntryHint(
+                entry: $0,
+                generation: catalogGeneration
+            )
+        }
         Task {
             _ = await server.ensureServing(
                 alias: target,
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: entry.map {
-                    ServerManager.CatalogEntryHint(
-                        entry: $0,
-                        generation: catalogGeneration
-                    )
-                }
+                catalogEntryHint: catalogEntryHint
             )
         }
     }
@@ -853,6 +855,12 @@ struct ContentView: View {
     private func restartModel(_ target: String) {
         let catalogEntry = catalogEntries.first(where: { $0.alias == target })
         let hfPath = catalogEntry?.hfRepo
+        let catalogEntryHint = catalogEntry.map {
+            ServerManager.CatalogEntryHint(
+                entry: $0,
+                generation: catalogGeneration
+            )
+        }
         Task {
             await server.stop()
             _ = await server.ensureServing(
@@ -860,12 +868,7 @@ struct ContentView: View {
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: catalogEntry.map {
-                    ServerManager.CatalogEntryHint(
-                        entry: $0,
-                        generation: catalogGeneration
-                    )
-                }
+                catalogEntryHint: catalogEntryHint
             )
         }
     }
@@ -1449,15 +1452,16 @@ struct ContentView: View {
             let catalogEntry = catalogEntries.first {
                 $0.alias.caseInsensitiveCompare(resume) == .orderedSame
             }
+            let catalogEntryHint = catalogEntry.map {
+                ServerManager.CatalogEntryHint(
+                    entry: $0,
+                    generation: catalogGeneration
+                )
+            }
             await server.start(
                 alias: resume,
                 isLaunchAutoStart: true,
-                catalogEntryHint: catalogEntry.map {
-                    ServerManager.CatalogEntryHint(
-                        entry: $0,
-                        generation: catalogGeneration
-                    )
-                }
+                catalogEntryHint: catalogEntryHint
             )
         case .promptDownload(let pending):
             let footprint = ModelSizing.estimate(alias: pending)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -796,7 +796,12 @@ struct ContentView: View {
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: catalogEntry
+                catalogEntryHint: catalogEntry.map {
+                    ServerManager.CatalogEntryHint(
+                        entry: $0,
+                        generation: catalogGeneration
+                    )
+                }
             )
         }
     }
@@ -828,7 +833,12 @@ struct ContentView: View {
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: entry
+                catalogEntryHint: entry.map {
+                    ServerManager.CatalogEntryHint(
+                        entry: $0,
+                        generation: catalogGeneration
+                    )
+                }
             )
         }
     }
@@ -850,7 +860,12 @@ struct ContentView: View {
                 hfPath: hfPath,
                 estimatedMemoryGB: nil,
                 replacementGroup: .assistant,
-                catalogEntryHint: catalogEntry
+                catalogEntryHint: catalogEntry.map {
+                    ServerManager.CatalogEntryHint(
+                        entry: $0,
+                        generation: catalogGeneration
+                    )
+                }
             )
         }
     }
@@ -929,6 +944,7 @@ struct ContentView: View {
             server: server,
             cachedModels: catalogEntries,
             catalogLoaded: catalogLoaded,
+            catalogGeneration: catalogGeneration,
             onSkip: {
                 modelChoiceRecoveryRequested = false
                 quickstartDismissedThisSession = true
@@ -1436,7 +1452,12 @@ struct ContentView: View {
             await server.start(
                 alias: resume,
                 isLaunchAutoStart: true,
-                catalogEntryHint: catalogEntry
+                catalogEntryHint: catalogEntry.map {
+                    ServerManager.CatalogEntryHint(
+                        entry: $0,
+                        generation: catalogGeneration
+                    )
+                }
             )
         case .promptDownload(let pending):
             let footprint = ModelSizing.estimate(alias: pending)

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -101,6 +101,9 @@ struct ModelPickerBar: View {
     /// See ``ModelPickerVisibility`` for the threshold and copy.
     @AppStorage(ModelPickerVisibility.showAllStorageKey) private var showAllModels: Bool = false
     @State private var catalog: [ModelEntry] = []
+    /// Generation that produced ``catalog``. Kept beside the rows so a click
+    /// cannot relabel a stale entry with a newer download generation.
+    @State private var catalogGeneration: UInt = 0
     @State private var loadingCatalog = false
     @State private var showCustom = false
     @State private var customDraft = ""
@@ -1570,7 +1573,12 @@ struct ModelPickerBar: View {
             await server.start(
                 alias: trimmed,
                 hfPath: hfPath,
-                catalogEntryHint: catalogEntry
+                catalogEntryHint: catalogEntry.map {
+                    ServerManager.CatalogEntryHint(
+                        entry: $0,
+                        generation: catalogGeneration
+                    )
+                }
             )
         }
     }
@@ -1983,11 +1991,15 @@ struct ModelPickerBar: View {
         // Route the catalog read through the shared cache (#1470) so re-entering
         // settings does not re-spawn the lister subprocess. Keep the ``loaded``
         // name so the phantom-alias filter below (``entries``) is unchanged.
+        let generation = downloads.cacheGeneration
         let loaded = await ModelCatalogCache.shared.entries(
             binary: binary,
-            generation: downloads.cacheGeneration
+            generation: generation
         )
-        guard !Task.isCancelled, catalogRefreshGeneration == refreshGeneration else { return }
+        guard !Task.isCancelled,
+              catalogRefreshGeneration == refreshGeneration,
+              generation == downloads.cacheGeneration
+        else { return }
         // Belt-and-braces against a phantom alias reaching the UI.
         // ``ModelCatalog.parseAvailable`` already drops engine banner
         // lines, but this guard means a NEW banner shape can at worst
@@ -1996,6 +2008,7 @@ struct ModelPickerBar: View {
         // ``recommendedDefault`` below.
         let entries = loaded.filter { !ModelDisplayName.isUnresolved($0.alias) }
         self.catalog = entries
+        catalogGeneration = generation
         // Default selection: only apply if the current alias is blank or
         // not in the catalog (catalog absence still means manual pick).
         if alias.isEmpty || !entries.contains(where: { $0.alias == alias }) {

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1567,18 +1567,19 @@ struct ModelPickerBar: View {
         }
         let catalogEntry = catalog.first(where: { $0.alias == trimmed })
         let hfPath = catalogEntry?.hfRepo
+        let catalogEntryHint = catalogEntry.map {
+            ServerManager.CatalogEntryHint(
+                entry: $0,
+                generation: catalogGeneration
+            )
+        }
         // Launch flags are applied inside ServerManager.start (one choke
         // point for every start path), RAM-gated to the recommended pick.
         Task {
             await server.start(
                 alias: trimmed,
                 hfPath: hfPath,
-                catalogEntryHint: catalogEntry.map {
-                    ServerManager.CatalogEntryHint(
-                        entry: $0,
-                        generation: catalogGeneration
-                    )
-                }
+                catalogEntryHint: catalogEntryHint
             )
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -4501,15 +4501,16 @@ struct QuickstartView: View {
             let catalogEntry = cachedModels.first {
                 $0.alias == coordinator.selection.alias
             }
+            let catalogEntryHint = catalogEntry.map {
+                ServerManager.CatalogEntryHint(
+                    entry: $0,
+                    generation: catalogGeneration
+                )
+            }
             Task {
                 await server.start(
                     alias: coordinator.selection.alias,
-                    catalogEntryHint: catalogEntry.map {
-                        ServerManager.CatalogEntryHint(
-                            entry: $0,
-                            generation: catalogGeneration
-                        )
-                    }
+                    catalogEntryHint: catalogEntryHint
                 )
             }
         case .openModelManagement, .openWebSearchSettings:
@@ -4596,15 +4597,16 @@ struct QuickstartView: View {
     /// integer a human watching it can actually see change.
     private func startCachedModel(_ cached: ModelEntry) {
         coordinator.enterSkippingDownload()
+        let catalogEntryHint = ServerManager.CatalogEntryHint(
+            entry: cached,
+            generation: catalogGeneration
+        )
         Task { @MainActor in
             await coordinator.afterSkippingDownloadBeat(duration: Self.skippingDownloadBeat) {
                 await server.start(
                     alias: cached.alias,
                     hfPath: cached.hfRepo,
-                    catalogEntryHint: ServerManager.CatalogEntryHint(
-                        entry: cached,
-                        generation: catalogGeneration
-                    )
+                    catalogEntryHint: catalogEntryHint
                 )
             }
         }
@@ -4700,16 +4702,17 @@ struct QuickstartView: View {
             let catalogEntry = cachedModels.first {
                 $0.alias == coordinator.selection.alias
             }
+            let catalogEntryHint = catalogEntry.map {
+                ServerManager.CatalogEntryHint(
+                    entry: $0,
+                    generation: catalogGeneration
+                )
+            }
             Task { @MainActor in
                 await server.start(
                     alias: coordinator.selection.alias,
                     hfPath: coordinator.selection.hfRepo,
-                    catalogEntryHint: catalogEntry.map {
-                        ServerManager.CatalogEntryHint(
-                            entry: $0,
-                            generation: catalogGeneration
-                        )
-                    }
+                    catalogEntryHint: catalogEntryHint
                 )
             }
         case .cancelled:

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1452,6 +1452,10 @@ struct QuickstartView: View {
     /// fixture keep rendering a settled list; ContentView passes the real flag.
     var catalogLoaded: Bool = true
 
+    /// Generation that produced ``cachedModels``. Catalog hints carry this
+    /// source identity so an entry cannot outlive the snapshot that proved it.
+    var catalogGeneration: UInt = 0
+
     /// This Mac, read once per view lifetime. Same pattern and same source as
     /// ``ModelPickerBar`` and ``SettingsModelManagementPanel``, so onboarding's
     /// "won't fit" decision is the one the rest of the app already makes.
@@ -4500,7 +4504,12 @@ struct QuickstartView: View {
             Task {
                 await server.start(
                     alias: coordinator.selection.alias,
-                    catalogEntryHint: catalogEntry
+                    catalogEntryHint: catalogEntry.map {
+                        ServerManager.CatalogEntryHint(
+                            entry: $0,
+                            generation: catalogGeneration
+                        )
+                    }
                 )
             }
         case .openModelManagement, .openWebSearchSettings:
@@ -4592,7 +4601,10 @@ struct QuickstartView: View {
                 await server.start(
                     alias: cached.alias,
                     hfPath: cached.hfRepo,
-                    catalogEntryHint: cached
+                    catalogEntryHint: ServerManager.CatalogEntryHint(
+                        entry: cached,
+                        generation: catalogGeneration
+                    )
                 )
             }
         }
@@ -4692,7 +4704,12 @@ struct QuickstartView: View {
                 await server.start(
                     alias: coordinator.selection.alias,
                     hfPath: coordinator.selection.hfRepo,
-                    catalogEntryHint: catalogEntry
+                    catalogEntryHint: catalogEntry.map {
+                        ServerManager.CatalogEntryHint(
+                            entry: $0,
+                            generation: catalogGeneration
+                        )
+                    }
                 )
             }
         case .cancelled:

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -128,9 +128,9 @@ struct ModelSurfaceRedesignTests {
         #expect(model.contains("func retryAssistantMessage(\n        id: UUID,\n        alias: String,\n        supportsImageInput: Bool? = nil"))
         #expect(!model.contains("imageCapabilityByAlias"),
                 "restored conversations must not depend on transient per-send state")
-        #expect(server.contains("let probedCatalogEntry = await ModelCatalogCache.shared.entries"))
+        #expect(server.contains("guard let catalogObservation = await stableFreshCatalogSnapshot"))
         let catalogProbe = try #require(server.range(
-            of: "let probedCatalogEntry = await ModelCatalogCache.shared.entries"
+            of: "guard let catalogObservation = await stableFreshCatalogSnapshot"
         ))
         #expect(server.contains("let catalogEntry = Self.readyCatalogEntry("),
                 "the authoritative probe and exact-alias start hint must converge before launch")
@@ -144,7 +144,7 @@ struct ModelSurfaceRedesignTests {
                 "a completed load must publish only its captured in-flight identity")
         #expect(cache.components(
             separatedBy: "if let inFlight,\n           inFlight.matches("
-        ).count == 2, "only the join path may match loads by inputs")
+        ).count == 3, "both cached and authoritative reads may join only matching loads")
     }
 
     // MARK: - ModelBrandStyle.displayFamily

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
@@ -53,7 +53,7 @@ struct ReadinessRecoveryActionWiringTests {
         let function = String(source[signature.lowerBound...functionEnd])
         #expect(
             function.contains(
-                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntry)"
+                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntry.map{ServerManager.CatalogEntryHint(entry:$0,generation:catalogGeneration)})"
             ),
             "Restart must stop the failed engine before bringing the selected model back."
         )

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
@@ -53,7 +53,13 @@ struct ReadinessRecoveryActionWiringTests {
         let function = String(source[signature.lowerBound...functionEnd])
         #expect(
             function.contains(
-                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntry.map{ServerManager.CatalogEntryHint(entry:$0,generation:catalogGeneration)})"
+                "letcatalogEntryHint=catalogEntry.map{ServerManager.CatalogEntryHint(entry:$0,generation:catalogGeneration)}"
+            ),
+            "Restart must bind the catalog row to its source generation before launching a task."
+        )
+        #expect(
+            function.contains(
+                "awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath,estimatedMemoryGB:nil,replacementGroup:.assistant,catalogEntryHint:catalogEntryHint)"
             ),
             "Restart must stop the failed engine before bringing the selected model back."
         )

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -322,6 +322,41 @@ struct SessionModelRestoreTests {
         #expect(reconciled[chat.alias.lowercased()]?.generation == 7)
     }
 
+    @Test("Cat 2364: surviving provenance refreshes capability metadata from the current row")
+    func provenanceRefreshesCurrentCatalogMetadata() {
+        let stale = ModelEntry(
+            alias: chat.alias,
+            hfRepo: chat.hfRepo,
+            sizeOnDisk: chat.sizeOnDisk,
+            cached: true,
+            kind: .chat,
+            isBuiltinProfile: true,
+            isTextOnly: false
+        )
+        let current = ModelEntry(
+            alias: chat.alias,
+            hfRepo: chat.hfRepo,
+            sizeOnDisk: chat.sizeOnDisk,
+            cached: true,
+            kind: .chat,
+            isBuiltinProfile: true,
+            isTextOnly: true
+        )
+
+        let reconciled = ServerManager.reconcilingProvenance(
+            [
+                chat.alias.lowercased(): ServerManager.CatalogEntryHint(
+                    entry: stale,
+                    generation: 7
+                ),
+            ],
+            against: [current],
+            generation: 7
+        )
+
+        #expect(reconciled[chat.alias.lowercased()]?.entry == current)
+    }
+
     @Test(
         "Cat 2364: a catalog-epoch change bounds the fallback lifecycle even when the alias stays chat"
     )
@@ -532,5 +567,45 @@ struct SessionModelRestoreTests {
         #expect(plan.chatAliasResolved)
         #expect(plan.models.chatAlias == chat.alias)
         #expect(plan.shouldAutoStart)
+    }
+
+    @Test("Lifecycle catalog reads await fresh metadata instead of stale presentation rows")
+    func lifecycleCatalogReadBypassesStaleWhileRevalidate() async {
+        let audioOnly = ModelEntry(
+            alias: chat.alias,
+            hfRepo: chat.hfRepo,
+            sizeOnDisk: chat.sizeOnDisk,
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let loader = SequencedCatalogLoader([[chat], [audioOnly]])
+        let cache = ModelCatalogCache(
+            loader: { _, _ in await loader.load() },
+            ttl: 0
+        )
+        let binary = URL(fileURLWithPath: "/tmp/rapid-session-fresh-catalog-test")
+
+        let presented = await cache.entries(binary: binary, generation: 0)
+        let authoritative = await cache.freshEntries(binary: binary, generation: 0)
+
+        #expect(presented == [chat])
+        #expect(authoritative == [audioOnly])
+    }
+
+    @Test("Lifecycle catalog reads reuse an unexpired snapshot")
+    func lifecycleCatalogReadKeepsTheFastPath() async {
+        let loader = SequencedCatalogLoader([[chat], [stt]])
+        let cache = ModelCatalogCache { _, _ in await loader.load() }
+        let binary = URL(fileURLWithPath: "/tmp/rapid-session-fresh-cache-test")
+
+        let first = await cache.entries(binary: binary, generation: 0)
+        let authoritative = await cache.freshEntries(binary: binary, generation: 0)
+        await cache.invalidate()
+        let nextLoaderValue = await cache.entries(binary: binary, generation: 0)
+
+        #expect(first == [chat])
+        #expect(authoritative == [chat])
+        #expect(nextLoaderValue == [stt])
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -250,6 +250,178 @@ struct SessionModelRestoreTests {
         )
     }
 
+    @Test(
+        "Cat 2364: removing the alias in a newer authoritative catalog invalidates its retained chat fallback"
+    )
+    func provenanceInvalidatedWhenAuthoritativeCatalogRemovesAlias() {
+        let fallback = ServerManager.CatalogProvenStart(
+            entry: chat, generation: 7
+        )
+        let retained = [chat.alias.lowercased(): fallback]
+
+        // A newer authoritative snapshot no longer lists the alias at all.
+        let reconciled = ServerManager.reconcilingProvenance(
+            retained,
+            against: [stt, tts],
+            generation: 7
+        )
+
+        #expect(reconciled.isEmpty)
+    }
+
+    @Test(
+        "Cat 2364: reclassifying the alias to audio in a newer authoritative catalog invalidates its retained chat fallback"
+    )
+    func provenanceInvalidatedWhenAuthoritativeCatalogReclassifiesLane() {
+        let fallback = ServerManager.CatalogProvenStart(
+            entry: chat, generation: 7
+        )
+        let retained = [chat.alias.lowercased(): fallback]
+
+        // Same generation — the engine moved the alias from the chat section to
+        // the audio registry without any on-disk change, so cacheGeneration
+        // never bumped. Content reconciliation must still drop the fallback.
+        let audioOnly = ModelEntry(
+            alias: chat.alias,
+            hfRepo: chat.hfRepo,
+            sizeOnDisk: chat.sizeOnDisk,
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        let reconciled = ServerManager.reconcilingProvenance(
+            retained,
+            against: [audioOnly, stt],
+            generation: 7
+        )
+
+        #expect(reconciled.isEmpty)
+    }
+
+    @Test(
+        "Cat 2364: a chat fallback survives while the authoritative catalog still classifies it as chat"
+    )
+    func provenanceSurvivesUnchangedAuthoritativeCatalog() {
+        let fallback = ServerManager.CatalogProvenStart(
+            entry: chat, generation: 7
+        )
+        let retained = [chat.alias.lowercased(): fallback]
+
+        // No on-disk change and the alias is still chat: the retained proof the
+        // memory-confirmation re-entry relies on must survive.
+        let reconciled = ServerManager.reconcilingProvenance(
+            retained,
+            against: [chat, stt],
+            generation: 7
+        )
+
+        #expect(reconciled[chat.alias.lowercased()]?.entry == chat)
+        #expect(reconciled[chat.alias.lowercased()]?.generation == 7)
+    }
+
+    @Test(
+        "Cat 2364: a catalog-epoch change bounds the fallback lifecycle even when the alias stays chat"
+    )
+    func provenanceIsBoundedToItsCatalogEpoch() {
+        let fallback = ServerManager.CatalogProvenStart(
+            entry: chat, generation: 7
+        )
+        let retained = [chat.alias.lowercased(): fallback]
+
+        // The authoritative catalog advanced to generation 8 (e.g. a download
+        // finished). A fallback derived from generation 7 is stale by
+        // definition and must be re-derived before it is trusted.
+        let reconciled = ServerManager.reconcilingProvenance(
+            retained,
+            against: [chat, stt],
+            generation: 8
+        )
+
+        #expect(reconciled.isEmpty)
+    }
+
+    @Test(
+        "Cat 2364: a failed (empty) catalog probe does not wipe retained provenance"
+    )
+    func provenanceSurvivesEmptyProbe() {
+        let fallback = ServerManager.CatalogProvenStart(
+            entry: chat, generation: 7
+        )
+        let retained = [chat.alias.lowercased(): fallback]
+
+        // An empty array is ModelCatalog's subprocess-failure sentinel — no
+        // authority, so the retained proof must not be cancelled by it.
+        let reconciled = ServerManager.reconcilingProvenance(
+            retained,
+            against: [],
+            generation: 7
+        )
+
+        #expect(reconciled.count == 1)
+    }
+
+    @Test(
+        "Cat 2364: after a reclassified authoritative snapshot, a later failed probe cannot rewrite the chat key",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func chatSelectionKeyIsSafeAfterReclassificationThenFailedProbe() async throws {
+        let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        // The user's chat choice is already on disk.
+        defaults.set(chat.alias, forKey: SessionModelRestore.chatAliasStorageKey)
+
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fakeServer = packageRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh")
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: fakeServer,
+            sessionDefaults: defaults
+        )
+
+        // A chat-proven start was retained under catalog generation 7.
+        server._testSetCatalogProvenStart([
+            chat.alias.lowercased(): ServerManager.CatalogProvenStart(
+                entry: chat, generation: 7
+            ),
+        ])
+
+        // A newer authoritative snapshot reclassifies the alias to audio.
+        let audioOnly = ModelEntry(
+            alias: chat.alias,
+            hfRepo: chat.hfRepo,
+            sizeOnDisk: chat.sizeOnDisk,
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription
+        )
+        server._testReconcileCatalogProvenStart(
+            against: [audioOnly, stt],
+            generation: 7
+        )
+
+        // The stale chat fallback is gone.
+        #expect(server._testCatalogProvenStartEntries[chat.alias.lowercased()] == nil)
+
+        // A later start's catalog probe fails (no hint, no retained fallback):
+        // the ready decision is nil, so the audio-only model cannot rewrite the
+        // user's chat selection.
+        let readyEntry = ServerManager.readyCatalogEntry(
+            alias: chat.alias,
+            probed: nil,
+            hint: server._testCatalogProvenStartEntries[chat.alias.lowercased()]?.entry
+        )
+        #expect(readyEntry == nil)
+
+        server.recordReadySelection(alias: chat.alias, catalogEntry: readyEntry)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        await server.stop()
+    }
+
     @Test("A catalog-proven chat ready transition owns the chat-lane key")
     @MainActor
     func chatReadyUpdatesPersistedChat() throws {

--- a/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SessionModelRestoreTests.swift
@@ -207,11 +207,11 @@ struct SessionModelRestoreTests {
     }
 
     @Test(
-        "ensureServing carries chat provenance when its ready-time catalog probe fails",
+        "ensureServing rejects a UI hint contradicted by the authoritative catalog",
         .timeLimit(.minutes(1))
     )
     @MainActor
-    func ensureServingPersistsHintedChatAfterProbeFailure() async throws {
+    func ensureServingRejectsHintMissingFromCatalog() async throws {
         let suite = "SessionModelRestoreTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defer { defaults.removePersistentDomain(forName: suite) }
@@ -234,12 +234,15 @@ struct SessionModelRestoreTests {
             hfPath: chat.hfRepo,
             estimatedMemoryGB: nil,
             replacementGroup: .assistant,
-            catalogEntryHint: chat
+            catalogEntryHint: ServerManager.CatalogEntryHint(
+                entry: chat,
+                generation: 0
+            )
         )
 
         #expect(ready)
         #expect(server.servingAlias == chat.alias)
-        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == chat.alias)
+        #expect(defaults.string(forKey: SessionModelRestore.chatAliasStorageKey) == "previous-chat")
         await server.stop()
     }
 
@@ -254,7 +257,7 @@ struct SessionModelRestoreTests {
         "Cat 2364: removing the alias in a newer authoritative catalog invalidates its retained chat fallback"
     )
     func provenanceInvalidatedWhenAuthoritativeCatalogRemovesAlias() {
-        let fallback = ServerManager.CatalogProvenStart(
+        let fallback = ServerManager.CatalogEntryHint(
             entry: chat, generation: 7
         )
         let retained = [chat.alias.lowercased(): fallback]
@@ -273,7 +276,7 @@ struct SessionModelRestoreTests {
         "Cat 2364: reclassifying the alias to audio in a newer authoritative catalog invalidates its retained chat fallback"
     )
     func provenanceInvalidatedWhenAuthoritativeCatalogReclassifiesLane() {
-        let fallback = ServerManager.CatalogProvenStart(
+        let fallback = ServerManager.CatalogEntryHint(
             entry: chat, generation: 7
         )
         let retained = [chat.alias.lowercased(): fallback]
@@ -302,7 +305,7 @@ struct SessionModelRestoreTests {
         "Cat 2364: a chat fallback survives while the authoritative catalog still classifies it as chat"
     )
     func provenanceSurvivesUnchangedAuthoritativeCatalog() {
-        let fallback = ServerManager.CatalogProvenStart(
+        let fallback = ServerManager.CatalogEntryHint(
             entry: chat, generation: 7
         )
         let retained = [chat.alias.lowercased(): fallback]
@@ -323,7 +326,7 @@ struct SessionModelRestoreTests {
         "Cat 2364: a catalog-epoch change bounds the fallback lifecycle even when the alias stays chat"
     )
     func provenanceIsBoundedToItsCatalogEpoch() {
-        let fallback = ServerManager.CatalogProvenStart(
+        let fallback = ServerManager.CatalogEntryHint(
             entry: chat, generation: 7
         )
         let retained = [chat.alias.lowercased(): fallback]
@@ -341,10 +344,47 @@ struct SessionModelRestoreTests {
     }
 
     @Test(
-        "Cat 2364: a failed (empty) catalog probe does not wipe retained provenance"
+        "Cat 2364: an epoch advance invalidates retained provenance even when the refreshed probe fails"
+    )
+    func provenanceDoesNotCrossEpochOnEmptyProbe() {
+        let fallback = ServerManager.CatalogEntryHint(
+            entry: chat, generation: 7
+        )
+
+        let reconciled = ServerManager.reconcilingProvenance(
+            [chat.alias.lowercased(): fallback],
+            against: [],
+            generation: 8
+        )
+
+        #expect(reconciled.isEmpty)
+    }
+
+    @Test("Cat 2364: a UI hint is accepted only in its source catalog epoch")
+    func catalogHintCarriesItsSourceEpoch() {
+        let hint = ServerManager.CatalogEntryHint(entry: chat, generation: 7)
+
+        #expect(
+            ServerManager.validatedCatalogHint(
+                alias: chat.alias,
+                hint: hint,
+                generation: 7
+            ) == hint
+        )
+        #expect(
+            ServerManager.validatedCatalogHint(
+                alias: chat.alias,
+                hint: hint,
+                generation: 8
+            ) == nil
+        )
+    }
+
+    @Test(
+        "Cat 2364: a failed (empty) catalog probe preserves same-epoch provenance"
     )
     func provenanceSurvivesEmptyProbe() {
-        let fallback = ServerManager.CatalogProvenStart(
+        let fallback = ServerManager.CatalogEntryHint(
             entry: chat, generation: 7
         )
         let retained = [chat.alias.lowercased(): fallback]
@@ -385,7 +425,7 @@ struct SessionModelRestoreTests {
 
         // A chat-proven start was retained under catalog generation 7.
         server._testSetCatalogProvenStart([
-            chat.alias.lowercased(): ServerManager.CatalogProvenStart(
+            chat.alias.lowercased(): ServerManager.CatalogEntryHint(
                 entry: chat, generation: 7
             ),
         ])


### PR DESCRIPTION
Fixes #2364

## Why

Fallback catalog provenance retained for a start was not tied end to end to the authoritative catalog generation that produced it. A newer snapshot could remove an alias or reclassify it from chat to audio, while a later failed lookup reused the old chat proof and allowed an audio-only model to overwrite the persisted chat selection.

## What

- Replace the bare `ModelEntry` start hint with `ServerManager.CatalogEntryHint`, which carries both the entry and the exact `DownloadManager.cacheGeneration` that produced the UI snapshot.
- Keep that generation beside catalog rows in ContentView, ModelPickerBar, and Quickstart; never stamp an old row with the generation current at click time.
- Reject hints whose alias or source generation does not match the requested start.
- Reconcile retained hints against every authoritative catalog observation: a missing/reclassified alias is dropped, and an epoch change drops old proof even when the refreshed catalog subprocess returns its empty failure sentinel.
- Add a lifecycle-grade cache read: unexpired snapshots keep the fast path, while an expired presentation snapshot is refreshed and awaited before start mutates process lane or persistence. If downloads advance the generation during that await, retry against the new epoch.
- Rebuild surviving provenance from the current catalog row so capability fields cannot remain stale after a same-lane metadata change.
- Construct each UI hint synchronously beside its row lookup before launching an async task, preventing an old row from being paired with a newer generation.
- Preserve a same-epoch hint across a transient empty probe so memory-confirmation re-entry does not lose valid provenance.
- Add table-shaped lifecycle coverage for removal, lane reclassification, same-epoch empty probes, generation changes with empty probes, and stale UI hints.

## Scope / Non-goals

- Scoped to catalog provenance supplied to Desktop start/ensure-serving paths and the UI snapshots that originate it.
- No alias-name, prefix, or repository heuristics.
- No memory-admission, engine, server-cap, or #2363 restart-policy changes.

## Design precedent

The implementation uses an immutable, generation-tagged snapshot token at the UI-to-lifecycle boundary and validates it before use. This follows the existing repository pattern in which catalog snapshots are keyed by `DownloadManager.cacheGeneration`: provenance travels with the value instead of being reconstructed from mutable global state after an await. Authoritative non-empty snapshots fail closed on removal or lane changes; an empty subprocess result carries no row authority but also cannot extend proof across an epoch boundary.

## Verification

- `swift test`: **2,981/2,981** tests in 250 suites passed.
- Focused session restore + catalog capability + readiness wiring: **62/62** passed on the exact head.
- `git diff --check`: clean.
- Exact-head hosted Desktop CI will exercise the GUI journeys and required status facade.

## Behaviour delta

- A catalog row is trusted only in the generation that produced it.
- An expired picker snapshot remains instant for presentation but is refreshed before a lifecycle mutation; an unexpired snapshot adds no subprocess work.
- A newer generation invalidates old start provenance even if its catalog subprocess fails.
- A same-generation transient catalog failure still preserves the valid proof needed by memory-confirmation re-entry.
- A removed or audio-reclassified alias cannot rewrite the saved chat-model key.
