### PR TITLE
ci: recover full-ci gate from cancelled duplicate runs

### DIFF
--- a/.github/workflows/full-ci-label-gate.yml
+++ b/.github/workflows/full-ci-label-gate.yml
@@ -174,11 +174,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NAME: ${{ github.event.workflow_run.name }}
           RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
           PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
@@ -216,25 +214,40 @@ jobs:
 
           RUNS_JSON="$RUNNER_TEMP/source-runs.json"
           gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${RUN_SHA}&event=pull_request&per_page=100" > "$RUNS_JSON"
-          LATEST_RUN_ID=$(jq -r '[.workflow_runs[]] | if length > 0 then max_by(.id).id else "" end' "$RUNS_JSON")
-          if [ "$LATEST_RUN_ID" != "$RUN_ID" ]; then
-            echo "Not settling superseded $RUN_NAME evidence (latest_run=${LATEST_RUN_ID:-missing} completed_run=$RUN_ID)."
+          # A label event can create a higher-ID duplicate after an already-
+          # successful exact-head run. If that duplicate is cancelled, its
+          # completion event must recover the pending status instead of hiding
+          # the valid evidence. Select the latest successful run, not merely
+          # the numerically newest run that GitHub returned.
+          EVIDENCE_RUN=$(jq -c --arg sha "$RUN_SHA" '
+            [.workflow_runs[]
+              | select(
+                  .head_sha == $sha and
+                  .status == "completed" and
+                  .conclusion == "success"
+                )]
+            | if length > 0 then max_by(.id) else empty end
+          ' "$RUNS_JSON")
+          EVIDENCE_RUN_ID=$(jq -r '.id // empty' <<< "$EVIDENCE_RUN")
+          EVIDENCE_RUN_URL=$(jq -r '.html_url // empty' <<< "$EVIDENCE_RUN")
+          if [ -z "$EVIDENCE_RUN_ID" ] || [ -z "$EVIDENCE_RUN_URL" ]; then
+            echo "No successful exact-head $RUN_NAME evidence is available (trigger_run=$TRIGGER_RUN_ID); leaving status pending."
             exit 0
           fi
 
           JOB_PAGES="$RUNNER_TEMP/jobs.json"
           gh api --paginate --slurp \
-            "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" > "$JOB_PAGES"
+            "repos/${REPO}/actions/runs/${EVIDENCE_RUN_ID}/jobs?per_page=100" > "$JOB_PAGES"
           JOB_CONCLUSION=$(jq -r --arg context "$CONTEXT" \
             '[.[] | .jobs[] | select(.name == $context)] | if length == 1 then .[0].conclusion else "" end' \
             "$JOB_PAGES")
-          if [ "$WORKFLOW_CONCLUSION" != success ] || [ "$JOB_CONCLUSION" != success ]; then
-            echo "The exact-head $RUN_NAME run did not pass its $CONTEXT aggregate (workflow=$WORKFLOW_CONCLUSION job=${JOB_CONCLUSION:-missing}); leaving status pending."
+          if [ "$JOB_CONCLUSION" != success ]; then
+            echo "The selected exact-head $RUN_NAME run did not pass its $CONTEXT aggregate (evidence_run=$EVIDENCE_RUN_ID job=${JOB_CONCLUSION:-missing}); leaving status pending."
             exit 0
           fi
 
           jq -n \
             --arg context "$CONTEXT" \
-            --arg target_url "$RUN_URL" \
+            --arg target_url "$EVIDENCE_RUN_URL" \
             '{state: "success", context: $context, description: "Exact-head full-CI merge gate passed", target_url: $target_url}' \
             | gh api --method POST "repos/${REPO}/statuses/${RUN_SHA}" --input - >/dev/null

--- a/.github/workflows/full-ci-label-gate.yml
+++ b/.github/workflows/full-ci-label-gate.yml
@@ -217,21 +217,26 @@ jobs:
           # A label event can create a higher-ID duplicate after an already-
           # successful exact-head run. If that duplicate is cancelled, its
           # completion event must recover the pending status instead of hiding
-          # the valid evidence. Select the latest successful run, not merely
-          # the numerically newest run that GitHub returned.
+          # the valid evidence. Ignore cancelled duplicates, but keep newer
+          # failures authoritative so an older success cannot mask them.
           EVIDENCE_RUN=$(jq -c --arg sha "$RUN_SHA" '
             [.workflow_runs[]
               | select(
                   .head_sha == $sha and
                   .status == "completed" and
-                  .conclusion == "success"
+                  .conclusion != "cancelled"
                 )]
             | if length > 0 then max_by(.id) else empty end
           ' "$RUNS_JSON")
           EVIDENCE_RUN_ID=$(jq -r '.id // empty' <<< "$EVIDENCE_RUN")
           EVIDENCE_RUN_URL=$(jq -r '.html_url // empty' <<< "$EVIDENCE_RUN")
+          EVIDENCE_RUN_CONCLUSION=$(jq -r '.conclusion // empty' <<< "$EVIDENCE_RUN")
           if [ -z "$EVIDENCE_RUN_ID" ] || [ -z "$EVIDENCE_RUN_URL" ]; then
-            echo "No successful exact-head $RUN_NAME evidence is available (trigger_run=$TRIGGER_RUN_ID); leaving status pending."
+            echo "No non-cancelled exact-head $RUN_NAME evidence is available (trigger_run=$TRIGGER_RUN_ID); leaving status pending."
+            exit 0
+          fi
+          if [ "$EVIDENCE_RUN_CONCLUSION" != success ]; then
+            echo "The latest non-cancelled exact-head $RUN_NAME run did not succeed (evidence_run=$EVIDENCE_RUN_ID workflow=${EVIDENCE_RUN_CONCLUSION:-missing}); leaving status pending."
             exit 0
           fi
 

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -278,13 +278,105 @@ def test_metadata_gate_settles_only_live_exact_head_successful_full_ci():
     run = settle["steps"][0]["run"]
     assert 'LIVE_HEAD_SHA" != "$RUN_SHA' in run
     assert 'FULL_CI" != true' in run
-    assert 'WORKFLOW_CONCLUSION" != success' in run
     assert 'JOB_CONCLUSION" != success' in run
-    assert 'LATEST_RUN_ID" != "$RUN_ID' in run
+    assert '.conclusion == "success"' in run
+    assert "actions/runs/${EVIDENCE_RUN_ID}/jobs" in run
     assert "actions/workflows/${WORKFLOW_FILE}/runs" in run
-    assert "actions/runs/${RUN_ID}/jobs" in run
     assert 'state: "success"' in run
     assert "statuses/${RUN_SHA}" in run
+
+
+def test_metadata_gate_uses_success_before_higher_cancelled_duplicate(tmp_path):
+    run = _step_run(
+        LABEL_GATE_WORKFLOW,
+        "settle-completed-gate",
+        "Settle an exact-head full-CI status",
+    )
+    mock_bin = tmp_path / "bin"
+    mock_bin.mkdir()
+    mock_gh = mock_bin / "gh"
+    mock_gh.write_text(
+        """#!/bin/bash
+set -euo pipefail
+case "$*" in
+  "api repos/test/repo/pulls/7") cat "$MOCK_PR_JSON" ;;
+  *"/actions/workflows/rapid-mac-ci.yml/runs?"*) cat "$MOCK_RUNS_JSON" ;;
+  *"/actions/runs/90/jobs?"*) cat "$MOCK_JOBS_JSON" ;;
+  *"--method POST"*) cat > "$MOCK_POST" ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 91 ;;
+esac
+"""
+    )
+    mock_gh.chmod(0o755)
+
+    head_sha = "b" * 40
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"workflow_run": {"pull_requests": [{"number": 7}]}}))
+    pr_json = tmp_path / "mock-pr.json"
+    pr_json.write_text(
+        json.dumps(
+            {
+                "state": "open",
+                "base": {"ref": "main"},
+                "head": {"sha": head_sha},
+                "labels": [{"name": "full-ci"}],
+            }
+        )
+    )
+    runs_json = tmp_path / "runs.json"
+    runs_json.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 91,
+                        "head_sha": head_sha,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                        "html_url": "https://example.invalid/run/91",
+                    },
+                    {
+                        "id": 90,
+                        "head_sha": head_sha,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://example.invalid/run/90",
+                    },
+                ]
+            }
+        )
+    )
+    jobs_json = tmp_path / "mock-jobs.json"
+    jobs_json.write_text(
+        json.dumps([{"jobs": [{"name": "desktop-tests", "conclusion": "success"}]}])
+    )
+    post = tmp_path / "post.json"
+    env = os.environ | {
+        "GH_TOKEN": "test-token",
+        "GITHUB_EVENT_PATH": str(event),
+        "MOCK_JOBS_JSON": str(jobs_json),
+        "MOCK_POST": str(post),
+        "MOCK_PR_JSON": str(pr_json),
+        "MOCK_RUNS_JSON": str(runs_json),
+        "PATH": f"{mock_bin}:{os.environ['PATH']}",
+        "REPO": "test/repo",
+        "RUN_NAME": "rapid-mac CI",
+        "RUN_SHA": head_sha,
+        "RUNNER_TEMP": str(tmp_path),
+        "TRIGGER_RUN_ID": "91",
+    }
+
+    completed = subprocess.run(
+        ["bash", "-c", run], check=True, env=env, capture_output=True, text=True
+    )
+    assert post.exists(), completed.stdout + completed.stderr
+    payload = json.loads(post.read_text())
+    assert payload == {
+        "state": "success",
+        "context": "desktop-tests",
+        "description": "Exact-head full-CI merge gate passed",
+        "target_url": "https://example.invalid/run/90",
+    }
 
 
 def test_all_strict_required_workflows_emit_on_merge_group():

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -279,14 +279,17 @@ def test_metadata_gate_settles_only_live_exact_head_successful_full_ci():
     assert 'LIVE_HEAD_SHA" != "$RUN_SHA' in run
     assert 'FULL_CI" != true' in run
     assert 'JOB_CONCLUSION" != success' in run
