### PR TITLE
ci: split merge queue by mac requirement

### DIFF
--- a/.github/workflows/authorize-merge-ready.yml
+++ b/.github/workflows/authorize-merge-ready.yml
@@ -1,0 +1,45 @@
+name: Bind merge-ready to head
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  authorize-ready-head:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.label.name == 'merge-ready' ||
+       github.event.label.name == 'merge-ready-mac')
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Bind ready authorization to the current head
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const readyLabels = new Set(["merge-ready", "merge-ready-mac"]);
+            const present = context.payload.pull_request.labels
+              .map((label) => label.name)
+              .filter((label) => readyLabels.has(label));
+            const authorized = present.length === 1;
+            const state = authorized ? "success" : "failure";
+            const description = authorized
+              ? `Authorized ${present[0]} on this exact head`
+              : "Apply exactly one merge-ready label";
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state,
+              context: "merge-ready-head",
+              description,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`,
+            });
+
+            if (!authorized) {
+              core.setFailed(description);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Merge queue candidates are synthetic commits.  They need their own trigger
   # or GitHub waits forever for the required `tests` check.
   merge_group:
@@ -40,11 +40,10 @@ jobs:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
-          FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            # Classify the actual diff even during full-ci promotion. Promotion
+            # Classify the actual diff before integration promotion. Promotion
             # broadens coverage inside the affected lane; it must not turn an
             # engine-only PR into a full Desktop run (or vice versa).
             # Disable rename folding so both the removed source path and the
@@ -54,10 +53,9 @@ jobs:
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"
             full_gate=false
-            if [ "$FULL_CI" = true ] || \
-              { [ "$HEAD_REPO" = "$REPO" ] && \
-                { [[ "$HEAD_REF" == train/* ]] || \
-                  [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; }; then
+            if [ "$HEAD_REPO" = "$REPO" ] && \
+              { [[ "$HEAD_REF" == train/* ]] || \
+                [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; then
               full_gate=true
             fi
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -29,7 +29,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
 
@@ -63,7 +63,6 @@ jobs:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
-          FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -75,9 +74,9 @@ jobs:
               echo 'full_gate=true'
             } >> "$GITHUB_OUTPUT"
           else
-            # Keep full-ci promotion scoped to the lanes selected by the real
-            # PR diff. An engine-only PR must not allocate a full GUI run, and
-            # a Desktop-only PR must not allocate model runners.
+            # Keep integration promotion scoped to the lanes selected by the
+            # real PR diff. An engine-only PR must not allocate a full GUI run,
+            # and a Desktop-only PR must not allocate model runners.
             # Disable rename folding so both the removed source path and the
             # new destination participate in classification.
             git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA" > /tmp/changed-paths
@@ -88,10 +87,9 @@ jobs:
               --paths-file /tmp/changed-paths \
               --github-output "$GITHUB_OUTPUT"
             full_gate=false
-            if [ "$FULL_CI" = true ] || \
-              { [ "$HEAD_REPO" = "$REPO" ] && \
-                { [[ "$HEAD_REF" == train/* ]] || \
-                  [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; }; then
+            if [ "$HEAD_REPO" = "$REPO" ] && \
+              { [[ "$HEAD_REF" == train/* ]] || \
+                [[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]; }; then
               full_gate=true
             fi
             echo "full_gate=$full_gate" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/revoke-merge-ready.yml
+++ b/.github/workflows/revoke-merge-ready.yml
@@ -1,0 +1,36 @@
+name: Revoke merge-ready on head update
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions: {}
+
+jobs:
+  revoke-merge-ready:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'merge-ready') ||
+      contains(github.event.pull_request.labels.*.name, 'merge-ready-mac')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Revoke stale merge authorization
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const readyLabels = ["merge-ready", "merge-ready-mac"];
+            const currentLabels = new Set(
+              context.payload.pull_request.labels.map((label) => label.name),
+            );
+            for (const name of readyLabels.filter((label) => currentLabels.has(label))) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name,
+              });
+              core.notice(
+                `Removed ${name} from #${context.issue.number} after its head changed.`,
+              );
+            }

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,6 +29,7 @@ queue_rules:
       - -label = version-bump
       - -label = skip-version-bump
       - "-title ~= ^chore: bump version to "
