### PR TITLE
test(gui): convert control-behaviour contract to symbol/behaviour checks (#2494)

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -116,18 +116,26 @@ die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 # journey guard from ``die`` to logging can no longer leave the unit contract
 # green: the helper is exercised with both allowed and forbidden fixtures.
 assert_no_fake_server_start() {
-    local events="$1" alias="$2" phase="$3"
+    local events="$1" alias="$2" phase="$3" query_status=0
     [[ -s "$events" ]] || return 0
     if [[ -n "$alias" ]]; then
-        if jq -e -s --arg alias "$alias" \
+        jq -e -s --arg alias "$alias" \
             'any(.[]; .event == "server_started" and .alias == $alias)' \
-            "$events" >/dev/null; then
-            die "$phase unexpectedly started $alias"
-        fi
-    elif jq -e -s 'any(.[]; .event == "server_started")' \
-        "$events" >/dev/null; then
-        die "$phase unexpectedly started a model"
+            "$events" >/dev/null || query_status=$?
+    else
+        jq -e -s 'any(.[]; .event == "server_started")' \
+            "$events" >/dev/null || query_status=$?
     fi
+    case "$query_status" in
+        0)
+            if [[ -n "$alias" ]]; then
+                die "$phase unexpectedly started $alias"
+            fi
+            die "$phase unexpectedly started a model"
+            ;;
+        1) return 0 ;; # valid JSONL with no matching event
+        *) die "$phase could not validate the sidecar event log" ;;
+    esac
 }
 
 require_observed_phase() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -115,25 +115,16 @@ die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 # harness tests. Keeping the failure inside these helpers means changing a
 # journey guard from ``die`` to logging can no longer leave the unit contract
 # green: the helper is exercised with both allowed and forbidden fixtures.
-assert_no_fake_server_start() {
-    local events="$1" alias="$2" phase="$3" query_status=0
-    [[ -s "$events" ]] || return 0
-    if [[ -n "$alias" ]]; then
-        jq -e -s --arg alias "$alias" \
-            'any(.[]; .event == "server_started" and .alias == $alias)' \
-            "$events" >/dev/null || query_status=$?
-    else
-        jq -e -s 'any(.[]; .event == "server_started")' \
-            "$events" >/dev/null || query_status=$?
-    fi
+assert_fake_server_starts() {
+    local events="$1" expected_count="$2" expected_alias="$3" phase="$4" query_status=0
+    jq -e -s --argjson count "$expected_count" --arg alias "$expected_alias" \
+        '[.[] | select(.event == "server_started")] as $starts
+         | (($starts | length) == $count
+            and ($alias == "" or all($starts[]; .alias == $alias)))' \
+        "$events" >/dev/null || query_status=$?
     case "$query_status" in
-        0)
-            if [[ -n "$alias" ]]; then
-                die "$phase unexpectedly started $alias"
-            fi
-            die "$phase unexpectedly started a model"
-            ;;
-        1) return 0 ;; # valid JSONL with no matching event
+        0) return 0 ;;
+        1) die "$phase observed an unexpected sidecar start set" ;;
         *) die "$phase could not validate the sidecar event log" ;;
     esac
 }
@@ -4710,8 +4701,8 @@ flow_audio_readiness() {
     # loading everywhere else; the default Audio pane is the easiest place for
     # it to creep back in, because dictation *does* load a model — just later,
     # when the user actually presses the hotkey.
-    assert_no_fake_server_start \
-        "$OUT/fake-events.jsonl" "" "Opening Audio before any user action"
+    assert_fake_server_starts \
+        "$OUT/fake-events.jsonl" 0 "" "Opening Audio before any user action"
 
     press "$OUT/dictation.json" Audio.Mode.Speech "$OUT/speech-tab-press.json" \
         || die "Audio Speech segment is not pressable from Dictation"
@@ -4759,8 +4750,8 @@ flow_audio_readiness() {
     done
     [[ "$speech_downloading" == 1 ]] \
         || die "Speech never exposed Downloading after Download"
-    assert_no_fake_server_start \
-        "$OUT/fake-events.jsonl" "fake-qwen3-tts" "Speech before pull completion"
+    assert_fake_server_starts \
+        "$OUT/fake-events.jsonl" 0 "" "Speech before pull completion"
 
     local speech_start_ready=0
     for ((i=0; i<120; i++)); do
@@ -4775,8 +4766,8 @@ flow_audio_readiness() {
     done
     [[ "$speech_start_ready" == 1 ]] \
         || die "Speech did not become Start-ready after its download completed"
-    assert_no_fake_server_start \
-        "$OUT/fake-events.jsonl" "fake-qwen3-tts" "Speech after download-only action"
+    assert_fake_server_starts \
+        "$OUT/fake-events.jsonl" 0 "" "Speech after download-only action"
     press "$OUT/speech-downloaded.json" Readiness.Action "$OUT/speech-start.json" \
         || die "Speech Start is not pressable after download"
     wait_fake_event \
@@ -5008,8 +4999,8 @@ flow_audio_readiness() {
     # rows render a grant button only while the permission is missing, so its
     # tree legitimately differs between a fresh runner and a developer machine.
     # A snapshot would encode the runner's TCC state as the contract.
-    assert_no_fake_server_start \
-        "$OUT/fake-events.jsonl" "fake-whisper-small" "Opening Dictation"
+    assert_fake_server_starts \
+        "$OUT/fake-events.jsonl" 1 "fake-qwen3-tts" "Opening Dictation"
 
     press "$OUT/dictation-return.json" Readiness.Action "$OUT/dictation-download.json" \
         || die "Dictation Download is not pressable"
@@ -5028,8 +5019,8 @@ flow_audio_readiness() {
     done
     [[ "$dictation_downloaded" == 1 ]] \
         || die "Dictation banner did not clear after the download landed"
-    assert_no_fake_server_start \
-        "$OUT/fake-events.jsonl" "fake-whisper-small" "Dictation after Download"
+    assert_fake_server_starts \
+        "$OUT/fake-events.jsonl" 1 "fake-qwen3-tts" "Dictation after Download"
 
     jq -n '{success: true,
             assertion: "Dictation is privacy-safe and inert on open, exposes the shared explicit Download lifecycle for an uncached model, and Speech keeps its explicit Download and Start"}' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -116,17 +116,26 @@ die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 # journey guard from ``die`` to logging can no longer leave the unit contract
 # green: the helper is exercised with both allowed and forbidden fixtures.
 assert_fake_server_starts() {
-    local events="$1" expected_count="$2" expected_alias="$3" phase="$4" query_status=0
-    jq -e -s --argjson count "$expected_count" --arg alias "$expected_alias" \
-        '[.[] | select(.event == "server_started")] as $starts
-         | (($starts | length) == $count
-            and ($alias == "" or all($starts[]; .alias == $alias)))' \
-        "$events" >/dev/null || query_status=$?
-    case "$query_status" in
-        0) return 0 ;;
-        1) die "$phase observed an unexpected sidecar start set" ;;
-        *) die "$phase could not validate the sidecar event log" ;;
-    esac
+    local events="$1" expected_count="$2" expected_alias="$3" phase="$4"
+    local query_status=0 attempt
+    # The app appends JSONL concurrently. A reader can briefly observe the
+    # final record between writes; retry parse/read failures for a bounded
+    # 400 ms, while a valid-but-wrong start set still fails immediately.
+    # Persistently malformed or unreadable evidence remains fail-closed.
+    for attempt in 1 2 3 4 5; do
+        query_status=0
+        jq -e -s --argjson count "$expected_count" --arg alias "$expected_alias" \
+            '[.[] | select(.event == "server_started")] as $starts
+             | (($starts | length) == $count
+                and ($alias == "" or all($starts[]; .alias == $alias)))' \
+            "$events" >/dev/null 2>&1 || query_status=$?
+        case "$query_status" in
+            0) return 0 ;;
+            1) die "$phase observed an unexpected sidecar start set" ;;
+        esac
+        [[ "$attempt" == 5 ]] || sleep 0.1
+    done
+    die "$phase could not validate the sidecar event log"
 }
 
 require_observed_phase() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -110,6 +110,38 @@ fi
 
 log() { printf '[gui-golden] %s\n' "$*"; }
 die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# Small executable contracts shared by the real journeys and the fast Python
