### PR TITLE
fix(engine): resolve pulled --bits variant at serve/load (#2340)

### DIFF
--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -511,6 +511,32 @@ def test_successful_ordinary_hf_pull_clears_previous_variant(marker_path):
     assert _download_gate.pulled_variant(RAW_REPO) is None
 
 
+def test_ordinary_hf_pull_survives_marker_clear_failure(capsys):
+    """Cleanup metadata is best-effort after a valid HF pull completes."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/snapshot"),
+        patch(
+            "vllm_mlx._download_gate.clear_pulled_variant",
+            side_effect=OSError("read-only cache"),
+        ),
+    ):
+        cli.pull_command(args)  # must not raise after a successful download
+
+    assert "Cached at: /cache/snapshot" in capsys.readouterr().out
+
+
 def test_successful_ordinary_mirror_pull_clears_previous_variant(marker_path):
     """The mirror-success early return applies the same marker transition."""
     import argparse
@@ -533,3 +559,32 @@ def test_successful_ordinary_mirror_pull_clears_previous_variant(marker_path):
         cli.pull_command(args)
 
     assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_ordinary_mirror_pull_survives_marker_clear_failure(capsys):
+    """Cleanup metadata is best-effort on the mirror-success early return."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    def mirror_success(repo_id, *, out):
+        out["network_fetch"] = False
+        return True
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", side_effect=mirror_success),
+        patch(
+            "vllm_mlx._download_gate.clear_pulled_variant",
+            side_effect=OSError("read-only cache"),
+        ),
+    ):
+        cli.pull_command(args)  # must not raise after a successful download
+
+    assert "Already cached" in capsys.readouterr().out

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -483,7 +483,6 @@ def test_pull_persist_failure_still_completes_the_pull(capsys):
     ):
         cli.pull_command(args)  # must not raise
     out = capsys.readouterr().out
-    assert "R2 mirror skipped" in out
     assert "could not record that serving choice" in out
     assert "may select an older or default checkpoint" in out
 
@@ -551,7 +550,8 @@ def test_successful_ordinary_mirror_pull_clears_previous_variant(marker_path):
         _original_alias=RAW_REPO,
     )
 
-    def mirror_success(repo_id, *, out):
+    def mirror_success(repo_id, *, allow_patterns, out):
+        assert allow_patterns is None
         out["network_fetch"] = False
         return True
 
@@ -574,7 +574,8 @@ def test_ordinary_mirror_pull_survives_marker_clear_failure(capsys):
         _original_alias=RAW_REPO,
     )
 
-    def mirror_success(repo_id, *, out):
+    def mirror_success(repo_id, *, allow_patterns, out):
+        assert allow_patterns is None
         out["network_fetch"] = False
         return True
 

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -209,6 +209,47 @@ def test_explicit_alias_overrides_repo_variant_marker(
     assert seen == {"repo_id": CATALOG_REPO, "allow_patterns": ["4bit/*"]}
 
 
+def test_serving_checkpoint_resolves_explicit_alias_before_lane_selection(
+    monkeypatch, tmp_path, marker_path
+):
+    """The server checkpoint choke point retains CLI alias precedence."""
+    from types import SimpleNamespace
+
+    import huggingface_hub
+
+    from vllm_mlx import server
+
+    snapshot = tmp_path / "snapshots" / "01234567"
+    checkpoint = snapshot / "4bit"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "config.json").write_text("{}")
+    (checkpoint / "model.safetensors").write_bytes(b"\x00" * 16)
+    seen: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen["repo_id"] = repo_id
+        seen["allow_patterns"] = kwargs.get("allow_patterns")
+        return str(snapshot)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _path: None)
+    monkeypatch.setattr(
+        server,
+        "resolve_serving_lane_decision",
+        lambda *args, **kwargs: SimpleNamespace(
+            auto_text_fallback=False,
+            reason="text_checkpoint",
+        ),
+    )
+    _download_gate.persist_pulled_variant(CATALOG_REPO, "8bit")
+
+    resolved = server._resolve_serving_checkpoint(CATALOG_ALIAS)
+
+    assert resolved.model_path == CATALOG_REPO
+    assert resolved.load_path == str(checkpoint)
+    assert seen == {"repo_id": CATALOG_REPO, "allow_patterns": ["4bit/*"]}
+
+
 def test_serve_uses_format_marker_folder(monkeypatch, tmp_path, marker_path):
     """``--format <folder>`` records the literal folder; serve joins it."""
     snapshot = tmp_path / "snap" / "abc"

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -251,9 +251,10 @@ def test_no_marker_resolves_repo_root_as_before(monkeypatch, tmp_path):
     assert _resolve_subfolder_checkpoint(RAW_REPO) == RAW_REPO
 
 
-def test_absent_variant_raises_actionable_message(monkeypatch, tmp_path, marker_path):
-    """A marker pointing at a folder that is neither present nor complete must
-    fail with an actionable message, not silently load the repo root."""
+def test_incomplete_variant_raises_actionable_message(
+    monkeypatch, tmp_path, marker_path
+):
+    """A present folder without weights must not be treated as a checkpoint."""
     snapshot = tmp_path / "snap"
     (snapshot / "4bit").mkdir(parents=True)
     # Only config.json — no weights. Incomplete, so it must be refused.
@@ -268,7 +269,31 @@ def test_absent_variant_raises_actionable_message(monkeypatch, tmp_path, marker_
     )
     _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
 
-    with pytest.raises(RuntimeError, match="4bit"):
+    with pytest.raises(RuntimeError, match="present but incomplete"):
+        _resolve_subfolder_checkpoint(RAW_REPO)
+
+
+def test_absent_variant_raises_actionable_message(monkeypatch, tmp_path, marker_path):
+    """A marker whose folder is absent names a valid recovery command."""
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo_id, **kw: str(snapshot),
+    )
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"does not exist after download.*"
+            r"rapid-mlx pull --format 4bit acme/MultiVariant-MLX"
+        ),
+    ):
         _resolve_subfolder_checkpoint(RAW_REPO)
 
 

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -65,7 +65,7 @@ def marker_path(tmp_path, monkeypatch):
 
 def test_persist_and_read_round_trip(marker_path):
     assert _download_gate.pulled_variant(RAW_REPO) is None
-    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.persist_pulled_variant(RAW_REPO, "4bit") is True
     assert _download_gate.pulled_variant(RAW_REPO) == "4bit"
     assert marker_path.read_text() == "4bit"
 
@@ -77,7 +77,7 @@ def test_persist_overwrites_a_previous_variant(marker_path):
 
 
 def test_persist_empty_is_a_noop(marker_path):
-    _download_gate.persist_pulled_variant(RAW_REPO, "")
+    assert _download_gate.persist_pulled_variant(RAW_REPO, "") is False
     assert _download_gate.pulled_variant(RAW_REPO) is None
     assert not marker_path.exists()
 
@@ -423,8 +423,24 @@ def test_persist_swallows_a_write_oserror(monkeypatch, marker_path):
         _os, "makedirs", lambda *a, **k: (_ for _ in ()).throw(OSError("full"))
     )
     # Must not raise.
-    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.persist_pulled_variant(RAW_REPO, "4bit") is False
     assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_failed_variant_update_invalidates_previous_marker(monkeypatch, marker_path):
+    """A failed 8-bit update must never leave an authoritative 4-bit choice."""
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.pulled_variant(RAW_REPO) == "4bit"
+
+    monkeypatch.setattr(
+        os,
+        "replace",
+        lambda *args: (_ for _ in ()).throw(OSError("read-only cache")),
+    )
+
+    assert _download_gate.persist_pulled_variant(RAW_REPO, "8bit") is False
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+    assert not marker_path.exists()
 
 
 def test_persist_read_swallows_an_unreadable_marker(monkeypatch, marker_path):
@@ -468,6 +484,8 @@ def test_pull_persist_failure_still_completes_the_pull(capsys):
         cli.pull_command(args)  # must not raise
     out = capsys.readouterr().out
     assert "R2 mirror skipped" in out
+    assert "could not record that serving choice" in out
+    assert "may select an older or default checkpoint" in out
 
 
 def test_successful_ordinary_hf_pull_clears_previous_variant(marker_path):

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -56,7 +56,7 @@ def _multi_variant_tree():
 @pytest.fixture
 def marker_path(tmp_path, monkeypatch):
     """Point the variant marker at a fresh tmp file and return its path."""
-    target = tmp_path / "models--acme--MultiVariant-MLX" / "refs" / ".rapidmlx-variant"
+    target = tmp_path / "models--acme--MultiVariant-MLX" / ".rapid-mlx" / "variant"
     monkeypatch.setattr(
         _download_gate, "_variant_marker_path", lambda repo_id: str(target)
     )
