### PR TITLE
fix(cli): keep mirror fallback for selected pull variants

### DIFF
--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -187,7 +187,7 @@ def test_partial_mirror_fetch_combines_into_fallback_verdict(
     )
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _mirror_partial(model_name: str, *, out=None) -> bool:
+    def _mirror_partial(model_name: str, *, out=None, allow_patterns=None) -> bool:
         # Mirror fetched some blobs (network_fetch=True) but ultimately
         # returned False (a file missed both R2 and HF).
         if out is not None:
@@ -304,7 +304,7 @@ def test_summary_printed_on_mirror_success(
     cache_root = tmp_path / "hub"
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
-    def _mirror_fetch(model_name: str, *, out=None) -> bool:
+    def _mirror_fetch(model_name: str, *, out=None, allow_patterns=None) -> bool:
         """Simulate the mirror downloading the snapshot during this pull."""
         repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
         refs_dir = repo_root / "refs"
@@ -357,7 +357,9 @@ def test_cached_pull_reports_verified_not_downloaded(
 
     # The mirror reports it fetched ZERO bytes this pull (every file was
     # already cached) -> "verified (nothing to download)", not "Downloaded".
-    def _mirror_already_cached(model_name: str, *, out=None) -> bool:
+    def _mirror_already_cached(
+        model_name: str, *, out=None, allow_patterns=None
+    ) -> bool:
         if out is not None:
             out["network_fetch"] = False
         return True
@@ -398,7 +400,7 @@ def test_moved_main_reported_as_download(
     (refs_dir / "main").write_text(stale_rev)
     _make_fake_snapshot(repo_root / "snapshots" / stale_rev, total_bytes=4096)
 
-    def _mirror_fetch(model_name: str, *, out=None) -> bool:
+    def _mirror_fetch(model_name: str, *, out=None, allow_patterns=None) -> bool:
         # Remote main advanced mid-pull: refs/main now points at a NEWER rev
         # whose snapshot bytes were actually fetched over the wire.
         (refs_dir / "main").write_text(head_rev)

--- a/tests/test_pull_variant_selection.py
+++ b/tests/test_pull_variant_selection.py
@@ -75,14 +75,10 @@ def _pull_capturing(**flags):
     return side
 
 
-def test_bits_narrows_snapshot_and_bypasses_mirror(capsys):
+def test_bits_narrows_snapshot_and_uses_mirror(capsys):
     side = _pull_capturing(bits="4", format=None)
     assert side["allow"] == ["4bit/*"]
-    # An explicit variant bypasses the whole-repo mirror prefetch (option B).
-    assert side["mirror_calls"] == 0
-    # Refinement (1): a clear line explains that the mirror was skipped.
-    out = capsys.readouterr().out
-    assert "R2 mirror skipped" in out
+    assert side["mirror_calls"] == 1
 
 
 def test_format_narrows_snapshot_by_folder_name():
@@ -253,6 +249,68 @@ def test_no_selector_still_consults_mirror():
     ):
         cli.pull_command(args)
     assert mirror.call_count == 1
+
+
+@pytest.mark.parametrize("bits,fmt", [("4", None), (None, "4bit")])
+def test_user_variant_consults_mirror_first(bits, fmt):
+    """Explicit bits/format selection keeps the mirror-first path enabled."""
+    requested = f"{bits}bit" if bits else fmt
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits=bits, format=fmt)
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree",
+            return_value=_multi_variant_tree(),
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=True) as mirror,
+        patch("huggingface_hub.snapshot_download") as snapshot,
+    ):
+        cli.pull_command(args)
+
+    assert mirror.call_count == 1
+    assert mirror.call_args.kwargs["allow_patterns"] == [f"{requested}/*"]
+    snapshot.assert_not_called()
+
+
+def test_mirror_variant_miss_falls_back_with_same_pattern(capsys):
+    """A mirror miss falls back upstream with the identical allow pattern."""
+    args = argparse.Namespace(model="LiquidAI/LFM2.5-2.6B-MLX", bits="4", format=None)
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree",
+            return_value=_multi_variant_tree(),
+        ),
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch("huggingface_hub.snapshot_download", return_value="/cache/x") as snap,
+    ):
+        cli.pull_command(args)
+
+    assert snap.call_args.kwargs["allow_patterns"] == ["4bit/*"]
+
+
+def test_mirror_prefetch_forwards_explicit_variant_allow():
+    """The mirror adapter passes an explicit variant override unchanged."""
+    with patch(
+        "vllm_mlx._mirror.download_with_mirror_fallback", return_value=True
+    ) as download:
+        assert cli._try_mirror_prefetch("org/repo", allow_patterns=["4bit/*"]) is True
+
+    assert download.call_args.kwargs["allow_patterns"] == ["4bit/*"]
+
+
+def test_mirror_prefetch_keeps_catalog_subfolder_default():
+    """The existing subfolder narrowing stays the default mirror filter."""
+    with (
+        patch(
+            "vllm_mlx.model_aliases.subfolder_allow_patterns",
+            return_value=["catalog/*"],
+        ),
+        patch(
+            "vllm_mlx._mirror.download_with_mirror_fallback", return_value=True
+        ) as download,
+    ):
+        assert cli._try_mirror_prefetch("org/repo") is True
+
+    assert download.call_args.kwargs["allow_patterns"] == ["catalog/*"]
 
 
 def test_orphan_reap_announces_cleaned_files(capsys):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1658,6 +1658,7 @@ def _try_mirror_prefetch(
     model_name: str,
     on_pull_start: Callable[[], None] | None = None,
     *,
+    allow_patterns: list[str] | None = None,
     out: dict | None = None,
 ) -> bool:
     """Pre-fetch a HuggingFace repo via R2-first / HF-fallback (per file).
@@ -1693,7 +1694,8 @@ def _try_mirror_prefetch(
     # assumption that none were mirrored; ``lfm2.5-2.6b-4bit`` is, and the
     # decline stranded its R2 copy while the HF path could hang the desktop
     # at "Starting…".)
-    allow_patterns = subfolder_allow_patterns(model_name)
+    if allow_patterns is None:
+        allow_patterns = subfolder_allow_patterns(model_name)
     try:
         from vllm_mlx._mirror import download_with_mirror_fallback
     except ImportError:
@@ -6928,18 +6930,7 @@ def pull_command(args):
     # R2-first / HuggingFace-fallback per file. Default mirror is
     # ``https://models.rapidmlx.com``; set ``RAPID_MLX_MODEL_MIRROR=""``
     # to force HF only. The function prints its own progress + summary.
-    # #2145: when the user explicitly selected a variant (--bits/--format), the
-    # mirror prefetch has no narrow-to-variant mode yet (Vector's #2279 adds
-    # allow_patterns there, unlanded) — it would pull the WHOLE (or catalog
-    # subfolder) repo and defeat the selection. So a requested variant bypasses
-    # the mirror and goes straight to the narrowed HF snapshot_download below.
-    # Revisit once #2279 lands allow_patterns in the mirror path.
-    if variant_allow is not None:
-        print(
-            "  R2 mirror skipped: a --bits/--format variant was requested "
-            "(the mirror cannot narrow to one variant yet)."
-        )
-    if variant_allow is None and _try_mirror_prefetch(repo_id, out=_mirror_out):
+    if _try_mirror_prefetch(repo_id, allow_patterns=variant_allow, out=_mirror_out):
         from pathlib import Path
 
         try:


### PR DESCRIPTION
## User-visible goal

Keep the fast mirror-first pull path enabled when the user explicitly selects a quantization with `--bits` or `--format`.

## Changes

- Thread the selected variant allow-pattern through `_try_mirror_prefetch`.
- Preserve the existing catalog subfolder narrowing when no explicit selector is present.
- Remove the previous variant-selector mirror bypass.
- Add coverage for explicit `bits`/`format` mirror requests, mirror-miss fallback with the identical allow-pattern, and direct mirror adapter forwarding.

## Non-goals

- No new transfer implementation.
- No mirror catalog or integrity contract changes.
- No unrelated pull summary behavior changes.

## Verification

- `pytest -q tests/test_pull_variant_selection.py tests/test_pull_summary.py tests/test_alias_subfolder.py` — 101 passed.
- `ruff check vllm_mlx/cli.py tests/test_pull_variant_selection.py tests/test_pull_summary.py`.
- `ruff format --check vllm_mlx/cli.py tests/test_pull_variant_selection.py tests/test_pull_summary.py`.

Fixes #2554.