+# harness tests. Keeping the failure inside these helpers means changing a
+# journey guard from ``die`` to logging can no longer leave the unit contract
+# green: the helper is exercised with both allowed and forbidden fixtures.
+assert_no_fake_server_start() {
+    local events="$1" alias="$2" phase="$3"
+    [[ -s "$events" ]] || return 0
+    if [[ -n "$alias" ]]; then
+        if jq -e -s --arg alias "$alias" \
+            'any(.[]; .event == "server_started" and .alias == $alias)' \
+            "$events" >/dev/null; then
+            die "$phase unexpectedly started $alias"
+        fi
+    elif jq -e -s 'any(.[]; .event == "server_started")' \
+        "$events" >/dev/null; then
+        die "$phase unexpectedly started a model"
+    fi
+}
+
+require_observed_phase() {
+    local observed="$1" phase="$2"
+    [[ "$observed" == 1 ]] || die "required $phase phase was not observed"
+}
+
+# When sourced, expose only the executable contract helpers above. Return
+# before cleanup traps, app launch, filesystem mutation, or tool preflight.
+# Direct execution cannot be bypassed with an environment variable.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
 write_result() {
     local status="$1" exit_code="$2" finished_epoch duration_seconds
@@ -4670,10 +4702,8 @@ flow_audio_readiness() {
     # loading everywhere else; the default Audio pane is the easiest place for
     # it to creep back in, because dictation *does* load a model — just later,
     # when the user actually presses the hotkey.
-    if [[ -s "$OUT/fake-events.jsonl" ]] \
-       && jq -e -s 'any(.[]; .event == "server_started")' "$OUT/fake-events.jsonl" >/dev/null; then
-        die "Opening Audio started a model before any user action"
-    fi
+    assert_no_fake_server_start \
+        "$OUT/fake-events.jsonl" "" "Opening Audio before any user action"
 
     press "$OUT/dictation.json" Audio.Mode.Speech "$OUT/speech-tab-press.json" \
         || die "Audio Speech segment is not pressable from Dictation"
@@ -4721,10 +4751,8 @@ flow_audio_readiness() {
     done
     [[ "$speech_downloading" == 1 ]] \
         || die "Speech never exposed Downloading after Download"
-    if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-qwen3-tts")' \
-        "$OUT/fake-events.jsonl" >/dev/null; then
-        die "Speech started fake-qwen3-tts before its pull completed and cache was verified"
-    fi
+    assert_no_fake_server_start \
+        "$OUT/fake-events.jsonl" "fake-qwen3-tts" "Speech before pull completion"
 
     local speech_start_ready=0
     for ((i=0; i<120; i++)); do
@@ -4739,10 +4767,8 @@ flow_audio_readiness() {
     done
     [[ "$speech_start_ready" == 1 ]] \
         || die "Speech did not become Start-ready after its download completed"
-    if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-qwen3-tts")' \
-        "$OUT/fake-events.jsonl" >/dev/null; then
-        die "Speech loaded automatically after a download-only action"
-    fi
+    assert_no_fake_server_start \
+        "$OUT/fake-events.jsonl" "fake-qwen3-tts" "Speech after download-only action"
     press "$OUT/speech-downloaded.json" Readiness.Action "$OUT/speech-start.json" \
         || die "Speech Start is not pressable after download"
     wait_fake_event \
@@ -4974,10 +5000,8 @@ flow_audio_readiness() {
     # rows render a grant button only while the permission is missing, so its
     # tree legitimately differs between a fresh runner and a developer machine.
     # A snapshot would encode the runner's TCC state as the contract.
-    if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-whisper-small")' \
-        "$OUT/fake-events.jsonl" >/dev/null; then
-        die "Opening Dictation loaded its model before the user dictated"
-    fi
+    assert_no_fake_server_start \
+        "$OUT/fake-events.jsonl" "fake-whisper-small" "Opening Dictation"
 
     press "$OUT/dictation-return.json" Readiness.Action "$OUT/dictation-download.json" \
         || die "Dictation Download is not pressable"
@@ -4996,10 +5020,8 @@ flow_audio_readiness() {
     done
     [[ "$dictation_downloaded" == 1 ]] \
         || die "Dictation banner did not clear after the download landed"
-    if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-whisper-small")' \
-        "$OUT/fake-events.jsonl" >/dev/null; then
-        die "Dictation loaded the model after Download while dictation was off"
-    fi
+    assert_no_fake_server_start \
+        "$OUT/fake-events.jsonl" "fake-whisper-small" "Dictation after Download"
 
     jq -n '{success: true,
             assertion: "Dictation is privacy-safe and inert on open, exposes the shared explicit Download lifecycle for an uncached model, and Speech keeps its explicit Download and Start"}' \
@@ -5243,8 +5265,7 @@ flow_dictation() {
         fi
         sleep 0.1
     done
-    [[ "$loading_seen" == 1 ]] \
-        || die "Dictation never exposed model loading before readiness"
+    require_observed_phase "$loading_seen" loading
     [[ "$(element_field "$OUT/dictation-loading.json" Dictation.Enable value)" == "1" ]] \
         || die "Dictation lost the user's Enabled intent while loading"
 
@@ -5262,8 +5283,7 @@ flow_dictation() {
         fi
         sleep 0.1
     done
-    [[ "$ready_seen" == 1 ]] \
-        || die "Dictation did not become Listening after model warmup"
+    require_observed_phase "$ready_seen" listening
 
     # The warmup request must have stayed on the conversation server. A
     # transcription-only start here is the exact silent-eviction regression.

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -23,6 +23,9 @@ they exist when they break.
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -98,6 +101,27 @@ def _owns_committed_baseline(flow: str) -> bool:
     return any(p.name.startswith(flow) for p in SNAPSHOTS.glob("*.txt"))
 
 
+def _run_harness_helper(tmp_path: Path, helper: str, *args: str):
+    env = os.environ.copy()
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'harness="$1"; shift; helper="$1"; shift; helper_args=("$@"); '
+            'set --; source "$harness"; "$helper" "${helper_args[@]}"',
+            "gui-contract-test",
+            str(HARNESS),
+            helper,
+            *args,
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 def test_audio_readiness_asserts_outcomes_not_just_presses():
     """The audio-readiness journey proves model lifecycle outcomes.
 
@@ -131,15 +155,53 @@ def test_audio_readiness_never_auto_starts_a_model():
     """
     flow = _harness_flow_body("flow_audio_readiness")
 
-    # Negative auto-load guards: `die` when a model started without an action.
-    # Both the Speech/TTS and the Dictation/transcription model paths must
-    # refuse premature `server_started`, so dropping either path fails here.
-    for alias in ("fake-qwen3-tts", "fake-whisper-small"):
-        assert (
-            f'any(.[]; .event == "server_started" and .alias == "{alias}")' in flow
-        ), f"audio-readiness no longer refutes premature auto-start of {alias}"
+    # The executable failure helper must control all five inert phases: opening
+    # Audio, before/after the TTS download, and before/after Dictation download.
+    assert flow.count("assert_no_fake_server_start") == 5
+    assert flow.count('"fake-qwen3-tts"') >= 2
+    assert flow.count('"fake-whisper-small"') >= 2
     # The one allowed start is asserted as a waited post-condition after Start.
     assert '"server_started" and .alias == "fake-qwen3-tts"' in flow
+
+
+@pytest.mark.parametrize("guarded_alias", ["", "fake-qwen3-tts", "fake-whisper-small"])
+def test_auto_start_guard_fails_on_forbidden_event(tmp_path: Path, guarded_alias: str):
+    events = tmp_path / "events.jsonl"
+    started_alias = guarded_alias or "some-model"
+    events.write_text(json.dumps({"event": "server_started", "alias": started_alias}))
+
+    result = _run_harness_helper(
+        tmp_path,
+        "assert_no_fake_server_start",
+        str(events),
+        guarded_alias,
+        "test phase",
+    )
+
+    assert result.returncode == 1
+    assert "FAIL:" in result.stderr
+
+
+def test_alias_guard_allows_unrelated_or_empty_events(tmp_path: Path):
+    events = tmp_path / "events.jsonl"
+    events.write_text(json.dumps({"event": "server_started", "alias": "other"}))
+    unrelated = _run_harness_helper(
+        tmp_path,
+        "assert_no_fake_server_start",
+        str(events),
+        "fake-qwen3-tts",
+        "test phase",
+    )
+    events.write_text("")
+    empty = _run_harness_helper(
+        tmp_path,
+        "assert_no_fake_server_start",
+        str(events),
+        "fake-qwen3-tts",
+        "test phase",
+    )
+    assert unrelated.returncode == 0
+    assert empty.returncode == 0
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
@@ -176,9 +238,18 @@ def test_dictation_journey_proves_loading_before_ready():
     assert '.event == "audio_transcription"' in flow
     # The status filter used to read readiness text off a control description.
     assert '(.description // .value // .label // "")' in flow
-    # Two distinct outcome-state predicates on Dictation.Status: the loading
-    # phase (before readiness) and the Listening phase (after warmup).
+    # Two distinct observed states feed the executable failure helper.
     assert flow.count('select(.identifier == "Dictation.Status"') == 2
+    assert 'require_observed_phase "$loading_seen" loading' in flow
+    assert 'require_observed_phase "$ready_seen" listening' in flow
+
+
+def test_required_phase_helper_controls_failure(tmp_path: Path):
+    observed = _run_harness_helper(tmp_path, "require_observed_phase", "1", "loading")
+    missing = _run_harness_helper(tmp_path, "require_observed_phase", "0", "loading")
+    assert observed.returncode == 0
+    assert missing.returncode == 1
+    assert "FAIL:" in missing.stderr
 
 
 def test_image_generation_shell_request_matches_the_swift_default():

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -119,17 +119,17 @@ def test_audio_download_and_start_actions_have_ordered_outcomes():
         flow,
         'press "$OUT/speech.json" Readiness.Action',
         '.subcommand == "pull" and .alias == "fake-qwen3-tts"',
-        '"fake-qwen3-tts" "Speech before pull completion"',
-        '"fake-qwen3-tts" "Speech after download-only action"',
+        '0 "" "Speech before pull completion"',
+        '0 "" "Speech after download-only action"',
         'press "$OUT/speech-downloaded.json" Readiness.Action',
         '.event == "server_started" and .alias == "fake-qwen3-tts"',
     )
     _assert_in_order(
         flow,
-        '"fake-whisper-small" "Opening Dictation"',
+        '1 "fake-qwen3-tts" "Opening Dictation"',
         'press "$OUT/dictation-return.json" Readiness.Action',
         '.subcommand == "pull" and .alias == "fake-whisper-small"',
-        '"fake-whisper-small" "Dictation after Download"',
+        '1 "fake-qwen3-tts" "Dictation after Download"',
     )
 
 
@@ -137,34 +137,43 @@ def test_audio_readiness_never_auto_starts_a_model():
     """Download-only actions must not start a model; only Start may.
 
     Previously pinned by grepping five exact `die` message strings. The
-    behavioural contract is structural: the flow contains a negative guard
-    (die when a `server_started` fake-event is observed prematurely) for
-    EACH model path — the Speech/TTS alias and the Dictation/transcription
-    alias — and a positive `wait_fake_event` that asserts `server_started`
-    only after the explicit Start gesture.
+    behavioural contract is structural: the flow pins the complete set of
+    `server_started` events before and after the explicit Start gesture, so an
+    unrelated stale model or a duplicate start fails as well.
     """
     flow = _harness_flow_body("flow_audio_readiness")
 
-    # The executable failure helper must control all five inert phases: opening
-    # Audio, before/after the TTS download, and before/after Dictation download.
-    assert flow.count("assert_no_fake_server_start") == 5
-    assert flow.count('"fake-qwen3-tts"') >= 2
-    assert flow.count('"fake-whisper-small"') >= 2
+    # The executable helper pins the complete start-event set in all five
+    # phases: none before the explicit Start, then exactly one TTS sidecar.
+    assert flow.count("assert_fake_server_starts") == 5
+    assert flow.count('"$OUT/fake-events.jsonl" 0 ""') == 3
+    assert flow.count('"$OUT/fake-events.jsonl" 1 "fake-qwen3-tts"') == 2
     # The one allowed start is asserted as a waited post-condition after Start.
     assert '"server_started" and .alias == "fake-qwen3-tts"' in flow
 
 
-@pytest.mark.parametrize("guarded_alias", ["", "fake-qwen3-tts", "fake-whisper-small"])
-def test_auto_start_guard_fails_on_forbidden_event(tmp_path: Path, guarded_alias: str):
+@pytest.mark.parametrize(
+    ("events_payload", "expected_count", "expected_alias"),
+    [
+        ({"event": "server_started", "alias": "other"}, "0", ""),
+        ({"event": "server_started", "alias": "other"}, "1", "fake-qwen3-tts"),
+    ],
+)
+def test_start_set_guard_rejects_unexpected_event(
+    tmp_path: Path,
+    events_payload: dict[str, str],
+    expected_count: str,
+    expected_alias: str,
+):
     events = tmp_path / "events.jsonl"
-    started_alias = guarded_alias or "some-model"
-    events.write_text(json.dumps({"event": "server_started", "alias": started_alias}))
+    events.write_text(json.dumps(events_payload))
 
     result = _run_harness_helper(
         tmp_path,
-        "assert_no_fake_server_start",
+        "assert_fake_server_starts",
         str(events),
-        guarded_alias,
+        expected_count,
+        expected_alias,
         "test phase",
     )
 
@@ -172,35 +181,56 @@ def test_auto_start_guard_fails_on_forbidden_event(tmp_path: Path, guarded_alias
     assert "FAIL:" in result.stderr
 
 
-def test_alias_guard_allows_unrelated_or_empty_events(tmp_path: Path):
+def test_start_set_guard_accepts_exact_empty_and_singleton_sets(tmp_path: Path):
     events = tmp_path / "events.jsonl"
-    events.write_text(json.dumps({"event": "server_started", "alias": "other"}))
-    unrelated = _run_harness_helper(
-        tmp_path,
-        "assert_no_fake_server_start",
-        str(events),
-        "fake-qwen3-tts",
-        "test phase",
-    )
     events.write_text("")
     empty = _run_harness_helper(
         tmp_path,
-        "assert_no_fake_server_start",
+        "assert_fake_server_starts",
         str(events),
+        "0",
+        "",
+        "test phase",
+    )
+    events.write_text(
+        json.dumps({"event": "server_started", "alias": "fake-qwen3-tts"})
+    )
+    singleton = _run_harness_helper(
+        tmp_path,
+        "assert_fake_server_starts",
+        str(events),
+        "1",
         "fake-qwen3-tts",
         "test phase",
     )
-    assert unrelated.returncode == 0
     assert empty.returncode == 0
+    assert singleton.returncode == 0
 
 
-def test_auto_start_guard_fails_closed_on_partial_jsonl(tmp_path: Path):
+def test_start_set_guard_rejects_duplicate_expected_alias(tmp_path: Path):
+    events = tmp_path / "events.jsonl"
+    event = json.dumps({"event": "server_started", "alias": "fake-qwen3-tts"})
+    events.write_text(f"{event}\n{event}\n")
+    result = _run_harness_helper(
+        tmp_path,
+        "assert_fake_server_starts",
+        str(events),
+        "1",
+        "fake-qwen3-tts",
+        "test phase",
+    )
+    assert result.returncode == 1
+    assert "FAIL:" in result.stderr
+
+
+def test_start_set_guard_fails_closed_on_partial_jsonl(tmp_path: Path):
     events = tmp_path / "events.jsonl"
     events.write_text('{"event":"server_started"')
     result = _run_harness_helper(
         tmp_path,
-        "assert_no_fake_server_start",
+        "assert_fake_server_starts",
         str(events),
+        "0",
         "fake-qwen3-tts",
         "test phase",
     )

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -223,6 +223,35 @@ def test_start_set_guard_rejects_duplicate_expected_alias(tmp_path: Path):
     assert "FAIL:" in result.stderr
 
 
+def test_start_set_guard_retries_a_transient_partial_record(tmp_path: Path):
+    events = tmp_path / "events.jsonl"
+    events.write_text('{"event":"server_started"')
+    repaired = json.dumps({"event": "server_started", "alias": "fake-qwen3-tts"})
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'harness="$1"; events="$2"; repaired="$3"; '
+            '(sleep 0.15; printf "%s\\n" "$repaired" > "$events") & '
+            'repair_pid=$!; set --; source "$harness"; '
+            'assert_fake_server_starts "$events" 1 "fake-qwen3-tts" "test phase"; '
+            'status=$?; wait "$repair_pid"; exit "$status"',
+            "gui-contract-test",
+            str(HARNESS),
+            str(events),
+            repaired,
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_start_set_guard_fails_closed_on_partial_jsonl(tmp_path: Path):
     events = tmp_path / "events.jsonl"
     events.write_text('{"event":"server_started"')

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -7,8 +7,9 @@ display string or rewording a `die` message used to fail the suite for no
 behavioural reason (#2494). Each guard below now asserts the structural
 *behaviour* that actually matters:
 
-* a journey performs an action and then evaluates a post-condition on the
-  resulting UI/fake-event state (counts of outcome assertions vs. presses);
+* readiness gestures and their phase-specific UI/fake-event outcomes remain
+  ordered, with shared failure helpers executed against positive and negative
+  fixtures;
 * the fake-event and fixture contracts the journey depends on are intact
   (`pull` lifecycle, machine aliases, watchdog events);
 * the flow is gated in CI and its failures leave usable evidence (parsed
@@ -48,25 +49,6 @@ def _harness_flow_body(flow_function: str) -> str:
     """
     source = HARNESS.read_text()
     return source.split(f"{flow_function}() {{", 1)[1].split("\n}", 1)[0]
-
-
-def _assertion_count(body: str) -> int:
-    """Outcome-assertion helper calls: `die`, `wait_fake_event`, `wait_identifier`."""
-    return (
-        body.count("die ")
-        + body.count("wait_fake_event")
-        + body.count("wait_identifier")
-    )
-
-
-def _action_count(body: str) -> int:
-    """Gesture helper calls that drive a control: `press`, `set-value`, `increment`, `decrement`."""
-    return (
-        body.count('press "$OUT/')
-        + body.count('"$AX_DRIVER" set-value')
-        + body.count('"$AX_DRIVER" increment')
-        + body.count('"$AX_DRIVER" decrement')
-    )
 
 
 def _golden_flow_steps() -> list[dict[str, Any]]:
@@ -122,25 +104,33 @@ def _run_harness_helper(tmp_path: Path, helper: str, *args: str):
     )
 
 
-def test_audio_readiness_asserts_outcomes_not_just_presses():
-    """The audio-readiness journey proves model lifecycle outcomes.
+def _assert_in_order(body: str, *anchors: str) -> None:
+    positions = [body.index(anchor) for anchor in anchors]
+    assert positions == sorted(positions), (
+        f"journey contract is out of order: {list(zip(anchors, positions, strict=True))}"
+    )
 
-    Every gesture (press / set-value) is followed by an outcome assertion
-    (`die`/`wait_fake_event`/`wait_identifier`) that verifies the resulting
-    state, and the total number of outcome assertions dwarfs the number of
-    gestures. A journey that merely pressed buttons and read one final tree
-    would fail here.
-    """
+
+def test_audio_download_and_start_actions_have_ordered_outcomes():
+    """Each readiness gesture is followed by its phase-specific outcome."""
     flow = _harness_flow_body("flow_audio_readiness")
 
-    # Proves control outcomes, not just presses: assertions > gestures.
-    assert _assertion_count(flow) > _action_count(flow)
-    # The lifecycle is two real downloads (Download -> Start) for model start,
-    # keyed on the fake's recorded `pull` command event.
-    assert flow.count('.subcommand == "pull"') == 2
-    # The journey watches both a TTS and a transcription model start/stop.
-    assert '.alias == "fake-qwen3-tts"' in flow
-    assert '.alias == "fake-whisper-small"' in flow
+    _assert_in_order(
+        flow,
+        'press "$OUT/speech.json" Readiness.Action',
+        '.subcommand == "pull" and .alias == "fake-qwen3-tts"',
+        '"fake-qwen3-tts" "Speech before pull completion"',
+        '"fake-qwen3-tts" "Speech after download-only action"',
+        'press "$OUT/speech-downloaded.json" Readiness.Action',
+        '.event == "server_started" and .alias == "fake-qwen3-tts"',
+    )
+    _assert_in_order(
+        flow,
+        '"fake-whisper-small" "Opening Dictation"',
+        'press "$OUT/dictation-return.json" Readiness.Action',
+        '.subcommand == "pull" and .alias == "fake-whisper-small"',
+        '"fake-whisper-small" "Dictation after Download"',
+    )
 
 
 def test_audio_readiness_never_auto_starts_a_model():
@@ -202,6 +192,20 @@ def test_alias_guard_allows_unrelated_or_empty_events(tmp_path: Path):
     )
     assert unrelated.returncode == 0
     assert empty.returncode == 0
+
+
+def test_auto_start_guard_fails_closed_on_partial_jsonl(tmp_path: Path):
+    events = tmp_path / "events.jsonl"
+    events.write_text('{"event":"server_started"')
+    result = _run_harness_helper(
+        tmp_path,
+        "assert_no_fake_server_start",
+        str(events),
+        "fake-qwen3-tts",
+        "test phase",
+    )
+    assert result.returncode == 1
+    assert "FAIL:" in result.stderr
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -1,7 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Source guards for GUI journeys that prove control outcomes, not just presses."""
+"""GUI journeys prove control *outcomes*, not just button presses.
+
+These contract tests replaced brittle source-string greps that re-read the
+harness and CI workflow and asserted on exact error-message copy. Renaming a
+display string or rewording a `die` message used to fail the suite for no
+behavioural reason (#2494). Each guard below now asserts the structural
+*behaviour* that actually matters:
+
+* a journey performs an action and then evaluates a post-condition on the
+  resulting UI/fake-event state (counts of outcome assertions vs. presses);
+* the fake-event and fixture contracts the journey depends on are intact
+  (`pull` lifecycle, machine aliases, watchdog events);
+* the flow is gated in CI and its failures leave usable evidence (parsed
+  structurally from the workflow YAML, mirroring ``test_gui_golden_ci_coverage``);
+* the only deliberately retained single-anchor source checks are the two sides
+  of a cross-language request-body contract (Swift default <-> shell request),
+  where no behavioural proxy exists — see ``test_image_generation_...``.
+
+The guarantees here are behaviour; the anchors are precise and loud about why
+they exist when they break.
+"""
+
+from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -10,105 +33,225 @@ ROOT = Path(__file__).resolve().parent.parent
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
 IMAGE_VIEW_MODEL = ROOT / "apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift"
+SNAPSHOTS = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__"
 
 
-def test_audio_readiness_actions_start_the_selected_model_and_clear_the_gate():
+def _harness_flow_body(flow_function: str) -> str:
+    """Return one named ``flow_*`` function's body from the golden harness.
+
+    Splitting on the function signature and the first closing brace is stable
+    across copy edits inside the body; only the function's name and structure
+    are load-bearing.
+    """
     source = HARNESS.read_text()
-    flow = source.split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
+    return source.split(f"{flow_function}() {{", 1)[1].split("\n}", 1)[0]
 
-    assert flow.count('press "$OUT/') >= 3
-    # Speech synthesis and file transcription each preserve the explicit
-    # Download → Start lifecycle. Dictation owns no readiness banner: it loads
-    # only after the user invokes the global hotkey.
+
+def _assertion_count(body: str) -> int:
+    """Outcome-assertion helper calls: `die`, `wait_fake_event`, `wait_identifier`."""
+    return (
+        body.count("die ")
+        + body.count("wait_fake_event")
+        + body.count("wait_identifier")
+    )
+
+
+def _action_count(body: str) -> int:
+    """Gesture helper calls that drive a control: `press`, `set-value`, `increment`, `decrement`."""
+    return (
+        body.count('press "$OUT/')
+        + body.count('"$AX_DRIVER" set-value')
+        + body.count('"$AX_DRIVER" increment')
+        + body.count('"$AX_DRIVER" decrement')
+    )
+
+
+def _golden_flow_steps() -> list[dict[str, Any]]:
+    """All 'Golden flow: <name>' steps in the GUI CI job, parsed structurally."""
+    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["gui-golden-flows"]["steps"]
+    return [
+        step for step in steps if str(step.get("name", "")).startswith("Golden flow:")
+    ]
+
+
+def _golden_flow_step(name: str) -> dict[str, Any]:
+    return next(
+        step
+        for step in _golden_flow_steps()
+        if step.get("name") == f"Golden flow: {name}"
+    )
+
+
+def _diagnostic_flow_list() -> list[str]:
+    """Names in the 'Regenerate baselines' step's ``for flow in ...`` list."""
+    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["gui-golden-flows"]["steps"]
+    (diagnostic,) = [
+        step
+        for step in steps
+        if step.get("name") == "Regenerate baselines on this runner (diagnostic)"
+    ]
+    run = str(diagnostic.get("run", ""))
+    return run.split("for flow in ", 1)[1].split("; do", 1)[0].split()
+
+
+def _owns_committed_baseline(flow: str) -> bool:
+    return any(p.name.startswith(flow) for p in SNAPSHOTS.glob("*.txt"))
+
+
+def test_audio_readiness_asserts_outcomes_not_just_presses():
+    """The audio-readiness journey proves model lifecycle outcomes.
+
+    Every gesture (press / set-value) is followed by an outcome assertion
+    (`die`/`wait_fake_event`/`wait_identifier`) that verifies the resulting
+    state, and the total number of outcome assertions dwarfs the number of
+    gestures. A journey that merely pressed buttons and read one final tree
+    would fail here.
+    """
+    flow = _harness_flow_body("flow_audio_readiness")
+
+    # Proves control outcomes, not just presses: assertions > gestures.
+    assert _assertion_count(flow) > _action_count(flow)
+    # The lifecycle is two real downloads (Download -> Start) for model start,
+    # keyed on the fake's recorded `pull` command event.
     assert flow.count('.subcommand == "pull"') == 2
+    # The journey watches both a TTS and a transcription model start/stop.
     assert '.alias == "fake-qwen3-tts"' in flow
     assert '.alias == "fake-whisper-small"' in flow
-    assert "before its pull completed" in flow
-    assert "Speech loaded automatically after a download-only action" in flow
-    assert "Opening Audio started a model before any user action" in flow
-    assert "Opening Dictation loaded its model before the user dictated" in flow
-    assert "Dictation loaded the model after Download while dictation was off" in flow
+
+
+def test_audio_readiness_never_auto_starts_a_model():
+    """Download-only actions must not start a model; only Start may.
+
+    Previously pinned by grepping five exact `die` message strings. The
+    behavioural contract is structural: the flow contains a negative guard
+    (die when a `server_started` fake-event is observed prematurely) for
+    EACH model path — the Speech/TTS alias and the Dictation/transcription
+    alias — and a positive `wait_fake_event` that asserts `server_started`
+    only after the explicit Start gesture.
+    """
+    flow = _harness_flow_body("flow_audio_readiness")
+
+    # Negative auto-load guards: `die` when a model started without an action.
+    # Both the Speech/TTS and the Dictation/transcription model paths must
+    # refuse premature `server_started`, so dropping either path fails here.
+    for alias in ("fake-qwen3-tts", "fake-whisper-small"):
+        assert (
+            f'any(.[]; .event == "server_started" and .alias == "{alias}")' in flow
+        ), f"audio-readiness no longer refutes premature auto-start of {alias}"
+    # The one allowed start is asserted as a waited post-condition after Start.
+    assert '"server_started" and .alias == "fake-qwen3-tts"' in flow
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
-    workflow = WORKFLOW.read_text()
-
-    assert "Golden flow: audio-readiness" in workflow
-    assert "--flow audio-readiness" in workflow
-    diagnostic = workflow.split("Regenerate baselines on this runner (diagnostic)", 1)[
-        1
-    ]
-    assert "image-generation audio-readiness" in diagnostic
+    """audio-readiness is CI-gated, and a baseline failure regenerates it."""
+    step = _golden_flow_step("audio-readiness")
+    assert "--flow audio-readiness" in str(step.get("run", ""))
+    assert step.get("env", {}).get("RAPID_GUI_GOLDEN_OUT") == (
+        "${{ runner.temp }}/golden/audio-readiness"
+    )
+    # audio-readiness owns a committed baseline, so regeneration is the right
+    # failure evidence for it (and image-generation, the other new-Images
+    # journey, is regenerated alongside in the same diagnostic pass).
+    assert _owns_committed_baseline("audio-readiness")
+    diagnostic = _diagnostic_flow_list()
+    assert "audio-readiness" in diagnostic
+    assert "image-generation" in diagnostic
 
 
 def test_dictation_journey_proves_loading_before_ready():
-    source = HARNESS.read_text()
-    flow = source.split("flow_dictation() {", 1)[1].split("\n}", 1)[0]
+    """The dictation journey asserts a cold-loading phase, then Listening.
+
+    The fixture keeps a fake STT probe open long enough to observe both
+    state transitions. Previously the two `die` message strings were pinned;
+    the stable guarantee is that the flow asserts *two* independent
+    `Dictation.Status` outcome predicates — a Loading phase and a
+    Listening/ready phase — via the shared ``.description // .value // .label``
+    status filter, plus the behavioural warmup probe.
+    """
+    flow = _harness_flow_body("flow_dictation")
 
     assert "RAPID_GUI_DICTATION_READINESS_FIXTURE=1" in flow
     assert "FAKE_AUDIO_TRANSCRIPTION_DELAY_MS=1800" in flow
-    assert "Dictation never exposed model loading before readiness" in flow
-    assert "Dictation did not become Listening after model warmup" in flow
+    # Warmup probe is waited on as a fake event.
     assert '.event == "audio_transcription"' in flow
-    assert 'and (((.description // .value // .label // "") | tostring)' in flow
+    # The status filter used to read readiness text off a control description.
+    assert '(.description // .value // .label // "")' in flow
+    # Two distinct outcome-state predicates on Dictation.Status: the loading
+    # phase (before readiness) and the Listening phase (after warmup).
+    assert flow.count('select(.identifier == "Dictation.Status"') == 2
 
 
-def test_image_generation_journey_asserts_the_product_default_request_size():
+def test_image_generation_shell_request_matches_the_swift_default():
     """Keep the shell E2E contract aligned with the Swift default.
 
     The view-model test catches a wrong UI default, while the golden journey
     catches a wrong request body. Pinning both sides here prevents changing
     one literal and leaving the other to fail only in the 20-minute GUI job.
+    These two single-anchor source checks are the deliberate exception to the
+    behaviour-test rule: a cross-language request-body default has no
+    behavioural proxy from Python, so we keep the precise anchors that make a
+    rename or drift fail loudly and explain why.
     """
     view_model = IMAGE_VIEW_MODEL.read_text()
-    flow = (
-        HARNESS.read_text().split("flow_image_generation() {", 1)[1].split("\n}", 1)[0]
+    flow = _harness_flow_body("flow_image_generation")
+
+    assert "var resolution: Resolution = .compact" in view_model, (
+        "ImageGenViewModel default drift: expected the compact (square) resolution every new canvas starts on"
+    )
+    assert '.size == "512x512"' in flow, (
+        "image-generation journey no longer requests the 512x512 default — it must match ImageGenViewModel's .compact default (see var resolution: Resolution = .compact)"
     )
 
-    assert "var resolution: Resolution = .compact" in view_model
-    assert '.size == "512x512"' in flow
-    assert "square size 512x512" in flow
+
+SNAP_AUDIT_FLOWS = [
+    "no-dead-controls",
+    "catalog-integrity",
+    "update-state",
+    "launch-integrations",
+]
+BASELINED_AUDIT_FLOWS = ["update-state", "launch-integrations"]
+# Semantic audits carry no committed AX snapshots; their failure evidence is
+# the flow's own output directory, which must sit inside the artifact uploaded
+# on failure.
+SNAPSHOT_LESS_AUDIT_FLOWS = ["no-dead-controls", "catalog-integrity"]
 
 
-SNAPSHOTS = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__"
-
-
-@pytest.mark.parametrize(
-    "flow",
-    ["no-dead-controls", "catalog-integrity", "update-state", "launch-integrations"],
-)
+@pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)
 def test_semantic_control_audits_are_blocking_gui_ci(flow: str):
     """Each semantic audit is gated, and its failure leaves usable evidence.
 
-    What "evidence" means depends on whether the flow owns committed AX
-    baselines. update-state and launch-integrations do, so they belong in the
-    regenerate-on-failure diagnostic loop (whose exact membership is pinned by
-    test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else:
-    gated flows WITH baselines, nothing else — a snapshot-less audit in that
-    loop has nothing to regenerate). no-dead-controls and catalog-integrity
-    carry no snapshots; their evidence is the flow's own output directory,
-    which must sit inside the artifact uploaded on failure.
+    Parsed structurally from the workflow YAML. What "evidence" means depends
+    on whether the flow owns committed AX baselines: update-state and
+    launch-integrations do, so they belong in the regenerate-on-failure
+    diagnostic loop; no-dead-controls and catalog-integrity carry no
+    snapshots, so their evidence is the per-flow output directory that the
+    upload-on-failure step ships.
     """
-    workflow = WORKFLOW.read_text()
+    step = _golden_flow_step(flow)
+    assert f"--flow {flow}" in str(step.get("run", ""))
 
-    assert f"Golden flow: {flow}" in workflow
-    assert f"--flow {flow}" in workflow
-
-    if any(p.name.startswith(flow) for p in SNAPSHOTS.glob("*.txt")):
-        diagnostic = workflow.split(
-            "Regenerate baselines on this runner (diagnostic)", 1
-        )[1]
-        assert flow in diagnostic
+    if _owns_committed_baseline(flow):
+        assert flow in _diagnostic_flow_list()
+        # Fix the guards above if these preconditions become stale.
+        assert flow in BASELINED_AUDIT_FLOWS
     else:
-        steps = yaml.safe_load(workflow)["jobs"]["gui-golden-flows"]["steps"]
-        audit = next(s for s in steps if s.get("name") == f"Golden flow: {flow}")
-        out = audit.get("env", {}).get("RAPID_GUI_GOLDEN_OUT", "")
-        assert out == "${{ runner.temp }}/golden/" + flow
-        upload = next(s for s in steps if s.get("name") == "Upload AX evidence")
+        assert flow in SNAPSHOT_LESS_AUDIT_FLOWS
+        assert step.get("env", {}).get("RAPID_GUI_GOLDEN_OUT") == (
+            f"${{{{ runner.temp }}}}/golden/{flow}"
+        )
+        upload = _upload_ax_evidence_step()
         assert upload.get("if") == "failure()"
-        paths = [
+        paths = {
             ln.strip()
             for ln in str(upload.get("with", {}).get("path", "")).splitlines()
             if ln.strip()
-        ]
+        }
         assert "${{ runner.temp }}/golden" in paths
+
+
+def _upload_ax_evidence_step() -> dict[str, Any]:
+    steps: list[dict[str, Any]] = yaml.safe_load(WORKFLOW.read_text())["jobs"][
+        "gui-golden-flows"
+    ]["steps"]
+    (upload,) = [step for step in steps if step.get("name") == "Upload AX evidence"]
+    return upload


### PR DESCRIPTION
Part of #2494. Refs #2365.

## Why

The GUI control contract family pinned literal shell error copy and comments instead of user-observable lifecycle behavior. Harmless wording changes failed CI, while weak aggregate checks could miss a removed post-condition.

## What

- Replace copy-sensitive audio readiness checks with ordered action/outcome contracts.
- Factor an executable shell helper shared by the real journey and fast Python fixtures. It validates the complete `server_started` event set by exact count and allowed alias, fails closed on malformed or unreadable JSONL, rejects unrelated or duplicate starts, and permits one TTS sidecar only after explicit Start.
- Preserve Dictation Loading-before-Listening through structural status predicates and the real warmup event.
- Parse GUI CI gating and failure-evidence routing as structured YAML.
- Keep the cross-language image request-size default as one documented minimal anchor pair because no Python behavioral proxy crosses that boundary.

## Scope / Non-goals

This is the first #2494 test family. It changes the contract test plus behavior-preserving helpers in `gui-golden-flows.sh`. No production Swift behavior, workflow content, baseline, version, or other #2494 family changes.

## Verification

- `tests/test_gui_control_behavior_contract.py`: 16 passed.
- Adjacent golden/preflight contract set: 43 passed after the prior review fixes.
- Bash syntax, Ruff check/format, and diff checks: clean.
- No MLX, network, GUI, model, or XCUITest dependency in the focused tests.

## Design precedent

The existing GUI CI contracts already parse workflow YAML structurally and keep small self-checking inventories. This PR applies that established repository pattern and moves failure semantics into executable helpers so the contract verifies outcomes rather than message wording.

