### PR TITLE
fix(engine): preserve Flash-Next MTP cache on prefix hits

### DIFF
--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1176,6 +1176,56 @@ def test_qwen4_state_cache_restores_atomic_slot_boundary():
     np.testing.assert_array_equal(np.array(cache.cache[1]), np.array([2]))
 
 
+def test_qwen4_state_cache_preserves_type_across_prefix_cache_lifecycle(tmp_path):
+    """A cache hit must retain the rollback API required by native MTP."""
+    from vllm_mlx.memory_cache import (
+        MemoryAwarePrefixCache,
+        MemoryCacheConfig,
+        _load_prompt_cache_compat,
+        _save_prompt_cache_compat,
+    )
+    from vllm_mlx.scheduler import Scheduler
+
+    first = Qwen4ExpStateCache(size=2)
+    first.cache = [mx.array([[1.0]]), mx.array([[2.0]])]
+    second = Qwen4ExpStateCache(size=2)
+    second.cache = [mx.array([[3.0]]), mx.array([[4.0]])]
+
+    batched = Qwen4ExpStateCache.merge([first, second])
+    extracted = batched.extract(0)
+    assert isinstance(extracted, Qwen4ExpStateCache)
+    extracted.record_slot_snapshots(0, [mx.array([1.0])])
+    extracted.record_slot_snapshots(1, [mx.array([2.0])], finalize=True)
+    extracted.rollback_state = None
+
+    memory_cache = MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(
+            max_memory_mb=64,
+            max_entries=4,
+            hybrid_reuse_max_entries=4,
+        ),
+    )
+    assert memory_cache.store([1, 2], [extracted])
+    fetched, remaining = memory_cache.fetch([1, 2, 3])
+    assert remaining == [3]
+    assert fetched is not None
+    assert isinstance(fetched[0], Qwen4ExpStateCache)
+
+    scheduler = Scheduler.__new__(Scheduler)
+    states = scheduler._extract_cache_states(fetched)
+    reconstructed = scheduler._reconstruct_cache_from_states(states)
+    assert reconstructed is not None
+    assert isinstance(reconstructed[0], Qwen4ExpStateCache)
+
+    path = tmp_path / "qwen4-state.safetensors"
+    _save_prompt_cache_compat(str(path), reconstructed, metadata={})
+    persisted = _load_prompt_cache_compat(str(path))
+    assert isinstance(persisted[0], Qwen4ExpStateCache)
+    persisted[0].record_slot_snapshots(0, [mx.array([1.0])])
+    persisted[0].record_slot_snapshots(1, [mx.array([2.0])], finalize=True)
+
+
 def test_qwen4_state_cache_rejects_incomplete_or_invalid_boundaries():
     cache = Qwen4ExpStateCache(size=2)
     cache.cache = [mx.array([1]), mx.array([2])]

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1192,8 +1192,12 @@ def test_qwen4_state_cache_preserves_type_across_prefix_cache_lifecycle(tmp_path
     second.cache = [mx.array([[3.0]]), mx.array([[4.0]])]
 
     batched = Qwen4ExpStateCache.merge([first, second])
+    batched.left_padding = mx.array([0, 3])
+    batched.lengths = mx.array([5, 2])
     extracted = batched.extract(0)
     assert isinstance(extracted, Qwen4ExpStateCache)
+    np.testing.assert_array_equal(np.array(extracted.left_padding), np.array([0]))
+    np.testing.assert_array_equal(np.array(extracted.lengths), np.array([5]))
     extracted.record_slot_snapshots(0, [mx.array([1.0])])
     extracted.record_slot_snapshots(1, [mx.array([2.0])], finalize=True)
     extracted.rollback_state = None

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -69,7 +69,7 @@ def _vendored_cache_registry() -> dict[str, type]:
         DeepseekV4PoolingCache,
         PoolingCache,
     )
-    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache
+    from vllm_mlx.models.qwen4_exp_cache import QSAIndexCache, Qwen4ExpStateCache
 
     classes = (
         PoolingCache,
@@ -77,6 +77,7 @@ def _vendored_cache_registry() -> dict[str, type]:
         DeepseekV4PoolingCache,
         BatchDeepseekV4PoolingCache,
         QSAIndexCache,
+        Qwen4ExpStateCache,
     )
     return {cls.__name__: cls for cls in classes}
 

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -30,12 +30,12 @@ from mlx_lm.models.base import (  # noqa: E402
     create_ssm_mask,
     scaled_dot_product_attention,
 )
-from mlx_lm.models.cache import ArraysCache, CacheList, KVCache  # noqa: E402
+from mlx_lm.models.cache import CacheList, KVCache  # noqa: E402
 from mlx_lm.models.gated_delta import gated_delta_update  # noqa: E402
 from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
