### PR TITLE
ops: harden shared macOS host lanes

### DIFF
--- a/apps/rapid-mac/scripts/dogfood-host-precheck.sh
+++ b/apps/rapid-mac/scripts/dogfood-host-precheck.sh
@@ -8,12 +8,11 @@ if [[ "${CI:-}" == "true" && "${RAPID_HOST_SAFETY_TESTING:-0}" != "1" ]]; then
     [[ "${1:-}" == "--" ]] && shift && exec "$@"
     exit 0
 fi
-[[ "$(uname -s)" == "Darwin" ]] || die "macOS is required"
-
 if [[ "${RAPID_HOST_SAFETY_TESTING:-0}" == "1" ]]; then
     locked="${RAPID_HOST_TEST_LOCKED:-false}"
     idle="${RAPID_HOST_TEST_IDLE_TIME:-0}"
 else
+    [[ "$(uname -s)" == "Darwin" ]] || die "macOS is required"
     locked="$(/usr/sbin/ioreg -n Root -d1 -a | /usr/bin/plutil -extract IOConsoleLocked raw - 2>/dev/null || printf true)"
     idle="$(/usr/bin/defaults -currentHost read com.apple.screensaver idleTime 2>/dev/null || printf missing)"
 fi

--- a/apps/rapid-mac/scripts/dogfood-host-precheck.sh
+++ b/apps/rapid-mac/scripts/dogfood-host-precheck.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 die() { printf 'dogfood-host-precheck: FAIL: %s\n' "$*" >&2; exit 1; }
 
-if [[ "${CI:-}" == "true" ]]; then
+if [[ "${CI:-}" == "true" && "${RAPID_HOST_SAFETY_TESTING:-0}" != "1" ]]; then
     [[ "${1:-}" == "--" ]] && shift && exec "$@"
     exit 0
 fi