+      - check-success = merge-ready-head
       - check-success = @github-actions/tests
       - check-success = @github-actions/desktop-tests
       - check-success = @github-actions/version-bump-guard
@@ -55,6 +56,7 @@ queue_rules:
       - -label = version-bump
       - -label = skip-version-bump
       - "-title ~= ^chore: bump version to "
+      - check-success = merge-ready-head
       - check-success = @github-actions/tests
       - check-success = @github-actions/desktop-tests
       - check-success = @github-actions/version-bump-guard

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,8 +4,40 @@ merge_queue:
   skip_intermediate_results: false
   status_comments: outcomes
 
+merge_protections_settings:
+  auto_merge_conditions:
+    - or:
+        - label = merge-ready
+        - label = merge-ready-mac
+
 queue_rules:
-  - name: main-batch
+  - name: no-mac-batch
+    queue_branch_prefix: mergify/merge-queue/
+    batch_size: 4
+    batch_max_wait_time: 5 min
+    batch_max_failure_resolution_attempts: 2
+    checks_timeout: 90 min
+    max_checks_retries: 0
+    merge_method: squash
+    branch_protection_injection_mode: queue
+    queue_conditions:
+      - base = main
+      - -draft
+      - -from-fork
+      - label = merge-ready
+      - -label = merge-ready-mac
+      - -label = version-bump
+      - -label = skip-version-bump
+      - "-title ~= ^chore: bump version to "
+      - check-success = @github-actions/tests
+      - check-success = @github-actions/desktop-tests
+      - check-success = @github-actions/version-bump-guard
+    merge_conditions:
+      - check-success = @github-actions/tests
+      - check-success = @github-actions/desktop-tests
+      - check-success = @github-actions/version-bump-guard
+
+  - name: mac-batch
     queue_branch_prefix: mergify/merge-queue/
     batch_size: 4
     batch_max_wait_time: 15 min
@@ -18,7 +50,8 @@ queue_rules:
       - base = main
       - -draft
       - -from-fork
-      - label = merge-ready
+      - label = merge-ready-mac
+      - -label = merge-ready
       - -label = version-bump
       - -label = skip-version-bump
       - "-title ~= ^chore: bump version to "
@@ -29,17 +62,3 @@ queue_rules:
       - check-success = @github-actions/tests
       - check-success = @github-actions/desktop-tests
       - check-success = @github-actions/version-bump-guard
-
-pull_request_rules:
-  - name: queue merge-ready pull requests
-    conditions:
-      - base = main
-      - -draft
-      - -from-fork
-      - label = merge-ready
-      - -label = version-bump
-      - -label = skip-version-bump
-      - "-title ~= ^chore: bump version to "
-    actions:
-      queue:
-        name: main-batch

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -236,18 +236,25 @@ Before merge, the PR description must accurately reflect actual current state:
   before queueing. Stop on `QUEUED`, `IN_PROGRESS`, `PENDING`,
   `FAILURE`, `CANCELLED`, or `TIMED_OUT` for any relevant check.
 
-- For an ordinary pull request, apply the integration authorization label and
-  let the managed queue combine and revalidate it. Do not manually rebase after
-  queue entry and do not click GitHub's merge button:
+- For an ordinary pull request, apply exactly one integration authorization
+  label and let the matching managed queue combine and revalidate it. Use
+  `merge-ready` when the classifier does not select the Desktop lane, or
+  `merge-ready-mac` when it does. Do not manually rebase after queue entry and
+  do not click GitHub's merge button:
 
   ```bash
+  # No Desktop/GUI lane:
   gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready
+
+  # Desktop/GUI lane required:
+  gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready-mac
   ```
 
