### PR TITLE
fix(mac): resolve active Tools key status and truthful dictation errors

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -437,7 +437,7 @@ final class DictationController {
             voiceLaneReady: voiceLaneReady
         )) else {
             if isEnabled, enableRequestID == requestID, modelAlias == preparingAlias {
-                lastError = "\(preparingAlias) couldn't load. There may not be enough memory to start dictation."
+                lastError = "\(preparingAlias) couldn't finish preparing for dictation. Try again."
                 phase = .off
             }
             return
@@ -948,12 +948,12 @@ final class DictationController {
             } else if facts?.cached != true {
                 lastError = "\(alias) isn't downloaded. Open Rapid → Audio to download it."
             } else {
-                lastError = "\(alias) couldn't start. There may not be enough memory to load it alongside the conversation model."
+                lastError = "\(alias) couldn't finish preparing for dictation. Try again."
             }
             // The user is mid-flow in another app with only the HUD visible.
             // Leaving "Transcribing…" up while silently failing reads as a
             // hang; name the problem there before the capsule goes away.
-            hud.update(.failed(message: facts?.cached != true ? "Model not downloaded" : "Couldn't start the model"))
+            hud.update(.failed(message: facts?.cached != true ? "Model not downloaded" : "Couldn't prepare the model"))
             try? await Task.sleep(nanoseconds: 1_600_000_000)
             return
         }

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -377,11 +377,10 @@ final class WebSearchConfig {
 
     // MARK: - Lazy async lookup
     //
-    // Settings must not touch Keychain merely because its Tools page opened.
-    // A required-key backend selection or an API-key field focus calls the
-    // single-provider helper below; actual tool dispatch can also resolve its
-    // selected provider through ``apiKey(for:)``. Both routes use the same
-    // no-authentication-UI storage contract.
+    // Settings resolves only the selected backend when its visible key row
+    // appears; it never scans every provider or blocks rendering. Actual tool
+    // dispatch can also resolve its selected provider through ``apiKey(for:)``.
+    // Both routes use the same no-authentication-UI storage contract.
     //
     // The pre-existing positive/negative cache contracts in
     // ``WebSearchKeyCacheTests`` are preserved verbatim: ``apiKey(for:)``
@@ -394,7 +393,7 @@ final class WebSearchConfig {
     // into the @State initializer would re-introduce a synchronous
     // Keychain read on the first construction of ``WebSearchConfig``,
     // which happens on the main actor during ``RapidApp`` boot. The
-    // caller decides when to warm.
+    // caller decides which visible account to warm.
 
     /// Cache-only read. Returns ``.unknown`` when this provider has
     /// not been probed yet, ``.present(value)`` when the cache holds

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -22,7 +22,6 @@ struct SettingsToolsPanel: View {
     @State private var keyDraftEdited: Bool = false
     @State private var saveFeedback: SettingsView.WebSearchKeySaveFeedback?
     @State private var feedbackGeneration: Int = 0
-    @FocusState private var focusedKeyProvider: WebSearchProvider?
     /// Which tool rows have their technical detail open. Session state:
     /// a disclosure is a reading aid, not a preference, so it
     /// deliberately does not persist.
@@ -273,13 +272,8 @@ struct SettingsToolsPanel: View {
                     .controlSize(.small)
                     .tint(nil)
                     .accessibilityIdentifier("Settings.Tools.WebSearch.Backend")
-                    .onChange(of: config.provider) { _, provider in
+                    .onChange(of: config.provider) { _, _ in
                         resetKeyDraft()
-                        // This is a user-driven provider selection, not view
-                        // appearance. Required-key backends may now inspect
-                        // their one account without presenting auth UI.
-                        guard provider.requiresKey else { return }
-                        Task { await webSearch.prefetchAPIKey(for: provider) }
                     }
 
                     Text(config.provider.subtitle)
@@ -309,13 +303,6 @@ struct SettingsToolsPanel: View {
                     .textFieldStyle(.roundedBorder)
                     .font(RapidFont.body)
                     .frame(minHeight: RapidTheme.ControlHeight.small)
-                    .focused($focusedKeyProvider, equals: provider)
-                    .onChange(of: focusedKeyProvider) { _, focused in
-                        guard focused == provider else { return }
-                        // Optional-key providers (notably Keenable) stay truly
-                        // zero-touch until the user enters their key field.
-                        Task { await webSearch.prefetchAPIKey(for: provider) }
-                    }
                     .onChange(of: keyDraft) { _, _ in keyDraftEdited = true }
                     .onSubmit { commitKey(for: provider) }
                     .accessibilityIdentifier(
@@ -348,33 +335,48 @@ struct SettingsToolsPanel: View {
                             : RapidTheme.textSecondary
                     )
                     .fixedSize(horizontal: false, vertical: true)
-            } else if webSearch.cachedKeyState(for: provider) == .unavailable {
-                Text("The saved key can’t be accessed. Enter it again and save to replace it.")
+            } else {
+                let state = webSearch.cachedKeyState(for: provider)
+                Text(Self.keyStatusCaption(for: provider, state: state))
                     .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.statusError)
+                    .foregroundStyle(
+                        state == .unavailable
+                            ? RapidTheme.statusError
+                            : RapidTheme.textSecondary
+                    )
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier(
-                        "Settings.Tools.WebSearch.KeyUnavailable.\(provider.id)"
+                        "Settings.Tools.WebSearch.KeyStatus.\(provider.id)"
                     )
-            } else if webSearch.cachedKeyState(for: provider) == .unknown {
-                Text("Saved key status hasn’t been checked. Select this backend or focus the field to check it.")
-                    .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else if webSearch.cachedKeyState(for: provider).hasKey {
-                Text("A key is stored for \(provider.displayName).")
-                    .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else {
-                Text(Self.noKeyCaption(for: provider))
-                    .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { resetKeyDraft() }
+        // Resolve the one account whose status is visible. The Keychain read
+        // is asynchronous and explicitly forbids authentication UI, so opening
+        // Settings stays responsive and never prompts. Keying the task by the
+        // selected provider also cancels a stale read when the user switches.
+        .task(id: provider) {
+            await webSearch.prefetchAPIKey(for: provider)
+        }
+    }
+
+    /// User-facing state for the selected backend's saved key. Kept pure so
+    /// every cache outcome is pinned without inspecting SwiftUI source text.
+    static func keyStatusCaption(
+        for provider: WebSearchProvider,
+        state: CachedKeyState
+    ) -> String {
+        switch state {
+        case .unknown:
+            return "Checking saved key…"
+        case .unavailable:
+            return "The saved key can’t be accessed. Enter it again and save to replace it."
+        case .present:
+            return "A key is stored for \(provider.displayName)."
+        case .absent:
+            return noKeyCaption(for: provider)
+        }
     }
 
     /// What an empty key slot means depends on the provider: a

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -166,7 +166,7 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Tools.WebSearch.Backend.\(provider.id)""#,
                 #""Settings.Tools.WebSearch.KeyField.\(provider.id)""#,
                 #""Settings.Tools.WebSearch.SaveKey.\(provider.id)""#,
-                #""Settings.Tools.WebSearch.KeyUnavailable.\(provider.id)""#,
+                #""Settings.Tools.WebSearch.KeyStatus.\(provider.id)""#,
                 // The "Get a <provider> key" Link is interactive too — it
                 // opens the provider's dashboard. It was missed on the first
                 // pass precisely because it only renders for a provider that

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -749,7 +749,7 @@ struct DictationTests {
     }
 
     @MainActor
-    @Test("failed model warmup leaves dictation visibly unarmed")
+    @Test("unknown preparation failure stays retryable without guessing memory pressure")
     func failedWarmupDoesNotArmHotkey() async {
         var hotkeyStartCount = 0
         let controller = readinessController(
@@ -764,7 +764,11 @@ struct DictationTests {
 
         #expect(controller.phase == .off)
         #expect(hotkeyStartCount == 0)
-        #expect(controller.lastError?.contains("couldn't load") == true)
+        #expect(
+            controller.lastError
+                == "whisper-small couldn't finish preparing for dictation. Try again."
+        )
+        #expect(controller.lastError?.localizedCaseInsensitiveContains("memory") == false)
     }
 
     @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsWebSearchKeyDraftTests.swift
@@ -53,13 +53,6 @@ private final class SettingsKeychainItems: KeychainItemAccessing, @unchecked Sen
 @MainActor
 @Suite("Settings web-search key draft commit")
 struct SettingsWebSearchKeyDraftTests {
-    private static var packageRoot: URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-    }
-
     @Test("Constructing the Tools configuration never reads Keychain")
     func constructionIsKeychainLazy() {
         let keychain = SettingsKeychainProbe()
@@ -198,26 +191,24 @@ struct SettingsWebSearchKeyDraftTests {
         #expect(store.read(account: account) == nil)
     }
 
-    @Test("Tools page has no appearance-time Keychain read and wires only user-driven probes")
-    func toolsPageUsesLazyReadTriggers() throws {
-        let panel = try String(
-            contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/UI/SettingsToolsPanel.swift"),
-            encoding: .utf8
-        )
-        #expect(!panel.contains("prefetchAllAPIKeys"))
-        #expect(panel.contains("guard provider.requiresKey else { return }"))
-        #expect(panel.contains("focusedKeyProvider"))
-        #expect(panel.contains("prefetchAPIKey(for: provider)"))
-        #expect(panel.contains("Saved key status hasn’t been checked."))
-
-        let store = try String(
-            contentsOf: Self.packageRoot.appendingPathComponent("Sources/Rapid/Tools/KeychainStore.swift"),
-            encoding: .utf8
-        )
-        #expect(store.contains("kSecUseAuthenticationContext"))
-        #expect(store.contains("interactionNotAllowed = true"))
-        #expect(!store.contains("kSecUseAuthenticationUISkip"))
-        #expect(store.contains("legacyService).development"))
+    @Test("Visible backend key status has truthful copy for every cached state")
+    func visibleBackendKeyStatusCopy() {
+        #expect(SettingsToolsPanel.keyStatusCaption(
+            for: .parallel,
+            state: .unknown
+        ) == "Checking saved key…")
+        #expect(SettingsToolsPanel.keyStatusCaption(
+            for: .parallel,
+            state: .present("secret-never-rendered")
+        ) == "A key is stored for Parallel.")
+        #expect(SettingsToolsPanel.keyStatusCaption(
+            for: .parallel,
+            state: .absent
+        ) == "No key stored — searches fall back to Keenable until you save one.")
+        #expect(SettingsToolsPanel.keyStatusCaption(
+            for: .parallel,
+            state: .unavailable
+        ) == "The saved key can’t be accessed. Enter it again and save to replace it.")
     }
 
     @Test("Untouched empty SecureField does not clear an existing stored key")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3160,6 +3160,21 @@ flow_no_dead_controls() {
 
     press "$OUT/dead-actions-models-favorite-restored.json" Settings.Category.tools \
         "$OUT/dead-actions-tools-open.json"
+    # The selected backend owns the visible key row. Opening Tools must resolve
+    # its cached Keychain state on its own; making users re-select the already
+    # selected radio or focus the secret field is the regression from #2462.
+    local key_status=""
+    for _ in {1..40}; do
+        see_main "$OUT/dead-actions-tools-key-status.json"
+        key_status="$(element_field \
+            "$OUT/dead-actions-tools-key-status.json" \
+            Settings.Tools.WebSearch.KeyStatus.keenable value)"
+        [[ -n "$key_status" && "$key_status" != "Checking saved key…" ]] && break
+        sleep 0.1
+    done
+    [[ -n "$key_status" && "$key_status" != "Checking saved key…" ]] \
+        || die "Tools left the active backend's saved-key status unresolved"
+    log "  active web-search backend resolves its saved-key status on appearance"
     local tool_name
     for tool_name in web_search browse weather; do
         round_trip_toggle "Settings.Tools.Toggle.$tool_name" "dead-actions-tool-$tool_name"


### PR DESCRIPTION
## Why

#2462 grouped four Desktop paper cuts. Runtime re-derivation on current main found two residual user-facing failures:

- Settings > Tools left the already-selected web-search backend at an unresolved saved-key status until the user reselected it or focused the secret field.
- An unknown dictation preparation failure claimed that memory was insufficient even when no memory diagnosis existed.

The other two reports are already covered on current main: #2585 owns interrupted pending-image retry/quarantine behavior, and the compact default download is already scoped to its catalog subfolder while progress observes the selected cache path. This PR keeps only the remaining delta.

## What

- Resolve exactly the visible backend key account asynchronously when its row appears, using the existing non-interactive Keychain read.
- Show explicit checking, present, absent, and inaccessible states without exposing secret material.
- Replace speculative dictation memory errors with neutral, retryable preparation copy.
- Add behavior-level copy coverage and a real AX journey assertion for the Tools first-open state.

## Design precedent

Native desktop settings commonly resolve the currently visible account status asynchronously, keep the surface responsive, and avoid credential prompts merely from opening settings. Unknown service failures should state the failed action and a recovery step without inventing a cause. This adapts those established patterns to the existing single-provider cache and non-interactive Keychain seam.

## User proof

Built and walked the Desktop app with the fake sidecar. The no-dead-controls golden flow opened Tools from a fresh persona and observed the selected Keenable status change from Checking saved key… to the resolved no-key state without reselection or field focus.

## Verification

- swift test --filter SettingsWebSearchKeyDraftTests — 19 passed
- swift test --filter DictationTests — 42 passed
- swift test --filter VoiceCoLoadTests — 10 passed
- swift test --filter AccessibilityIdentifierInventoryTests — 20 passed
- pytest GUI behavior/coverage/preflight contracts — 43 passed
- gui-golden-flows.sh --flow no-dead-controls — PASS
- Full Swift run exercised 3032 tests; unrelated concurrent timeout/state failures all passed when rerun serially: Download/catalog 22/22, Quickstart 17/17, Dictation 42/42, Resident-load 7/7.

Fixes #2462