### PR TITLE
fix(api): pass chat_template_kwargs through to apply_chat_template (#2474)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,7 @@ jobs:
             tests/test_mllm_penalty_passthrough.py \
             tests/test_guided.py \
             tests/test_chat_streaming_guided.py \
+            tests/test_chat_template_kwargs_passthrough.py \
             tests/test_anthropic_output_config.py \
             tests/test_response_format_json_schema_strict.py \
             tests/test_mllm_cache.py \

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -89,7 +89,7 @@ vllm_mlx/reasoning/think_parser.py 2
 vllm_mlx/repetition_guard.py 2
 vllm_mlx/routes/anthropic.py 7
 vllm_mlx/routes/audio.py 6
-vllm_mlx/routes/chat.py 49
+vllm_mlx/routes/chat.py 48
 vllm_mlx/routes/completions.py 1
 vllm_mlx/routes/embeddings.py 4
 vllm_mlx/routes/images.py 4

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -89,7 +89,7 @@ vllm_mlx/reasoning/think_parser.py 2
 vllm_mlx/repetition_guard.py 2
 vllm_mlx/routes/anthropic.py 7
 vllm_mlx/routes/audio.py 6
-vllm_mlx/routes/chat.py 48
+vllm_mlx/routes/chat.py 39
 vllm_mlx/routes/completions.py 1
 vllm_mlx/routes/embeddings.py 4
 vllm_mlx/routes/images.py 4

--- a/tests/test_chat_template_kwargs_passthrough.py
+++ b/tests/test_chat_template_kwargs_passthrough.py
@@ -10,6 +10,7 @@ route → engine → ``shared_apply_chat_template``, merging unknown keys into
 
 from __future__ import annotations
 
+from vllm_mlx.engine.batched import BatchedEngine
 from vllm_mlx.utils.chat_template import apply_chat_template
 
 
@@ -22,6 +23,9 @@ class FakeTokenizer:
     def apply_chat_template(self, messages, **kwargs):
         self.received_kwargs = kwargs
         return "rendered"
+
+    def encode(self, _text):
+        return [1, 2]
 
 
 def _make_applicator():
@@ -86,3 +90,100 @@ class TestChatTemplateKwargsPassthrough:
             },
         )
         assert tok.received_kwargs["tools"] == server_tools