-    assert '.conclusion == "success"' in run
+    assert '.conclusion != "cancelled"' in run
+    assert 'EVIDENCE_RUN_CONCLUSION" != success' in run
     assert "actions/runs/${EVIDENCE_RUN_ID}/jobs" in run
     assert "actions/workflows/${WORKFLOW_FILE}/runs" in run
     assert 'state: "success"' in run
     assert "statuses/${RUN_SHA}" in run
 
 
-def test_metadata_gate_uses_success_before_higher_cancelled_duplicate(tmp_path):
+def _execute_metadata_settlement(
+    tmp_path: Path, *, runs: list[tuple[int, str]]
+) -> tuple[dict[str, str] | None, str]:
     run = _step_run(
         LABEL_GATE_WORKFLOW,
         "settle-completed-gate",
@@ -301,7 +304,7 @@ set -euo pipefail
 case "$*" in
   "api repos/test/repo/pulls/7") cat "$MOCK_PR_JSON" ;;
   *"/actions/workflows/rapid-mac-ci.yml/runs?"*) cat "$MOCK_RUNS_JSON" ;;
-  *"/actions/runs/90/jobs?"*) cat "$MOCK_JOBS_JSON" ;;
+  *"/actions/runs/"*"/jobs?"*) cat "$MOCK_JOBS_JSON" ;;
   *"--method POST"*) cat > "$MOCK_POST" ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 91 ;;
 esac
