### PR TITLE
perf(qsa): batch Flash-Next compressed-key prefill

### DIFF
--- a/docs/benchmarks/qwen38-flash-next-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-m3-ultra.md
@@ -246,6 +246,46 @@ allocation but made it 1.8x slower because MLX had to materialize the gathered
 rows. A future direct sparse-attention kernel can consume the compact indices
 without that copy; the rejected gather path is not included in the candidate.
 
+## QSA compressed-key cache follow-up
+
+The next 0.13.2 candidate batches QSA compressed-key pooling, normalization,
+RoPE, and cache insertion for the common aligned single-request prefill path.
+Previously, each QSA layer processed one four-token compression group at a
+time. A 32K request therefore scheduled thousands of small array operations
+before attention began. The candidate performs the same FP32 group mean and
+per-group transforms as one device batch. Continuous batches, padded rows, and
+prefills that begin inside a compression group retain the scalar compatibility
+path. `RAPID_MLX_QSA_VECTORIZED_CACHE=0` is the A/B escape hatch.
+
+The comparison below uses the previous vectorized-mask candidate as its
+baseline, so it measures only the compressed-key cache change. Both sides ran
+the exact Qwen3.8-Flash-Next revision, 2,048-token prefill chunks, MLX 0.32.2,
+three cold-cache runs per length, and 256 decode tokens on the same 256 GB M3
+Ultra. The candidate ran from `eab8e28c` plus the cache experiment.
+
+| Target (reported) | Previous TTFT | Batched-cache TTFT | TTFT reduction | Previous prefill | Batched-cache prefill | Candidate decode |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 128 (92) | 0.385 s | 0.346 s | 10.1% | 238.9 tok/s | 266.3 tok/s | 25.67 tok/s |
+| 2,048 (2,012) | 3.346 s | 2.262 s | **32.4%** | 601.4 tok/s | **889.4 tok/s** | 24.27 tok/s |
+| 8,192 (8,156) | 13.689 s | 9.236 s | **32.5%** | 595.8 tok/s | **883.1 tok/s** | 23.40 tok/s |
+| 32,768 (32,732) | 62.851 s | 44.659 s | **28.9%** | 520.8 tok/s | **732.9 tok/s** | 21.72 tok/s |
+
+MLX active memory remained approximately 102.8--103.8 GB. The process reported
+the same 148.1 GB allocator peak previously observed during model loading and
+long-context work; peak RSS remained 54.32 GiB and is not a unified-memory
+sizing number.
+
+Five deterministic real-model paths matched the scalar-cache baseline after
+normalizing the generated tool-call ID: exact text, Chinese, strict JSON, a
+forced tool call, and 8K needle recall. The full 45-case battery passed every
+project, tool, JSON, protocol, and 8K/32K long-context case. Eleven thinking
+cases exhausted their intentionally small initial output limits, then all 12
+thinking cases passed with `max_tokens=4096` and again on the user-default
+OpenAI budget path. The palindrome case reproduced the documented scorer false
+negative while returning the same valid implementation as the release
+baseline. After those harness adjudications, the candidate's effective result
+was 45/45.
+
 ## Interpretation
 
 Flash-Next reached the first visible token sooner at the 128- and 2K-target

--- a/docs/benchmarks/qwen38-flash-next-m3-ultra.md
+++ b/docs/benchmarks/qwen38-flash-next-m3-ultra.md
@@ -249,13 +249,15 @@ without that copy; the rejected gather path is not included in the candidate.
 ## QSA compressed-key cache follow-up
 
 The next 0.13.2 candidate batches QSA compressed-key pooling, normalization,
-RoPE, and cache insertion for the common aligned single-request prefill path.
+RoPE, and cache insertion for aligned single-request prefills containing at
+least two complete compression groups.
 Previously, each QSA layer processed one four-token compression group at a
 time. A 32K request therefore scheduled thousands of small array operations
 before attention began. The candidate performs the same FP32 group mean and