--- a/apps/rapid-mac/scripts/dogfood-host-precheck.sh
+++ b/apps/rapid-mac/scripts/dogfood-host-precheck.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fail before a GUI lane starts on a locked/sleeping host; keep it awake while it runs.
+set -euo pipefail
+
+die() { printf 'dogfood-host-precheck: FAIL: %s\n' "$*" >&2; exit 1; }
+
+if [[ "${CI:-}" == "true" ]]; then
+    [[ "${1:-}" == "--" ]] && shift && exec "$@"
+    exit 0
+fi
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS is required"
+
+if [[ "${RAPID_HOST_SAFETY_TESTING:-0}" == "1" ]]; then
+    locked="${RAPID_HOST_TEST_LOCKED:-false}"
+    idle="${RAPID_HOST_TEST_IDLE_TIME:-0}"
+else
+    locked="$(/usr/sbin/ioreg -n Root -d1 -a | /usr/bin/plutil -extract IOConsoleLocked raw - 2>/dev/null || printf true)"
+    idle="$(/usr/bin/defaults -currentHost read com.apple.screensaver idleTime 2>/dev/null || printf missing)"
+fi
+[[ "$locked" == "false" || "$locked" == "0" ]] || die "console is locked"
+[[ "$idle" == "0" ]] || die "screensaver idleTime must be 0 (got $idle)"
+
+if [[ "${1:-}" == "--" ]]; then
+    shift
+    [[ $# -gt 0 ]] || die "missing command after --"
+    # Watch this shell's PID, then replace the shell with the lane command.
+    # The assertion ends with that PID, while exec preserves the PID expected
+    # by AX tooling and process-owned cleanup.
+    /usr/bin/caffeinate -dimsu -w $$ >/dev/null 2>&1 &
+    exec "$@"
+fi
+printf 'dogfood-host-precheck: PASS (unlocked, idleTime=0)\n'

--- a/apps/rapid-mac/scripts/dogfood-isolate.sh
+++ b/apps/rapid-mac/scripts/dogfood-isolate.sh
@@ -39,6 +39,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
 print_help() {
     cat <<'EOF'
 dogfood-isolate.sh — CFPreferences-isolated copy of a built .app
@@ -61,6 +64,10 @@ ENVIRONMENT:
     DOGFOOD_PORT=<49152-65535>
                    Pin the isolated app to this port. By default the helper
                    chooses a free high port from the persona's random suffix.
+    DOGFOOD_WORKING_SET_GB=<number>
+                   Estimated model working set for host admission. Defaults
+                   conservatively to 21 GiB, which serializes real Desktop
+                   dogfood on the shared large-model lock.
 
 OUTPUT:
     Progress and diagnostics are written to STDERR.
@@ -336,6 +343,18 @@ fi
 mkdir -p "$HOME_DIR/Library/Application Support"
 printf 'Created by dogfood-isolate.sh. Safe to delete with the target dir.\n' \
     > "$HOME_MARKER"
+printf 'Created by dogfood-isolate.sh. Cleanup requires .dogfood-finished.\n' \
+    > "$TARGET_ABS/.dogfood-owned"
+
+# Keep the generated persona runnable after its source worktree is retired.
+# Both helpers are small and immutable for the persona's lifetime.
+SAFETY_DIR="$TARGET_ABS/.rapid-host-safety"
+mkdir -p "$SAFETY_DIR"
+cp "$SCRIPT_DIR/dogfood-host-precheck.sh" "$SAFETY_DIR/"
+cp "$REPO_ROOT/scripts/large-model-run.py" "$SAFETY_DIR/"
+cp "$REPO_ROOT/vllm_mlx/aliases.json" "$SAFETY_DIR/"
+cp "$REPO_ROOT/vllm_mlx/model_sizes.json" "$SAFETY_DIR/"
+chmod +x "$SAFETY_DIR/dogfood-host-precheck.sh" "$SAFETY_DIR/large-model-run.py"
 
 # The model cache is the one thing worth SHARING by default: it is tens of
 # gigabytes and mostly read, and re-downloading it per run makes isolation
@@ -387,9 +406,30 @@ export RAPID_DESKTOP_NO_PORT_SWEEP=1
 # would quietly point the run back at their real cache — including under
 # DOGFOOD_COLD_MODEL_CACHE=1, where the whole point is that there isn't one.
 unset HF_HUB_CACHE
-exec "$TARGET_APP/Contents/MacOS/$EXECUTABLE" "\$@"
+rm -f "$TARGET_ABS/.dogfood-finished"
+if [[ "\${CI:-}" == "true" ]]; then
+    exec "$TARGET_APP/Contents/MacOS/$EXECUTABLE" "\$@"
+fi
+working_set_gb="\${DOGFOOD_WORKING_SET_GB:-21}"
+exec "$SAFETY_DIR/dogfood-host-precheck.sh" -- \
+    python3 "$SAFETY_DIR/large-model-run.py" \
+        --working-set-gb "\$working_set_gb" -- \
+        "$TARGET_APP/Contents/MacOS/$EXECUTABLE" "\$@"
 LAUNCHEOF
 chmod +x "$LAUNCHER"
+
+FINISHER="$TARGET_ABS/finish.sh"
+cat > "$FINISHER" <<FINISHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+if pgrep -f "$TARGET_APP" >/dev/null 2>&1; then
+    echo "finish.sh: isolated app is still running: $TARGET_APP" >&2
+    exit 1
+fi
+touch "$TARGET_ABS/.dogfood-finished"
+echo "finish.sh: marked finished: $TARGET_ABS"
+FINISHEOF
+chmod +x "$FINISHER"
 
 # --- done --------------------------------------------------------------------
 log "isolated .app ready: $TARGET_APP"
@@ -399,6 +439,8 @@ log "  model cache:    $HF_HOME_FOR_RUN"
 log "  isolated port:  $ISOLATED_PORT (launch sweep disabled)"
 log "  LAUNCH WITH:   $LAUNCHER &          # NOT 'open -n' — that drops \$HOME"
 log "  cleanup later: defaults delete '$NEW_ID' && rm -rf '$TARGET_ABS'"
+log "  shared cleanup: run '$FINISHER' after the app exits; hygiene will then"
+log "                  consider this directory after its minimum age"
 log "  shutdown:      pkill -f '$TARGET_APP'    # path-qualified, do NOT use bare 'pkill -f Rapid'"
 log ""
 log "  STILL SHARED (not isolated by this script):"

--- a/apps/rapid-mac/scripts/gui-ax-smoke.sh
+++ b/apps/rapid-mac/scripts/gui-ax-smoke.sh
@@ -7,6 +7,12 @@
 # plus screenshots for diagnosis.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "${RAPID_HOST_PRECHECK_HELD:-0}" != "1" && "${CI:-}" != "true" ]]; then
+    export RAPID_HOST_PRECHECK_HELD=1
+    exec "$SCRIPT_DIR/dogfood-host-precheck.sh" -- "$0" "$@"
+fi
+
 APP="${RAPID_GUI_APP:-Rapid-MLX}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT="${RAPID_GUI_OUT:-/tmp/rapid-gui-ax-${STAMP}}"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -582,6 +582,7 @@ start_persona() {
         mv "$updated" "$config"
     done
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+        DOGFOOD_WORKING_SET_GB=0.1 \
         FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
         "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
         "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
@@ -597,6 +598,7 @@ relaunch_persona() {
     # killing the old fake (and potentially an operator's real server too).
     cleanup_fake_sidecars
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+        DOGFOOD_WORKING_SET_GB=0.1 \
         FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
         "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
         "$PERSONA/launch.sh" >> "$OUT/app.log" 2>&1 &

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -6,6 +6,8 @@
 # fake sidecar keeps the suite deterministic and prevents model-related OOMs.
 set -euo pipefail
 
+ORIGINAL_ARGS=("$@")
+
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_SOURCE="${RAPID_GUI_SOURCE_APP:-$ROOT/build/Rapid-MLX Desktop.app}"
 OUT_ROOT="${RAPID_GUI_GOLDEN_OUT:-/tmp/rapid-gui-golden-$(date -u +%Y%m%dT%H%M%SZ)}"
@@ -106,6 +108,11 @@ if [[ -n "${GUI_FLOWS:-}" && "$FLOW" != all ]]; then
     else
         printf '[gui-golden] WARN: invalid GUI_FLOWS; running %s fail-closed\n' "$FLOW" >&2
     fi
+fi
+
+if [[ "${RAPID_HOST_PRECHECK_HELD:-0}" != "1" && "${CI:-}" != "true" ]]; then
+    export RAPID_HOST_PRECHECK_HELD=1
+    exec "$ROOT/scripts/dogfood-host-precheck.sh" -- "$0" "${ORIGINAL_ARGS[@]}"
 fi
 
 log() { printf '[gui-golden] %s\n' "$*"; }

--- a/docs/engineering/operations/shared-macos-host-safety.md
+++ b/docs/engineering/operations/shared-macos-host-safety.md
@@ -19,8 +19,10 @@ deleted by this command.
 `--apply` is destructive and is reserved for an explicitly authorized cleanup.
 Even then, a worktree must be older than six hours, live below the configured
 scratch root, be porcelain-clean, have an upstream, have no unpushed commits,
-and have no open files. The script rechecks those conditions immediately before
-removal and uses `git worktree remove` rather than deleting a registered tree.
+A branch with an open pull request is retained, and inability to read pull
+request state makes every worktree ineligible. The script also requires no open
+files, rechecks all conditions immediately before removal, and uses
+`git worktree remove` rather than deleting a registered tree.
 A dogfood directory needs both tool-owned and operator-finished markers.
 
 ## Run model loads

--- a/docs/engineering/operations/shared-macos-host-safety.md
+++ b/docs/engineering/operations/shared-macos-host-safety.md
@@ -1,0 +1,57 @@
+# Shared macOS host safety
+
+These helpers keep release builds, GUI dogfood, and large-model verification
+from interfering with one another on a shared Mac.
+
+## Report host hygiene
+
+Run the report from any registered Rapid-MLX worktree:
+
+```bash
+scripts/studio-hygiene.sh --repo /path/to/rapid-mlx
+```
+
+Dry-run is the default. The report identifies each registered worktree and why
+it is retained, lists finished dogfood directories eligible for cleanup, and
+marks the protected model inventory as untouchable. Model caches are never
+deleted by this command.
+
+`--apply` is destructive and is reserved for an explicitly authorized cleanup.
+Even then, a worktree must be older than six hours, live below the configured
+scratch root, be porcelain-clean, have an upstream, have no unpushed commits,
+and have no open files. The script rechecks those conditions immediately before
+removal and uses `git worktree remove` rather than deleting a registered tree.
+A dogfood directory needs both tool-owned and operator-finished markers.
+
+## Run model loads
+
+Wrap a direct model command so loads with an estimated working set above 20 GiB
+share one host-wide lock:
+
+```bash
+python3 scripts/large-model-run.py --model qwen3.5-35b-4bit -- \
+  rapid-mlx serve qwen3.5-35b-4bit
+```
+
+The wrapper estimates the working set from the checked-in alias and size
+registries. Unknown models fail closed and require `--working-set-gb`. After
+acquiring the lock, it checks available memory again and preserves a 4 GiB
+reserve before executing the command. The dogfood MVP and generated Desktop
+dogfood launchers already use this wrapper.
+
+## Prepare GUI and VM lanes
+
+`apps/rapid-mac/scripts/dogfood-host-precheck.sh` rejects a locked console or a
+nonzero screensaver idle time before a local GUI lane starts. When given a
+command after `--`, it keeps the host awake for exactly that process lifetime.
+The AX smoke and golden-flow launchers invoke it automatically outside hosted
+CI.
+
+For a Tart guest, use a bounded guest-agent wait instead of a fixed sleep:
+
+```bash
+scripts/tart-guest-ready.sh --timeout 120 rapid-mac-ci
+```
+
+The command succeeds only after `tart exec` works, and otherwise exits with a
+clear timeout.

--- a/scripts/large-model-run.py
+++ b/scripts/large-model-run.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Serialize large model commands and re-check memory while holding the lock."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[0]
+ALIASES = (
+    SCRIPT_DIR / "aliases.json"
+    if (SCRIPT_DIR / "aliases.json").is_file()
+    else ROOT / "vllm_mlx/aliases.json"
+)
+SIZES = (
+    SCRIPT_DIR / "model_sizes.json"
+    if (SCRIPT_DIR / "model_sizes.json").is_file()
+    else ROOT / "vllm_mlx/model_sizes.json"
+)
+DEFAULT_LOCK = Path("/var/tmp/rapid-mlx-large-model.lock")
+GIB = 1024**3
+
+
+def estimate_gib(model: str) -> float:
+    aliases = json.loads(ALIASES.read_text())
+    repository = aliases.get(model, {}).get("hf_path", model)
+    sizes = json.loads(SIZES.read_text())["sizes"]
+    size = sizes.get(repository)
+    if not isinstance(size, int) or size <= 0:
+        raise ValueError(
+            f"model size is unknown for {model!r}; pass --working-set-gb explicitly"
+        )
+    return size * 1.5 / GIB
+
+
+def available_gib() -> float:
+    override = os.environ.get("RAPID_LARGE_MODEL_TEST_AVAILABLE_GB")
+    if override is not None:
+        if os.environ.get("RAPID_HOST_SAFETY_TESTING") != "1":
+            raise ValueError(
+                "test memory override requires RAPID_HOST_SAFETY_TESTING=1"
+            )
+        return float(override)
+    try:
+        import psutil
+
+        return psutil.virtual_memory().available / GIB
+    except ImportError:
+        page_size = int(subprocess.check_output(["sysctl", "-n", "hw.pagesize"]))
+        vm = subprocess.check_output(["vm_stat"], text=True)
+        pages = 0
+        for line in vm.splitlines():
+            if line.startswith(("Pages free:", "Pages inactive:", "Pages purgeable:")):
+                pages += int(line.rsplit(None, 1)[-1].rstrip("."))
+        return pages * page_size / GIB
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    choice = parser.add_mutually_exclusive_group(required=True)
+    choice.add_argument("--model")
+    choice.add_argument("--working-set-gb", type=float)
+    parser.add_argument("--threshold-gb", type=float, default=20.0)
+    parser.add_argument("--reserve-gb", type=float, default=4.0)
+    parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK)
+    parser.add_argument("--lock-timeout", type=int, default=7200)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a command is required after --")
+    required = (
+        args.working_set_gb
+        if args.working_set_gb is not None
+        else estimate_gib(args.model)
+    )
+    if required <= 0:
+        parser.error("working-set size must be positive")
+    if required <= args.threshold_gb:
+        os.execvp(command[0], command)
+
+    lockf = shutil.which("lockf")
+    if lockf is None:
+        print(
+            "large-model-run: lockf is required for a large model load", file=sys.stderr
+        )
+        return 2
+    if os.environ.get("RAPID_LARGE_MODEL_LOCK_HELD") != "1":
+        print(
+            f"large-model-run: waiting for host lock ({required:.1f} GiB working set)",
+            file=sys.stderr,
+            flush=True,
+        )
+        inner = [sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]]
+        env = dict(os.environ, RAPID_LARGE_MODEL_LOCK_HELD="1")
+        return subprocess.call(
+            [lockf, "-k", "-t", str(args.lock_timeout), str(args.lock_file), *inner],
+            env=env,
+        )
+
+    available = available_gib()
+    minimum = required + args.reserve_gb
+    if available < minimum:
+        print(
+            f"large-model-run: insufficient memory under lock: {available:.1f} GiB "
+            f"available, {minimum:.1f} GiB required ({required:.1f} + "
+            f"{args.reserve_gb:.1f} reserve)",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "large-model-run: host lock acquired; memory precheck passed", file=sys.stderr
+    )
+    os.execvp(command[0], command)
+    return 127
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(run())
+    except ValueError as exc:
+        print(f"large-model-run: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/scripts/large-model-run.py
+++ b/scripts/large-model-run.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -86,13 +87,14 @@ def run(argv: list[str] | None = None) -> int:
     if required <= args.threshold_gb:
         os.execvp(command[0], command)
 
-    lockf = shutil.which("lockf")
-    if lockf is None:
-        print(
-            "large-model-run: lockf is required for a large model load", file=sys.stderr
-        )
-        return 2
     if os.environ.get("RAPID_LARGE_MODEL_LOCK_HELD") != "1":
+        lockf = shutil.which("lockf")
+        if lockf is None:
+            print(
+                "large-model-run: lockf is required for a large model load",
+                file=sys.stderr,
+            )
+            return 2
         print(
             f"large-model-run: waiting for host lock ({required:.1f} GiB working set)",
             file=sys.stderr,
@@ -100,10 +102,26 @@ def run(argv: list[str] | None = None) -> int:
         )
         inner = [sys.executable, str(Path(__file__).resolve()), *raw_argv]
         env = dict(os.environ, RAPID_LARGE_MODEL_LOCK_HELD="1")
-        return subprocess.call(
+        child = subprocess.Popen(
             [lockf, "-k", "-t", str(args.lock_timeout), str(args.lock_file), *inner],
             env=env,
+            start_new_session=True,
         )
+        previous: dict[signal.Signals, object] = {}
+
+        def forward(signum: int, _frame: object) -> None:
+            try:
+                os.killpg(child.pid, signum)
+            except ProcessLookupError:
+                pass
+
+        for name in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            previous[name] = signal.signal(name, forward)
+        try:
+            return child.wait()
+        finally:
+            for name, handler in previous.items():
+                signal.signal(name, handler)
 
     available = available_gib()
     minimum = required + args.reserve_gb

--- a/scripts/large-model-run.py
+++ b/scripts/large-model-run.py
@@ -62,6 +62,7 @@ def available_gib() -> float:
 
 
 def run(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
     parser = argparse.ArgumentParser()
     choice = parser.add_mutually_exclusive_group(required=True)
     choice.add_argument("--model")
@@ -71,7 +72,7 @@ def run(argv: list[str] | None = None) -> int:
     parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK)
     parser.add_argument("--lock-timeout", type=int, default=7200)
     parser.add_argument("command", nargs=argparse.REMAINDER)
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
     command = args.command[1:] if args.command[:1] == ["--"] else args.command
     if not command:
         parser.error("a command is required after --")
@@ -97,7 +98,7 @@ def run(argv: list[str] | None = None) -> int:
             file=sys.stderr,
             flush=True,
         )
-        inner = [sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]]
+        inner = [sys.executable, str(Path(__file__).resolve()), *raw_argv]
         env = dict(os.environ, RAPID_LARGE_MODEL_LOCK_HELD="1")
         return subprocess.call(
             [lockf, "-k", "-t", str(args.lock_timeout), str(args.lock_file), *inner],

--- a/scripts/protected_models.json
+++ b/scripts/protected_models.json
@@ -1,0 +1,20 @@
+{
+  "schema": 1,
+  "models": [
+    {"repository": "mlx-community/Qwen3.5-9B-4bit", "revision": "8b2b98c00a6b4d291155e4890773ca8f769aee53", "sources": ["sidecar", "telemetry_top10"]},
+    {"repository": "mlx-community/gemma-4-e2b-it-8bit", "revision": "03dcf209f3f549b4075e7191e77cf69b3d48e1b2", "sources": ["sidecar"]},
+    {"repository": "mlx-community/Qwen3.5-4B-MLX-4bit", "sources": ["release_fleet", "telemetry_top10"]},
+    {"repository": "mlx-community/Qwen3.5-35B-A3B-4bit", "sources": ["release_fleet"]},
+    {"repository": "mlx-community/Qwen3.6-27B-4bit", "sources": ["release_fleet", "telemetry_top10"]},
+    {"repository": "mlx-community/Qwen3.6-35B-A3B-4bit", "sources": ["telemetry_top10"]},
+    {"repository": "mlx-community/Qwen3.6-35B-A3B-8bit", "sources": ["telemetry_top10"]},
+    {"repository": "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX", "sources": ["telemetry_top10"]},
+    {"repository": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX", "sources": ["telemetry_top10"]},
+    {"repository": "mlx-community/gemma-4-26b-a4b-it-4bit", "sources": ["telemetry_top10"]},
+    {"repository": "prism-ml/Ternary-Bonsai-27B-mlx-2bit", "sources": ["telemetry_top10"]},
+    {"repository": "mlx-community/gemma-4-12B-it-4bit", "sources": ["release_fleet"]},
+    {"repository": "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit", "sources": ["release_fleet"]},
+    {"repository": "mlx-community/gpt-oss-20b-MXFP4-Q8", "sources": ["release_fleet"]},
+    {"repository": "mlx-community/Hy3-preview-4bit", "sources": ["release_fleet"]}
+  ]
+}

--- a/scripts/protected_models.py
+++ b/scripts/protected_models.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate and print the host-hygiene protected model inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = Path(__file__).with_name("protected_models.json")
+
+
+def cache_name(repository: str) -> str:
+    return "models--" + repository.replace("/", "--")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> list[dict[str, object]]:
+    raw = json.loads(path.read_text())
+    if raw.get("schema") != 1 or not isinstance(raw.get("models"), list):
+        raise ValueError("protected-model manifest must use schema 1 with models")
+    seen: set[str] = set()
+    result: list[dict[str, object]] = []
+    for model in raw["models"]:
+        repository = model.get("repository")
+        sources = model.get("sources")
+        if not isinstance(repository, str) or repository.count("/") != 1:
+            raise ValueError(f"invalid protected repository: {repository!r}")
+        if repository in seen:
+            raise ValueError(f"duplicate protected repository: {repository}")
+        if (
+            not isinstance(sources, list)
+            or not sources
+            or not all(isinstance(source, str) for source in sources)
+        ):
+            raise ValueError(f"{repository} needs non-empty sources")
+        revision = model.get("revision")
+        if revision is not None and (
+            not isinstance(revision, str) or len(revision) != 40
+        ):
+            raise ValueError(f"{repository} has an invalid pinned revision")
+        seen.add(repository)
+        result.append(model)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--cache-names", action="store_true")
+    args = parser.parse_args(argv)
+    for model in load_manifest(args.manifest):
+        repository = str(model["repository"])
+        if args.cache_names:
+            print(cache_name(repository))
+            continue
+        revision = model.get("revision")
+        pin = f"@{revision}" if revision else ""
+        print(f"{repository}{pin}\t{','.join(model['sources'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -28,6 +28,8 @@
 
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 MODEL="${MODEL:-qwen3.5-35b}"
 PORT="${PORT:-8765}"
 API_KEY="${API_KEY:-$(openssl rand -hex 24)}"
@@ -136,7 +138,16 @@ echo "Starting $RAPID_MLX_CMD ($MODEL on :$PORT) [extra: $EXTRA_SERVE_ARGS] …"
 # (e.g. `--cors-origins *`) survives the unquoted expansion instead of
 # globbing against $PWD. Restore right after.
 set -f
-nohup $RAPID_MLX_CMD serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
+if [[ -n "${DOGFOOD_WORKING_SET_GB:-}" ]]; then
+  size_args=(--working-set-gb "$DOGFOOD_WORKING_SET_GB")
+else
+  size_args=(--model "$MODEL")
+fi
+# The wrapper execs the serve command, so SERVER_PID remains the process that
+# owns the host lock and stop/status retain their existing ownership semantics.
+# shellcheck disable=SC2086  # RAPID_MLX_CMD and EXTRA_SERVE_ARGS are command fragments by contract.
+nohup python3 "$ROOT/scripts/large-model-run.py" "${size_args[@]}" -- \
+  $RAPID_MLX_CMD serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \
   --log-level INFO $EXTRA_SERVE_ARGS >"$SERVER_LOG" 2>&1 &
 set +f
 echo $! > "$SERVER_PID"

--- a/scripts/run_dogfood_mvp.sh
+++ b/scripts/run_dogfood_mvp.sh
@@ -143,8 +143,9 @@ if [[ -n "${DOGFOOD_WORKING_SET_GB:-}" ]]; then
 else
   size_args=(--model "$MODEL")
 fi
-# The wrapper execs the serve command, so SERVER_PID remains the process that
-# owns the host lock and stop/status retain their existing ownership semantics.
+# SERVER_PID owns the locked process group. The wrapper forwards stop signals
+# to lockf and every server descendant before it exits, so cleanup cannot
+# orphan a model server behind a dead wrapper.
 # shellcheck disable=SC2086  # RAPID_MLX_CMD and EXTRA_SERVE_ARGS are command fragments by contract.
 nohup python3 "$ROOT/scripts/large-model-run.py" "${size_args[@]}" -- \
   $RAPID_MLX_CMD serve "$MODEL" --port "$PORT" --api-key "$API_KEY" \

--- a/scripts/studio-hygiene.sh
+++ b/scripts/studio-hygiene.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Report-first shared-host cleanup. Mutations require the explicit --apply flag.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 "$ROOT/scripts/studio_hygiene.py" "$@"

--- a/scripts/studio_hygiene.py
+++ b/scripts/studio_hygiene.py
@@ -74,7 +74,7 @@ def open_pr_heads(repo: Path) -> set[str] | None:
             "--state",
             "open",
             "--limit",
-            "200",
+            "1000",
             "--json",
             "headRefName",
         ],
@@ -86,7 +86,10 @@ def open_pr_heads(repo: Path) -> set[str] | None:
     if result.returncode:
         return None
     try:
-        return {row["headRefName"] for row in json.loads(result.stdout)}
+        rows = json.loads(result.stdout)
+        if len(rows) >= 1000:
+            return None
+        return {row["headRefName"] for row in rows}
     except (json.JSONDecodeError, KeyError, TypeError):
         return None
 

--- a/scripts/studio_hygiene.py
+++ b/scripts/studio_hygiene.py
@@ -180,7 +180,7 @@ def stale_rapid_dmg(image: Path, mount: Path, cutoff: float) -> bool:
     if not image.is_file() or not mount.is_dir():
         return False
     mount_text = str(mount.resolve())
-    tool_mount = mount_text.startswith("/private/tmp/rapid-") or (
+    tool_mount = mount_text.startswith(("/private/tmp/rapid-", "/tmp/rapid-")) or (
         mount_text.startswith("/private/var/folders/")
         and mount.name.startswith("rapid-")
     )
@@ -191,6 +191,30 @@ def stale_rapid_dmg(image: Path, mount: Path, cutoff: float) -> bool:
     if max(image.stat().st_mtime, mount.stat().st_mtime) >= cutoff:
         return False
     return not in_use(mount)
+
+
+def owner_remains_removable(
+    repo: Path,
+    owner: Path,
+    worktree_owners: set[Path],
+    dogfood_owners: set[Path],
+    scratch: Path,
+    cutoff: float,
+) -> bool:
+    if owner in worktree_owners:
+        heads = open_pr_heads(repo)
+        if heads is None or not owner.resolve().is_relative_to(scratch):
+            return False
+        current = next(
+            (row for row in worktrees(repo) if Path(row["path"]) == owner), None
+        )
+        return (
+            current is not None
+            and classify_worktree(repo, current, cutoff, heads) == "eligible"
+        )
+    if owner in dogfood_owners:
+        return owner in set(finished_dogfood_dirs(scratch, cutoff))
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -237,6 +261,7 @@ def main(argv: list[str] | None = None) -> int:
 
     dogfoods = finished_dogfood_dirs(scratch, cutoff)
     dogfood_set = set(dogfoods)
+    worktree_set = set(eligible_worktrees)
     removable_owners = [*eligible_worktrees, *dogfoods]
     for image, mount in mounted_images():
         owner = next(
@@ -251,6 +276,15 @@ def main(argv: list[str] | None = None) -> int:
         action = "eligible" if owner or legacy_stale else "skip-unowned"
         print(f"DMG {action} {mount} image={image}")
         if args.apply and (owner or legacy_stale):
+            if owner is not None and (
+                in_use(mount)
+                or not owner_remains_removable(
+                    repo, owner, worktree_set, dogfood_set, scratch, cutoff
+                )
+            ):
+                raise RuntimeError(
+                    f"DMG owner or mount changed after planning; refusing: {mount}"
+                )
             if owner is None and not stale_rapid_dmg(image, mount, cutoff):
                 raise RuntimeError(
                     f"DMG mount changed after planning; refusing: {mount}"
@@ -260,10 +294,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"DOGFOOD eligible {path}")
 
     if args.apply:
-        current_open_heads = open_pr_heads(repo)
-        if current_open_heads is None:
-            raise RuntimeError("GitHub PR state unavailable at apply time; refusing")
         for path in eligible_worktrees:
+            current_open_heads = open_pr_heads(repo)
+            if current_open_heads is None:
+                raise RuntimeError(
+                    "GitHub PR state unavailable at apply time; refusing"
+                )
             current = next(
                 (row for row in worktrees(repo) if Path(row["path"]) == path), None
             )

--- a/scripts/studio_hygiene.py
+++ b/scripts/studio_hygiene.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Conservative, report-first hygiene for a shared macOS build host."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from protected_models import cache_name, load_manifest
+
+
+def command(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    result = subprocess.run(args, cwd=cwd, check=False, text=True, capture_output=True)
+    if check and result.returncode:
+        raise RuntimeError(result.stderr.strip() or "command failed: " + " ".join(args))
+    return result.stdout
+
+
+def worktrees(repo: Path) -> list[dict[str, object]]:
+    fields: dict[str, object] | None = None
+    rows: list[dict[str, object]] = []
+    raw = command("git", "worktree", "list", "--porcelain", "-z", cwd=repo)
+    for token in raw.split("\0"):
+        if not token:
+            if fields:
+                rows.append(fields)
+                fields = None
+            continue
+        key, _, value = token.partition(" ")
+        if key == "worktree":
+            if fields:
+                rows.append(fields)
+            fields = {"path": Path(value)}
+        elif fields is not None:
+            fields[key] = value if value else True
+    if fields:
+        rows.append(fields)
+    return rows
+
+
+def in_use(path: Path) -> bool:
+    lsof = shutil.which("lsof")
+    if not lsof:
+        return True
+    try:
+        result = subprocess.run(
+            [lsof, "+D", str(path)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return True
+    return result.returncode == 0
+
+
+def classify_worktree(repo: Path, row: dict[str, object], cutoff: float) -> str:
+    path = Path(row["path"])
+    if path.resolve() == repo.resolve():
+        return "primary"
+    if "locked" in row:
+        return "locked"
+    if not path.exists():
+        return "missing"
+    if path.stat().st_mtime >= cutoff:
+        return "recent"
+    if command("git", "status", "--porcelain", cwd=path).strip():
+        return "dirty"
+    upstream = command(
+        "git", "rev-parse", "--abbrev-ref", "@{upstream}", cwd=path, check=False
+    ).strip()
+    if not upstream:
+        return "no-upstream"
+    ahead = command("git", "rev-list", "--count", f"{upstream}..HEAD", cwd=path)
+    if int(ahead) != 0:
+        return "unpushed"
+    if in_use(path):
+        return "in-use"
+    return "eligible"
+
+
+def finished_dogfood_dirs(scratch: Path, cutoff: float) -> list[Path]:
+    if not scratch.exists():
+        return []
+    rows: list[Path] = []
+    for marker in scratch.glob("rapid-*/.dogfood-finished"):
+        candidate = marker.parent.resolve()
+        try:
+            candidate.relative_to(scratch.resolve())
+        except ValueError:
+            continue
+        if (
+            (candidate / ".dogfood-owned").is_file()
+            and candidate.stat().st_mtime < cutoff
+            and not in_use(candidate)
+        ):
+            rows.append(candidate)
+    return rows
+
+
+def mounted_images() -> list[tuple[Path, Path]]:
+    if sys.platform != "darwin" or not shutil.which("hdiutil"):
+        return []
+    raw = command("hdiutil", "info", "-plist", check=False)
+    if not raw:
+        return []
+    import plistlib
+
+    result: list[tuple[Path, Path]] = []
+    for image in plistlib.loads(raw.encode()).get("images", []):
+        image_path = image.get("image-path")
+        if not image_path:
+            continue
+        for entity in image.get("system-entities", []):
+            mount = entity.get("mount-point")
+            if mount:
+                result.append((Path(image_path), Path(mount)))
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--scratch", type=Path, default=Path("/private/tmp"))
+    parser.add_argument("--min-age-hours", type=float, default=6)
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+    repo = args.repo.resolve()
+    scratch = args.scratch.resolve()
+    if scratch == Path("/") or str(scratch).startswith("/Volumes/Extreme SSD"):
+        parser.error("scratch must be a narrow local directory, never / or Extreme SSD")
+    cutoff = time.time() - args.min_age_hours * 3600
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"MODE {mode}")
+
+    hf_root = Path(
+        os.environ.get(
+            "HF_HUB_CACHE",
+            Path(os.environ.get("HF_HOME", Path.home() / ".cache/huggingface")) / "hub",
+        )
+    )
+    for model in load_manifest():
+        cache = hf_root / cache_name(str(model["repository"]))
+        state = "present" if cache.exists() else "absent"
+        print(f"PROTECTED {model['repository']} {state} {cache}")
+    print("POLICY model caches are report-only and are never removed")
+
+    eligible_worktrees: list[Path] = []
+    for row in worktrees(repo):
+        path = Path(row["path"])
+        reason = classify_worktree(repo, row, cutoff)
+        if reason == "eligible" and not path.resolve().is_relative_to(scratch):
+            reason = "outside-scratch"
+        print(f"WORKTREE {reason} {path}")
+        if reason == "eligible":
+            eligible_worktrees.append(path)
+
+    dogfoods = finished_dogfood_dirs(scratch, cutoff)
+    dogfood_set = set(dogfoods)
+    removable_owners = [*eligible_worktrees, *dogfoods]
+    for image, mount in mounted_images():
+        owner = next(
+            (
+                path
+                for path in removable_owners
+                if image.resolve().is_relative_to(path.resolve())
+            ),
+            None,
+        )
+        action = "eligible" if owner else "skip-unowned"
+        print(f"DMG {action} {mount} image={image}")
+        if args.apply and owner:
+            subprocess.run(["hdiutil", "detach", str(mount)], check=True)
+    for path in dogfoods:
+        print(f"DOGFOOD eligible {path}")
+
+    if args.apply:
+        for path in eligible_worktrees:
+            current = next(
+                (row for row in worktrees(repo) if Path(row["path"]) == path), None
+            )
+            if current is None or classify_worktree(repo, current, cutoff) != "eligible":
+                raise RuntimeError(f"worktree changed after planning; refusing: {path}")
+            subprocess.run(
+                ["git", "worktree", "remove", str(path)], cwd=repo, check=True
+            )
+            print(f"REMOVED worktree {path}")
+        for path in dogfood_set:
+            marker = path / ".dogfood-finished"
+            if (
+                not path.resolve().is_relative_to(scratch)
+                or not marker.is_file()
+                or not (path / ".dogfood-owned").is_file()
+                or in_use(path)
+            ):
+                raise RuntimeError(f"dogfood changed after planning; refusing: {path}")
+            shutil.rmtree(path)
+            print(f"REMOVED dogfood {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/studio_hygiene.py
+++ b/scripts/studio_hygiene.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Set
 from pathlib import Path
 
 from protected_models import cache_name, load_manifest
@@ -60,7 +62,41 @@ def in_use(path: Path) -> bool:
     return result.returncode == 0
 
 
-def classify_worktree(repo: Path, row: dict[str, object], cutoff: float) -> str:
+def open_pr_heads(repo: Path) -> set[str] | None:
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    result = subprocess.run(
+        [
+            gh,
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "headRefName",
+        ],
+        cwd=repo,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        return None
+    try:
+        return {row["headRefName"] for row in json.loads(result.stdout)}
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def classify_worktree(
+    repo: Path,
+    row: dict[str, object],
+    cutoff: float,
+    open_heads: Set[str] | None = frozenset(),
+) -> str:
     path = Path(row["path"])
     if path.resolve() == repo.resolve():
         return "primary"
@@ -87,6 +123,11 @@ def classify_worktree(repo: Path, row: dict[str, object], cutoff: float) -> str:
     ahead = command("git", "rev-list", "--count", f"{upstream}..HEAD", cwd=path)
     if int(ahead) != 0:
         return "unpushed"
+    branch = str(row.get("branch", "")).removeprefix("refs/heads/")
+    if open_heads is None:
+        return "pr-status-unknown"
+    if branch in open_heads:
+        return "open-pr"
     if in_use(path):
         return "in-use"
     return "eligible"
@@ -131,6 +172,24 @@ def mounted_images() -> list[tuple[Path, Path]]:
     return result
 
 
+def stale_rapid_dmg(image: Path, mount: Path, cutoff: float) -> bool:
+    """Recognize only old tool-owned temporary mounts, including legacy ones."""
+    if not image.is_file() or not mount.is_dir():
+        return False
+    mount_text = str(mount.resolve())
+    tool_mount = mount_text.startswith("/private/tmp/rapid-") or (
+        mount_text.startswith("/private/var/folders/")
+        and mount.name.startswith("rapid-")
+    )
+    if not tool_mount:
+        return False
+    if not (image.name.startswith("rapid-mlx-desktop") and image.name.endswith(".dmg")):
+        return False
+    if max(image.stat().st_mtime, mount.stat().st_mtime) >= cutoff:
+        return False
+    return not in_use(mount)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", type=Path, default=Path.cwd())
@@ -160,10 +219,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"PROTECTED {model['repository']} {state} {cache}")
     print("POLICY model caches are report-only and are never removed")
 
+    open_heads = open_pr_heads(repo)
+    if open_heads is None:
+        print("POLICY GitHub PR state unavailable; no worktree is cleanup-eligible")
     eligible_worktrees: list[Path] = []
     for row in worktrees(repo):
         path = Path(row["path"])
-        reason = classify_worktree(repo, row, cutoff)
+        reason = classify_worktree(repo, row, cutoff, open_heads)
         if reason == "eligible" and not path.resolve().is_relative_to(scratch):
             reason = "outside-scratch"
         print(f"WORKTREE {reason} {path}")
@@ -182,21 +244,30 @@ def main(argv: list[str] | None = None) -> int:
             ),
             None,
         )
-        action = "eligible" if owner else "skip-unowned"
+        legacy_stale = owner is None and stale_rapid_dmg(image, mount, cutoff)
+        action = "eligible" if owner or legacy_stale else "skip-unowned"
         print(f"DMG {action} {mount} image={image}")
-        if args.apply and owner:
+        if args.apply and (owner or legacy_stale):
+            if owner is None and not stale_rapid_dmg(image, mount, cutoff):
+                raise RuntimeError(
+                    f"DMG mount changed after planning; refusing: {mount}"
+                )
             subprocess.run(["hdiutil", "detach", str(mount)], check=True)
     for path in dogfoods:
         print(f"DOGFOOD eligible {path}")
 
     if args.apply:
+        current_open_heads = open_pr_heads(repo)
+        if current_open_heads is None:
+            raise RuntimeError("GitHub PR state unavailable at apply time; refusing")
         for path in eligible_worktrees:
             current = next(
                 (row for row in worktrees(repo) if Path(row["path"]) == path), None
             )
             if (
                 current is None
-                or classify_worktree(repo, current, cutoff) != "eligible"
+                or classify_worktree(repo, current, cutoff, current_open_heads)
+                != "eligible"
             ):
                 raise RuntimeError(f"worktree changed after planning; refusing: {path}")
             subprocess.run(

--- a/scripts/studio_hygiene.py
+++ b/scripts/studio_hygiene.py
@@ -73,10 +73,17 @@ def classify_worktree(repo: Path, row: dict[str, object], cutoff: float) -> str:
     if command("git", "status", "--porcelain", cwd=path).strip():
         return "dirty"
     upstream = command(
-        "git", "rev-parse", "--abbrev-ref", "@{upstream}", cwd=path, check=False
+        "git",
+        "rev-parse",
+        "--symbolic-full-name",
+        "@{upstream}",
+        cwd=path,
+        check=False,
     ).strip()
     if not upstream:
         return "no-upstream"
+    if not upstream.startswith("refs/remotes/"):
+        return "non-remote-upstream"
     ahead = command("git", "rev-list", "--count", f"{upstream}..HEAD", cwd=path)
     if int(ahead) != 0:
         return "unpushed"
@@ -131,6 +138,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--min-age-hours", type=float, default=6)
     parser.add_argument("--apply", action="store_true")
     args = parser.parse_args(argv)
+    if args.min_age_hours <= 0:
+        parser.error("min-age-hours must be positive")
     repo = args.repo.resolve()
     scratch = args.scratch.resolve()
     if scratch == Path("/") or str(scratch).startswith("/Volumes/Extreme SSD"):
@@ -185,7 +194,10 @@ def main(argv: list[str] | None = None) -> int:
             current = next(
                 (row for row in worktrees(repo) if Path(row["path"]) == path), None
             )
-            if current is None or classify_worktree(repo, current, cutoff) != "eligible":
+            if (
+                current is None
+                or classify_worktree(repo, current, cutoff) != "eligible"
+            ):
                 raise RuntimeError(f"worktree changed after planning; refusing: {path}")
             subprocess.run(
                 ["git", "worktree", "remove", str(path)], cwd=repo, check=True

--- a/scripts/tart-guest-ready.sh
+++ b/scripts/tart-guest-ready.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Wait until Tart's guest agent can execute commands, with a bounded deadline.
+set -euo pipefail
+
+timeout=120
+interval=2
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --timeout) timeout="$2"; shift 2 ;;
+        --interval) interval="$2"; shift 2 ;;
+        -h|--help) echo "usage: tart-guest-ready.sh [--timeout SECONDS] [--interval SECONDS] VM"; exit 0 ;;
+        --*) echo "tart-guest-ready: unknown option $1" >&2; exit 2 ;;
+        *) vm="$1"; shift ;;
+    esac
+done
+[[ -n "${vm:-}" ]] || { echo "tart-guest-ready: VM is required" >&2; exit 2; }
+command -v tart >/dev/null || { echo "tart-guest-ready: tart is not installed" >&2; exit 2; }
+deadline=$((SECONDS + timeout))
+printf 'tart-guest-ready: waiting for %s (timeout %ss)\n' "$vm" "$timeout" >&2
+while (( SECONDS < deadline )); do
+    if tart exec "$vm" /usr/bin/true >/dev/null 2>&1; then
+        printf 'tart-guest-ready: %s is ready\n' "$vm"
+        exit 0
+    fi
+    sleep "$interval"
+done
+printf 'tart-guest-ready: timed out waiting for guest agent in %s\n' "$vm" >&2
+exit 1

--- a/tests/test_host_hygiene.py
+++ b/tests/test_host_hygiene.py
@@ -168,7 +168,7 @@ def test_only_old_unused_rapid_temp_dmg_mount_is_stale(
 ) -> None:
     image = tmp_path / "rapid-mlx-desktop.udrw.dmg"
     image.write_bytes(b"stub")
-    mount = Path(tempfile.mkdtemp(prefix="rapid-test-dmg-mount.", dir="/private/tmp"))
+    mount = Path(tempfile.mkdtemp(prefix="rapid-test-dmg-mount.", dir="/tmp"))
     old = time.time() - 10_000
     os.utime(image, (old, old))
     os.utime(mount, (old, old))
@@ -182,6 +182,58 @@ def test_only_old_unused_rapid_temp_dmg_mount_is_stale(
         assert not studio_hygiene.stale_rapid_dmg(
             image, Path("/Volumes/Rapid-MLX"), time.time() - 3600
         )
+    finally:
+        mount.rmdir()
+
+
+def test_apply_rechecks_owner_and_mount_before_detaching(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked").write_text("one\n")
+    _git(repo, "add", "tracked")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    tree = tmp_path / "eligible"
+    _git(repo, "worktree", "add", "-b", "eligible", str(tree), "main")
+    _git(tree, "push", "-u", "origin", "eligible")
+    image = tree / "rapid-mlx-desktop.dmg"
+    image.write_bytes(b"stub")
+    _git(tree, "add", image.name)
+    _git(tree, "commit", "-m", "artifact")
+    _git(tree, "push")
+    mount = Path(tempfile.mkdtemp(prefix="rapid-test-owner-mount.", dir="/tmp"))
+    old = time.time() - 10_000
+    os.utime(tree, (old, old))
+    os.utime(image, (old, old))
+    os.utime(mount, (old, old))
+    monkeypatch.setattr(studio_hygiene, "open_pr_heads", lambda _: set())
+    monkeypatch.setattr(studio_hygiene, "mounted_images", lambda: [(image, mount)])
+    monkeypatch.setattr(studio_hygiene, "in_use", lambda path: path == mount)
+    try:
+        with pytest.raises(RuntimeError, match="owner or mount changed"):
+            studio_hygiene.main(
+                [
+                    "--repo",
+                    str(repo),
+                    "--scratch",
+                    str(tmp_path),
+                    "--min-age-hours",
+                    "1",
+                    "--apply",
+                ]
+            )
+        assert tree.exists()
+        assert mount.exists()
     finally:
         mount.rmdir()
 

--- a/tests/test_host_hygiene.py
+++ b/tests/test_host_hygiene.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -81,9 +82,19 @@ def test_worktree_is_eligible_only_when_clean_old_and_pushed(
     os.utime(tree, (old, old))
     monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
     row = next(row for row in studio_hygiene.worktrees(repo) if row["path"] == tree)
-    assert studio_hygiene.classify_worktree(repo, row, time.time() - 3600) == "eligible"
+    assert (
+        studio_hygiene.classify_worktree(repo, row, time.time() - 3600, set())
+        == "eligible"
+    )
+    assert (
+        studio_hygiene.classify_worktree(repo, row, time.time() - 3600, {"safe"})
+        == "open-pr"
+    )
     (tree / "tracked").write_text("dirty\n")
-    assert studio_hygiene.classify_worktree(repo, row, time.time() - 3600) == "dirty"
+    assert (
+        studio_hygiene.classify_worktree(repo, row, time.time() - 3600, set())
+        == "dirty"
+    )
 
 
 def test_apply_uses_git_to_remove_only_an_eligible_worktree(
@@ -110,6 +121,7 @@ def test_apply_uses_git_to_remove_only_an_eligible_worktree(
     os.utime(tree, (old, old))
     monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
     monkeypatch.setattr(studio_hygiene, "mounted_images", lambda: [])
+    monkeypatch.setattr(studio_hygiene, "open_pr_heads", lambda _: set())
     assert (
         studio_hygiene.main(
             [
@@ -149,6 +161,29 @@ def test_only_explicitly_finished_dogfood_is_a_candidate(
     assert studio_hygiene.finished_dogfood_dirs(tmp_path, time.time() - 3600) == [
         finished
     ]
+
+
+def test_only_old_unused_rapid_temp_dmg_mount_is_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "rapid-mlx-desktop.udrw.dmg"
+    image.write_bytes(b"stub")
+    mount = Path(tempfile.mkdtemp(prefix="rapid-test-dmg-mount.", dir="/private/tmp"))
+    old = time.time() - 10_000
+    os.utime(image, (old, old))
+    os.utime(mount, (old, old))
+    monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
+    try:
+        assert studio_hygiene.stale_rapid_dmg(image, mount, time.time() - 3600)
+        other = tmp_path / "personal-backup.dmg"
+        other.write_bytes(b"stub")
+        os.utime(other, (old, old))
+        assert not studio_hygiene.stale_rapid_dmg(other, mount, time.time() - 3600)
+        assert not studio_hygiene.stale_rapid_dmg(
+            image, Path("/Volumes/Rapid-MLX"), time.time() - 3600
+        )
+    finally:
+        mount.rmdir()
 
 
 def test_hygiene_default_is_dry_run_and_never_removes_models() -> None:

--- a/tests/test_host_hygiene.py
+++ b/tests/test_host_hygiene.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import protected_models  # noqa: E402
+import studio_hygiene  # noqa: E402
+
+
+def test_protected_inventory_tracks_sidecar_pins_and_release_fleet() -> None:
+    models = protected_models.load_manifest()
+    by_repository = {str(model["repository"]): model for model in models}
+    sidecars = json.loads(
+        (ROOT / "apps/rapid-mac/scripts/sidecar-smoke-models.json").read_text()
+    )["models"]
+    for pin in sidecars.values():
+        protected = by_repository[pin["repository"]]
+        assert protected["revision"] == pin["revision"]
+        assert "sidecar" in protected["sources"]
+
+    aliases = json.loads((ROOT / "vllm_mlx/aliases.json").read_text())
+    fleet = json.loads((ROOT / "scripts/release_fleet.json").read_text())
+    for family in fleet["families"].values():
+        repository = aliases[family["coherence_model"]]["hf_path"]
+        assert "release_fleet" in by_repository[repository]["sources"]
+
+
+def test_protected_inventory_has_the_telemetry_roster() -> None:
+    expected = {
+        "mlx-community/Qwen3.5-4B-MLX-4bit",
+        "mlx-community/Qwen3.5-9B-4bit",
+        "mlx-community/Qwen3.6-35B-A3B-4bit",
+        "mlx-community/Qwen3.6-35B-A3B-8bit",
+        "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX",
+        "mlx-community/Qwen3.6-27B-4bit",
+        "mlx-community/gemma-4-26b-a4b-it-4bit",
+        "prism-ml/Ternary-Bonsai-27B-mlx-2bit",
+        "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
+    }
+    actual = {
+        str(model["repository"])
+        for model in protected_models.load_manifest()
+        if "telemetry_top10" in model["sources"]
+    }
+    assert actual == expected
+
+
+def _git(path: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=path, check=True, capture_output=True)
+
+
+def test_worktree_is_eligible_only_when_clean_old_and_pushed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked").write_text("one\n")
+    _git(repo, "add", "tracked")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    tree = tmp_path / "tree"
+    _git(repo, "worktree", "add", "-b", "safe", str(tree), "main")
+    _git(tree, "push", "-u", "origin", "safe")
+    old = time.time() - 10_000
+    os.utime(tree, (old, old))
+    monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
+    row = next(row for row in studio_hygiene.worktrees(repo) if row["path"] == tree)
+    assert studio_hygiene.classify_worktree(repo, row, time.time() - 3600) == "eligible"
+    (tree / "tracked").write_text("dirty\n")
+    assert studio_hygiene.classify_worktree(repo, row, time.time() - 3600) == "dirty"
+
+
+def test_apply_uses_git_to_remove_only_an_eligible_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked").write_text("one\n")
+    _git(repo, "add", "tracked")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    tree = tmp_path / "eligible"
+    _git(repo, "worktree", "add", "-b", "eligible", str(tree), "main")
+    _git(tree, "push", "-u", "origin", "eligible")
+    old = time.time() - 10_000
+    os.utime(tree, (old, old))
+    monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
+    monkeypatch.setattr(studio_hygiene, "mounted_images", lambda: [])
+    assert (
+        studio_hygiene.main(
+            [
+                "--repo",
+                str(repo),
+                "--scratch",
+                str(tmp_path),
+                "--min-age-hours",
+                "1",
+                "--apply",
+            ]
+        )
+        == 0
+    )
+    assert not tree.exists()
+    assert repo.exists()
+
+
+def test_only_explicitly_finished_dogfood_is_a_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    finished = tmp_path / "rapid-finished"
+    active = tmp_path / "rapid-active"
+    unowned = tmp_path / "rapid-unowned"
+    finished.mkdir()
+    active.mkdir()
+    unowned.mkdir()
+    (finished / ".dogfood-owned").touch()
+    (finished / ".dogfood-finished").touch()
+    (active / ".dogfood-owned").touch()
+    (unowned / ".dogfood-finished").touch()
+    old = time.time() - 10_000
+    os.utime(finished, (old, old))
+    os.utime(active, (old, old))
+    os.utime(unowned, (old, old))
+    monkeypatch.setattr(studio_hygiene, "in_use", lambda _: False)
+    assert studio_hygiene.finished_dogfood_dirs(tmp_path, time.time() - 3600) == [
+        finished
+    ]
+
+
+def test_hygiene_default_is_dry_run_and_never_removes_models() -> None:
+    source = (ROOT / "scripts/studio_hygiene.py").read_text()
+    assert 'parser.add_argument("--apply", action="store_true")' in source
+    assert "model caches are report-only and are never removed" in source
+    assert "HF_HUB_CACHE" in source
+    assert "shutil.rmtree(cache" not in source

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -139,3 +139,4 @@ def test_real_dogfood_entrypoints_share_the_host_guards() -> None:
     assert 'size_args=(--model "$MODEL")' in mvp
     assert 'exec "$SCRIPT_DIR/dogfood-host-precheck.sh"' in ax
     assert 'exec "$ROOT/scripts/dogfood-host-precheck.sh"' in golden
+    assert golden.count("DOGFOOD_WORKING_SET_GB=0.1") == 2

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -112,6 +112,59 @@ def test_memory_is_rechecked_after_lock_is_acquired(tmp_path: Path) -> None:
     assert "insufficient memory under lock" in result.stderr
 
 
+@pytest.mark.skipif(shutil.which("lockf") is None, reason="BSD lockf required")
+def test_termination_reaches_locked_server_descendants(tmp_path: Path) -> None:
+    pid_file = tmp_path / "descendant.pid"
+    child = (
+        "import pathlib,subprocess,sys,time; "
+        "p=subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); time.sleep(60)"
+    )
+    env = dict(
+        os.environ,
+        RAPID_HOST_SAFETY_TESTING="1",
+        RAPID_LARGE_MODEL_TEST_AVAILABLE_GB="100",
+    )
+    wrapper = subprocess.Popen(
+        [
+            sys.executable,
+            str(LOCK),
+            "--working-set-gb",
+            "21",
+            "--lock-file",
+            str(tmp_path / "lock"),
+            "--",
+            sys.executable,
+            "-c",
+            child,
+            str(pid_file),
+        ],
+        env=env,
+    )
+    deadline = time.monotonic() + 5
+    while not pid_file.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert pid_file.exists()
+    descendant = int(pid_file.read_text())
+    wrapper.terminate()
+    wrapper.wait(timeout=5)
+    deadline = time.monotonic() + 5
+    while (
+        subprocess.run(
+            ["ps", "-p", str(descendant)], capture_output=True, check=False
+        ).returncode
+        == 0
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.05)
+    assert (
+        subprocess.run(
+            ["ps", "-p", str(descendant)], capture_output=True, check=False
+        ).returncode
+        != 0
+    )
+
+
 def test_tart_ready_retries_then_succeeds(tmp_path: Path) -> None:
     fake = tmp_path / "tart"
     count = tmp_path / "count"

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PRECHECK = ROOT / "apps/rapid-mac/scripts/dogfood-host-precheck.sh"
+LOCK = ROOT / "scripts/large-model-run.py"
+TART = ROOT / "scripts/tart-guest-ready.sh"
+
+
+def test_host_precheck_names_lock_and_screensaver_faults() -> None:
+    env = dict(os.environ, RAPID_HOST_SAFETY_TESTING="1", RAPID_HOST_TEST_IDLE_TIME="0")
+    locked = subprocess.run(
+        [str(PRECHECK)],
+        env=dict(env, RAPID_HOST_TEST_LOCKED="true"),
+        text=True,
+        capture_output=True,
+    )
+    assert locked.returncode == 1
+    assert "console is locked" in locked.stderr
+    idle = subprocess.run(
+        [str(PRECHECK)],
+        env=dict(env, RAPID_HOST_TEST_LOCKED="false", RAPID_HOST_TEST_IDLE_TIME="300"),
+        text=True,
+        capture_output=True,
+    )
+    assert idle.returncode == 1
+    assert "idleTime must be 0" in idle.stderr
+
+
+def test_ci_precheck_executes_command_without_host_assumptions() -> None:
+    result = subprocess.run(
+        [str(PRECHECK), "--", "/usr/bin/printf", "ok"],
+        env=dict(os.environ, CI="true"),
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "ok"
+
+
+@pytest.mark.skipif(shutil.which("lockf") is None, reason="BSD lockf required")
+def test_two_large_loads_serialize_on_one_host_lock(tmp_path: Path) -> None:
+    lock = tmp_path / "large.lock"
+    ledger = tmp_path / "ledger"
+    child = (
+        "import pathlib,sys,time; p=pathlib.Path(sys.argv[1]); name=sys.argv[2]; "
+        "p.open('a').write(name+'-start\\n'); time.sleep(.35); "
+        "p.open('a').write(name+'-end\\n')"
+    )
+    env = dict(
+        os.environ,
+        RAPID_HOST_SAFETY_TESTING="1",
+        RAPID_LARGE_MODEL_TEST_AVAILABLE_GB="100",
+    )
+    base = [
+        sys.executable,
+        str(LOCK),
+        "--working-set-gb",
+        "21",
+        "--lock-file",
+        str(lock),
+        "--",
+        sys.executable,
+        "-c",
+        child,
+        str(ledger),
+    ]
+    first = subprocess.Popen([*base, "a"], env=env)
+    time.sleep(0.05)
+    second = subprocess.Popen([*base, "b"], env=env)
+    assert first.wait(timeout=10) == 0
+    assert second.wait(timeout=10) == 0
+    assert ledger.read_text().splitlines() == ["a-start", "a-end", "b-start", "b-end"]
+
+
+def test_memory_is_rechecked_after_lock_is_acquired(tmp_path: Path) -> None:
+    env = dict(
+        os.environ,
+        RAPID_HOST_SAFETY_TESTING="1",
+        RAPID_LARGE_MODEL_TEST_AVAILABLE_GB="22",
+        RAPID_LARGE_MODEL_LOCK_HELD="1",
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(LOCK),
+            "--working-set-gb",
+            "21",
+            "--lock-file",
+            str(tmp_path / "lock"),
+            "--",
+            "/usr/bin/true",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 1
+    assert "insufficient memory under lock" in result.stderr
+
+
+def test_tart_ready_retries_then_succeeds(tmp_path: Path) -> None:
+    fake = tmp_path / "tart"
+    count = tmp_path / "count"
+    fake.write_text(
+        '#!/bin/sh\nn=0; [ -f "$COUNT" ] && n=$(cat "$COUNT"); '
+        'n=$((n+1)); echo $n > "$COUNT"; [ $n -ge 2 ]\n'
+    )
+    fake.chmod(0o755)
+    env = dict(os.environ, PATH=f"{tmp_path}:{os.environ['PATH']}", COUNT=str(count))
+    result = subprocess.run(
+        [str(TART), "--timeout", "3", "--interval", "0", "guest"],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert "guest is ready" in result.stdout
+
+
+def test_real_dogfood_entrypoints_share_the_host_guards() -> None:
+    isolate = (ROOT / "apps/rapid-mac/scripts/dogfood-isolate.sh").read_text()
+    mvp = (ROOT / "scripts/run_dogfood_mvp.sh").read_text()
+    ax = (ROOT / "apps/rapid-mac/scripts/gui-ax-smoke.sh").read_text()
+    golden = (ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh").read_text()
+
+    assert 'working_set_gb="\\${DOGFOOD_WORKING_SET_GB:-21}"' in isolate
+    assert '"$SAFETY_DIR/dogfood-host-precheck.sh"' in isolate
+    assert '"$SAFETY_DIR/large-model-run.py"' in isolate
+    assert '"$ROOT/scripts/large-model-run.py"' in mvp
+    assert 'size_args=(--model "$MODEL")' in mvp
+    assert 'exec "$SCRIPT_DIR/dogfood-host-precheck.sh"' in ax
+    assert 'exec "$ROOT/scripts/dogfood-host-precheck.sh"' in golden

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -74,7 +74,12 @@ def test_two_large_loads_serialize_on_one_host_lock(tmp_path: Path) -> None:
         str(ledger),
     ]
     first = subprocess.Popen([*base, "a"], env=env)
-    time.sleep(0.05)
+    deadline = time.monotonic() + 2
+    while (
+        not ledger.exists() or "a-start" not in ledger.read_text()
+    ) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ledger.exists() and "a-start" in ledger.read_text()
     second = subprocess.Popen([*base, "b"], env=env)
     assert first.wait(timeout=10) == 0
     assert second.wait(timeout=10) == 0


### PR DESCRIPTION
## Why

Shared macOS release and dogfood lanes have lost live model caches, filled disks with abandoned worktrees, stalled on stale DMG mounts or locked GUI sessions, and overlapped large model loads strongly enough to OOM the host. These failures currently appear late and can take unrelated operator processes down with them.

## What

- Add one protected-model inventory covering pinned sidecar snapshots, the release fleet, and the telemetry residency roster. Host hygiene reports every entry as untouchable and never deletes model caches.
- Add a dry-run-by-default hygiene command. Its explicit apply mode accepts only old, scratch-local, clean, remote-backed, fully pushed, unused worktrees and explicitly finished tool-owned dogfood directories; it revalidates immediately before removal and detaches only DMGs owned by those candidates.
- Add an unlocked-session/screensaver precheck with a process-lifetime power assertion for local GUI lanes, plus a bounded Tart guest-agent readiness wait.
- Add a host-wide large-model lock that estimates working memory from checked-in registries and rechecks free memory while holding the lock. Wire it into the dogfood server and self-contained Desktop dogfood launchers.
- Document the operator workflow and add executable safety contracts.

## Scope / Non-goals

This changes shared-host operations and test launchers only. It does not alter inference scheduling, product model residency, release publication, CI branch protection, or user model-cache ownership. Hygiene intentionally does not offer model-cache deletion. No destructive cleanup was run on Studio or mini.

## Verification

- `python3 -m pytest -q tests/test_host_hygiene.py tests/test_host_prechecks.py tests/test_gui_preflight_contract.py` — 29 passed (also with `CI=true`)
- Ruff check and format checks on the new Python tools/tests
- ShellCheck and `bash -n` on all changed shell entrypoints
- `git diff --check`
- Two concurrent 21 GiB test commands produced strict `a-start, a-end, b-start, b-end` ordering under the shared lock
- Real unlocked-host precheck passed on Studio; locked/idle failures are covered separately
- Default six-hour dry run on mini classified protected caches, dirty/no-upstream/missing worktrees, and unowned DMGs without mutation
- Conservative Studio dry run listed every protected cache and made no changes

## Behaviour delta

Local real-model Desktop dogfood now serializes conservatively by default; operators may supply the measured working-set size for a known smaller model. Local AX/golden flows fail immediately when the console is locked or screensaver idle time is nonzero and keep the host awake for the lane lifetime. Hosted CI keeps its existing fake-sidecar path.

## Design precedent

The implementation adopts established host-orchestration patterns: kernel-released command-lifetime locks, capacity checks performed inside the lock, command-execution readiness rather than fixed sleeps, and source-control-native worktree enumeration/removal. Cache state is classified separately from disposable build output, so cleanup cannot turn a disk-space operation into a model download during a later gate.

Fixes #2498
