### PR TITLE
fix(mac): defer dictation restart until the next hotkey

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -356,8 +356,8 @@ final class DictationController {
             cancelModelPreparation()
             // Preserve the user's Enabled intent, but publish a terminal
             // non-ready phase. Keep the feature-owned event tap registered:
-            // foreground revalidation or a later server transition can retry
-            // the model without asking the user to arm dictation by hand.
+            // the next explicit hotkey press or a later server transition can
+            // retry the model without asking the user to arm dictation again.
             phase = .off
         }
     }
@@ -447,10 +447,10 @@ final class DictationController {
     }
 
     @discardableResult
-    private func registerHotkey() -> Bool {
+    private func registerHotkey(phaseOnSuccess: Phase = .idle) -> Bool {
         guard !isHotkeyArmed else {
             lastError = nil
-            phase = .idle
+            phase = phaseOnSuccess
             return true
         }
         guard testingHotkeyStart?() ?? hotkey.start() else {
@@ -468,7 +468,7 @@ final class DictationController {
         accessibilityNeedsRelaunch = false
         isHotkeyArmed = true
         lastError = nil
-        phase = .idle
+        phase = phaseOnSuccess
         return true
     }
 
@@ -561,10 +561,15 @@ final class DictationController {
             return
         }
         // Returning to the app is also when a permission granted elsewhere
-        // becomes usable, so a session that failed to arm gets another try
-        // rather than staying dead until the switch is cycled by hand.
-        guard phase != .off else {
-            Task { await enable() }
+        // becomes usable, so a session that failed to arm gets another try.
+        // Keep that repair separate from model residency: foregrounding Rapid
+        // after Stop or a crash is not consent to launch an audio sidecar.
+        if phase == .off {
+            if isHotkeyArmed {
+                hotkey.reEnableIfDisabled()
+            } else {
+                _ = registerHotkey(phaseOnSuccess: .off)
+            }
             return
         }
         // A foreground activation must never sneak the event tap back in
@@ -803,7 +808,16 @@ final class DictationController {
                 self.beginRecordingRequestID = nil
             }
         case .starting, .recording: finishRecording()
-        case .preparingModel, .transcribing, .off: break
+        case .off:
+            // A terminal server state leaves the user's shortcut armed but
+            // releases its model. Only this explicit action owns loading it
+            // again; app activation merely repairs the event tap.
+            guard isEnabled else { return }
+            phase = .preparingModel
+            Task { [weak self] in
+                await self?.enable(replacingCurrentPrewarm: true)
+            }
+        case .preparingModel, .transcribing: break
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -134,7 +134,7 @@ struct DictationView: View {
         }
         if controller.phase == .off {
             return controller.isHotkeyArmed
-                ? "Listening paused — reconnecting the speech model"
+                ? "Listening paused — press \(controller.trigger.label) to reconnect"
                 : "Not listening — the hotkey isn't armed"
         }
         return "Listening — press \(controller.trigger.label) in any app"
@@ -151,7 +151,7 @@ struct DictationView: View {
         }
         if controller.phase == .off {
             return controller.lastError
-                ?? "Rapid will reconnect the speech model automatically."
+                ?? "Rapid will load \(controller.modelAlias) when you next use dictation."
         }
         var parts = [controller.modelAlias]
         if let latency = controller.lastLatency {

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -182,8 +182,8 @@ struct AudioCatalogTests {
         #expect(!source.contains("Dictation.Arm"))
         #expect(source.contains("controller.isHotkeyArmed"))
         #expect(source.contains("Listening — press"))
-        #expect(source.contains("Listening paused — reconnecting the speech model"))
-        #expect(source.contains("Rapid will reconnect the speech model automatically."))
+        #expect(source.contains("Listening paused — press \\(controller.trigger.label) to reconnect"))
+        #expect(source.contains("Rapid will load \\(controller.modelAlias) when you next use dictation."))
     }
 
     @Test("parser extracts audio rows and preserves subtype, family, size, and repo")

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -476,14 +476,14 @@ struct DictationTests {
     }
 
     @MainActor
-    @Test("failed chat-model switch leaves enabled dictation retryable")
-    func failedChatModelSwitchIsRetryable() async {
-        var warmupContinuation: CheckedContinuation<Bool, Never>?
+    @Test("foreground after a terminal server state waits for the next dictation hotkey")
+    func terminalServerStateDoesNotPrewarmOnForeground() async {
+        var prewarmCount = 0
         var hotkeyStartCount = 0
         let controller = readinessController(
-            phase: .idle,
             prewarm: {
-                await withCheckedContinuation { warmupContinuation = $0 }
+                prewarmCount += 1
+                return true
             },
             hotkeyStart: {
                 hotkeyStartCount += 1
@@ -491,22 +491,64 @@ struct DictationTests {
             }
         )
 
-        controller.serverStateDidChange(.starting(alias: "lfm2.5-1b-4bit"))
-        controller.serverStateDidChange(.crashed(
-            alias: "lfm2.5-1b-4bit",
-            message: "fixture failure"
-        ))
-        #expect(controller.isEnabled)
-        #expect(controller.phase == .off)
-        #expect(hotkeyStartCount == 0)
+        await controller.enable()
+        #expect(controller.phase == .idle)
+        #expect(controller.isHotkeyArmed)
+        #expect(prewarmCount == 1)
+        #expect(hotkeyStartCount == 1)
+
+        let terminalStates: [ServerState] = [
+            .stopped,
+            .crashed(alias: "lfm2.5-1b-4bit", message: "fixture failure"),
+        ]
+        for state in terminalStates {
+            controller.serverStateDidChange(state)
+            #expect(controller.isEnabled)
+            #expect(controller.phase == .off)
+            #expect(controller.isHotkeyArmed)
+
+            let beforeForeground = prewarmCount
+            controller.revalidate()
+            await waitUntil(timeout: .milliseconds(100)) {
+                prewarmCount > beforeForeground
+            }
+
+            #expect(prewarmCount == beforeForeground)
+            #expect(controller.phase == .off)
+            #expect(controller.isHotkeyArmed)
+
+            controller.toggleFromUI()
+            await waitUntil { controller.phase == .idle }
+            #expect(prewarmCount == beforeForeground + 1)
+            #expect(controller.phase == .idle)
+            #expect(controller.isHotkeyArmed)
+            #expect(hotkeyStartCount == 1)
+        }
+    }
+
+    @MainActor
+    @Test("foreground permission recovery arms only the hotkey")
+    func foregroundPermissionRecoveryDoesNotPrewarm() async {
+        var prewarmCount = 0
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
 
         controller.revalidate()
-        while warmupContinuation == nil { await Task.yield() }
-        #expect(controller.phase == .preparingModel)
-        warmupContinuation?.resume(returning: true)
-        await waitUntil { controller.phase == .idle }
-        #expect(controller.phase == .idle)
+        await waitUntil(timeout: .milliseconds(100)) { prewarmCount > 0 }
+
+        #expect(prewarmCount == 0)
         #expect(hotkeyStartCount == 1)
+        #expect(controller.phase == .off)
+        #expect(controller.isHotkeyArmed)
     }
 
     @MainActor

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5434,7 +5434,7 @@ flow_dictation() {
     done
     [[ "$listening_after_relaunch" == 1 ]] \
         || die "Dictation did not finish restoring after relaunch"
-    local crash_pid crash_command starts_before_foreground
+    local crash_pid crash_command audio_starts_before_foreground
     crash_pid="$(jq -rs 'map(select(.event == "server_started" and .alias == "fake-alias"))
                          | last | .pid // empty' "$OUT/fake-events.jsonl")"
     [[ "$crash_pid" =~ ^[0-9]+$ ]] || die "Dictation crash fixture has no owned sidecar pid"
@@ -5442,7 +5442,8 @@ flow_dictation() {
     [[ "$crash_command" == *"serve fake-alias"* ]] \
         || die "Dictation crash fixture refused to signal an unowned process"
     local paused_seen=0
-    starts_before_foreground="$(jq -rs 'map(select(.event == "server_started")) | length' \
+    audio_starts_before_foreground="$(jq -rs \
+        'map(select(.event == "server_started" and .alias == "fake-whisper-small")) | length' \
         "$OUT/fake-events.jsonl")"
     osascript - "$APP_PID" > "$OUT/dictation-background.json" <<'APPLESCRIPT'
 on run argv
@@ -5462,9 +5463,6 @@ on run argv
     return "{\"success\":true,\"method\":\"frontmost-after-crash\"}"
 end run
 APPLESCRIPT
-    [[ "$(jq -rs 'map(select(.event == "server_started")) | length' \
-            "$OUT/fake-events.jsonl")" == "$starts_before_foreground" ]] \
-        || die "Foreground activation silently restarted a Dictation sidecar"
     for ((i=0; i<10; i++)); do
         see_main "$OUT/dictation-after-foreground.json"
         if jq -e '.data.ui_elements[]?
@@ -5478,6 +5476,17 @@ APPLESCRIPT
     done
     [[ "$paused_seen" == 1 ]] \
         || die "Foreground activation hid the explicit Dictation reconnect action"
+    # Observe beyond the activation itself instead of taking one instant
+    # sample. The expected chat auto-respawn may start fake-alias during this
+    # window; only a transcription-owned process proves the foreground path
+    # restarted Dictation behind the user's back.
+    for ((i=0; i<60; i++)); do
+        [[ "$(jq -rs \
+                'map(select(.event == "server_started" and .alias == "fake-whisper-small")) | length' \
+                "$OUT/fake-events.jsonl")" == "$audio_starts_before_foreground" ]] \
+            || die "Foreground activation silently restarted a Dictation sidecar"
+        sleep 0.05
+    done
 
     log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, relaunch, preserved chat, and foreground-after-crash produced effects"
     log "  dictation OK"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5416,7 +5416,70 @@ flow_dictation() {
     [[ "$(element_field "$OUT/dictation-relaunch-audio.json" Dictation.Enable value)" == "1" ]] \
         || die "Relaunch disabled the user's persisted Dictation intent"
 
-    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, relaunch, and preserved chat produced effects"
+    # A crashed process releases its mounted speech lane. Moving away from
+    # Rapid and returning must repair only the global input tap; app activation
+    # must not race the server's bounded crash recovery by launching an
+    # audio-only sidecar. The pane stays honest about the next user action.
+    local listening_after_relaunch=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/dictation-relaunch-ready.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Dictation.Status"
+                           and (((.description // .value // .label // "") | tostring)
+                                | startswith("Listening — press")))' \
+                 "$OUT/dictation-relaunch-ready.json" >/dev/null; then
+            listening_after_relaunch=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$listening_after_relaunch" == 1 ]] \
+        || die "Dictation did not finish restoring after relaunch"
+    local crash_pid crash_command starts_before_foreground
+    crash_pid="$(jq -rs 'map(select(.event == "server_started" and .alias == "fake-alias"))
+                         | last | .pid // empty' "$OUT/fake-events.jsonl")"
+    [[ "$crash_pid" =~ ^[0-9]+$ ]] || die "Dictation crash fixture has no owned sidecar pid"
+    crash_command="$(ps -p "$crash_pid" -o command= 2>/dev/null || true)"
+    [[ "$crash_command" == *"serve fake-alias"* ]] \
+        || die "Dictation crash fixture refused to signal an unowned process"
+    local paused_seen=0
+    starts_before_foreground="$(jq -rs 'map(select(.event == "server_started")) | length' \
+        "$OUT/fake-events.jsonl")"
+    osascript - "$APP_PID" > "$OUT/dictation-background.json" <<'APPLESCRIPT'
+on run argv
+    tell application "Finder" to activate
+    delay 0.2
+    return "{\"success\":true,\"method\":\"finder\"}"
+end run
+APPLESCRIPT
+    kill "$crash_pid"
+    osascript - "$APP_PID" > "$OUT/dictation-foreground.json" <<'APPLESCRIPT'
+on run argv
+    set targetPID to (item 1 of argv) as integer
+    tell application "System Events"
+        set frontmost of first application process whose unix id is targetPID to true
+    end tell
+    delay 0.5
+    return "{\"success\":true,\"method\":\"frontmost-after-crash\"}"
+end run
+APPLESCRIPT
+    [[ "$(jq -rs 'map(select(.event == "server_started")) | length' \
+            "$OUT/fake-events.jsonl")" == "$starts_before_foreground" ]] \
+        || die "Foreground activation silently restarted a Dictation sidecar"
+    for ((i=0; i<10; i++)); do
+        see_main "$OUT/dictation-after-foreground.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Dictation.Status"
+                           and (((.description // .value // .label // "") | tostring)
+                                | startswith("Listening paused — press")))' \
+                 "$OUT/dictation-after-foreground.json" >/dev/null; then
+            paused_seen=1; break
+        fi
+        sleep 0.05
+    done
+    [[ "$paused_seen" == 1 ]] \
+        || die "Foreground activation hid the explicit Dictation reconnect action"
+
+    log "  setup controls, privacy toggle, vocabulary, co-loaded warmup, relaunch, preserved chat, and foreground-after-crash produced effects"
     log "  dictation OK"
     cleanup_persona
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5441,7 +5441,7 @@ flow_dictation() {
     crash_command="$(ps -p "$crash_pid" -o command= 2>/dev/null || true)"
     [[ "$crash_command" == *"serve fake-alias"* ]] \
         || die "Dictation crash fixture refused to signal an unowned process"
-    local paused_seen=0
+    local terminal_seen=0 paused_seen=0
     audio_starts_before_foreground="$(jq -rs \
         'map(select(.event == "server_started" and .alias == "fake-whisper-small")) | length' \
         "$OUT/fake-events.jsonl")"
@@ -5453,6 +5453,19 @@ on run argv
 end run
 APPLESCRIPT
     kill "$crash_pid"
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/dictation-crashed-background.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Dictation.Status"
+                           and (((.description // .value // .label // "") | tostring)
+                                | startswith("Listening paused — press")))' \
+                 "$OUT/dictation-crashed-background.json" >/dev/null; then
+            terminal_seen=1; break
+        fi
+        sleep 0.05
+    done
+    [[ "$terminal_seen" == 1 ]] \
+        || die "Dictation did not observe the crashed sidecar before foreground activation"
     osascript - "$APP_PID" > "$OUT/dictation-foreground.json" <<'APPLESCRIPT'
 on run argv
     set targetPID to (item 1 of argv) as integer

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -302,9 +302,10 @@ def test_dictation_journey_proves_loading_before_ready():
     assert '.event == "audio_transcription"' in flow
     # The status filter used to read readiness text off a control description.
     assert '(.description // .value // .label // "")' in flow
-    # The two required observed states feed the executable failure helper;
-    # later lifecycle checks are allowed to observe additional states.
-    assert flow.count('select(.identifier == "Dictation.Status"') >= 2
+    # Pin the two required predicates themselves. A later lifecycle assertion
+    # cannot keep this contract green if either loading or ready disappears.
+    assert 'contains("Loading fake-whisper-small into memory")' in flow
+    assert 'startswith("Listening — press")' in flow
     assert 'require_observed_phase "$loading_seen" loading' in flow
     assert 'require_observed_phase "$ready_seen" listening' in flow
 

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -288,10 +288,11 @@ def test_dictation_journey_proves_loading_before_ready():
 
     The fixture keeps a fake STT probe open long enough to observe both
     state transitions. Previously the two `die` message strings were pinned;
-    the stable guarantee is that the flow asserts *two* independent
+    the stable guarantee is that the flow asserts at least two independent
     `Dictation.Status` outcome predicates — a Loading phase and a
     Listening/ready phase — via the shared ``.description // .value // .label``
-    status filter, plus the behavioural warmup probe.
+    status filter, plus the behavioural warmup probe. Later lifecycle checks
+    may add more status predicates without weakening that guarantee.
     """
     flow = _harness_flow_body("flow_dictation")
 
@@ -301,8 +302,9 @@ def test_dictation_journey_proves_loading_before_ready():
     assert '.event == "audio_transcription"' in flow
     # The status filter used to read readiness text off a control description.
     assert '(.description // .value // .label // "")' in flow
-    # Two distinct observed states feed the executable failure helper.
-    assert flow.count('select(.identifier == "Dictation.Status"') == 2
+    # The two required observed states feed the executable failure helper;
+    # later lifecycle checks are allowed to observe additional states.
+    assert flow.count('select(.identifier == "Dictation.Status"') >= 2
     assert 'require_observed_phase "$loading_seen" loading' in flow
     assert 'require_observed_phase "$ready_seen" listening' in flow
 


### PR DESCRIPTION
## Summary

- keep app activation limited to repairing the global dictation hotkey
- load a released speech model only after the user's next dictation hotkey press
- replace the inaccurate automatic-reconnect copy with the explicit next action
- cover stopped/crashed states, permission recovery, and the foreground-after-crash GUI journey

## Root cause

`DictationController.revalidate()` treated an enabled `.off` phase as a request
to run the full `enable()` path. After the chat process stopped or crashed,
bringing Rapid to the foreground therefore loaded an audio sidecar even though
the user had not started dictation.

The controller now keeps event-tap readiness and model residency separate.
Foreground activation may register or re-enable the hotkey, while the `.off`
hotkey action owns model preparation. Chat-process replacement still restores
an enabled voice lane as before.

## User proof

The `dictation` GUI golden journey now enables and warms dictation, relaunches
the app, crashes the owned fake chat sidecar while Rapid is in the background,
then foregrounds Rapid. It proves no additional sidecar starts and the visible
status remains `Listening paused — press … to reconnect`.

## Verification

- `./scripts/desktop-test-timeout.sh` — 3,033 passed
- focused Dictation + Audio catalog suites — 62 passed
- GUI harness contracts — 66 passed
- `SKIP_SIDECAR=1 SKIP_BUNDLED_MODEL=1 ./scripts/build.sh`
- `./scripts/gui-golden-flows.sh --flow dictation --keep` — PASS
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`

## Design precedent

Mature desktop voice-input flows start recording and on-demand model loading
from an explicit microphone or hotkey action. Keeping a voice model resident is
an opt-in preference, not a side effect of window activation. This change
adapts that separation to Rapid: activation maintains the input listener; the
user gesture owns heavyweight model work.

## Scope

This PR changes only the Desktop dictation foreground/server lifecycle, its
paused-state copy, and directly corresponding unit/GUI coverage. It does not
change engine protocol, memory policy, speech payloads, or general crash
recovery.

Fixes #2459
