### PR TITLE
perf(qsa): add opt-in block-sparse long-context prefill

### DIFF
--- a/docs/benchmarks/qwen38-flash-next-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-m3-ultra.md
@@ -243,6 +243,78 @@ allocation but made it 1.8x slower because MLX had to materialize the gathered
 rows. A future direct sparse-attention kernel can consume the compact indices
 without that copy; the rejected gather path is not included in the candidate.
 
+## Direct block-sparse QSA kernel follow-up
+
+The next candidate makes QSA's selected blocks first-class inputs to attention
+instead of rebuilding a dense mask and asking dense SDPA to visit every
+physical key. A fused Metal kernel reads only the selected four-token blocks,
+shares each K/V block across the 12 grouped-query heads, and performs QK,
+online softmax, and PV accumulation in FP32. Selected blocks are sorted into
+physical-key order before dispatch, and the incomplete causal tail is handled
+separately.
+
+The feature is default-off behind `RAPID_MLX_QSA_BLOCK_SPARSE=1`. It is eligible
+only for prefill calls with at least 64 query tokens and 16,384 physical KV
+tokens. Decode, short contexts, unsupported head layouts, and non-Metal systems
+retain the existing dense path.
+
+The comparison below rebased the baseline from the published 0.13.1 binary to
+current `main` at `05b896eaebafed00f33998491669bdde36a692a4`, which already
+contains the vectorized QSA mask builder measured above. The candidate kernel
+is commit `2e6e91244d3a5a483ca403e83ea5385752eb47b0`. Both sides used the
+same M3 Ultra, immutable artifact, BF16 KV cache, dependency versions, prompt
+builder, prefix-cache clearing, one-sequence batch limits, and three-run / 256
+decode-token method.
+
+```bash
+# Candidate only: set this in the shell; leave it unset for the baseline.
+export RAPID_MLX_QSA_BLOCK_SPARSE=1
+
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+PYTHONPATH=/path/to/baseline-or-candidate \
+/private/tmp/rapid-flash-pypi-0131/bin/rapid-mlx serve \
+  /path/to/dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --served-model-name rapid-mlx/Qwen3.8-Flash-Next-4bit \
+  --host 127.0.0.1 --port 8464 --disable-prefix-cache \
+  --max-num-seqs 1 --prefill-batch-size 1 --completion-batch-size 1
+
+/private/tmp/rapid-flash-pypi-0131/bin/python \
+  .orca/flash-next-eval/benchmark.py \
+  --url http://127.0.0.1:8464/v1 \
+  --model rapid-mlx/Qwen3.8-Flash-Next-4bit \
+  --tokenizer-path /path/to/dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --server-pid SERVER_PID --label LABEL --runs 3 --decode-tokens 256 \
+  --prompt-tokens 128,2048,8192,32768 \
+  --artifact-revision dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --rapid-sha RAPID_SHA --output OUTPUT.json --timeout 3600
+```
+
+For the baseline process, the feature variable was omitted. For the candidate,
+it was set to `1` as shown.
+
+| Target (reported) | Baseline TTFT | Candidate TTFT | TTFT change | Baseline prefill | Candidate prefill | Prefill change | Baseline decode | Candidate decode |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 128 (92) | 0.366 s | 0.374 s | +2.1% | 251.2 tok/s | 246.0 tok/s | -2.1% | 25.58 tok/s | 25.55 tok/s |
+| 2,048 (2,012) | 3.306 s | 3.360 s | +1.6% | 608.5 tok/s | 598.8 tok/s | -1.6% | 24.10 tok/s | 23.89 tok/s |
+| 8,192 (8,156) | 13.534 s | 13.492 s | -0.3% | 602.6 tok/s | 604.5 tok/s | +0.3% | 23.24 tok/s | 23.19 tok/s |
+| 32,768 (32,732) | 62.539 s | **56.516 s** | **-9.6%** | 523.4 tok/s | **579.2 tok/s** | **+10.7%** | 21.61 tok/s | 21.59 tok/s |
+
+The 128, 2K, and 8K rows do not cross the kernel's physical-KV threshold in
+the server's prefill schedule, so their small differences are run-to-run
+noise. At 32K, the direct kernel removes 6.02 seconds from median TTFT while
+decode remains unchanged, as expected for a prefill-only optimization. Both
+processes stayed at approximately 103--104 GB MLX active memory and 54.1--54.4
+GiB process RSS; the candidate did not increase the model's practical memory
+requirement.
+
+Five deterministic user-path comparisons passed and produced byte-identical
+normalized outputs between baseline and candidate: multi-turn exact text,
+Chinese exact text, strict JSON schema, a forced tool call, and 32K needle
+recall. The outputs were `BLUE-LANTERN`, `测试通过`,
+`{"point": {"x": 3, "y": -2}}`, the `get_weather` tool name, and
+`ZEPHYR-9135`, respectively. The 32K needle request fell from 63.884 to 57.428
+seconds end to end.
+
 ## Interpretation
 
 Flash-Next reached the first visible token sooner at the 128- and 2K-target

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -150,6 +150,11 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # fires, which tier engages — none of that changes. Read by
         # ``moe_fusion.fuse_gate_up()`` only.
         "RAPID_MLX_MOE_GATE_UP_FUSION",
