### PR TITLE
fix(qsa): materialize batched index keys before cache commit

### DIFF
--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -12,6 +12,7 @@ pytest.importorskip("mlx_lm")
 from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 
 import vllm_mlx.models.qwen4_exp as qwen4_exp
+import vllm_mlx.models.qwen4_exp_cache as qwen4_exp_cache
 from scripts import qwen38_streaming_convert as converter
 from scripts.qwen38_streaming_convert import quantized_tensor_names
 from vllm_mlx.models.qwen4_exp import (
@@ -581,6 +582,35 @@ def test_qsa_cache_vectorized_chunks_and_scalar_tail_keep_identical_state():
         np.testing.assert_array_equal(
             np.array(scalar.compressed_keys), np.array(vectorized.compressed_keys)
         )
+
+
+def test_qsa_cache_materializes_vector_transform_before_persistent_write(monkeypatch):
+    evaluated = []
+    produced = []
+    real_eval = mx.eval
+
+    def recording_eval(*arrays):
+        evaluated.append(arrays)
+        return real_eval(*arrays)
+
+    def transform(group, start):
+        return group + start
+
+    def transform_many(groups, starts):
+        transformed = groups + starts[None, :, None]
+        produced.append(transformed)
+        return transformed
+
+    monkeypatch.setattr(qwen4_exp_cache.mx, "eval", recording_eval)
+    cache = QSAIndexCache(compress_ratio=2)
+    cache.update(
+        mx.arange(8, dtype=mx.float32).reshape(1, 8, 1),
+        transform,
+        transform_groups=transform_many,
+    )
+
+    assert len(evaluated) == 1
+    assert evaluated[0][0] is produced[0]
 
 
 def test_qsa_vectorized_cache_matches_architecture_reference():

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -288,6 +288,10 @@ class QSAIndexCache(ArraysCache):
         pooled = mx.mean(groups.astype(mx.float32), axis=2).astype(raw_keys.dtype)
         starts = self._offsets[0] + mx.arange(group_count) * ratio
         transformed = transform_groups(pooled, starts)
+        # The batched Metal transform is lazy.  Materialize it before the
+        # persistent cache's in-place commit so its request-owned graph cannot
+        # outlive cache teardown and corrupt a subsequent generation (#2591).
+        mx.eval(transformed)
 
         ring = raw_keys[:, complete_length - ratio : complete_length, :]
         remainder = length - complete_length


### PR DESCRIPTION
## Why

Fixes #2591.

After the QSA compressed-key prefill optimization landed, one 32K Flash-Next request left the serving process producing token id 0 (`!`) for every later fresh request until restart. The long request itself remained coherent, so the failure was a cross-request lifecycle corruption rather than an ordinary generation-quality regression.

## Scope

- Materialize the batched QSA key transform before committing it into the persistent compressed-key cache.
- Add a focused regression contract proving the vector transform crosses that evaluation boundary before the cache write.

## Non-goals

- No QSA math, selection, or cache-layout change.
- No MTP, prefix-cache, scheduler, model-family, Desktop, or CI changes.
- No rollback of the batched prefill optimization.

## Acceptance

- A fresh short request remains coherent after a 32K Flash-Next request in the same process.
- The 32K request remains coherent.
- The optimized long-prefill latency remains effectively unchanged.
- Scalar and vector QSA cache state contracts remain green.

## Design precedent

Lazy accelerator results that cross into mutable persistent state need an explicit execution boundary before an in-place commit. This change applies that established ownership rule at Rapid-MLX's request-cache boundary: request-owned batched work is completed before the persistent cache mutates, without changing the architecture math or adding a model-specific fallback.

## Verification

- `python3.12 -m pytest -q tests/test_qwen4_exp_vendored.py` — 94 passed.
- Focused QSA selection — 8 passed.
- `python3.12 -m ruff check vllm_mlx/models/qwen4_exp_cache.py tests/test_qwen4_exp_vendored.py` — passed.
- `python3.12 -m ruff format --check ...` — passed.
- `git diff --check` — passed.
- Exact local model `rapid-mlx/Qwen3.8-Flash-Next-4bit@dcf657e4`, MTP off, prefix cache off, one process:
  - current main: `BEFORE` → coherent 32K answer in 45.929s → 32 `!` tokens.
  - this head: `BEFORE` → coherent 32K answer in 46.384s → `AFTER`.
- Negative controls: contiguous cache storage, functional cache reconstruction, and 1024-group chunking all still reproduced the corruption; scalar transform was correct but regressed the 32K request to 58.847s.

## Behaviour delta

A successful 32K Flash-Next request corrupts subsequent fresh generations until process restart → subsequent requests remain coherent, with the optimized 32K prefill latency retained.

## AI assistance disclosure

Codex diagnosed the regression boundary, ran the single-variable real-model experiments, and wrote the implementation and focused test. The output was reviewed against the exact two-file diff, the full vendored-model test file, lint/format checks, and the same-process 32K lifecycle reproduction above.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally (proportional 94-test vendored Qwen4-Exp suite)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
- [x] New critical-path test fails when the production evaluation boundary is removed
- [x] README/docs not applicable; the user-visible benchmark result is recorded above
- [x] No breaking changes to existing API

## Author