-- The queue waits up to 15 minutes for as many as four merge-ready pull
-  requests, runs the affected full lanes once on their combined tree, and then
-  squash-merges each original pull request. A failed batch is split to identify
-  the blocking member; do not add an independent rerun.
+- The non-Desktop queue waits up to five minutes; the Desktop queue waits up to
+  15 minutes. Each collects as many as four same-class pull requests, runs the
+  affected full lanes once on the combined tree, and then squash-merges each
+  original. A failed batch is split to identify the blocking member; do not add
+  an independent rerun.
 - Version bumps and human-authorized hotfixes do not enter the general batch.
   Follow their explicit release/hotfix contract and use a direct squash merge
   only when that contract authorizes it.

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -92,6 +92,11 @@ four candidates of the same class and validates their combined tree once. The
 non-Desktop queue waits at most five minutes to favor latency; the Desktop queue
 waits at most 15 minutes to amortize scarce macOS capacity.
 
+Labeling writes a `merge-ready-head` success status onto that exact pull-request
+head. Both queues require the status before admission, while their synthetic
+combined heads do not. A later push has a different SHA and therefore cannot
+reuse the authorization even if asynchronous label cleanup has not run yet.
+
 The queue creates an internal pull request from a branch whose name is exactly
 `mergify/merge-queue/<10 lowercase hex characters>`. The engine and Desktop
 workflows treat only that exact same-repository shape as a promoted head. A fork
@@ -127,6 +132,8 @@ The queue contract lives in `.mergify.yml`:
 
 - label-gated `auto_merge_conditions`, so a ready label automatically enqueues
   the pull request without a second command or checkbox;
+- an exact-head authorization status in both queue conditions, preventing a
+  newly pushed head from racing asynchronous label revocation;
 - serial mode with one batch in flight, so speculative checks cannot multiply
   scarce macOS capacity;
 - separate non-Desktop and Desktop queues, each with mutually exclusive

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -81,26 +81,31 @@ the threshold is not the normal escape hatch.
 
 Ordinary pull requests run the path-aware PR gate and leave the required
 `tests`, `desktop-tests`, and `version-bump-guard` contexts satisfiable. A pull
-request becomes an integration candidate only when a maintainer applies the
-`merge-ready` label after review and PR validation have converged. The managed
-queue collects up to four such pull requests, waits at most 15 minutes from the
-first entry, and validates their combined tree once.
+request becomes an integration candidate only when a maintainer applies exactly
+one authorization label after review and PR validation have converged:
+
+- `merge-ready` when the diff does not select the Desktop lane;
+- `merge-ready-mac` when the diff selects the Desktop lane.
+
+The managed queue never mixes the two labels in one batch. It collects up to
+four candidates of the same class and validates their combined tree once. The
+non-Desktop queue waits at most five minutes to favor latency; the Desktop queue
+waits at most 15 minutes to amortize scarce macOS capacity.
 
 The queue creates an internal pull request from a branch whose name is exactly
 `mergify/merge-queue/<10 lowercase hex characters>`. The engine and Desktop
 workflows treat only that exact same-repository shape as a promoted head. A fork
 using the same branch name remains on the ordinary PR path.
 
-The optional `full-ci` label provides an exact-head rehearsal before queueing.
-Both that label and a queue batch upgrade the lanes selected by the actual diff:
+An internal queue batch upgrades the lanes selected by the actual diff:
 
 - Engine changes expand to the full five-model L1 matrix.
 - Desktop changes build the release GUI once, then run every journey group
   mapped to the changed controls and product sources in
   `Tests/GUIGoldenFlows/journeys.yaml`.
 - Cross-cutting or unknown changes expand both lanes.
-- Documentation-only changes require neither product lane and do not need the
-  label.
+- Documentation-only changes require neither product lane and use
+  `merge-ready`.
 
 GUI routing expands a changed source to its complete journey group, so sibling
 flows around the same user workflow remain covered. It fails closed: empty or
