### PR TITLE
feat(engine): add native MTP for Qwen3.8 Flash-Next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,7 @@ jobs:
             tests/test_qwen4_exp_reference_parity.py \
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
+            tests/test_mtp_cli_wiring.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/.orca/flash-next-eval/capture_outputs.py
+++ b/.orca/flash-next-eval/capture_outputs.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Capture deterministic Flash-Next outputs for baseline/MTP byte comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import httpx
+from transformers import AutoTokenizer
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_service_prefill import (  # noqa: E402
+    clear_prefix_cache,
+    make_messages,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8465/v1")
+    parser.add_argument("--tokenizer-path", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer_path,
+        local_files_only=True,
+        trust_remote_code=True,
+    )
+    client = httpx.Client(timeout=3600)
+    api = args.url.rstrip("/")
+    root = api.removesuffix("/v1")
+    model = client.get(f"{api}/models").json()["data"][0]["id"]
+    captures = []
+    for target in (128, 2048):
+        messages = make_messages(
+            tokenizer,
+            target,
+            suffix="\nReply with a detailed but direct explanation.",
+        )
+        clear_prefix_cache(client, root)
+        response = client.post(
+            f"{api}/chat/completions",
+            json={
+                "model": model,
+                "messages": messages,
+                "max_tokens": 256,
+                "temperature": 0.0,
+                "enable_thinking": False,
+            },
+        )
+        response.raise_for_status()
+        body = response.json()
+        content = body["choices"][0]["message"].get("content") or ""
+        token_ids = tokenizer.encode(content, add_special_tokens=False)
+        captures.append(
+            {
+                "target_prompt_tokens": target,
+                "finish_reason": body["choices"][0]["finish_reason"],
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+                "content": content,
+                "token_ids": token_ids,
+                "usage": body.get("usage"),
+            }
+        )
+    args.output.write_text(
+        json.dumps({"label": args.label, "captures": captures}, indent=2) + "\n"
+    )
+    for item in captures:
+        print(
+            item["target_prompt_tokens"],
+            item["finish_reason"],
+            item["usage"],
+            item["content_sha256"],
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/benchmarks/qwen38-flash-next-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-m3-ultra.md
@@ -4,6 +4,9 @@ These are post-release correctness and performance results for Rapid-MLX
 0.13.1. Qwen3.8-Flash-Next is an experimental text-only model in this release;
 Flash-Next MTP and vision are outside this measurement.
 
+The later default-off native MTP experiment is documented in
+[Qwen3.8 Flash-Next native MTP on M3 Ultra](qwen38-flash-next-mtp-m3-ultra.md).
+
 > **Hardware boundary:** these results were measured on the 256 GB machine
 > described below. **128 GB hardware was not physically tested.** The catalog's
 > 128 GB minimum is an admission floor, not a benchmark claim for a 128 GB Mac.

--- a/docs/benchmarks/qwen38-flash-next-mtp-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-mtp-m3-ultra.md
@@ -1,0 +1,156 @@
+# Qwen3.8 Flash-Next native MTP on M3 Ultra
+
+This follow-up measures the default-off native MTP path for
+`rapid-mlx/Qwen3.8-Flash-Next-4bit`. The comparison uses the same candidate
+engine, immutable checkpoint, prompts, process isolation, and benchmark script
+on both sides; only the MTP configuration changes.
+
+> **Hardware boundary:** the measurements were made on a 256 GB M3 Ultra.
+> **128 GB hardware was not physically tested.** The q4 weights are roughly
+> 99 GB before the MTP head, allocator, and context-cache headroom. A 192 GB
+> machine remains the practical recommended tier; 128 GB is tight and
+> unverified.
+
+## Environment
+
+| Component | Value |
+| --- | --- |
+| Machine | Mac Studio (`Mac15,14`) |
+| Chip | Apple M3 Ultra, 28 CPU cores |
+| Unified memory | 256 GB |
+| macOS | 26.5.2 (25F84) |
+| Architecture | arm64 |
+| Python | 3.12.14 |
+| Rapid-MLX implementation | `279426b0` |
+| MLX | 0.32.2 |
+| MLX-LM | 0.31.3 |
+| Transformers | 5.12.1 |
+| Artifact | `rapid-mlx/Qwen3.8-Flash-Next-4bit` at `dcf657e4acda2aae72da99cde65b6c491cd96998` |
+| Quantization | PLE q4-g32; routing gates q8-g64; remainder q4-g64 |
+| MTP | Native one-layer head from the same immutable checkpoint; fixed K=1 for measurement |
+
+No other model server was resident during either run. Each variant used a
+fresh server process. Prefix cache was cleared before every timed request.
+
+## Exact commands
+
+The baseline and MTP servers ran from the same worktree and environment. The
+placeholder below is the immutable local snapshot for the artifact revision in
+the environment table.
+
+```bash
+export SNAPSHOT=/path/to/dcf657e4acda2aae72da99cde65b6c491cd96998
+
+# Baseline
+HF_HUB_OFFLINE=1 PYTHONPATH="$PWD" python3.12 -m vllm_mlx.cli serve \
+  "$SNAPSHOT" --host 127.0.0.1 --port 8465 --no-thinking
+
+# MTP, in a fresh process after the baseline server exits
+HF_HUB_OFFLINE=1 PYTHONPATH="$PWD" python3.12 -m vllm_mlx.cli serve \
+  "$SNAPSHOT" --host 127.0.0.1 --port 8465 --no-thinking \
+  --speculative-config '{"method":"mtp","disable_auto_k":true}'
+```
+
+The same command was used for each benchmark variant, changing only the label,
+server PID, and output path:
+
+```bash
+python3.12 .orca/flash-next-eval/benchmark.py \
+  --url http://127.0.0.1:8465/v1 \
+  --model "$SNAPSHOT" \
+  --tokenizer-path "$SNAPSHOT" \
+  --server-pid SERVER_PID \
+  --label VARIANT_LABEL \
+  --rapid-sha 279426b0 \
+  --artifact-revision dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --output OUTPUT.json
+```
+
+The MTP correctness run used the repository's 45-case Flash-Next battery:
+
+```bash
+python3.12 .orca/flash-next-eval/run_eval.py \
+  --base-url http://127.0.0.1:8465 \
+  --model "$SNAPSHOT" \
+  --tokenizer-path "$SNAPSHOT" \
+  --allow-project-exec \
+  --output /private/tmp/rapid-qwen4-mtp-final-correctness.jsonl
+```
+
+## Methodology
+
+- Batch size is one; thinking is disabled and temperature is zero.
+- Prompt targets are 128, 2,048, 8,192, and 32,768 tokens. The server reports
+  92, 2,012, 8,156, and 32,732 tokens after chat templating.
+- Every request asks for 256 decode tokens. Each prompt length has three runs;
+  the table reports median TTFT and rates plus maximum sampled RSS.
+- TTFT is the first visible SSE content, reasoning, or tool delta. Prefill rate
+  is reported prompt tokens divided by TTFT. Decode rate excludes TTFT.
+- RSS is process memory and does not account for all Metal/unified-memory
+  allocations. MLX active memory is taken from the serving engine's allocator
+  telemetry and is the relevant sizing measurement.
+- The benchmark pins K=1 and disables adaptive depth so it measures the native
+  MTP path on every eligible step. Normal opt-in serving leaves the expected-
+  value controller enabled, so it can park speculation when a workload does
+  not benefit.
+
+## Results
+
+| Target (reported) prompt tokens | Baseline TTFT | MTP TTFT | TTFT delta | Baseline prefill | MTP prefill | Baseline decode | MTP decode | Decode speedup | Baseline / MTP peak RSS |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 128 (92) | 0.393 s | 0.381 s | -3.0% | 234.2 tok/s | 241.3 tok/s | 25.17 tok/s | **34.85 tok/s** | **1.38x** | 54.54 / 56.43 GiB |
+| 2,048 (2,012) | 3.346 s | 3.515 s | +5.1% | 601.4 tok/s | 572.4 tok/s | 23.64 tok/s | **33.53 tok/s** | **1.42x** | 54.82 / 56.45 GiB |
+| 8,192 (8,156) | 13.643 s | 14.581 s | +6.9% | 597.8 tok/s | 559.4 tok/s | 22.82 tok/s | **32.20 tok/s** | **1.41x** | 54.72 / 56.47 GiB |
+| 32,768 (32,732) | 62.844 s | 67.707 s | +7.7% | 520.8 tok/s | 483.4 tok/s | 21.16 tok/s | **28.82 tok/s** | **1.36x** | 54.74 / 56.54 GiB |
+
+The baseline used 103.1 GB MLX active memory at the short prompts and 104.7 GB
+at 32K. The MTP process used approximately 107 GB at the shorter prompts,
+107.2--107.5 GB at 8K, and 109.2--111.3 GB across the three 32K runs. Its
+largest observed active footprint was therefore 6.6 GB above the corresponding
+baseline. Both processes reported a 148.1 GB allocator peak inherited from
+model loading; that historical peak is not the steady active footprint.
+
+## Correctness and qualification gate
+
+The MTP run completed all 45 cases covering English and Chinese, math,
+structured JSON, OpenAI and Anthropic tool calls, code generation, an
+executable CLI todo project, multi-turn/system behavior, stop sequences, and
+8K/32K needle recall. All 45 functional outcomes matched the ordinary-decode
+baseline. The raw scorer marked 43/45 because of two pre-existing adjudication
+artifacts shared by the baseline: one probability answer differs from the
+fixture's expected value, and one correct lowercase-before-return function does
+not match the fixture's order-sensitive regular expression.
+
+Across the correctness battery and four-length benchmark, fixed K=1 recorded
+1,844 proposals and 1,409 accepts, an aggregate **76.41% accept ratio**. The
+release-qualification floor for this exact family and workload is 70% after at
+least 256 proposals. That is a reproducible performance gate, not a universal
+runtime cutoff: acceptance is workload-dependent, and normal serving uses the
+expected-value controller's observed committed-token and round-cost signals.
+
+Every proposal is checked by the target model before it is emitted, and a
+rejection restores the coupled GDN, PLE, QSA, and KV state to one atomic token
+boundary. Multi-token target verification can nevertheless choose a different
+temperature-zero token at a near-tied logit because its floating-point
+accumulation order differs from serial one-token decode. The real-checkpoint
+outputs were therefore functionally equivalent but not promised byte-identical
+to the baseline. MTP remains default-off and activates only through an explicit
+`--speculative-config` request.
+
+## Interpretation
+
+Native MTP is a decode optimization. It raises median sustained generation by
+36--42% over the same optimized engine and checkpoint. It does not improve
+long-prompt prefill: at 2K--32K it adds 5--8% to TTFT, and it adds several GB of
+unified-memory pressure. Users whose workload is dominated by long prefill and
+short answers should leave it off; coding agents and other workloads that emit
+long responses are the stronger fit.
+
+The production path is deliberately limited to the checkpoint's single native
+draft layer. An explicit deeper request fails at startup instead of silently
+running a different depth. Failed tensor validation also fails attachment
+rather than serving with partially loaded draft weights.
+
+Two candidate optimizations were rejected during profiling: splitting the QSA
+verify block reduced throughput, and a custom short-row quantized matrix-vector
+kernel regressed decode. Neither is included in the implementation.

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -29,6 +29,8 @@ Deliberately out of scope (deferred to PR-B / PR-C):
 
 from __future__ import annotations
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # 1. detect_mtp_eligibility(has_external_sidecar=...) contract
 # ---------------------------------------------------------------------------
@@ -281,8 +283,18 @@ def test_config_vetted_mtp_support_allowlist_is_qwen_only():
 
     assert _config_vetted_mtp_supports_spec_decode("qwen3_5") is True
     assert _config_vetted_mtp_supports_spec_decode("qwen3_5_moe") is True
+    assert _config_vetted_mtp_supports_spec_decode("qwen4_exp") is True
     assert _config_vetted_mtp_supports_spec_decode("gemma4_unified") is False
     assert _config_vetted_mtp_supports_spec_decode(None) is False
+
+
+def test_qwen4_native_mtp_depth_is_one_and_rejects_explicit_deeper_chain():
+    from vllm_mlx.cli import _resolve_mtp_depth_for_model
+
+    assert _resolve_mtp_depth_for_model("qwen4_exp", 3, explicit=False) == 1
+    assert _resolve_mtp_depth_for_model("qwen3_5", 3, explicit=True) == 3
+    with pytest.raises(ValueError, match="num_speculative_tokens=1 only"):
+        _resolve_mtp_depth_for_model("qwen4_exp", 2, explicit=True)
 
 
 # ---------------------------------------------------------------------------
@@ -816,6 +828,41 @@ def test_apply_mtp_dispatch_returns_attached_on_happy_path(monkeypatch):
     assert result == _batched._DISPATCH_ATTACHED
 
 
+def test_apply_mtp_dispatch_uses_loaded_snapshot_for_qwen4_native_head(monkeypatch):
+    """Flash-Next reads mtp.* from the exact snapshot selected by load."""
+    from vllm_mlx.engine import batched as _batched
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    captured = {}
+
+    def fake_dispatch(model, model_name, mtp_sidecar, **kwargs):
+        captured["model"] = model
+        captured["model_name"] = model_name
+        captured["mtp_sidecar"] = mtp_sidecar
+        captured.update(kwargs)
+        return _batched._DISPATCH_ATTACHED
+
+    monkeypatch.setattr(_batched, "_run_dispatch_mtp_inject", fake_dispatch)
+    model = object()
+    sc = SchedulerConfig(spec_decode="mtp", mtp_model_type="qwen4_exp")
+    result = _batched._apply_mtp_dispatch(
+        model=model,
+        model_name="qwen3.8-flash-next-4bit",
+        scheduler_config=sc,
+        executor=_SyncExecutor(),
+        checkpoint_source="/cache/snapshots/immutable-revision",
+    )
+
+    assert result == _batched._DISPATCH_ATTACHED
+    assert captured == {
+        "model": model,
+        "model_name": "qwen3.8-flash-next-4bit",
+        "mtp_sidecar": "/cache/snapshots/immutable-revision",
+        "preferred_model_type": "qwen4_exp",
+    }
+    assert sc.mtp_sidecar is None
+
+
 def test_apply_mtp_dispatch_raises_on_rejected(monkeypatch):
     """Codex round-G NIT #4: end-to-end runtime coverage of the
     hard-fail branch — not a source-string check.
@@ -1204,7 +1251,7 @@ def test_start_llm_calls_apply_mtp_dispatch():
             """
 
         def _recording_apply_mtp_dispatch(
-            *, model, model_name, scheduler_config, executor
+            *, model, model_name, scheduler_config, executor, checkpoint_source=None
         ) -> str:
             dispatch_calls.append(
                 {
@@ -1212,6 +1259,7 @@ def test_start_llm_calls_apply_mtp_dispatch():
                     "model_name": model_name,
                     "scheduler_config": scheduler_config,
                     "executor": executor,
+                    "checkpoint_source": checkpoint_source,
                 }
             )
             raise _ScopedTestSentinelError("apply_mtp_dispatch invoked")
@@ -1244,6 +1292,7 @@ def test_start_llm_calls_apply_mtp_dispatch():
     call = dispatch_calls[0]
     assert call["model_name"] == engine._model_name
     assert call["scheduler_config"] is engine._scheduler_config
+    assert call["checkpoint_source"] == "/fake/immutable-snapshot"
     assert call["executor"] is engine._model_load_executor, (
         "codex round-L NIT: dispatch was called with the wrong "
         "executor — must be the same mlx-step worker that loaded "

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1436,10 +1436,12 @@ def test_install_mtp_vendored_uses_inner_language_model_surface(monkeypatch):
             pass
 
     inner = _StubModel()
+    inner.mtp_max_speculative_tokens = 1
     outer = SimpleNamespace(language_model=inner)
 
     def _recording_mtp_generate_step(*args, **kwargs):
         seen["model"] = kwargs["model"]
+        seen["max_k"] = kwargs["max_k"]
         return _FakeGen()
 
     monkeypatch.setattr(_gen_mod, "mtp_generate_step", _recording_mtp_generate_step)
@@ -1455,11 +1457,13 @@ def test_install_mtp_vendored_uses_inner_language_model_surface(monkeypatch):
         model=outer,
         requests={"req-42": request_stub},
         uid_to_request_id={42: "req-42"},
+        max_k=3,
     )
     assert ok is True
 
     gb._step()
     assert seen["model"] is inner
+    assert seen["max_k"] == 1
 
 
 def _make_batch_gen_with_gb():
@@ -2858,6 +2862,43 @@ def test_apply_mtp_cli_model_type_reconciliation_prefers_eligibility_on_disagree
         "the round-I contract: on skew, the eligibility gate's read "
         "wins because it's what decided the accept/reject."
     )
+
+
+def test_apply_mtp_cli_reconciliation_caps_qwen4_default_depth():
+    from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    sc = SchedulerConfig(spec_decode="mtp", mtp_max_k=3)
+    _apply_mtp_cli_model_type_reconciliation(
+        scheduler_config=sc,
+        hf_cfg_eligibility={"model_type": "qwen4_exp", "mtp_num_hidden_layers": 1},
+        logger=None,
+        requested_depth=3,
+        explicit_depth=False,
+    )
+
+    assert sc.mtp_model_type == "qwen4_exp"
+    assert sc.mtp_max_k == 1
+
+
+def test_apply_mtp_cli_reconciliation_rejects_explicit_qwen4_depth(capsys):
+    from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    sc = SchedulerConfig(spec_decode="mtp", mtp_max_k=3)
+    with pytest.raises(SystemExit, match="2"):
+        _apply_mtp_cli_model_type_reconciliation(
+            scheduler_config=sc,
+            hf_cfg_eligibility={
+                "model_type": "qwen4_exp",
+                "mtp_num_hidden_layers": 1,
+            },
+            logger=None,
+            requested_depth=2,
+            explicit_depth=True,
+        )
+
+    assert "num_speculative_tokens=1 only" in capsys.readouterr().err
 
 
 def test_install_mtp_vendored_uid_reuse_clears_stale_state(monkeypatch):

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -155,6 +155,23 @@ def test_detect_eligibility_qwen3_5_accepts_text_config_mtp_layers():
     assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
 
 
+def test_detect_eligibility_qwen4_exp_accepts_nested_mtp_layer():
+    """Flash-Next advertises its native MTP head in nested text_config."""
+    from vllm_mlx.spec_decode.mtp import (
+        MTPEligibility,
+        detect_mtp_eligibility,
+    )
+
+    config = {
+        "model_type": "qwen4_exp",
+        "text_config": {
+            "model_type": "qwen4_exp_text",
+            "mtp_num_hidden_layers": 1,
+        },
+    }
+    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+
+
 def test_detect_eligibility_qwen3_5_tree_reserved():
     """mtp_num_hidden_layers >= 2 → TREE (reserved, not implemented)."""
     from vllm_mlx.spec_decode.mtp import (
@@ -878,6 +895,22 @@ def test_metrics_family_falls_back_to_gemma4_on_model_name():
     body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
     assert 'family="gemma4"' in body
     assert 'family="qwen3.5"' not in body
+
+
+def test_metrics_family_falls_back_to_flash_next_on_model_path():
+    from vllm_mlx.routes.metrics import _render_spec_decode_mtp_counters
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+
+    reset_global_counter_for_tests()
+
+    class _Cfg:
+        model_alias = None
+        model_path = "rapid-mlx/Qwen3.8-Flash-Next-4bit"
+
+    body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
+    assert 'family="qwen3.8-flash-next"' in body
 
 
 def test_metrics_includes_park_and_k_chosen_counters():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1077,6 +1077,33 @@ def test_qwen4_state_cache_restores_atomic_slot_boundary():
     np.testing.assert_array_equal(np.array(cache.cache[1]), np.array([2]))
 
 
+def test_qwen4_state_cache_rejects_incomplete_or_invalid_boundaries():
+    cache = Qwen4ExpStateCache(size=2)
+    cache.cache = [mx.array([1]), mx.array([2])]
+
+    cache.record_slot_snapshots(0, [])
+    cache.record_slot_snapshots(0, [mx.array([1])])
+    with pytest.raises(AssertionError, match="every state slot"):
+        cache.record_slot_snapshots(0, [mx.array([1])], finalize=True)
+
+    cache._rollback_slots = None
+    cache.record_slot_snapshots(0, [mx.array([1])])
+    with pytest.raises(AssertionError, match="lengths diverged"):
+        cache.record_slot_snapshots(
+            1,
+            [mx.array([2]), mx.array([3])],
+            finalize=True,
+        )
+
+    cache.rollback_state = None
+    with pytest.raises(AssertionError, match="no saved boundary"):
+        cache.restore_rollback(1, 2)
+
+    cache.rollback_state = [[mx.array([1]), mx.array([2])]]
+    with pytest.raises(AssertionError, match="invalid Qwen4 rollback boundary"):
+        cache.restore_rollback(0, 2)
+
+
 def test_qwen4_verify_block_matches_tokenwise_forward():
     args = _ple_args()
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
@@ -1142,7 +1169,7 @@ def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):
         _MTP_VALIDATE_DISPATCH,
     )
 
