### PR TITLE
fix(mac): quarantine an image after its second terminal retry failure

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -397,8 +397,16 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// subsequent plain-text follow-up. A direct Retry still sends the image.
     enum ImageDeliveryStatus: String, Codable, Sendable {
         case pending
+        /// One pre-token failure has already been allowed to retry through a
+        /// later plain-text turn. Persisting this state on the image-bearing
+        /// message keeps the retry budget tied to that exact turn.
+        case retryable
         case accepted
         case rejected
+
+        var permitsFollowUpInheritance: Bool {
+            self == .retryable || self == .accepted
+        }
 
         /// A newer outcome must fail closed for attachment inheritance rather
         /// than make one message undecodable and side the whole conversation

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -207,7 +207,8 @@ struct ChatStreamClient {
                     if let attachmentTurn,
                         !modelMessages[attachmentTurn].imageAttachments.isEmpty,
                         modelMessages[attachmentTurn].imageDeliveryStatus == nil
-                            || modelMessages[attachmentTurn].imageDeliveryStatus == .accepted
+                            || modelMessages[attachmentTurn]
+                                .imageDeliveryStatus?.permitsFollowUpInheritance == true
                     {
                         imageMessageIndex = attachmentTurn
                     } else {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -690,41 +690,68 @@ final class ChatViewModel {
         return messages[index]
     }
 
-    /// Persist attachment acceptance on the user turn itself. Failed empty
-    /// assistant placeholders are intentionally removed from later wire
-    /// history, so they cannot safely own this focus state.
-    private func setImageDeliveryStatus(
+    /// Persist attachment delivery progress on the user turn itself. Failed
+    /// empty assistant placeholders are intentionally removed from later wire
+    /// history, so they cannot safely own this focus state or retry budget.
+    private func applyImageDeliveryEvent(
         messageID: UUID?,
-        status: ChatMessage.ImageDeliveryStatus?,
+        event: ImageDeliveryEvent,
         epoch: Int
     ) {
         guard epoch == conversationEpoch else { return }
-        Self.updateImageDeliveryStatus(
+        Self.applyImageDeliveryEvent(
             in: &messages,
             messageID: messageID,
-            status: status
+            event: event
         )
     }
 
-    /// Pure state-layer seam for the request lifecycle. Matching by persisted
+    enum ImageDeliveryEvent: Sendable {
+        case accepted
+        case terminalRejection
+        case transientFailure
+        case abandoned
+    }
+
+    /// Pure state machine for the request lifecycle. Matching by persisted
     /// message identity prevents a late response from changing a newer image
-    /// turn after conversation branching or editing.
-    static func updateImageDeliveryStatus(
+    /// turn after conversation branching or editing. A first pre-token failure
+    /// remains eligible for one implicit retry; the second quarantines that
+    /// image. Cancellation or startup failure does not spend the retry budget.
+    static func applyImageDeliveryEvent(
         in messages: inout [ChatMessage],
         messageID: UUID?,
-        status: ChatMessage.ImageDeliveryStatus?
+        event: ImageDeliveryEvent
     ) {
         guard let messageID,
               let index = messages.firstIndex(where: { $0.id == messageID })
         else { return }
-        // Acceptance is monotonic for one request: once the server emits a
-        // token, a later transport failure means the response was interrupted,
-        // not that the image was rejected. An explicit retry may still move a
-        // previously rejected image to accepted when its own first token lands.
-        if messages[index].imageDeliveryStatus == .accepted, status != .accepted {
-            return
+
+        switch event {
+        case .accepted:
+            // An explicit Retry may prove a previously rejected image works.
+            messages[index].imageDeliveryStatus = .accepted
+        case .terminalRejection:
+            // Once the server emits a token, a later transport failure means
+            // the response was interrupted, not that the image was rejected.
+            guard messages[index].imageDeliveryStatus != .accepted else { return }
+            messages[index].imageDeliveryStatus = .rejected
+        case .transientFailure:
+            switch messages[index].imageDeliveryStatus {
+            case .accepted, .rejected:
+                return
+            case .retryable:
+                messages[index].imageDeliveryStatus = .rejected
+            case .pending, nil:
+                messages[index].imageDeliveryStatus = .retryable
+            }
+        case .abandoned:
+            // Only a newly-created request owns `.pending`. A cancelled retry
+            // preserves its prior retryable/rejected state by identity.
+            if messages[index].imageDeliveryStatus == .pending {
+                messages[index].imageDeliveryStatus = nil
+            }
         }
-        messages[index].imageDeliveryStatus = status
     }
 
     /// Start a fresh conversation — drops the transcript and any stale
@@ -996,9 +1023,9 @@ final class ChatViewModel {
         epoch: Int? = nil
     ) {
         if let epoch, epoch != conversationEpoch { return }
-        setImageDeliveryStatus(
+        applyImageDeliveryEvent(
             messageID: imageMessageID,
-            status: nil,
+            event: .abandoned,
             epoch: conversationEpoch
         )
         let message = "Couldn't start \(alias). Try again, or pick a different model in the box below."
@@ -1046,9 +1073,9 @@ final class ChatViewModel {
         epoch: Int? = nil
     ) {
         if let epoch, epoch != conversationEpoch { return }
-        setImageDeliveryStatus(
+        applyImageDeliveryEvent(
             messageID: imageMessageID,
-            status: nil,
+            event: .abandoned,
             epoch: conversationEpoch
         )
         if var placeholder = currentMessage(index: placeholderIndex) {
@@ -2649,9 +2676,9 @@ Your previous draft refused the question by claiming you lack real-time access o
                 guard let self else { return }
                 switch event {
                 case .firstToken(let at):
-                    self.setImageDeliveryStatus(
+                    self.applyImageDeliveryEvent(
                         messageID: request.imageMessageID,
-                        status: .accepted,
+                        event: .accepted,
                         epoch: epoch
                     )
                     // The stream says the first generated token landed, on
@@ -2687,9 +2714,9 @@ Your previous draft refused the question by claiming you lack real-time access o
                     capturedPromptTokens = prompt
                     capturedCompletionTokens = completion
                 case .finished(let reason):
-                    self.setImageDeliveryStatus(
+                    self.applyImageDeliveryEvent(
                         messageID: request.imageMessageID,
-                        status: .accepted,
+                        event: .accepted,
                         epoch: epoch
                     )
                     capturedFinish = reason
@@ -2874,12 +2901,11 @@ Your previous draft refused the question by claiming you lack real-time access o
             let imageRejection = request.imageMessageID == nil
                 ? nil
                 : (error as? ChatStreamError)?.attachmentFailureMessage
-            setImageDeliveryStatus(
+            applyImageDeliveryEvent(
                 messageID: request.imageMessageID,
-                // A transient transport/busy/runtime failure does not prove
-                // the attachment was unsupported. Return it to the legacy
-                // unknown state so a later plain follow-up can retry it.
-                status: imageRejection == nil ? nil : .rejected,
+                // A transient transport/busy/runtime failure gets one bounded
+                // implicit retry. A typed rejection is terminal immediately.
+                event: imageRejection == nil ? .transientFailure : .terminalRejection,
                 epoch: epoch
             )
             current.status = .failed

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1105,6 +1105,13 @@ final class ChatViewModel {
     func stopAndPersist() {
         inflight?.cancel()
         guard isStreaming else { return }
+        // App termination snapshots synchronously, before the cancelled
+        // stream task can reach its catch block. No request remains live, so
+        // every `.pending` image delivery is abandoned rather than persisted
+        // as an attachment that can never be inherited again.
+        for index in messages.indices where messages[index].imageDeliveryStatus == .pending {
+            messages[index].imageDeliveryStatus = nil
+        }
         // Finalise through the SHARED cancellation contract before snapshotting.
         // Persisting a message still marked ``.streaming`` writes a turn that
         // reopens after relaunch as a permanent typing indicator, with no live
@@ -2884,6 +2891,11 @@ Your previous draft refused the question by claiming you lack real-time access o
                 self.writeStreamMessage(at: placeholderIndex, epoch: epoch, current)
             }
         } catch where Self.isCancellation(error) {
+            applyImageDeliveryEvent(
+                messageID: request.imageMessageID,
+                event: .abandoned,
+                epoch: epoch
+            )
             // v0.4.29 pin: cancel MUST land as .complete (not .failed)
             // so the half-streamed content the user already saw stays
             // in the transcript with normal styling. Flipping to

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -275,10 +275,10 @@ struct ChatImageAttachmentTests {
             ),
         ]
 
-        ChatViewModel.updateImageDeliveryStatus(
+        ChatViewModel.applyImageDeliveryEvent(
             in: &messages,
             messageID: firstID,
-            status: .rejected
+            event: .terminalRejection
         )
 
         #expect(messages[0].imageDeliveryStatus == .rejected)
@@ -293,34 +293,105 @@ struct ChatImageAttachmentTests {
             ChatMessage(id: id, role: .user, imageDeliveryStatus: .pending)
         ]
 
-        ChatViewModel.updateImageDeliveryStatus(
-            in: &messages, messageID: id, status: .accepted
+        ChatViewModel.applyImageDeliveryEvent(
+            in: &messages, messageID: id, event: .accepted
         )
-        ChatViewModel.updateImageDeliveryStatus(
-            in: &messages, messageID: id, status: .rejected
+        ChatViewModel.applyImageDeliveryEvent(
+            in: &messages, messageID: id, event: .terminalRejection
         )
         #expect(messages[0].imageDeliveryStatus == .accepted)
 
         messages[0].imageDeliveryStatus = .rejected
-        ChatViewModel.updateImageDeliveryStatus(
-            in: &messages, messageID: id, status: .accepted
+        ChatViewModel.applyImageDeliveryEvent(
+            in: &messages, messageID: id, event: .accepted
         )
         #expect(messages[0].imageDeliveryStatus == .accepted)
     }
 
-    @Test("transient pre-token failure leaves an image eligible for a later follow-up")
+    @Test("first transient failure leaves one bounded image retry")
     @MainActor
-    func transientFailureRestoresUnknownDelivery() {
+    func firstTransientFailureAllowsOneRetry() {
         let id = UUID()
         var messages = [
             ChatMessage(id: id, role: .user, imageDeliveryStatus: .pending)
         ]
 
-        ChatViewModel.updateImageDeliveryStatus(
-            in: &messages, messageID: id, status: nil
+        ChatViewModel.applyImageDeliveryEvent(
+            in: &messages, messageID: id, event: .transientFailure
         )
 
-        #expect(messages[0].imageDeliveryStatus == nil)
+        #expect(messages[0].imageDeliveryStatus == .retryable)
+    }
+
+    @Test("cancellation does not spend an image retry")
+    @MainActor
+    func cancellationPreservesRetryableDelivery() {
+        let id = UUID()
+        var messages = [
+            ChatMessage(id: id, role: .user, imageDeliveryStatus: .retryable)
+        ]
+
+        ChatViewModel.applyImageDeliveryEvent(
+            in: &messages, messageID: id, event: .abandoned
+        )
+
+        #expect(messages[0].imageDeliveryStatus == .retryable)
+    }
+
+    @Test("a second terminal image failure quarantines only that image turn")
+    @MainActor
+    func secondTerminalFailureQuarantinesImage() async throws {
+        ImageFailureQuarantineProtocol.reset()
+        let image = try ChatImageAttachment(
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: Data("persistent-failure-photo".utf8)
+        )
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://image-failure")!,
+                session: ImageFailureQuarantineProtocol.session()
+            ),
+            persistsConversations: false
+        )
+
+        model.send(
+            "Describe this",
+            alias: "vision-model",
+            supportsImageInput: true,
+            imageAttachments: [image]
+        )
+        try await Self.waitForStream(model)
+        #expect(model.messages.first?.imageDeliveryStatus != .rejected)
+
+        model.send(
+            "Try that image once more",
+            alias: "vision-model",
+            supportsImageInput: true
+        )
+        try await Self.waitForStream(model)
+        #expect(model.messages.first?.imageDeliveryStatus == .rejected)
+        let secondFailure = try #require(model.messages.last)
+        #expect(secondFailure.status == .failed)
+        #expect(!(secondFailure.errorMessage ?? "").isEmpty)
+        #expect(!(secondFailure.errorMessage ?? "").contains("temporary runtime failure"))
+        #expect(!(secondFailure.errorMessage ?? "").contains("HTTP 500"))
+
+        model.send(
+            "Continue without the image",
+            alias: "vision-model",
+            supportsImageInput: true
+        )
+        try await Self.waitForStream(model)
+
+        let requestBodies = ImageFailureQuarantineProtocol.capturedBodies()
+        try #require(requestBodies.count == 3)
+        let encodedImage = image.data.base64EncodedString()
+        #expect(String(decoding: requestBodies[0], as: UTF8.self).contains(encodedImage))
+        #expect(String(decoding: requestBodies[1], as: UTF8.self).contains(encodedImage))
+        #expect(!String(decoding: requestBodies[2], as: UTF8.self).contains(encodedImage))
+        #expect(model.messages.last?.content == "recovered")
+        #expect(model.messages.last?.status == .complete)
     }
 
     @Test("model-start failure clears pending image delivery before persistence")
@@ -425,6 +496,19 @@ struct ChatImageAttachmentTests {
             from: JSONEncoder().encode(rejected)
         )
         #expect(restored.imageDeliveryStatus == .rejected)
+
+        let retryable = ChatMessage(
+            role: .user,
+            content: "look",
+            imageAttachments: [attachment],
+            imageDeliveryStatus: .retryable
+        )
+        #expect(
+            try JSONDecoder().decode(
+                ChatMessage.self,
+                from: JSONEncoder().encode(retryable)
+            ).imageDeliveryStatus == .retryable
+        )
 
         var legacyObject = try #require(
             JSONSerialization.jsonObject(with: JSONEncoder().encode(rejected)) as? [String: Any]
@@ -712,5 +796,89 @@ struct ChatImageAttachmentTests {
         CGImageDestinationAddImage(destination, image, nil)
         #expect(CGImageDestinationFinalize(destination))
         try (output as Data).write(to: url)
+    }
+
+    @MainActor
+    private static func waitForStream(_ model: ChatViewModel) async throws {
+        // The full Swift suite runs hundreds of MainActor tests in parallel.
+        // Keep a hard bound, but leave enough room for actor scheduling under
+        // that load so this transport test measures behavior, not queue delay.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(30))
+        while model.isStreaming, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(!model.isStreaming, "the canned chat request must finish")
+    }
+}
+
+private final class ImageFailureQuarantineProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var bodies: [Data] = []
+
+    static func reset() {
+        lock.lock()
+        bodies = []
+        lock.unlock()
+    }
+
+    static func capturedBodies() -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return bodies
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ImageFailureQuarantineProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let body = Self.requestBody(from: request)
+        Self.lock.lock()
+        Self.bodies.append(body)
+        let requestNumber = Self.bodies.count
+        Self.lock.unlock()
+
+        let statusCode = requestNumber <= 2 ? 500 : 200
+        let contentType = requestNumber <= 2 ? "application/json" : "text/event-stream"
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": contentType]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let responseBody = requestNumber <= 2
+            ? Data(#"{"error":{"message":"temporary runtime failure","type":"server_error"}}"#.utf8)
+            : Data("""
+                data: {"choices":[{"delta":{"content":"recovered"},"finish_reason":"stop"}]}
+
+                data: [DONE]
+
+                """.utf8)
+        client?.urlProtocol(self, didLoad: responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func requestBody(from request: URLRequest) -> Data {
+        guard let stream = request.httpBodyStream else { return request.httpBody ?? Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while true {
+            let count = buffer.withUnsafeMutableBufferPointer { pointer in
+                stream.read(pointer.baseAddress!, maxLength: pointer.count)
+            }
+            if count > 0 { data.append(buffer, count: count) }
+            if count == 0 { return data }
+            if count < 0 { return Data() }
+        }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -338,6 +338,40 @@ struct ChatImageAttachmentTests {
         #expect(messages[0].imageDeliveryStatus == .retryable)
     }
 
+    @Test("stopping an in-flight image request restores its unused retry")
+    @MainActor
+    func streamCancellationClearsPendingDelivery() async throws {
+        ImageCancellationProtocol.reset()
+        let image = try ChatImageAttachment(
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: Data("cancelled-photo".utf8)
+        )
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://image-cancellation")!,
+                session: ImageCancellationProtocol.session()
+            ),
+            persistsConversations: false
+        )
+
+        model.send(
+            "Describe this",
+            alias: "vision-model",
+            supportsImageInput: true,
+            imageAttachments: [image]
+        )
+        try await Self.waitUntil { ImageCancellationProtocol.didStart }
+        #expect(model.messages.first?.imageDeliveryStatus == .pending)
+
+        model.stop()
+        try await Self.waitForStream(model)
+
+        #expect(ImageCancellationProtocol.didStop)
+        #expect(model.messages.first?.imageDeliveryStatus == nil)
+        #expect(model.messages.last?.status == .complete)
+    }
+
     @Test("a second terminal image failure quarantines only that image turn")
     @MainActor
     func secondTerminalFailureQuarantinesImage() async throws {
@@ -808,6 +842,63 @@ struct ChatImageAttachmentTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         try #require(!model.isStreaming, "the canned chat request must finish")
+    }
+
+    @MainActor
+    private static func waitUntil(_ condition: () -> Bool) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(30))
+        while !condition(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(condition(), "the canned transport event must arrive")
+    }
+}
+
+private final class ImageCancellationProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var started = false
+    nonisolated(unsafe) private static var stopped = false
+
+    static var didStart: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return started
+    }
+
+    static var didStop: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    static func reset() {
+        lock.lock()
+        started = false
+        stopped = false
+        lock.unlock()
+    }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ImageCancellationProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.started = true
+        Self.lock.unlock()
+        // Intentionally never answer. Cancelling ChatViewModel's in-flight
+        // task must cancel URLSession and route through the real catch path.
+    }
+
+    override func stopLoading() {
+        Self.lock.lock()
+        Self.stopped = true
+        Self.lock.unlock()
     }
 }
 


### PR DESCRIPTION
## Why

An image-bearing chat turn that received an untyped server failure stayed eligible for inheritance forever. A user could then send unrelated text and repeatedly resend the same broken image, wedging every later turn.

Fixes #2455

## What

- persist a retryable attachment-delivery state on the exact image-bearing message
- allow one plain-text follow-up to retry that image, then quarantine it after the second pre-token untyped failure
- preserve immediate quarantine for typed attachment rejections
- avoid spending the retry allowance on cancellation or model-start failure
- keep direct Retry able to recover an image after a later successful response

## Scope

The attachment delivery state machine, follow-up inheritance gate, and focused behavior/serialization tests only.

## Non-goals

- no engine or wire-protocol changes
- no model-name inference
- no telemetry, error-copy, or attachment UI redesign
- no changes to retry behavior for text-only turns

## Design precedent

Mature chat clients keep failed media scoped to the originating message and distinguish retryable transport failures from terminal attachment rejection. This change adapts that finite-state lifecycle so an unrelated later text turn cannot inherit a permanently failing image, while preserving one bounded recovery attempt and explicit user Retry.

## Verification

- reproduced pre-fix with a real `ChatViewModel` → `ChatStreamClient` HTTP sequence: two 500 responses followed by a successful SSE response; the third text request incorrectly still contained the image
- `swift test --filter ChatImageAttachmentTests` — 29/29 passed
- `swift test --no-parallel` — 3028 tests in 254 suites passed on exact head
- `swift build -c release` — passed
- `gui-golden-flows.sh --flow chat-multimodal-attachments` — passed against the exact-head app bundle
- request-level regression proves image present on requests 1–2, absent on request 3, and request 3 completes with text

The full parallel Swift suite also exercised this regression successfully; its remaining failure is an unrelated existing 3-second MainActor timeout in `DeferredTelemetryConsentWiringTests`. The full serial suite is green.
