### PR TITLE
ci: batch merge-ready PRs behind one integration gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
               --github-output "$GITHUB_OUTPUT"
             full_gate=false
             if [ "$FULL_CI" = true ] || \
-              { [[ "$HEAD_REF" == train/* ]] && [ "$HEAD_REPO" = "$REPO" ]; }; then
+              { [ "$HEAD_REPO" = "$REPO" ] && \
+                { [[ "$HEAD_REF" == train/* ]] || \
+                  [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; }; then
               full_gate=true
             fi
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,7 @@ jobs:
             tests/test_desktop_manifest.py \
             tests/test_classify_ci_changes.py \
             tests/test_ci_lane_promotion.py \
+            tests/test_mergify_batch_queue.py \
             tests/test_ci_apple_coverage_union.py \
             tests/test_check_mlx_upstream_calls.py \
             tests/test_no_out_of_band_routing.py \

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -89,7 +89,9 @@ jobs:
               --github-output "$GITHUB_OUTPUT"
             full_gate=false
             if [ "$FULL_CI" = true ] || \
-              { [[ "$HEAD_REF" == train/* ]] && [ "$HEAD_REPO" = "$REPO" ]; }; then
+              { [ "$HEAD_REPO" = "$REPO" ] && \
+                { [[ "$HEAD_REF" == train/* ]] || \
+                  [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; }; then
               full_gate=true
             fi
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,45 @@
+merge_queue:
+  mode: serial
+  max_parallel_checks: 1
+  skip_intermediate_results: false
+  status_comments: outcomes
+
+queue_rules:
+  - name: main-batch
+    queue_branch_prefix: mergify/merge-queue/
+    batch_size: 4
+    batch_max_wait_time: 15 min
+    batch_max_failure_resolution_attempts: 2
+    checks_timeout: 90 min
+    max_checks_retries: 0
+    merge_method: squash
+    branch_protection_injection_mode: queue
+    queue_conditions:
+      - base = main
+      - -draft
+      - -from-fork
+      - label = merge-ready
+      - -label = version-bump
+      - -label = skip-version-bump
+      - "-title ~= ^chore: bump version to "
+      - check-success = @github-actions/tests
+      - check-success = @github-actions/desktop-tests
+      - check-success = @github-actions/version-bump-guard
+    merge_conditions:
+      - check-success = @github-actions/tests
+      - check-success = @github-actions/desktop-tests
+      - check-success = @github-actions/version-bump-guard
+
+pull_request_rules:
+  - name: queue merge-ready pull requests
+    conditions:
+      - base = main
+      - -draft
+      - -from-fork
+      - label = merge-ready
+      - -label = version-bump
+      - -label = skip-version-bump
+      - "-title ~= ^chore: bump version to "
+    actions:
+      queue:
+        name: main-batch

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -233,15 +233,24 @@ Before merge, the PR description must accurately reflect actual current state:
 ## Step 12 — Merge
 
 - Re-run the Step 10 `statusCheckRollup` query after the final push and directly
-  before invoking `gh pr merge`. Stop on `QUEUED`, `IN_PROGRESS`, `PENDING`,
+  before queueing. Stop on `QUEUED`, `IN_PROGRESS`, `PENDING`,
   `FAILURE`, `CANCELLED`, or `TIMED_OUT` for any relevant check.
 
-- **Squash-merge** for clean main history:
+- For an ordinary pull request, apply the integration authorization label and
+  let the managed queue combine and revalidate it. Do not manually rebase after
+  queue entry and do not click GitHub's merge button:
 
   ```bash
-  gh pr merge <PR#> --repo raullenchai/Rapid-MLX --squash --delete-branch
+  gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready
   ```
 
+- The queue waits up to 15 minutes for as many as four merge-ready pull
+  requests, runs the affected full lanes once on their combined tree, and then
+  squash-merges each original pull request. A failed batch is split to identify
+  the blocking member; do not add an independent rerun.
+- Version bumps and human-authorized hotfixes do not enter the general batch.
+  Follow their explicit release/hotfix contract and use a direct squash merge
+  only when that contract authorizes it.
 - If version was bumped: verify `Auto-release on version bump` workflow triggers post-merge.
 - If the squash subject contains `(#NN)` GitHub auto-suffix on a `chore: bump version to X.Y.Z` commit, override with `--subject` — the regex in `auto-release.yml` is strict.
 - After merge, verify `git log raullenchai/main --oneline -1` shows your squash commit.

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -79,9 +79,20 @@ the threshold is not the normal escape hatch.
 
 ## Merge gate
 
-Adding the `full-ci` label upgrades the lanes selected by the pull request's
-actual diff. Apply it only when the PR is ready to merge; removing it returns
-subsequent commits to the path-aware PR gate.
+Ordinary pull requests run the path-aware PR gate and leave the required
+`tests`, `desktop-tests`, and `version-bump-guard` contexts satisfiable. A pull
+request becomes an integration candidate only when a maintainer applies the
+`merge-ready` label after review and PR validation have converged. The managed
+queue collects up to four such pull requests, waits at most 15 minutes from the
+first entry, and validates their combined tree once.
+
+The queue creates an internal pull request from a branch whose name is exactly
+`mergify/merge-queue/<10 lowercase hex characters>`. The engine and Desktop
+workflows treat only that exact same-repository shape as a promoted head. A fork
+using the same branch name remains on the ordinary PR path.
+
+The optional `full-ci` label provides an exact-head rehearsal before queueing.
+Both that label and a queue batch upgrade the lanes selected by the actual diff:
 
 - Engine changes expand to the full five-model L1 matrix.
 - Desktop changes build the release GUI once, then run every journey group
@@ -103,46 +114,31 @@ preflight, app launch, or artifact creation. The final verdict requires exactly
 the number of result records selected by the classifier, so a selected journey
 cannot silently disappear.
 
-The label never changes lane classification. This prevents an engine-only PR
-from allocating the full Desktop gate, or a Desktop-only PR from allocating
-the full model gate.
+Promotion never changes lane classification. This prevents an engine-only
+batch from allocating the full Desktop gate, or a Desktop-only batch from
+allocating model runners. A mixed or fail-closed batch selects both.
 
-### Pending, not failing, before promotion
+The queue contract lives in `.mergify.yml`:
 
-An unpromoted product PR is a waiting release candidate, not a test failure.
-The aggregate Action check therefore passes after its inexpensive PR checks,
-while `.github/workflows/full-ci-label-gate.yml` publishes a same-name pending
-commit status for each selected product lane. GitHub requires both a check run
-and a commit status when they share a required name, so the pending status keeps
-the merge blocked without showing a false red failure.
+- serial mode with one batch in flight, so speculative checks cannot multiply
+  scarce macOS capacity;
+- up to four pull requests per batch and a 15-minute maximum fill wait;
+- no blind CI retry and no skipped intermediate failures;
+- at most two batch-split attempts to isolate a failing member;
+- a 90-minute check timeout, covering normal hosted macOS queue delay;
+- the three GitHub Actions required checks must pass both before queue entry and
+  again on the combined temporary pull request;
+- successful members are squash-merged individually, preserving one commit per
+  pull request and GitHub's `Fixes #N` issue closure behavior.
 
-The status transition is fail closed:
+Release bump and version-correction pull requests are excluded by title and
+labels. They continue through the separately authorized release transaction;
+they must never be combined with ordinary changes.
 
-1. A trusted `pull_request_target` workflow reads the live PR and immediately
-   posts pending `tests` and `desktop-tests` statuses before classification.
-2. It checks out only the base revision of the policy and classifies filenames
-   obtained from the GitHub API. It never checks out or executes the PR head.
-3. An unselected lane becomes successful immediately. A selected lane remains
-   pending both before and after the `full-ci` label is applied.
-4. Only a successful exact-head full-CI aggregate may replace that selected
-   lane's pending status with success. The aggregate job settles same-repository
-   PRs directly; a trusted `workflow_run` completion hook settles fork PRs.
-5. A stale SHA, removed label, superseded exact-head run, failed/cancelled
-   workflow, missing aggregate job, classifier failure, or metadata mismatch
-   leaves the status pending.
-
-Do not replace this with a job-level `if` condition. GitHub reports a skipped
-job as successful, which would allow a required skipped context to bypass the
-promotion gate. Do not publish success when the label is observed: doing so
-would briefly reuse old exact-SHA check evidence during label churn.
-
-All three required workflows subscribe to GitHub's `merge_group` event. Every
-queue candidate will therefore receive `tests`, `desktop-tests`, and
-`version-bump-guard` on its synthetic candidate commit. Product workflows run
-full combined-tree coverage for merge groups. The version guard emits its
-stable context because the individual PR contract was already validated before
-queue entry. This validates the state that will actually reach `main`, rather
-than repeatedly validating each PR against an obsolete base.
+All three required workflows retain `merge_group` support so an eventual
+organization transfer can use the native queue without another trigger
+migration. The managed queue itself uses ordinary `pull_request` events for its
+temporary batch pull requests.
 
 Pushes to `main` retain the full engine coverage as a post-merge signal.
 
@@ -172,69 +168,54 @@ bundled sidecar and release credentials.
 
 ## Repository configuration
 
-GitHub currently offers merge queues only to public repositories owned by an
-organization, or private repositories owned by an Enterprise Cloud
-organization. Rapid-MLX is a public repository owned by a personal account, so
-the queue cannot be enabled until ownership moves to an organization.
+GitHub's native queue is unavailable while this public repository belongs to a
+personal account. The checked-in managed-queue policy is therefore the
+authoritative integration configuration.
 
-The current `main` protection is strict and requires three GitHub Actions
-contexts from app id `15368`: `tests`, `desktop-tests`, and
-`version-bump-guard`. There are no repository rulesets. Keep that protection
-unchanged until the owner enables a queue.
+Production activation is an owner operation and must happen in this order:
 
-After ownership moves to an eligible organization and these workflows are on
-the default branch, the owner should enable **Require merge queue** in the
-existing non-wildcard `main` branch-protection rule and configure:
+1. Land `.mergify.yml`, the workflow recognition logic, and their contract
+   tests before installing or enabling the app.
+2. Install the GitHub App for this repository only. Do not grant it access to
+   unrelated repositories. Confirm its configuration check validates the
+   default-branch policy.
+3. Create the `merge-ready` label. Applying it is the explicit authorization to
+   enter the queue; removing it dequeues the pull request.
+   Fork pull requests are deliberately ineligible because composing fork code
+   onto an internal queue branch changes GitHub's token and secret boundary.
+   After review, bring an accepted external change onto a same-repository
+   maintainer branch before authorizing it for the batch queue.
+4. In the existing `main` protection, retain required contexts `tests`,
+   `desktop-tests`, and `version-bump-guard`, required conversation resolution,
+   administrator enforcement, and linear history. Disable only **Require
+   branches to be up to date before merging**: temporary batch validation is
+   incompatible with that strict flag because the combined branch, rather than
+   every original head, is the artifact tested by CI.
+5. Keep manual merges limited to the documented version-bump and
+   human-authorized hotfix paths. Normal pull requests enter through the
+   `merge-ready` label and are merged by the queue.
+6. Rehearse with two harmless pull requests that are individually green. Apply
+   `merge-ready` to both within the fill window and verify one temporary batch
+   PR contains both exact heads, runs each affected full lane once, reports all
+   three required checks, and squash-merges both originals in order.
+7. Confirm a fork branch named like a queue branch does not receive promoted
+   lanes. Then remove `merge-ready` from a queued test PR and verify it leaves
+   the queue without merging.
 
-- merge queue required and squash as the allowed merge method;
-- required status checks `tests`, `desktop-tests`, and `version-bump-guard`;
-- the existing strict status-check policy retained; the queue candidate
-  provides the up-to-date combined tree without repeated author rebases;
-- build concurrency `1` initially;
-- merge only non-failing entries enabled;
-- status-check timeout `60 minutes`;
-- minimum and maximum merge group size `1`, with a `0` minute minimum wait.
-
-After five consecutive green merge groups, increase maximum group size to `3`
-and use a `5` minute wait to amortize busy integration trains. Keep concurrency
-at `1` until failure attribution and runner capacity are demonstrated at that
-batch size.
-
-Before changing `main`, rehearse on a scratch target branch in an eligible
-organization-owned repository:
-
-1. Create the scratch branch from the intended `main` SHA and temporarily add
-   that branch to all three workflows' event filters in the sandbox only.
-2. Apply the exact required contexts and queue settings above to the scratch
-   branch.
-3. Queue one documentation-only PR and one harmless cross-cutting workflow PR.
-   Confirm all three contexts appear on both synthetic merge-group SHAs, and
-   confirm the cross-cutting PR runs both product lanes.
-4. Queue two PRs concurrently. Confirm strict protection groups or restacks
-   them without direct pushes, and that deliberately failing the second PR
-   removes only its group.
-5. Remove the sandbox changes and record run URLs before applying the settings
-   to `main`.
-
-A hosted scratch rehearsal cannot be performed in the current personal-account
-repository because GitHub does not expose merge queues there. Local event
-fixtures and workflow contract tests verify the `merge_group` wiring now; the
-organization-owned scratch rehearsal above remains a hard prerequisite to the
-owner's production configuration change.
-
-Do not enable the queue before every required workflow trigger reaches `main`:
-otherwise GitHub creates a merge-group commit whose required check remains
-`Expected` forever. Treat an indefinitely expected
-`version-bump-guard` as a trigger defect and stop; never bypass the required
-context.
+Do not enable batching while strict up-to-date protection remains on, and do
+not weaken or remove any required context to make a batch move. A missing,
+cancelled, or failed aggregate is a queue failure.
 
 ## Rollback
 
-Disable the merge queue first, restore `full-ci` label-based merging, and leave
-the `merge_group` triggers in place. The triggers are harmless while the queue
-is disabled. If path classification is suspect, make its policy select both
-lanes for every PR; this restores the previous validation coverage without
-renaming required checks. For GUI routing specifically, removing the
+Pause the managed queue and remove `merge-ready` from every queued pull request
+first. Wait for the active batch to stop, restore strict up-to-date protection,
+and only then disable or uninstall the app. Keep the batch-head and
+`merge_group` workflow triggers in place; they are inert without a queue and
+make rollback recoverable without weakening CI. If path classification is
+suspect, make its policy select both lanes for every PR; this restores the
+previous validation coverage without renaming required checks. For GUI routing
+specifically, removing the
 `GUI_FLOWS` job environment or making `scripts/select_gui_flows.py` return the
 full manifest roster restores the previous all-journey behavior.
 If GUI matrix execution is suspect, remove the matrix strategy, restore

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -122,7 +122,7 @@ def _workflow_strings(workflow: Path) -> dict[str, object]:
     return yaml.load(workflow.read_text(), Loader=yaml.BaseLoader)
 
 
-def test_product_promotion_keeps_diff_scope_and_accepts_train_heads():
+def test_product_promotion_keeps_diff_scope_and_accepts_integration_heads():
     for workflow, job_name, step_name in (
         (ENGINE_WORKFLOW, "changes", "Classify validation lanes"),
         (DESKTOP_WORKFLOW, "changes", "Classify desktop lane"),
@@ -130,7 +130,9 @@ def test_product_promotion_keeps_diff_scope_and_accepts_train_heads():
         run = _step_run(workflow, job_name, step_name)
         assert 'git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA"' in run
         assert '[ "$FULL_CI" = true ] ||' in run
-        assert '[[ "$HEAD_REF" == train/* ]] && [ "$HEAD_REPO" = "$REPO" ]' in run
+        assert '[ "$HEAD_REPO" = "$REPO" ] &&' in run
+        assert '[[ "$HEAD_REF" == train/* ]] ||' in run
+        assert '[[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]' in run
         assert 'echo "full_gate=$full_gate"' in run
 
 
@@ -183,6 +185,41 @@ def test_fork_cannot_claim_train_branch_promotion(tmp_path):
                 **common,
             )
             == "full_gate=true"
+        )
+
+
+@pytest.mark.parametrize(
+    ("head_ref", "head_repo", "expected"),
+    (
+        ("mergify/merge-queue/a76b1f3d25", "owner/repo", "full_gate=true"),
+        ("mergify/merge-queue/A76B1F3D25", "owner/repo", "full_gate=false"),
+        ("mergify/merge-queue/a76b1f3d2", "owner/repo", "full_gate=false"),
+        ("mergify/merge-queue/a76b1f3d25-extra", "owner/repo", "full_gate=false"),
+        ("tmp-mergify/merge-queue/a76b1f3d25", "owner/repo", "full_gate=false"),
+        ("mergify/merge-queue/a76b1f3d25", "attacker/fork", "full_gate=false"),
+    ),
+)
+def test_only_exact_internal_mergify_batch_heads_promote_full_ci(
+    tmp_path, head_ref, head_repo, expected
+):
+    for index, (workflow, job_name, step_name) in enumerate(
+        (
+            (ENGINE_WORKFLOW, "changes", "Classify validation lanes"),
+            (DESKTOP_WORKFLOW, "changes", "Classify desktop lane"),
+        )
+    ):
+        assert (
+            _execute_promotion(
+                workflow,
+                job_name,
+                step_name,
+                GITHUB_OUTPUT=str(tmp_path / f"mergify-{index}"),
+                FULL_CI="false",
+                HEAD_REF=head_ref,
+                HEAD_REPO=head_repo,
+                REPO="owner/repo",
+            )
+            == expected
         )
 
 

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed contracts for the managed batch merge queue."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / ".mergify.yml"
+REQUIRED_CHECKS = {
+    "check-success = @github-actions/tests",
+    "check-success = @github-actions/desktop-tests",
+    "check-success = @github-actions/version-bump-guard",
+}
+
+
+def _config() -> dict[str, object]:
+    return yaml.safe_load(CONFIG.read_text())
+
+
+def test_queue_batches_four_ready_prs_after_a_bounded_wait():
+    config = _config()
+    queue = config["merge_queue"]
+    (rule,) = config["queue_rules"]
+
+    assert queue["mode"] == "serial"
+    assert queue["max_parallel_checks"] == 1
+    assert queue["skip_intermediate_results"] is False
+    assert rule["batch_size"] == 4
+    assert rule["batch_max_wait_time"] == "15 min"
+    assert rule["checks_timeout"] == "90 min"
+
+
+def test_queue_revalidates_every_required_check_on_the_combined_batch():
+    (rule,) = _config()["queue_rules"]
+
+    assert set(rule["queue_conditions"]) >= REQUIRED_CHECKS
+    assert set(rule["merge_conditions"]) == REQUIRED_CHECKS
+    assert rule["branch_protection_injection_mode"] == "queue"
+    assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
+
+
+def test_ready_label_queues_without_enabling_blind_retries():
+    config = _config()
+    (queue_rule,) = config["queue_rules"]
+    (enqueue_rule,) = config["pull_request_rules"]
+
+    assert enqueue_rule["actions"] == {"queue": {"name": "main-batch"}}
+    assert "label = merge-ready" in enqueue_rule["conditions"]
+    assert "-from-fork" in enqueue_rule["conditions"]
+    assert "-from-fork" in queue_rule["queue_conditions"]
+    assert queue_rule["max_checks_retries"] == 0
+    assert queue_rule["batch_max_failure_resolution_attempts"] == 2
+
+
+def test_release_bumps_cannot_enter_the_general_batch_queue():
+    config = _config()
+    (queue_rule,) = config["queue_rules"]
+    (enqueue_rule,) = config["pull_request_rules"]
+    exclusions = {
+        "-label = version-bump",
+        "-label = skip-version-bump",
+        "-title ~= ^chore: bump version to ",
+    }
+
+    assert exclusions <= set(queue_rule["queue_conditions"])
+    assert exclusions <= set(enqueue_rule["conditions"])
+    assert queue_rule["merge_method"] == "squash"


### PR DESCRIPTION
## Why

Ordinary pull requests now finish their path-aware checks quickly, but landing several ready changes still either forces repeated rebases or repeats the expensive integration gate per head. The repository is personal-account owned, so the native hosted merge queue is unavailable. A managed batched queue gives maintainers one combined-tree validation per group while preserving the existing required checks and one-PR-one-commit history.

Part of #2252.

## Scope

- Add a managed queue policy that collects up to four `merge-ready` internal PRs, waits at most 15 minutes, and allows only one batch check at a time.
- Require `tests`, `desktop-tests`, and `version-bump-guard` on both the original PR and the combined batch; disable blind retries and intermediate-result skipping.
- Promote only exact same-repository `mergify/merge-queue/<10 lowercase hex>` heads to the affected full CI lanes.
- Exclude forks and release/version-correction PRs from the general queue.
- Update the merge SOP, activation order, rehearsal, and rollback procedure.

## Non-goals

This PR does not install a GitHub App, mutate live branch protection, create labels, enable production auto-merge, close the existing train-driver PR, tag, publish, load a model, or run fork code through an internal queue branch. Those external configuration steps occur only after this policy lands and the owner authorizes activation.

## Acceptance

A `merge-ready` internal PR can enter the `main-batch` queue only after all three required checks pass. Up to four entries share one combined validation after no more than 15 minutes; only one batch consumes CI at a time. A correctly shaped internal queue branch receives full affected-lane coverage, while lookalike, malformed, temporary, or fork heads do not. Successful originals are squash-merged individually. Release bumps cannot enter this queue.

## Verification

- Official queue CLI 2026.8.28.1, checksum verified from its signed release checksum list: `.mergify.yml` schema valid.
- `python3.12 -m pytest -q tests/test_mergify_batch_queue.py tests/test_ci_lane_promotion.py tests/test_ci_apple_coverage_union.py tests/test_gui_golden_ci_coverage.py tests/test_train_gates_matches_ci.py` — 63 passed.
- `python3 scripts/check_workflow_expressions.py` — 14 workflows passed.
- `python3 scripts/check_gha_pinning.py` — 14 workflows clean.
- `actionlint .github/workflows/ci.yml .github/workflows/rapid-mac-ci.yml` — passed.
- Ruff lint/format and `git diff --check` — passed.

## Behaviour delta

Before: merge-ready changes are integrated manually or through one-off train branches, and strict up-to-date protection causes repeated behind/rebase cycles. After owner activation: applying `merge-ready` authorizes an internal PR for a four-member/15-minute batch; the combined tree runs the affected full lanes once and each original lands via squash. Until activation, the checked-in configuration is dormant and ordinary PR behavior is unchanged.

## Design precedent

Established managed queues separate fast per-PR checks from a comprehensive pre-merge check on a synthesized combined head, cap speculative concurrency to scarce runner capacity, and split a failed batch to isolate the responsible member. This adopts that two-step model. Parallel speculative batches and automatic flaky retries were rejected initially because they would multiply macOS demand and could hide reproducible failures. A single batch with bounded bisection preserves the project's diagnosed-rerun discipline.

## AI assistance disclosure

Codex authored the queue policy, workflow recognition, tests, and documentation under maintainer direction. Every changed condition was reviewed against the official current schema and queue lifecycle; the configuration was validated with the checksum-verified official CLI, and the focused workflow/security contracts and static gates above passed. I can explain the intent, risk, and behavior of every non-generated change.