-    args = _ple_args()
+    args = _ple_args(tie_word_embeddings=True)
     args.mtp_num_hidden_layers = 1
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
     # The tiny fixture's hidden width is below a production q4 group. Weight
@@ -1170,6 +1197,182 @@ def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):
     mtp_logits = inner.mtp_forward(hidden, mx.array([[2]]), cache)
     mx.eval(logits, mtp_logits)
     assert mtp_logits.shape == (1, 1, args.vocab_size)
+
+
+def test_qwen4_mtp_checkpoint_file_discovery_and_weight_sanitize(tmp_path):
+    from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+    direct = tmp_path / "direct.safetensors"
+    direct.touch()
+    assert inject._mtp_weight_files(direct) == [direct]
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        inject._mtp_weight_files(tmp_path / "missing")
+
+    indexed = tmp_path / "indexed"
+    indexed.mkdir()
+    (indexed / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "mtp.a": "b.safetensors",
+                    "mtp.b": "a.safetensors",
+                    "model.c": "ignored.safetensors",
+                }
+            }
+        )
+    )
+    assert inject._mtp_weight_files(indexed) == [
+        indexed / "a.safetensors",
+        indexed / "b.safetensors",
+    ]
+
+    single = tmp_path / "single"
+    single.mkdir()
+    (single / "model.safetensors").touch()
+    assert inject._mtp_weight_files(single) == [single / "model.safetensors"]
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match=r"No safetensors containing mtp\.\*"):
+        inject._mtp_weight_files(empty)
+
+    gate_up = mx.arange(16).reshape(2, 4, 2)
+    down = mx.ones((2, 2, 2))
+    sanitized = inject._sanitize_mtp_weights(
+        {
+            "model.ignored": mx.zeros((1,)),
+            "mtp.layers.0.mlp.experts.gate_up_proj": gate_up,
+            "mtp.layers.0.mlp.experts.gate_up_proj.unknown": gate_up,
+            "mtp.layers.0.mlp.experts.down_proj": down,
+            "mtp.layers.0.keep": mx.ones((1,)),
+        }
+    )
+    assert set(sanitized) == {
+        "layers.0.mlp.switch_mlp.gate_proj.weight",
+        "layers.0.mlp.switch_mlp.up_proj.weight",
+        "layers.0.mlp.experts.gate_up_proj.unknown",
+        "layers.0.mlp.switch_mlp.down_proj.weight",
+        "layers.0.keep",
+    }
+    np.testing.assert_array_equal(
+        np.asarray(sanitized["layers.0.mlp.switch_mlp.gate_proj.weight"]),
+        np.asarray(gate_up[..., :2, :]),
+    )
+
+
+def test_qwen4_mtp_quantization_predicate_delegates_only_quantizable_modules(
+    monkeypatch,
+):
+    import mlx.nn as nn
+
+    from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+    args = _ple_args()
+    args.mtp_num_hidden_layers = 1
+    inner = Model(
+        ModelArgs(model_type="qwen4_exp", text_config=asdict(args))
+    ).language_model
+    observed = []
+
+    class Quantizable:
+        to_quantized = object()
+
+    def fake_quantize(_model, *, class_predicate, **_kwargs):
+        observed.append(class_predicate("plain", object()))
+        observed.append(class_predicate("quantized", Quantizable()))
+
+    monkeypatch.setattr(nn, "quantize", fake_quantize)
+    inject._build_mtp(inner)
+    assert observed == [False, True]
+
+
+def test_qwen4_mtp_inject_loads_complete_local_tensor_contract(tmp_path, monkeypatch):
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+    args = _ple_args()
+    args.mtp_num_hidden_layers = 1
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
+    expected_mtp = inject._build_mtp(model.language_model)
+    checkpoint = tmp_path / "mtp.safetensors"
+    mx.save_safetensors(
+        str(checkpoint),
+        {f"mtp.{key}": value for key, value in tree_flatten(expected_mtp.parameters())},
+    )
+
+    assert inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=checkpoint) is True
+    assert inject.validate_qwen4_exp_mtp_support(model) is True
+
+
+def test_qwen4_mtp_inject_fails_closed_on_guards_tensor_mismatch_and_exception(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    import mlx.nn as nn
+
+    from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+    assert inject._resolve_inner(object()) is None
+    assert inject.validate_qwen4_exp_mtp_support(object()) is False
+    direct = SimpleNamespace(model_type="qwen4_exp_text")
+    assert inject._resolve_inner(direct) is direct
+    assert (
+        inject.inject_qwen4_exp_mtp_support(object(), allow_random_init=True) is False
+    )
+
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    assert inject.inject_qwen4_exp_mtp_support(model, allow_random_init=True) is False
+
+    args.mtp_num_hidden_layers = 1
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    assert inject.inject_qwen4_exp_mtp_support(model) is False
+
+    monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
+    bad_checkpoint = tmp_path / "bad.safetensors"
+    mx.save_safetensors(str(bad_checkpoint), {"mtp.unexpected": mx.ones((2,))})
+    assert (
+        inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=bad_checkpoint) is False
+    )
+    assert "tensor contract mismatch" in caplog.text
+
+    monkeypatch.setattr(
+        inject,
+        "_build_mtp",
+        lambda _inner: (_ for _ in ()).throw(RuntimeError("injected build failure")),
+    )
+    assert inject.inject_qwen4_exp_mtp_support(model, allow_random_init=True) is False
+    assert "native MTP attachment failed" in caplog.text
+
+
+def test_qwen4_mtp_untied_logits_and_validation_signature_failure(monkeypatch):
+    import mlx.nn as nn
+
+    from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+    args = _ple_args(tie_word_embeddings=False)
+    args.mtp_num_hidden_layers = 1
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
+    assert inject.inject_qwen4_exp_mtp_support(model, allow_random_init=True) is True
+
+    inner = model.language_model
+    _, hidden = inner(mx.array([[1]]), cache=inner.make_cache(), return_hidden=True)
+    logits = inner.mtp_forward(hidden, mx.array([[2]]), inner.make_mtp_cache())
+    mx.eval(logits)
+    assert logits.shape == (1, 1, args.vocab_size)
+
+    monkeypatch.setattr(
+        inject.inspect,
+        "signature",
+        lambda _call: (_ for _ in ()).throw(ValueError("injected signature failure")),
+    )
+    assert inject.validate_qwen4_exp_mtp_support(model) is False
 
 
 def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():
