### PR TITLE
fix(api): preserve zero request timeout as server default

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -40,7 +40,7 @@ flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
 | `--trusted-hosts` | Opt-in Host-header allowlist; non-matching requests get HTTP 400 | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--max-request-bytes` | Max HTTP request body size; oversized requests get HTTP 413 before parsing (0 disables) | 8 MiB (8388608) |
-| `--timeout` | Request timeout in seconds | 1800 |
+| `--timeout` | Default request timeout in seconds; per-request `timeout: null` or `timeout: 0` uses this value | 1800 |
 | `--max-num-seqs` | Max concurrent sequences | 256 |
 | `--max-concurrent-requests` | Admission cap on in-flight requests (queued + running); excess requests get HTTP 503 with `Retry-After` | 256 |
 | `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower for better first-token latency under concurrent cold load | 8 |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,7 +78,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | `--trusted-hosts` | Opt-in Host-header allowlist (DNS-rebinding hardening): non-matching requests get HTTP 400. Space- or comma-separated; also settable via `RAPID_MLX_TRUSTED_HOSTS`. | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--max-request-bytes` | Maximum HTTP request body size in bytes; larger requests are rejected with HTTP 413 before JSON parsing. 0 disables. Falls back to `RAPID_MLX_MAX_REQUEST_BYTES`. | 8 MiB (8388608) |
-| `--timeout` | Request timeout in seconds | 1800 |
+| `--timeout` | Default request timeout in seconds; per-request `timeout: null` or `timeout: 0` uses this value | 1800 |
 
 #### Admission and batching
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,7 +33,7 @@ category. The exhaustive flag list (every flag visible in
 | `--trusted-hosts` | Opt-in Host-header allowlist; non-matching requests get HTTP 400 (also via `RAPID_MLX_TRUSTED_HOSTS`) | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | `0` |
 | `--max-request-bytes` | Max HTTP request body size in bytes; oversized requests get HTTP 413 before parsing. 0 disables. (also via `RAPID_MLX_MAX_REQUEST_BYTES`) | 8 MiB (8388608) |
-| `--timeout` | Request timeout in seconds | `1800` |
+| `--timeout` | Default request timeout in seconds; per-request `timeout: null` or `timeout: 0` uses this value | `1800` |
 
 #### MLLM media input guards (environment only)
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -685,6 +685,9 @@ class TestStopAndTimeoutHelpers:
             with pytest.raises(ValueError, match="not a boolean"):
                 _validate_timeout(bad)
 
+    def test_validate_timeout_defers_non_numeric_types_to_pydantic(self):
+        assert _validate_timeout(["seconds"]) == ["seconds"]
+
     def test_validate_timeout_nonfinite_rejected(self):
         for bad in (float("nan"), float("inf"), float("-inf")):
             with pytest.raises(ValueError):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -639,11 +639,16 @@ class TestTimeoutValidation:
     when it reaches the request-timeout guard in the routes."""
 
     @pytest.mark.parametrize("factory", [_chat, _completion])
-    @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
+    @pytest.mark.parametrize("bad", [-1, -0.5, -1.0, False, True])
     def test_non_positive_rejected(self, factory, bad):
         with pytest.raises(ValidationError) as excinfo:
             factory(timeout=bad)
         assert "timeout" in str(excinfo.value)
+
+    @pytest.mark.parametrize("factory", [_chat, _completion])
+    @pytest.mark.parametrize("value", [0, 0.0])
+    def test_zero_normalizes_to_server_default(self, factory, value):
+        assert factory(timeout=value).timeout is None
 
     @pytest.mark.parametrize("factory", [_chat, _completion])
     @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
@@ -670,6 +675,15 @@ class TestStopAndTimeoutHelpers:
 
     def test_validate_timeout_none_passthrough(self):
         assert _validate_timeout(None) is None
+
+    def test_validate_timeout_zero_sentinel(self):
+        assert _validate_timeout(0) is None
+        assert _validate_timeout(0.0) is None
+
+    def test_validate_timeout_boolean_rejected(self):
+        for bad in (False, True):
+            with pytest.raises(ValueError, match="not a boolean"):
+                _validate_timeout(bad)
 
     def test_validate_timeout_nonfinite_rejected(self):
         for bad in (float("nan"), float("inf"), float("-inf")):

--- a/tests/test_stop_and_timeout_request_schema.py
+++ b/tests/test_stop_and_timeout_request_schema.py
@@ -3,9 +3,9 @@
 
 Covers one behaviour on both ``/v1/chat/completions`` and ``/v1/completions``:
 
-  * a non-positive / non-finite ``timeout`` is rejected with the unified
-    ``invalid_request_error`` 400 naming the field — NOT an instant 504
-    from an ``asyncio.wait_for``-style guard consuming the bad value.
+  * omitted, null, and numeric-zero ``timeout`` follow the server-default
+    path; negative, boolean, and non-finite values are rejected with the
+    unified ``invalid_request_error`` 400 naming the field.
 
 The schema-level normalization / rejection logic itself is unit-tested in
 ``tests/test_api_models.py`` (scalar-``stop`` acceptance + ``timeout``
@@ -110,11 +110,9 @@ def _completion_body(**kw) -> dict:
         ("completion_client", "/v1/completions", _completion_body),
     ],
 )
-@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -1.0])
-def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
-    """A ``timeout <= 0`` must 400 with the unified envelope naming the
-    field (pre-fix it reached the route's timeout guard and fired an
-    instant 504)."""
+@pytest.mark.parametrize("bad", [-1, -0.5, -1.0, False, True])
+def test_negative_or_boolean_timeout_400(request, client_name, url, body_fn, bad):
+    """A malformed timeout must 400 with the unified envelope naming the field."""
     client = request.getfixturevalue(client_name)
     r = client.post(url, json=body_fn(timeout=bad))
     assert r.status_code == 400, (
@@ -123,6 +121,23 @@ def test_nonpositive_timeout_400(request, client_name, url, body_fn, bad):
     body = r.json()
     assert body["error"]["type"] == "invalid_request_error"
     assert "timeout" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_name,url,body_fn",
+    [
+        ("chat_client", "/v1/chat/completions", _chat_body),
+        ("completion_client", "/v1/completions", _completion_body),
+    ],
+)
+@pytest.mark.parametrize("value", [0, 0.0])
+def test_zero_timeout_uses_server_default(request, client_name, url, body_fn, value):
+    """Zero is a compatibility sentinel, never a malformed request."""
+    client = request.getfixturevalue(client_name)
+    response = client.post(url, json=body_fn(timeout=value))
+
+    assert response.status_code != 400
+    assert "timeout" not in response.text.lower()
 
 
 @pytest.mark.parametrize(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -13,7 +13,7 @@ import math
 import re
 import time
 import uuid
-from typing import Literal
+from typing import Literal, SupportsFloat
 
 from pydantic import (
     BaseModel,
@@ -126,10 +126,9 @@ def _validate_timeout(v: object) -> object:
         raise ValueError("timeout must be a number of seconds, not a boolean")
     if v is None:
         return None
-    try:
-        timeout = float(v)
-    except (TypeError, ValueError):
+    if not isinstance(v, SupportsFloat):
         return v
+    timeout = float(v)
     if not math.isfinite(timeout):
         raise ValueError("timeout must be a finite number of seconds (not NaN or inf)")
     if timeout == 0:

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -112,27 +112,34 @@ def _reject_nonfinite_float(v: float | None) -> float | None:
     return v
 
 
-def _validate_timeout(v: float | None) -> float | None:
-    """Reject a non-positive / non-finite request ``timeout`` at the
-    schema layer so both OpenAI surfaces share one contract.
+def _validate_timeout(v: object) -> object:
+    """Normalize a request ``timeout`` at the shared schema boundary.
 
-    ``timeout`` feeds ``asyncio.wait_for``-style guards in the routes
-    (the non-streaming path and the disconnect watcher). A value that is
-    ``<= 0`` or NaN/±inf makes those guards fire an immediate timeout →
-    a 504 the client can't diagnose. Rejecting here (4xx naming the
-    ``timeout`` field) surfaces the malformed field instead. ``None``
-    passes through so the server-default path is preserved.
+    Numeric zero is a compatibility sentinel for the server default,
+    preserving the pre-0.13.0 behavior used by clients that serialize
+    an explicit default as ``0``. Negative and non-finite values remain
+    invalid so they cannot turn into immediate or unbounded timeout
+    guards. ``None`` passes through so the server-default path is
+    preserved.
     """
+    if isinstance(v, bool):
+        raise ValueError("timeout must be a number of seconds, not a boolean")
     if v is None:
         return None
-    if not math.isfinite(v):
+    try:
+        timeout = float(v)
+    except (TypeError, ValueError):
+        return v
+    if not math.isfinite(timeout):
         raise ValueError("timeout must be a finite number of seconds (not NaN or inf)")
-    if v <= 0:
+    if timeout == 0:
+        return None
+    if timeout < 0:
         raise ValueError(
-            "timeout must be > 0 seconds when set (got "
-            f"{v}); omit the field to use the server default."
+            "timeout must be 0 or a positive number of seconds (got "
+            f"{v}); omit the field or pass 0 to use the server default."
         )
-    return v
+    return timeout
 
 
 def _normalize_stop(v) -> list[str] | None:
@@ -1915,9 +1922,9 @@ class ChatCompletionRequest(BaseModel):
     def _normalize_stop(cls, v):
         return _normalize_stop(v)
 
-    @field_validator("timeout")
+    @field_validator("timeout", mode="before")
     @classmethod
-    def _validate_timeout(cls, v: float | None) -> float | None:
+    def _validate_timeout_before(cls, v: object) -> object:
         return _validate_timeout(v)
 
     def stop_sequences(self) -> list[str] | None:
@@ -2358,9 +2365,9 @@ class CompletionRequest(BaseModel):
     def _normalize_stop(cls, v):
         return _normalize_stop(v)
 
-    @field_validator("timeout")
+    @field_validator("timeout", mode="before")
     @classmethod
-    def _validate_timeout(cls, v: float | None) -> float | None:
+    def _validate_timeout_before(cls, v: object) -> object:
         return _validate_timeout(v)
 
     def stop_sequences(self) -> list[str] | None:


### PR DESCRIPTION
## User-visible goal

Restore compatibility for OpenAI-compatible clients that serialize an explicit default request timeout as `timeout: 0`, while keeping malformed timeouts rejected.

## Changes

- Normalize omitted, `null`, and numeric-zero `timeout` values to the server-default path at the shared request-schema boundary.
- Retain finite positive timeouts as per-request overrides.
- Reject negative, boolean, NaN, and infinite timeout values with a field-specific 4xx.
- Document the zero sentinel and rejection contract.

## Non-goals

- No engine cancellation semantics changes.
- No public API redesign.
- No client-side timeout behavior changes.

## Verification

- `pytest -q tests/test_api_models.py tests/test_stop_and_timeout_request_schema.py tests/test_server.py` — 233 passed.
- `ruff check vllm_mlx/api/models.py tests/test_api_models.py tests/test_stop_and_timeout_request_schema.py`.
- `ruff format --check vllm_mlx/api/models.py tests/test_api_models.py tests/test_stop_and_timeout_request_schema.py`.

Fixes #2551.
