### PR TITLE
fix(mac): reap exited server leaders without blocking a shared worker (#2363)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -4371,12 +4371,27 @@ final class ProcessGroupChild: @unchecked Sendable {
     /// ``signalProcessGroup`` call becomes a no-op.
     let isStub: Bool
 
+    /// Process exit observation is event-driven. A blocking `waitpid` parked
+    /// on a shared GCD pool can starve on small hosted runners; the resulting
+    /// unreaped group leader makes `terminateChild` burn its entire SIGTERM
+    /// grace and can strand the next launch behind the old port. The source
+    /// wakes this dedicated serial queue only after the kernel reports exit.
+    private static let exitMonitorQueue = DispatchQueue(
+        label: "com.rapidmlx.desktop.process-exit-monitor",
+        qos: .userInitiated
+    )
+
     private let lock = NSLock()
+    /// Serializes the event-source reaper with the non-blocking liveness
+    /// fallback. The fallback can race the exit event on hosted runners; one
+    /// waiter must reap and publish the lifecycle transition exactly once.
+    private let reapLock = NSLock()
     private var running: Bool = true
     private var monitorStarted: Bool = false
     private var rawTerminationStatus: Int32 = 0
     private var rawTerminationReason: Process.TerminationReason = .exit
     private var terminationHandler: (@Sendable (ProcessGroupChild) -> Void)?
+    private var exitSource: (any DispatchSourceProcess)?
 
     var isRunning: Bool {
         lock.lock()
@@ -4398,6 +4413,12 @@ final class ProcessGroupChild: @unchecked Sendable {
 
     var isProcessGroupAlive: Bool {
         if isStub { return false }
+        // DispatchSourceProcess delivery has occasionally been deferred on a
+        // saturated hosted runner. Reap an already-exited leader without
+        // blocking before asking whether anything remains in its process
+        // group; otherwise the zombie leader makes kill(-pgid, 0) report a
+        // false live group through the entire shutdown grace period.
+        _ = reapExitedProcess(waitOptions: WNOHANG)
         if kill(-processGroupID, 0) == 0 { return true }
         return errno == EPERM
     }
@@ -4575,20 +4596,61 @@ final class ProcessGroupChild: @unchecked Sendable {
         }
         monitorStarted = true
         lock.unlock()
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self else { return }
-            var waitStatus: Int32 = 0
-            let waited = waitpid(self.processIdentifier, &waitStatus, 0)
-            guard waited == self.processIdentifier else { return }
-            let decoded = Self.decode(waitStatus: waitStatus)
-            self.lock.lock()
-            self.running = false
-            self.rawTerminationStatus = decoded.status
-            self.rawTerminationReason = decoded.reason
-            let handler = self.terminationHandler
-            self.lock.unlock()
-            handler?(self)
+
+        let source = DispatchSource.makeProcessSource(
+            identifier: processIdentifier,
+            eventMask: .exit,
+            queue: Self.exitMonitorQueue
+        )
+        source.setEventHandler { [weak self] in
+            self?.reapExitedProcess(waitOptions: 0)
         }
+        lock.lock()
+        exitSource = source
+        lock.unlock()
+        source.activate()
+    }
+
+    /// Reap only after the process-exit source fires, so `waitpid` is no
+    /// longer a blocking worker-pool reservation. Retry EINTR, then publish
+    /// the same once-only lifecycle callback as the prior monitor. The
+    /// liveness fallback (``isProcessGroupAlive``) calls this with `WNOHANG`
+    /// so an already-exited leader is reaped without blocking; `reapLock`
+    /// ensures exactly one waiter publishes the transition.
+    @discardableResult
+    private func reapExitedProcess(waitOptions: Int32) -> Bool {
+        reapLock.lock()
+        lock.lock()
+        guard running else {
+            lock.unlock()
+            reapLock.unlock()
+            return true
+        }
+        lock.unlock()
+
+        var waitStatus: Int32 = 0
+        var waited: pid_t
+        repeat {
+            waited = waitpid(processIdentifier, &waitStatus, waitOptions)
+        } while waited == -1 && errno == EINTR
+        guard waited == processIdentifier else {
+            reapLock.unlock()
+            return false
+        }
+
+        let decoded = Self.decode(waitStatus: waitStatus)
+        lock.lock()
+        running = false
+        rawTerminationStatus = decoded.status
+        rawTerminationReason = decoded.reason
+        let handler = terminationHandler
+        let source = exitSource
+        exitSource = nil
+        lock.unlock()
+        reapLock.unlock()
+        source?.cancel()
+        handler?(self)
+        return true
     }
 
     private static func dup(

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -4609,6 +4609,12 @@ final class ProcessGroupChild: @unchecked Sendable {
         exitSource = source
         lock.unlock()
         source.activate()
+
+        // Process sources are armed asynchronously. A very short-lived child
+        // can exit before the source begins observing it, so close that race
+        // with the same non-blocking reap used by the liveness probe. If the
+        // source won the race, `reapLock` makes this an exactly-once no-op.
+        _ = reapExitedProcess(waitOptions: WNOHANG)
     }
 
     /// Reap only after the process-exit source fires, so `waitpid` is no

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -48,6 +48,106 @@ struct ServerManagerStateTests {
         #expect(exited)
     }
 
+    private final class ExitObservationBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int32] = []
+
+        func record(_ status: Int32) {
+            lock.withLock { values.append(status) }
+        }
+
+        var snapshot: [Int32] {
+            lock.withLock { values }
+        }
+    }
+
+    @Test("Process exit is observed by the event source and reaped exactly once")
+    func processExitIsObservedByEventSource() async throws {
+        let observations = ExitObservationBox()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let child = try ProcessGroupChild.spawn(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 31"],
+            standardInput: .nullDevice,
+            standardOutput: stdout,
+            standardError: stderr
+        ) { child in
+            observations.record(child.terminationStatus)
+        }
+        defer {
+            if child.isProcessGroupAlive {
+                child.signalProcessGroup(SIGKILL)
+            }
+        }
+
+        let exited = await waitUntil(deadline: Date().addingTimeInterval(3)) {
+            !child.isProcessGroupAlive
+        }
+        #expect(exited)
+        #expect(!child.isRunning)
+        #expect(child.terminationStatus == 31)
+        // The transition is published exactly once by a single reaper.
+        #expect(observations.snapshot == [31])
+    }
+
+    @Test("Process liveness reaps an exited leader when the event source is delayed")
+    func processLivenessHasNonblockingReapFallback() async throws {
+        let observations = ExitObservationBox()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        // startMonitorImmediately: false — only the non-blocking liveness
+        // reap (isProcessGroupAlive) can publish the transition, not the
+        // event source.
+        let child = try ProcessGroupChild.spawn(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 31"],
+            standardInput: .nullDevice,
+            standardOutput: stdout,
+            standardError: stderr,
+            startMonitorImmediately: false
+        ) { child in
+            observations.record(child.terminationStatus)
+        }
+        defer {
+            if child.isProcessGroupAlive {
+                child.signalProcessGroup(SIGKILL)
+            }
+        }
+
+        let reaped = await waitUntil(deadline: Date().addingTimeInterval(3)) {
+            !child.isProcessGroupAlive
+        }
+        #expect(reaped)
+        #expect(!child.isRunning)
+        #expect(observations.snapshot == [31])
+    }
+
+    @Test("The child-exit monitor never blocks a shared GCD worker")
+    func childExitMonitorDoesNotBlockSharedWorker() throws {
+        // Regression guard for #2363: the prior monitor ran a blocking
+        // `waitpid(pid, &status, 0)` on `DispatchQueue.global(qos:.utility)`,
+        // reserving a shared worker for the lifetime of the child and
+        // starving restarts on saturated hosted runners. Exit must be
+        // observed via a `DispatchSourceProcess(.exit)` on a dedicated
+        // serial queue instead.
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/Rapid/Server/ServerManager.swift"),
+            encoding: .utf8
+        )
+        let stripped = source.replacingOccurrences(of: "\\s+", with: "", options: .regularExpression)
+        #expect(stripped.contains(
+            "DispatchSource.makeProcessSource(identifier:processIdentifier,eventMask:.exit"
+        ), "startMonitor must observe exits via a DispatchSourceProcess.")
+        #expect(!stripped.contains(
+            "DispatchQueue.global(qos:.utility).async{[weakself]in"
+        ), "startMonitor must not park a blocking waitpid on the shared pool.")
+    }
+
     @Test("dismissTerminalState: .crashed with a binary path → .idle")
     func dismissCrashedWithBinary() {
         let mgr = ServerManager(

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -81,14 +81,18 @@ struct ServerManagerStateTests {
             }
         }
 
+        // Observe only the termination callback here. Polling
+        // `isProcessGroupAlive` would exercise the WNOHANG fallback and could
+        // make this test pass even if the dispatch source never fired.
         let exited = await waitUntil(deadline: Date().addingTimeInterval(3)) {
-            !child.isProcessGroupAlive
+            !observations.snapshot.isEmpty
         }
         #expect(exited)
         #expect(!child.isRunning)
         #expect(child.terminationStatus == 31)
         // The transition is published exactly once by a single reaper.
         #expect(observations.snapshot == [31])
+        #expect(!child.isProcessGroupAlive)
     }
 
     @Test("Process liveness reaps an exited leader when the event source is delayed")

