### PR TITLE
docs: clarify queued candidate handling

### DIFF
--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -245,10 +245,10 @@ Before merge, the PR description must accurately reflect actual current state:
   click GitHub's merge button:
 
   ```bash
-  # No Desktop/GUI lane:
+  # No macOS lane:
   gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready
 
-  # Desktop/GUI lane required:
+  # Any macOS lane required:
   gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready-mac
   ```
 
@@ -257,6 +257,11 @@ Before merge, the PR description must accurately reflect actual current state:
   affected full lanes once on the combined tree, and then squash-merges each
   original. A failed batch is split to identify the blocking member; do not add
   an independent rerun.
+- After labeling, leave the candidate head untouched. Follow the temporary
+  queue pull request for integration evidence; do not rebase, force-push, or
+  manually merge an original while it is queued. To withdraw authorization,
+  remove whichever ready label is present and confirm that the queue removes
+  the candidate before changing its branch.
 - Version bumps and human-authorized hotfixes do not enter the general batch.
   Follow their explicit release/hotfix contract and use a direct squash merge
   only when that contract authorizes it.


### PR DESCRIPTION
## Why

A maintainer can invalidate a queue candidate by rebasing, force-pushing, or manually merging it after authorization. The SOP needs an explicit safe handling rule. This docs-only change also provides a real no-Mac queue rehearsal on the final two-label policy.

## What

- Freeze the candidate head after either ready label is applied.
- Follow the generated batch pull request for integration evidence.
- Remove the applicable ready label and confirm dequeue before changing a candidate.
- Clarify the operator comments as no-macOS versus any-macOS capacity.

## Scope / Non-goals

Documentation only. No workflow, product, release, or repository-setting changes.

## Design precedent

A managed queue owns candidate composition between admission and merge. Mutating an admitted head must revoke and repeat that authorization boundary.

## Verification

- Exact head `74f02c3f` rebased onto main `eee5668f`.
- `merge-lane-no-mac` succeeded and `merge-lane-mac` skipped.
- `tests`, `desktop-tests`, `version-bump-guard`, and `pr_validate` succeeded without allocating a Mac runner.
- `git diff --check` passed.

Part of #2252