-per-group transforms as one device batch. Continuous batches, padded rows, and
-prefills that begin inside a compression group retain the scalar compatibility
-path. `RAPID_MLX_QSA_VECTORIZED_CACHE=0` is the A/B escape hatch.
+per-group transforms as one device batch. Decode and one-group speculative
+verification receive no batching benefit, so those paths retain their existing
+cache-update order. Continuous batches, padded rows, and prefills that begin
+inside a compression group likewise retain the lifecycle-compatible path.
 
 The comparison below uses the previous vectorized-mask candidate as its
 baseline, so it measures only the compressed-key cache change. Both sides ran

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -164,6 +164,11 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # loads, which parser fires, which tier engages — none of that
         # changes. Read by ``gdn_in_proj_fusion.fuse_gdn_in_proj()`` only.
         "RAPID_MLX_GDN_IN_PROJ_FUSION",
+        # Opt-out of batched QSA compressed-key cache updates. This chooses
+        # between numerically identical cache-update implementations after
+        # the Qwen4 model and QSA layer are already selected; it cannot change
+        # model, parser, tier, or engine routing.
+        "RAPID_MLX_QSA_VECTORIZED_CACHE",
         # Opt-in re-quantization of the lm_head when serving fp8-block
         # checkpoints through the load-time mxfp8 repack
         # (vllm_mlx/fp8_repack.py). A precision/speed knob on an

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -164,11 +164,6 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # loads, which parser fires, which tier engages — none of that
         # changes. Read by ``gdn_in_proj_fusion.fuse_gdn_in_proj()`` only.
         "RAPID_MLX_GDN_IN_PROJ_FUSION",
-        # Opt-out of batched QSA compressed-key cache updates. This chooses
-        # between numerically identical cache-update implementations after
-        # the Qwen4 model and QSA layer are already selected; it cannot change
-        # model, parser, tier, or engine routing.
-        "RAPID_MLX_QSA_VECTORIZED_CACHE",
         # Opt-in re-quantization of the lm_head when serving fp8-block
         # checkpoints through the load-time mxfp8 repack
         # (vllm_mlx/fp8_repack.py). A precision/speed knob on an

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -525,6 +525,95 @@ def test_qsa_cache_keeps_only_raw_ring_and_persistent_compressed_keys():
     )
 
 