+
+
+class TestBatchedEngineChatTemplateKwargs:
+    """All BatchedEngine chat entry points preserve template kwargs."""
+
+    def _engine(self) -> BatchedEngine:
+        received: dict = {}
+        engine = BatchedEngine("test-model")
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+
+        def apply_chat_template(*_args, **kwargs):
+            received.update(kwargs.get("chat_template_kwargs") or {})
+            return "prompt"
+
+        engine._apply_chat_template = apply_chat_template
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        return engine, received
+
+    async def test_chat_forwards_chat_template_kwargs(self):
+        engine, received = self._engine()
+        seen_kwargs = {}
+
+        async def generate(**kwargs):
+            seen_kwargs.update(kwargs)
+            return "output"
+
+        engine.generate = generate
+
+        await engine.chat(
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+
+        assert received == {"reasoning_effort": "low"}
+        assert seen_kwargs.get("chat_template_kwargs") is None
+
+    async def test_stream_chat_forwards_chat_template_kwargs(self):
+        engine, received = self._engine()
+        engine._create_output_router = lambda: None
+        engine.stream_generate = lambda **kwargs: kwargs
+
+        async def route_stream(stream, _router):
+            stream["consumed"] = True
+            yield "output"
+
+        engine._stream_with_output_router = route_stream
+
+        outputs = [
+            output
+            async for output in engine.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                chat_template_kwargs={"reasoning_effort": "medium"},
+            )
+        ]
+
+        assert outputs == ["output"]
+        assert received == {"reasoning_effort": "medium"}
+
+    async def test_generate_with_schema_forwards_chat_template_kwargs(
+        self, monkeypatch
+    ):
+        class GuidedEngine(BatchedEngine):
+            @property
+            def supports_guided_generation(self):
+                return True
+
+            @property
+            def tokenizer(self):
+                return FakeTokenizer()
+
+        engine = GuidedEngine("test-model")
+        engine._loaded = True
+        engine._run_guided_generation = lambda **_kwargs: '{"ok": true}'
+
+        received = {}
+
+        def fake_shared_apply(tokenizer, messages, **kwargs):
+            received.update(kwargs.get("chat_template_kwargs") or {})
+            return kwargs.get("chat_template_kwargs")
+
+        monkeypatch.setattr(
+            "vllm_mlx.engine.batched.shared_apply_chat_template",
+            fake_shared_apply,
+        )
+
+        output = await engine.generate_with_schema(
+            messages=[{"role": "user", "content": "hi"}],
+            json_schema={"type": "object"},
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+
+        assert output.text == '{"ok": true}'
+        assert received == {"reasoning_effort": "low"}

--- a/tests/test_chat_template_kwargs_passthrough.py
+++ b/tests/test_chat_template_kwargs_passthrough.py
@@ -10,10 +10,6 @@ route → engine → ``shared_apply_chat_template``, merging unknown keys into
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-import pytest
-
 from vllm_mlx.utils.chat_template import apply_chat_template
 
 

--- a/tests/test_chat_template_kwargs_passthrough.py
+++ b/tests/test_chat_template_kwargs_passthrough.py
@@ -10,6 +10,9 @@ route → engine → ``shared_apply_chat_template``, merging unknown keys into
 
 from __future__ import annotations
 
+import pytest
+
+from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.engine.batched import BatchedEngine
 from vllm_mlx.utils.chat_template import apply_chat_template
 
@@ -90,6 +93,17 @@ class TestChatTemplateKwargsPassthrough:
             },
         )
         assert tok.received_kwargs["tools"] == server_tools
+
+    def test_client_tools_key_is_never_forwarded(self):
+        tok = _make_applicator()
+        apply_chat_template(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={
+                "tools": [{"type": "function", "function": {"name": "evil"}}]
+            },
+        )
+        assert "tools" not in tok.received_kwargs
 
 
 class TestBatchedEngineChatTemplateKwargs:
@@ -187,3 +201,140 @@ class TestBatchedEngineChatTemplateKwargs:
 
         assert output.text == '{"ok": true}'
         assert received == {"reasoning_effort": "low"}