@@ -329,19 +332,13 @@ esac
             {
                 "workflow_runs": [
                     {
-                        "id": 91,
+                        "id": run_id,
                         "head_sha": head_sha,
                         "status": "completed",
-                        "conclusion": "cancelled",
-                        "html_url": "https://example.invalid/run/91",
-                    },
-                    {
-                        "id": 90,
-                        "head_sha": head_sha,
-                        "status": "completed",
-                        "conclusion": "success",
-                        "html_url": "https://example.invalid/run/90",
-                    },
+                        "conclusion": conclusion,
+                        "html_url": f"https://example.invalid/run/{run_id}",
+                    }
+                    for run_id, conclusion in runs
                 ]
             }
         )
@@ -363,20 +360,36 @@ esac
         "RUN_NAME": "rapid-mac CI",
         "RUN_SHA": head_sha,
         "RUNNER_TEMP": str(tmp_path),
-        "TRIGGER_RUN_ID": "91",
+        "TRIGGER_RUN_ID": str(max(run_id for run_id, _ in runs)),
     }
 
     completed = subprocess.run(
         ["bash", "-c", run], check=True, env=env, capture_output=True, text=True
     )
-    assert post.exists(), completed.stdout + completed.stderr
-    payload = json.loads(post.read_text())
+    payload = json.loads(post.read_text()) if post.exists() else None
+    return payload, completed.stdout + completed.stderr
+
+
+def test_metadata_gate_uses_success_before_higher_cancelled_duplicate(tmp_path):
+    payload, output = _execute_metadata_settlement(
+        tmp_path, runs=[(91, "cancelled"), (90, "success")]
+    )
+    assert payload is not None, output
     assert payload == {
         "state": "success",
         "context": "desktop-tests",
         "description": "Exact-head full-CI merge gate passed",
         "target_url": "https://example.invalid/run/90",
     }