+@pytest.mark.parametrize("length", [1, 4, 7, 8, 9])
+def test_qsa_cache_vectorized_aligned_prefill_matches_scalar_update(length):
+    values = mx.arange(length, dtype=mx.float32).reshape(1, length, 1)
+
+    def transform(group, start):
+        return group + start
+
+    def transform_many(groups, starts):
+        return groups + starts[None, :, None]
+
+    scalar = QSAIndexCache(compress_ratio=4)
+    vectorized = QSAIndexCache(compress_ratio=4)
+    scalar.update(values, transform)
+    vectorized.update(values, transform, transform_groups=transform_many)
+    mx.eval(scalar.state, vectorized.state)
+
+    assert scalar.meta_state == vectorized.meta_state
+    np.testing.assert_array_equal(
+        np.array(scalar.raw_ring), np.array(vectorized.raw_ring)
+    )
+    if scalar.compressed_keys is None:
+        assert vectorized.compressed_keys is None
+    else:
+        np.testing.assert_array_equal(
+            np.array(scalar.compressed_keys), np.array(vectorized.compressed_keys)
+        )
+
+
+def test_qsa_cache_vectorized_chunks_and_scalar_tail_keep_identical_state():
+    def transform(group, start):
+        return group + start
+
+    def transform_many(groups, starts):
+        return groups + starts[None, :, None]
+
+    scalar = QSAIndexCache(compress_ratio=4)
+    vectorized = QSAIndexCache(compress_ratio=4)
+    for start, length in ((0, 8), (8, 7), (15, 1), (16, 5)):
+        values = mx.arange(start, start + length, dtype=mx.float32).reshape(
+            1, length, 1
+        )
+        scalar.update(values, transform)
+        vectorized.update(values, transform, transform_groups=transform_many)
+        mx.eval(scalar.state, vectorized.state)
+        assert scalar.meta_state == vectorized.meta_state
+        np.testing.assert_array_equal(
+            np.array(scalar.raw_ring), np.array(vectorized.raw_ring)
+        )
+        np.testing.assert_array_equal(
+            np.array(scalar.compressed_keys), np.array(vectorized.compressed_keys)
+        )
+
+
+def test_qsa_vectorized_cache_default_matches_scalar_attention(monkeypatch):
+    args = _args(
+        indexer_budget=4,
+        indexer_compress_ratio=2,
+        rope_parameters={"rope_theta": 10_000_000, "partial_rotary_factor": 0.5},
+    )
+    attention = QSAAttention(args)
+    prompt = mx.arange(9 * args.hidden_size, dtype=mx.float32).reshape(
+        1, 9, args.hidden_size
+    )
+
+    monkeypatch.setenv("RAPID_MLX_QSA_VECTORIZED_CACHE", "0")
+    scalar_cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+    scalar = attention(prompt, scalar_cache)
+    mx.eval(scalar, scalar_cache.state)
+
+    monkeypatch.delenv("RAPID_MLX_QSA_VECTORIZED_CACHE")
+    vectorized_cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
+    vectorized = attention(prompt, vectorized_cache)
+    mx.eval(vectorized, vectorized_cache.state)
+
+    np.testing.assert_array_equal(np.array(scalar), np.array(vectorized))
+    for scalar_state, vectorized_state in zip(
+        scalar_cache.state, vectorized_cache.state
+    ):
+        if isinstance(scalar_state, tuple):
+            for scalar_array, vectorized_array in zip(scalar_state, vectorized_state):
+                np.testing.assert_array_equal(
+                    np.array(scalar_array), np.array(vectorized_array)
+                )
+        else:
+            np.testing.assert_array_equal(
+                np.array(scalar_state), np.array(vectorized_state)
+            )
+
+
 @pytest.mark.parametrize("length", [8, 9])
 def test_qsa_cache_rewinds_recoverable_group_and_recomputes_divergence(length):
     def transform(group, start):

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -562,7 +562,12 @@ def test_qsa_cache_vectorized_chunks_and_scalar_tail_keep_identical_state():
 
     scalar = QSAIndexCache(compress_ratio=4)
     vectorized = QSAIndexCache(compress_ratio=4)
-    for start, length in ((0, 8), (8, 7), (15, 1), (16, 5)):
+    # A small allocation step exercises initial allocation, reuse within the
+    # existing capacity, and growth without constructing a synthetic 1K token
+    # input solely for the production step=256 boundary.
+    scalar.step = 4
+    vectorized.step = 4
+    for start, length in ((0, 8), (8, 8), (16, 8), (24, 7), (31, 1), (32, 5)):
         values = mx.arange(start, start + length, dtype=mx.float32).reshape(
             1, length, 1
         )

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -578,7 +578,7 @@ def test_qsa_cache_vectorized_chunks_and_scalar_tail_keep_identical_state():
         )
 
 