+
+    async def test_build_prompt_forwards_chat_template_kwargs(self):
+        engine = self._engine()[0]
+        engine._apply_chat_template = lambda *_args, **kwargs: kwargs.get(
+            "chat_template_kwargs"
+        )
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._loaded = True
+
+        assert engine.build_prompt(
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"reasoning_effort": "low"},
+        ) == {"reasoning_effort": "low"}
+
+
+class _RawRequest:
+    def __init__(self):
+        self.headers = {}
+
+    async def json(self):
+        return {}
+
+    async def is_disconnected(self):
+        return False
+
+
+class _CapturingChatEngine:
+    supports_guided_generation = False
+    preserve_native_tool_format = False
+    is_mllm = False
+    model_name = "test-model"
+
+    def __init__(self):
+        self.chat_kwargs = {}
+        self.build_prompt_kwargs = {}
+
+    def build_prompt(
+        self, messages, *, tools=None, enable_thinking=None, chat_template_kwargs=None
+    ):
+        self.build_prompt_kwargs.update(
+            {
+                "tools": tools,
+                "enable_thinking": enable_thinking,
+                "chat_template_kwargs": chat_template_kwargs,
+            }
+        )
+        raise ValueError("Chat template error: unsupported reasoning_effort")
+
+    async def chat(self, messages, **kwargs):
+        self.chat_kwargs.update(kwargs)
+        return GenerationOutput(
+            text="ok",
+            finish_reason="stop",
+            prompt_tokens=1,
+            completion_tokens=1,
+        )
+
+
+async def _await_direct(coro, *_args, **_kwargs):
+    return await coro
+
+
+def _patch_chat_route(monkeypatch, engine):
+    from vllm_mlx.routes import chat
+
+    monkeypatch.setattr(chat, "_resolve_max_tokens", lambda *_args, **_kwargs: 64)
+    monkeypatch.setattr(chat, "get_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(chat, "_validate_model_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(chat, "_check_admission_or_503", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        chat, "_release_admission_unless_committed", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(chat, "_wait_with_disconnect", _await_direct)
+    monkeypatch.setattr(
+        chat, "validate_content_blocks_for_capabilities", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(chat, "enforce_context_length_for_messages", lambda *a, **k: 1)
+
+
+class TestChatRouteChatTemplateKwargs:
+    """Chat route forwards the resolved template kwargs to the engine."""
+
+    async def test_nonstreaming_route_forwards_chat_template_kwargs(self, monkeypatch):
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.routes import chat
+
+        engine = _CapturingChatEngine()
+        _patch_chat_route(monkeypatch, engine)
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=8,
+            stream=False,
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+
+        await chat._create_chat_completion_impl(
+            request,
+            _RawRequest(),
+            engine,
+            _commit_state=[False],
+            _admission_acquired=[False],
+        )
+
+        assert engine.chat_kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "low"
+        }
+
+    async def test_streaming_route_validates_chat_template_kwargs(self, monkeypatch):
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.routes import chat
+
+        engine = _CapturingChatEngine()
+        _patch_chat_route(monkeypatch, engine)
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=8,
+            stream=True,
+            chat_template_kwargs={"reasoning_effort": "unsupported"},
+        )
+
+        with pytest.raises(Exception, match="unsupported reasoning_effort"):
+            await chat._create_chat_completion_impl(
+                request,
+                _RawRequest(),
+                engine,
+                _commit_state=[False],
+                _admission_acquired=[False],
+            )
+
+        assert engine.build_prompt_kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "unsupported"
+        }

--- a/tests/test_chat_template_kwargs_passthrough.py
+++ b/tests/test_chat_template_kwargs_passthrough.py
@@ -81,6 +81,8 @@ class TestChatTemplateKwargsPassthrough:
             tok,
             [{"role": "user", "content": "hi"}],
             tools=server_tools,
-            chat_template_kwargs={"tools": [{"type": "function", "function": {"name": "evil"}}]},
+            chat_template_kwargs={
+                "tools": [{"type": "function", "function": {"name": "evil"}}]
+            },
         )
         assert tok.received_kwargs["tools"] == server_tools

