### PR TITLE
docs: add managed queue observation steps

### DIFF
--- a/.github/workflows/revoke-merge-ready.yml
+++ b/.github/workflows/revoke-merge-ready.yml
@@ -1,0 +1,28 @@
+name: Revoke merge-ready on head update
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions: {}
+
+jobs:
+  revoke-merge-ready:
+    if: contains(github.event.pull_request.labels.*.name, 'merge-ready')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Revoke stale merge authorization
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "merge-ready",
+            });
+            core.notice(
+              `Removed merge-ready from #${context.issue.number} after its head changed.`,
+            );

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -219,6 +219,12 @@ contain the recorded candidate heads, and its `tests`, `desktop-tests`, and
 original pull requests are admission evidence, not a substitute for the
 combined result.
 
+Every `synchronize` event removes `merge-ready` before the updated head can be
+admitted. A new commit therefore requires a fresh review and an explicit new
+authorization after its own required checks pass. The revocation workflow uses
+`pull_request_target` without checking out or executing pull-request code, and
+holds only `pull-requests: write` permission.
+
 Do not enable batching while strict up-to-date protection remains on, and do
 not weaken or remove any required context to make a batch move. A missing,
 cancelled, or failed aggregate is a queue failure.

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -202,6 +202,23 @@ Production activation is an owner operation and must happen in this order:
    lanes. Then remove `merge-ready` from a queued test PR and verify it leaves
    the queue without merging.
 
+### Operator observation
+
+Capture the immutable head of every candidate before authorizing it:
+
+```bash
+gh pr view <PR_NUMBER> --repo raullenchai/Rapid-MLX \
+  --json headRefOid,mergeStateStatus,statusCheckRollup
+gh pr edit <PR_NUMBER> --repo raullenchai/Rapid-MLX \
+  --add-label merge-ready
+```
+
+The queue-generated pull request is the integration artifact. Its commit must
+contain the recorded candidate heads, and its `tests`, `desktop-tests`, and
+`version-bump-guard` checks must all complete successfully. Green checks on the
+original pull requests are admission evidence, not a substitute for the
+combined result.
+
 Do not enable batching while strict up-to-date protection remains on, and do
 not weaken or remove any required context to make a batch move. A missing,
 cancelled, or failed aggregate is a queue failure.

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -66,3 +66,26 @@ def test_release_bumps_cannot_enter_the_general_batch_queue():
     assert exclusions <= set(queue_rule["queue_conditions"])
     assert exclusions <= set(enqueue_rule["conditions"])
     assert queue_rule["merge_method"] == "squash"
+
+
+def test_head_updates_revoke_merge_ready_authorization():
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/revoke-merge-ready.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+
+    assert workflow["on"] == {"pull_request_target": {"types": ["synchronize"]}}
+    assert workflow["permissions"] == {}
+
+    job = workflow["jobs"]["revoke-merge-ready"]
+    assert job["if"] == (
+        "contains(github.event.pull_request.labels.*.name, 'merge-ready')"
+    )
+    assert job["permissions"] == {"pull-requests": "write"}
+
+    (step,) = job["steps"]
+    assert step["uses"].startswith("actions/github-script@")
+    script = step["with"]["script"]
+    assert "github.rest.issues.removeLabel" in script
+    assert 'name: "merge-ready"' in script
+    assert "checkout" not in script.lower()


### PR DESCRIPTION
## Why

The managed queue needs both observable combined-head evidence and an authorization boundary tied to the reviewed head. Without revocation on `synchronize`, a later push could retain `merge-ready` and become eligible without a fresh maintainer decision. This PR is also one member of the first live batching rehearsal after #2569.

## What

- Record each candidate's immutable head before applying `merge-ready`.
- Treat the generated batch PR and its three required checks as integration proof.
- Revoke `merge-ready` on every pull-request head update.
- Keep the revoker on `pull_request_target` with no checkout and only `pull-requests: write`.
- Contract-test the event, label condition, permissions, pinned action, and API call.

## Scope

Managed-queue authorization and operator documentation only. No product or release behavior changes.

## Design precedent

Managed queues validate a synthetic combined candidate, while merge authorization belongs to a reviewed immutable head. A head mutation revokes that authorization and requires the new head to pass review and admission checks again.

## Verification

- `python3.12 -m pytest -q tests/test_mergify_batch_queue.py` — 5 passed
- `python3 scripts/check_workflow_expressions.py` — 15 workflows passed
- `python3 scripts/check_gha_pinning.py` — 15 workflows clean
- `actionlint .github/workflows/revoke-merge-ready.yml`
- Ruff check and format
- `git diff --check`

## Review

Codex round 1 found that `merge-ready` survived head updates. Fixed in `9faff4ab`; no finding was rejected. Per the one-round quota, no second Codex request will be sent.

Part of #2252