+        # Opt-in direct QSA block-sparse attention on an already-selected
+        # Qwen4-Exp model. This changes only the prefill kernel after a measured
+        # context crossover; model, parser, tier, and engine routing are
+        # unchanged. Unsupported layouts and the default path remain dense.
+        "RAPID_MLX_QSA_BLOCK_SPARSE",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -14,6 +14,10 @@ from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 import vllm_mlx.models.qwen4_exp as qwen4_exp
 from scripts import qwen38_streaming_convert as converter
 from scripts.qwen38_streaming_convert import quantized_tensor_names
+from vllm_mlx.kernels.qsa_block_sparse import (
+    block_sparse_attention,
+    should_use_block_sparse,
+)
 from vllm_mlx.models.qwen4_exp import (
     GatedDeltaNet,
     GatedResidual,
@@ -627,8 +631,9 @@ def test_qsa_vectorized_mask_preserves_budget_tail_and_causality():
         physical_kv_length=65,
     )
     assert selected is not None
-    mx.eval(selected)
-    mask = np.array(selected[0, 0])
+    mask_array = selected.dense_mask()
+    mx.eval(mask_array)
+    mask = np.array(mask_array[0, 0])
 
     expected_counts = []
     for position in range(65):
@@ -639,6 +644,240 @@ def test_qsa_vectorized_mask_preserves_budget_tail_and_causality():
     assert mask[0, 0]
     assert mask[-1, -1]
     assert not np.any(np.triu(mask, k=1))
