### PR TITLE
ci: enforce no-mac and mac queue lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,28 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+  merge-lane-no-mac:
+    needs: changes
+    if: >-
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.engine != 'true' &&
+      needs.changes.outputs.desktop != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark no-Mac merge lane
+        run: echo "This head requires neither the engine nor Desktop lane."
+
+  merge-lane-mac:
+    needs: changes
+    if: >-
+      needs.changes.result == 'success' &&
+      (needs.changes.outputs.engine == 'true' ||
+       needs.changes.outputs.desktop == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark Mac-required merge lane
+        run: echo "This head requires the engine, Desktop, or both lanes."
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,6 +30,7 @@ queue_rules:
       - -label = skip-version-bump
       - "-title ~= ^chore: bump version to "
       - check-success = merge-ready-head
+      - check-success = @github-actions/merge-lane-no-mac
       - check-success = @github-actions/tests
       - check-success = @github-actions/desktop-tests
       - check-success = @github-actions/version-bump-guard
@@ -57,6 +58,7 @@ queue_rules:
       - -label = skip-version-bump
       - "-title ~= ^chore: bump version to "
       - check-success = merge-ready-head
+      - check-success = @github-actions/merge-lane-mac
       - check-success = @github-actions/tests
       - check-success = @github-actions/desktop-tests
       - check-success = @github-actions/version-bump-guard

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -238,9 +238,11 @@ Before merge, the PR description must accurately reflect actual current state:
 
 - For an ordinary pull request, apply exactly one integration authorization
   label and let the matching managed queue combine and revalidate it. Use
-  `merge-ready` when the classifier does not select the Desktop lane, or
-  `merge-ready-mac` when it does. Do not manually rebase after queue entry and
-  do not click GitHub's merge button:
+  `merge-ready` only when both `merge-lane-no-mac` is green and
+  `merge-lane-mac` is skipped. Use `merge-ready-mac` when
+  `merge-lane-mac` is green; this includes engine-only, Desktop-only, and
+  cross-cutting changes. Do not manually rebase after queue entry and do not
+  click GitHub's merge button:
 
   ```bash
   # No Desktop/GUI lane:
@@ -250,7 +252,7 @@ Before merge, the PR description must accurately reflect actual current state:
   gh pr edit <PR#> --repo raullenchai/Rapid-MLX --add-label merge-ready-mac
   ```
 
-- The non-Desktop queue waits up to five minutes; the Desktop queue waits up to
+- The no-Mac queue waits up to five minutes; the Mac-required queue waits up to
   15 minutes. Each collects as many as four same-class pull requests, runs the
   affected full lanes once on the combined tree, and then squash-merges each
   original. A failed batch is split to identify the blocking member; do not add

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -84,13 +84,23 @@ Ordinary pull requests run the path-aware PR gate and leave the required
 request becomes an integration candidate only when a maintainer applies exactly
 one authorization label after review and PR validation have converged:
 
-- `merge-ready` when the diff does not select the Desktop lane;
-- `merge-ready-mac` when the diff selects the Desktop lane.
+- `merge-ready` only when the classifier selects neither the engine nor the
+  Desktop lane (`engine=false`, `desktop=false`);
+- `merge-ready-mac` when the classifier selects the engine lane, the Desktop
+  lane, or both.
 
 The managed queue never mixes the two labels in one batch. It collects up to
 four candidates of the same class and validates their combined tree once. The
-non-Desktop queue waits at most five minutes to favor latency; the Desktop queue
+no-Mac queue waits at most five minutes to favor latency; the Mac-required queue
 waits at most 15 minutes to amortize scarce macOS capacity.
+
+The Linux `changes` classifier publishes exactly one successful lane marker per
+head: `merge-lane-no-mac` for the false/false state, or `merge-lane-mac` for the
+other three engine/Desktop combinations. Each queue requires its matching
+marker, so a mistaken human label cannot route a Mac-dependent change into the
+no-Mac batch. The combined batch still runs only the union selected by its real
+diff: an engine-only batch does not acquire GUI work, and a Desktop-only batch
+does not acquire engine work.
 
 Labeling writes a `merge-ready-head` success status onto that exact pull-request
 head. Both queues require the status before admission, while their synthetic
@@ -136,7 +146,7 @@ The queue contract lives in `.mergify.yml`:
   newly pushed head from racing asynchronous label revocation;
 - serial mode with one batch in flight, so speculative checks cannot multiply
   scarce macOS capacity;
-- separate non-Desktop and Desktop queues, each with mutually exclusive
+- separate no-Mac and Mac-required queues, each with mutually exclusive
   authorization labels;
 - up to four pull requests per batch, with five-minute and 15-minute maximum
   fill waits respectively;

--- a/tests/test_ci_lane_promotion.py
+++ b/tests/test_ci_lane_promotion.py
@@ -240,6 +240,27 @@ def test_merge_authorization_labels_do_not_retrigger_product_ci():
         assert "unlabeled" not in triggers["types"]
 
 
+def test_merge_lane_checks_partition_all_classifier_states():
+    no_mac = _job(ENGINE_WORKFLOW, "merge-lane-no-mac")
+    mac = _job(ENGINE_WORKFLOW, "merge-lane-mac")
+
+    assert no_mac["needs"] == "changes"
+    assert mac["needs"] == "changes"
+    assert no_mac["runs-on"] == "ubuntu-latest"
+    assert mac["runs-on"] == "ubuntu-latest"
+
+    no_mac_condition = str(no_mac["if"])
+    assert "needs.changes.result == 'success'" in no_mac_condition
+    assert "needs.changes.outputs.engine != 'true'" in no_mac_condition
+    assert "needs.changes.outputs.desktop != 'true'" in no_mac_condition
+
+    mac_condition = str(mac["if"])
+    assert "needs.changes.result == 'success'" in mac_condition
+    assert "needs.changes.outputs.engine == 'true'" in mac_condition
+    assert "needs.changes.outputs.desktop == 'true'" in mac_condition
+    assert "||" in mac_condition
+
+
 def test_unpromoted_engine_aggregate_requires_fast_linux_and_apple_lanes():
     run = _step_run(ENGINE_WORKFLOW, "tests", "Check test results")
     no_lane = run.index('if [ "$expected" != "true" ]')

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -13,6 +13,10 @@ REQUIRED_CHECKS = {
     "check-success = @github-actions/version-bump-guard",
 }
 HEAD_AUTHORIZATION = "check-success = merge-ready-head"
+LANE_CHECKS = {
+    "no-mac-batch": "check-success = @github-actions/merge-lane-no-mac",
+    "mac-batch": "check-success = @github-actions/merge-lane-mac",
+}
 
 
 def _config() -> dict[str, object]:
@@ -42,11 +46,16 @@ def test_queue_batches_four_ready_prs_after_a_bounded_wait():
 def test_queue_revalidates_every_required_check_on_the_combined_batch():
     rules = _rules_by_name("queue_rules")
 
-    for rule in rules.values():
+    for name, rule in rules.items():
         assert set(rule["queue_conditions"]) >= REQUIRED_CHECKS
         assert HEAD_AUTHORIZATION in rule["queue_conditions"]
+        assert LANE_CHECKS[name] in rule["queue_conditions"]
+        assert not ({*LANE_CHECKS.values()} - {LANE_CHECKS[name]}) & set(
+            rule["queue_conditions"]
+        )
         assert set(rule["merge_conditions"]) == REQUIRED_CHECKS
         assert HEAD_AUTHORIZATION not in rule["merge_conditions"]
+        assert not set(LANE_CHECKS.values()) & set(rule["merge_conditions"])
         assert rule["branch_protection_injection_mode"] == "queue"
         assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
 


### PR DESCRIPTION
## Why

The two ready labels must describe whether a pull request needs any macOS capacity, not only whether it changes Desktop code. Engine-only changes still require Apple Silicon validation, so treating them as no-Mac work would place them in the wrong batch and recreate runner contention.

## What

- Publish `merge-lane-no-mac` when both classifier outputs are false.
- Publish `merge-lane-mac` when either the engine or Desktop classifier output is true.
- Require the matching exact-head lane check in each Mergify queue rule.
- Document the complete four-state engine/Desktop truth table as two operational labels.

## Scope / Non-goals

This only binds the existing classifier outputs to the two queue labels. It does not change path classification, required checks, test selection, runner placement, queue size, wait times, retry policy, or product code.

## Design precedent

The queue uses a cheap classification result as an admission condition and keeps expensive validation on the combined candidate. This mirrors merge-group designs that separate routing from integration evidence and prevents a human label from overriding the authoritative diff classifier.

## Verification

- 68 focused queue, promotion, and path-classification tests passed.
- `actionlint` passed.
- GitHub Actions pinning validation passed across all 16 workflows.
- Ruff check and format verification passed.
- Official Mergify CLI schema validation passed.
- `git diff --check` passed.

## Behaviour delta

`merge-ready` is valid only for `engine=false, desktop=false`. `merge-ready-mac` is valid for engine-only, Desktop-only, and cross-cutting changes. A mismatched label cannot enter either queue.
