### PR TITLE
fix(mac): localize photo-unavailable remedies

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
@@ -511,6 +511,134 @@
           }
         }
       }
+    },
+    "image_input.unavailable.legacy_model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model doesn't support photos. Choose a vision-capable model to add one."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型不支持照片。要添加照片，请选择支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.text_lane_forced" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model runs text-only; its vision path isn't available. Choose a vision-capable model to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型当前只能处理文字，视觉功能不可用。要添加照片，请选择支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.speculative_decode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model is running text-only because speculative decoding is on. Turn it off in Settings → Performance to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由于已开启推测解码，此模型当前只能处理文字。请在设置中的“Performance”里将其关闭，然后再添加照片。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.vision_memory_insufficient" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model's vision mode needs more memory than this Mac has. Choose a different vision-capable model to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.vision_runtime_unsupported" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model is running text-only because its vision runtime isn't supported here. Choose a different vision-capable model to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由于这台 Mac 不支持此模型的视觉运行环境，它当前只能处理文字。要添加照片，请选择另一个支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.vision_features_unavailable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model is running text-only because its vision features aren't available. Choose a different vision-capable model to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型当前只能处理文字，因为其视觉功能不可用。要添加照片，请选择另一个支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.text_checkpoint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model doesn't support photos. Choose a vision-capable model to add photos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型不支持照片。要添加照片，请选择支持视觉的模型。"
+          }
+        }
+      }
+    },
+    "image_input.unavailable.generic_text_lane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model is running text-only. Photos need a vision-capable model."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此模型当前只能处理文字。要添加照片，请选择支持视觉的模型。"
+          }
+        }
+      }
     }
   }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