--- a/tests/test_chat_template_kwargs_passthrough.py
+++ b/tests/test_chat_template_kwargs_passthrough.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test that ``chat_template_kwargs`` extra keys reach ``apply_chat_template``.
+
+Pins issue #2474: ``chat_template_kwargs["reasoning_effort"]`` was silently
+dropped before the template render, so Qwen3.8 was permanently pinned to its
+``xhigh`` template default. The fix threads the client-supplied dict through
+route → engine → ``shared_apply_chat_template``, merging unknown keys into
+``template_kwargs`` without overriding server-resolved values.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.utils.chat_template import apply_chat_template
+
+
+class FakeTokenizer:
+    """Minimal tokenizer that records the kwargs it receives."""
+
+    def __init__(self):
+        self.received_kwargs: dict | None = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.received_kwargs = kwargs
+        return "rendered"
+
+
+def _make_applicator():
+    tok = FakeTokenizer()
+    # Guard against the sanitiser rejecting the fake applicator.
+    tok.chat_template = "fake"
+    return tok
+
+
+class TestChatTemplateKwargsPassthrough:
+    """``chat_template_kwargs`` extra keys are merged into template_kwargs."""
+
+    def test_reasoning_effort_reaches_the_template(self):
+        tok = _make_applicator()
+        apply_chat_template(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+        assert tok.received_kwargs is not None
+        assert tok.received_kwargs["reasoning_effort"] == "low"
+
+    def test_server_resolved_keys_are_not_overridden(self):
+        tok = _make_applicator()
+        apply_chat_template(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            enable_thinking=False,
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        assert tok.received_kwargs["enable_thinking"] is False
+
+    def test_tokenize_and_add_generation_prompt_not_overridden(self):
+        tok = _make_applicator()
+        apply_chat_template(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            add_generation_prompt=False,
+            chat_template_kwargs={
+                "tokenize": True,
+                "add_generation_prompt": True,
+            },
+        )
+        assert tok.received_kwargs["tokenize"] is False
+        assert tok.received_kwargs["add_generation_prompt"] is False
+
+    def test_none_chat_template_kwargs_is_a_noop(self):
+        tok = _make_applicator()
+        apply_chat_template(tok, [{"role": "user", "content": "hi"}])
+        assert tok.received_kwargs is not None
+        assert "reasoning_effort" not in tok.received_kwargs
+
+    def test_tools_key_not_overridden_by_client(self):
+        tok = _make_applicator()
+        server_tools = [{"type": "function", "function": {"name": "f"}}]
+        apply_chat_template(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            tools=server_tools,
+            chat_template_kwargs={"tools": [{"type": "function", "function": {"name": "evil"}}]},
+        )
+        assert tok.received_kwargs["tools"] == server_tools

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -510,7 +510,9 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
 
         captured: dict = {}
 
-        def _fake_render(tok, messages, *, tools, enable_thinking, model_name, **kwargs):
+        def _fake_render(
+            tok, messages, *, tools, enable_thinking, model_name, **kwargs
+        ):
             captured["enable_thinking"] = enable_thinking
             return "PROMPT"
 

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -510,7 +510,7 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
 
         captured: dict = {}
 
-        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
+        def _fake_render(tok, messages, *, tools, enable_thinking, model_name, **kwargs):
             captured["enable_thinking"] = enable_thinking
             return "PROMPT"
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1631,8 +1631,8 @@ class ChatCompletionRequest(BaseModel):
     # Thinking/reasoning control (Qwen3 style).  None = server default.
     enable_thinking: bool | None = None
     # OpenAI extended spec: arbitrary kwargs forwarded to the chat template.
-    # We currently honor the ``enable_thinking`` key here; other keys are
-    # accepted (no Pydantic drop) but not yet forwarded — see
+    # ``enable_thinking`` remains the server-resolved control; other
+    # keys are passed through for model-specific template variables. See
     # ``_resolve_enable_thinking`` in service/helpers.py for precedence.
     chat_template_kwargs: dict | None = None
     # reasoning_max_tokens — caps the THINKING portion only (tokens inside

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -315,8 +315,8 @@ class ResponsesRequest(BaseModel):
     # to /v1/chat/completions.
     #
     # ``chat_template_kwargs`` is intentionally typed as a dict — the
-    # only key rapid-mlx consumes today is ``enable_thinking`` (other
-    # keys round-trip but no-op), and the chat surface uses the same
+    # only server-resolved key is ``enable_thinking`` (other
+    # keys are model-specific template variables), and the chat surface
     # unconstrained ``dict`` shape (api/models.py line 1511) so the
     # two routes share one contract.
     chat_template_kwargs: dict | None = None

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -453,6 +453,7 @@ class BaseEngine(ABC):
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
         add_generation_prompt: bool = True,
+        chat_template_kwargs: dict | None = None,
     ) -> str:
         """Render the chat prompt for ``messages`` + ``tools`` without
         starting generation.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1972,6 +1972,7 @@ class BatchedEngine(BaseEngine):
         num_images: int = 0,
         enable_thinking: bool | None = None,
         add_generation_prompt: bool = True,
+        chat_template_kwargs: dict | None = None,
     ) -> str:
         """Apply chat template to messages.
 
@@ -2029,6 +2030,7 @@ class BatchedEngine(BaseEngine):
             enable_thinking=enable_thinking,
             model_name=self._model_name,
             add_generation_prompt=add_generation_prompt,
+            chat_template_kwargs=chat_template_kwargs,
         )
 
     @staticmethod
