### PR TITLE
fix(guided): constrain Flash-Next structured output

### DIFF
--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -505,6 +505,37 @@ class TestGuidedGenerator:
 
         assert generator._get_lltokenizer() is not None
 
+    @requires_guided
+    def test_passes_inner_hf_tokenizer_not_forwarding_wrapper(self, monkeypatch):
+        """A wrapper can proxy the fast-tokenizer attributes to its inner.
+
+        Shape detection must still pass the actual HF tokenizer to the grammar
+        adapter; selecting the proxy regresses the standard loader path.
+        """
+        import vllm_mlx.api.guided as guided
+
+        tokenizer = _build_byte_level_fast_tokenizer()
+
+        class _ForwardingWrapper:
+            def __init__(self, inner):
+                self._tokenizer = inner
+
+            def __getattr__(self, name):
+                return getattr(self._tokenizer, name)
+
+        captured = []
+        sentinel = object()
+
+        def _from_tokenizer(candidate):
+            captured.append(candidate)
+            return sentinel
+
+        monkeypatch.setattr(guided._llguidance_hf, "from_tokenizer", _from_tokenizer)
+        generator = guided.GuidedGenerator(object(), _ForwardingWrapper(tokenizer))
+
+        assert generator._get_lltokenizer() is sentinel
+        assert captured == [tokenizer]
+
 
 # ---------------------------------------------------------------------------
 # Real-llguidance constrained decode over a fake model

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -490,6 +490,21 @@ class TestGuidedGenerator:
         finally:
             guided.HAS_LLGUIDANCE = original
 
+    @requires_guided
+    def test_accepts_direct_hf_fast_tokenizer_from_vendored_loader(self):
+        """Vendored loaders return the HF fast tokenizer directly.
+
+        Its ``._tokenizer`` attribute is the raw Rust tokenizer, not another
+        HF wrapper. Guided decoding must pass the outer fast tokenizer to
+        llguidance instead of unwrapping it one level too far.
+        """
+        import vllm_mlx.api.guided as guided
+
+        tokenizer = _build_byte_level_fast_tokenizer()
+        generator = guided.GuidedGenerator(object(), tokenizer)
+
+        assert generator._get_lltokenizer() is not None
+
 
 # ---------------------------------------------------------------------------
 # Real-llguidance constrained decode over a fake model

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -310,6 +310,7 @@ def test_strict_true_guided_available_non_streaming_routes_to_constrained():
     # un-wrapped from ``response_format`` so llguidance can interpret
     # ``$defs``/``$ref``/``additionalProperties:false`` natively (PR #419).
     assert engine.guided_calls[0]["json_schema"] == _VALID_SCHEMA
+    assert engine.guided_calls[0]["kwargs"]["raise_on_failure"] is True
 
     # The strict counter must have ticked exactly once.
     snap = response_format_metrics.snapshot()
@@ -1497,6 +1498,7 @@ def test_strict_false_guided_available_routes_to_guided():
     resp = client.post("/v1/chat/completions", json=_payload(strict=False))
     assert resp.status_code == 200, resp.text
     assert len(engine.guided_calls) == 1
+    assert engine.guided_calls[0]["kwargs"]["raise_on_failure"] is False
     # Strict counter must NOT have ticked — only strict=true requests count.
     snap = response_format_metrics.snapshot()
     assert snap["strict_requests_total"] == 0

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -218,11 +218,11 @@ class GuidedGenerator:
     ``json_object`` mode, any valid JSON object).
 
     The llguidance ``LLTokenizer`` is built lazily on first use and cached
-    on the instance — it is derived from the INNER transformers fast/Rust
-    tokenizer (``tokenizer._tokenizer``), not the ``mlx_lm``
-    ``TokenizerWrapper``. If the model ships without a fast tokenizer,
-    tokenizer construction fails gracefully (logged, returns ``None`` from
-    generation) rather than crashing.
+    on the instance — it is derived from a transformers fast tokenizer,
+    whether the loader returned that tokenizer directly or wrapped it in an
+    ``mlx_lm`` ``TokenizerWrapper``. If the model ships without a fast
+    tokenizer, tokenizer construction fails gracefully (logged, returns
+    ``None`` from generation) rather than crashing.
     """
 
     def __init__(self, model, tokenizer):
@@ -250,12 +250,12 @@ class GuidedGenerator:
     def _get_lltokenizer(self):
         """Get or build the llguidance ``LLTokenizer``.
 
-        llguidance needs the underlying *fast* (Rust-backed) transformers
-        tokenizer, exposed by ``mlx_lm``'s ``TokenizerWrapper`` as
-        ``._tokenizer``. Models loaded with a slow (pure-Python)
-        tokenizer do not have that attribute in a usable form; in that
-        case we log once and return ``None`` so the caller can degrade to
-        unconstrained generation instead of raising.
+        llguidance needs the *fast* (Rust-backed) transformers tokenizer.
+        Standard ``mlx_lm`` loads expose it through ``TokenizerWrapper``'s
+        ``._tokenizer``; vendored loaders can return it directly. Models
+        loaded with a slow (pure-Python) tokenizer have neither supported
+        shape; in that case we log once and return ``None`` so the caller can
+        degrade to unconstrained generation instead of raising.
 
         Returns:
             An ``LLTokenizer`` instance, or ``None`` if one cannot be
@@ -266,24 +266,28 @@ class GuidedGenerator:
         if self._lltokenizer is not False:
             return self._lltokenizer
 