@@ -398,7 +398,21 @@ def test_marker_path_falls_back_when_hub_constants_unavailable(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "huggingface_hub.constants", _NoConstants())
     path = _download_gate._variant_marker_path(RAW_REPO)
-    assert path.endswith("models--acme--MultiVariant-MLX/refs/.rapidmlx-variant")
+    assert path.endswith("models--acme--MultiVariant-MLX/.rapid-mlx/variant")
+
+
+def test_marker_does_not_corrupt_hub_cache_scan(tmp_path, marker_path):
+    """Rapid-MLX metadata must stay outside Hub's commit-ref namespace."""
+    from huggingface_hub import scan_cache_dir
+
+    snapshot = marker_path.parents[1] / "snapshots" / "deadbeef"
+    snapshot.mkdir(parents=True)
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+
+    cache = scan_cache_dir(tmp_path)
+
+    assert not cache.warnings
+    assert {repo.repo_id for repo in cache.repos} == {RAW_REPO}
 
 
 def test_persist_swallows_a_write_oserror(monkeypatch, marker_path):

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -10,7 +10,7 @@ The pulled variant is persisted as a small marker in the HF cache at pull time
 These tests pin that:
 
 1. ``persist_pulled_variant`` / ``pulled_variant`` round-trip: a narrowed pull
-   records the folder, and an unrecorded repo reads back ``None``.
+   records the folder, while a later ordinary pull clears that choice.
 2. the core #2340 scenario: a repo id pulled with ``--bits`` resolves, at load
    time, to that exact snapshot subfolder, even when a catalog reverse lookup
    names a different default subfolder.
@@ -41,6 +41,7 @@ from vllm_mlx.utils.tokenizer import _resolve_subfolder_checkpoint
 # can select the subfolder.
 RAW_REPO = "acme/MultiVariant-MLX"
 CATALOG_REPO = "LiquidAI/LFM2.5-2.6B-MLX"
+CATALOG_ALIAS = "lfm2.5-2.6b-4bit"
 
 
 def _multi_variant_tree():
@@ -78,6 +79,20 @@ def test_persist_overwrites_a_previous_variant(marker_path):
 def test_persist_empty_is_a_noop(marker_path):
     _download_gate.persist_pulled_variant(RAW_REPO, "")
     assert _download_gate.pulled_variant(RAW_REPO) is None
+    assert not marker_path.exists()
+
+
+def test_clear_removes_a_previous_variant(marker_path):
+    _download_gate.persist_pulled_variant(RAW_REPO, "8bit")
+
+    _download_gate.clear_pulled_variant(RAW_REPO)
+
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+    assert not marker_path.exists()
+
+
+def test_clear_missing_marker_is_a_noop(marker_path):
+    _download_gate.clear_pulled_variant(RAW_REPO)
     assert not marker_path.exists()
 
 