-def test_qsa_vectorized_cache_default_matches_scalar_attention(monkeypatch):
+def test_qsa_vectorized_cache_matches_architecture_reference():
     args = _args(
         indexer_budget=4,
         indexer_compress_ratio=2,
@@ -588,30 +588,35 @@ def test_qsa_vectorized_cache_default_matches_scalar_attention(monkeypatch):
     prompt = mx.arange(9 * args.hidden_size, dtype=mx.float32).reshape(
         1, 9, args.hidden_size
     )
+    projected = attention.indexer.index_qk_proj(prompt)
+    query_width = args.indexer_n_heads * args.indexer_head_dim
+    _, raw_keys = mx.split(projected, [query_width], axis=-1)
+    raw_keys = raw_keys.reshape(1, 9, 1, args.indexer_head_dim).squeeze(2)
+    pooled = mx.mean(
+        raw_keys[:, :8, :].reshape(1, 4, 2, args.indexer_head_dim).astype(mx.float32),
+        axis=2,
+    ).astype(raw_keys.dtype)
+    normalized = attention.indexer.k_layernorm(pooled)
+    expected = apply_qwen4_exp_rope(
+        normalized[:, None, :, :],
+        mx.arange(0, 8, 2, dtype=mx.int64)[None, :],
+        rotary_dim=attention.indexer.rotary_dim,
+        base=attention.indexer.rope_theta,
+    )[:, 0, :, :]
+    mx.eval(expected, raw_keys)
 
-    monkeypatch.setenv("RAPID_MLX_QSA_VECTORIZED_CACHE", "0")
-    scalar_cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
-    scalar = attention(prompt, scalar_cache)
-    mx.eval(scalar, scalar_cache.state)
+    cache = QSAIndexCache(compress_ratio=2)
+    attention.indexer(prompt, cache, physical_kv_length=9)
+    mx.eval(expected, cache.state)
 
-    monkeypatch.delenv("RAPID_MLX_QSA_VECTORIZED_CACHE")
-    vectorized_cache = CacheList(KVCache(), QSAIndexCache(compress_ratio=2))
-    vectorized = attention(prompt, vectorized_cache)
-    mx.eval(vectorized, vectorized_cache.state)
-
-    np.testing.assert_array_equal(np.array(scalar), np.array(vectorized))
-    for scalar_state, vectorized_state in zip(
-        scalar_cache.state, vectorized_cache.state
-    ):
-        if isinstance(scalar_state, tuple):
-            for scalar_array, vectorized_array in zip(scalar_state, vectorized_state):
-                np.testing.assert_array_equal(
-                    np.array(scalar_array), np.array(vectorized_array)
-                )
-        else:
-            np.testing.assert_array_equal(
-                np.array(scalar_state), np.array(vectorized_state)
-            )
+    assert cache._compressed_count == 4
+    np.testing.assert_array_equal(
+        np.array(cache.compressed_keys[:, :4, :]), np.array(expected)
+    )
+    np.testing.assert_array_equal(
+        np.array(cache.raw_ring),
+        np.array(mx.concatenate([raw_keys[:, 8:9, :], raw_keys[:, 7:8, :]], axis=1)),
+    )
 
 
 @pytest.mark.parametrize("length", [8, 9])

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -13,7 +13,6 @@ milestones have independent numerical and lifecycle coverage.
 from __future__ import annotations
 
 import math
-import os
 from dataclasses import dataclass, field
 from functools import cache
 from typing import Any, cast
@@ -729,11 +728,7 @@ class QSAIndexer(nn.Module):
         cache.update(
             raw_keys,
             transform_group,
-            transform_groups=(
-                transform_groups
-                if os.getenv("RAPID_MLX_QSA_VECTORIZED_CACHE", "1") != "0"
-                else None
-            ),
+            transform_groups=transform_groups,
         )
         # The architecture reference stays on ordinary causal attention while
         # every complete block fits the QSA budget. Preserve that exact math

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -13,6 +13,7 @@ milestones have independent numerical and lifecycle coverage.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass, field
 from functools import cache
 from typing import Any, cast
@@ -716,7 +717,24 @@ class QSAIndexer(nn.Module):
                 base=self.rope_theta,
             )[:, 0, 0, :]
 
