### PR TITLE
test: declare hermetic integration inputs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,12 @@ def _hermetic_hf_and_config_dirs(tmp_path, monkeypatch, request):
         _install_hf_offline(monkeypatch, request)
         _install_network_guard(monkeypatch, request.node.nodeid)
 
+    # Application state is independent of the HF cache opt-in. A test that
+    # reads real cached weights must still never read or mutate the developer's
+    # first-run/config/bench state under ~/.rapid-mlx.
+    for var in _RAPID_MLX_DIR_ENV_VARS:
+        monkeypatch.setenv(var, str(tmp_path / var.lower()))
+
     if request.node.get_closest_marker("real_hf_cache"):
         yield
         return
@@ -272,9 +278,6 @@ def _hermetic_hf_and_config_dirs(tmp_path, monkeypatch, request):
             monkeypatch.setenv(var, str(hf_hub_cache))
         else:  # TRANSFORMERS_CACHE
             monkeypatch.setenv(var, str(hf_hub_cache))
-
-    for var in _RAPID_MLX_DIR_ENV_VARS:
-        monkeypatch.setenv(var, str(tmp_path / var.lower()))
 
     # Hermeticity for hub *readers*, not just env readers. huggingface_hub
     # snapshots several of these paths into module constants at import time

--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -38,6 +38,12 @@ from unittest.mock import patch
 
 import pytest
 
+# These contracts stub every downloader/loader boundary and intentionally
+# exercise the online serve-admission path.  Keep the suite hermetic (the
+# socket guard remains active) while opting out of the default HF offline
+# sentinel that would reject the model before the mocked dispatch is reached.
+pytestmark = pytest.mark.usefixtures("hub_online_env")
+
 # ---------------------------------------------------------------------------
 # A) Registry resolution table
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_cheetah_banner.py
+++ b/tests/test_cli_cheetah_banner.py
@@ -201,6 +201,10 @@ def _run_main(argv, *, stdout_tty=True, stdin_tty=True, env=None):
     saved_env = dict(os.environ)
     os.environ.clear()
     os.environ.update(saved_env)
+    # The no-override path models a user who did not set NO_COLOR. Do not let
+    # the developer/CI host's preference silently turn that control case mono;
+    # tests that exercise the opt-out add it back through ``env`` below.
+    os.environ.pop("NO_COLOR", None)
     if env:
         os.environ.update(env)
     try:

--- a/tests/test_hermetic_network_off.py
+++ b/tests/test_hermetic_network_off.py
@@ -127,11 +127,18 @@ def test_leaked_prefetch_cannot_download_under_default_fixture(capsys):
 
 
 @pytest.mark.real_hf_cache
-def test_real_hf_cache_alone_does_not_grant_network():
+def test_real_hf_cache_only_opts_out_of_hf_cache_redirection(tmp_path):
     hf_constants = pytest.importorskip("huggingface_hub.constants")
     assert os.environ.get("HF_HUB_OFFLINE") == "1"
     assert hf_constants.is_offline_mode() is True
     assert _guard_armed()
+    for var in (
+        "RAPID_MLX_STATE_DIR",
+        "RAPID_MLX_HOME",
+        "RAPID_MLX_DDTREE_PATCH_CACHE",
+        "RAPID_MLX_CONFIG_HOME",
+    ):
+        assert Path(os.environ[var]).is_relative_to(tmp_path)
 
 
 @pytest.mark.requires_network

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -32,6 +32,8 @@ import textwrap
 
 import pytest
 
+pytestmark = pytest.mark.real_hf_cache
+
 from vllm_mlx.api.models import Message
 from vllm_mlx.api.responses_adapter import _merge_system_messages as _merge_raw
 

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -32,10 +32,10 @@ import textwrap
 
 import pytest
 
-pytestmark = pytest.mark.real_hf_cache
-
 from vllm_mlx.api.models import Message
 from vllm_mlx.api.responses_adapter import _merge_system_messages as _merge_raw
+
+pytestmark = pytest.mark.real_hf_cache
 
 
 def _merge_system_messages(messages):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -5,8 +5,6 @@ import gc
 
 import pytest
 