@@ -120,9 +125,14 @@ allocating model runners. A mixed or fail-closed batch selects both.
 
 The queue contract lives in `.mergify.yml`:
 
+- label-gated `auto_merge_conditions`, so a ready label automatically enqueues
+  the pull request without a second command or checkbox;
 - serial mode with one batch in flight, so speculative checks cannot multiply
   scarce macOS capacity;
-- up to four pull requests per batch and a 15-minute maximum fill wait;
+- separate non-Desktop and Desktop queues, each with mutually exclusive
+  authorization labels;
+- up to four pull requests per batch, with five-minute and 15-minute maximum
+  fill waits respectively;
 - no blind CI retry and no skipped intermediate failures;
 - at most two batch-split attempts to isolate a failing member;
 - a 90-minute check timeout, covering normal hosted macOS queue delay;
@@ -179,8 +189,9 @@ Production activation is an owner operation and must happen in this order:
 2. Install the GitHub App for this repository only. Do not grant it access to
    unrelated repositories. Confirm its configuration check validates the
    default-branch policy.
-3. Create the `merge-ready` label. Applying it is the explicit authorization to
-   enter the queue; removing it dequeues the pull request.
+3. Create the `merge-ready` and `merge-ready-mac` labels. Applying exactly one
+   is the explicit authorization to enter the matching queue; removing it
+   dequeues the pull request. Applying both fails closed and enters neither.
    Fork pull requests are deliberately ineligible because composing fork code
    onto an internal queue branch changes GitHub's token and secret boundary.
    After review, bring an accepted external change onto a same-repository
@@ -193,14 +204,20 @@ Production activation is an owner operation and must happen in this order:
    every original head, is the artifact tested by CI.
 5. Keep manual merges limited to the documented version-bump and
    human-authorized hotfix paths. Normal pull requests enter through the
-   `merge-ready` label and are merged by the queue.
+   matching merge-ready label and are merged by the queue.
 6. Rehearse with two harmless pull requests that are individually green. Apply
    `merge-ready` to both within the fill window and verify one temporary batch
    PR contains both exact heads, runs each affected full lane once, reports all
    three required checks, and squash-merges both originals in order.
 7. Confirm a fork branch named like a queue branch does not receive promoted
-   lanes. Then remove `merge-ready` from a queued test PR and verify it leaves
-   the queue without merging.
+   lanes. Then remove the applicable ready label from a queued test PR and
+   verify it leaves the queue without merging.
+
+Every `synchronize` event removes either ready label before the updated head can
+be admitted. A new commit therefore requires fresh review and an explicit new
+authorization after its own required checks pass. The revocation workflow uses
+`pull_request_target` without checking out or executing pull-request code, and
+holds only pull-request label write permission.
 
 Do not enable batching while strict up-to-date protection remains on, and do
 not weaken or remove any required context to make a batch move. A missing,
@@ -208,9 +225,10 @@ cancelled, or failed aggregate is a queue failure.
 
 ## Rollback
 
-Pause the managed queue and remove `merge-ready` from every queued pull request
-first. Wait for the active batch to stop, restore strict up-to-date protection,
-and only then disable or uninstall the app. Keep the batch-head and
+Pause the managed queue and remove both merge-ready labels from every queued
+pull request first. Wait for the active batch to stop, restore strict
+up-to-date protection, and only then disable or uninstall the app. Keep the
+batch-head and
 `merge_group` workflow triggers in place; they are inert without a queue and
 make rollback recoverable without weakening CI. If path classification is
 suspect, make its policy select both lanes for every PR; this restores the

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -3,7 +3,7 @@
 
 These tests intentionally inspect the workflows: ordinary PRs must keep their
 fast product checks while release-grade model/GUI lanes are reserved for a
