### PR TITLE
fix(engine): distinguish cancellations from max-length completions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,7 @@ jobs:
           COVERAGE_FILE: coverage-apple.data
         run: |
           pytest \
+            tests/test_cancellation_protocol.py \
             tests/test_mllm.py \
             tests/test_server.py \
             tests/test_paged_cache.py \

--- a/tests/test_cancellation_protocol.py
+++ b/tests/test_cancellation_protocol.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cancellation terminal-state mapping across public serving protocols."""
+
+import json
+
+import pytest
+
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.api.models import ChatCompletionRequest, CompletionRequest
+from vllm_mlx.api.responses_adapter import _convert_status
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+
+
+class _CancelledChatEngine:
+    preserve_native_tool_format = False
+    tokenizer = None
+
+    def __init__(self, *, before_first_token: bool):
+        self.before_first_token = before_first_token
+
+    async def stream_chat(self, messages, **kwargs):
+        del messages
+        if "request_admitted_event" in kwargs:
+            kwargs["request_admitted_event"].set()
+        if not self.before_first_token:
+            yield GenerationOutput(
+                text="partial",
+                new_text="partial",
+                finished=False,
+                finish_reason=None,
+                prompt_tokens=1,
+                completion_tokens=1,
+            )
+        yield GenerationOutput(
+            text="partial" if not self.before_first_token else "",
+            new_text="" if self.before_first_token else "partial",
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="cancelled",
+        )
+
+
+class _CancelledCompletionEngine:
+    async def stream_generate(self, **kwargs):
+        del kwargs
+        yield GenerationOutput(text="partial", new_text="partial")
+        yield GenerationOutput(
+            text="partial",
+            new_text="partial",
+            finished=True,
+            finish_reason="cancelled",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("before_first_token", [True, False])
+async def test_chat_stream_cancellation_has_no_successful_finish_frame(
+    before_first_token,
+):
+    from vllm_mlx.routes.chat import stream_chat_completion
+
+    cfg = reset_config()
+    cfg.model_name = "test-model"
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            _CancelledChatEngine(before_first_token=before_first_token),
+            request.messages,
+            request,
+        )
+    ]
+    events = [json.loads(chunk.removeprefix("data: ")) for chunk in chunks]
+
+    if not before_first_token:
+        assert any(
+            choice.get("delta", {}).get("content") == "partial"
+            for event in events
+            for choice in event.get("choices", [])
+        )
+    assert all(
+        event.get("finish_reason") not in ("cancelled", "length") for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_completion_stream_cancellation_has_no_successful_finish_frame():
+    from vllm_mlx.routes.completions import stream_completion
+
+    cfg = reset_config()
+    cfg.model_name = "test-model"
+    request = CompletionRequest(model="test-model", prompt="hi", stream=True)
+
+    chunks = [
+        chunk
+        async for chunk in stream_completion(
+            _CancelledCompletionEngine(), "hi", request
+        )
+    ]
+    events = [json.loads(chunk.removeprefix("data: ")) for chunk in chunks]
+
+    assert any(event["choices"][0]["text"] == "partial" for event in events)
+    assert all(
+        event["choices"][0]["finish_reason"] not in ("cancelled", "length")
+        for event in events
+    )
+
+
+def test_responses_status_does_not_treat_cancellation_as_truncation():
+    assert _convert_status("cancelled") == "failed"
+    assert _convert_status("length") == "incomplete"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_cancellation_uses_protocol_error():
+    from vllm_mlx.routes.anthropic import _stream_anthropic_messages
+
+    cfg = reset_config()
+    cfg.model_name = "test-model"
+    openai_request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    anthropic_request = AnthropicRequest(
+        model="test-model",
+        max_tokens=32,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    chunks = [
+        chunk
+        async for chunk in _stream_anthropic_messages(
+            _CancelledChatEngine(before_first_token=False),
+            openai_request,
+            anthropic_request,
+        )
+    ]
+
+    events = [
+        json.loads(chunk.split("data: ", 1)[1])
+        for chunk in chunks
+        if chunk.startswith("event:") and "data: " in chunk
+    ]
+    assert any(event["type"] == "error" for event in events)
+    assert all(event["type"] != "message_delta" for event in events)

--- a/tests/test_cancellation_protocol.py
+++ b/tests/test_cancellation_protocol.py
@@ -154,6 +154,7 @@ async def test_chat_stream_cancellation_has_no_successful_finish_frame(
 async def test_completion_stream_cancellation_has_no_successful_finish_frame():
     from vllm_mlx.routes.completions import stream_completion
 
+    pytest.importorskip("mlx")
     cfg = reset_config()
     cfg.model_name = "test-model"
     request = CompletionRequest(model="test-model", prompt="hi", stream=True)
@@ -182,15 +183,18 @@ def test_responses_status_does_not_treat_cancellation_as_truncation():
 
 
 @pytest.mark.asyncio
-async def test_chat_non_stream_cancellation_returns_client_closed():
-    from vllm_mlx.routes.chat import _create_chat_completion_impl
+async def test_chat_non_stream_cancellation_returns_client_closed(monkeypatch):
+    from vllm_mlx.routes import chat
+
+    monkeypatch.setattr(chat, "_check_admission_or_503", lambda *_: None)
+    monkeypatch.setattr(chat, "_wait_with_disconnect", _await_direct)
 
     _test_config()
     request = ChatCompletionRequest(
         model="test-model", messages=[{"role": "user", "content": "hi"}]
     )
 
-    response = await _create_chat_completion_impl(
+    response = await chat._create_chat_completion_impl(
         request,
         _RawRequest(),
         _CancelledChatEngine(before_first_token=False),
@@ -250,9 +254,11 @@ async def test_anthropic_non_stream_cancellation_returns_client_closed(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_responses_non_stream_cancellation_returns_client_closed():
+async def test_responses_non_stream_cancellation_returns_client_closed(monkeypatch):
     from vllm_mlx.api.responses_models import ResponsesRequest
-    from vllm_mlx.routes.responses import _non_stream
+    from vllm_mlx.routes import responses
+
+    monkeypatch.setattr(responses, "_wait_with_disconnect", _await_direct)
 
     _test_config()
     openai_request = ChatCompletionRequest(
@@ -263,7 +269,7 @@ async def test_responses_non_stream_cancellation_returns_client_closed():
         input=[{"type": "message", "role": "user", "content": "hi"}],
     )
 
-    response = await _non_stream(
+    response = await responses._non_stream(
         _CancelledChatEngine(before_first_token=False),
         openai_request,
         responses_request,
@@ -361,6 +367,7 @@ async def test_completion_json_stream_cancellation_has_no_terminal_chunk():
 
 
 def test_text_scheduler_abort_marks_terminal_cancelled():
+    pytest.importorskip("mlx")
     from vllm_mlx.scheduler import Scheduler
 
     tokenizer = SimpleNamespace(
@@ -376,6 +383,7 @@ def test_text_scheduler_abort_marks_terminal_cancelled():
 
 
 def test_mllm_scheduler_abort_marks_terminal_cancelled():
+    pytest.importorskip("mlx")
     from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
 
     scheduler = MLLMScheduler.__new__(MLLMScheduler)

--- a/tests/test_cancellation_protocol.py
+++ b/tests/test_cancellation_protocol.py
@@ -2,6 +2,8 @@
 """Cancellation terminal-state mapping across public serving protocols."""
 
 import json
+import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,10 +12,14 @@ from vllm_mlx.api.models import ChatCompletionRequest, CompletionRequest
 from vllm_mlx.api.responses_adapter import _convert_status
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
 
 
 class _CancelledChatEngine:
+    supports_guided_generation = False
     preserve_native_tool_format = False
+    is_mllm = False
+    model_name = "test-model"
     tokenizer = None
 
     def __init__(self, *, before_first_token: bool):
@@ -41,17 +47,71 @@ class _CancelledChatEngine:
             finish_reason="cancelled",
         )
 
+    async def chat(self, messages, **kwargs):
+        del messages, kwargs
+        return GenerationOutput(
+            text="cancelled",
+            finish_reason="cancelled",
+            prompt_tokens=1,
+            completion_tokens=1,
+        )
+
 
 class _CancelledCompletionEngine:
+    supports_completion_logprobs = True
+    tokenizer = SimpleNamespace(encode=lambda _text: [1], decode=lambda _ids: "x")
+
     async def stream_generate(self, **kwargs):
         del kwargs
-        yield GenerationOutput(text="partial", new_text="partial")
+        yield GenerationOutput(
+            text="partial",
+            new_text="partial",
+            tokens=[0],
+            logprobs=[0.8],
+        )
         yield GenerationOutput(
             text="partial",
             new_text="partial",
             finished=True,
             finish_reason="cancelled",
         )
+
+    async def generate(self, **kwargs):
+        del kwargs
+        return GenerationOutput(
+            text="cancelled",
+            finish_reason="cancelled",
+            prompt_tokens=1,
+            completion_tokens=1,
+        )
+
+
+class _RawRequest:
+    headers = {}
+
+    async def json(self):
+        return {}
+
+    async def is_disconnected(self):
+        return False
+
+
+async def _await_direct(coro, *_args, **_kwargs):
+    return await coro
+
+
+async def _async_json_body():
+    return {
+        "model": "test-model",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def _test_config():
+    cfg = reset_config()
+    cfg.model_name = "test-model"
+    return cfg
 
 
 @pytest.mark.asyncio
@@ -98,15 +158,18 @@ async def test_completion_stream_cancellation_has_no_successful_finish_frame():
     cfg.model_name = "test-model"
     request = CompletionRequest(model="test-model", prompt="hi", stream=True)
 
+    logprobs_request = request.model_copy(update={"logprobs": 0})
+
     chunks = [
         chunk
         async for chunk in stream_completion(
-            _CancelledCompletionEngine(), "hi", request
+            _CancelledCompletionEngine(), "hi", logprobs_request
         )
     ]
     events = [json.loads(chunk.removeprefix("data: ")) for chunk in chunks]
 
-    assert any(event["choices"][0]["text"] == "partial" for event in events)
+    assert any(event["choices"][0]["text"] for event in events)
+    assert any("logprobs" in event["choices"][0] for event in events)
     assert all(
         event["choices"][0]["finish_reason"] not in ("cancelled", "length")
         for event in events
@@ -116,6 +179,98 @@ async def test_completion_stream_cancellation_has_no_successful_finish_frame():
 def test_responses_status_does_not_treat_cancellation_as_truncation():
     assert _convert_status("cancelled") == "failed"
     assert _convert_status("length") == "incomplete"
+
+
+@pytest.mark.asyncio
+async def test_chat_non_stream_cancellation_returns_client_closed():
+    from vllm_mlx.routes.chat import _create_chat_completion_impl
+
+    _test_config()
+    request = ChatCompletionRequest(
+        model="test-model", messages=[{"role": "user", "content": "hi"}]
+    )
+
+    response = await _create_chat_completion_impl(
+        request,
+        _RawRequest(),
+        _CancelledChatEngine(before_first_token=False),
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert response.status_code == 499
+
+
+@pytest.mark.asyncio
+async def test_completion_non_stream_cancellation_returns_client_closed(monkeypatch):
+    from vllm_mlx.routes import completions
+
+    engine = _CancelledCompletionEngine()
+    monkeypatch.setattr(completions, "_resolve_max_tokens", lambda *_: 32)
+    monkeypatch.setattr(completions, "get_engine", lambda *_: engine)
+    monkeypatch.setattr(completions, "_validate_model_name", lambda *_: None)
+    monkeypatch.setattr(completions, "_check_admission_or_503", lambda *_: None)
+    monkeypatch.setattr(
+        completions, "_release_admission_unless_committed", lambda *_: None
+    )
+    monkeypatch.setattr(completions, "_wait_with_disconnect", _await_direct)
+    monkeypatch.setattr(
+        completions, "enforce_context_length_for_prompt", lambda *_, **__: None
+    )
+
+    response = await completions.create_completion(
+        CompletionRequest(model="test-model", prompt="hi"), _RawRequest()
+    )
+
+    assert response.status_code == 499
+
+
+@pytest.mark.asyncio
+async def test_anthropic_non_stream_cancellation_returns_client_closed(monkeypatch):
+    from vllm_mlx.routes import anthropic
+
+    engine = _CancelledChatEngine(before_first_token=False)
+    monkeypatch.setattr(anthropic, "get_engine", lambda *_: engine)
+    monkeypatch.setattr(anthropic, "_validate_model_name", lambda *_: None)
+    monkeypatch.setattr(anthropic, "_check_admission_or_503", lambda *_: None)
+    monkeypatch.setattr(
+        anthropic, "_release_admission_unless_committed", lambda *_: None
+    )
+    monkeypatch.setattr(anthropic, "_wait_with_disconnect", _await_direct)
+    monkeypatch.setattr(
+        anthropic, "enforce_context_length_for_messages", lambda *_, **__: None
+    )
+    monkeypatch.setattr(anthropic, "_resolve_max_tokens", lambda *_: 32)
+
+    response = await anthropic.create_anthropic_message(
+        SimpleNamespace(json=_async_json_body)
+    )
+
+    assert response.status_code == 499
+
+
+@pytest.mark.asyncio
+async def test_responses_non_stream_cancellation_returns_client_closed():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _non_stream
+
+    _test_config()
+    openai_request = ChatCompletionRequest(
+        model="test-model", messages=[{"role": "user", "content": "hi"}]
+    )
+    responses_request = ResponsesRequest(
+        model="test-model",
+        input=[{"type": "message", "role": "user", "content": "hi"}],
+    )
+
+    response = await _non_stream(
+        _CancelledChatEngine(before_first_token=False),
+        openai_request,
+        responses_request,
+        _RawRequest(),
+    )
+
+    assert response.status_code == 499
 
 
 @pytest.mark.asyncio
@@ -151,3 +306,98 @@ async def test_anthropic_stream_cancellation_uses_protocol_error():
     ]
     assert any(event["type"] == "error" for event in events)
     assert all(event["type"] != "message_delta" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_cancellation_emits_response_failed():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _stream_responses
+
+    _test_config()
+    openai_request = ChatCompletionRequest(
+        model="test-model", stream=True, messages=[{"role": "user", "content": "hi"}]
+    )
+    responses_request = ResponsesRequest(
+        model="test-model",
+        input=[{"type": "message", "role": "user", "content": "hi"}],
+    )
+
+    events = []
+    async for chunk in _stream_responses(
+        _CancelledChatEngine(before_first_token=False),
+        openai_request,
+        responses_request,
+    ):
+        if chunk.startswith("event:"):
+            event_type = chunk.split("\n", 1)[0].removeprefix("event: ")
+            data = json.loads(chunk.split("data: ", 1)[1])
+            events.append((event_type, data))
+
+    assert events[-1][0] == "response.failed"
+    assert events[-1][1]["response"]["status"] == "failed"
+    assert events[-1][1]["response"]["error"]["code"] == "request_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_completion_json_stream_cancellation_has_no_terminal_chunk():
+    from vllm_mlx.routes.completions import stream_completion
+
+    _test_config()
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        stream=True,
+        response_format={"type": "json_object"},
+    )
+
+    chunks = [
+        chunk
+        async for chunk in stream_completion(
+            _CancelledCompletionEngine(), "hi", request
+        )
+    ]
+
+    assert chunks == []
+
+
+def test_text_scheduler_abort_marks_terminal_cancelled():
+    from vllm_mlx.scheduler import Scheduler
+
+    tokenizer = SimpleNamespace(
+        eos_token_id=2, encode=lambda _text: [1, 2], decode=lambda _ids: ""
+    )
+    scheduler = Scheduler(SimpleNamespace(), tokenizer)
+    request = Request("req-1", "hello", SamplingParams(max_tokens=4))
+    scheduler.add_request(request)
+
+    assert scheduler._do_abort_request("req-1") is True
+    assert request.status is RequestStatus.FINISHED_CANCELLED
+    assert request.get_finish_reason() == "cancelled"
+
+
+def test_mllm_scheduler_abort_marks_terminal_cancelled():
+    from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.requests = {}
+    scheduler.waiting = []
+    scheduler.running = {}
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler.batch_generator = None
+    scheduler.finished_req_ids = set()
+    scheduler._detokenizer_pool = {}
+    scheduler._aborted_queue_ids = set()
+    scheduler._pending_abort_ids = set()
+    scheduler._cancelled_request_ids = set()
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_cancelled = 0
+    request = MLLMRequest(request_id="req-1", prompt="hello")
+    scheduler.requests["req-1"] = request
+
+    assert scheduler.abort_request("req-1") is True
+    scheduler._do_abort_request("req-1")
+
+    assert request.status is RequestStatus.FINISHED_CANCELLED

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -54,6 +54,12 @@ class TestRequestStatus:
             RequestStatus.get_finish_reason(RequestStatus.FINISHED_ABORTED) == "abort"
         )
 
+    def test_get_finish_reason_cancelled(self):
+        assert (
+            RequestStatus.get_finish_reason(RequestStatus.FINISHED_CANCELLED)
+            == "cancelled"
+        )
+
     def test_get_finish_reason_waiting(self):
         assert RequestStatus.get_finish_reason(RequestStatus.WAITING) is None
 

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -44,6 +44,9 @@ from vllm_mlx.api.responses_models import (
 
 
 class TestConvertStatus:
+    def test_cancelled_to_failed(self):
+        assert _convert_status("cancelled") == "failed"
+
     def test_length_to_incomplete(self):
         assert _convert_status("length") == "incomplete"
 

--- a/vllm_mlx/api/protocol_mapping.py
+++ b/vllm_mlx/api/protocol_mapping.py
@@ -1,0 +1,20 @@
+"""Shared terminal-state mapping for public serving protocols."""
+
+ENGINE_CANCELLATION_FINISH_REASON = "cancelled"
+
+
+def is_cancellation_finish_reason(finish_reason: str | None) -> bool:
+    """Whether an engine finish reason denotes an inference cancellation."""
+
+    return finish_reason == ENGINE_CANCELLATION_FINISH_REASON
+
+
+def cancellation_error(
+    *,
+    type_: str = "server_error",
+    code: str = "request_cancelled",
+    message: str = "The request was cancelled.",
+) -> dict[str, str]:
+    """Build the public error payload for a cancellation."""
+
+    return {"type": type_, "code": code, "message": message}

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -1431,10 +1431,12 @@ def _convert_text_format(text: dict | None) -> ResponseFormat | None:
 def _convert_status(openai_finish_reason: str | None) -> str:
     """Map OpenAI ``finish_reason`` to Responses ``status``.
 