--- a/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerManagerStateTests.swift
@@ -68,7 +68,10 @@ struct ServerManagerStateTests {
         let stderr = Pipe()
         let child = try ProcessGroupChild.spawn(
             executableURL: URL(fileURLWithPath: "/bin/sh"),
-            arguments: ["-c", "exit 31"],
+            // Keep the child alive long enough for startMonitor's immediate
+            // WNOHANG race check to return without reaping. The callback must
+            // therefore arrive through the process exit source.
+            arguments: ["-c", "sleep 0.2; exit 31"],
             standardInput: .nullDevice,
             standardOutput: stdout,
             standardError: stderr
@@ -92,6 +95,43 @@ struct ServerManagerStateTests {
         #expect(child.terminationStatus == 31)
         // The transition is published exactly once by a single reaper.
         #expect(observations.snapshot == [31])
+        #expect(!child.isProcessGroupAlive)
+    }
+
+    @Test("Starting a monitor after a short-lived child exits still publishes termination")
+    func processExitBeforeSourceActivationIsReaped() async throws {
+        let observations = ExitObservationBox()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let child = try ProcessGroupChild.spawn(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 29"],
+            standardInput: .nullDevice,
+            standardOutput: stdout,
+            standardError: stderr,
+            startMonitorImmediately: false
+        ) { child in
+            observations.record(child.terminationStatus)
+        }
+        defer {
+            if child.isProcessGroupAlive {
+                child.signalProcessGroup(SIGKILL)
+            }
+        }
+
+        // Deliberately let the process exit before constructing its event
+        // source. Dispatch documents this creation race; startMonitor's
+        // post-activation WNOHANG reap must close it without a liveness poll.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        child.startMonitor()
+
+        let exited = await waitUntil(deadline: Date().addingTimeInterval(3)) {
+            !observations.snapshot.isEmpty
+        }
+        #expect(exited)
+        #expect(!child.isRunning)
+        #expect(child.terminationStatus == 29)
+        #expect(observations.snapshot == [29])
         #expect(!child.isProcessGroupAlive)
     }
 


### PR DESCRIPTION
Fixes #2363

## Why

A proven chat model must be able to stop and restart in one app session before its selection can be restored reliably. The existing child monitor parked a blocking `waitpid` on a shared GCD worker for the lifetime of every server child. Under worker starvation, an exited group leader remained unreaped, shutdown consumed the full grace period, and the next launch could remain stranded behind the old port.

## What

- Observe child exit with `DispatchSourceProcess(.exit)` on a dedicated serial queue; call blocking `waitpid` only after the kernel reports exit.
- Serialize the event-source reaper and the `WNOHANG` liveness fallback so lifecycle state and the termination callback publish exactly once.
- Reap an already-exited leader before `kill(-pgid, 0)` evaluates process-group liveness, preventing a zombie from looking live through shutdown.
- Close the documented source-creation race with an immediate non-blocking reap after activation, so a short-lived child cannot lose its termination callback.

## Scope / Non-goals

- Scoped to `ProcessGroupChild` exit observation and reaping.
- The selection-persistence half of #2363 landed in #2545; this PR completes the independent restart-readiness half.
- No polling loop, timeout change, alias heuristic, server change, or user-data migration.

## Design precedent

The implementation follows the platform process-event contract: arm an exit dispatch source, retain and activate it after installing the handler, and use `waitpid(..., WNOHANG)` to close source-creation and liveness races without reserving a shared worker.

## Verification

- Reproduced on pre-fix `8631acc5`: an immediate `exit 31` remained falsely alive after 1 second, `isRunning` stayed true, and no termination callback arrived.
- `swift test --filter ServerManagerStateTests`: 16/16 pass; repeated 20 times with no failure.
- Related Desktop lifecycle suites: 111/111 pass across state, respawn, residency, health, bearer, and memory-projection coverage.
- Prior full branch suite: 2,973/2,973 pass; exact-head hosted checks will rerun after this update.
- `git diff --check`: clean.