-        cache.update(raw_keys, transform_group)
+        def transform_groups(groups: mx.array, starts: mx.array) -> mx.array:
+            normalized = self.k_layernorm(groups)
+            return apply_qwen4_exp_rope(
+                normalized[:, None, :, :],
+                starts[None, :],
+                rotary_dim=self.rotary_dim,
+                base=self.rope_theta,
+            )[:, 0, :, :]
+
+        cache.update(
+            raw_keys,
+            transform_group,
+            transform_groups=(
+                transform_groups
+                if os.getenv("RAPID_MLX_QSA_VECTORIZED_CACHE", "1") != "0"
+                else None
+            ),
+        )
         # The architecture reference stays on ordinary causal attention while
         # every complete block fits the QSA budget. Preserve that exact math
         # and kernel selection while still updating Rapid's persistent index

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -208,21 +208,15 @@ class QSAIndexCache(ArraysCache):
         ratio = self.compress_ratio
         complete_length = length // ratio * ratio
         group_count = complete_length // ratio
-        transformed = None
-        if group_count:
-            groups = raw_keys[:, :complete_length, :].reshape(
-                1, group_count, ratio, dim
-            )
-            pooled = mx.mean(groups.astype(mx.float32), axis=2).astype(raw_keys.dtype)
-            starts = self._offsets[0] + mx.arange(group_count) * ratio
-            transformed = transform_groups(pooled, starts)
+        # ``update`` enters this fast path only with at least two complete
+        # groups, so keep the implementation free of unreachable empty-group
+        # branches and make every cache transition explicit.
+        groups = raw_keys[:, :complete_length, :].reshape(1, group_count, ratio, dim)
+        pooled = mx.mean(groups.astype(mx.float32), axis=2).astype(raw_keys.dtype)
+        starts = self._offsets[0] + mx.arange(group_count) * ratio
+        transformed = transform_groups(pooled, starts)
 