-from .qwen4_exp_cache import QSAIndexCache  # noqa: E402
+from .qwen4_exp_cache import QSAIndexCache, Qwen4ExpStateCache  # noqa: E402
 
 
 @dataclass
@@ -1414,63 +1414,6 @@ class Qwen4ExpTextModel(nn.Module):
             )
         output = self.hyper_connection_mixer(hidden_states)
         return (output, hidden_states) if return_hidden else output
-
-
-class Qwen4ExpStateCache(ArraysCache):
-    """Recurrent Qwen4 state with speculative-verify restore points.
-
-    The four-slot PLE layer cache couples GDN convolution/state with PLE
-    convolution/ngram history.  A rejected speculative token must restore all
-    four slots to the same accepted boundary; restoring GDN alone silently
-    desynchronizes later PLE inputs.
-    """
-
-    rollback_state: list[list[mx.array | None]] | None = None
-    _rollback_slots: dict[int, list[mx.array]] | None = None
-
-    def record_slot_snapshots(
-        self,
-        slot: int,
-        snapshots: list[mx.array],
-        *,
-        finalize: bool = False,
-    ) -> None:
-        """Stage per-position recurrent state and publish atomic boundaries."""
-        if not snapshots:
-            return
-        if self._rollback_slots is None:
-            self._rollback_slots = {}
-        self._rollback_slots[slot] = snapshots
-        if not finalize:
-            return
-        expected_slots = set(range(len(self.cache)))
-        if set(self._rollback_slots) != expected_slots:
-            raise AssertionError(
-                "Qwen4 speculative cache snapshots do not cover every state slot"
-            )
-        lengths = {len(items) for items in self._rollback_slots.values()}
-        if len(lengths) != 1:
-            raise AssertionError("Qwen4 speculative cache snapshot lengths diverged")
-        count = lengths.pop()
-        self.rollback_state = [
-            [self._rollback_slots[slot][position] for slot in range(len(self.cache))]
-            for position in range(count)
-        ]
-        self._rollback_slots = None
-
-    def restore_rollback(self, n_to_drop: int, verify_size: int) -> None:
-        snapshots = self.rollback_state
-        if not snapshots:
-            raise AssertionError("Qwen4 verify rollback has no saved boundary")
-        keep = verify_size - n_to_drop
-        if keep < 1 or keep > len(snapshots):
-            raise AssertionError(
-                f"invalid Qwen4 rollback boundary: keep={keep}, "
-                f"snapshots={len(snapshots)}"
-            )
-        self.cache = list(snapshots[keep - 1])
-        self.rollback_state = None
-        self._rollback_slots = None
 
 
 class TextModel(nn.Module):

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Qwen4-Exp QSA side cache for the MLX text decoder.
+"""Qwen4-Exp cache types for the MLX text decoder.
 
 The cache follows the engine request-lifecycle contract: a fixed raw-key ring
 feeds one compressed key per complete group, while the compressed cache is
@@ -20,6 +20,79 @@ from .. import _mlx_compat as _mlx_compat
 _mlx_compat.install()
 
 from mlx_lm.models.cache import ArraysCache  # noqa: E402
+
+
+class Qwen4ExpStateCache(ArraysCache):
+    """Recurrent Qwen4 state with speculative-verify restore points.
+
+    The four-slot PLE layer cache couples GDN convolution/state with PLE
+    convolution/ngram history. A rejected speculative token must restore all
+    four slots to the same accepted boundary; restoring GDN alone silently
+    desynchronizes later PLE inputs.
+
+    ``ArraysCache.extract`` constructs the base class explicitly. Override it
+    here so continuous batching and prefix-cache reuse retain this cache's
+    atomic rollback contract when a single request leaves a batch.
+    """
+
+    rollback_state: list[list[mx.array | None]] | None = None
+    _rollback_slots: dict[int, list[mx.array]] | None = None
+
+    def extract(self, idx):
+        cache = type(self)(len(self.cache))
+        cache.cache = [
+            None if item is None else mx.contiguous(item[idx : idx + 1])
+            for item in self.cache
+        ]
+        if self.left_padding is not None:
+            cache.left_padding = mx.contiguous(self.left_padding[idx : idx + 1])
+        if self.lengths is not None:
+            cache.lengths = mx.contiguous(self.lengths[idx : idx + 1])
+        return cache
+
+    def record_slot_snapshots(
+        self,
+        slot: int,
+        snapshots: list[mx.array],
+        *,
+        finalize: bool = False,
+    ) -> None:
+        """Stage per-position recurrent state and publish atomic boundaries."""
+        if not snapshots:
+            return
+        if self._rollback_slots is None:
+            self._rollback_slots = {}
+        self._rollback_slots[slot] = snapshots
+        if not finalize:
+            return
+        expected_slots = set(range(len(self.cache)))
+        if set(self._rollback_slots) != expected_slots:
+            raise AssertionError(
+                "Qwen4 speculative cache snapshots do not cover every state slot"
+            )
+        lengths = {len(items) for items in self._rollback_slots.values()}
+        if len(lengths) != 1:
+            raise AssertionError("Qwen4 speculative cache snapshot lengths diverged")
+        count = lengths.pop()
+        self.rollback_state = [
+            [self._rollback_slots[slot][position] for slot in range(len(self.cache))]
+            for position in range(count)
+        ]
+        self._rollback_slots = None
+
+    def restore_rollback(self, n_to_drop: int, verify_size: int) -> None:
+        snapshots = self.rollback_state
+        if not snapshots:
+            raise AssertionError("Qwen4 verify rollback has no saved boundary")
+        keep = verify_size - n_to_drop
+        if keep < 1 or keep > len(snapshots):
+            raise AssertionError(
+                f"invalid Qwen4 rollback boundary: keep={keep}, "
+                f"snapshots={len(snapshots)}"
+            )
+        self.cache = list(snapshots[keep - 1])
+        self.rollback_state = None
+        self._rollback_slots = None
 
 
 class QSAIndexCache(ArraysCache):


### PR DESCRIPTION
## Why

Flash-Next with native MTP completes a cold long-context turn, but the next growing turn aborts immediately after a successful prefix-cache hit because batching downgraded the Qwen4 recurrent cache to a plain base cache.

Fixes #2586.

## Scope

- Preserve the Qwen4 recurrent cache subtype when continuous batching extracts one request.
- Register that subtype for prefix-cache state reconstruction and disk persistence.
- Cover batch extraction, in-memory prefix fetch, scheduler reconstruction, persistence, and the MTP rollback API in one regression.

## Non-goals

- No speculative-decoding policy or default changes.
- No cache eviction, quantization, scheduler, model-weight, or performance tuning changes.
- No behavior changes for other model families.

## Acceptance

- A prefix-extension hit retains the Qwen4 atomic rollback API used by native MTP.
- In-memory and persisted cache round trips preserve the cache subtype.
- Existing Flash-Next model, MTP, hybrid-cache, and persistence tests remain green.
- A real growing 32K user turn reuses the cached prefix and completes.

## Design precedent

The fix follows the established cache lifecycle contract: model-specific cache types own their batch extraction behavior, while the shared cache registry reconstructs those types from serialized state. This keeps model semantics at the cache boundary rather than adding a scheduler special case.

## Verification

- `python3.12 -m ruff format --check vllm_mlx/models/qwen4_exp.py vllm_mlx/models/qwen4_exp_cache.py vllm_mlx/memory_cache.py tests/test_qwen4_exp_vendored.py`
- `python3.12 -m ruff check vllm_mlx/models/qwen4_exp.py vllm_mlx/models/qwen4_exp_cache.py vllm_mlx/memory_cache.py tests/test_qwen4_exp_vendored.py`
- `python3.12 -m pytest -q tests/test_qwen4_exp_vendored.py tests/test_prefix_cache_persistence.py tests/test_hybrid_prefix_cache_growth.py tests/test_mtp_spec_decode.py` — 332 passed
- Regression test confirmed against the pre-fix extraction behavior: the base cache lacks `record_slot_snapshots`.
- Real MTP growing-turn validation: a 2,012-token cold turn completed coherently; the next 2,061-token turn reported `cached_tokens=2,035`, answered `5` correctly, and completed in 0.341 s without a rollback exception.
- Real 32K lifecycle validation: a 32,720-token cold turn completed coherently; the growing 32,806-token turn reported `cached_tokens=32,779` and completed without the pre-fix crash.
- The same run exposed a separate current-main long-request lifecycle defect, tracked in #2591. Exact-main A/B reproduces it with MTP and prefix caching both disabled, so it is not caused by this diff.

## Behaviour delta

Flash-Next MTP after a prefix-cache hit: aborts after the first few tokens → retains its rollback-capable recurrent cache and continues generation.

## AI assistance disclosure

Codex implemented and reviewed the four touched files. The change was verified with focused lifecycle, persistence, hybrid-cache, and MTP tests; exact-head review and user-path validation are required before queueing.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
- [x] The regression fails at the production extraction seam without the fix
- [x] Updated README/docs if applicable (not applicable)
- [x] No breaking changes to existing API

## Author