-    ``"length"`` is the only one Codex CLI reads specially — it
-    surfaces as a follow-up prompt to extend. The rest are folded
-    into ``"completed"``.
+    ``"length"`` is the one Codex CLI reads specially — it surfaces as a
+    follow-up prompt to extend. Engine cancellations become ``"failed"``;
+    the rest are folded into ``"completed"``.
     """
+    if openai_finish_reason == "cancelled":
+        return "failed"
     if openai_finish_reason == "length":
         return "incomplete"
     return "completed"

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1323,7 +1323,7 @@ class EngineCore:
                         RequestOutput(
                             request_id=request_id,
                             finished=True,
-                            finish_reason="length",
+                            finish_reason="cancelled",
                             error=(
                                 "Inference aborted by a cancellation request"
                                 if error_kind == "lifecycle"

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -833,7 +833,7 @@ class MLLMScheduler:
 
         # Mark as aborted
         if request is not None:
-            request.status = RequestStatus.FINISHED_ABORTED
+            request.status = RequestStatus.FINISHED_CANCELLED
         self.finished_req_ids.add(request_id)
 
         # D-M01-2X + D-M01-DEAD (0.8.2 dogfood): do NOT discard the
@@ -1416,7 +1416,7 @@ class MLLMScheduler:
                         RequestOutput(
                             request_id=request_id,
                             finished=True,
-                            finish_reason="length",
+                            finish_reason="cancelled",
                             error="Inference aborted by a cancellation request",
                             error_kind="lifecycle",
                         )
@@ -1431,7 +1431,7 @@ class MLLMScheduler:
                         RequestOutput(
                             request_id=request_id,
                             finished=True,
-                            finish_reason="length",
+                            finish_reason="cancelled",
                             error="Inference aborted by a cancellation request",
                             error_kind="lifecycle",
                         )

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -30,6 +30,9 @@ class RequestStatus(enum.IntEnum):
     FINISHED_LENGTH_CAPPED = enum.auto()
     # Request was aborted by user
     FINISHED_ABORTED = enum.auto()
+    # Request was cancelled before or during inference. This is distinct
+    # from a genuine max-token truncation and must not leak as "length".
+    FINISHED_CANCELLED = enum.auto()
 
     @staticmethod
     def is_finished(status: "RequestStatus") -> bool:
@@ -45,6 +48,8 @@ class RequestStatus(enum.IntEnum):
             return "length"
         elif status == RequestStatus.FINISHED_ABORTED:
             return "abort"
+        elif status == RequestStatus.FINISHED_CANCELLED:
+            return "cancelled"
         return None
 
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -24,6 +24,7 @@ from ..api.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
+from ..api.protocol_mapping import cancellation_error, is_cancellation_finish_reason
 from ..api.tool_calling import (
     convert_tools_for_template,
     extract_json_schema_for_guided,
@@ -912,6 +913,9 @@ async def create_anthropic_message(
                 raise HTTPException(status_code=400, detail=err_msg)
             raise
         if output is None:
+            return Response(status_code=499)
+
+        if is_cancellation_finish_reason(output.finish_reason):
             return Response(status_code=499)
 
         elapsed = time.perf_counter() - start_time
@@ -3065,6 +3069,16 @@ async def _stream_anthropic_messages(
                 )
 
             yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': tool_index})}\n\n"
+
+    if is_cancellation_finish_reason(stream_finish_reason):
+        cancellation_event = {
+            "type": "error",
+            "error": cancellation_error(
+                type_="api_error", message="The request was cancelled."
+            ),
+        }
+        yield f"event: error\ndata: {json.dumps(cancellation_event)}\n\n"
+        return
 
     # R-07 (r5-A bundle): synthesize a zero-text ``content_block`` pair
     # ONLY for the malformed-message case the dogfood actually caught

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -30,6 +30,7 @@ from ..api.models import (
     TokenLogProb,
     Usage,
 )
+from ..api.protocol_mapping import is_cancellation_finish_reason
 from ..api.response_format_metrics import (
     incr_strict_repair_attempt,
     incr_strict_repair_skipped_context_overflow,
@@ -6037,6 +6038,8 @@ async def _create_chat_completion_impl(
 
     # Determine finish reason
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
+    if is_cancellation_finish_reason(finish_reason):
+        return Response(status_code=499)
 
     # Clean and strip thinking tags from content
     final_content = None
@@ -6849,6 +6852,11 @@ async def stream_chat_completion(
         # it here as ordinary exhaustion, so cancellation alone is not enough
         # to distinguish this path.
         if _client_disconnect_state and _client_disconnect_state[0]:
+            return
+
+        if buffered_finish is not None and is_cancellation_finish_reason(
+            buffered_finish[1].finish_reason
+        ):
             return
 
         # Fallback tool call detection (post-stream). Collect ALL fallback

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -20,6 +20,7 @@ from ..api.models import (
     PromptTokensDetails,
     Usage,
 )
+from ..api.protocol_mapping import is_cancellation_finish_reason
 from ..api.utils import extract_json_from_response
 from ..config import get_config
 from ..middleware.auth import check_rate_limit, verify_api_key
@@ -633,6 +634,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             )
             total_cached_tokens += getattr(output, "cached_tokens", 0) or 0
 
+        if is_cancellation_finish_reason(output.finish_reason):
+            return Response(status_code=499)
+
         elapsed = time.perf_counter() - start_time
         tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
         logger.info(
@@ -832,6 +836,8 @@ async def stream_completion(
                 _final_usage = get_usage(output)
                 _buffered_finish_reason = output.finish_reason
             continue
+        if output.finished and is_cancellation_finish_reason(output.finish_reason):
+            return
         choice = {
             "index": 0,
             "text": output.new_text,
@@ -915,6 +921,8 @@ async def stream_completion(
     # and clients consuming json-mode don't expect partial-JSON
     # streaming anyway.
     if _json_mode:
+        if is_cancellation_finish_reason(_buffered_finish_reason):
+            return
         cleaned = extract_json_from_response(_buffered_text) if _buffered_text else ""
         # Emit content + finish in a single chunk for symmetry with
         # the non-stream sync path; if the buffer is empty (model

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -850,7 +850,7 @@ async def stream_completion(
             if entries:
                 tokens_arr = []
                 token_lps = []
-                top_lps = []
+                top_lps: list[dict[str, float]] = []
                 text_offsets = []
                 for entry in entries:
                     tokens_arr.append(entry.token)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -34,6 +34,7 @@ from ..api.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
+from ..api.protocol_mapping import cancellation_error, is_cancellation_finish_reason
 from ..api.response_format_metrics import (
     incr_strict_repair_attempt,
     incr_strict_repair_skipped_context_overflow,
@@ -2194,6 +2195,8 @@ async def _non_stream(
             final_content = extract_json_from_response(final_content)
 
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
+    if is_cancellation_finish_reason(finish_reason):
+        return Response(status_code=499)
 
     # Issue #858: /v1/responses mirror of the cutoff sentinel.
     # Default-on (PR #802 / H-01 semantics restored) — clients that only
@@ -4828,6 +4831,19 @@ async def _stream_responses(
         # regardless of the underlying truncation, so a mid-think
         # ``max_output_tokens`` cutoff was indistinguishable from a
         # clean finish on the wire.
+        if is_cancellation_finish_reason(last_finish_reason):
+            yield _emit(
+                "response.failed",
+                {
+                    "type": "response.failed",
+                    "response": _stream_response_payload(
+                        "failed",
+                        error=cancellation_error(),
+                    ),
+                },
+            )
+            return
+
         if last_finish_reason == "length":
             completed_status = "incomplete"
             incomplete_details: dict | None = {"reason": "max_output_tokens"}

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6606,7 +6606,7 @@ class Scheduler:
             self.total_prompt_tokens += request.num_prompt_tokens
 
         if request is not None:
-            request.set_finished(RequestStatus.FINISHED_ABORTED)
+            request.set_finished(RequestStatus.FINISHED_CANCELLED)
             # Release cache references so Metal buffers can be freed
             request.prompt_cache = None
             request._extracted_cache = None


### PR DESCRIPTION
Closes #2553

## Summary
- Adds an engine-level `cancelled` terminal state so lifecycle and request cancellations are no longer represented as `length`.
- Maps cancellation through OpenAI chat/completions, Responses, and Anthropic surfaces using protocol-compatible outcomes.
- Preserves genuine `length` truncation and runtime abort behavior.
- Adds coverage for cancellation before the first token, after partial output, and protocol terminal mapping.

## Verification
- `pytest tests/test_cancellation_protocol.py tests/test_request.py tests/test_engine_lifecycle.py tests/test_responses_adapter.py tests/test_api_models.py tests/test_chat_streaming_spec.py tests/test_disconnect_guard_aborts_scheduler.py tests/test_engine_step_thread.py tests/test_mllm.py tests/test_mllm_batch_generator.py -q` (528 passed, 6 deselected)
- `ruff check` and `ruff format --check` on the touched files
- `git diff --check`

## Notes
- The local mypy budget script reports the same pre-existing growth on current `main`; this PR does not change the mypy baseline.