@@ -1554,3 +1757,29 @@ def test_qwen4_registration_probes_native_and_fails_closed(monkeypatch, caplog):
     tokenizer._register_vendored_archs()
     assert "qwen4_exp" not in tokenizer._VENDORED_MODEL_TYPES
     assert "failed to register" in caplog.text
+
+
+def test_qwen4_gdn_verify_single_step_initializes_state_and_empty_boundaries():
+    """Exercise the one-token reference edge after other GPU tests.
+
+    MLX's shapeless compile cache can recycle a thread-local stream after a
+    one-step shape, so keep this edge last in the module while still asserting
+    the production fallback used outside multi-token verification.
+    """
+    from vllm_mlx.kernels.qwen4_gdn_verify import gated_delta_verify_with_states
+
+    output, state, boundaries = gated_delta_verify_with_states(
+        mx.ones((1, 1, 1, 4)),
+        mx.ones((1, 1, 1, 4)),
+        mx.ones((1, 1, 2, 3)),
+        mx.zeros((1, 1, 2)),
+        mx.zeros((1, 1, 2)),
+        mx.zeros((2,)),
+        mx.zeros((2,)),
+        use_kernel=False,
+    )
+    mx.eval(output, state, boundaries)
+
+    assert output.shape == (1, 1, 2, 3)
+    assert state.shape == (1, 2, 3, 4)
+    assert boundaries.shape == (1, 0, 2, 3, 4)

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1129,12 +1129,20 @@ def test_qwen4_verify_block_matches_tokenwise_forward():
 
 
 def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch):
+    import importlib
+
     import mlx.nn as nn
     from mlx_lm.generate import generate_step
 
     from vllm_mlx.spec_decode.mtp import MTPAcceptCounter, dispatch_mtp_inject
     from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
 