@@ -2657,6 +2659,7 @@ class BatchedEngine(BaseEngine):
 
         # Extract enable_thinking before passing kwargs downstream
         enable_thinking = kwargs.pop("enable_thinking", None)
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
         # PFlash routing hints (#287). ``requires_prompt_integrity`` is
         # set by the route layer for response_format / structured-output
         # requests — those are hard-protected (no opt-out flag exists).
@@ -2680,6 +2683,7 @@ class BatchedEngine(BaseEngine):
             template_tools,
             num_images=len(all_images),
             enable_thinking=enable_thinking,
+            chat_template_kwargs=chat_template_kwargs,
         )
         prompt, output_router_seed = self._prepare_harmony_no_thinking_prompt(
             prompt,
@@ -3403,6 +3407,7 @@ class BatchedEngine(BaseEngine):
 
         # Extract enable_thinking before passing kwargs downstream
         enable_thinking = kwargs.pop("enable_thinking", None)
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
         # PFlash routing hints (#287) — parity with chat(). Tools are
         # NOT auto-folded into ``requires_prompt_integrity``; the
         # ``has_tools`` flag plus ``skip_when_tools`` is the user-
@@ -3419,6 +3424,7 @@ class BatchedEngine(BaseEngine):
             template_tools,
             num_images=len(all_images),
             enable_thinking=enable_thinking,
+            chat_template_kwargs=chat_template_kwargs,
         )
         prompt, output_router_seed = self._prepare_harmony_no_thinking_prompt(
             prompt,
@@ -3734,6 +3740,7 @@ class BatchedEngine(BaseEngine):
         # into ``shared_apply_chat_template`` identically to the
         # non-guided ``chat()`` path.
         enable_thinking = kwargs.pop("enable_thinking", None)
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
         # Build prompt from messages. Route through the central
         # ``shared_apply_chat_template`` wrapper so the role-marker
         # sanitisation runs on user/tool message content here too —
@@ -3747,6 +3754,7 @@ class BatchedEngine(BaseEngine):
             tools=None,
             enable_thinking=enable_thinking,
             model_name=getattr(self, "_model_name", "") or "",
+            chat_template_kwargs=chat_template_kwargs,
         )
 
         # Run guided generation on the mlx-step worker. The model was

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1935,6 +1935,7 @@ class BatchedEngine(BaseEngine):
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
         add_generation_prompt: bool = True,