@@ -161,6 +176,37 @@ def test_pulled_variant_overrides_catalog_default(monkeypatch, tmp_path, marker_
 
     assert resolved == os.path.join(str(snapshot), "8bit")
     assert seen == {"repo_id": CATALOG_REPO, "allow_patterns": ["8bit/*"]}
+
+
+def test_explicit_alias_overrides_repo_variant_marker(
+    monkeypatch, tmp_path, marker_path
+):
+    """An explicit 4-bit alias keeps its meaning despite an 8-bit repo marker."""
+    from vllm_mlx.model_aliases import resolve_model, resolve_subfolder
+
+    assert resolve_model(CATALOG_ALIAS) == CATALOG_REPO
+    assert resolve_subfolder(CATALOG_ALIAS) == "4bit"
+
+    snapshot = tmp_path / "snapshots" / "feedface"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text("{}")
+    (snapshot / "4bit" / "model.safetensors").write_bytes(b"\x00" * 16)
+    seen: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen["repo_id"] = repo_id
+        seen["allow_patterns"] = kwargs.get("allow_patterns")
+        return str(snapshot)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    _download_gate.persist_pulled_variant(CATALOG_REPO, "8bit")
+
+    resolved = _resolve_subfolder_checkpoint(CATALOG_ALIAS)
+
+    assert resolved == os.path.join(str(snapshot), "4bit")
+    assert seen == {"repo_id": CATALOG_REPO, "allow_patterns": ["4bit/*"]}
 
 
 def test_serve_uses_format_marker_folder(monkeypatch, tmp_path, marker_path):
@@ -296,3 +342,50 @@ def test_pull_persist_failure_still_completes_the_pull(capsys):
         cli.pull_command(args)  # must not raise
     out = capsys.readouterr().out
     assert "R2 mirror skipped" in out
+
+
+def test_successful_ordinary_hf_pull_clears_previous_variant(marker_path):
+    """Switching back to an ordinary pull must not leave a stale selector."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    _download_gate.persist_pulled_variant(RAW_REPO, "8bit")
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/snapshot"),
+    ):
+        cli.pull_command(args)
+
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_successful_ordinary_mirror_pull_clears_previous_variant(marker_path):
+    """The mirror-success early return applies the same marker transition."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    _download_gate.persist_pulled_variant(RAW_REPO, "8bit")
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    def mirror_success(repo_id, *, out):
+        out["network_fetch"] = False
+        return True
+
+    with patch.object(cli, "_try_mirror_prefetch", side_effect=mirror_success):
+        cli.pull_command(args)
+
+    assert _download_gate.pulled_variant(RAW_REPO) is None

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for #2340 — serve/load resolution of a ``--bits/--format`` pulled variant.
+
+``rapid-mlx pull --bits 4 <multi-variant-repo>`` fetches only ``4bit/``. A later
+``serve <repo>`` must reach that same subfolder, not the weightless repo root.
+The pulled variant is persisted as a small marker in the HF cache at pull time
+(``_download_gate.persist_pulled_variant``) and recovered at load time
+(``_resolve_subfolder_checkpoint`` ``pulled_variant`` fallback).
+
+These tests pin that:
+
+1. ``persist_pulled_variant`` / ``pulled_variant`` round-trip: a narrowed pull
+   records the folder, and an unrecorded repo reads back ``None``.
+2. the core #2340 scenario: a RAW repo id (no catalog alias) that was pulled
+   with ``--bits 4`` resolves, at load time, to its ``4bit/`` snapshot subfolder.
+3. without a recorded variant (no ``--bits/--format`` pull), the same raw repo
+   id resolves to the repo root as before — the marker never invents one.
+4. a genuinely absent variant still raises the actionable message (the pulled
+   marker points at a folder that is neither present nor complete).
+
+The repo id is deliberately NOT a catalog alias so ``resolve_subfolder`` returns
+``None`` and only the marker fallback can select the subfolder — the real
+``LiquidAI/LFM2.5-2.6B-MLX`` layout (root has only README/LICENSE, ``4bit/`` is
+self-contained) is reproduced by fixtures. ``snapshot_download`` and the marker
+path are mocked; no weights and no network are touched.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from huggingface_hub import RepoFile, RepoFolder
+
+from vllm_mlx import _download_gate
+from vllm_mlx.utils.tokenizer import _resolve_subfolder_checkpoint
+
+# A raw multi-variant repo id with NO catalog alias — ``resolve_subfolder``
+# and ``resolve_model`` both leave it untouched, so only the marker fallback
+# can select the subfolder.
+RAW_REPO = "acme/MultiVariant-MLX"
+
+
+def _multi_variant_tree():
+    """A multi-variant repo layout: several quant folders + root README only."""
+    return [
+        RepoFolder(path="4bit", oid="a"),
+        RepoFolder(path="8bit", oid="b"),
+        RepoFile(path="README.md", size=100, oid="c"),
+    ]
+
+
+@pytest.fixture
+def marker_path(tmp_path, monkeypatch):
+    """Point the variant marker at a fresh tmp file and return its path."""
+    target = tmp_path / "models--acme--MultiVariant-MLX" / "refs" / ".rapidmlx-variant"
+    monkeypatch.setattr(
+        _download_gate, "_variant_marker_path", lambda repo_id: str(target)
+    )
+    return target
+
+
+def test_persist_and_read_round_trip(marker_path):
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.pulled_variant(RAW_REPO) == "4bit"
+    assert marker_path.read_text() == "4bit"
+
+
+def test_persist_overwrites_a_previous_variant(marker_path):
+    _download_gate.persist_pulled_variant(RAW_REPO, "8bit")
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.pulled_variant(RAW_REPO) == "4bit"
+
+
+def test_persist_empty_is_a_noop(marker_path):
+    _download_gate.persist_pulled_variant(RAW_REPO, "")
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+    assert not marker_path.exists()
+
+
+def test_missing_marker_returns_none_without_error(marker_path):
+    # No task-scoped file means "never narrowed" — never an exception.
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_serve_resolves_a_pulled_bits_variant(monkeypatch, tmp_path, marker_path):
+    """The core #2340 scenario: ``pull --bits 4 RAW_REPO`` then serve RAW_REPO.
+
+    The repo has no catalog alias, so the ONLY thing that can select the
+    subfolder is the persisted marker. The served load must land on the
+    ``4bit/`` snapshot subfolder (with the ``4bit/*`` narrow allow-pattern),
+    not on the weightless repo root.
+    """
+    snapshot = tmp_path / "snapshots" / "deadbeef"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text("{}")
+    (snapshot / "4bit" / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    seen: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen["repo_id"] = repo_id
+        seen["allow_patterns"] = kwargs.get("allow_patterns")
+        return str(snapshot)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    # Record what the pull would have persisted (``_variant_name == "4bit"``).
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+
+    resolved = _resolve_subfolder_checkpoint(RAW_REPO)
+
+    assert resolved == os.path.join(str(snapshot), "4bit")
+    assert seen["repo_id"] == RAW_REPO
+    assert seen["allow_patterns"] == ["4bit/*"], (
+        "the loader must fetch only the pulled variant, not all quantizations"
+    )
+    # The handed-over directory must be where mlx-lm's loader glob will hit.
+    assert Path(resolved, "config.json").exists()
+    assert list(Path(resolved).glob("model*.safetensors"))
+
+
+def test_serve_uses_format_marker_folder(monkeypatch, tmp_path, marker_path):
+    """``--format <folder>`` records the literal folder; serve joins it."""
+    snapshot = tmp_path / "snap" / "abc"
+    (snapshot / "mxfp4").mkdir(parents=True)
+    (snapshot / "mxfp4" / "config.json").write_text("{}")
+    (snapshot / "mxfp4" / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo_id, **kw: str(snapshot),
+    )
+    _download_gate.persist_pulled_variant(RAW_REPO, "mxfp4")
+
+    assert _resolve_subfolder_checkpoint(RAW_REPO) == os.path.join(
+        str(snapshot), "mxfp4"
+    )
+
+
+def test_no_marker_resolves_repo_root_as_before(monkeypatch, tmp_path):
+    """Without a recorded variant, a raw repo id is resolved unchanged.
+
+    This is the historical behaviour for flat repos whose root IS the
+    checkpoint; the marker fallback must never invent a subfolder for a repo
+    that was not narrowed with ``--bits/--format``.
+    """
+    import huggingface_hub
+
+    # snapshot_download must NOT be reached for a root-resolved id in a
+    # cold-cache mirror of the prior behaviour (the offline-first path still
+    # probes, but the resolution decision is the marker, which is empty).
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo_id, **kw: str(tmp_path),
+    )
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+    assert _resolve_subfolder_checkpoint(RAW_REPO) == RAW_REPO
+
+
+def test_absent_variant_raises_actionable_message(monkeypatch, tmp_path, marker_path):
+    """A marker pointing at a folder that is neither present nor complete must
+    fail with an actionable message, not silently load the repo root."""
+    snapshot = tmp_path / "snap"
+    (snapshot / "4bit").mkdir(parents=True)
+    # Only config.json — no weights. Incomplete, so it must be refused.
+    (snapshot / "4bit" / "config.json").write_text("{}")
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo_id, **kw: str(snapshot),
+    )
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+
+    with pytest.raises(RuntimeError, match="4bit"):
+        _resolve_subfolder_checkpoint(RAW_REPO)
+
+
+# --- defensive branches that keep the marker off the hot path ---
+
+
+def test_marker_path_falls_back_when_hub_constants_unavailable(monkeypatch):
+    """If huggingface_hub's constants cannot be imported, the marker uses a
+    best-effort default cache location instead of raising."""
+    import sys
+
+    class _NoConstants:
+        def __getattr__(self, name):
+            raise ImportError("huggingface_hub.constants unavailable")
+
+    monkeypatch.setitem(sys.modules, "huggingface_hub.constants", _NoConstants())
+    path = _download_gate._variant_marker_path(RAW_REPO)
+    assert path.endswith("models--acme--MultiVariant-MLX/refs/.rapidmlx-variant")
+
+
+def test_persist_swallows_a_write_oserror(monkeypatch, marker_path):
+    """A failed marker write must not break an already-valid pull."""
+    import os as _os
+
+    monkeypatch.setattr(
+        _os, "makedirs", lambda *a, **k: (_ for _ in ()).throw(OSError("full"))
+    )
+    # Must not raise.
+    _download_gate.persist_pulled_variant(RAW_REPO, "4bit")
+    assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_persist_read_swallows_an_unreadable_marker(monkeypatch, marker_path):
+    """An unreadable marker reads back None, never raises."""
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("4bit")
+    with patch("builtins.open", side_effect=OSError("denied")):
+        assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_pull_persist_failure_still_completes_the_pull(capsys):
+    """The best-effort persist in ``pull_command`` must never fail the pull."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    args = argparse.Namespace(
+        model="LiquidAI/LFM2.5-2.6B-MLX",
+        bits="4",
+        format=None,
+        _original_alias="LiquidAI/LFM2.5-2.6B-MLX",
+    )
+
+    def fake_snapshot(*a, **kw):
+        return "/cache/snapshot"
+
+    def boom_persist(repo_id, variant):
+        raise OSError("cannot write marker")
+
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree", return_value=_multi_variant_tree()
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", fake_snapshot),
+        patch(
+            "vllm_mlx._download_gate.persist_pulled_variant",
+            side_effect=boom_persist,
+        ),
+    ):
+        cli.pull_command(args)  # must not raise
+    out = capsys.readouterr().out
+    assert "R2 mirror skipped" in out

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -97,12 +97,17 @@ def test_clear_missing_marker_is_a_noop(marker_path):
 
 
 @pytest.mark.parametrize(
-    "invalid", ["../escape", "/absolute", "C:/drive", "4bit\\escape", "*", "4bit/"]
+    "invalid", ["../escape", "/absolute", "C:/drive", "4bit\\escape", "4bit/"]
 )
 def test_invalid_marker_values_fail_closed(marker_path, invalid):
     marker_path.parent.mkdir(parents=True, exist_ok=True)
     marker_path.write_text(invalid)
     assert _download_gate.pulled_variant(RAW_REPO) is None
+
+
+def test_glob_metacharacters_round_trip_as_literal_variant(marker_path):
+    _download_gate.persist_pulled_variant(RAW_REPO, "quant[4]*?")
+    assert _download_gate.pulled_variant(RAW_REPO) == "quant[4]*?"
 
 
 def test_missing_marker_returns_none_without_error(marker_path):
@@ -269,6 +274,47 @@ def test_serve_uses_format_marker_folder(monkeypatch, tmp_path, marker_path):
     assert _resolve_subfolder_checkpoint(RAW_REPO) == os.path.join(
         str(snapshot), "mxfp4"
     )
+
+
+def test_serve_escapes_format_marker_glob_metacharacters(
+    monkeypatch, tmp_path, marker_path
+):
+    """A literal format survives the real pull-to-serve marker transition."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    variant = "quant[4]*?"
+    snapshot = tmp_path / "snap" / "def"
+    (snapshot / variant).mkdir(parents=True)
+    (snapshot / variant / "config.json").write_text("{}")
+    (snapshot / variant / "model.safetensors").write_bytes(b"\x00" * 16)
+    seen_patterns: list[object] = []
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen_patterns.append(kwargs.get("allow_patterns"))
+        return str(snapshot)
+
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=variant,
+        _original_alias=RAW_REPO,
+    )
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree",
+            return_value=[RepoFolder(path=variant, oid="variant")],
+        ),
+        patch("huggingface_hub.snapshot_download", fake_snapshot_download),
+    ):
+        cli.pull_command(args)
+        resolved = _resolve_subfolder_checkpoint(RAW_REPO)
+
+    escaped = ["quant[[]4[]][*][?]/*"]
+    assert _download_gate.pulled_variant(RAW_REPO) == variant
+    assert resolved == os.path.join(str(snapshot), variant)
+    assert seen_patterns == [escaped, escaped]
 
 
 def test_no_marker_resolves_repo_root_as_before(monkeypatch, tmp_path):

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -11,18 +11,17 @@ These tests pin that:
 
 1. ``persist_pulled_variant`` / ``pulled_variant`` round-trip: a narrowed pull
    records the folder, and an unrecorded repo reads back ``None``.
-2. the core #2340 scenario: a RAW repo id (no catalog alias) that was pulled
-   with ``--bits 4`` resolves, at load time, to its ``4bit/`` snapshot subfolder.
+2. the core #2340 scenario: a repo id pulled with ``--bits`` resolves, at load
+   time, to that exact snapshot subfolder, even when a catalog reverse lookup
+   names a different default subfolder.
 3. without a recorded variant (no ``--bits/--format`` pull), the same raw repo
    id resolves to the repo root as before — the marker never invents one.
 4. a genuinely absent variant still raises the actionable message (the pulled
    marker points at a folder that is neither present nor complete).
 