+    # Earlier executor tests may leave MLX's process-global default tagged to
+    # a worker-owned stream. Rebind this real-device test to the current
+    # thread before its random model parameters are allocated.
+    current_stream = mx.new_stream(mx.default_device())
+    mx.set_default_stream(current_stream)
+    importlib.import_module("mlx_lm.generate").generation_stream = current_stream
     args = _ple_args()
     args.mtp_num_hidden_layers = 1
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -23,7 +23,9 @@ from vllm_mlx.models.qwen4_exp import (
     PLELayer,
     QSAAttention,
     QSAIndexer,
+    Qwen4ExpStateCache,
     ShardedEmbedding,
+    SparseMoeBlock,
     TextModelArgs,
     ZeroCenteredRMSNorm,
     apply_qwen4_exp_rope,
@@ -245,6 +247,79 @@ def test_gated_residual_matches_reference_equations():
     np.testing.assert_allclose(
         np.array(injection), expected_injection, rtol=3e-5, atol=3e-5
     )
+
+
+def test_qwen4_moe_verify_rows_match_fused_projection_path():
+    from vllm_mlx.moe_fusion import fuse_gate_up
+
+    block = SparseMoeBlock(_args())
+    inputs = mx.array(
+        np.random.default_rng(19).normal(size=(1, 2, 8)).astype(np.float32)
+    )
+    expected = block(inputs)
+    assert fuse_gate_up(block) == 1
+    actual = block(inputs, target_verify=True)
+    mx.eval(expected, actual)
+    np.testing.assert_allclose(
+        np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-6
+    )
+
+
+@pytest.mark.parametrize("masked", [False, True])
+def test_qwen4_gdn_verify_kernel_matches_reference_and_boundaries(masked):
+    from vllm_mlx.kernels.qwen4_gdn_verify import (
+        gated_delta_verify_with_states,
+    )
+
+    rng = np.random.default_rng(23)
+    batch, steps, key_heads, value_heads = 1, 3, 1, 2
+    key_dim, value_dim = 32, 4
+
+    def array(shape, scale=0.1):
+        return mx.array((rng.normal(size=shape) * scale).astype(np.float32))
+
+    query = array((batch, steps, key_heads, key_dim))
+    key = array((batch, steps, key_heads, key_dim))
+    value = array((batch, steps, value_heads, value_dim))
+    alpha = array((batch, steps, value_heads))
+    beta = array((batch, steps, value_heads))
+    a_log = array((value_heads,), scale=0.01)
+    dt_bias = array((value_heads,), scale=0.01)
+    state = array((batch, value_heads, value_dim, key_dim))
+    mask = mx.array([[True, False, True]]) if masked else None
+
+    expected = gated_delta_verify_with_states(
+        query,
+        key,
+        value,
+        alpha,
+        beta,
+        a_log,
+        dt_bias,
+        state,
+        mask,
+        use_kernel=False,
+    )
+    actual = gated_delta_verify_with_states(
+        query,
+        key,
+        value,
+        alpha,
+        beta,
+        a_log,
+        dt_bias,
+        state,
+        mask,
+        use_kernel=True,
+    )
+    mx.eval(*expected, *actual)
+    for expected_array, actual_array in zip(expected, actual):
+        np.testing.assert_allclose(
+            np.asarray(actual_array),
+            np.asarray(expected_array),
+            rtol=1e-5,
+            atol=1e-6,
+        )
 
 
 def test_gated_residual_shape_guard_and_read_only_variant():
@@ -930,6 +1005,171 @@ def test_complete_synthetic_text_model_prefill_and_decode():
     assert next_logits.shape == (1, 1, args.vocab_size)
     assert cache[1][0].offset == 4
     assert cache[1][1].offset == 4
+
+
+def test_return_hidden_exposes_pre_final_mixer_multistream():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    logits, hidden = model(mx.array([[1, 2, 3]]), return_hidden=True)
+    mx.eval(logits, hidden)
+
+    assert logits.shape == (1, 3, args.vocab_size)
+    assert hidden.shape == (1, 3, args.hc_count * args.hidden_size)
+
+
+def test_speculative_reject_restores_gdn_ple_and_qsa_state():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    baseline_cache = model.make_cache()
+    verify_cache = model.make_cache()
+    prompt = mx.array([[1, 2, 3]])
+    mx.eval(model(prompt, cache=baseline_cache), model(prompt, cache=verify_cache))
+
+    mx.eval(model(mx.array([[4]]), cache=baseline_cache))
+    baseline_logits = model(mx.array([[6]]), cache=baseline_cache)
+
+    verify_logits, verify_hidden = model(
+        mx.array([[4, 5]]),
+        cache=verify_cache,
+        return_hidden=True,
+        n_confirmed=1,
+    )
+    mx.eval(verify_logits, verify_hidden)
+    for layer_cache in verify_cache:
+        if isinstance(layer_cache, Qwen4ExpStateCache):
+            layer_cache.restore_rollback(1, 2)
+        elif layer_cache.is_trimmable():
+            assert layer_cache.trim(1) == 1
+    restored_logits = model(mx.array([[6]]), cache=verify_cache)
+    mx.eval(
+        baseline_logits,
+        restored_logits,
+        [cache.state for cache in baseline_cache],
+        [cache.state for cache in verify_cache],
+    )
+
+    np.testing.assert_array_equal(
+        np.array(mx.argmax(restored_logits, axis=-1)),
+        np.array(mx.argmax(baseline_logits, axis=-1)),
+    )
+    np.testing.assert_allclose(
+        np.array(restored_logits), np.array(baseline_logits), rtol=1e-5, atol=1e-6
+    )
+    for baseline, restored in zip(baseline_cache, verify_cache):
+        if isinstance(baseline, Qwen4ExpStateCache):
+            for expected, actual in zip(baseline.state, restored.state):
+                np.testing.assert_allclose(
+                    np.array(actual), np.array(expected), rtol=1e-5, atol=1e-6
+                )
+        else:
+            assert baseline[0].offset == restored[0].offset
+            assert baseline[1].offset == restored[1].offset
+
+
+def test_qwen4_state_cache_restores_atomic_slot_boundary():
+    cache = Qwen4ExpStateCache(size=2)
+    cache.cache = [mx.array([1]), mx.array([2])]
+    cache.record_slot_snapshots(0, [mx.array([1])])
+    cache.record_slot_snapshots(1, [mx.array([2])], finalize=True)
+    cache.cache = [mx.array([3]), mx.array([4])]
+    cache.restore_rollback(1, 2)
+    np.testing.assert_array_equal(np.array(cache.cache[0]), np.array([1]))
+    np.testing.assert_array_equal(np.array(cache.cache[1]), np.array([2]))
+
+
+def test_qwen4_verify_block_matches_tokenwise_forward():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    block_cache = model.make_cache()
+    step_cache = model.make_cache()
+    prompt = mx.array([[1, 2, 3]])
+    mx.eval(model(prompt, cache=block_cache), model(prompt, cache=step_cache))
+
+    verify = mx.array([[4, 5, 6]])
+    block_logits = model(verify, cache=block_cache)
+    step_logits = mx.concatenate(
+        [model(verify[:, i : i + 1], cache=step_cache) for i in range(3)],
+        axis=1,
+    )
+    mx.eval(block_logits, step_logits)
+    np.testing.assert_array_equal(
+        np.array(mx.argmax(block_logits, axis=-1)),
+        np.array(mx.argmax(step_logits, axis=-1)),
+    )
+    np.testing.assert_allclose(
+        np.array(block_logits), np.array(step_logits), rtol=1e-5, atol=2e-7
+    )
+
+
+def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch):
+    import mlx.nn as nn
+    from mlx_lm.generate import generate_step
+
+    from vllm_mlx.spec_decode.mtp import MTPAcceptCounter, dispatch_mtp_inject
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    args = _ple_args()
+    args.mtp_num_hidden_layers = 1
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    prompt = mx.array([1, 2, 3], dtype=mx.uint32)
+    baseline = [int(token) for token, _ in generate_step(prompt, model, max_tokens=12)]
+
+    monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
+    assert dispatch_mtp_inject(model, "qwen4_exp", allow_random_init=True) is True
+    counter = MTPAcceptCounter()
+    speculative = [
+        int(token)
+        for token, _logprobs, _draft in mtp_generate_step(
+            prompt,
+            model.language_model,
+            max_tokens=12,
+            max_k=1,
+            disable_auto_k=True,
+            accept_counter=counter,
+        )
+    ]
+
+    assert speculative == baseline
+    assert counter.snapshot().attempts > 0
+
+
+def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):
+    import mlx.nn as nn
+
+    from vllm_mlx.spec_decode.mtp import dispatch_mtp_inject, dispatch_mtp_validate
+    from vllm_mlx.spec_decode.mtp.dispatch import (
+        _MTP_INJECT_DISPATCH,
+        _MTP_VALIDATE_DISPATCH,
+    )
+
+    args = _ple_args()
+    args.mtp_num_hidden_layers = 1
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    # The tiny fixture's hidden width is below a production q4 group. Weight
+    # quantization is separately covered by the real checkpoint experiment;
+    # this unit test exercises dispatch and protocol attachment only.
+    monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
+
+    assert _MTP_INJECT_DISPATCH["qwen4_exp"] == (
+        "vllm_mlx.spec_decode.mtp.qwen4_exp_inject",
+        "inject_qwen4_exp_mtp_support",
+    )
+    assert _MTP_VALIDATE_DISPATCH["qwen4_exp"] == (
+        "vllm_mlx.spec_decode.mtp.qwen4_exp_inject",
+        "validate_qwen4_exp_mtp_support",
+    )
+    assert dispatch_mtp_inject(model, "qwen4_exp", allow_random_init=True) is True
+    assert dispatch_mtp_validate(model, "qwen4_exp") is True
+    assert model.mtp_max_speculative_tokens == 1
+
+    inner = model.language_model
+    cache = inner.make_mtp_cache()
+    logits, hidden = inner(
+        mx.array([[1]]), cache=inner.make_cache(), return_hidden=True
+    )
+    mtp_logits = inner.mtp_forward(hidden, mx.array([[2]]), cache)
+    mx.eval(logits, mtp_logits)
+    assert mtp_logits.shape == (1, 1, args.vocab_size)
 
 
 def test_sanitize_preserves_ple_shards_and_maps_experts_without_concat():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1189,6 +1189,8 @@ def _apply_mtp_cli_model_type_reconciliation(
     scheduler_config,
     hf_cfg_eligibility,
     logger=None,
+    requested_depth: int | None = None,
+    explicit_depth: bool = False,
 ) -> None:
     """Thread the eligibility gate's ``model_type`` down into
     ``SchedulerConfig.mtp_model_type``.
@@ -1270,6 +1272,17 @@ def _apply_mtp_cli_model_type_reconciliation(
         else:
             print(_msg % (_prior, _eligibility_model_type), file=sys.stderr)
     scheduler_config.mtp_model_type = _eligibility_model_type
+    if requested_depth is None:
+        return
+    try:
+        scheduler_config.mtp_max_k = _resolve_mtp_depth_for_model(
+            _eligibility_model_type,
+            requested_depth,
+            explicit=explicit_depth,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
 
 
 def _resolve_mtp_depth_for_model(
@@ -4267,27 +4280,21 @@ def serve_command(args):
         # block cannot be exercised without spinning up
         # ``serve_command``, which lets the test pass even if the
         # production block is later deleted).
-        _apply_mtp_cli_model_type_reconciliation(
+        _apply_mtp_cli_model_type_reconciliation(  # pragma: no cover - serve boundary
             scheduler_config=scheduler_config,
             hf_cfg_eligibility=hf_cfg_eligibility,
             logger=logger,
+            requested_depth=int(getattr(scheduler_config, "mtp_max_k", 1)),
+            explicit_depth=(
+                getattr(
+                    getattr(args, "_speculative_config", None),
+                    "num_speculative_tokens",
+                    None,
+                )
+                is not None
+            ),
         )
-        _spec_config = getattr(args, "_speculative_config", None)
-        _explicit_mtp_depth = bool(
-            _spec_config is not None
-            and getattr(_spec_config, "num_speculative_tokens", None) is not None
-        )
-        try:
-            _effective_mtp_depth = _resolve_mtp_depth_for_model(
-                scheduler_config.mtp_model_type,
-                int(getattr(scheduler_config, "mtp_max_k", 1)),
-                explicit=_explicit_mtp_depth,
-            )
-        except ValueError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            sys.exit(2)
-        scheduler_config.mtp_max_k = _effective_mtp_depth
-        args.mtp_max_k = _effective_mtp_depth
+        args.mtp_max_k = scheduler_config.mtp_max_k  # pragma: no cover - serve boundary
 
         sidecar_note = (
             f" +sidecar={getattr(args, 'mtp_sidecar', None)}" if has_sidecar else ""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1272,6 +1272,24 @@ def _apply_mtp_cli_model_type_reconciliation(
     scheduler_config.mtp_model_type = _eligibility_model_type
 
 
+def _resolve_mtp_depth_for_model(
+    model_type: str | None,
+    requested: int,
+    *,
+    explicit: bool,
+) -> int:
+    """Return the validated native-MTP depth for a checkpoint family."""
+
+    if model_type != "qwen4_exp":
+        return requested
+    if explicit and requested != 1:
+        raise ValueError(
+            "Qwen3.8 Flash-Next native MTP currently supports "
+            "num_speculative_tokens=1 only"
+        )
+    return 1
+
+
 def _check_alias_min_memory(user_typed: str) -> None:
     """Alias-level unified-memory guard — warn if the user's Mac is
     smaller than the alias's declared ``min_memory_gb`` floor.
@@ -4221,16 +4239,16 @@ def serve_command(args):
         if eligibility is MTPEligibility.NONE:
             if has_sidecar:
                 print(
-                    "error: MTP speculative-config requires either a Qwen3.5 / "
-                    "Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in "
+                    "error: MTP speculative-config requires a supported "
+                    "checkpoint with mtp_num_hidden_layers >= 1 in "
                     "config.json. Assistant sidecars are reserved for future "
                     "validated support and do not make this model eligible.",
                     file=sys.stderr,
                 )
             else:
                 print(
-                    "error: MTP speculative-config requires a Qwen3.5 / "
-                    "Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in "
+                    "error: MTP speculative-config requires a supported "
+                    "checkpoint with mtp_num_hidden_layers >= 1 in "
                     "config.json. Assistant sidecars are not currently "
                     "supported. The loaded model does not qualify.",
                     file=sys.stderr,
@@ -4254,6 +4272,22 @@ def serve_command(args):
             hf_cfg_eligibility=hf_cfg_eligibility,
             logger=logger,
         )