@@ -159,9 +159,56 @@ struct ImageInputAvailability: Equatable, Sendable {
     let isAvailable: Bool
     let unavailableMessage: String?
 
+    /// Stable String Catalog identities for every photo-unavailable remedy.
+    ///
+    /// The engine reason remains machine-readable; this enum is the single
+    /// bridge from that wire contract to user-facing language. Keeping a
+    /// reviewed English fallback beside each key means an incomplete bundle
+    /// fails legibly instead of showing a catalog identifier to the user.
+    enum PhotoHint: String, CaseIterable, Sendable {
+        case legacyModel = "image_input.unavailable.legacy_model"
+        case textLaneForced = "image_input.unavailable.text_lane_forced"
+        case speculativeDecode = "image_input.unavailable.speculative_decode"
+        case visionMemoryInsufficient = "image_input.unavailable.vision_memory_insufficient"
+        case visionRuntimeUnsupported = "image_input.unavailable.vision_runtime_unsupported"
+        case visionFeaturesUnavailable = "image_input.unavailable.vision_features_unavailable"
+        case textCheckpoint = "image_input.unavailable.text_checkpoint"
+        case genericTextLane = "image_input.unavailable.generic_text_lane"
+
+        var englishValue: String {
+            switch self {
+            case .legacyModel:
+                "This model doesn't support photos. Choose a vision-capable model to add one."
+            case .textLaneForced:
+                "This model runs text-only; its vision path isn't available. Choose a vision-capable model to add photos."
+            case .speculativeDecode:
+                "This model is running text-only because speculative decoding is on. Turn it off in Settings → Performance to add photos."
+            case .visionMemoryInsufficient:
+                "This model's vision mode needs more memory than this Mac has. Choose a different vision-capable model to add photos."
+            case .visionRuntimeUnsupported:
+                "This model is running text-only because its vision runtime isn't supported here. Choose a different vision-capable model to add photos."
+            case .visionFeaturesUnavailable:
+                "This model is running text-only because its vision features aren't available. Choose a different vision-capable model to add photos."
+            case .textCheckpoint:
+                "This model doesn't support photos. Choose a vision-capable model to add photos."
+            case .genericTextLane:
+                "This model is running text-only. Photos need a vision-capable model."
+            }
+        }
+
+        func localized(in bundle: Bundle) -> String {
+            bundle.localizedString(
+                forKey: rawValue,
+                value: englishValue,
+                table: nil
+            )
+        }
+    }
+
     static func resolve(
         fallbackSupportsImageInput: Bool,
-        profile: ServerModelProfile?
+        profile: ServerModelProfile?,
+        localizationBundle: Bundle = .main
     ) -> ImageInputAvailability {
         guard let profile,
               profile.servingLane != nil || profile.capabilities != nil
@@ -170,7 +217,7 @@ struct ImageInputAvailability: Equatable, Sendable {
                 isAvailable: fallbackSupportsImageInput,
                 unavailableMessage: fallbackSupportsImageInput
                     ? nil
-                    : "This model doesn't support photos. Choose a vision-capable model to add one."
+                    : PhotoHint.legacyModel.localized(in: localizationBundle)
             )
         }
 
@@ -180,7 +227,8 @@ struct ImageInputAvailability: Equatable, Sendable {
         guard supportsVision && isVisionLane else {
             return ImageInputAvailability(
                 isAvailable: false,
-                unavailableMessage: message(for: profile.servingLaneReason)
+                unavailableMessage: photoHint(for: profile.servingLaneReason)
+                    .localized(in: localizationBundle)
             )
         }
         return ImageInputAvailability(isAvailable: true, unavailableMessage: nil)
@@ -199,32 +247,32 @@ struct ImageInputAvailability: Equatable, Sendable {
     /// engine's CLI has escape hatches the GUI does not expose, so a reason
     /// that is operator-reversible on the command line can still be fixed
     /// here only by choosing a different model.
-    private static func message(for laneReason: String?) -> String {
+    static func photoHint(for laneReason: String?) -> PhotoHint {
         switch laneReason {
         case "text_lane_forced":
             // In the app this only arrives from an alias pinned `is_text_only`
             // in the registry — a vision-config checkpoint deliberately served
             // through the text lane. There is no switch to flip, so the model
             // picker is the only way out.
-            return "This model runs text-only; its vision path isn't available. Choose a vision-capable model to add photos."
+            return .textLaneForced
         case "text_lane_speculative_decode":
-            return "This model is running text-only because speculative decoding is on. Turn it off in Settings → Performance to add photos."
+            return .speculativeDecode
         case "vision_memory_insufficient":
             // The engine gates on physical RAM against a per-alias floor
             // (`vision_min_memory_gb`), not on free RAM or model size: quitting
             // apps cannot lift this, and a smaller quant of the same model
             // carries the same floor. Only a different vision-capable model
             // is a remedy the user can actually apply.
-            return "This model's vision mode needs more memory than this Mac has. Choose a different vision-capable model to add photos."
+            return .visionMemoryInsufficient
         case "vision_hybrid_runtime_unsupported":
-            return "This model is running text-only because its vision runtime isn't supported here. Choose a different vision-capable model to add photos."
+            return .visionRuntimeUnsupported
         case "vision_architecture_unavailable", "vision_hybrid_cache_unsupported",
              "vision_weights_unavailable":
-            return "This model is running text-only because its vision features aren't available. Choose a different vision-capable model to add photos."
+            return .visionFeaturesUnavailable
         case "text_checkpoint":
-            return "This model doesn't support photos. Choose a vision-capable model to add photos."
+            return .textCheckpoint
         default:
-            return "This model is running text-only. Photos need a vision-capable model."
+            return .genericTextLane
         }
     }
 }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -210,8 +210,8 @@ journeys:
     risk: high
     driver: hybrid
     ci_tier: pr
-    fixtures: [fake-sidecar, two-images, document, native-file-drag, isolated-home]
-    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]
+    fixtures: [fake-sidecar, two-images, document, native-file-drag, zh-Hans, isolated-home]
+    source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift, apps/rapid-mac/Sources/Rapid/Resources/, apps/rapid-mac/scripts/build.sh]
     owns_baseline: false
   - name: image-generation
     group: images

--- a/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
@@ -9,13 +9,24 @@ import Testing
 @Suite("Localizable.xcstrings — catalog shape and zh-Hans resolution")
 struct LocalizationTests {
 
+    private static let photoHintCatalogKeys = [
+        "image_input.unavailable.legacy_model",
+        "image_input.unavailable.text_lane_forced",
+        "image_input.unavailable.speculative_decode",
+        "image_input.unavailable.vision_memory_insufficient",
+        "image_input.unavailable.vision_runtime_unsupported",
+        "image_input.unavailable.vision_features_unavailable",
+        "image_input.unavailable.text_checkpoint",
+        "image_input.unavailable.generic_text_lane"
+    ]
+
     /// Look up the catalog from the test bundle. The .xcstrings file
     /// is declared as a resource on the Rapid executable target, so
     /// at test time it lives next to the test bundle's bundleURL
     /// under the host process's resource lookup chain. We probe the
     /// known SPM bundle path first, then fall back to the source
     /// tree path which is always present in a CI checkout.
-    private func loadCatalog() throws -> [String: Any] {
+    private func catalogURL() throws -> URL {
         let candidates: [URL] = [
             Bundle.module.url(forResource: "Localizable", withExtension: "xcstrings"),
             URL(fileURLWithPath: #filePath)
@@ -25,10 +36,14 @@ struct LocalizationTests {
                 .appendingPathComponent("Sources/Rapid/Resources/Localizable.xcstrings")
         ].compactMap { $0 }
 
-        let url = try #require(
+        return try #require(
             candidates.first { FileManager.default.fileExists(atPath: $0.path) },
             "Localizable.xcstrings not found on any candidate path"
         )
+    }
+
+    private func loadCatalog() throws -> [String: Any] {
+        let url = try catalogURL()
         let data = try Data(contentsOf: url)
         let any = try JSONSerialization.jsonObject(with: data)
         return try #require(any as? [String: Any])
@@ -105,5 +120,86 @@ struct LocalizationTests {
                 "zh-Hans not marked translated for key: \(key)"
             )
         }
+    }
+
+    @Test("Every photo-unavailable remedy has reviewed English and zh-Hans catalog values")
+    func localizedPhotoHintsUseStableCatalogKeys() throws {
+        let json = try loadCatalog()
+        let strings = try #require(json["strings"] as? [String: Any])
+
+        #expect(
+            Set(ImageInputAvailability.PhotoHint.allCases.map(\.rawValue))
+                == Set(Self.photoHintCatalogKeys),
+            "The production photo-hint key set and the reviewed catalog contract must move together."
+        )
+
+        for hint in ImageInputAvailability.PhotoHint.allCases {
+            let key = hint.rawValue
+            let entry = try #require(
+                strings[key] as? [String: Any],
+                "Missing photo-hint catalog entry for key: \(key)"
+            )
+            let localizations = try #require(entry["localizations"] as? [String: Any])
+            for language in ["en", "zh-Hans"] {
+                let localization = try #require(
+                    localizations[language] as? [String: Any],
+                    "Missing \(language) photo-hint value for key: \(key)"
+                )
+                let unit = try #require(localization["stringUnit"] as? [String: Any])
+                #expect(unit["state"] as? String == "translated")
+                #expect(!(unit["value"] as? String ?? "").isEmpty)
+                if language == "en" {
+                    #expect(
+                        unit["value"] as? String == hint.englishValue,
+                        "The catalog's source copy and the fail-safe English value diverged for \(key)."
+                    )
+                }
+            }
+        }
+    }
+
+    @Test("Compiled zh-Hans catalog resolves through the production photo-hint path")
+    func compiledCatalogLocalizesPhotoHints() throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-localization-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: output) }
+
+        let compiler = Process()
+        compiler.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        compiler.arguments = [
+            "xcstringstool", "compile", try catalogURL().path,
+            "--output-directory", output.path,
+            "--serialization-format", "binary"
+        ]
+        try compiler.run()
+        compiler.waitUntilExit()
+        #expect(compiler.terminationStatus == 0)
+
+        let zhBundle = try #require(
+            Bundle(url: output.appendingPathComponent("zh-Hans.lproj", isDirectory: true)),
+            "xcstringstool did not emit a loadable zh-Hans localization bundle"
+        )
+        let memory = ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: true,
+            profile: ServerModelProfile(
+                id: "model",
+                capabilities: ["text", "vision"],
+                servingLane: "text",
+                servingLaneReason: "vision_memory_insufficient"
+            ),
+            localizationBundle: zhBundle
+        )
+        #expect(
+            memory.unavailableMessage
+                == "此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+        )
+
+        let legacy = ImageInputAvailability.resolve(
+            fallbackSupportsImageInput: false,
+            profile: nil,
+            localizationBundle: zhBundle
+        )
+        #expect(legacy.unavailableMessage == "此模型不支持照片。要添加照片，请选择支持视觉的模型。")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -251,6 +251,29 @@ final class ServerModelProfileTests {
         #expect(availability.unavailableMessage == Self.genericLaneCopy)
     }
 