+
+
+def test_qsa_block_sparse_selection_keeps_sorted_compact_blocks(monkeypatch):
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    monkeypatch.setenv("RAPID_MLX_QSA_BLOCK_SPARSE", "1")
+    selected = QSAIndexer(args)(
+        mx.zeros((1, 65, args.hidden_size)),
+        QSAIndexCache(compress_ratio=2),
+        physical_kv_length=65,
+    )
+    assert isinstance(selected, qwen4_exp._QSASelection)
+    mx.eval(selected.token_indices, selected.valid)
+    block_starts = np.array(selected.token_indices[0, :, :8:2])
+    block_valid = np.array(selected.valid[0, :, :8:2])
+    for row, valid in zip(block_starts, block_valid):
+        np.testing.assert_array_equal(row[valid], np.sort(row[valid]))
+    np.testing.assert_array_equal(
+        np.array(selected.dense_mask()[0, 0]).sum(axis=-1),
+        [
+            min((position + 1) // 2, 4) * 2 + (position + 1) % 2
+            for position in range(65)
+        ],
+    )
+
+
+def test_qsa_attention_routes_compact_selection_to_block_kernel(monkeypatch):
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    attention = QSAAttention(args)
+    observed = []
+    monkeypatch.setenv("RAPID_MLX_QSA_BLOCK_SPARSE", "1")
+
+    class FakeIndexer:
+        token_budget = 8
+        compress_ratio = 2
+        rope_theta = 10_000_000
+
+        def __call__(self, hidden_states, cache, *, physical_kv_length):
+            length = int(hidden_states.shape[1])
+            block_tokens = mx.broadcast_to(
+                mx.array([0, 1, 4, 5, 8, 9, 12, 13], dtype=mx.int32),
+                (1, length, 8),
+            )
+            tail = mx.broadcast_to(mx.array([16, 17], dtype=mx.int32), (1, length, 2))
+            return qwen4_exp._QSASelection(
+                token_indices=mx.concatenate([block_tokens, tail], axis=-1),
+                valid=mx.ones((1, length, 10), dtype=mx.bool_),
+                physical_kv_length=physical_kv_length,
+            )
+
+    class FakeKVCache:
+        offset = 16_384
+        _idx = 16_384
+
+        def size(self):
+            return self._idx
+
+        def update_and_fetch(self, keys, values):
+            return keys, values
+
+    def fake_sparse(
+        queries,
+        keys,
+        values,
+        block_starts,
+        block_counts,
+        tail_indices,
+        tail_counts,
+        *,
+        block_size,
+    ):
+        observed.append(
+            (
+                block_starts.shape,
+                np.array(block_counts),
+                tail_indices.shape,
+                np.array(tail_counts),
+                block_size,
+            )
+        )
+        return mx.zeros_like(queries)
+
+    attention.indexer = FakeIndexer()
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fake_sparse)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    assert output.shape == (1, 64, args.hidden_size)
+    assert len(observed) == 1
+    block_shape, block_counts, tail_shape, tail_counts, block_size = observed[0]
+    assert block_shape == (1, 64, 4)
+    assert tail_shape == (1, 64, 2)
+    np.testing.assert_array_equal(block_counts, 4)
+    np.testing.assert_array_equal(tail_counts, 2)
+    assert block_size == 2
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA block-sparse kernel requires Metal"
+)
+def test_qsa_block_sparse_matches_dense_mask_with_tail_and_padding():
+    rng = np.random.default_rng(11)
+    batch = 2
+    query_heads = 24
+    kv_heads = 2
+    query_length = 3
+    key_length = 17
+    head_dim = 256
+    block_size = 4
+    topk = 3
+
+    queries = mx.array(
+        rng.normal(size=(batch, query_heads, query_length, head_dim)),
+        dtype=mx.float16,
+    )
+    keys = mx.array(
+        rng.normal(size=(batch, kv_heads, key_length, head_dim)),
+        dtype=mx.float16,
+    )
+    values = mx.array(
+        rng.normal(size=(batch, kv_heads, key_length, head_dim)),
+        dtype=mx.float16,
+    )
+    block_starts_np = np.array(
+        [
+            [[1, 9, 0], [1, 5, 9], [5, 9, 0]],
+            [[0, 8, 0], [4, 8, 12], [0, 0, 0]],
+        ],
+        dtype=np.int32,
+    )
+    block_counts_np = np.array([[2, 3, 2], [2, 3, 0]], dtype=np.int32)
+    tail_indices_np = np.array(
+        [
+            [[13, 14, 0, 0], [13, 0, 0, 0], [13, 14, 15, 0]],
+            [[16, 0, 0, 0], [16, 0, 0, 0], [0, 0, 0, 0]],
+        ],
+        dtype=np.int32,
+    )
+    tail_counts_np = np.array([[2, 1, 3], [1, 1, 0]], dtype=np.int32)
+
+    output = block_sparse_attention(
+        queries,
+        keys,
+        values,
+        mx.array(block_starts_np),
+        mx.array(block_counts_np),
+        mx.array(tail_indices_np),
+        mx.array(tail_counts_np),
+        block_size=block_size,
+    )
+
+    mask = np.zeros((batch, 1, query_length, key_length), dtype=np.bool_)
+    for row in range(batch):
+        for query_index in range(query_length):
+            for block_index in range(block_counts_np[row, query_index]):
+                start = block_starts_np[row, query_index, block_index]
+                mask[row, 0, query_index, start : start + block_size] = True
+            for tail_index in range(tail_counts_np[row, query_index]):
+                token = tail_indices_np[row, query_index, tail_index]
+                mask[row, 0, query_index, token] = True
+    additive = mx.where(
+        mx.array(mask),
+        mx.array(0.0, dtype=queries.dtype),
+        mx.array(-1e9, dtype=queries.dtype),
+    )
+    reference = mx.fast.scaled_dot_product_attention(
+        queries,
+        keys,
+        values,
+        scale=head_dim**-0.5,
+        mask=additive,
+    )
+    mx.eval(output, reference)
+
+    np.testing.assert_allclose(
+        np.array(output)[:, :, :2],
+        np.array(reference)[:, :, :2],
+        rtol=2e-3,
+        atol=1e-3,
+    )
+    np.testing.assert_array_equal(np.array(output)[1, :, 2], 0)
+
+
+def test_qsa_block_sparse_rejects_incompatible_grouped_query_shapes():
+    queries = mx.zeros((1, 3, 1, 256), dtype=mx.float16)
+    keys = mx.zeros((1, 2, 4, 256), dtype=mx.float16)
+    with pytest.raises(ValueError, match="divisible"):
+        block_sparse_attention(
+            queries,
+            keys,
+            keys,
+            mx.zeros((1, 1, 1), dtype=mx.int32),
+            mx.ones((1, 1), dtype=mx.int32),
+            mx.zeros((1, 1, 4), dtype=mx.int32),
+            mx.zeros((1, 1), dtype=mx.int32),
+            block_size=4,
+        )
+
+    valid_queries = mx.zeros((1, 2, 1, 256), dtype=mx.float16)
+    with pytest.raises(ValueError, match="tail indices"):
+        block_sparse_attention(
+            valid_queries,
+            keys,
+            keys,
+            mx.zeros((1, 1, 1), dtype=mx.int32),
+            mx.ones((1, 1), dtype=mx.int32),
+            mx.zeros((1, 1, 3), dtype=mx.int32),
+            mx.zeros((1, 1), dtype=mx.int32),
+            block_size=4,
+        )
+
+    with pytest.raises(ValueError, match="same dtype"):
+        block_sparse_attention(
+            valid_queries,
+            keys,
+            keys.astype(mx.float32),
+            mx.zeros((1, 1, 1), dtype=mx.int32),
+            mx.ones((1, 1), dtype=mx.int32),
+            mx.zeros((1, 1, 4), dtype=mx.int32),
+            mx.zeros((1, 1), dtype=mx.int32),
+            block_size=4,
+        )
+
+
+def test_qsa_block_sparse_flag_is_opt_in_and_crossover_gated(monkeypatch):
+    monkeypatch.delenv("RAPID_MLX_QSA_BLOCK_SPARSE", raising=False)
+    assert not should_use_block_sparse(2_048, 32_768)
+    monkeypatch.setenv("RAPID_MLX_QSA_BLOCK_SPARSE", "true")
+    assert not should_use_block_sparse(63, 32_768)
+    assert not should_use_block_sparse(2_048, 16_383)
+    assert should_use_block_sparse(64, 16_384) == mx.metal.is_available()
 
 
 def test_qsa_batch_prefill_builds_mask_before_kv_update(monkeypatch):
