### PR TITLE
fix(cli): report Flash-Next native MTP capability

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -149,6 +149,17 @@ def test_native_mtp_alias_metadata_is_strict_and_unambiguous() -> None:
             "native-mtp-without-depth",
             {"hf_path": "publisher/model", "supports_native_mtp": True},
         )
+    with pytest.raises(ValueError, match="native MTP is AR-only"):
+        _coerce(
+            "image-native-mtp",
+            {
+                "hf_path": "publisher/model",
+                "modality": "image-gen",
+                "supports_spec_decode": False,
+                "supports_native_mtp": True,
+                "mtp_speculative_tokens": 1,
+            },
+        )
     with pytest.raises(ValueError, match="mutually exclusive"):
         _coerce(
             "ambiguous-mtp-source",
@@ -158,6 +169,17 @@ def test_native_mtp_alias_metadata_is_strict_and_unambiguous() -> None:
                 "mtp_draft_model": "publisher/drafter",
             },
         )
+
+
+def test_flash_next_native_mtp_capability_label_is_opt_in() -> None:
+    from vllm_mlx.model_auto_config import _mtp_path_label
+
+    profile = list_profiles()["qwen3.8-flash-next-4bit"]
+
+    assert (
+        _mtp_path_label("qwen3.8-flash-next-4bit", profile)
+        == "native (opt-in: --speculative-config)"
+    )
 
 
 @pytest.mark.parametrize("bad_value", [0, 1, "true", None])

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -144,6 +144,11 @@ def test_native_mtp_alias_metadata_is_strict_and_unambiguous() -> None:
             "bad-native-mtp-bool",
             {"hf_path": "publisher/model", "supports_native_mtp": "true"},
         )
+    with pytest.raises(ValueError, match="requires explicit mtp_speculative_tokens"):
+        _coerce(
+            "native-mtp-without-depth",
+            {"hf_path": "publisher/model", "supports_native_mtp": True},
+        )
     with pytest.raises(ValueError, match="mutually exclusive"):
         _coerce(
             "ambiguous-mtp-source",

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -68,6 +68,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "is_hybrid_explicit",
         "is_moe",
         "supports_spec_decode",
+        "supports_native_mtp",
         "mtp_draft_model",
         "mtp_speculative_tokens",
         "default_max_tokens",
@@ -116,6 +117,8 @@ def test_qwen38_flash_next_alias_is_experimental_and_memory_gated() -> None:
     assert profile.is_hybrid_explicit is True
     assert profile.is_moe is True
     assert profile.supports_spec_decode is False
+    assert profile.supports_native_mtp is True
+    assert profile.mtp_speculative_tokens == 1
     assert profile.tool_call_parser == "hermes"
     assert profile.reasoning_parser == "qwen3"
     assert detect_model_config(alias) == profile
@@ -131,6 +134,25 @@ def test_qwen38_27b_aliases_pin_the_native_named_xml_tool_contract() -> None:
         assert profile.tool_call_parser == "qwen3_coder_xml"
         assert detect_model_config(alias) == profile
         assert detect_model_config(profile.hf_path) == profile
+
+
+def test_native_mtp_alias_metadata_is_strict_and_unambiguous() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="supports_native_mtp"):
+        _coerce(
+            "bad-native-mtp-bool",
+            {"hf_path": "publisher/model", "supports_native_mtp": "true"},
+        )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _coerce(
+            "ambiguous-mtp-source",
+            {
+                "hf_path": "publisher/model",
+                "supports_native_mtp": True,
+                "mtp_draft_model": "publisher/drafter",
+            },
+        )
 
 
 @pytest.mark.parametrize("bad_value", [0, 1, "true", None])
@@ -701,7 +723,7 @@ def test_mtp_preset_requires_a_valid_drafter_and_positive_token_count() -> None:
 def test_mtp_token_count_without_a_drafter_is_rejected() -> None:
     from vllm_mlx.model_aliases import _coerce
 