+    @Test("Every serving-lane reason maps to its stable photo-hint catalog key")
+    func laneReasonsMapToCatalogKeys() {
+        let cases: [(String?, ImageInputAvailability.PhotoHint)] = [
+            ("text_lane_forced", .textLaneForced),
+            ("text_lane_speculative_decode", .speculativeDecode),
+            ("vision_memory_insufficient", .visionMemoryInsufficient),
+            ("vision_hybrid_runtime_unsupported", .visionRuntimeUnsupported),
+            ("vision_architecture_unavailable", .visionFeaturesUnavailable),
+            ("vision_hybrid_cache_unsupported", .visionFeaturesUnavailable),
+            ("vision_weights_unavailable", .visionFeaturesUnavailable),
+            ("text_checkpoint", .textCheckpoint),
+            ("reason_from_a_future_sidecar", .genericTextLane),
+            (nil, .genericTextLane)
+        ]
+
+        for (reason, expected) in cases {
+            #expect(
+                ImageInputAvailability.photoHint(for: reason) == expected,
+                "Unexpected catalog key for serving-lane reason \(reason ?? "nil")"
+            )
+        }
+    }
+
     @Test("A replacement sidecar invalidates the selected-model profile task")
     func selectedProfileTracksServerSession() {
         let first = SelectedModelProfileKey(

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -138,19 +138,26 @@ for asset in cheetah.png cheetah-sm.png; do
     fi
 done
 
-# Localizable.xcstrings: same Bundle.main vs Bundle.module story as
-# the PNGs above. SPM compiles the catalog into Rapid_Rapid.bundle
-# for tests, but the production .app uses Bundle.main and ships
-# without the SPM bundle wrapper (codesign --deep --strict rejects
-# the SPM bundle directory at the .app root). Copy the catalog as
-# a flat file into Contents/Resources/ so macOS 14+'s
-# NSLocalizedString / SwiftUI String catalog reader resolves it.
-# Without this, zh-Hans users see English strings in the shipped
-# DMG even though `swift test` reports a fully translated catalog.
+# Localizable.xcstrings: same Bundle.main vs Bundle.module story as the PNGs
+# above. A String Catalog is build input, not a runtime localization resource:
+# copying only the JSON file leaves Bundle.main with no .lproj strings to
+# resolve. Compile it exactly as Xcode does, directly into Contents/Resources,
+# and retain the source catalog beside the products for the bundle-integrity
+# verifier and support diagnostics.
 if [[ -f "$ROOT/Sources/Rapid/Resources/Localizable.xcstrings" ]]; then
-    cp "$ROOT/Sources/Rapid/Resources/Localizable.xcstrings" "$CONTENTS/Resources/Localizable.xcstrings"
+    LOCALIZABLE_CATALOG="$ROOT/Sources/Rapid/Resources/Localizable.xcstrings"
+    XCSTRINGSTOOL="$(xcrun --find xcstringstool 2>/dev/null || true)"
+    if [[ -z "$XCSTRINGSTOOL" ]]; then
+        echo "ERR: xcstringstool is required to compile Desktop localizations" >&2
+        exit 1
+    fi
+    "$XCSTRINGSTOOL" compile "$LOCALIZABLE_CATALOG" \
+        --output-directory "$CONTENTS/Resources" \
+        --serialization-format binary
+    cp "$LOCALIZABLE_CATALOG" "$CONTENTS/Resources/Localizable.xcstrings"
 else
-    echo "warning: Localizable.xcstrings missing — shipped .app will fall back to English only" >&2
+    echo "ERR: Localizable.xcstrings missing — refusing to ship an English-only app" >&2
+    exit 1
 fi
 
 # v0.7.16: benchmark-scores.json drives the picker hover tooltip.

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -608,10 +608,11 @@ class Handler(BaseHTTPRequestHandler):
                 self._owns_active_chat_request = False
 
     def do_GET(self):
-        if self.path == "/healthz":
+        path = urlsplit(self.path).path
+        if path == "/healthz":
             self._json(200, {"ok": True})
             return
-        if self.path == "/v1/models":
+        if path == "/v1/models":
             # ModelPickerBar reads this on real rapid-mlx — return
             # one canned entry so the picker isn't empty.
             self._json(200, {
@@ -620,17 +621,29 @@ class Handler(BaseHTTPRequestHandler):
                 ]
             })
             return
-        if self.path == "/v1/models/residency":
+        if path == "/v1/models/residency":
             self._json(200, self._residency_snapshot())
             return
-        if self.path.partition("?")[0] == "/v1/images/progress":
+        if path.startswith("/v1/models/"):
+            lane_reason = _setting("FAKE_SERVING_LANE_REASON")
+            if lane_reason:
+                self._json(200, {
+                    "id": path.rsplit("/", 1)[-1],
+                    "object": "model",
+                    "owned_by": "rapid-mlx",
+                    "capabilities": ["text", "vision"],
+                    "serving_lane": "text",
+                    "serving_lane_reason": lane_reason,
+                })
+                return
+        if path == "/v1/images/progress":
             # Polled every few hundred ms while a render is in flight. Answer
             # it even when nothing is running: the client treats a transport
             # failure and "idle" identically, so a 404 here would be
             # indistinguishable from the daemon being down.
             self._json(200, RENDERS.snapshot())
             return
-        if self.path.partition("?")[0] == "/v1/audio/voices":
+        if path == "/v1/audio/voices":
             _event("audio_voices")
             self._json(200, {"voices": ["Golden", "Harbor"]})
             return

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -574,22 +574,34 @@ start_persona() {
         --arg event_log "$OUT/fake-events.jsonl" \
         --arg pull_state "$OUT/pulled-models" \
         '{FAKE_EVENT_LOG: $event_log, FAKE_PULL_STATE: $pull_state}' > "$config"
-    local assignment key value updated
+    local assignment key value updated app_language=""
     # macOS ships Bash 3.2, where expanding a declared-but-empty array under
     # `set -u` raises "unbound variable". The `+` form expands to nothing
     # when the array has no elements and preserves argv boundaries otherwise.
     for assignment in "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}"; do
         key="${assignment%%=*}"
         value="${assignment#*=}"
+        if [[ "$key" == "RAPID_GUI_APP_LANGUAGE" ]]; then
+            app_language="$value"
+        fi
         updated="$config.next"
         jq --arg key "$key" --arg value "$value" '.[$key] = $value' "$config" > "$updated"
         mv "$updated" "$config"
     done
-    env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-        DOGFOOD_WORKING_SET_GB=0.1 \
-        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
-        "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
-        "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
+    if [[ -n "$app_language" ]]; then
+        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+            DOGFOOD_WORKING_SET_GB=0.1 \
+            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
+            "$PERSONA/launch.sh" -AppleLanguages "($app_language)" \
+            > "$OUT/app.log" 2>&1 &
+    else
+        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+            DOGFOOD_WORKING_SET_GB=0.1 \
+            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
+            "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
+    fi
     APP_PID=$!
     wait_for_window
 }
@@ -3858,6 +3870,42 @@ PY
                  and contains("Region: APAC"))
     ' "$OUT/fake-events.jsonl" >/dev/null \
         || die "the document request retained historical images or omitted extracted text"