+        chat_template_kwargs: dict | None = None,
     ) -> str:
         """Render the chat prompt for ``messages`` + ``tools`` without starting
         generation.
@@ -1956,6 +1957,7 @@ class BatchedEngine(BaseEngine):
             tools=template_tools,
             enable_thinking=enable_thinking,
             add_generation_prompt=add_generation_prompt,
+            chat_template_kwargs=chat_template_kwargs,
         )
         prepared, _ = self._prepare_harmony_no_thinking_prompt(
             prompt,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -11,6 +11,7 @@ import threading
 import time
 import uuid
 from collections.abc import AsyncIterator
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4415,6 +4415,15 @@ async def _create_chat_completion_impl(
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
 
+    # Thread client-supplied ``chat_template_kwargs`` through to the engine
+    # so model-specific template variables (e.g. Qwen3.8 ``reasoning_effort``)
+    # reach ``apply_chat_template`` (#2474). ``enable_thinking`` is already
+    # resolved above; the engine-side merge never overwrites server-resolved
+    # keys.
+    ctk = getattr(request, "chat_template_kwargs", None)
+    if isinstance(ctk, dict) and ctk:
+        chat_kwargs["chat_template_kwargs"] = ctk
+
     # Context-length pre-check (DoS defense + UX, rapid-desktop#273 / #463).
     # See ``service/helpers.py::enforce_context_length_for_messages`` for
     # the rationale (8 MiB body still holds ~2M tokens → context window

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -82,6 +82,7 @@ from ..service.helpers import (
     SSE_RESPONSE_HEADERS,
     _append_tool_use_suffix,
     _apply_reasoning_cutoff_notice,
+    _build_prompt_with_thinking_compat,
     _build_usage,
     _check_admission_or_503,
     _disconnect_guard,
@@ -4449,6 +4450,7 @@ async def _create_chat_completion_impl(
         tools=request.tools,
         max_tokens=chat_kwargs.get("max_tokens"),
         enable_thinking=resolved_thinking,
+        chat_template_kwargs=chat_kwargs.get("chat_template_kwargs"),
     )
 
     # LINE① (#558, codex r4 #1) — HARD context-window allowance check. With
@@ -4981,10 +4983,12 @@ async def _create_chat_completion_impl(
         # Validate chat template eagerly so template errors return 400
         if not engine.is_mllm:
             try:
-                engine.build_prompt(
+                _build_prompt_with_thinking_compat(
+                    engine.build_prompt,
                     messages,
                     tools=chat_kwargs.get("tools"),
                     enable_thinking=chat_kwargs.get("enable_thinking"),
+                    chat_template_kwargs=chat_kwargs.get("chat_template_kwargs"),
                 )
             except Exception as e:
                 err_msg = str(e)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4260,7 +4260,7 @@ async def _create_chat_completion_impl(
     resolved_thinking = _resolve_enable_thinking(request)
 
     # Prepare kwargs
-    chat_kwargs = {
+    chat_kwargs: dict[str, Any] = {
         "max_tokens": _resolve_max_tokens(request.max_tokens, resolved_thinking),
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -817,6 +817,7 @@ class DiffusionEngine(BaseEngine):
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
         add_generation_prompt: bool = True,
+        chat_template_kwargs: dict | None = None,
     ) -> str:
         self._ensure_loaded()
         template_kwargs: dict[str, Any] = {

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -4620,6 +4620,7 @@ def _build_prompt_with_thinking_compat(
     *,
     tools: list | None,
     enable_thinking: bool | None,
+    chat_template_kwargs: dict | None = None,
 ):
     """Call ``engine.build_prompt`` with ``enable_thinking=...``,
     falling back to the pre-#280 two-argument shape when the callable