-pytestmark = pytest.mark.real_hf_cache
-
 from vllm_mlx import (
     EngineConfig,
     EngineCore,
@@ -15,6 +13,8 @@ from vllm_mlx import (
     SchedulerConfig,
     get_registry,
 )
+
+pytestmark = pytest.mark.real_hf_cache
 
 # Use a small model for fast tests
 TEST_MODEL = "mlx-community/Qwen3-0.6B-8bit"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -5,6 +5,8 @@ import gc
 
 import pytest
 
+pytestmark = pytest.mark.real_hf_cache
+
 from vllm_mlx import (
     EngineConfig,
     EngineCore,

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -30,6 +30,17 @@ def _cached_model_and_tokenizer():
     return load(TEST_MODEL)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _release_cached_model_and_tokenizer():
+    """Return model memory when this integration module finishes."""
+    yield
+    _cached_model_and_tokenizer.cache_clear()
+    gc.collect()
+    import mlx.core as mx
+
+    mx.clear_cache()
+
+
 @pytest.fixture
 def model_and_tokenizer():
     """Load once, but only after the function-scoped hermetic guard is armed."""

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for model registry and multi-engine scenarios."""
 
+import functools
 import gc
+import os
+import socket
 
 import pytest
 
@@ -20,12 +23,19 @@ pytestmark = pytest.mark.real_hf_cache
 TEST_MODEL = "mlx-community/Qwen3-0.6B-8bit"
 
 
-@pytest.fixture(scope="module")
-def model_and_tokenizer():
-    """Load model once for all tests in module."""
+@functools.cache
+def _cached_model_and_tokenizer():
     from mlx_lm import load
 
     return load(TEST_MODEL)
+
+
+@pytest.fixture
+def model_and_tokenizer():
+    """Load once, but only after the function-scoped hermetic guard is armed."""
+    assert os.environ.get("HF_HUB_OFFLINE") == "1"
+    assert getattr(socket.socket.connect, "_hermetic_network_guard", False)
+    return _cached_model_and_tokenizer()
 
 
 class TestModelRegistry:

--- a/tests/test_tokenizer_gemma4_hybrid.py
+++ b/tests/test_tokenizer_gemma4_hybrid.py
@@ -42,6 +42,9 @@ download required, runs in CI) AND a real-Gemma-4 reproducer
 
 from __future__ import annotations
 
+import os
+import socket
+
 import pytest
 from tokenizers import Tokenizer, decoders, models, pre_tokenizers
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
@@ -227,8 +230,10 @@ class TestGate2RealGemma4:
     """Pin the issue-#950 reproducer end-to-end on the real Gemma 4
     tokenizer. Tokenizer files only — no model weights, no MLX load."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def gemma4_tokenizer(self):
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert getattr(socket.socket.connect, "_hermetic_network_guard", False)
         return AutoTokenizer.from_pretrained(_GEMMA4_ALIAS)
 
     def test_issue_950_reproducer_fixed(self, gemma4_tokenizer) -> None:

--- a/tests/test_tokenizer_gemma4_hybrid.py
+++ b/tests/test_tokenizer_gemma4_hybrid.py
@@ -43,6 +43,8 @@ download required, runs in CI) AND a real-Gemma-4 reproducer
 from __future__ import annotations
 
 import pytest
+
+pytestmark = pytest.mark.real_hf_cache
 from tokenizers import Tokenizer, decoders, models, pre_tokenizers
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 

--- a/tests/test_tokenizer_gemma4_hybrid.py
+++ b/tests/test_tokenizer_gemma4_hybrid.py
@@ -43,8 +43,6 @@ download required, runs in CI) AND a real-Gemma-4 reproducer
 from __future__ import annotations
 
 import pytest
-
-pytestmark = pytest.mark.real_hf_cache
 from tokenizers import Tokenizer, decoders, models, pre_tokenizers
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
@@ -53,6 +51,8 @@ from vllm_mlx.utils.tokenizer import (
     _decoder_has_metaspace_replace,
     repair_byte_level_decoder,
 )
+
+pytestmark = pytest.mark.real_hf_cache
 
 # Real Gemma 4 alias the bug reporter used. The model weights are NOT
 # downloaded — ``AutoTokenizer.from_pretrained`` only fetches the


### PR DESCRIPTION
## Why

The network-off, empty-cache autouse fixture exposed tests whose environment contracts were not declared: mocked audio serve tests were rejected before their stubs ran, while intentional real tokenizer/model integrations were redirected away from locally cached checkpoints. Separately, the banner color control inherited host `NO_COLOR=1`, making its default-color assertion machine-dependent. These deterministic failures block `pr_validate` for unrelated PRs, including #2387.

## What

- Opt the mocked audio serve-dispatch module into the existing `hub_online_env` fixture. It clears only the product offline sentinel; the socket guard remains active.
- Mark the intentional real tokenizer/model integration modules with `real_hf_cache`, while keeping all Rapid-MLX state directories isolated under the per-test temporary directory.
- Ensure broader-scoped model/tokenizer fixtures cannot load before the function-scoped offline/socket guard is active.
- Cache the small registry model only within its test module, then clear references, collect Python objects, and release the MLX allocator cache at module teardown.
- Make the banner helper control path explicitly represent an unset `NO_COLOR`; its opt-out case adds the variable back.
- Extend the hermetic contract test to prove that `real_hf_cache` opts out only from HF-cache redirection, never from app-state isolation.

## Scope / Non-goals

Test declarations and harness determinism only across seven test files. No engine, audio, banner, tokenizer, or model product behavior changes. No model weights change and no test receives outbound network access.

## Design precedent

The suite already centralizes these capabilities as reviewed fixtures and markers: mocked online admission through `hub_online_env`, offline access to intentional integration fixtures through `real_hf_cache`, and temporary app-state roots through the autouse hermetic fixture. This change reuses and tightens those boundaries instead of adding per-test network exceptions.

## Verification

- Focused hermetic/audio/banner/real-cache set: 167 passed.
- Ruff check/format and `git diff --check`: clean.
- Initial full `pr_validate` identified the five omitted declarations after 19,433 passes; exact-head full validation follows independent review.

Fixes #2565