+
+    cleanup_persona
+    flow_localized_photo_hint
+}
+
+flow_localized_photo_hint() {
+    start_persona localized-photo-hint \
+        RAPID_GUI_APP_LANGUAGE=zh-Hans \
+        FAKE_SERVING_LANE_REASON=vision_memory_insufficient
+    dismiss_first_run
+    start_model
+
+    local expected="此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+    local localized=0
+    for _ in {1..40}; do
+        see_main "$OUT/zh-main.json"
+        press "$OUT/zh-main.json" ChatView.AddAttachments "$OUT/zh-menu-press.json"
+        wait_identifier ChatView.Attachments.UploadPhoto "$OUT/zh-menu.json"
+        if jq -e --arg expected "$expected" '
+            .data.ui_elements[]?
+            | select(.identifier == "ChatView.Attachments.UploadPhoto"
+                     and .enabled == false
+                     and .help == $expected)
+        ' "$OUT/zh-menu.json" >/dev/null; then
+            localized=1
+            break
+        fi
+        press "$OUT/zh-menu.json" ChatView.AddAttachments "$OUT/zh-menu-close.json"
+        sleep 0.25
+    done
+    [[ "$localized" == 1 ]] \
+        || die "the disabled photo action never exposed its zh-Hans memory remedy"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "ContentView.Settings" and .description == "设置")' \
+        "$OUT/zh-menu.json" >/dev/null \
+        || die "the release-shaped app did not load its compiled zh-Hans resources"
 
     cleanup_persona
 }

