### PR TITLE
fix(residency): serve residents through reject-mode replacement loads

### DIFF
--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1933,6 +1933,48 @@ async def test_rejected_busy_replacement_reopens_engine_admission():
     assert registry.default_name == "chat-old"
 
 
+@pytest.mark.asyncio
+async def test_reject_replacement_keeps_old_engine_open_during_slow_load():
+    """The healthy assistant serves while a reject-mode replacement loads."""
+    registry = ModelRegistry()
+    old_engine = FakeLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    request_started = asyncio.Event()
+    release_loader = asyncio.Event()
+
+    async def loader(name: str, path: str | None, performance=None):
+        old_engine.running = 1
+        request_started.set()
+        await asyncio.sleep(0)
+        await release_loader.wait()
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant")
+    )
+    await asyncio.wait_for(request_started.wait(), timeout=1)
+
+    assert old_engine.paused is False
+    assert old_engine.pauses == [("wait", 0)]
+    assert old_engine.running == 1
+    assert registry.default_name == "chat-old"
+
+    release_loader.set()
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await asyncio.wait_for(replacement, timeout=1)
+
+    assert old_engine.pauses == [("wait", 0), ("wait", 0)]
+    assert old_engine.paused is False
+    assert old_engine.running == 1
+    assert old_engine.stopped is False
+    assert registry.default_name == "chat-old"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-old"]
+
+
 def test_residency_status_uses_engine_owned_request_counts():
     registry = ModelRegistry()
     engine = FakeLifecycleEngine()

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -710,6 +710,9 @@ class ResidentModelManager:
                         )
                         destructive_replacement = True
                         paused_engines = []
+                    elif paused_engines:
+                        await self._resume_engines(paused_engines)
+                        paused_engines = []
                 await self._evict_for_locked(
                     estimate,
                     exclude={model_name, *(item.model_id for item in candidates)},
@@ -739,14 +742,20 @@ class ResidentModelManager:
                     record.primary = destructive_primary
                     if destructive_primary:
                         record.pinned = True
-                elif replace_group is not None and replace_mode != "reject":
-                    (
-                        candidates,
-                        paused_engines,
-                    ) = await self._quiesce_replacement_group_locked(
-                        replace_group,
-                        replace_mode,
-                    )
+                elif replace_group is not None:
+                    if replace_mode != "reject":
+                        (
+                            candidates,
+                            paused_engines,
+                        ) = await self._quiesce_replacement_group_locked(
+                            replace_group,
+                            replace_mode,
+                        )
+                    else:
+                        paused_engines = await self._quiesce_records_locked(
+                            candidates,
+                            replace_mode,
+                        )
                 elif group is not None and replace_group is None:
                     candidates, paused_engines = await self._quiesce_group_locked(
                         record, group, replace_mode


### PR DESCRIPTION
## User-visible goal

Keep the resident assistant serving while a reject-mode replacement model loads, instead of returning `503 generation-is-paused` for the entire load.

## Changes

- Reopen admission on the retiring group before the replacement loader runs.
- Close admission again only at the bounded replacement commit decision.
- Preserve wait and abort replacement semantics and destructive capacity paths.
- Roll back cleanly if the candidate load or commit fails, leaving the old assistant published.
- Add a concurrency regression test for a slow replacement loader with an active request at the commit boundary.

## Non-goals

- No residency routing-policy redesign.
- No model heuristics or capacity-policy changes.
- No route-local replacement exceptions.

## Verification

- `pytest -q tests/test_resident_models.py tests/test_engine_lifecycle.py tests/test_routing_groups_0131.py` — 140 passed; 2 unrelated baseline failures in the same file also fail without this patch.
- `ruff check vllm_mlx/runtime/resident_models.py tests/test_resident_models.py`.
- `ruff format --check vllm_mlx/runtime/resident_models.py tests/test_resident_models.py`.

Fixes #2550.