+        _spec_config = getattr(args, "_speculative_config", None)
+        _explicit_mtp_depth = bool(
+            _spec_config is not None
+            and getattr(_spec_config, "num_speculative_tokens", None) is not None
+        )
+        try:
+            _effective_mtp_depth = _resolve_mtp_depth_for_model(
+                scheduler_config.mtp_model_type,
+                int(getattr(scheduler_config, "mtp_max_k", 1)),
+                explicit=_explicit_mtp_depth,
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        scheduler_config.mtp_max_k = _effective_mtp_depth
+        args.mtp_max_k = _effective_mtp_depth
 
         sidecar_note = (
             f" +sidecar={getattr(args, 'mtp_sidecar', None)}" if has_sidecar else ""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -455,6 +455,7 @@ def _apply_mtp_dispatch(
     model_name: str,
     scheduler_config: Any,
     executor: Any,
+    checkpoint_source: str | None = None,
 ) -> str:
     """Executor-side MTP dispatch step used by ``_start_llm``.
 
@@ -475,6 +476,12 @@ def _apply_mtp_dispatch(
 
     preferred_mt = getattr(scheduler_config, "mtp_model_type", None)
     sidecar = getattr(scheduler_config, "mtp_sidecar", None)
+    if preferred_mt == "qwen4_exp" and sidecar is None:
+        # Flash-Next stores its native MTP tensors beside the target tensors.
+        # Use the exact immutable snapshot selected by this load rather than
+        # resolving the mutable alias a second time or requiring users to pass
+        # the target checkpoint back as an artificial sidecar.
+        sidecar = checkpoint_source
 
     future = executor.submit(
         _run_dispatch_mtp_inject,
@@ -1720,6 +1727,7 @@ class BatchedEngine(BaseEngine):
                 model_name=self._model_name,
                 scheduler_config=sc,
                 executor=self._model_load_executor,
+                checkpoint_source=checkpoint_source,
             )
 
         # Set Metal memory limits on the SAME mlx-step worker that loaded

--- a/vllm_mlx/kernels/qwen4_gdn_verify.py
+++ b/vllm_mlx/kernels/qwen4_gdn_verify.py
@@ -27,7 +27,7 @@ def _compute_g_beta(a_log, alpha, beta, dt_bias):
 
 @cache
 def _kernel(has_mask: bool):
-    if not mx.metal.is_available():
+    if not mx.metal.is_available():  # pragma: no cover - Apple-only module
         return None
     mask_source = "mask[b_idx * T + t]" if has_mask else "true"
     source = f"""

--- a/vllm_mlx/kernels/qwen4_gdn_verify.py
+++ b/vllm_mlx/kernels/qwen4_gdn_verify.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+"""Gated-delta verify kernel that also returns rollback boundaries.
+
+The ordinary MLX gated-delta kernel returns only the final recurrent state.
+Native MTP verification needs the state after each potentially committed
+position so a rejected draft can restore the target cache without replaying
+the accepted prefix.  This batch-one Metal path performs the same recurrence
+once and writes only the intermediate states that can become rollback
+boundaries.  Unsupported shapes use the transparent MLX reference path.
+
+The kernel is adapted from the MLX Qwen hybrid-model implementation.
+"""
+
+from __future__ import annotations
+
+from functools import cache, partial
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@partial(mx.compile, shapeless=True)
+def _compute_g_beta(a_log, alpha, beta, dt_bias):
+    decay = mx.exp(-mx.exp(a_log.astype(mx.float32)) * nn.softplus(alpha + dt_bias))
+    return decay, mx.sigmoid(beta)
+
+
+@cache
+def _kernel(has_mask: bool):
+    if not mx.metal.is_available():
+        return None
+    mask_source = "mask[b_idx * T + t]" if has_mask else "true"
+    source = f"""
+        auto n = thread_position_in_grid.z;
+        auto b_idx = n / Hv;
+        auto hv_idx = n % Hv;
+        auto hk_idx = hv_idx / (Hv / Hk);
+        constexpr int n_per_t = Dk / 32;
+
+        auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+        y += b_idx * T * Hv * Dv + hv_idx * Dv;
+        boundaries += ((b_idx * StateT * Hv + hv_idx) * Dv) * Dk;
+
+        auto dk_idx = thread_position_in_threadgroup.x;
+        auto dv_idx = thread_position_in_grid.y;
+        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+        auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+        auto boundary_ = boundaries + dv_idx * Dk;
+
+        float state[n_per_t];
+        for (int i = 0; i < n_per_t; ++i) {{
+            auto s_idx = n_per_t * dk_idx + i;
+            state[i] = static_cast<float>(i_state[s_idx]);
+        }}
+
+        auto g_ = g + b_idx * T * Hv;
+        auto beta_ = beta + b_idx * T * Hv;
+        for (int t = 0; t < T; ++t) {{
+            if ({mask_source}) {{
+                float kv_mem = 0.0f;
+                for (int i = 0; i < n_per_t; ++i) {{
+                    auto s_idx = n_per_t * dk_idx + i;
+                    state[i] = state[i] * g_[hv_idx];
+                    kv_mem += state[i] * k_[s_idx];
+                }}
+                kv_mem = simd_sum(kv_mem);
+                auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+                float out = 0.0f;
+                for (int i = 0; i < n_per_t; ++i) {{
+                    auto s_idx = n_per_t * dk_idx + i;
+                    state[i] = state[i] + k_[s_idx] * delta;
+                    out += state[i] * q_[s_idx];
+                }}
+                out = simd_sum(out);
+                if (thread_index_in_simdgroup == 0) {{
+                    y[dv_idx] = static_cast<InT>(out);
+                }}
+            }} else {{
+                y[dv_idx] = static_cast<InT>(0);
+            }}
+
+            if (t < StateT) {{
+                for (int i = 0; i < n_per_t; ++i) {{
+                    auto s_idx = n_per_t * dk_idx + i;
+                    boundary_[s_idx] = static_cast<StT>(state[i]);
+                }}
+                boundary_ += Hv * Dv * Dk;
+            }}
+            q_ += Hk * Dk;
+            k_ += Hk * Dk;
+            v_ += Hv * Dv;
+            y += Hv * Dv;
+            g_ += Hv;
+            beta_ += Hv;
+        }}
+
+        for (int i = 0; i < n_per_t; ++i) {{
+            auto s_idx = n_per_t * dk_idx + i;
+            o_state[s_idx] = static_cast<StT>(state[i]);
+        }}
+    """
+    inputs = ["q", "k", "v", "g", "beta", "state_in", "T"]
+    if has_mask:
+        inputs.append("mask")
+    return mx.fast.metal_kernel(
+        name=f"rapid_qwen4_gdn_verify{'_mask' if has_mask else ''}",
+        input_names=inputs,
+        output_names=["y", "state_out", "boundaries"],
+        source=source,
+    )
+
+
+def _reference(q, k, v, g, beta, state, mask):
+    batch, steps, key_heads, _ = q.shape
+    value_heads = v.shape[-2]
+    repeat = value_heads // key_heads
+    if repeat > 1:
+        q = mx.repeat(q, repeat, axis=-2)
+        k = mx.repeat(k, repeat, axis=-2)
+    outputs = []
+    boundaries = []
+    for position in range(steps):
+        old_state = state
+        state = state * g[:, position, :, None, None]
+        memory = (state * k[:, position, :, None, :]).sum(axis=-1)
+        delta = (v[:, position] - memory) * beta[:, position, :, None]
+        state = state + k[:, position, :, None, :] * delta[..., None]
+        output = (state * q[:, position, :, None, :]).sum(axis=-1)
+        if mask is not None:
+            valid = mask[:, position]
+            state = mx.where(valid[:, None, None, None], state, old_state)
+            output = mx.where(valid[:, None, None], output, 0)
+        outputs.append(output.astype(q.dtype))
+        if position < steps - 1:
+            boundaries.append(state)
+    if boundaries:
+        rollback_states = mx.stack(boundaries, axis=1)
+    else:
+        rollback_states = mx.zeros(
+            (batch, 0, value_heads, v.shape[-1], k.shape[-1]),
+            dtype=state.dtype,
+        )
+    return mx.stack(outputs, axis=1), state, rollback_states
+
+
+def gated_delta_verify_with_states(
+    query,
+    key,
+    value,
+    alpha,
+    beta,
+    a_log,
+    dt_bias,
+    state=None,
+    mask=None,
+    *,
+    use_kernel: bool = True,
+):
+    """Return ``(output, final_state, rollback_states)`` for a verify block."""
+
+    decay, update = _compute_g_beta(a_log, alpha, beta, dt_bias)
+    batch, steps, key_heads, key_dim = key.shape
+    value_heads, value_dim = value.shape[2:]
+    if state is None:
+        state = mx.zeros((batch, value_heads, value_dim, key_dim), dtype=mx.float32)
+    kernel = _kernel(mask is not None) if use_kernel else None
+    if kernel is None or mx.default_device() != mx.gpu or key_dim % 32 or steps < 2:
+        return _reference(query, key, value, decay, update, state, mask)
+
+    inputs = [query, key, value, decay, update, state, steps]
+    if mask is not None:
+        inputs.append(mask)
+    state_steps = steps - 1
+    return kernel(
+        inputs=inputs,
+        template=[
+            ("InT", query.dtype),
+            ("StT", state.dtype),
+            ("Dk", key_dim),
+            ("Dv", value_dim),
+            ("Hk", key_heads),
+            ("Hv", value_heads),
+            ("StateT", state_steps),
+        ],
+        grid=(32, value_dim, batch * value_heads),
+        threadgroup=(32, 4, 1),
+        output_shapes=[
+            (batch, steps, value_heads, value_dim),
+            state.shape,
+            (batch, state_steps, value_heads, value_dim, key_dim),
+        ],
+        output_dtypes=[query.dtype, state.dtype, state.dtype],
+    )

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -97,6 +97,7 @@ class TextModelArgs(BaseModelArgs):
     split_ngram_parts: int = 128
     seed: int = 1234
     eos_token_id: int | list[int] | None = None
+    mtp_num_hidden_layers: int = 0
 
     def __post_init__(self):
         rope = dict(self.rope_parameters or {})
@@ -316,13 +317,35 @@ class SparseMoeBlock(nn.Module):
         self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
         self.sharding_group = None
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(self, x: mx.array, *, target_verify: bool = False) -> mx.array:
         gates = mx.softmax(self.gate(x), axis=-1, precise=True)
         indices = mx.argpartition(gates, kth=-self.top_k, axis=-1)[..., -self.top_k :]
         scores = mx.take_along_axis(gates, indices, axis=-1)
         if self.norm_topk_prob:
             scores = scores / scores.sum(axis=-1, keepdims=True)
-        routed = self.switch_mlp(x, indices)
+        if target_verify and x.ndim == 3 and x.shape[1] > 1:
+            batch, steps, width = x.shape
+            experts_per_token = indices.shape[-1]
+            flat_x = x.reshape(batch * steps, width)
+            flat_indices = indices.reshape(batch * steps, experts_per_token)
+            flat_x = mx.expand_dims(flat_x, (-2, -3))
+            gate_up_proj = getattr(self.switch_mlp, "gate_up_proj", None)
+            if gate_up_proj is not None:
+                gate_up = gate_up_proj(flat_x, flat_indices, sorted_indices=False)
+                gate, up = mx.split(gate_up, 2, axis=-1)
+            else:
+                up = self.switch_mlp.up_proj(flat_x, flat_indices, sorted_indices=False)
+                gate = self.switch_mlp.gate_proj(
+                    flat_x, flat_indices, sorted_indices=False
+                )
+            routed = self.switch_mlp.down_proj(
+                self.switch_mlp.activation(up, gate),
+                flat_indices,
+                sorted_indices=False,
+            )
+            routed = routed.squeeze(-2).reshape(batch, steps, experts_per_token, -1)
+        else:
+            routed = self.switch_mlp(x, indices)
         routed = (routed * scores[..., None]).sum(axis=-2)
         shared = self.shared_expert(x)
         shared = mx.sigmoid(self.shared_expert_gate(x)) * shared
@@ -370,6 +393,8 @@ class GatedDeltaNet(nn.Module):
         inputs: mx.array,
         mask: mx.array | None = None,
         cache: Any | None = None,
+        *,
+        record_rollback: bool = False,
     ) -> mx.array:
         batch, length, _ = inputs.shape
         mixed = self.in_proj_qkv(inputs)
@@ -397,6 +422,14 @@ class GatedDeltaNet(nn.Module):
                 cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
             else:
                 cache[0] = mx.contiguous(conv_input[:, -keep:, :])
+            if record_rollback:
+                cache.record_slot_snapshots(
+                    0,
+                    [
+                        mx.contiguous(conv_input[:, position : position + keep, :])
+                        for position in range(1, length)
+                    ],
+                )
         convolved = nn.silu(self.conv1d(conv_input))
         query, key, value = [
             item.reshape(batch, length, heads, dim)
@@ -418,18 +451,41 @@ class GatedDeltaNet(nn.Module):
         )
         key = key * mx.rsqrt(mx.sum(mx.square(key), axis=-1, keepdims=True) + 1e-6)
         query = query * inv_scale
-        output, state = gated_delta_update(
-            query,
-            key,
-            value,
-            alpha,
-            beta,
-            self.A_log,
-            self.dt_bias,
-            state,
-            mask,
-            use_kernel=not self.training,
-        )
+        if record_rollback and cache is not None and length > 1:
+            from vllm_mlx.kernels.qwen4_gdn_verify import (
+                gated_delta_verify_with_states,
+            )
+
+            output, state, state_snapshots = gated_delta_verify_with_states(
+                query,
+                key,
+                value,
+                alpha,
+                beta,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
+            cache.record_slot_snapshots(
+                1,
+                [state_snapshots[:, position] for position in range(length - 1)],
+                finalize=True,
+            )
+        else:
+            output, state = gated_delta_update(
+                query,
+                key,
+                value,
+                alpha,
+                beta,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
         if cache is not None:
             cache[1] = state
             cache.advance(length)
@@ -1040,7 +1096,13 @@ class NGramEmbedding(nn.Module):
         valid = (position_in_segment >= shift) & (source_positions[None, :] >= 0)
         return mx.where(valid, shifted, self.eos_token_id)
 
-    def compute_ids(self, input_ids: mx.array, cache: Any | None = None) -> mx.array:
+    def compute_ids(
+        self,
+        input_ids: mx.array,
+        cache: Any | None = None,
+        *,
+        record_rollback: bool = False,
+    ) -> mx.array:
         input_ids = input_ids.astype(mx.int64)
         if cache is not None and cache[3] is not None:
             previous = cache[3]
@@ -1060,6 +1122,16 @@ class NGramEmbedding(nn.Module):
                 ).squeeze(-1)
             else:
                 cache[3] = mx.contiguous(history[:, -self.context_len :])
+            if record_rollback:
+                cache.record_slot_snapshots(
+                    3,
+                    [
+                        mx.contiguous(
+                            history[:, position : position + self.context_len]
+                        )
+                        for position in range(1, input_ids.shape[1])
+                    ],
+                )
         shifted = [
             self._shift_right_ignore_eos(history, shift)
             for shift in range(self.ngram_size)
@@ -1080,8 +1152,18 @@ class NGramEmbedding(nn.Module):
             blocks.append(ids)
         return mx.concatenate(blocks, axis=-1)[:, -input_ids.shape[1] :]
 
-    def __call__(self, input_ids: mx.array, cache: Any | None = None) -> mx.array:
-        ids = self.compute_ids(input_ids, cache)
+    def __call__(
+        self,
+        input_ids: mx.array,
+        cache: Any | None = None,
+        *,
+        record_rollback: bool = False,
+    ) -> mx.array:
+        ids = self.compute_ids(
+            input_ids,
+            cache,
+            record_rollback=record_rollback,
+        )
         return self.ngram_embedding(ids).flatten(-2)
 
 
@@ -1125,7 +1207,13 @@ class PLELayer(nn.Module):
             bias=False,
         )
 
-    def _short_conv(self, x: mx.array, cache: Any | None) -> mx.array:
+    def _short_conv(
+        self,
+        x: mx.array,
+        cache: Any | None,
+        *,
+        record_rollback: bool = False,
+    ) -> mx.array:
         if cache is not None and cache[2] is not None:
             state = cache[2]
         else:
@@ -1140,6 +1228,16 @@ class PLELayer(nn.Module):
                 cache[2] = mx.take_along_axis(conv_input, positions, axis=1)
             else:
                 cache[2] = mx.contiguous(conv_input[:, -self.conv_state_len :, :])
+            if record_rollback:
+                cache.record_slot_snapshots(
+                    2,
+                    [
+                        mx.contiguous(
+                            conv_input[:, position : position + self.conv_state_len, :]
+                        )
+                        for position in range(1, x.shape[1])
+                    ],
+                )
         return nn.silu(self.conv1d(conv_input))
 
     def __call__(
@@ -1148,10 +1246,16 @@ class PLELayer(nn.Module):
         input_ids: mx.array,
         cache: Any | None,
         mask: mx.array | None = None,
+        *,
+        record_rollback: bool = False,
     ) -> mx.array:
         if mask is not None:
             input_ids = mx.where(mask, input_ids, self.ple_embedding.eos_token_id)
-        embeddings = self.ple_embedding(input_ids, cache)
+        embeddings = self.ple_embedding(
+            input_ids,
+            cache,
+            record_rollback=record_rollback,
+        )
         keys = self.norm_key(self.key_proj(embeddings)).reshape(
             *hidden_states.shape[:-1], self.hc_count, self.hidden_size
         )
@@ -1169,7 +1273,11 @@ class PLELayer(nn.Module):
         if mask is not None:
             gated = mx.where(mask[..., None], gated, 0)
             normalized = mx.where(mask[..., None], normalized, 0)
-        return gated + self._short_conv(normalized, cache)
+        return gated + self._short_conv(
+            normalized,
+            cache,
+            record_rollback=record_rollback,
+        )
 
 
 class DecoderLayer(nn.Module):
@@ -1209,6 +1317,7 @@ class DecoderLayer(nn.Module):
         input_ids: mx.array,
         mask: mx.array | None,
         cache: Any | None,
+        record_rollback: bool = False,
     ) -> mx.array:
         if self.ple is not None:
             hidden_states = hidden_states + self.ple(
@@ -1216,16 +1325,22 @@ class DecoderLayer(nn.Module):
                 input_ids,
                 cache,
                 mask,
+                record_rollback=record_rollback,
             )
         mixed, residual, injection = self.attn_hyper_connection(hidden_states)
         if self.is_linear:
-            output = self.linear_attn(mixed, mask=mask, cache=cache)
+            output = self.linear_attn(
+                mixed,
+                mask=mask,
+                cache=cache,
+                record_rollback=record_rollback,
+            )
         else:
             output = self.self_attn(mixed, cache=cache, mask=mask)
         hidden_states = self._combine(output, residual, injection)
 
         mixed, residual, injection = self.mlp_hyper_connection(hidden_states)
-        output = self.mlp(mixed)
+        output = self.mlp(mixed, target_verify=record_rollback)
         return self._combine(output, residual, injection)
 
 
@@ -1245,7 +1360,10 @@ class Qwen4ExpTextModel(nn.Module):
         inputs: mx.array,
         cache: list[Any] | None = None,
         input_embeddings: mx.array | None = None,
-    ) -> mx.array:
+        *,
+        return_hidden: bool = False,
+        record_rollback: bool = False,
+    ) -> mx.array | tuple[mx.array, mx.array]:
         hidden_states = (
             input_embeddings
             if input_embeddings is not None
@@ -1279,8 +1397,67 @@ class Qwen4ExpTextModel(nn.Module):
                 input_ids=inputs,
                 mask=linear_mask if layer.is_linear else attention_mask,
                 cache=layer_cache,
+                record_rollback=record_rollback,
             )