--- a/apps/rapid-mac/scripts/verify-app-resources.swift
+++ b/apps/rapid-mac/scripts/verify-app-resources.swift
@@ -92,6 +92,27 @@ if packageSrc.contains("Localizable.xcstrings") {
         FileHandle.standardError.write(Data("FAIL: Localizable.xcstrings NOT found or unreadable in bundle\n".utf8))
         ok = false
     }
+
+    // The catalog is build input. Bundle.localizedString reads the compiled
+    // .lproj product, so a copied JSON catalog alone is not a localized app.
+    if let url = bundle.url(
+        forResource: "Localizable",
+        withExtension: "strings",
+        subdirectory: nil,
+        localization: "zh-Hans"
+    ),
+       let data = try? Data(contentsOf: url),
+       let strings = (try? PropertyListSerialization.propertyList(from: data, format: nil))
+           as? [String: String],
+       strings["Settings"] == "设置",
+       strings["image_input.unavailable.generic_text_lane"] != nil {
+        print("OK: compiled zh-Hans Localizable.strings keys=\(strings.count) at \(url.path)")
+    } else {
+        FileHandle.standardError.write(Data(
+            "FAIL: compiled zh-Hans Localizable.strings missing or incomplete\n".utf8
+        ))
+        ok = false
+    }
 }
 
 // SwiftMath must resolve from the assembled app itself. A development build

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -121,6 +121,7 @@ def test_manifest_fields_are_valid_and_fail_closed():
         "two-images",
         "update-busy",
         "update-state",