-``full-ci`` promotion or an integration candidate.
+an integration candidate.
 """
 
 import os
@@ -129,7 +129,6 @@ def test_product_promotion_keeps_diff_scope_and_accepts_integration_heads():
     ):
         run = _step_run(workflow, job_name, step_name)
         assert 'git diff --no-renames --name-only "$PR_BASE_SHA" "$GITHUB_SHA"' in run
-        assert '[ "$FULL_CI" = true ] ||' in run
         assert '[ "$HEAD_REPO" = "$REPO" ] &&' in run
         assert '[[ "$HEAD_REF" == train/* ]] ||' in run
         assert '[[ "$HEAD_REF" =~ ^mergify/merge-queue/[0-9a-f]{10}$ ]]' in run
@@ -160,7 +159,6 @@ def test_fork_cannot_claim_train_branch_promotion(tmp_path):
         )
     ):
         common = {
-            "FULL_CI": "false",
             "HEAD_REF": "train/spoofed",
             "REPO": "owner/repo",
         }
@@ -214,7 +212,6 @@ def test_only_exact_internal_mergify_batch_heads_promote_full_ci(
                 job_name,
                 step_name,
                 GITHUB_OUTPUT=str(tmp_path / f"mergify-{index}"),
-                FULL_CI="false",
                 HEAD_REF=head_ref,
                 HEAD_REPO=head_repo,
                 REPO="owner/repo",
@@ -232,6 +229,15 @@ def test_only_promoted_heads_allocate_expensive_lanes():
         condition = str(_job(DESKTOP_WORKFLOW, job_name)["if"])
         assert "needs.changes.outputs.desktop == 'true'" in condition
         assert "needs.changes.outputs.full_gate == 'true'" in condition
+
+
+def test_merge_authorization_labels_do_not_retrigger_product_ci():
+    expected = ["opened", "synchronize", "reopened", "ready_for_review"]
+    for workflow in (ENGINE_WORKFLOW, DESKTOP_WORKFLOW):
+        triggers = _workflow_strings(workflow)["on"]["pull_request"]
+        assert triggers["types"] == expected
+        assert "labeled" not in triggers["types"]
+        assert "unlabeled" not in triggers["types"]
 
 
 def test_unpromoted_engine_aggregate_requires_fast_linux_and_apple_lanes():

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -18,51 +18,94 @@ def _config() -> dict[str, object]:
     return yaml.safe_load(CONFIG.read_text())
 
 
+def _rules_by_name(kind: str) -> dict[str, dict[str, object]]:
+    return {rule["name"]: rule for rule in _config()[kind]}
+
+
 def test_queue_batches_four_ready_prs_after_a_bounded_wait():
     config = _config()
     queue = config["merge_queue"]
-    (rule,) = config["queue_rules"]
+    rules = _rules_by_name("queue_rules")
 
     assert queue["mode"] == "serial"
     assert queue["max_parallel_checks"] == 1
     assert queue["skip_intermediate_results"] is False
-    assert rule["batch_size"] == 4
-    assert rule["batch_max_wait_time"] == "15 min"
-    assert rule["checks_timeout"] == "90 min"
+    assert set(rules) == {"no-mac-batch", "mac-batch"}
+    assert rules["no-mac-batch"]["batch_size"] == 4
+    assert rules["no-mac-batch"]["batch_max_wait_time"] == "5 min"
+    assert rules["mac-batch"]["batch_size"] == 4
+    assert rules["mac-batch"]["batch_max_wait_time"] == "15 min"
+    assert {rule["checks_timeout"] for rule in rules.values()} == {"90 min"}
 
 
 def test_queue_revalidates_every_required_check_on_the_combined_batch():
-    (rule,) = _config()["queue_rules"]
+    rules = _rules_by_name("queue_rules")
 
-    assert set(rule["queue_conditions"]) >= REQUIRED_CHECKS
-    assert set(rule["merge_conditions"]) == REQUIRED_CHECKS
-    assert rule["branch_protection_injection_mode"] == "queue"
-    assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
+    for rule in rules.values():
+        assert set(rule["queue_conditions"]) >= REQUIRED_CHECKS
+        assert set(rule["merge_conditions"]) == REQUIRED_CHECKS
+        assert rule["branch_protection_injection_mode"] == "queue"
+        assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
 
 
-def test_ready_label_queues_without_enabling_blind_retries():
+def test_ready_labels_autoqueue_without_enabling_blind_retries():
     config = _config()
-    (queue_rule,) = config["queue_rules"]
-    (enqueue_rule,) = config["pull_request_rules"]
+    queues = _rules_by_name("queue_rules")
+    auto_merge = config["merge_protections_settings"]["auto_merge_conditions"]
 
-    assert enqueue_rule["actions"] == {"queue": {"name": "main-batch"}}
-    assert "label = merge-ready" in enqueue_rule["conditions"]
-    assert "-from-fork" in enqueue_rule["conditions"]
-    assert "-from-fork" in queue_rule["queue_conditions"]
-    assert queue_rule["max_checks_retries"] == 0
-    assert queue_rule["batch_max_failure_resolution_attempts"] == 2
+    assert auto_merge == [{"or": ["label = merge-ready", "label = merge-ready-mac"]}]
+    assert "pull_request_rules" not in config
+
+    expected_labels = {
+        "no-mac-batch": {"label = merge-ready", "-label = merge-ready-mac"},
+        "mac-batch": {"label = merge-ready-mac", "-label = merge-ready"},
+    }
+    for name, queue_rule in queues.items():
+        assert expected_labels[name] <= set(queue_rule["queue_conditions"])
+        assert "-from-fork" in queue_rule["queue_conditions"]
+        assert queue_rule["max_checks_retries"] == 0
+        assert queue_rule["batch_max_failure_resolution_attempts"] == 2
+
+
+def test_ready_labels_are_mutually_exclusive_in_every_rule():
+    for rule in _config()["queue_rules"]:
+        conditions = set(rule["queue_conditions"])
+        assert {"label = merge-ready", "-label = merge-ready-mac"} <= conditions or {
+            "label = merge-ready-mac",
+            "-label = merge-ready",
+        } <= conditions
 
 
 def test_release_bumps_cannot_enter_the_general_batch_queue():
     config = _config()
-    (queue_rule,) = config["queue_rules"]
-    (enqueue_rule,) = config["pull_request_rules"]
     exclusions = {
         "-label = version-bump",
         "-label = skip-version-bump",
         "-title ~= ^chore: bump version to ",
     }
 
-    assert exclusions <= set(queue_rule["queue_conditions"])
-    assert exclusions <= set(enqueue_rule["conditions"])
-    assert queue_rule["merge_method"] == "squash"
+    for queue_rule in config["queue_rules"]:
+        assert exclusions <= set(queue_rule["queue_conditions"])
+        assert queue_rule["merge_method"] == "squash"
+
+
+def test_head_updates_revoke_both_merge_ready_authorizations():
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/revoke-merge-ready.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+
+    assert workflow["on"] == {"pull_request_target": {"types": ["synchronize"]}}
+    assert workflow["permissions"] == {}
+
+    job = workflow["jobs"]["revoke-merge-ready"]
+    assert "merge-ready" in job["if"]
+    assert "merge-ready-mac" in job["if"]
+    assert job["permissions"] == {"pull-requests": "write"}
+
+    (step,) = job["steps"]
+    assert step["uses"].startswith("actions/github-script@")
+    script = step["with"]["script"]
+    assert '["merge-ready", "merge-ready-mac"]' in script
+    assert "github.rest.issues.removeLabel" in script
+    assert "checkout" not in script.lower()

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -12,6 +12,7 @@ REQUIRED_CHECKS = {
     "check-success = @github-actions/desktop-tests",
     "check-success = @github-actions/version-bump-guard",
 }
+HEAD_AUTHORIZATION = "check-success = merge-ready-head"
 
 
 def _config() -> dict[str, object]:
@@ -43,7 +44,9 @@ def test_queue_revalidates_every_required_check_on_the_combined_batch():
 
     for rule in rules.values():
         assert set(rule["queue_conditions"]) >= REQUIRED_CHECKS
+        assert HEAD_AUTHORIZATION in rule["queue_conditions"]
         assert set(rule["merge_conditions"]) == REQUIRED_CHECKS
+        assert HEAD_AUTHORIZATION not in rule["merge_conditions"]
         assert rule["branch_protection_injection_mode"] == "queue"
         assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
 
@@ -108,4 +111,29 @@ def test_head_updates_revoke_both_merge_ready_authorizations():
     script = step["with"]["script"]
     assert '["merge-ready", "merge-ready-mac"]' in script
     assert "github.rest.issues.removeLabel" in script
+    assert "checkout" not in script.lower()
+
+
+def test_ready_authorization_is_bound_to_the_exact_head_commit():
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/authorize-merge-ready.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+
+    assert workflow["on"] == {"pull_request_target": {"types": ["labeled"]}}
+    assert workflow["permissions"] == {}
+
+    job = workflow["jobs"]["authorize-ready-head"]
+    assert "head.repo.full_name == github.repository" in job["if"]
+    assert "merge-ready" in job["if"]
+    assert "merge-ready-mac" in job["if"]
+    assert job["permissions"] == {"statuses": "write"}
+
+    (step,) = job["steps"]
+    assert step["uses"].startswith("actions/github-script@")
+    script = step["with"]["script"]
+    assert "github.rest.repos.createCommitStatus" in script
+    assert "sha: context.payload.pull_request.head.sha" in script
+    assert 'context: "merge-ready-head"' in script
+    assert "present.length === 1" in script
     assert "checkout" not in script.lower()


### PR DESCRIPTION
## Why

Ready pull requests currently share one queue even though only a subset changes Desktop or GUI behavior. Mixing both classes makes inexpensive changes wait behind scarce hosted macOS capacity and encourages redundant CI when labels change.

## What

- Route `merge-ready` pull requests to a five-minute non-Desktop batch and `merge-ready-mac` pull requests to a 15-minute Desktop batch, with up to four pull requests per batch.
- Auto-queue either ready label through merge protections while making the two queue rules mutually exclusive.
- Bind ready authorization to the exact labeled head SHA so a later push cannot race asynchronous label cleanup.
- Stop product CI workflows from retriggering on label-only events; promoted same-repository queue heads still expand the affected integration lanes.
- Revoke either ready label whenever a pull request head changes, without checking out pull-request code.
- Document and test the operator contract, required-check preservation, fork boundary, and rollback path.

## Scope / Non-goals

This changes queue routing, CI triggers, ready-label authorization, tests, and operator documentation. It does not change product code, required-check names, branch protection, release bump handling, runner placement, retry policy, or the one-batch-at-a-time safety limit.

## Design precedent

The design uses the managed queue's documented multiple queue rules and label-gated auto-merge conditions. Expensive integration work runs on the synthetic combined head, analogous to merge-group validation, while ordinary pull-request checks remain path-aware. Ready authorization is bound to the reviewed head and revoked on synchronization.

## Verification

- 158 focused queue, lane-classification, GUI-routing, and Desktop workflow contract tests passed.
- `actionlint` passed for the two product workflows and the authorization-revocation workflow.
- Ruff check and format verification passed for the changed Python tests.
- Official Mergify CLI schema validation passed.
- `git diff --check` passed.

## Behaviour delta

Applying exactly one ready label now selects an automatic same-class batch: non-Desktop batches wait up to five minutes, while Desktop/GUI batches wait up to 15 minutes to amortize Mac capacity. Applying both labels fails closed. Pushing a new head removes either authorization and requires review and checks again.