@@ -4655,6 +4656,18 @@ def _build_prompt_with_thinking_compat(
     only fires on the first call for an engine with the legacy
     signature.
     """
+    if chat_template_kwargs is not None:
+        signature = inspect.signature(build_prompt)
+        if signature is not None and ("chat_template_kwargs" in signature.parameters):
+            return build_prompt(
+                messages,
+                tools=tools,
+                enable_thinking=enable_thinking,
+                chat_template_kwargs=chat_template_kwargs,
+            )
+
+        return build_prompt(messages, tools=tools, enable_thinking=enable_thinking)
+
     try:
         return build_prompt(messages, tools=tools, enable_thinking=enable_thinking)
     except TypeError as exc:
@@ -4680,6 +4693,7 @@ def enforce_context_length_for_messages(
     tools: list | None = None,
     max_tokens: int | None = None,
     enable_thinking: bool | None = None,
+    chat_template_kwargs: dict | None = None,
 ) -> int | None:
     """Run the context-length gate for a chat-style request and return
     the rendered prompt's token count (``None`` on permissive-skip paths).
@@ -4747,6 +4761,7 @@ def enforce_context_length_for_messages(
             messages,
             tools=tools,
             enable_thinking=enable_thinking,
+            chat_template_kwargs=chat_template_kwargs,
         )
     except HTTPException:
         raise

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1383,6 +1383,8 @@ def apply_chat_template(
     # below (and the ``reasoning_effort`` pop in the second retry) handles
     # that exactly as it does today.
     for key, value in (chat_template_kwargs or {}).items():
+        if key in ("tokenize", "add_generation_prompt", "enable_thinking", "tools"):
+            continue
         if key not in template_kwargs:
             template_kwargs[key] = value
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1230,6 +1230,7 @@ def apply_chat_template(
     enable_thinking: bool | None = None,
     model_name: str = "",
     add_generation_prompt: bool = True,
+    chat_template_kwargs: dict | None = None,
 ) -> str:
     """Apply a chat template to messages with consistent fallback behavior.
 
@@ -1373,6 +1374,18 @@ def apply_chat_template(
     if tools:
         template_kwargs["tools"] = tools
 
+    # Pass through client-supplied ``chat_template_kwargs`` keys (e.g.
+    # ``reasoning_effort`` for Qwen3.8) into the template render. Server-
+    # controlled keys (``tokenize``, ``add_generation_prompt``,
+    # ``enable_thinking``, ``tools``) are never overridden — the resolved
+    # values above take precedence. Unknown keys may raise ``TypeError``
+    # on templates that do not accept them; the error-driven fallback
+    # below (and the ``reasoning_effort`` pop in the second retry) handles
+    # that exactly as it does today.
+    for key, value in (chat_template_kwargs or {}).items():
+        if key not in template_kwargs:
+            template_kwargs[key] = value
+
     # GPT-OSS / Harmony-style templates do not expose an on/off
     # ``enable_thinking`` switch; they expose ``reasoning_effort`` and default
     # it to ``medium``. When a route already resolved ``enable_thinking=False``
@@ -1397,16 +1410,9 @@ def apply_chat_template(
     #     match via `_HY3_MODEL_NAME_RE` — not a loose substring)
     #   * ``enable_thinking`` is not False (a client that explicitly
     #     disabled thinking wants no_think — respect that intent)
-    # NOTE (codex R12 NIT): there is presently NO request-side
-    # ``reasoning_effort`` plumb-through — the value is template-only, and this
-    # override is the sole injection point. ``setdefault`` (not direct
-    # assignment) is deliberate future-proofing: IF a later revision plumbs a
-    # graded effort (``medium`` / ``high``) through and pre-populates
-    # ``template_kwargs["reasoning_effort"]`` upstream of this call, the
-    # explicit value survives instead of being silently overwritten. Until that
-    # plumb-through exists, ``setdefault`` behaves identically to assignment
-    # here (the key is never pre-populated). Non-Hy3 models never see the kwarg,
-    # so no risk of TypeError on other templates.
+    # ``setdefault`` (not direct assignment) preserves a client-supplied
+    # ``chat_template_kwargs.reasoning_effort`` (plumbed in above) so an
+    # explicit request wins over the Hy3 ``low`` default.
     if _looks_like_hy3(model_name) and enable_thinking is not False:
         template_kwargs.setdefault("reasoning_effort", "low")
 


### PR DESCRIPTION
## Why

`chat_template_kwargs` keys other than `enable_thinking` were silently dropped before `apply_chat_template`, so model-specific template variables such as Qwen3.8's `reasoning_effort` were unreachable. This pinned Qwen3.8 to its `xhigh` template default.

Fixes #2474

## What

- Thread `chat_template_kwargs` from the Chat Completions route into `BatchedEngine` chat, streaming, and guided-schema paths.
- Merge client template variables into `apply_chat_template` without overriding server-resolved `tokenize`, `add_generation_prompt`, `enable_thinking`, or `tools`.
- Forward the kwargs through prompt building, eager streaming validation, and context-length accounting.
- Preserve existing fallback behavior when a template rejects an unsupported kwarg.
- Add regression coverage for template merging, all BatchedEngine chat entry points, route forwarding, streaming validation, and server-controlled key precedence.

## Verification

- `pytest tests/test_chat_template_kwargs_passthrough.py tests/test_responses_chat_template_kwargs.py tests/test_chat_streaming_guided.py tests/test_response_format_json_schema_strict.py tests/test_enable_thinking_prompt_accounting.py` — 119 passed
- Changed-line diff coverage — 100% (`14/14`)
- CI pinned mypy error budget — no growth
- Full CI, Apple Silicon CI, lint, type-check, `changed-lines-coverage`, and PR validation pipeline are green on head `78ed99b12b61f0a2c7092f83101582ad6af4cc3a`
- One adversarial Codex review round was completed; its findings were fixed with tests and runtime-path hardening

## Non-goals

- Do not add Qwen3.8 values such as `xhigh` to the OpenAI `reasoning_effort` enum.
- Do not change auto-thinking defaults or OpenAI surface semantics beyond `chat_template_kwargs` passthrough.