+        "zh-Hans",
     }
     expected_keys = {
         "name",

--- a/tests/test_gui_walk_completeness.py
+++ b/tests/test_gui_walk_completeness.py
@@ -42,7 +42,10 @@ def test_catalog_absence_checks_require_complete_walks():
 def test_empty_persona_environment_is_safe_on_macos_bash3():
     source = (ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh").read_text()
     safe = '${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}'
-    assert source.count(safe) == 3
+    # start_persona has two mutually exclusive launch branches so a localized
+    # persona can pass -AppleLanguages, while relaunch_persona has one. The
+    # loop that persists persona config is the fourth safe expansion.
+    assert source.count(safe) == 4
 
     program = r"""
 set -u

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -197,4 +197,5 @@ def test_real_dogfood_entrypoints_share_the_host_guards() -> None:
     assert 'size_args=(--model "$MODEL")' in mvp
     assert 'exec "$SCRIPT_DIR/dogfood-host-precheck.sh"' in ax
     assert 'exec "$ROOT/scripts/dogfood-host-precheck.sh"' in golden
-    assert golden.count("DOGFOOD_WORKING_SET_GB=0.1") == 2
+    # Localized, default, and restart launches must all keep the host guard.
+    assert golden.count("DOGFOOD_WORKING_SET_GB=0.1") == 3

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -548,11 +548,13 @@ def _engine_reasons() -> dict[str, bool]:
 
 
 def _swift_case_labels() -> set[str]:
-    """Every string matched by ``ImageInputAvailability.message(for:)``."""
+    """Every string matched by ``ImageInputAvailability.photoHint(for:)``."""
     text = PROFILE_SWIFT.read_text()
-    marker = "private static func message(for laneReason: String?) -> String"
+    marker = "static func photoHint(for laneReason: String?) -> PhotoHint"
     start = text.find(marker)
-    assert start != -1, f"message(for:) not found in {PROFILE_SWIFT} — parser is stale"
+    assert start != -1, (
+        f"photoHint(for:) not found in {PROFILE_SWIFT} — parser is stale"
+    )
 
     depth, body_start = 0, text.index("{", start)
     body = ""
@@ -564,14 +566,14 @@ def _swift_case_labels() -> set[str]:
             if depth == 0:
                 body = text[body_start : i + 1]
                 break
-    assert body, f"unbalanced message(for:) body in {PROFILE_SWIFT}"
+    assert body, f"unbalanced photoHint(for:) body in {PROFILE_SWIFT}"
 
     # Only quoted strings between `case` and its `:` are matched values; the
     # rest of the body is user-facing copy.
     labels: set[str] = set()
     for arm in re.finditer(r"case\s+((?:\"[^\"]+\"\s*,?\s*)+):", body):
         labels.update(re.findall(r'"([^"]+)"', arm.group(1)))
-    assert labels, "no case labels parsed out of message(for:) — parser is stale"
+    assert labels, "no case labels parsed out of photoHint(for:) — parser is stale"
     return labels
 
 


### PR DESCRIPTION
## Why

Serving-lane photo remedies were hard-coded English strings, so users running Rapid-MLX Desktop in another language received an English reason and recovery action. Reproduction also found that the assembled app copied `Localizable.xcstrings` as raw JSON but never compiled runtime `.lproj/Localizable.strings`; with `-AppleLanguages (zh-Hans)`, even existing catalog entries still appeared in English.

## What

- Map every legacy and live serving-lane reason to one stable semantic catalog key with a reviewed English fallback.
- Add complete English and Simplified Chinese values for all eight photo-unavailable outcomes.
- Compile the String Catalog into runtime `.lproj` resources during app assembly and fail closed when the compiler or catalog is absent.
- Extend bundle verification to require a real compiled Chinese catalog.
- Extend the existing multimodal attachment journey with a Chinese persona that proves the disabled photo action exposes the localized memory remedy.

## Scope and non-goals

Scope is Desktop photo-remedy localization, the release-shaped catalog pipeline, and focused behavior coverage. Engine lane selection, capability policy, English remedy wording, and unrelated Desktop strings are unchanged.

## Design precedent

Mature desktop localization keeps runtime failures behind one keyed localization boundary, preserves a readable source-language fallback, compiles catalogs into platform-native resources, and verifies the shipped bundle rather than only checking source JSON. This change adopts that pattern: the engine reason stays machine-readable, one typed table selects the message identity, and the bundle owns language resolution.

## Verification

- Red first: the catalog-key contract failed on the first missing photo-hint entry.
- `swift test --filter "ServerModelProfileTests|ChatImageAttachmentTests|LocalizationTests"` — 73/73 passed on exact head.
- Python serving-lane + GUI routing/preflight contracts — 43/43 passed on exact head.
- Release-shaped debug app build with sidecar/model staging disabled — passed; resource verifier found 59 catalog keys and compiled `zh-Hans.lproj/Localizable.strings`.
- `chat-multimodal-attachments` GUI journey — passed on exact head, including two images, a document, and the Simplified Chinese disabled-photo remedy.
- AX user evidence: `ContentView.Settings` described as `设置`; `ChatView.Attachments.UploadPhoto` disabled with `此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。`

Fixes #2521