### PR TITLE
fix(mac): keep Quickstart starter copy truthful

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -30,11 +30,12 @@ import SwiftUI
 ///
 /// ## Starter policy
 ///
-/// Below 16 GB, onboarding starts from LFM2.5 2.6B; at 16 GB and above,
+/// Below 16 GB, onboarding starts from LFM2.5 1.2B; at 16 GB and above,
 /// it starts from Qwen 3.5 4B. An eligible cached chat model takes priority
-/// so an existing installation does not force another download. LFM2.5 1.2B
-/// remains visible as an explicit low-memory alternative, but is never chosen
-/// automatically. The policy is pure and covered by the starter matrix tests.
+/// so an existing installation does not force another download. LFM2.5 2.6B
+/// remains available as a more capable step-up for a lower-memory Mac, while
+/// 1.2B remains the explicit low-memory alternative on larger Macs. The policy
+/// is pure and covered by the starter matrix tests.
 ///
 /// ### What this means for the empty state
 ///
@@ -396,10 +397,9 @@ final class QuickstartCoordinator {
     var seedMessage: String {
         if selection.alias == baselineStarterAlias {
             return """
-You're chatting with \(selection.displayName) — a model picked so you can start \
-chatting in about a minute. Open the picker any time to trade up to a larger \
-model: the Recommended row is chosen for this Mac's RAM, and a bigger pick is a \
-great first upgrade when you want more.
+You're chatting with \(selection.displayName), selected to fit this Mac. You're \
+ready for your first message. Open the picker any time to choose a different \
+model; the Recommended row is tailored to this Mac's memory.
 """
         }
         return """

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -63,7 +63,23 @@ struct QuickstartStarterPolicyTests {
         coordinator.applyDefaultChoice(hardware: hardware(8), catalog: [])
 
         #expect(coordinator.selection.alias == "lfm2.5-1b-4bit")
-        #expect(coordinator.seedMessage.contains("a model picked so you can start"))
+        #expect(coordinator.seedMessage.contains("selected to fit this Mac"))
+        #expect(coordinator.seedMessage.contains("ready for your first message"))
+    }
+
+    @Test(
+        "Every automatic RAM-tier welcome avoids a fixed download-time promise",
+        arguments: [8.0, 15.99, 16.0, 64.0]
+    )
+    func starterWelcomeIsHardwareTruthful(ramGB: Double) {
+        let coordinator = QuickstartCoordinator()
+        coordinator.applyDefaultChoice(hardware: hardware(ramGB), catalog: [])
+
+        let copy = coordinator.seedMessage
+        #expect(copy.contains(coordinator.selection.displayName))
+        #expect(copy.contains("selected to fit this Mac"))
+        #expect(copy.contains("ready for your first message"))
+        #expect(!copy.localizedCaseInsensitiveContains("minute"))
     }
 
     @Test("The automatic 8 GB choice keeps its lowest-memory spoken category")
@@ -95,7 +111,8 @@ struct QuickstartStarterPolicyTests {
 
         let relaunched = QuickstartCoordinator(defaults: defaults)
         #expect(relaunched.selection.alias == "lfm2.5-1b-4bit")
-        #expect(relaunched.seedMessage.contains("a model picked so you can start"))
+        #expect(relaunched.seedMessage.contains("selected to fit this Mac"))
+        #expect(!relaunched.seedMessage.localizedCaseInsensitiveContains("minute"))
     }
 
     @Test("The 1.2B choice remains a fallback, not a starter, on a 16 GB Mac")
@@ -107,7 +124,7 @@ struct QuickstartStarterPolicyTests {
         )
         coordinator.select(QuickstartCoordinator.lowMemoryChoice)
 
-        #expect(!coordinator.seedMessage.contains("a model picked so you can start"))
+        #expect(!coordinator.seedMessage.contains("selected to fit this Mac"))
         #expect(coordinator.seedMessage.contains("running entirely on your Mac"))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -41,6 +41,8 @@ struct QuickstartViewTests {
         let copy = makeCoordinator().seedMessage
         #expect(copy.contains(QuickstartCoordinator.defaultChoice.displayName))
         #expect(copy.lowercased().contains("picker"))
+        #expect(copy.contains("ready for your first message"))
+        #expect(!copy.localizedCaseInsensitiveContains("minute"))
     }
 
     @Test("F-LWT-1: welcome message does NOT promise tool calling on 0.6B")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2031,6 +2031,23 @@ flow_cached_curated_tradeup() {
             | select(((.description // "") | contains("Download 2.9 GB")) | not)' \
         "$OUT/chooser.json" >/dev/null \
         || die "cached hardware-fit starter is hidden or advertises a download"
+    # Finish the exact 16 GB starter journey without a network pull. The
+    # welcome is shown only after the model is ready, so it must describe that
+    # achieved state instead of promising a network-dependent duration.
+    press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/start-existing.json"
+    wait_fake_event \
+        '.event == "server_started" and .alias == "qwen3.5-4b-4bit"' \
+        "cached 16 GB starter did not start"
+    wait_identifier Quickstart.Ready.StartChatting "$OUT/ready-confirmation.json"
+    press "$OUT/ready-confirmation.json" Quickstart.Ready.StartChatting \
+        "$OUT/start-chatting.json"
+    wait_identifier rapid.chat.compose "$OUT/ready.json"
+    assert_tree_text "$OUT/ready.json" "selected to fit this Mac."
+    assert_tree_text "$OUT/ready.json" "ready for your first message."
+    if jq -e '.. | strings | select(test("about a minute"; "i"))' \
+        "$OUT/ready.json" >/dev/null; then
+        die "16 GB starter welcome still promises a fixed download time"
+    fi
     cleanup_persona
 }
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2054,10 +2054,10 @@ flow_cached_curated_tradeup() {
         if [[ "$memory_confirmed" == 0 ]]; then
             see_main "$OUT/starter-after-start.json"
             if jq -e '.data.ui_elements[]?
-                      | select(.identifier == "MemoryWarning.Confirm"
+                      | select(.identifier == "Quickstart.Memory.LoadAnyway"
                                and .enabled == true)' \
                 "$OUT/starter-after-start.json" >/dev/null; then
-                "$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm \
+                "$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway \
                     > "$OUT/starter-memory-confirm.json"
                 memory_confirmed=1
                 log "  confirmed hosted-runner memory warning for cached starter"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2035,9 +2035,37 @@ flow_cached_curated_tradeup() {
     # welcome is shown only after the model is ready, so it must describe that
     # achieved state instead of promising a network-dependent duration.
     press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/start-existing.json"
-    wait_fake_event \
-        '.event == "server_started" and .alias == "qwen3.5-4b-4bit"' \
-        "cached 16 GB starter did not start"
+    # The 16 GB fixture owns recommendation policy, not the host's live
+    # pressure. A busy hosted runner can therefore (correctly) ask for the
+    # existing explicit memory confirmation before it starts this zero-weight
+    # fake. Handle that real branch exactly as start_model does: confirm only
+    # when the enabled warning is present, then still require the independent
+    # sidecar event. Without this, ambient runner pressure made the flow wait
+    # for a start the app was intentionally holding for user consent.
+    local memory_confirmed=0 starter_started=0
+    for _ in {1..240}; do
+        if [[ -s "$OUT/fake-events.jsonl" ]] \
+           && jq -e -s 'any(.[]; .event == "server_started"
+                                   and .alias == "qwen3.5-4b-4bit")' \
+                "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
+            starter_started=1
+            break
+        fi
+        if [[ "$memory_confirmed" == 0 ]]; then
+            see_main "$OUT/starter-after-start.json"
+            if jq -e '.data.ui_elements[]?
+                      | select(.identifier == "MemoryWarning.Confirm"
+                               and .enabled == true)' \
+                "$OUT/starter-after-start.json" >/dev/null; then
+                "$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm \
+                    > "$OUT/starter-memory-confirm.json"
+                memory_confirmed=1
+                log "  confirmed hosted-runner memory warning for cached starter"
+            fi
+        fi
+        sleep 0.25
+    done
+    [[ "$starter_started" == 1 ]] || die "cached 16 GB starter did not start"
     wait_identifier Quickstart.Ready.StartChatting "$OUT/ready-confirmation.json"
     press "$OUT/ready-confirmation.json" Quickstart.Ready.StartChatting \
         "$OUT/start-chatting.json"

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -208,9 +208,7 @@ def test_cached_curated_tradeup_confirms_the_quickstart_memory_sheet():
     flow = source.split("flow_cached_curated_tradeup() {", 1)[1].split("\n}", 1)[0]
 
     assert 'identifier == "Quickstart.Memory.LoadAnyway"' in flow
-    assert (
-        '"$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway' in flow
-    )
+    assert '"$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway' in flow
     assert 'identifier == "MemoryWarning.Confirm"' not in flow
 
 

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -202,6 +202,18 @@ def test_preflight_runs_before_any_persona_starts():
     )
 
 
+def test_cached_curated_tradeup_confirms_the_quickstart_memory_sheet():
+    """The onboarding sheet and main-window warning use different AX IDs."""
+    source = HARNESS.read_text()
+    flow = source.split("flow_cached_curated_tradeup() {", 1)[1].split("\n}", 1)[0]
+
+    assert 'identifier == "Quickstart.Memory.LoadAnyway"' in flow
+    assert (
+        '"$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway' in flow
+    )
+    assert 'identifier == "MemoryWarning.Confirm"' not in flow
+
+
 def test_peekaboo_requirement_is_default_deny():
     """A new flow must be assumed to need peekaboo until stated otherwise.
 


### PR DESCRIPTION
## Why

#2461 originally tracked a serving-lane reason mismatch plus two Quickstart copy mismatches. The serving-lane item already shipped in #2514. Reproduction on current main confirmed the remaining first-run contradictions:

- Below 16 GB the production policy selects LFM2.5 1.2B, while the source contract still described 2.6B as the automatic starter.
- The seeded welcome promised about a minute even for the 3.06 GB Qwen 3.5 4B download, where network and cache conditions make that claim unknowable.

## What

- Align the Quickstart policy documentation with the tested 1.2B and 4B RAM split.
- Describe the achieved post-start state: the selected model fits this Mac and chat is ready.
- Keep live download progress and ETA as the only owners of timing information.
- Add a table-driven welcome invariant across 8, 15.99, 16, and 64 GB.
- Extend the real AX cached-starter journey through Ready and the first chat.
- When a constrained test host presents the production memory-safety confirmation before starting the zero-weight fake, acknowledge that explicit branch and still require independent sidecar-start evidence.

The already-shipped legacy welcome string remains recognized by session migration, so changing new-user copy does not reinterpret old local transcripts.

## Scope and constraints

Allowed scope is Quickstart starter/welcome copy, its focused tests, and the cached 16 GB AX journey that proves the copy after a real Ready transition. The journey must not bypass memory safety, fabricate readiness, or accept UI state alone as proof of a start.

## Non-goals

- changing starter selection policy or memory thresholds
- changing model loading, download, or serving behavior
- changing session migration behavior
- weakening the memory confirmation or the sidecar event assertion

## Acceptance criteria

- policy documentation names the shipped 1.2B/4B split
- post-start welcome makes no fixed-duration promise
- a cached 16 GB starter reaches Ready and first chat without a pull
- hosted-runner memory confirmation is handled only when visibly enabled
- the exact qwen3.5-4b-4bit `server_started` event remains mandatory

## Design precedent

Established desktop onboarding separates a hardware-derived model choice from the live download state. Entry and completion copy stays short and action-oriented; bytes, speed, and ETA appear only after measured progress exists. This change adapts that pattern to the existing RAM-policy and download-progress single sources instead of introducing another estimate.

## User proof

Built the exact rebased head and walked a fresh 16 GB persona through cached Qwen 3.5 4B selection, model start, Ready confirmation, and first chat. The resulting AX transcript says the model was selected to fit this Mac and is ready for the first message; the tree contains no fixed download-time promise.

## Verification

- `swift test --no-parallel --filter Quickstart` — 104 passed
- `python3.12 -m pytest tests/test_gui_*.py -q` — 81 passed
- `gui-golden-flows.sh --flow cached-curated-tradeup` — PASS repeatedly on the exact head
- exact prior queue app artifact replayed through `fresh-install`, `cached-quickstart`, and `cached-curated-tradeup` — PASS
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `git diff --check`

Fixes #2461