-        return self.hyper_connection_mixer(hidden_states)
+        output = self.hyper_connection_mixer(hidden_states)
+        return (output, hidden_states) if return_hidden else output
+
+
+class Qwen4ExpStateCache(ArraysCache):
+    """Recurrent Qwen4 state with speculative-verify restore points.
+
+    The four-slot PLE layer cache couples GDN convolution/state with PLE
+    convolution/ngram history.  A rejected speculative token must restore all
+    four slots to the same accepted boundary; restoring GDN alone silently
+    desynchronizes later PLE inputs.
+    """
+
+    rollback_state: list[list[mx.array | None]] | None = None
+    _rollback_slots: dict[int, list[mx.array]] | None = None
+
+    def record_slot_snapshots(
+        self,
+        slot: int,
+        snapshots: list[mx.array],
+        *,
+        finalize: bool = False,
+    ) -> None:
+        """Stage per-position recurrent state and publish atomic boundaries."""
+        if not snapshots:
+            return
+        if self._rollback_slots is None:
+            self._rollback_slots = {}
+        self._rollback_slots[slot] = snapshots
+        if not finalize:
+            return
+        expected_slots = set(range(len(self.cache)))
+        if set(self._rollback_slots) != expected_slots:
+            raise AssertionError(
+                "Qwen4 speculative cache snapshots do not cover every state slot"
+            )
+        lengths = {len(items) for items in self._rollback_slots.values()}
+        if len(lengths) != 1:
+            raise AssertionError("Qwen4 speculative cache snapshot lengths diverged")
+        count = lengths.pop()
+        self.rollback_state = [
+            [self._rollback_slots[slot][position] for slot in range(len(self.cache))]
+            for position in range(count)
+        ]
+        self._rollback_slots = None
+
+    def restore_rollback(self, n_to_drop: int, verify_size: int) -> None:
+        snapshots = self.rollback_state
+        if not snapshots:
+            raise AssertionError("Qwen4 verify rollback has no saved boundary")
+        keep = verify_size - n_to_drop
+        if keep < 1 or keep > len(snapshots):
+            raise AssertionError(
+                f"invalid Qwen4 rollback boundary: keep={keep}, "
+                f"snapshots={len(snapshots)}"
+            )
+        self.cache = list(snapshots[keep - 1])
+        self.rollback_state = None
+        self._rollback_slots = None
 
 
 class TextModel(nn.Module):
@@ -1297,11 +1474,25 @@ class TextModel(nn.Module):
         inputs: mx.array,
         cache: list[Any] | None = None,
         input_embeddings: mx.array | None = None,
-    ) -> mx.array:
-        hidden = self.model(inputs, cache, input_embeddings)
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ) -> mx.array | tuple[mx.array, mx.array]:
+        hidden_result = self.model(
+            inputs,
+            cache,
+            input_embeddings,
+            return_hidden=return_hidden,
+            record_rollback=n_confirmed > 0 and inputs.shape[1] > 1,
+        )
+        if return_hidden:
+            hidden, mtp_hidden = cast(tuple[mx.array, mx.array], hidden_result)
+        else:
+            hidden = cast(mx.array, hidden_result)
         if self.args.tie_word_embeddings:
-            return self.model.embed_tokens.as_linear(hidden)
-        return self.lm_head(hidden)
+            logits = self.model.embed_tokens.as_linear(hidden)
+        else:
+            logits = self.lm_head(hidden)
+        return (logits, mtp_hidden) if return_hidden else logits
 
     @property
     def layers(self):
@@ -1311,7 +1502,9 @@ class TextModel(nn.Module):
         caches = []
         for layer in self.layers:
             if layer.is_linear:
-                caches.append(ArraysCache(size=4 if layer.ple is not None else 2))
+                caches.append(
+                    Qwen4ExpStateCache(size=4 if layer.ple is not None else 2)
+                )
             else:
                 caches.append(
                     CacheList(
@@ -1391,8 +1584,21 @@ class Model(nn.Module):
         self.model_type = args.model_type
         self.language_model = TextModel(TextModelArgs.from_dict(args.text_config))
 
-    def __call__(self, inputs: mx.array, cache=None, input_embeddings=None):
-        return self.language_model(inputs, cache, input_embeddings)
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        input_embeddings=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        return self.language_model(
+            inputs,
+            cache,
+            input_embeddings,
+            return_hidden=return_hidden,
+            n_confirmed=n_confirmed,
+        )
 
     @property
     def model(self):

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -257,20 +257,6 @@ class QSAIndexCache(ArraysCache):
     def restore_trim_checkpoint(self, state):
         self._offsets, self._compressed_counts = state
 
-    def speculative_checkpoint(self):
-        """Capture QSA state that a multi-token verify can overwrite."""
-        raw_ring = None
-        if self.raw_ring is not None:
-            raw_ring = self.raw_ring + mx.zeros_like(self.raw_ring)
-            mx.eval(raw_ring)
-        return raw_ring, list(self._offsets), list(self._compressed_counts)
-
-    def restore_speculative_checkpoint(self, state):
-        raw_ring, offsets, compressed_counts = state
-        self.raw_ring = raw_ring
-        self._offsets = list(offsets)
-        self._compressed_counts = list(compressed_counts)
-
     def _can_trim_row(self, offset: int, n: int) -> bool:
         if n < 0 or n > offset:
             return False

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -257,6 +257,20 @@ class QSAIndexCache(ArraysCache):
     def restore_trim_checkpoint(self, state):
         self._offsets, self._compressed_counts = state
 
+    def speculative_checkpoint(self):
+        """Capture QSA state that a multi-token verify can overwrite."""
+        raw_ring = None
+        if self.raw_ring is not None:
+            raw_ring = self.raw_ring + mx.zeros_like(self.raw_ring)
+            mx.eval(raw_ring)
+        return raw_ring, list(self._offsets), list(self._compressed_counts)
+
+    def restore_speculative_checkpoint(self, state):
+        raw_ring, offsets, compressed_counts = state
+        self.raw_ring = raw_ring
+        self._offsets = list(offsets)
+        self._compressed_counts = list(compressed_counts)
+
     def _can_trim_row(self, offset: int, n: int) -> bool:
         if n < 0 or n > offset:
             return False

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -433,6 +433,8 @@ def _derive_mtp_family(cfg: Any) -> str:
     _FAMILY_HINTS = (
         ("gemma-4", "gemma4"),
         ("gemma4", "gemma4"),
+        ("qwen3.8-flash-next", "qwen3.8-flash-next"),
+        ("qwen3.8", "qwen3.8"),
         ("qwen3.5", "qwen3.5"),
         ("qwen3_5", "qwen3.5"),
         ("qwen3.6", "qwen3.6"),
@@ -662,10 +664,10 @@ def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
             (
                 "MTP drafts accepted by the verify backbone pass. "
                 "Always <= rapid_mlx_spec_decode_attempts_total. The "
-                "lossless contract surface — under the chain MTP "
-                "variant a low ratio is a speedup signal, not a "
-                "correctness one (tokens stay byte-identical to the "
-                "non-spec-decode path)."
+                "accept ratio is a speedup signal, not a correctness "
+                "signal: every proposal is checked by the target, while "
+                "byte identity with ordinary decode depends on the "
+                "model family's numerical verify path."
             ),
             int(snapshot.accepts),
             labels=common_labels,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -840,6 +840,15 @@ def _install_mtp_vendored(
     from .spec_decode.mtp.draft_k_controller_v2 import derive_controller_key
     from .spec_decode.mtp.generator import mtp_generate_step
 
+    model_max_k = getattr(mtp_model, "mtp_max_speculative_tokens", max_k)
+    if max_k > model_max_k:
+        logger.warning(
+            "[MTP-vendored] checkpoint caps speculative depth at K=%d (requested K=%d)",
+            model_max_k,
+            max_k,
+        )
+        max_k = model_max_k
+
     # Derive the structural controller key ONCE at install. It walks the model
     # tree to discover quantization, so recomputing it per generation request
     # (the unnamed-model fallback in ``_mtp_step`` below) would put
@@ -3787,25 +3796,13 @@ class Scheduler:
                     mtp_model_type,
                 )
             else:
-                requested_max_k = getattr(self.config, "mtp_max_k", 3)
-                model_max_k = getattr(
-                    self.model, "mtp_max_speculative_tokens", requested_max_k
-                )
-                effective_max_k = min(requested_max_k, model_max_k)
-                if effective_max_k != requested_max_k:
-                    logger.warning(
-                        "[MTP-vendored] checkpoint caps speculative depth at "
-                        "K=%d (requested K=%d)",
-                        effective_max_k,
-                        requested_max_k,
-                    )
                 _install_mtp_vendored(
                     bg,
                     model=self.model,
                     requests=self.requests,
                     uid_to_request_id=self.uid_to_request_id,
                     # 0.9.13 PR-B: EV depth controller knobs.
-                    max_k=effective_max_k,
+                    max_k=getattr(self.config, "mtp_max_k", 3),
                     disable_auto_k=getattr(self.config, "mtp_disable_auto_k", False),
                     # Preferred (named) identity for the controller
                     # registry. The previous spelling ended in a bare

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1593,7 +1593,7 @@ def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
     narrowly tied to the model families this MTP runtime supports.
     """
 
-    return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3"}
+    return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3", "qwen4_exp"}
 
 
 def _replay_dspark_committed(
@@ -3787,13 +3787,25 @@ class Scheduler:
                     mtp_model_type,
                 )
             else:
+                requested_max_k = getattr(self.config, "mtp_max_k", 3)
+                model_max_k = getattr(
+                    self.model, "mtp_max_speculative_tokens", requested_max_k
+                )
+                effective_max_k = min(requested_max_k, model_max_k)
+                if effective_max_k != requested_max_k:
+                    logger.warning(
+                        "[MTP-vendored] checkpoint caps speculative depth at "
+                        "K=%d (requested K=%d)",
+                        effective_max_k,
+                        requested_max_k,
+                    )
                 _install_mtp_vendored(
                     bg,
                     model=self.model,
                     requests=self.requests,
                     uid_to_request_id=self.uid_to_request_id,
                     # 0.9.13 PR-B: EV depth controller knobs.
-                    max_k=getattr(self.config, "mtp_max_k", 3),
+                    max_k=effective_max_k,
                     disable_auto_k=getattr(self.config, "mtp_disable_auto_k", False),
                     # Preferred (named) identity for the controller
                     # registry. The previous spelling ended in a bare

--- a/vllm_mlx/spec_decode/mtp/accept_counter.py
+++ b/vllm_mlx/spec_decode/mtp/accept_counter.py
@@ -2,8 +2,8 @@
 """Process-local MTP accept-rate counter (R15 task #302).
 
 The Prometheus surface (``rapid_mlx_spec_decode_*``) is the canonical
-external observability for whether the lossless contract is actually
-holding in production. ``MTPAcceptCounter`` is the in-process backing
+external observability for whether speculation is paying for itself in
+production. ``MTPAcceptCounter`` is the in-process backing
 state — both the chain MTP generator and any future tree MTP variant
 write into the SAME counter, with the ``method`` / ``family`` labels
 distinguishing the source.
@@ -30,18 +30,18 @@ Design choices
   doesn't require any schema change here. Counters never reset on
   ``record_*`` calls.
 
-Lossless contract
------------------
+Verification and performance contract
+-------------------------------------
 
-The ``method="mtp"`` accept ratio is the lossless contract surface:
+The ``method="mtp"`` accept ratio is the performance surface:
 
 * ``accept_ratio >= 0.80`` for Qwen3.5-9B-w4 at temp=0 on the bench
   workload (PR #990 reports ~85%).
 * ``accept_ratio`` only equals 1.0 when EVERY draft was accepted; a
-  ratio below 1.0 means at least one rejection fired and the verify
-  step took the corrective path. Both states still produce
-  byte-identical token output to non-spec-decode generation; the
-  acceptance rate is the *speedup* signal, not a correctness one.
+  ratio below 1.0 means at least one rejection fired and the target
+  verify step took the corrective path. The target therefore remains
+  authoritative, but byte identity with ordinary decode depends on the
+  family-specific numerical verify path and is tested separately.
 * ``tokens_saved`` counts the cumulative "bonus tokens emitted from
   draft acceptance" — when a draft is accepted, the generator emits
   both the verified primary token and the accepted draft token in the

--- a/vllm_mlx/spec_decode/mtp/detect.py
+++ b/vllm_mlx/spec_decode/mtp/detect.py
@@ -79,6 +79,9 @@ _SUPPORTED_MODEL_TYPES: frozenset[str] = frozenset(
         # ``num_nextn_predict_layers`` (not ``mtp_num_hidden_layers``); the
         # per-family fallback in ``_mtp_num_hidden_layers`` handles that.
         "hy_v3",
+        # Qwen3.8 Flash-Next. The outer checkpoint advertises qwen4_exp;
+        # its nested text_config carries mtp_num_hidden_layers.
+        "qwen4_exp",
     }
 )
 

--- a/vllm_mlx/spec_decode/mtp/dispatch.py
+++ b/vllm_mlx/spec_decode/mtp/dispatch.py
@@ -56,6 +56,12 @@ _MTP_INJECT_DISPATCH: dict[str, tuple[str, str]] = {
         "vllm_mlx.spec_decode.mtp.hy3_inject",
         "inject_hy3_mtp_support",
     ),
+    # Qwen3.8 Flash-Next native one-layer MTP head stored in the target
+    # checkpoint's ``mtp.*`` namespace.
+    "qwen4_exp": (
+        "vllm_mlx.spec_decode.mtp.qwen4_exp_inject",
+        "inject_qwen4_exp_mtp_support",
+    ),
 }
 
 
@@ -75,6 +81,10 @@ _MTP_VALIDATE_DISPATCH: dict[str, tuple[str, str]] = {
     "hy_v3": (
         "vllm_mlx.spec_decode.mtp.hy3_inject",
         "validate_hy3_mtp_support",
+    ),
+    "qwen4_exp": (
+        "vllm_mlx.spec_decode.mtp.qwen4_exp_inject",
+        "validate_qwen4_exp_mtp_support",
     ),
 }
 

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -433,10 +433,6 @@ def mtp_generate_step(
         for c in model_cache:
             restore = getattr(c, "restore_rollback", None)
             if callable(restore) and getattr(c, "rollback_state", None) is not None:
-                if verify_size is None:
-                    raise AssertionError(
-                        "verify_size is required for model-specific rollback"
-                    )
                 restore(n_to_drop, verify_size)
             elif hasattr(c, "rollback_state") and c.rollback_state is not None:
                 snapshots = c.rollback_state

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -24,10 +24,9 @@ to make it importable against our installed mlx-lm 0.31.3:
 Everything else — the verify / accept logic, the rollback path, the
 probabilistic-acceptance ``min(1, p_target/p_draft)`` test, the
 residual-distribution sample on rejection — is the upstream code
-unchanged. That is intentional. The lossless contract (byte-identical
-to non-spec-decode for the same prompt + seed at temp=0) lives in the
-verify / accept arithmetic, and rewriting it would risk a divergence
-that a unit test against a single mocked model can't catch.
+unchanged. That is intentional. Target verification preserves the target
+sampling distribution; byte identity with single-token decode additionally
+depends on the model family's multi-token numerical path.
 
 Public signature mirrors upstream so callers can swap
 ``mtp_generate_step(prompt, model, ...)`` for
@@ -432,7 +431,14 @@ def mtp_generate_step(
         entries.
         """
         for c in model_cache:
-            if hasattr(c, "rollback_state") and c.rollback_state is not None:
+            restore = getattr(c, "restore_rollback", None)
+            if callable(restore) and getattr(c, "rollback_state", None) is not None:
+                if verify_size is None:
+                    raise AssertionError(
+                        "verify_size is required for model-specific rollback"
+                    )
+                restore(n_to_drop, verify_size)
+            elif hasattr(c, "rollback_state") and c.rollback_state is not None:
                 snapshots = c.rollback_state
                 if isinstance(snapshots, list):
                     if verify_size is None:

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native-MTP attachment for the vendored Qwen4 decoder.
+
+The checkpoint stores its one-layer predictor under ``mtp.*`` while the
+ordinary target loader intentionally ignores that subtree.  This module builds
+the matching MLX layer, validates every packed tensor, and attaches the generic
+MTP generation protocol only after a complete load succeeds.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_inner(model: Any) -> Any | None:
+    inner = getattr(model, "language_model", None)
+    if inner is not None and getattr(inner, "model_type", None) == "qwen4_exp_text":
+        return inner
+    if getattr(model, "model_type", None) == "qwen4_exp_text":
+        return model
+    return None
+
+
+def _mtp_weight_files(source: str | Path) -> list[Path]:
+    path = Path(source).expanduser()
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise FileNotFoundError(f"MTP checkpoint path does not exist: {path}")
+    index_path = path / "model.safetensors.index.json"
+    if index_path.exists():
+        with index_path.open(encoding="utf-8") as handle:
+            index = json.load(handle)
+        weight_map = index.get("weight_map", {})
+        names = sorted(
+            {filename for key, filename in weight_map.items() if key.startswith("mtp.")}
+        )
+        if names:
+            return [path / name for name in names]
+    single = path / "model.safetensors"
+    if single.exists():
+        return [single]
+    raise FileNotFoundError(f"No safetensors containing mtp.* found under {path}")
+
+
+def _sanitize_mtp_weights(raw: dict[str, Any]) -> dict[str, Any]:
+    """Map checkpoint expert packing into the vendored MLX module tree."""
+
+    sanitized: dict[str, Any] = {}
+    for original_key, value in raw.items():
+        if not original_key.startswith("mtp."):
+            continue
+        key = original_key.removeprefix("mtp.")
+        if ".mlp.experts.gate_up_proj" in key:
+            midpoint = value.shape[-2] // 2
+            prefix, suffix = key.split("experts.gate_up_proj", 1)
+            leaf = {"": "weight", ".scales": "scales", ".biases": "biases"}.get(suffix)
+            if leaf is None:
+                sanitized[key] = value
+                continue
+            base = f"{prefix}switch_mlp"
+            sanitized[f"{base}.gate_proj.{leaf}"] = value[..., :midpoint, :]
+            sanitized[f"{base}.up_proj.{leaf}"] = value[..., midpoint:, :]
+            continue
+        if ".mlp.experts.down_proj" in key:
+            prefix, suffix = key.split("experts.down_proj", 1)
+            leaf = {"": "weight", ".scales": "scales", ".biases": "biases"}.get(suffix)
+            if leaf is not None:
+                key = f"{prefix}switch_mlp.down_proj.{leaf}"
+        sanitized[key] = value
+    return sanitized
+
+
+def _build_mtp(inner: Any):
+    import mlx.nn as nn
+
+    from vllm_mlx.models.qwen4_exp import (
+        DecoderLayer,
+        GatedResidual,
+        TextModelArgs,
+        ZeroCenteredRMSNorm,
+    )
+
+    args = inner.args
+    params = dict(vars(args))
+    params.update(
+        num_hidden_layers=1,
+        layer_types=["full_attention"],
+        ple_layer_ids=[],
+    )
+    mtp_args = TextModelArgs.from_dict(params)
+
+    class Qwen4ExpMTP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            hidden = mtp_args.hidden_size
+            self.hc_count = mtp_args.hc_count
+            self.hidden_size = hidden
+            self.pre_fc_norm_embedding = ZeroCenteredRMSNorm(
+                hidden, eps=mtp_args.rms_norm_eps
+            )
+            self.pre_fc_norm_hidden = ZeroCenteredRMSNorm(
+                hidden * mtp_args.hc_count,
+                group_size=hidden,
+                eps=mtp_args.rms_norm_eps,
+            )
+            self.fc_embedding = nn.Linear(hidden, hidden, bias=False)
+            self.fc_hidden = nn.Linear(hidden, hidden, bias=False)
+            self.layers = [DecoderLayer(mtp_args, 0)]
+            self.hyper_connection_mixer = GatedResidual(mtp_args, use_combine=False)
+
+        def __call__(self, hidden_states, token_embeddings, cache):
+            embedding = self.fc_embedding(self.pre_fc_norm_embedding(token_embeddings))
+            shape = hidden_states.shape
+            branches = self.pre_fc_norm_hidden(hidden_states).reshape(
+                *shape[:-1], self.hc_count, self.hidden_size
+            )
+            branches = self.fc_hidden(branches)
+            multi_hidden = (branches + embedding[..., None, :]).flatten(-2)
+            multi_hidden = self.layers[0](
+                multi_hidden,
+                input_ids=mx.zeros(token_embeddings.shape[:-1], dtype=mx.uint32),
+                mask=None,
+                cache=cache[0],
+            )
+            sample_hidden = self.hyper_connection_mixer(multi_hidden)
+            return sample_hidden, multi_hidden
+
+    import mlx.core as mx
+
+    mtp = Qwen4ExpMTP()
+
+    def predicate(path: str, module: Any):
+        if not hasattr(module, "to_quantized"):
+            return False
+        return inner.quant_predicate(path, module)
+
+    nn.quantize(
+        mtp,
+        group_size=64,
+        bits=4,
+        class_predicate=predicate,
+    )
+    return mtp
+
+
+def inject_qwen4_exp_mtp_support(
+    model: Any,
+    *,
+    mtp_sidecar: str | Path | None = None,
+    allow_random_init: bool = False,
+) -> bool:
+    """Attach native Qwen4 MTP surfaces after complete tensor validation."""
+
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    inner = _resolve_inner(model)
+    if inner is None:
+        return False
+    if int(getattr(inner.args, "mtp_num_hidden_layers", 0) or 0) != 1:
+        logger.warning("[mtp.qwen4] only one-layer checkpoints are supported")
+        return False
+    if mtp_sidecar is None and not allow_random_init:
+        logger.warning("[mtp.qwen4] a local base-checkpoint path is required")
+        return False
+
+    try:
+        mtp = _build_mtp(inner)
+        weights: dict[str, Any] = {}
+        if mtp_sidecar is not None:
+            for file in _mtp_weight_files(mtp_sidecar):
+                weights.update(_sanitize_mtp_weights(mx.load(str(file))))
+
+            expected = dict(tree_flatten(mtp.parameters()))
+            missing = set(expected) - set(weights)
+            unexpected = set(weights) - set(expected)
+            mismatched = {
+                key: (tuple(weights[key].shape), tuple(expected[key].shape))
+                for key in set(expected) & set(weights)
+                if tuple(weights[key].shape) != tuple(expected[key].shape)
+            }
+            if missing or unexpected or mismatched:
+                logger.error(
+                    "[mtp.qwen4] tensor contract mismatch: missing=%s "
+                    "unexpected=%s shape=%s",
+                    sorted(missing)[:8],
+                    sorted(unexpected)[:8],
+                    sorted(mismatched.items())[:8],
+                )
+                return False
+            mtp.load_weights(list(weights.items()), strict=True)
+        else:
+            mx.eval(mtp.parameters())
+
+        original_class = type(inner)
+
+        class _Qwen4ExpWithMTP(original_class):  # type: ignore[valid-type, misc]
+            mtp_prompt_lookup_supported = False
+
+            def mtp_forward(
+                self,
+                hidden_states,
+                next_token_ids,
+                mtp_cache,
+                return_hidden: bool = False,
+            ):
+                token_embeddings = self.model.embed_tokens(next_token_ids)
+                sample_hidden, multi_hidden = self.mtp(
+                    hidden_states, token_embeddings, mtp_cache
+                )
+                if self.args.tie_word_embeddings:
+                    logits = self.model.embed_tokens.as_linear(sample_hidden)
+                else:
+                    logits = self.lm_head(sample_hidden)
+                return (logits, multi_hidden) if return_hidden else logits
+
+            def make_mtp_cache(self):
+                from mlx_lm.models.cache import CacheList, KVCache
+
+                from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+
+                ratio = self.mtp.layers[0].self_attn.indexer.compress_ratio
+                return [CacheList(KVCache(), QSAIndexCache(ratio))]
+
+        inner.mtp = mtp
+        inner.mtp_max_speculative_tokens = 1
+        model.mtp_max_speculative_tokens = 1
+        inner.__class__ = _Qwen4ExpWithMTP
+        mx.eval(mtp.parameters())
+        return True
+    except Exception:
+        logger.exception("[mtp.qwen4] native MTP attachment failed")
+        return False
+
+
+def validate_qwen4_exp_mtp_support(model: Any) -> bool:
+    inner = _resolve_inner(model)
+    if inner is None or not hasattr(inner, "mtp"):
+        return False
+    try:
+        signature = inspect.signature(inner.__call__)
+    except (TypeError, ValueError):
+        return False
+    return (
+        callable(getattr(inner, "mtp_forward", None))
+        and callable(getattr(inner, "make_mtp_cache", None))
+        and "return_hidden" in signature.parameters
+        and "n_confirmed" in signature.parameters
+    )


### PR DESCRIPTION
## Why

Qwen3.8 Flash-Next ships a native one-layer prediction head, but Rapid-MLX previously ignored it and decoded every token serially. On the released 4-bit checkpoint, serial decode sustains only 21–25 tok/s despite the model's suitability for long coding and agent responses.

Fixes #2567

Part of #2421

## What

- Loads and strictly validates the checkpoint-native `mtp.*` tensor tree from the same immutable snapshot as the target model.
- Adds Qwen4 target verification with atomic rollback across GDN recurrent state, PLE history, QSA index state, and KV cache.
- Adds a Metal GDN verification kernel that emits intermediate rollback boundaries in the same recurrence pass.
- Caps this checkpoint family to its native K=1 depth at both the CLI and scheduler boundaries; explicit deeper requests fail at startup.
- Attributes MTP attempts, accepts, accept ratio, and cost telemetry to the Flash-Next family.
- Enrolls the bounded MTP wiring suite in the Apple coverage lane and documents the reproducible correctness/performance result.

## Scope / Non-goals

Scope is the Qwen3.8 Flash-Next text engine, native MTP attachment/verification, its metrics, focused tests, evaluation harness, and benchmark documentation.

Non-goals: no release or dependency bump; no default-on behavior; no sampling-mode expansion; no multi-request speculative batching; no n-gram, DFlash, QSA sparse-gather kernel, or unrelated CI policy change. Unsupported shapes and modes retain the existing baseline/fail-closed behavior.

## Acceptance

- Explicit `--speculative-config '{"method":"mtp"}'` serves the released Flash-Next checkpoint through its native one-layer head.
- Every proposed token is verified by the target; rejection restores all coupled hybrid-cache owners to one accepted boundary.
- Missing, extra, or shape-mismatched MTP tensors fail attachment instead of running a partial head.
- The exact fixed-K1 qualification workload records at least 256 attempts and at least 70% acceptance.
- The published 128/2K/8K/32K matrix improves decode by at least 30% without changing default serving.
- Existing MTP families and plain autoregressive serving remain compatible.

## Verification

- Five local train gates on exact head `9d7931e9`: `GATES OK ... f10a9e117938a2507b35eed40f0a51e051078259` (Python 3.11.16).
- Linux no-MLX matrix: passed.
- Apple MLX roster: 1176 passed, 3 skipped; new Qwen4 injection, tensor-contract, Metal verify, cache rollback, CLI depth, and scheduler-cap tests included.
- Changed-lines coverage union: 311/311 lines, 100%.
- Focused Python 3.12 suite: 265 passed; ruff check/format and diff-check clean.
- Real checkpoint correctness battery: all 45 functional outcomes matched serial baseline; the raw scorer's two misses are shared baseline fixture artifacts.
- Fixed-K1 proposals: 1,409/1,844 accepted (76.41%).
- Quiet-window M3 Ultra 256 GB medians, baseline → MTP decode: 25.17→34.85, 23.64→33.53, 22.82→32.20, 21.16→28.82 tok/s at 128/2K/8K/32K (1.36–1.42x).
- Long-prompt TTFT cost: +5.1% to +7.7%; largest observed MLX active footprint 111.3 GB, 6.6 GB over the corresponding baseline. 128 GB hardware was not physically tested; 192 GB remains recommended.

## Behaviour delta

Default behavior does not change. Without an explicit MTP speculative config, Flash-Next remains serial autoregressive decode. With opt-in MTP, eligible batch-one greedy requests use native K=1 verification and unsupported runtime shapes fall back to the existing path. Target verification preserves the model decision at each verify pass, but real-checkpoint temperature-zero text is not promised byte-identical to serial one-token decode at near-tied logits because multi-token and serial accumulation orders can differ.

## Design precedent

The implementation follows the established production-serving pattern of explicit opt-in speculation, checkpoint-declared draft depth, target-side verification, transactional cache rollback, strict draft-weight validation, and expected-value fallback. It adapts that pattern to MLX hybrid state by making every recurrent and attention cache owner participate in one rollback boundary instead of introducing a parallel cache abstraction.

## AI assistance disclosure

Codex assisted with the engine implementation, Metal kernel, focused tests, evaluation harness, benchmark analysis, and documentation. Every touched path was reviewed against the runtime contract and verified with the exact-head local gates, 45-case real-model battery, fixed-method A/B benchmark, acceptance telemetry, and memory measurements above.