-        hf_tok = getattr(self._tokenizer, "_tokenizer", None)
+        # ``mlx_lm`` normally passes a TokenizerWrapper whose ``._tokenizer``
+        # is the HF fast tokenizer. Vendored model loaders may instead return
+        # that HF tokenizer directly; in that shape ``._tokenizer`` is the
+        # lower-level Rust object, which llguidance.hf intentionally rejects.
+        # Normalize both supported shapes to the HF wrapper that owns
+        # ``backend_tokenizer``.
+        candidates = (self._tokenizer, getattr(self._tokenizer, "_tokenizer", None))
+        hf_tok = next(
+            (
+                candidate
+                for candidate in candidates
+                if candidate is not None
+                and getattr(candidate, "is_fast", False) is True
+                and hasattr(candidate, "backend_tokenizer")
+            ),
+            None,
+        )
         if hf_tok is None:
             logger.warning(
                 "Guided generation unavailable: the model's tokenizer has "
-                "no underlying fast (Rust) tokenizer (`._tokenizer`), which "
-                "llguidance requires. Falling back to unconstrained "
-                "generation."
-            )
-            self._lltokenizer = None
-            return None
-
-        # A fast tokenizer is required for `llguidance.hf.from_tokenizer`;
-        # a slow tokenizer lacks `is_fast`/the Rust internals it reads.
-        if getattr(hf_tok, "is_fast", True) is False:
-            logger.warning(
-                "Guided generation unavailable: the model's tokenizer is a "
-                "slow (non-fast) tokenizer, which llguidance cannot consume. "
-                "Falling back to unconstrained generation."
+                "no supported fast Hugging Face tokenizer, which llguidance "
+                "requires. Falling back to unconstrained generation."
             )
             self._lltokenizer = None
             return None

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -272,7 +272,13 @@ class GuidedGenerator:
         # lower-level Rust object, which llguidance.hf intentionally rejects.
         # Normalize both supported shapes to the HF wrapper that owns
         # ``backend_tokenizer``.
-        candidates = (self._tokenizer, getattr(self._tokenizer, "_tokenizer", None))
+        # Prefer the inner object: mlx_lm's wrapper forwards unknown
+        # attributes, so probing the wrapper first can make it masquerade as
+        # the HF tokenizer even though llguidance requires the HF object
+        # itself. For a directly returned HF tokenizer the inner object is a
+        # raw Rust tokenizer and fails the shape check, so the outer object is
+        # selected next.
+        candidates = (getattr(self._tokenizer, "_tokenizer", None), self._tokenizer)
         hf_tok = next(
             (
                 candidate

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5246,12 +5246,24 @@ async def _create_chat_completion_impl(
                     text=_forced_prefix_value + (output.text or ""),
                 )
         elif use_guided and json_schema:
+            # ``generate_with_schema`` owns a legacy best-effort fallback to
+            # ordinary chat. That is valid for suggestion-only schemas but not
+            # for strict=true: an unconstrained result that happens to validate
+            # is still not evidence that the requested constraint was applied.
+            # Own the flag at the route boundary and remove any colliding
+            # internal kwarg, matching the streaming and Responses paths.
+            _guided_kwargs = {
+                key: value
+                for key, value in chat_kwargs.items()
+                if key != "raise_on_failure"
+            }
             try:
                 output = await _wait_with_disconnect(
                     engine.generate_with_schema(
                         messages=messages,
                         json_schema=json_schema,
-                        **chat_kwargs,
+                        raise_on_failure=strict_mode,
+                        **_guided_kwargs,
                     ),
                     raw_request,
                     timeout=timeout,


### PR DESCRIPTION
## Summary

- normalize both supported tokenizer load shapes before constructing the grammar tokenizer
- keep wrapped-tokenizer behavior unchanged while accepting a directly returned fast tokenizer
- make strict non-stream schema generation fail closed when guided setup/generation fails internally
- preserve the existing best-effort fallback for `strict=false`

Fixes #2617

## User impact

Strict JSON-schema requests on Flash-Next no longer unwrap a valid fast tokenizer into a raw backend object that the grammar adapter rejects. If constrained generation still cannot be established, `strict=true` now returns the existing typed violation instead of accepting unconstrained output merely because it happens to match the schema.

## Scope

- guided tokenizer-shape normalization
- strict non-stream route ownership of the engine's failure policy
- focused guided and strict-schema regressions

## Non-goals

- no model architecture, sampling, prefix-cache, dependency, CI, or release changes
- no change to suggestion-only (`strict=false`) fallback semantics
- no change to the documented post-generation enforcement path used when guided generation is unavailable

## Design precedent

Production structured-output paths normalize tokenizer implementations at the grammar boundary and make the request contract authoritative over fallback policy. This change adopts that boundary: it recognizes the two loader shapes Rapid-MLX produces, selects the object that owns the fast backend, and makes strict callers explicitly prohibit unconstrained fallback while suggestion-only callers retain best-effort behavior.

## Verification

- `128 passed`: strict JSON-schema, guided streaming/non-streaming, engine failure-policy, and tokenizer-adapter suites
- `ruff check` passed
- `ruff format --check` passed
- `git diff --check` passed
- prior exact-model proof remains applicable: Flash-Next strict-schema request on revision `dcf657e4` used guided enforcement and returned schema-valid Chinese JSON with HTTP 200 / `finish_reason=stop`