-        if self.raw_ring is None:
-            ring = mx.zeros((1, ratio, dim), dtype=raw_keys.dtype)
-        else:
-            ring = self.raw_ring
-        if group_count:
-            ring = raw_keys[:, complete_length - ratio : complete_length, :]
+        ring = raw_keys[:, complete_length - ratio : complete_length, :]
         remainder = length - complete_length
         if remainder:
             ring = mx.concatenate(
@@ -236,26 +230,20 @@ class QSAIndexCache(ArraysCache):
 
         old_count = self._compressed_counts[0]
         new_count = old_count + group_count
-        if group_count:
-            capacity = ((new_count + self.step - 1) // self.step) * self.step
-            if self.compressed_keys is None:
-                expanded = mx.zeros((1, capacity, dim), dtype=raw_keys.dtype)
-            elif capacity > self.compressed_keys.shape[1]:
-                expanded = mx.zeros(
-                    (1, capacity, dim), dtype=self.compressed_keys.dtype
-                )
-                expanded[:, : self.compressed_keys.shape[1], :] = self.compressed_keys
-            else:
-                expanded = self.compressed_keys
-            assert transformed is not None
-            expanded[:, old_count:new_count, :] = transformed
-            self.compressed_keys = expanded
+        capacity = ((new_count + self.step - 1) // self.step) * self.step
+        if self.compressed_keys is None:
+            expanded = mx.zeros((1, capacity, dim), dtype=raw_keys.dtype)
+        elif capacity > self.compressed_keys.shape[1]:
+            expanded = mx.zeros((1, capacity, dim), dtype=self.compressed_keys.dtype)
+            expanded[:, : self.compressed_keys.shape[1], :] = self.compressed_keys
+        else:
+            expanded = self.compressed_keys
+        expanded[:, old_count:new_count, :] = transformed
+        self.compressed_keys = expanded
 
         self._offsets[0] += length
         self._pending_left_padding[0] = 0
         self._compressed_counts[0] = new_count
-        if self.compressed_keys is None:
-            return mx.zeros((1, 0, dim), dtype=raw_keys.dtype)
         return self.compressed_keys[:, :new_count, :]
 
     def keys_for_blocks(self, row: int, block_count: int) -> mx.array:

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -145,6 +145,7 @@ class QSAIndexCache(ArraysCache):
             and batch == 1
             and valid_spans == [(0, length)]
             and self._offsets[0] % self.compress_ratio == 0
+            and length // self.compress_ratio >= 2
         ):
             return self._update_aligned_single_row(raw_keys, transform_groups)
         if self.raw_ring is None:
@@ -224,7 +225,13 @@ class QSAIndexCache(ArraysCache):
             ring = raw_keys[:, complete_length - ratio : complete_length, :]
         remainder = length - complete_length
         if remainder:
-            ring[:, :remainder, :] = raw_keys[:, complete_length:, :]
+            ring = mx.concatenate(
+                [
+                    raw_keys[:, complete_length:, :],
+                    ring[:, remainder:, :],
+                ],
+                axis=1,
+            )
         self.raw_ring = ring
 
         old_count = self._compressed_counts[0]

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -127,6 +127,7 @@ class QSAIndexCache(ArraysCache):
         self,
         raw_keys: mx.array,
         transform_group: Callable[[mx.array, int], mx.array],
+        transform_groups: Callable[[mx.array, mx.array], mx.array] | None = None,
     ) -> mx.array:
         """Commit valid raw rows and cache every newly completed group.
 
@@ -138,6 +139,14 @@ class QSAIndexCache(ArraysCache):
 
         batch, length, dim = raw_keys.shape
         self._ensure_batch(batch)
+        valid_spans = self.valid_spans(length)
+        if (
+            transform_groups is not None
+            and batch == 1
+            and valid_spans == [(0, length)]
+            and self._offsets[0] % self.compress_ratio == 0
+        ):
+            return self._update_aligned_single_row(raw_keys, transform_groups)
         if self.raw_ring is None:
             self.raw_ring = mx.zeros(
                 (batch, self.compress_ratio, dim), dtype=raw_keys.dtype
@@ -146,7 +155,6 @@ class QSAIndexCache(ArraysCache):
             raise ValueError("QSA raw-key cache shape changed within one request")
 
         completed: list[list[mx.array]] = [[] for _ in range(batch)]
-        valid_spans = self.valid_spans(length)
         for row, (input_start, valid_length) in enumerate(valid_spans):
             for token in range(valid_length):
                 position = self._offsets[row] + token
@@ -188,6 +196,60 @@ class QSAIndexCache(ArraysCache):
         if self.compressed_keys is None:
             return mx.zeros((batch, 0, dim), dtype=raw_keys.dtype)
         return self.compressed_keys[:, :max_count, :]
+
+    def _update_aligned_single_row(
+        self,
+        raw_keys: mx.array,
+        transform_groups: Callable[[mx.array, mx.array], mx.array],
+    ) -> mx.array:
+        """Batch complete ratio-sized groups for the common B=1 prefill path."""
+        _, length, dim = raw_keys.shape
+        ratio = self.compress_ratio
+        complete_length = length // ratio * ratio
+        group_count = complete_length // ratio
+        transformed = None
+        if group_count:
+            groups = raw_keys[:, :complete_length, :].reshape(
+                1, group_count, ratio, dim
+            )
+            pooled = mx.mean(groups.astype(mx.float32), axis=2).astype(raw_keys.dtype)
+            starts = self._offsets[0] + mx.arange(group_count) * ratio
+            transformed = transform_groups(pooled, starts)
+
+        if self.raw_ring is None:
+            ring = mx.zeros((1, ratio, dim), dtype=raw_keys.dtype)
+        else:
+            ring = self.raw_ring
+        if group_count:
+            ring = raw_keys[:, complete_length - ratio : complete_length, :]
+        remainder = length - complete_length
+        if remainder:
+            ring[:, :remainder, :] = raw_keys[:, complete_length:, :]
+        self.raw_ring = ring
+
+        old_count = self._compressed_counts[0]
+        new_count = old_count + group_count
+        if group_count:
+            capacity = ((new_count + self.step - 1) // self.step) * self.step
+            if self.compressed_keys is None:
+                expanded = mx.zeros((1, capacity, dim), dtype=raw_keys.dtype)
+            elif capacity > self.compressed_keys.shape[1]:
+                expanded = mx.zeros(
+                    (1, capacity, dim), dtype=self.compressed_keys.dtype
+                )
+                expanded[:, : self.compressed_keys.shape[1], :] = self.compressed_keys
+            else:
+                expanded = self.compressed_keys
+            assert transformed is not None
+            expanded[:, old_count:new_count, :] = transformed
+            self.compressed_keys = expanded
+
+        self._offsets[0] += length
+        self._pending_left_padding[0] = 0
+        self._compressed_counts[0] = new_count
+        if self.compressed_keys is None:
+            return mx.zeros((1, 0, dim), dtype=raw_keys.dtype)
+        return self.compressed_keys[:, :new_count, :]
 
     def keys_for_blocks(self, row: int, block_count: int) -> mx.array:
         if block_count < 0 or block_count > self._compressed_counts[row]:


### PR DESCRIPTION
## Why

Qwen3.8-Flash-Next's QSA index cache compressed raw keys one four-token group at a time. At 32K, that scheduled thousands of small pooling, normalization, RoPE, and cache-write operations before attention. Component profiling attributed 18.7% of total prefill time to this indexer path even after the existing QSA mask optimization.

## What

- batch complete QSA compression groups for aligned single-request prefills with at least two complete groups
- preserve FP32 pooling, normalization, RoPE positions, cache capacity, raw-ring state, and compressed-key ordering
- retain the existing update order for decode, one-group MTP verification, continuous batches, padded rows, and prefills beginning inside a compression group
- record reproducible M3 Ultra performance, correctness, and unified-memory evidence

## Scope / Non-goals

Scope is the vendored Qwen4 QSA index-cache seam, focused cache/attention lifecycle tests, and the existing Flash-Next benchmark document. The required native MTP base landed in #2572; this exact head is rebased on main. Non-goals are MoE or GDN kernels, direct sparse attention, dependency or release bumps, CI changes, and Desktop/GUI changes.

## Design precedent

Established high-throughput serving implementations batch compressed-key pooling across the token dimension and keep scalar cache updates for irregular tails, heterogeneous rows, and single-group verification where batching has no launch-count benefit. This change adopts that vectorized prefill boundary while preserving Rapid-MLX's persistent raw-ring and compressed-key lifecycle. A custom sparse-attention kernel was rejected here because its measured 9.6% long-context gain did not justify the substantially larger platform-specific maintenance surface.

## Verification

- `426 passed, 4 skipped`: complete Qwen4 vendored/reference/artifact parity, MTP suites, and routing contract
- the one-group Qwen4 MTP target-verify regression passed four consecutive isolated runs after narrowing the batching boundary
- Ruff check and format clean; `git diff --check` and credential scan clean
- mypy budget: 719 grandfathered errors across 143 files; no growth
- vectorized cache state matches scalar cache state across aligned chunks and incomplete tails
- the vectorized compressed keys match the architecture-reference FP32 mean, normalization, and explicit-position RoPE computation exactly
- five real-model paths matched after normalizing the generated tool-call ID: exact English, Chinese, strict JSON, forced tool call, and 8K needle recall
- effective 45/45 correctness: all project/tool/JSON/protocol/long-context cases passed; 12/12 thinking cases passed at 4,096 and on the user-default OpenAI budget path; the release-baseline palindrome scorer false negative reproduced the same valid code
- quiet-window medians of three, 256 decode tokens: 2K TTFT 3.346s to 2.262s (-32.4%), 8K 13.689s to 9.236s (-32.5%), 32K 62.851s to 44.659s (-28.9%)
- decode remained 24.27/23.40/21.72 tok/s at 2K/8K/32K; MLX active memory remained approximately 102.8-103.8 GB and allocator peak remained 148.1 GB

## Behaviour delta

Eligible aligned single-request QSA prefills use the batched cache update. Decode and one-group speculative verification retain their exact existing execution order because batching one group has no performance benefit. Mathematical precision, API output, cache ownership, and lifecycle behavior are unchanged for those paths.