-The repo id is deliberately NOT a catalog alias so ``resolve_subfolder`` returns
-``None`` and only the marker fallback can select the subfolder — the real
-``LiquidAI/LFM2.5-2.6B-MLX`` layout (root has only README/LICENSE, ``4bit/`` is
-self-contained) is reproduced by fixtures. ``snapshot_download`` and the marker
-path are mocked; no weights and no network are touched.
+Both an unregistered repo and the real cataloged multi-variant layout are
+covered. ``snapshot_download`` and the marker path are mocked; no weights and
+no network are touched.
 """
 
 from __future__ import annotations
@@ -41,6 +40,7 @@ from vllm_mlx.utils.tokenizer import _resolve_subfolder_checkpoint
 # and ``resolve_model`` both leave it untouched, so only the marker fallback
 # can select the subfolder.
 RAW_REPO = "acme/MultiVariant-MLX"
+CATALOG_REPO = "LiquidAI/LFM2.5-2.6B-MLX"
 
 
 def _multi_variant_tree():
@@ -79,6 +79,15 @@ def test_persist_empty_is_a_noop(marker_path):
     _download_gate.persist_pulled_variant(RAW_REPO, "")
     assert _download_gate.pulled_variant(RAW_REPO) is None
     assert not marker_path.exists()
+
+
+@pytest.mark.parametrize(
+    "invalid", ["../escape", "/absolute", "C:/drive", "4bit\\escape", "*", "4bit/"]
+)
+def test_invalid_marker_values_fail_closed(marker_path, invalid):
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(invalid)
+    assert _download_gate.pulled_variant(RAW_REPO) is None
 
 
 def test_missing_marker_returns_none_without_error(marker_path):
@@ -123,6 +132,35 @@ def test_serve_resolves_a_pulled_bits_variant(monkeypatch, tmp_path, marker_path
     # The handed-over directory must be where mlx-lm's loader glob will hit.
     assert Path(resolved, "config.json").exists()
     assert list(Path(resolved).glob("model*.safetensors"))
+
+
+def test_pulled_variant_overrides_catalog_default(monkeypatch, tmp_path, marker_path):
+    """An explicit 8-bit pull wins over this repo's catalog 4-bit default."""
+    from vllm_mlx.model_aliases import resolve_subfolder
+
+    assert resolve_subfolder(CATALOG_REPO) == "4bit", "precondition: catalog default"
+
+    snapshot = tmp_path / "snapshots" / "cafebabe"
+    (snapshot / "8bit").mkdir(parents=True)
+    (snapshot / "8bit" / "config.json").write_text("{}")
+    (snapshot / "8bit" / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    seen: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen["repo_id"] = repo_id
+        seen["allow_patterns"] = kwargs.get("allow_patterns")
+        return str(snapshot)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    _download_gate.persist_pulled_variant(CATALOG_REPO, "8bit")
+
+    resolved = _resolve_subfolder_checkpoint(CATALOG_REPO)
+
+    assert resolved == os.path.join(str(snapshot), "8bit")
+    assert seen == {"repo_id": CATALOG_REPO, "allow_patterns": ["8bit/*"]}
 
 
 def test_serve_uses_format_marker_folder(monkeypatch, tmp_path, marker_path):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -268,6 +268,51 @@ async def test_dynamic_resident_loads_singleton_no_refs_snapshot_offline(
 
 
 @pytest.mark.asyncio
+async def test_dynamic_resident_preserves_explicit_subfolder_alias(
+    monkeypatch, scheduler_config_stub
+):
+    """Residency and startup must apply the same alias-over-marker precedence."""
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    alias = "lfm2.5-2.6b-4bit"
+    repo = "LiquidAI/LFM2.5-2.6B-MLX"
+    seen: list[str] = []
+    captured: dict[str, object] = {}
+
+    class FakeEngine:
+        is_mllm = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            pass
+
+        def generate_warmup(self):
+            pass
+
+    def fake_resolve_checkpoint(model_name, **kwargs):
+        seen.append(model_name)
+        return SimpleNamespace(
+            model_path=repo,
+            load_path="/cache/snapshots/revision/4bit",
+            auto_text_fallback=False,
+            lane_reason="text_checkpoint",
+        )
+
+    monkeypatch.setattr(server, "BatchedEngine", FakeEngine)
+    monkeypatch.setattr(server, "_resolve_serving_checkpoint", fake_resolve_checkpoint)
+
+    entry = await server._load_dynamic_resident_model(alias, repo)
+
+    assert seen == [alias]
+    assert captured["model_name"] == "/cache/snapshots/revision/4bit"
+    assert entry.model_path == repo
+
+
+@pytest.mark.asyncio
 async def test_dynamic_switch_restores_hybrid_text_lane(
     monkeypatch, tmp_path, scheduler_config_stub
 ):

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -424,6 +424,50 @@ def test_serve_command_threads_auto_detected_hybrid_into_cache_admission(
     assert scheduler.non_trimmable_exact_prefix_reuse is True
 
 
+def test_serve_command_detects_defaults_from_pulled_variant_checkpoint(
+    stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
+):
+    """CLI defaults follow the marker-resolved checkpoint, not the repo root."""
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.model_profile import ModelProfile
+
+    checkpoint = "/cache/snapshots/revision/8bit"
+    resolved: list[str] = []
+
+    def resolve_checkpoint(model_name):
+        resolved.append(model_name)
+        return checkpoint
+
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
+        resolve_checkpoint,
+    )
+    detected: list[str] = []
+
+    def detect_model_config(model_name):
+        detected.append(model_name)
+        return ModelProfile(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+        )
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_auto_config.detect_model_config", detect_model_config
+    )
+    monkeypatch.setattr(server_mod, "load_model", lambda *_args, **_kwargs: None)
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns(port=_free_tcp_port())
+    ns.model = "publisher/multi-variant"
+    ns._original_alias = None
+
+    cli.serve_command(ns)
+
+    assert resolved == ["publisher/multi-variant"]
+    assert detected == [checkpoint]
+    assert ns.tool_call_parser == "hermes"
+    assert ns.reasoning_parser == "qwen3"
+
+
 def test_serve_command_cache_is_first_metadata_consumer(
     stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -244,6 +244,57 @@ def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypat
     assert server._engine.kwargs["model_name"] == "/cache/snapshots/revision/4bit"
 
 
+def test_load_model_detects_config_from_resolved_pulled_variant(monkeypatch):
+    """An uncatalogued repo must inspect the same subfolder it loads.
+
+    ``pull --bits`` leaves the repository root without a ``config.json``.  The
+    marker-aware checkpoint resolver supplies the selected local directory;
+    auto-config and generation defaults must not probe the bare repo first.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+    from vllm_mlx.model_profile import ModelProfile
+
+    _stub_routing_globals(monkeypatch, server)
+    checkpoint = "/cache/snapshots/revision/8bit"
+    monkeypatch.setattr(
+        server,
+        "_resolve_serving_checkpoint",
+        lambda _name, **_kwargs: SimpleNamespace(
+            model_path="publisher/multi-variant",
+            load_path=checkpoint,
+            auto_text_fallback=False,
+            lane_reason="text_checkpoint",
+        ),
+    )
+    detected: list[str] = []
+
+    def detect(path):
+        detected.append(path)
+        return ModelProfile()
+
+    # A bare repo can reverse-resolve to the catalog's default alias. The
+    # persisted 8-bit choice must still make checkpoint metadata authoritative.
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_profile", lambda _name: ModelProfile()
+    )
+    monkeypatch.setattr("vllm_mlx._download_gate.pulled_variant", lambda _name: "8bit")
+    monkeypatch.setattr("vllm_mlx.model_auto_config.detect_model_config", detect)
+    generation_paths: list[str] = []
+    monkeypatch.setattr(
+        "vllm_mlx.utils.generation_config.load_generation_config_sampling",
+        lambda path: generation_paths.append(path) or {},
+    )
+
+    server.load_model("publisher/multi-variant")
+
+    assert detected == [checkpoint]
+    assert generation_paths == [checkpoint]
+    assert server._engine is not None
+    assert server._engine.kwargs["model_name"] == checkpoint
+
+
 def test_materialized_checkpoint_keeps_catalog_vision_memory_floor(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -211,6 +211,39 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     assert server._engine.kwargs.get("force_text") is False
 
 
+def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypatch):
+    """CLI alias identity must survive its early alias-to-repo normalization."""
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    _stub_routing_globals(monkeypatch, server)
+    monkeypatch.setattr(
+        server,
+        "_model_alias",
+        "lfm2.5-2.6b-4bit",
+        raising=False,
+    )
+    seen: list[str] = []
+
+    def fake_resolve_checkpoint(model_name, **kwargs):
+        seen.append(model_name)
+        return SimpleNamespace(
+            model_path="LiquidAI/LFM2.5-2.6B-MLX",
+            load_path="/cache/snapshots/revision/4bit",
+            auto_text_fallback=False,
+            lane_reason="text_checkpoint",
+        )
+
+    monkeypatch.setattr(server, "_resolve_serving_checkpoint", fake_resolve_checkpoint)
+
+    server.load_model("LiquidAI/LFM2.5-2.6B-MLX")
+
+    assert seen == ["lfm2.5-2.6b-4bit"]
+    assert server._engine is not None
+    assert server._engine.kwargs["model_name"] == "/cache/snapshots/revision/4bit"
+
+
 def test_materialized_checkpoint_keeps_catalog_vision_memory_floor(monkeypatch):
     from types import SimpleNamespace
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -406,11 +406,18 @@ def pulled_variant(repo_id: str) -> str | None:
         return None
 
 
+def _escape_variant_glob_literal(name: str) -> str:
+    """Escape one validated variant folder for an HF allow-pattern glob."""
+    out: list[str] = []
+    for char in name:
+        out.append(f"[{char}]" if char in "[]*?" else char)
+    return "".join(out)
+
+
 def _valid_variant_subfolder(variant: object) -> bool:
-    """Whether a marker is a relative, downward, non-glob repo subfolder."""
+    """Whether a marker is a relative, downward repo subfolder."""
     if not isinstance(variant, str) or not variant:
         return False
-    glob_meta = set("*?[]!")
     drive_qualified = len(variant) >= 2 and variant[1] == ":"
     return not (
         variant.startswith("/")
@@ -419,7 +426,6 @@ def _valid_variant_subfolder(variant: object) -> bool:
         or "\\" in variant
         or ".." in variant.split("/")
         or variant.endswith("/")
-        or glob_meta & set(variant)
     )
 
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -352,7 +352,7 @@ def persist_pulled_variant(repo_id: str, variant: str) -> None:
     the pull valid and merely means the serve path falls back to (honest)
     whole-repo-root resolution for that repo.
     """
-    if not variant:
+    if not _valid_variant_subfolder(variant):
         return
     try:
         refs_dir = os.path.dirname(_variant_marker_path(repo_id))
@@ -377,9 +377,26 @@ def pulled_variant(repo_id: str) -> str | None:
     try:
         with open(_variant_marker_path(repo_id), encoding="utf-8") as fh:
             variant = fh.read().strip()
-        return variant or None
+        return variant if _valid_variant_subfolder(variant) else None
     except OSError:
         return None
+
+
+def _valid_variant_subfolder(variant: object) -> bool:
+    """Whether a marker is a relative, downward, non-glob repo subfolder."""
+    if not isinstance(variant, str) or not variant:
+        return False
+    glob_meta = set("*?[]!")
+    drive_qualified = len(variant) >= 2 and variant[1] == ":"
+    return not (
+        variant.startswith("/")
+        or os.path.isabs(variant)
+        or drive_qualified
+        or "\\" in variant
+        or ".." in variant.split("/")
+        or variant.endswith("/")
+        or glob_meta & set(variant)
+    )
 
 
 def _model_info_with_timeout(repo_id: str, timeout: float):

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -355,15 +355,25 @@ def persist_pulled_variant(repo_id: str, variant: str) -> None:
     if not _valid_variant_subfolder(variant):
         return
     try:
+        import tempfile
+
         refs_dir = os.path.dirname(_variant_marker_path(repo_id))
         os.makedirs(refs_dir, exist_ok=True)
         target = _variant_marker_path(repo_id)
-        temporary = f"{target}.{os.getpid()}.tmp"
+        fd, temporary = tempfile.mkstemp(
+            dir=refs_dir,
+            prefix=".rapidmlx-variant.",
+            suffix=".tmp",
+        )
         try:
-            with open(temporary, "w", encoding="utf-8") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(variant)
-        finally:
             os.replace(temporary, target)
+        finally:
+            try:
+                os.remove(temporary)
+            except FileNotFoundError:
+                pass
     except OSError:
         pass
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -307,6 +307,81 @@ def pin_main_ref(repo_id: str, revision: str) -> None:
         pass
 
 
+# ---------------------------------------------------------------------------
+# Pull-persisted variant marker (#2340).
+#
+# ``pull --bits N / --format name`` fetches only ONE subfolder of a
+# multi-variant repo (``LiquidAI/LFM2.5-2.6B-MLX`` → ``4bit/``, ``8bit/``,
+# ``bf16/`` ...). Nothing downstream, however, remembers which one was
+# fetched: a raw repo id has no catalog subfolder, so ``serve <repo>``
+# resolves the repo ROOT, which ships no weights. The marker below records
+# the pulled variant in the HF cache so the serve/load path can join the
+# same subfolder — the pulled variant is the SSOT for what can be served.
+#
+# It mirrors the ``pin_main_ref`` shape: a tiny file written atomically
+# under ``models--<repo>/refs/``, best-effort, never on the hot path.
+# ---------------------------------------------------------------------------
+
+
+def _variant_marker_path(repo_id: str) -> str:
+    """The HF-cache path holding a ``--bits/--format`` pulled variant name.
+
+    Lives in the same ``refs/`` directory the loader keys off for the
+    snapshot sha (``refs/main``), namespaced so it can never collide with a
+    real branch ref. Pure path computation — no network, no state.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+    except Exception:
+        HF_HUB_CACHE = os.path.join(
+            os.path.expanduser("~"), ".cache", "huggingface", "hub"
+        )
+    return os.path.join(
+        HF_HUB_CACHE,
+        f"models--{repo_id.replace('/', '--')}",
+        "refs",
+        ".rapidmlx-variant",
+    )
+
+
+def persist_pulled_variant(repo_id: str, variant: str) -> None:
+    """Atomically record the subfolder a narrowed ``pull --bits/--format`` fetched.
+
+    Called only on the narrowed pull path (after the variant was validated to
+    exist and its files were fetched). Best-effort: a failure to write leaves
+    the pull valid and merely means the serve path falls back to (honest)
+    whole-repo-root resolution for that repo.
+    """
+    if not variant:
+        return
+    try:
+        refs_dir = os.path.dirname(_variant_marker_path(repo_id))
+        os.makedirs(refs_dir, exist_ok=True)
+        target = _variant_marker_path(repo_id)
+        temporary = f"{target}.{os.getpid()}.tmp"
+        try:
+            with open(temporary, "w", encoding="utf-8") as fh:
+                fh.write(variant)
+        finally:
+            os.replace(temporary, target)
+    except OSError:
+        pass
+
+
+def pulled_variant(repo_id: str) -> str | None:
+    """The subfolder a previous ``pull --bits/--format`` fetched for ``repo_id``.
+
+    ``None`` means "no variant has been recorded" — the caller keeps whatever
+    resolution it had (catalog subfolder, or the repo root for a flat repo).
+    """
+    try:
+        with open(_variant_marker_path(repo_id), encoding="utf-8") as fh:
+            variant = fh.read().strip()
+        return variant or None
+    except OSError:
+        return None
+
+
 def _model_info_with_timeout(repo_id: str, timeout: float):
     """Call ``HfApi().model_info`` with a hard timeout.
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -368,6 +368,20 @@ def persist_pulled_variant(repo_id: str, variant: str) -> None:
         pass
 
 
+def clear_pulled_variant(repo_id: str) -> None:
+    """Forget a prior narrowed-pull choice after a successful ordinary pull.
+
+    The marker describes the user's latest successful pull mode, not every
+    variant that may happen to remain in the cache.  Clearing is best-effort
+    for the same reason writing is: cache metadata must never turn a completed
+    model download into a failed command.
+    """
+    try:
+        os.remove(_variant_marker_path(repo_id))
+    except OSError:
+        pass
+
+
 def pulled_variant(repo_id: str) -> str | None:
     """The subfolder a previous ``pull --bits/--format`` fetched for ``repo_id``.
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -318,17 +318,20 @@ def pin_main_ref(repo_id: str, revision: str) -> None:
 # the pulled variant in the HF cache so the serve/load path can join the
 # same subfolder — the pulled variant is the SSOT for what can be served.
 #
-# It mirrors the ``pin_main_ref`` shape: a tiny file written atomically
-# under ``models--<repo>/refs/``, best-effort, never on the hot path.
+# It mirrors the atomic-write shape of ``pin_main_ref`` but lives outside the
+# Hub-managed ``refs/`` directory. Every file under ``refs/`` is interpreted as
+# a commit ref by ``scan_cache_dir``; application metadata there corrupts Hub
+# cache scans. The repository-local ``.rapid-mlx/`` directory is ignored by
+# that scanner and is deleted naturally with the cached repository.
 # ---------------------------------------------------------------------------
 
 
 def _variant_marker_path(repo_id: str) -> str:
     """The HF-cache path holding a ``--bits/--format`` pulled variant name.
 
-    Lives in the same ``refs/`` directory the loader keys off for the
-    snapshot sha (``refs/main``), namespaced so it can never collide with a
-    real branch ref. Pure path computation — no network, no state.
+    Lives under a Rapid-MLX-owned directory beside the Hub-managed
+    ``refs/``/``snapshots/`` trees, so Hub cache scans never interpret the
+    variant as a commit hash. Pure path computation — no network, no state.
     """
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
@@ -339,8 +342,8 @@ def _variant_marker_path(repo_id: str) -> str:
     return os.path.join(
         HF_HUB_CACHE,
         f"models--{repo_id.replace('/', '--')}",
-        "refs",
-        ".rapidmlx-variant",
+        ".rapid-mlx",
+        "variant",
     )
 
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -347,24 +347,25 @@ def _variant_marker_path(repo_id: str) -> str:
     )
 
 
-def persist_pulled_variant(repo_id: str, variant: str) -> None:
+def persist_pulled_variant(repo_id: str, variant: str) -> bool:
     """Atomically record the subfolder a narrowed ``pull --bits/--format`` fetched.
 
     Called only on the narrowed pull path (after the variant was validated to
-    exist and its files were fetched). Best-effort: a failure to write leaves
-    the pull valid and merely means the serve path falls back to (honest)
-    whole-repo-root resolution for that repo.
+    exist and its files were fetched). Returns whether the marker was updated.
+    On failure, removes any older marker when possible so a successful 8-bit
+    pull cannot silently leave a stale 4-bit serving choice behind. The caller
+    must surface ``False`` because cleanup can also fail on an unwritable cache.
     """
     if not _valid_variant_subfolder(variant):
-        return
+        return False
+    target = _variant_marker_path(repo_id)
     try:
         import tempfile
 
-        refs_dir = os.path.dirname(_variant_marker_path(repo_id))
-        os.makedirs(refs_dir, exist_ok=True)
-        target = _variant_marker_path(repo_id)
+        marker_dir = os.path.dirname(target)
+        os.makedirs(marker_dir, exist_ok=True)
         fd, temporary = tempfile.mkstemp(
-            dir=refs_dir,
+            dir=marker_dir,
             prefix=".rapidmlx-variant.",
             suffix=".tmp",
         )
@@ -378,7 +379,16 @@ def persist_pulled_variant(repo_id: str, variant: str) -> None:
             except FileNotFoundError:
                 pass
     except OSError:
-        pass
+        # A previous variant is actively worse than no metadata: serving the
+        # repo would confidently load the wrong checkpoint. Best-effort
+        # invalidation plus a False return lets the CLI warn even when cache
+        # permissions also prevent cleanup.
+        try:
+            os.remove(target)
+        except OSError:
+            pass
+        return False
+    return True
 
 
 def clear_pulled_variant(repo_id: str) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7068,19 +7068,34 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         # #2340: persist the pulled variant so a later ``serve <repo>`` can
         # join the same subfolder. A later successful ordinary pull clears an
         # older marker so stale cache metadata cannot override that newer
-        # choice. Best-effort — the pull itself is already done and valid.
-        try:
-            if variant_allow is not None:
-                _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
+        # choice. The pull itself is already done and valid, so metadata I/O
+        # does not turn it into a failed download; a narrowed-pull metadata
+        # failure is surfaced loudly because serving could otherwise reuse an
+        # older choice.
+        if variant_allow is not None:
+            _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
+            _marker_updated = False
+            try:
                 from vllm_mlx._download_gate import persist_pulled_variant
 
-                persist_pulled_variant(repo_id, _variant_name)
-            else:
+                _marker_updated = persist_pulled_variant(repo_id, _variant_name)
+            except Exception:
+                pass
+            if not _marker_updated:
+                print(
+                    f"  Warning: downloaded {_variant_name}/, but could not "
+                    "record that serving choice in the model cache. "
+                    f"`rapid-mlx serve {repo_id}` may select an older or "
+                    "default checkpoint. Fix the cache permissions and "
+                    "re-run this pull."
+                )
+        else:
+            try:
                 from vllm_mlx._download_gate import clear_pulled_variant
 
                 clear_pulled_variant(repo_id)
-        except Exception:
-            pass
+            except Exception:
+                pass
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7057,6 +7057,19 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         )
         _after = _blob_identifier(_cache_root)
         _was_cached = (_before == _after and _before != ()) and not _mirror_fetched
+        # #2340: persist the pulled variant so a later ``serve <repo>`` can
+        # join the same subfolder. Only the narrowed ``--bits/--format`` path
+        # records one; a whole-repo pull leaves no marker and serve keeps its
+        # normal (root or catalog-subfolder) resolution. Best-effort — the
+        # pull itself is already done and valid at this point.
+        if variant_allow is not None:
+            _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
+            try:
+                from vllm_mlx._download_gate import persist_pulled_variant
+
+                persist_pulled_variant(repo_id, _variant_name)
+            except Exception:
+                pass
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6957,6 +6957,15 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         # ``network_fetch`` is the mirror's authoritative "any bytes fetched
         # this pull" verdict (covers a fetched zero-byte file, codex #4).
         _was_cached = not _mirror_out.get("network_fetch", True)
+        # A successful ordinary pull supersedes any earlier explicit
+        # ``--bits/--format`` choice for this repo. Keep cache metadata aligned
+        # even on the mirror-success early return.
+        try:
+            from vllm_mlx._download_gate import clear_pulled_variant
+
+            clear_pulled_variant(repo_id)
+        except Exception:
+            pass
         _print_pull_summary(
             repo_id,
             snapshot_dir,
@@ -7058,18 +7067,21 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         _after = _blob_identifier(_cache_root)
         _was_cached = (_before == _after and _before != ()) and not _mirror_fetched
         # #2340: persist the pulled variant so a later ``serve <repo>`` can
-        # join the same subfolder. Only the narrowed ``--bits/--format`` path
-        # records one; a whole-repo pull leaves no marker and serve keeps its
-        # normal (root or catalog-subfolder) resolution. Best-effort — the
-        # pull itself is already done and valid at this point.
-        if variant_allow is not None:
-            _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
-            try:
+        # join the same subfolder. A later successful ordinary pull clears an
+        # older marker so stale cache metadata cannot override that newer
+        # choice. Best-effort — the pull itself is already done and valid.
+        try:
+            if variant_allow is not None:
+                _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
                 from vllm_mlx._download_gate import persist_pulled_variant
 
                 persist_pulled_variant(repo_id, _variant_name)
-            except Exception:
-                pass
+            else:
+                from vllm_mlx._download_gate import clear_pulled_variant
+
+                clear_pulled_variant(repo_id)
+        except Exception:
+            pass
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3356,7 +3356,16 @@ def serve_command(args):
             auto_config_resolved = True
             return None
         try:
-            auto_config = detect_model_config(args.model)
+            # ``pull --bits/--format`` records the selected subfolder for a
+            # bare multi-variant repo. Read defaults from that concrete
+            # checkpoint, not the config-less repository root. Preserve an
+            # explicit alias because its catalog subfolder outranks a repo
+            # marker by contract.
+            from .utils.tokenizer import _resolve_subfolder_checkpoint
+
+            config_identity = getattr(args, "_original_alias", None) or args.model
+            config_path = _resolve_subfolder_checkpoint(config_identity)
+            auto_config = detect_model_config(config_path)
         except Exception as e:
             if not non_fatal:
                 raise

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6794,10 +6794,9 @@ def _escape_glob_literal(name: str) -> str:
     (``4bit``, ``mxfp4``) never hit this, but the selector claims to handle
     arbitrary multi-variant repos, so it must not corrupt their folder names.
     """
-    out: list[str] = []
-    for ch in name:
-        out.append(f"[{ch}]" if ch in "[]*?" else ch)
-    return "".join(out)
+    from ._download_gate import _escape_variant_glob_literal
+
+    return _escape_variant_glob_literal(name)
 
 
 def _resolve_variant_allow_patterns(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1993,11 +1993,18 @@ def load_model(
     # resolve_profile handles both alias-name and HF-path lookups, so a
     # single call suffices regardless of which form load_model was passed.
     _profile = resolve_profile(effective_model_alias or requested_model_name)
-    _model_config = _profile
-    if _model_config is None:
-        from .model_auto_config import detect_model_config
+    # A reverse-catalog profile is only a default for a bare repo ID. When a
+    # narrowed pull marker selects another checkpoint in that repo, its local
+    # metadata is authoritative for auto-config just as an explicit alias is.
+    _bare_repo_has_pulled_variant = False
+    if effective_model_alias is None:
+        try:
+            from ._download_gate import pulled_variant
 
-        _model_config = detect_model_config(model_name)
+            _bare_repo_has_pulled_variant = pulled_variant(model_name) is not None
+        except Exception:
+            pass
+    _model_config = None if _bare_repo_has_pulled_variant else _profile
     if _profile is not None and _profile.recommended_sampling:
         _alias_recommended_sampling = dict(_profile.recommended_sampling)
 
@@ -2100,6 +2107,16 @@ def load_model(
         _engine_model_path = _serving_checkpoint.load_path
         _auto_text_fallback = _serving_checkpoint.auto_text_fallback
         _serving_lane_reason = _serving_checkpoint.lane_reason
+
+    # A bare multi-variant repo has no useful config at its root. Resolve the
+    # concrete checkpoint first, then derive every checkpoint-owned default
+    # from that same directory the engine will load. Before #2340 this probe
+    # ran above ``_resolve_serving_checkpoint`` and could silently configure an
+    # uncatalogued ``pull --bits/--format`` model from the empty repo root.
+    if _model_config is None:
+        from .model_auto_config import detect_model_config
+
+        _model_config = detect_model_config(_engine_model_path)
     if _auto_text_fallback:
         fallback_detail = {
             "text_lane_speculative_decode": (
@@ -2128,7 +2145,7 @@ def load_model(
         )
 
     try:
-        gen_cfg = load_generation_config_sampling(model_name)
+        gen_cfg = load_generation_config_sampling(_engine_model_path)
     except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders
         logger.debug(f"generation_config load failed (non-fatal): {_e}")
         gen_cfg = {}
@@ -3348,7 +3365,10 @@ Examples:
             auto_config_resolved = True
             return None
         try:
-            auto_config = detect_model_config(args.model)
+            from .utils.tokenizer import _resolve_subfolder_checkpoint
+
+            config_path = _resolve_subfolder_checkpoint(args.model)
+            auto_config = detect_model_config(config_path)
         except Exception as exc:
             if not non_fatal:
                 raise

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2413,8 +2413,14 @@ async def _load_dynamic_resident_model(
     effective_force_text = profile_force_text
     serving_lane_reason = "not_applicable"
     if modality == "text":
+        # Keep an explicit alias authoritative when the control plane also
+        # supplies its canonical path. A genuine path override still wins;
+        # only use the alias spelling when it resolves to that same checkpoint.
+        checkpoint_identity = (
+            model_name if resolve_model(model_name) == resolved_path else resolved_path
+        )
         serving_checkpoint = _resolve_serving_checkpoint(
-            resolved_path,
+            checkpoint_identity,
             force_text=profile_force_text,
             # Residency loads carry no spec-decode request; keep the lane
             # contract identical to startup (whose default is also "none").

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1998,12 +1998,9 @@ def load_model(
     # metadata is authoritative for auto-config just as an explicit alias is.
     _bare_repo_has_pulled_variant = False
     if effective_model_alias is None:
-        try:
-            from ._download_gate import pulled_variant
+        from ._download_gate import pulled_variant
 
-            _bare_repo_has_pulled_variant = pulled_variant(model_name) is not None
-        except Exception:
-            pass
+        _bare_repo_has_pulled_variant = pulled_variant(model_name) is not None
     _model_config = None if _bare_repo_has_pulled_variant else _profile
     if _profile is not None and _profile.recommended_sampling:
         _alias_recommended_sampling = dict(_profile.recommended_sampling)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1745,19 +1745,30 @@ def _resolve_serving_checkpoint(
     the engine must receive that local path rather than retrying the repo id.
     """
     from .model_aliases import resolve_model, resolve_profile
+    from .utils.tokenizer import _resolve_subfolder_checkpoint
 
     model_path = resolve_model(model_name)
+    # Resolve a multi-variant repository before reading metadata or choosing a
+    # serving lane. This is the one checkpoint-identity choke point shared by
+    # startup and residency: an explicit alias keeps its declared subfolder,
+    # while a bare repo ID may recover the latest ``pull --bits/--format``
+    # marker. Deferring this to BatchedEngine loses the CLI's alias spelling
+    # and lets reverse-catalog metadata select the default checkpoint first.
+    resolved_subfolder_path = _resolve_subfolder_checkpoint(model_name)
+    checkpoint_path = (
+        model_path if resolved_subfolder_path == model_name else resolved_subfolder_path
+    )
     if not force_mllm and not force_text:
-        _ensure_routing_config(model_path)
+        _ensure_routing_config(checkpoint_path)
     from .model_metadata import read_model_metadata
 
-    metadata = read_model_metadata(model_path)
+    metadata = read_model_metadata(checkpoint_path)
     load_path = (
         str(metadata.snapshot_dir)
         if metadata is not None and metadata.snapshot_dir is not None
-        else model_path
+        else checkpoint_path
     )
-    profile = resolve_profile(model_path)
+    profile = resolve_profile(model_name) or resolve_profile(model_path)
     decision = resolve_serving_lane_decision(
         load_path,
         force_mllm=force_mllm,
@@ -2077,7 +2088,7 @@ def load_model(
     _serving_lane_reason = "not_applicable"
     if not _is_generative_media:
         _serving_checkpoint = _resolve_serving_checkpoint(
-            model_name,
+            effective_model_alias or model_name,
             force_mllm=force_mllm,
             force_text=force_text,
             requested_spec_decode=(

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1024,24 +1024,23 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     # A malformed aliases.json is a hard error everywhere else too
     # (``resolve_model`` loads the same registry at CLI startup), so this
     # is consistent, not a new failure mode.
-    from ..model_aliases import resolve_model, resolve_subfolder
-
-    subfolder = resolve_subfolder(model_name)
-
     from huggingface_hub import snapshot_download
 
     from .._download_gate import _snapshot_is_complete, pulled_variant
+    from ..model_aliases import resolve_model, resolve_subfolder
 
-    # #2340: a raw repo id (no catalog alias) that was pulled with
-    # ``--bits/--format`` recorded its chosen variant in the HF cache. Recover
-    # it so ``serve <repo>`` after ``pull --bits 4 <repo>`` joins the same
-    # subfolder instead of pointing at the weightless repo root.
+    repo_id = resolve_model(model_name)
+
+    # #2340: a repo pulled with ``--bits/--format`` recorded its chosen variant
+    # in the HF cache. Recover it before consulting the catalog: the marker is
+    # the user's latest explicit pull choice, whereas a reverse catalog lookup
+    # can only recover the repo's default subfolder after the CLI has resolved
+    # an alias to its bare repo id. Without this precedence, ``pull --bits 8``
+    # followed by ``serve <repo>`` silently loads the catalog's 4-bit default.
     # ``pulled_variant`` is best-effort and returns ``None`` when the repo was
-    # never narrowed (or the marker is unreadable) — both fall through to the
-    # historical whole-repo-root resolution below.
-    if subfolder is None:
-        repo_id = resolve_model(model_name)
-        subfolder = pulled_variant(repo_id)
+    # never narrowed (or the marker is invalid/unreadable) — those cases retain
+    # the historical catalog-subfolder or whole-repo-root resolution.
+    subfolder = pulled_variant(repo_id) or resolve_subfolder(model_name)
     if not subfolder:
         return model_name
     # ``resolve_subfolder`` answers for BOTH spellings — the alias the user
@@ -1050,8 +1049,6 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     # programmatic callers reach with a bare alias, skipping the CLI's
     # pre-resolution, so normalize here instead of assuming someone
     # upstream already did.
-    repo_id = resolve_model(model_name)
-
     patterns = [f"{subfolder}/*"]
 
     # Offline-first: a warm, COMPLETE cache resolves with zero network. The

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1031,16 +1031,19 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
 
     repo_id = resolve_model(model_name)
 
-    # #2340: a repo pulled with ``--bits/--format`` recorded its chosen variant
-    # in the HF cache. Recover it before consulting the catalog: the marker is
-    # the user's latest explicit pull choice, whereas a reverse catalog lookup
-    # can only recover the repo's default subfolder after the CLI has resolved
-    # an alias to its bare repo id. Without this precedence, ``pull --bits 8``
-    # followed by ``serve <repo>`` silently loads the catalog's 4-bit default.
-    # ``pulled_variant`` is best-effort and returns ``None`` when the repo was
-    # never narrowed (or the marker is invalid/unreadable) — those cases retain
-    # the historical catalog-subfolder or whole-repo-root resolution.
-    subfolder = pulled_variant(repo_id) or resolve_subfolder(model_name)
+    # #2340 precedence is intentional:
+    #
+    # 1. An explicit alias names a specific catalog checkpoint and must win.
+    # 2. A bare repo id uses the latest successful ``pull --bits/--format``
+    #    marker, when present.
+    # 3. Otherwise retain the historical reverse-catalog default/root lookup.
+    #
+    # This lets ``pull --bits 8 <repo>`` followed by ``serve <repo>`` recover
+    # 8bit without letting stale repo-level cache metadata change what
+    # ``serve lfm2.5-2.6b-4bit`` explicitly means.
+    catalog_subfolder = resolve_subfolder(model_name)
+    explicit_alias_subfolder = catalog_subfolder if model_name != repo_id else None
+    subfolder = explicit_alias_subfolder or pulled_variant(repo_id) or catalog_subfolder
     if not subfolder:
         return model_name
     # ``resolve_subfolder`` answers for BOTH spellings — the alias the user

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1027,6 +1027,21 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     from ..model_aliases import resolve_model, resolve_subfolder
 
     subfolder = resolve_subfolder(model_name)
+
+    from huggingface_hub import snapshot_download
+
+    from .._download_gate import _snapshot_is_complete, pulled_variant
+
+    # #2340: a raw repo id (no catalog alias) that was pulled with
+    # ``--bits/--format`` recorded its chosen variant in the HF cache. Recover
+    # it so ``serve <repo>`` after ``pull --bits 4 <repo>`` joins the same
+    # subfolder instead of pointing at the weightless repo root.
+    # ``pulled_variant`` is best-effort and returns ``None`` when the repo was
+    # never narrowed (or the marker is unreadable) — both fall through to the
+    # historical whole-repo-root resolution below.
+    if subfolder is None:
+        repo_id = resolve_model(model_name)
+        subfolder = pulled_variant(repo_id)
     if not subfolder:
         return model_name
     # ``resolve_subfolder`` answers for BOTH spellings — the alias the user
@@ -1036,10 +1051,6 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     # pre-resolution, so normalize here instead of assuming someone
     # upstream already did.
     repo_id = resolve_model(model_name)
-
-    from huggingface_hub import snapshot_download
-
-    from .._download_gate import _snapshot_is_complete
 
     patterns = [f"{subfolder}/*"]
 
@@ -1094,10 +1105,12 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     resolved = os.path.join(local, subfolder)
     if not os.path.isdir(resolved):
         raise RuntimeError(
-            f"{repo_id} declares subfolder {subfolder!r} but {resolved} "
+            f"{repo_id} resolves to subfolder {subfolder!r} but {resolved} "
             "does not exist after download — the publisher has probably "
-            "reorganized the repo. Update the alias rather than loading the "
-            "repo root, which is not a checkpoint."
+            "reorganized the repo, or the variant was pulled to a different "
+            "cache. Re-run `pull --bits/--format` for the variant (or update "
+            "the alias) rather than loading the repo root, which is not a "
+            "checkpoint."
         )
     # A directory is not a checkpoint. An interrupted or disk-full pull
     # leaves the folder present with its shards missing, and a publisher who

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1026,7 +1026,11 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     # is consistent, not a new failure mode.
     from huggingface_hub import snapshot_download
 
-    from .._download_gate import _snapshot_is_complete, pulled_variant
+    from .._download_gate import (
+        _escape_variant_glob_literal,
+        _snapshot_is_complete,
+        pulled_variant,
+    )
     from ..model_aliases import resolve_model, resolve_subfolder
 
     repo_id = resolve_model(model_name)
@@ -1052,7 +1056,7 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
     # programmatic callers reach with a bare alias, skipping the CLI's
     # pre-resolution, so normalize here instead of assuming someone
     # upstream already did.
-    patterns = [f"{subfolder}/*"]
+    patterns = [f"{_escape_variant_glob_literal(subfolder)}/*"]
 
     # Offline-first: a warm, COMPLETE cache resolves with zero network. The
     # online call used to run first and, on a poisoned-DNS network, hangs in

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1108,9 +1108,9 @@ def _resolve_subfolder_checkpoint(model_name: str) -> str:
             f"{repo_id} resolves to subfolder {subfolder!r} but {resolved} "
             "does not exist after download — the publisher has probably "
             "reorganized the repo, or the variant was pulled to a different "
-            "cache. Re-run `pull --bits/--format` for the variant (or update "
-            "the alias) rather than loading the repo root, which is not a "
-            "checkpoint."
+            f"cache. Re-run `rapid-mlx pull --format {subfolder} {repo_id}` "
+            "(or update the alias) rather than loading the repo root, which "
+            "is not a checkpoint."
         )
     # A directory is not a checkpoint. An interrupted or disk-full pull
     # leaves the folder present with its shards missing, and a publisher who


### PR DESCRIPTION
## Why

`rapid-mlx pull --bits 4 <multi-variant-repo>` downloads only the selected subfolder, but a later `serve <repo>` previously resolved the repository root or catalog default because the pull choice was discarded. Multi-variant repository roots can contain no loadable weights, so the successfully downloaded checkpoint was unreachable or the wrong quantization could be loaded.

The fix must also preserve an explicitly typed alias, behave identically for startup and dynamic residency, remain compatible with standard cache inspection, and never silently retain an older serving choice when metadata cannot be updated.

## What

- `vllm_mlx/_download_gate.py`
  - Stores the latest narrowed-pull choice atomically at `models--<repo>/.rapid-mlx/variant`, outside the cache manager's `refs/` and `snapshots/` namespaces.
  - Validates relative subfolder names, supports literal glob metacharacters safely, reads the marker fail-soft, and clears it after a successful ordinary pull.
  - Returns marker-update success and best-effort invalidates an older marker when a replacement fails.
- `vllm_mlx/cli.py`
  - Persists a successful `--bits/--format` selection on the Hugging Face fallback path.
  - Clears stale selection after ordinary pulls on both mirror-success and fallback exits.
  - Warns when weights downloaded but serving-choice metadata could not be updated, including the stale/default-checkpoint risk and recovery action.
- `vllm_mlx/utils/tokenizer.py`
  - Applies explicit alias > bare-repo pulled marker > reverse-catalog default precedence.
  - Escapes literal variant folder names before building narrow allow-patterns.
  - Keeps distinct actionable errors for absent and incomplete variant folders.
- `vllm_mlx/server.py`
  - Resolves concrete subfolder identity before metadata and serving-lane selection.
  - Preserves the CLI-saved alias after early alias normalization and applies the same rule to dynamic residency when alias and canonical path identify the same checkpoint.
- `.github/workflows/ci.yml`
  - Registers the new regression file for changed-lines coverage.

## Scope / Non-goals

Chosen approach: persist the successful pull choice and consume it in the shared checkpoint-resolution path.

Non-goals: no new `serve --bits/--format` syntax, no download-transport or mirror-protocol change, no alias-registry schema change, no scheduler or modality-policy change, no Desktop selector UI, and no version bump.

## Design precedent

The existing catalog `subfolder` contract remains authoritative for explicit aliases, but it cannot represent which one of several sibling variants a user selected for a bare repository ID. The pull path already validates and narrows that selection; this change preserves that state instead of inferring it later from an ambiguous snapshot tree.

The cache manager treats every file under `refs/` as a commit reference, so application metadata belongs in a repository-local application namespace. The marker therefore uses `.rapid-mlx/variant`; a real cache-scan regression verifies that the repository remains inspectable. Writes use the codebase's existing atomic replace pattern with unique temporary files.

The shared server checkpoint resolver is the mechanism boundary: it chooses the concrete checkpoint before routing metadata is read, and both startup and residency consume that result. A separate serve-side selector was rejected because it would require users to repeat and synchronize a choice already made at pull time.

## Verification

- `pytest tests/test_pull_variant_serve_resolution.py tests/test_server_load_model_order.py tests/test_resident_models.py tests/test_alias_subfolder.py tests/test_pull_variant_selection.py tests/test_download_gate.py tests/test_chat_template_registry.py` — 385 passed.
- Ruff check and format checks on all changed Python files — clean.
- Real cache scan with marker present — no corruption warning.
- Independent Codex review rounds dispositioned on the PR; the latest static review before the marker-failure fix found no other merge-blocking issue.
- Exact-head required CI and final `pr_validate` must be green before merge.

No local network pull, GUI run, or large-model load is used by these tests.

## Behaviour delta

- Before: a narrowed pull could be unreachable at serve time, a stale marker could select the wrong quantization, and explicit alias intent could be lost after CLI normalization or in residency.
- After: bare-repo serve recovers the latest successfully recorded narrowed choice; explicit aliases retain their declared subfolder in startup and residency; ordinary pulls clear stale narrowing.
- Literal format names containing glob metacharacters remain literal and cannot broaden the download pattern.
- If marker replacement fails, an older marker is invalidated when possible and the CLI always warns that bare-repo serve may select an older/default checkpoint. Downloaded weights are not falsely reported as failed.
- Flat repositories, local paths, and commit-pinned snapshot resolution retain their existing behavior.

Refs #2145, #2338. Fixes #2340.