@@ -728,7 +967,8 @@ def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
         cache,
         physical_kv_length=6,
     )
-    mx.eval(selected)
+    assert selected is not None
+    mx.eval(selected.token_indices, selected.valid)
     assert shapes == [
         (
             (args.indexer_n_heads, 6, args.indexer_head_dim),

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -16,6 +16,7 @@ from scripts import qwen38_streaming_convert as converter
 from scripts.qwen38_streaming_convert import quantized_tensor_names
 from vllm_mlx.kernels.qsa_block_sparse import (
     block_sparse_attention,
+    block_sparse_layout_supported,
     should_use_block_sparse,
 )
 from vllm_mlx.models.qwen4_exp import (
@@ -670,7 +671,14 @@ def test_qsa_block_sparse_selection_keeps_sorted_compact_blocks(monkeypatch):
 
 
 def test_qsa_attention_routes_compact_selection_to_block_kernel(monkeypatch):
-    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    args = _args(
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_head_dim=64,
+    )
     attention = QSAAttention(args)
     observed = []
     monkeypatch.setenv("RAPID_MLX_QSA_BLOCK_SPARSE", "1")
@@ -742,6 +750,56 @@ def test_qsa_attention_routes_compact_selection_to_block_kernel(monkeypatch):
     np.testing.assert_array_equal(block_counts, 4)
     np.testing.assert_array_equal(tail_counts, 2)
     assert block_size == 2
+
+
+def test_qsa_attention_unsupported_layout_stays_on_dense_fallback(monkeypatch):
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    attention = QSAAttention(args)
+    observed_masks = []
+    monkeypatch.setenv("RAPID_MLX_QSA_BLOCK_SPARSE", "1")
+
+    class FakeIndexer:
+        token_budget = 8
+        compress_ratio = 2
+        rope_theta = 10_000_000
+
+        def __call__(self, hidden_states, cache, *, physical_kv_length):
+            length = int(hidden_states.shape[1])
+            return qwen4_exp._QSASelection(
+                token_indices=mx.zeros((1, length, 10), dtype=mx.int32),
+                valid=mx.ones((1, length, 10), dtype=mx.bool_),
+                physical_kv_length=physical_kv_length,
+            )
+
+    class FakeKVCache:
+        offset = 16_384
+        _idx = 16_384
+
+        def size(self):
+            return self._idx
+
+        def update_and_fetch(self, keys, values):
+            return keys, values
+
+    def fail_sparse(*args, **kwargs):
+        raise AssertionError("unsupported layout must not reach sparse attention")
+
+    def fake_dense(queries, keys, values, *, cache, scale, mask):
+        observed_masks.append(mask.shape)
+        return mx.zeros_like(queries)
+
+    attention.indexer = FakeIndexer()
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fail_sparse)
+    monkeypatch.setattr(qwen4_exp, "scaled_dot_product_attention", fake_dense)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    assert output.shape == (1, 64, args.hidden_size)
+    assert observed_masks == [(1, 1, 64, 16_448)]
 
 
 @pytest.mark.skipif(
@@ -878,6 +936,27 @@ def test_qsa_block_sparse_flag_is_opt_in_and_crossover_gated(monkeypatch):
     assert not should_use_block_sparse(63, 32_768)
     assert not should_use_block_sparse(2_048, 16_383)
     assert should_use_block_sparse(64, 16_384) == mx.metal.is_available()
+    assert block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not block_sparse_layout_supported(
+        query_heads=65,
+        kv_heads=1,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        block_size=128,
+        dtype=mx.bfloat16,
+    )
 
 
 def test_qsa_batch_prefill_builds_mask_before_kv_update(monkeypatch):

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -652,7 +652,7 @@ def test_qsa_block_sparse_selection_keeps_sorted_compact_blocks(monkeypatch):
     selected = QSAIndexer(args)(
         mx.zeros((1, 65, args.hidden_size)),
         QSAIndexCache(compress_ratio=2),
-        physical_kv_length=65,
+        physical_kv_length=16_384,
     )
     assert isinstance(selected, qwen4_exp._QSASelection)
     mx.eval(selected.token_indices, selected.valid)

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 ENABLE_ENV = "RAPID_MLX_QSA_BLOCK_SPARSE"
 MIN_QUERY_LENGTH = 64
 MIN_PHYSICAL_KV_LENGTH = 16_384
+MAX_GQA_HEADS = 32
+MAX_THREADGROUP_MEMORY_BYTES = 32 * 1024
 
 _SOURCE = r"""
     constexpr int VALUES_PER_LANE = HEAD_DIM / 32;
@@ -166,6 +168,28 @@ def should_use_block_sparse(query_length: int, physical_kv_length: int) -> bool:
     return enabled and mx.metal.is_available()
 
 
+def block_sparse_layout_supported(
+    *,
+    query_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    dtype: mx.Dtype,
+) -> bool:
+    """Return whether the layout fits the kernel and Metal threadgroup limits."""
+    if kv_heads <= 0 or block_size <= 0 or head_dim <= 0:
+        return False
+    if head_dim % 32 or query_heads % kv_heads:
+        return False
+    gqa_heads = query_heads // kv_heads
+    if not 0 < gqa_heads <= MAX_GQA_HEADS:
+        return False
+    if dtype not in {mx.float16, mx.bfloat16, mx.float32}:
+        return False
+    threadgroup_bytes = 2 * block_size * head_dim * int(dtype.size)
+    return threadgroup_bytes <= MAX_THREADGROUP_MEMORY_BYTES
+
+
 @lru_cache(maxsize=1)
 def _log_activation() -> None:
     logger.info(
@@ -210,11 +234,23 @@ def block_sparse_attention(
         raise ValueError("QSA query/K/V arrays must have the same dtype")
     if head_dim % 32:
         raise ValueError("QSA head dimension must be divisible by 32")
+    if kv_heads <= 0:
+        raise ValueError("QSA requires at least one KV head")
     if query_heads % kv_heads:
         raise ValueError("QSA query heads must be divisible by KV heads")
     gqa_heads = query_heads // kv_heads
-    if gqa_heads > 32:
-        raise ValueError("QSA supports at most 32 query heads per KV head")
+    if gqa_heads > MAX_GQA_HEADS:
+        raise ValueError(
+            f"QSA supports at most {MAX_GQA_HEADS} query heads per KV head"
+        )
+    if not block_sparse_layout_supported(
+        query_heads=query_heads,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        dtype=queries.dtype,
+    ):
+        raise ValueError("QSA query/KV layout is unsupported by the sparse kernel")
     block_starts = block_starts.astype(mx.int32)
     block_counts = block_counts.astype(mx.int32)
     tail_indices = tail_indices.astype(mx.int32)

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact block-sparse QSA attention for Apple Silicon."""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV = "RAPID_MLX_QSA_BLOCK_SPARSE"
+MIN_QUERY_LENGTH = 64
+MIN_PHYSICAL_KV_LENGTH = 16_384
+
+_SOURCE = r"""
+    constexpr int VALUES_PER_LANE = HEAD_DIM / 32;
+    constexpr int THREADS = GQA_HEADS * 32;
+
+    const uint tid = thread_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const uint simdgroup = simdgroup_index_in_threadgroup;
+    const int query_index = int(threadgroup_position_in_grid.x);
+    const int batch_kv = int(threadgroup_position_in_grid.y);
+    const int batch = batch_kv / KV_HEADS;
+    const int kv_head = batch_kv - batch * KV_HEADS;
+    const int query_head = kv_head * GQA_HEADS + int(simdgroup);
+
+    threadgroup T shared_keys[BLOCK_SIZE * HEAD_DIM];
+    threadgroup T shared_values[BLOCK_SIZE * HEAD_DIM];
+
+    float query_values[VALUES_PER_LANE];
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    float output_values[VALUES_PER_LANE];
+
+    for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+        const int dim = int(lane) + value_index * 32;
+        const int offset =
+            ((batch * QUERY_HEADS + query_head) * QUERY_LENGTH + query_index)
+            * HEAD_DIM + dim;
+        query_values[value_index] = float(queries[offset]);
+        output_values[value_index] = 0.0f;
+    }
+
+    const int query_offset = batch * QUERY_LENGTH + query_index;
+    const int block_count = block_counts[query_offset];
+    const int block_base = query_offset * BLOCK_TOPK;
+    for (int block_index = 0; block_index < block_count; ++block_index) {
+        const int physical_start = block_starts[block_base + block_index];
+        for (int element = int(tid); element < BLOCK_SIZE * HEAD_DIM;
+             element += THREADS) {
+            const int token = element / HEAD_DIM;
+            const int dim = element - token * HEAD_DIM;
+            const int key_index = physical_start + token;
+            const int offset =
+                ((batch * KV_HEADS + kv_head) * KEY_LENGTH + key_index)
+                * HEAD_DIM + dim;
+            shared_keys[element] = keys[offset];
+            shared_values[element] = values[offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int token = 0; token < BLOCK_SIZE; ++token) {
+            float partial = 0.0f;
+            for (int value_index = 0; value_index < VALUES_PER_LANE;
+                 ++value_index) {
+                const int dim = int(lane) + value_index * 32;
+                partial += query_values[value_index]
+                    * float(shared_keys[token * HEAD_DIM + dim]);
+            }
+            const float score = simd_sum(partial)
+                * metal::rsqrt(float(HEAD_DIM));
+            const float next_max = metal::max(running_max, score);
+            const float old_weight = metal::exp(running_max - next_max);
+            const float new_weight = metal::exp(score - next_max);
+            running_sum = running_sum * old_weight + new_weight;
+            for (int value_index = 0; value_index < VALUES_PER_LANE;
+                 ++value_index) {
+                const int dim = int(lane) + value_index * 32;
+                output_values[value_index] =
+                    output_values[value_index] * old_weight
+                    + new_weight * float(shared_values[token * HEAD_DIM + dim]);
+            }
+            running_max = next_max;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const int tail_count = tail_counts[query_offset];
+    const int tail_base = query_offset * BLOCK_SIZE;
+    for (int tail_index = 0; tail_index < tail_count; ++tail_index) {
+        const int key_index = tail_indices[tail_base + tail_index];
+        for (int dim = int(tid); dim < HEAD_DIM; dim += THREADS) {
+            const int offset =
+                ((batch * KV_HEADS + kv_head) * KEY_LENGTH + key_index)
+                * HEAD_DIM + dim;
+            shared_keys[dim] = keys[offset];
+            shared_values[dim] = values[offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        float partial = 0.0f;
+        for (int value_index = 0; value_index < VALUES_PER_LANE;
+             ++value_index) {
+            const int dim = int(lane) + value_index * 32;
+            partial += query_values[value_index] * float(shared_keys[dim]);
+        }
+        const float score = simd_sum(partial) * metal::rsqrt(float(HEAD_DIM));
+        const float next_max = metal::max(running_max, score);
+        const float old_weight = metal::exp(running_max - next_max);
+        const float new_weight = metal::exp(score - next_max);
+        running_sum = running_sum * old_weight + new_weight;
+        for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+            const int dim = int(lane) + value_index * 32;
+            output_values[value_index] = output_values[value_index] * old_weight
+                + new_weight * float(shared_values[dim]);
+        }
+        running_max = next_max;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+        const int dim = int(lane) + value_index * 32;
+        const int output_index =
+            ((batch * QUERY_HEADS + query_head) * QUERY_LENGTH + query_index)
+            * HEAD_DIM + dim;
+        output[output_index] = running_sum == 0.0f
+            ? T(0.0f)
+            : T(output_values[value_index] / running_sum);
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_qsa_block_sparse",
+        input_names=[
+            "queries",
+            "keys",
+            "values",
+            "block_starts",
+            "block_counts",
+            "tail_indices",
+            "tail_counts",
+        ],
+        output_names=["output"],
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def should_use_block_sparse(query_length: int, physical_kv_length: int) -> bool:
+    """Return whether the opt-in kernel is valid and past its measured crossover."""
+    if query_length < MIN_QUERY_LENGTH or physical_kv_length < MIN_PHYSICAL_KV_LENGTH:
+        return False
+    enabled = os.environ.get(ENABLE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    return enabled and mx.metal.is_available()
+
+
+@lru_cache(maxsize=1)
+def _log_activation() -> None:
+    logger.info(
+        "QSA block-sparse prefill enabled (query>=%d, physical_kv>=%d)",
+        MIN_QUERY_LENGTH,
+        MIN_PHYSICAL_KV_LENGTH,
+    )
+
+
+def block_sparse_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_starts: mx.array,
+    block_counts: mx.array,
+    tail_indices: mx.array,
+    tail_counts: mx.array,
+    *,
+    block_size: int,
+) -> mx.array:
+    """Attend to exact sorted blocks plus the current incomplete tail."""
+    _log_activation()
+    if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
+        raise ValueError("QSA query/K/V arrays must be rank four")
+    if block_size <= 0:
+        raise ValueError("QSA block size must be positive")
+    batch, query_heads, query_length, head_dim = map(int, queries.shape)
+    key_batch, kv_heads, key_length, key_dim = map(int, keys.shape)
+    expected_rows = (batch, query_length)
+    if block_starts.ndim != 3 or tuple(block_starts.shape[:2]) != expected_rows:
+        raise ValueError("QSA block starts must have shape [batch, query, topk]")
+    if tuple(block_counts.shape) != expected_rows:
+        raise ValueError("QSA block counts must have shape [batch, query]")
+    if tuple(tail_indices.shape) != (*expected_rows, block_size):
+        raise ValueError("QSA tail indices must have shape [batch, query, block_size]")
+    if tuple(tail_counts.shape) != expected_rows:
+        raise ValueError("QSA tail counts must have shape [batch, query]")
+    block_topk = int(block_starts.shape[-1])
+    if key_batch != batch or key_dim != head_dim or values.shape != keys.shape:
+        raise ValueError("QSA query/KV shapes are inconsistent")
+    if queries.dtype != keys.dtype or queries.dtype != values.dtype:
+        raise ValueError("QSA query/K/V arrays must have the same dtype")
+    if head_dim % 32:
+        raise ValueError("QSA head dimension must be divisible by 32")
+    if query_heads % kv_heads:
+        raise ValueError("QSA query heads must be divisible by KV heads")
+    gqa_heads = query_heads // kv_heads
+    if gqa_heads > 32:
+        raise ValueError("QSA supports at most 32 query heads per KV head")
+    block_starts = block_starts.astype(mx.int32)
+    block_counts = block_counts.astype(mx.int32)
+    tail_indices = tail_indices.astype(mx.int32)
+    tail_counts = tail_counts.astype(mx.int32)
+    (output,) = _kernel()(
+        inputs=[
+            queries,
+            keys,
+            values,
+            block_starts,
+            block_counts,
+            tail_indices,
+            tail_counts,
+        ],
+        template=[
+            ("T", queries.dtype),
+            ("QUERY_HEADS", query_heads),
+            ("KV_HEADS", kv_heads),
+            ("GQA_HEADS", gqa_heads),
+            ("QUERY_LENGTH", query_length),
+            ("KEY_LENGTH", key_length),
+            ("HEAD_DIM", head_dim),
+            ("BLOCK_SIZE", block_size),
+            ("BLOCK_TOPK", block_topk),
+        ],
+        grid=(gqa_heads * 32 * query_length, batch * kv_heads, 1),
+        threadgroup=(gqa_heads * 32, 1, 1),
+        output_shapes=[queries.shape],
+        output_dtypes=[queries.dtype],
+    )
+    return output

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -37,6 +37,7 @@ from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
 from ..kernels.qsa_block_sparse import (  # noqa: E402
     block_sparse_attention,
+    block_sparse_layout_supported,
     should_use_block_sparse,
 )
 from .qwen4_exp_cache import QSAIndexCache  # noqa: E402
@@ -876,8 +877,16 @@ class QSAAttention(nn.Module):
         )
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
-        if isinstance(selected, _QSASelection) and should_use_block_sparse(
-            length, physical_length
+        if (
+            isinstance(selected, _QSASelection)
+            and should_use_block_sparse(length, physical_length)
+            and block_sparse_layout_supported(
+                query_heads=self.num_attention_heads,
+                kv_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                block_size=self.indexer.compress_ratio,
+                dtype=queries.dtype,
+            )
         ):
             block_slots = slice(
                 0, self.indexer.token_budget, self.indexer.compress_ratio

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -876,10 +876,9 @@ class QSAAttention(nn.Module):
         )
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
-        use_sparse_kernel = isinstance(
-            selected, _QSASelection
-        ) and should_use_block_sparse(length, physical_length)
-        if use_sparse_kernel:
+        if isinstance(selected, _QSASelection) and should_use_block_sparse(
+            length, physical_length
+        ):
             block_slots = slice(
                 0, self.indexer.token_budget, self.indexer.compress_ratio
             )

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -35,6 +35,10 @@ from mlx_lm.models.gated_delta import gated_delta_update  # noqa: E402
 from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
+from ..kernels.qsa_block_sparse import (  # noqa: E402
+    block_sparse_attention,
+    should_use_block_sparse,
+)
 from .qwen4_exp_cache import QSAIndexCache  # noqa: E402
 
 
@@ -624,7 +628,7 @@ class QSAIndexer(nn.Module):
         cache: QSAIndexCache,
         *,
         physical_kv_length: int,
-    ) -> mx.array | None:
+    ) -> _QSASelection | None:
         batch, length, _ = hidden_states.shape
         cache._ensure_batch(batch)
         offsets = list(cache._offsets)
@@ -726,6 +730,9 @@ class QSAIndexer(nn.Module):
                 selected_blocks,
                 dense_blocks,
             )
+            if should_use_block_sparse(length, physical_kv_length):
+                # The block-sparse kernel reduces in physical key order.
+                blocks = mx.sort(blocks, axis=-1)
             block_valid = mx.arange(self.block_topk)[None, :] < mx.minimum(
                 complete_counts[:, None], self.block_topk
             )
@@ -761,7 +768,7 @@ class QSAIndexer(nn.Module):
             valid=mx.stack(compact_valid),
             physical_kv_length=physical_kv_length,
         )
-        return selection.dense_mask()
+        return selection
 
 
 class QSAAttention(nn.Module):
@@ -869,23 +876,48 @@ class QSAAttention(nn.Module):
         )
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
-        additive_mask = (
-            mask
-            if selected is None
-            else mx.where(
-                selected,
-                mx.array(0.0, dtype=queries.dtype),
-                mx.array(-1e9, dtype=queries.dtype),
+        use_sparse_kernel = isinstance(
+            selected, _QSASelection
+        ) and should_use_block_sparse(length, physical_length)
+        if use_sparse_kernel:
+            block_slots = slice(
+                0, self.indexer.token_budget, self.indexer.compress_ratio
             )
-        )
-        output = scaled_dot_product_attention(
-            queries,
-            keys,
-            values,
-            cache=kv_cache,
-            scale=self.scale,
-            mask=additive_mask,
-        )
+            tail_slots = slice(self.indexer.token_budget, None)
+            block_starts = selected.token_indices[..., block_slots]
+            block_valid = selected.valid[..., block_slots]
+            tail_indices = selected.token_indices[..., tail_slots]
+            tail_valid = selected.valid[..., tail_slots]
+            output = block_sparse_attention(
+                queries,
+                keys,
+                values,
+                block_starts,
+                mx.sum(block_valid, axis=-1).astype(mx.int32),
+                tail_indices,
+                mx.sum(tail_valid, axis=-1).astype(mx.int32),
+                block_size=self.indexer.compress_ratio,
+            )
+        else:
+            if isinstance(selected, _QSASelection):
+                selected = selected.dense_mask()
+            additive_mask = (
+                mask
+                if selected is None
+                else mx.where(
+                    selected,
+                    mx.array(0.0, dtype=queries.dtype),
+                    mx.array(-1e9, dtype=queries.dtype),
+                )
+            )
+            output = scaled_dot_product_attention(
+                queries,
+                keys,
+                values,
+                cache=kv_cache,
+                scale=self.scale,
+                mask=additive_mask,
+            )
         output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
         return self.o_proj(output * mx.sigmoid(gate))
 


### PR DESCRIPTION
## Why

Qwen3.8-Flash-Next selects a fixed QSA token budget at long context, but the existing attention path still rebuilds a dense mask and runs dense SDPA across every physical key. On the measured 32K workload, that leaves prefill doing work the architecture has already declared irrelevant.

## What

- keep compact selected QSA block indices first-class through attention
- add a fused Metal kernel that consumes selected blocks directly, shares K/V across grouped-query heads, and performs QK, FP32 online softmax, and PV without materializing gathered K/V
- preserve physical-key reduction order, the exact incomplete causal tail, left-padding offsets, and the existing dense fallback
- gate the candidate behind `RAPID_MLX_QSA_BLOCK_SPARSE=1`, with the measured crossover at query length 64 and physical KV length 16,384
- record reproducible M3 Ultra baseline/candidate results and user-path correctness evidence

## Scope / Non-goals

Scope is the vendored Qwen4-Exp QSA selection/attention seam, one model-specific Metal kernel, focused tests, and the benchmark report. Non-goals are decode/MTP, MoE kernels, quantized-KV specialization, model or dependency bumps, release changes, CI edits, and default enablement.

## Design precedent

Established serving backends keep sparse top-k indices first-class and consume them directly in a fused attention backend. The candidate adopts that direct-index boundary and grouped-query K/V sharing. It rejects per-query gathered K/V because the materialization was 1.8x slower, and rejects two-row query tiling because the model's exact geometry lost scheduling parallelism. Platform-native dense SDPA remains the compatibility fallback.

## Verification

- MLX 0.32.2: `76 passed` across `tests/test_qwen4_exp_vendored.py` plus the environment-variable routing guard
- adjacent QSA cache/routing/model-config subset: `5 passed, 2 skipped`
- pinned mypy budget: `719 grandfathered errors; no growth`
- Ruff check and format clean; diff-check and credential scan clean
- five deterministic real-model user paths passed and were byte-identical after normalizing text/tool names: multi-turn exact, Chinese exact, strict JSON, forced tool call, and 32K needle recall
- quiet-window, medians of three: 32K TTFT `62.539s -> 56.516s` (-9.6%), prefill `523.4 -> 579.2 tok/s` (+10.7%), decode `21.61 -> 21.59 tok/s`; MLX active memory remained about 103--104 GB

The local all-roster freeze exposed the branch's missing non-routing env allowlist and a threshold-misaligned sorting test; both are fixed on the current head and the focused gates above are green. Its no-MLX leg also reproduced two existing clean-main blockers: inherited `NO_COLOR=1` breaks the banner-color assertion, and the pre-#2518 hermetic fixture lets a server-load test attempt a checkpoint download. Authoritative hosted checks remain required.

## Behaviour delta

Defaults do not change. Without the opt-in environment variable, requests use the existing dense attention path. With it enabled, eligible long-context prefills use the block-sparse kernel; short context, decode, unsupported layouts, and non-Metal systems remain on the dense path.