+
+
+def test_metadata_gate_does_not_mask_newer_failure_with_older_success(tmp_path):
+    payload, output = _execute_metadata_settlement(
+        tmp_path,
+        runs=[(92, "failure"), (91, "cancelled"), (90, "success")],
+    )
+    assert payload is None
+    assert "evidence_run=92 workflow=failure" in output
 
 
 def test_all_strict_required_workflows_emit_on_merge_group():


### PR DESCRIPTION
## Why

A pull request can emit duplicate source-workflow runs for one head SHA (for example, `opened` followed by `labeled`). The metadata gate selected the numerically newest run even when that duplicate was cancelled, hiding an earlier successful aggregate and leaving a protected status pending forever.

This is a human-authorized hotfix. It intentionally uses the not-applicable required-check path and must not receive the `full-ci` label. The human authorized Harbor to self-merge it once the exact-head required statuses are green.

## What

- Select the highest-ID **completed, non-cancelled** source run for the exact head; require that selected run to succeed, so cancelled duplicates are ignored but newer failures remain authoritative.
- Read the aggregate job and target URL from that selected evidence run.
- Let a cancelled duplicate's completion hook recover the prior successful evidence idempotently.
- Add executable regressions for successful run 90 followed by cancelled run 91, and for a newer failed run 92 that must not be masked by the older success.

## Scope / non-goals

This changes only metadata status settlement. It does not rerun source workflows, weaken exact-head/open-PR/main-base/`full-ci` guards, or alter product-test scheduling.

## Verification

- `python3.12 -m pytest -q tests/test_ci_lane_promotion.py tests/test_ci_apple_coverage_union.py tests/test_gui_golden_ci_coverage.py tests/test_train_gates_matches_ci.py` — 54 passed
- `python3 scripts/check_workflow_expressions.py` — 15 workflows passed
- `python3 scripts/check_gha_pinning.py` — 15 workflows passed
- `python3.12 -m ruff check tests/test_ci_lane_promotion.py` — passed
- `python3.12 -m ruff format --check tests/test_ci_lane_promotion.py` — passed
- `git diff --check` — passed

## Design precedent

Workflow-completion events are notifications, not proof that the triggering run is the canonical evidence. The durable pattern is to re-query authoritative workflow-run state, choose the latest exact-head terminal evidence after excluding cancellation-only duplicates, and then require that selected run and its aggregate to succeed. This keeps duplicate/cancelled delivery idempotent without allowing an older success to mask a newer failure or adding custom retry state.

Fixes #2559