-    with pytest.raises(ValueError, match="requires mtp_draft_model"):
+    with pytest.raises(ValueError, match="requires .*mtp_draft_model"):
         _coerce(
             "fake-alias",
             {"hf_path": "fake/Model", "mtp_speculative_tokens": 3},

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -231,6 +231,13 @@ def test_models_command_renders_hybrid_marker_for_qwen35_moe():
     assert "n/a" in row, f"expected suffix tier 'n/a' in row: {row!r}"
 
 
+def test_models_command_surfaces_flash_next_native_mtp_preset():
+    out = _capture_models_output()
+    row = next(line for line in out.splitlines() if "qwen3.8-flash-next-4bit " in line)
+    assert "✓ MTP" in row
+    assert "MTP@native@1" in row
+
+
 def test_models_command_renders_parser_for_hermes3_8b():
     """Non-hybrid model with parser + benched tier renders both columns.
 

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -36,6 +36,7 @@ def test_available_payload_shape() -> None:
         "is_hybrid",
         "is_moe",
         "supports_spec_decode",
+        "supports_native_mtp",
         "mtp_draft_model",
         "mtp_speculative_tokens",
         "modality",
@@ -45,6 +46,7 @@ def test_available_payload_shape() -> None:
         assert key in entry, f"text entry missing {key!r}"
     assert isinstance(entry["is_hybrid"], bool)
     assert isinstance(entry["is_moe"], bool)
+    assert isinstance(entry["supports_native_mtp"], bool)
     assert isinstance(entry["is_builtin"], bool)
     assert isinstance(entry["is_text_only"], bool)
     assert entry["size_bytes"] is None or isinstance(entry["size_bytes"], int)

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -973,6 +973,7 @@ class TestVisibility:
 
         assert "experimental" in summary
         assert "Status           : ⚠ experimental" in table
+        assert "MTP path         : native (opt-in: --speculative-config)" in table
 
     def test_table_for_pure_attention_shows_supported(self):
         cfg = detect_model_config("mlx-community/Qwen3-0.6B-8bit")
@@ -1104,6 +1105,7 @@ class TestVisibility:
 
         matched_allowed = {
             "native",
+            "native (opt-in: --speculative-config)",
             "sidecar",
             "sidecar (opt-in: --speculative-config)",
             "disabled",

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -28,6 +28,7 @@ import pytest
 # registry and the serve path disagreed, so the test has to read the registry.
 ALIAS_WITH_MTP = "qwen3.8-27b-mixed-3.5bpw"
 ALIAS_WITHOUT_MTP = "qwen3.5-27b-4bit"
+NATIVE_MTP_ALIAS = "qwen3.8-flash-next-4bit"
 
 # Popular aliases with a published, architecture-matched sidecar and a
 # production-registered MTP injector.  This is intentionally curated rather
@@ -125,6 +126,22 @@ def test_alias_declaration_supplies_the_sidecar_and_depth():
     assert args.spec_decode == "mtp"
     assert args.mtp_sidecar == declared.mtp_draft_model
     assert args.mtp_max_k == declared.mtp_speculative_tokens
+
+
+def test_native_alias_declaration_supplies_depth_without_a_sidecar():
+    """The advertised native preset must drive the serve normalization too."""
+    from vllm_mlx.model_aliases import resolve_profile
+
+    declared = resolve_profile(NATIVE_MTP_ALIAS)
+    args = _normalize(
+        _args(model=NATIVE_MTP_ALIAS, speculative_config='{"method":"mtp"}')
+    )
+
+    assert declared.supports_native_mtp is True
+    assert declared.mtp_draft_model is None
+    assert args.spec_decode == "mtp"
+    assert args.mtp_sidecar is None
+    assert args.mtp_max_k == declared.mtp_speculative_tokens == 1
 
 
 def test_alias_without_a_declaration_still_gets_no_sidecar():

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -409,6 +409,8 @@
     "is_moe": true,
     "is_text_only": true,
     "supports_spec_decode": false,
+    "supports_native_mtp": true,
+    "mtp_speculative_tokens": 1,
     "min_memory_gb": 128,
     "experimental": true
   },

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6242,6 +6242,7 @@ def _available_models_json_payload() -> dict:
             "is_hybrid": bool(getattr(p, "is_hybrid", False)),
             "is_moe": bool(getattr(p, "is_moe", False)),
             "supports_spec_decode": bool(getattr(p, "supports_spec_decode", False)),
+            "supports_native_mtp": bool(getattr(p, "supports_native_mtp", False)),
             "mtp_draft_model": getattr(p, "mtp_draft_model", None),
             "mtp_speculative_tokens": getattr(p, "mtp_speculative_tokens", None),
             "modality": _modality(p),
@@ -6397,7 +6398,11 @@ def models_command(args):
         p = profiles[alias]
         tools = p.tool_call_parser or "—"
         reasoning = p.reasoning_parser or "—"
-        if p.mtp_draft_model:
+        if getattr(p, "supports_native_mtp", False):
+            spec = "✓ MTP"
+            tier = "n/a"
+            preset = f"MTP@native@{p.mtp_speculative_tokens}"
+        elif p.mtp_draft_model:
             spec = "✓ MTP"
             tier = "n/a"
             preset = f"MTP@{p.mtp_draft_model}@{p.mtp_speculative_tokens}"
@@ -6410,7 +6415,11 @@ def models_command(args):
             spec = "✓" if p.supports_spec_decode else "✗"
             tier = p.suffix_decoding_tier
             preset = "Suffix" if p.supports_spec_decode else "—"
-        if p.is_hybrid and not p.mtp_draft_model:
+        if (
+            p.is_hybrid
+            and not p.mtp_draft_model
+            and not getattr(p, "supports_native_mtp", False)
+        ):
             preset = "—"
 
         # DFlash column — eligible aliases show ✓, everything else "—" so

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2062,12 +2062,12 @@ def _build_benchmark_context(target_tokens: int) -> str:
 def _alias_mtp_declaration(model_name) -> tuple[str | None, int | None]:
     """Return ``(mtp_draft_model, mtp_speculative_tokens)`` declared by an alias.
 
-    ``(None, None)`` when the model is not a known alias, declares no MTP
-    sidecar, or the registry cannot be read. Resolution is best-effort by
-    design: this only supplies DEFAULTS for a request that already asked for
-    MTP, so a registry problem must degrade to "no default" and let the
-    injector's own hard-fail speak — never turn a serve into a crash of its
-    own (#1998).
+    ``(None, None)`` when the model is not a known alias, declares neither an
+    MTP sidecar nor a native MTP head, or the registry cannot be read.
+    Resolution is best-effort by design: this only supplies DEFAULTS for a
+    request that already asked for MTP, so a registry problem must degrade to
+    "no default" and let the injector's own hard-fail speak — never turn a
+    serve into a crash of its own (#1998).
 
     ``mtp_speculative_tokens`` is returned only when it is a positive int. The
     alias schema already rejects the alternatives (``model_aliases`` requires
@@ -2090,9 +2090,10 @@ def _alias_mtp_declaration(model_name) -> tuple[str | None, int | None]:
     # hand-edited-registry case it promises it for (codex nit).
     raw_sidecar = getattr(profile, "mtp_draft_model", None)
     sidecar = raw_sidecar.strip() or None if isinstance(raw_sidecar, str) else None
-    if sidecar is None:
-        # Depth without a sidecar is meaningless — the injector has nothing to
-        # load — so don't hand back a lone K either.
+    native_head = getattr(profile, "supports_native_mtp", False) is True
+    if sidecar is None and not native_head:
+        # Depth without either a sidecar or a native target head is
+        # meaningless, so don't hand back a lone K.
         return None, None
     depth = getattr(profile, "mtp_speculative_tokens", None)
     if not isinstance(depth, int) or isinstance(depth, bool) or depth <= 0:

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -544,6 +544,11 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: mtp_speculative_tokens requires "
             "supports_native_mtp=true or mtp_draft_model"
         )
+    if supports_native_mtp and "mtp_speculative_tokens" not in value:
+        raise ValueError(
+            f"alias {alias!r}: supports_native_mtp=true requires explicit "
+            "mtp_speculative_tokens"
+        )
     mtp_speculative_tokens = value.get("mtp_speculative_tokens", 3)
     if (
         isinstance(mtp_speculative_tokens, bool)

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -179,6 +179,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "is_hybrid_explicit",
             "is_moe",
             "supports_spec_decode",
+            "supports_native_mtp",
             "mtp_draft_model",
             "mtp_speculative_tokens",
             "default_max_tokens",
@@ -372,6 +373,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: ddtree_draft_model must be a string, "
             f"got {type(ddtree_draft_model).__name__}"
         )
+    supports_native_mtp = _strict_bool("supports_native_mtp", False)
 
     def _optional_positive_int(key: str) -> int | None:
         raw = value.get(key)
@@ -513,6 +515,11 @@ def _coerce(alias: str, value: object) -> AliasProfile:
                 f"alias {alias!r}: supports_ddtree must be false when "
                 f"modality={modality!r} (DDTree is AR-only)"
             )
+        if supports_native_mtp:
+            raise ValueError(
+                f"alias {alias!r}: supports_native_mtp must be false when "
+                f"modality={modality!r} (native MTP is AR-only)"
+            )
 
     mtp_draft_model = value.get("mtp_draft_model")
     if mtp_draft_model is not None and (
@@ -523,9 +530,19 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         raise ValueError(
             f"alias {alias!r}: mtp_draft_model must use non-empty 'org/repo' format"
         )
-    if "mtp_speculative_tokens" in value and mtp_draft_model is None:
+    if supports_native_mtp and mtp_draft_model is not None:
         raise ValueError(
-            f"alias {alias!r}: mtp_speculative_tokens requires mtp_draft_model"
+            f"alias {alias!r}: supports_native_mtp and mtp_draft_model are "
+            "mutually exclusive (native head versus sidecar drafter)"
+        )
+    if (
+        "mtp_speculative_tokens" in value
+        and mtp_draft_model is None
+        and not supports_native_mtp
+    ):
+        raise ValueError(
+            f"alias {alias!r}: mtp_speculative_tokens requires "
+            "supports_native_mtp=true or mtp_draft_model"
         )
     mtp_speculative_tokens = value.get("mtp_speculative_tokens", 3)
     if (
@@ -562,6 +579,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         is_hybrid_explicit=_strict_bool("is_hybrid_explicit", False),
         is_moe=_strict_bool("is_moe", False),
         supports_spec_decode=_strict_bool("supports_spec_decode", True),
+        supports_native_mtp=supports_native_mtp,
         mtp_draft_model=mtp_draft_model,
         mtp_speculative_tokens=mtp_speculative_tokens,
         default_max_tokens=value.get("default_max_tokens"),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2285,19 +2285,24 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
 def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     """Truth-in-labeling for the MTP spec-decode path of a model.
 
-    Returns one of ``native`` / ``sidecar`` /
+    Returns one of ``native`` /
+    ``native (opt-in: --speculative-config)`` / ``sidecar`` /
     ``sidecar (opt-in: --speculative-config)`` / ``disabled``:
 
     * ``native``   — the family ships a native MTP head in the checkpoint
       (Qwen3.5 / Qwen3.6 / HY3) AND the resolved profile enables spec
       decode (``supports_spec_decode=True``). This is the path
       ``vllm_mlx.spec_decode.mtp`` drives directly.
+    * ``native (opt-in: --speculative-config)`` — method-specific profile
+      metadata declares a validated native head while the generic speculative
+      lane remains disabled (for example, a coupled hybrid verifier).
     * ``sidecar``  — Gemma 4: MTP is provided by an assistant drafter
       loaded alongside the base weights (no head baked in), and the
       profile enables spec decode.
     * ``sidecar (opt-in: --speculative-config)`` — the alias declares an MTP
       sidecar, but Rapid leaves it disabled until the user explicitly opts in.
-    * ``disabled`` — spec decode is off for this profile
+    * ``disabled`` — no native/sidecar MTP capability is declared and spec
+      decode is off for this profile
       (``supports_spec_decode=False`` — hybrid arch, or no MTP head /
       drafter registered for this alias), the family has no MTP mechanism
       at all (SuffixDecoding / DFlash are separate lanes surfaced by the
@@ -2307,6 +2312,12 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     Derivation is from the resolved profile only (no ``config.json``
     read), keeping the ``rapid-mlx info`` path weight-free.
     """
+    if getattr(cfg, "supports_native_mtp", False):
+        # Method-specific capability metadata is authoritative here. A hybrid
+        # checkpoint can disable the generic speculative lane while its
+        # native MTP injector remains verified. The feature is still
+        # explicit opt-in; this reports capability, never default-on state.
+        return "native (opt-in: --speculative-config)"
     if (getattr(cfg, "mtp_draft_model", None) or "").strip():
         # #1998: the alias DECLARES its own MTP sidecar, and that declaration
         # now drives the serve path, so MTP genuinely runs for this checkpoint

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -166,6 +166,10 @@ class ModelProfile:
     # Optional, bench-verified MTP preset. Presence takes precedence over the
     # generic suffix preset in catalog/UI surfaces; the target alias remains
     # opt-in and the engine never enables it automatically.
+    # Native MTP is separate from ``supports_spec_decode``: a hybrid model may
+    # disable the generic suffix/draft verifier while its model-specific MTP
+    # injector remains valid.
+    supports_native_mtp: bool = False
     mtp_draft_model: str | None = None
     mtp_speculative_tokens: int = 3
     default_max_tokens: int | None = None  # Per-model default when user omits


### PR DESCRIPTION
## Intention

Make the validated Flash-Next native MTP path discoverable from `rapid-mlx info` and the model catalog without implying that MTP is default-on.

Fixes #2609

## Scope

- add method-specific `supports_native_mtp` model capability metadata
- mark the exact Flash-Next alias as native MTP, K=1
- align text and JSON model catalog surfaces plus `rapid-mlx info`
- validate native-head versus sidecar metadata as mutually exclusive
- add focused registry and CLI contracts

## Non-goals

- no MTP runtime, sampler, scheduler, or kernel changes
- no change to default-on/off policy
- no model or dependency changes
- no Desktop or CI workflow changes

## Design precedent

Mature serving engines represent speculative decoding as a method-specific capability/configuration rather than overloading the generic draft-model gate. This adapts that separation: native target heads and external sidecars are distinct metadata, while startup still validates the checkpoint config before attaching MTP.

## Acceptance

- `rapid-mlx info qwen3.8-flash-next-4bit` reports `native (opt-in: --speculative-config)`
- `rapid-mlx models` reports `MTP@native@1`
- hybrid models without validated native MTP remain disabled
- malformed or ambiguous alias metadata fails closed

## Verification

- 3,518 focused registry/CLI/MTP/routing tests passed
- ruff check passed
- ruff format --check passed
- git diff --check passed
- user-side CLI output verified from the exact branch