### PR TITLE
fix(mac): keep image deletion confirmation pressable

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -41,32 +41,19 @@ struct ImagesView: View {
         .task(id: ImageCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)) {
             await viewModel.refreshCatalog()
         }
-        .confirmationDialog(
-            "Delete this image?",
-            isPresented: Binding(
-                get: { pendingDeletion != nil },
-                set: { if !$0 { pendingDeletion = nil } }
-            ),
-            titleVisibility: .visible,
-            presenting: pendingDeletion
-        ) { image in
-            Button("Delete Image", role: .destructive) {
-                viewModel.delete(image)
-                pendingDeletion = nil
-            }
-            .accessibilityIdentifier("Images.Result.Delete.Confirm")
-            // SwiftUI re-hosts confirmation actions in an AppKit alert. On a
-            // headless Mac the cancel-role proxy can publish an enabled
-            // AXButton while rejecting AXPress. Keep this as an ordinary
-            // button and assign the safe default explicitly so Return keeps
-            // the image and automation receives a real press action.
-            Button("Keep") {
-                pendingDeletion = nil
-            }
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("Images.Result.Delete.Keep")
-        } message: { _ in
-            Text("This removes it from this session. Copies you've saved stay on disk.")
+        // `confirmationDialog` re-hosts its actions inside an AppKit alert on
+        // macOS. That proxy can expose an enabled AXButton while rejecting the
+        // button's press action. A plain SwiftUI sheet keeps the confirmation
+        // controls in the app's own accessibility tree, matching the proven
+        // tool-approval and folder-prompt patterns elsewhere in the app.
+        .sheet(item: $pendingDeletion) { image in
+            ImageDeletionConfirmationSheet(
+                onKeep: { pendingDeletion = nil },
+                onDelete: {
+                    viewModel.delete(image)
+                    pendingDeletion = nil
+                }
+            )
         }
     }
 
@@ -1095,6 +1082,39 @@ enum EditImageImporter {
             throw ImportedEditImageError.tooLarge
         }
         return png
+    }
+}
+
+/// A session-local destructive confirmation whose controls stay as ordinary
+/// SwiftUI buttons on macOS. Escape takes the safe Keep path; Return is not
+/// bound to deletion, so a stray keypress can never remove an image.
+private struct ImageDeletionConfirmationSheet: View {
+    let onKeep: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+            Text("Delete this image?")
+                .font(RapidFont.bodyEmphasis)
+            Text("This removes it from this session. Copies you've saved stay on disk.")
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: RapidTheme.Space.sm) {
+                Spacer()
+                Button("Keep", role: .cancel, action: onKeep)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("Images.Result.Delete.Keep")
+                Button("Delete Image", role: .destructive, action: onDelete)
+                    .buttonStyle(.borderedProminent)
+                    .tint(RapidTheme.destructiveActionFill)
+                    .accessibilityHint("Removes this image from the current session. Saved copies stay on disk.")
+                    .accessibilityIdentifier("Images.Result.Delete.Confirm")
+            }
+        }
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 420)
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageResultDeletionTests.swift
@@ -4,17 +4,22 @@ import Testing
 
 @Suite("Image result deletion")
 struct ImageResultDeletionTests {
-    @Test("The native Keep action remains pressable through AppKit re-hosting")
-    func keepActionUsesAnOrdinaryDefaultButton() throws {
+    @Test("The delete confirmation keeps both actions in a SwiftUI sheet")
+    func deleteConfirmationUsesPressableSheetControls() throws {
         let source = try String(
             contentsOf: packageRoot.appendingPathComponent("Sources/Rapid/UI/ImagesView.swift"),
             encoding: .utf8
         )
 
-        #expect(source.contains("Button(\"Keep\")"))
-        #expect(source.contains(".keyboardShortcut(.defaultAction)"))
+        #expect(source.contains(".sheet(item: $pendingDeletion)"))
+        #expect(source.contains("private struct ImageDeletionConfirmationSheet: View"))
+        #expect(!source.contains(".confirmationDialog("))
+        #expect(source.contains("Button(\"Keep\", role: .cancel"))
+        #expect(source.contains(".keyboardShortcut(.cancelAction)"))
         #expect(source.contains(".accessibilityIdentifier(\"Images.Result.Delete.Keep\")"))
-        #expect(!source.contains("Button(\"Keep\", role: .cancel)"))
+        #expect(source.contains("Button(\"Delete Image\", role: .destructive"))
+        #expect(source.contains(".accessibilityIdentifier(\"Images.Result.Delete.Confirm\")"))
+        #expect(!source.contains(".keyboardShortcut(.defaultAction)"))
     }
 
     @Test("Deleting the active result selects the adjacent older image")


### PR DESCRIPTION
## Why

Main's image-generation GUI flow regressed after #2387 (tracked as #2564): macOS re-hosts SwiftUI `confirmationDialog` actions in an AppKit alert, where the visible and enabled **Keep** accessibility element rejects `AXPress`. The result is a user-facing confirmation whose safe action is not reliably interactive, plus a 4/4 failure in the exact headless image-generation flow that blocks the Mac merge queue.

## What

- Replace the image-delete `confirmationDialog` with an app-owned SwiftUI sheet.
- Keep both actions as ordinary SwiftUI buttons with their existing accessibility identifiers.
- Make Escape take the safe **Keep** path and leave Return unbound so it cannot trigger deletion.
- Update the focused deletion contract and retain the behavioural deletion tests.

## Design precedent

Rapid-MLX already uses app-owned SwiftUI sheets for tool approval and folder prompts when actions must remain stable in the app accessibility hierarchy. This adapts that established pattern to destructive image confirmation instead of relying on a system alert proxy whose accessibility action can diverge from its visible state.

## Scope / non-goals

Scope is limited to the Images result deletion confirmation and its focused tests. No image-generation, gallery-state, model, engine, or GUI-harness behaviour changes.

## Verification

- `swift test --package-path apps/rapid-mac --filter 'ImageResultDeletionTests|CoreWorkspaceVisualFoundationTests|AccessibilityIdentifierInventoryTests'` — 57/57 passed
- `python3.12 -m pytest -q tests/test_gui_preflight_contract.py tests/test_gui_golden_ci_coverage.py tests/test_gui_control_behavior_contract.py` — 35/35 passed
- Built the exact app and ran `gui-golden-flows.sh --flow image-generation --keep` — PASS in 152 s. The unchanged journey pressed **Keep**, confirmed the image remained, then reopened each confirmation and pressed **Delete Image** until the gallery reached its empty state.
- `git diff --check`

Hosted exact-head GUI evidence and `pr_validate` will be attached before queue authorization.

## Behaviour delta

The confirmation is now a compact app-owned sheet with the same title, explanation, and outcomes. **Keep** is reliably pressable and dismisses safely; Escape also keeps the image; **Delete Image** remains explicitly destructive; saved copies remain untouched.

Regression follow-up to #2387 (issue #2564).
