### PR TITLE
test(mac): make active-switch journey fail closed

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5247,11 +5247,13 @@ flow_model_switch_active_request() {
            | select(.identifier == "ModelSwitchGuard.Cancel")' \
         "$OUT/switch-guard.json" >/dev/null \
         || die "active stream did not present the native switch guard"
-    # Press the dialog's semantic Cancel action directly. Posting Escape can
+    # Click the semantic Cancel button's bounds directly. Posting Escape can
     # succeed at the CoreGraphics boundary while the hosted confirmation
-    # dialog ignores it, leaving both the guard and target selection on screen.
-    # AXPress fails closed if the actual user action was not available.
-    "$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel \
+    # dialog ignores it, and hosted macOS can expose a native dialog button
+    # while returning kAXErrorActionUnsupported for AXPress. A bounds click is
+    # the same explicit user action and still fails closed unless the stable
+    # product-owned identifier resolves to a visible control.
+    "$AX_DRIVER" click-center "$APP_PID" ModelSwitchGuard.Cancel \
         > "$OUT/switch-cancelled.json" \
         || die "switch guard did not honor the native Cancel action"
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5236,23 +5236,23 @@ flow_model_switch_active_request() {
     [[ "$busy" == 1 ]] || die "fake residency never reported the active stream"
 
     see_main "$OUT/busy.json"
-    # SwiftUI bridges these rows into a transient native NSMenu, outside the
-    # window-only AX tree used for evidence dumps. Exercise the standard macOS
-    # type-to-select interaction, then let the switch guard prove it resolved
-    # the requested alternate alias.
-    "$AX_DRIVER" select-menu-title "$APP_PID" ModelPickerBar.ModelMenu \
-        fake-external-alias > "$OUT/switch-requested.json" \
+    # SwiftUI creates these rows only after the native menu opens. Resolve the
+    # requested row from that fresh AX tree and press its stable identifier;
+    # the driver fails closed if opening the menu did not expose the row.
+    "$AX_DRIVER" select-menu-item "$APP_PID" ModelPickerBar.ModelMenu \
+        ModelPickerBar.Alias.fake-external-alias > "$OUT/switch-requested.json" \
         || die "alternate cached model could not be selected during an active stream"
     wait_identifier ModelSwitchGuard.Cancel "$OUT/switch-guard.json"
     jq -e '.data.ui_elements[]?
            | select(.identifier == "ModelSwitchGuard.Cancel")' \
         "$OUT/switch-guard.json" >/dev/null \
         || die "active stream did not present the native switch guard"
-    # This is a native confirmation dialog, whose cancel role maps to Escape.
-    # Hosted SwiftUI exposes the enabled Cancel button in AX but may reject
-    # AXPress for that transient element. Exercise the platform cancel action
-    # and let the state assertions below prove that it took effect.
-    "$AX_DRIVER" key "$APP_PID" escape > "$OUT/switch-cancelled.json" \
+    # Press the dialog's semantic Cancel action directly. Posting Escape can
+    # succeed at the CoreGraphics boundary while the hosted confirmation
+    # dialog ignores it, leaving both the guard and target selection on screen.
+    # AXPress fails closed if the actual user action was not available.
+    "$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel \
+        > "$OUT/switch-cancelled.json" \
         || die "switch guard did not honor the native Cancel action"
 
     # Cancellation occurs before /v1/models/load or process teardown. The

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -112,7 +112,7 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|select-menu-title|key|click-center|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
+    fail("usage: rapid-ax <dump|press|select-menu-item|key|click-center|set-scroll-value|increment|decrement|set-value|paste-file|set-window-size|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
@@ -427,15 +427,15 @@ case "click-center":
     down.post(tap: .cghidEventTap)
     up.post(tap: .cghidEventTap)
     usleep(150_000)
-case "select-menu-title":
+case "select-menu-item":
     guard CommandLine.arguments.count > 4 else {
-        fail("select-menu-title requires the exact searchable menu title")
+        fail("select-menu-item requires the menu item's accessibility identifier")
     }
-    let searchText = CommandLine.arguments[4]
+    let itemIdentifier = CommandLine.arguments[4]
     guard let origin = point(target, kAXPositionAttribute as CFString),
           let extent = size(target, kAXSizeAttribute as CFString),
           extent.width > 0, extent.height > 0
-    else { fail("select-menu-title \(identifier) has no usable AX bounds") }
+    else { fail("select-menu-item \(identifier) has no usable AX bounds") }
     let center = CGPoint(x: origin.x + extent.width / 2, y: origin.y + extent.height / 2)
     guard let mouseDown = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
                                   mouseCursorPosition: center, mouseButton: .left),
@@ -444,29 +444,57 @@ case "select-menu-title":
     else { fail("could not create menu click events for \(identifier)") }
     mouseDown.post(tap: .cghidEventTap)
     mouseUp.post(tap: .cghidEventTap)
-    usleep(200_000)
 
-    let utf16 = Array(searchText.utf16)
-    guard let typeDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
-          let typeUp = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false),
-          let returnDown = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: true),
-          let returnUp = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: false)
-    else { fail("could not create menu keyboard events for \(identifier)") }
-    utf16.withUnsafeBufferPointer { buffer in
-        guard let base = buffer.baseAddress else { return }
-        typeDown.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
-        typeUp.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: base)
+    // The menu does not exist in the AX tree until the click above opens it.
+    // Resolve the row from the fresh tree and press that exact semantic item.
+    // Typing a title and Return can be accepted by CoreGraphics while the
+    // native menu ignores both events, which makes a driver claim success even
+    // though no product action ran. The identifier + AXPress path fails closed
+    // when the requested row never appears or cannot be activated.
+    func findFreshElement(identifier wantedIdentifier: String) -> AXUIElement? {
+        var seen = Set<AXUIElement>()
+        var visitedCount = 0
+
+        func visit(_ element: AXUIElement, depth: Int) -> AXUIElement? {
+            guard depth <= 40, visitedCount < 12_000 else { return nil }
+            guard seen.insert(element).inserted else { return nil }
+            visitedCount += 1
+            if string(element, kAXIdentifierAttribute as CFString) == wantedIdentifier {
+                return element
+            }
+            guard let children = attribute(
+                element, kAXChildrenAttribute as CFString
+            ) as? [AXUIElement] else { return nil }
+            for child in children {
+                if let found = visit(child, depth: depth + 1) { return found }
+            }
+            return nil
+        }
+
+        for window in windowElements {
+            if let found = visit(window, depth: 0) { return found }
+        }
+        return nil
     }
-    typeDown.postToPid(pid)
-    typeUp.postToPid(pid)
-    usleep(150_000)
-    returnDown.postToPid(pid)
-    returnUp.postToPid(pid)
+
+    var menuItem: AXUIElement?
+    for _ in 0..<20 {
+        menuItem = findFreshElement(identifier: itemIdentifier)
+        if menuItem != nil { break }
+        usleep(50_000)
+    }
+    guard let menuItem else {
+        fail("menu item identifier not found after opening \(identifier): \(itemIdentifier)")
+    }
+    let result = AXUIElementPerformAction(menuItem, kAXPressAction as CFString)
+    guard result == .success else {
+        fail("AXPress menu item \(itemIdentifier) failed: \(result.rawValue)")
+    }
     usleep(150_000)
     let payload: [String: Any] = [
         "success": true,
-        "identifier": identifier,
-        "selected_title": searchText,
+        "menu_identifier": identifier,
+        "item_identifier": itemIdentifier,
         "action": command,
     ]
     let data = try! JSONSerialization.data(

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -471,8 +471,15 @@ case "select-menu-item":
             return nil
         }
 
-        for window in windowElements {
-            if let found = visit(window, depth: 0) { return found }
+        // Re-read every application root after opening the menu. Depending on
+        // the AppKit/SwiftUI host version, a transient NSMenu can be exposed as
+        // a window descendant or as a separate application child; the initial
+        // window-only snapshot cannot represent both shapes.
+        guard let freshRoots = attribute(
+            application, kAXChildrenAttribute as CFString
+        ) as? [AXUIElement] else { return nil }
+        for root in freshRoots {
+            if let found = visit(root, depth: 0) { return found }
         }
         return nil
     }

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -87,6 +87,30 @@ def test_ax_escape_posts_a_real_key_without_answering_nonmodal_consent():
     assert "dismissed telemetry invitation returned after relaunch" in fresh_install
 
 
+def test_active_switch_selects_the_fresh_native_menu_item_by_identifier():
+    """The driver must not report success merely because key events posted."""
+    driver = DRIVER.read_text()
+    selection = driver.split('case "select-menu-item":', 1)[1].split(
+        'case "set-scroll-value":', 1
+    )[0]
+    assert "findFreshElement(identifier: itemIdentifier)" in selection
+    assert "AXUIElementPerformAction(menuItem, kAXPressAction" in selection
+    assert "menu item identifier not found after opening" in selection
+    assert "selected_title" not in selection
+
+    flow = (
+        HARNESS.read_text()
+        .split("flow_model_switch_active_request() {", 1)[1]
+        .split("\n}", 1)[0]
+    )
+    assert (
+        'select-menu-item "$APP_PID" ModelPickerBar.ModelMenu '
+        "\\\n        ModelPickerBar.Alias.fake-external-alias"
+    ) in flow
+    assert '"$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel' in flow
+    assert '"$AX_DRIVER" key "$APP_PID" escape' not in flow
+
+
 def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():
     source = HARNESS.read_text()
     sink = source.split("start_telemetry_sink() {", 1)[1].split("\n}", 1)[0]

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -109,7 +109,8 @@ def test_active_switch_selects_the_fresh_native_menu_item_by_identifier():
         'select-menu-item "$APP_PID" ModelPickerBar.ModelMenu '
         "\\\n        ModelPickerBar.Alias.fake-external-alias"
     ) in flow
-    assert '"$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel' in flow
+    assert '"$AX_DRIVER" click-center "$APP_PID" ModelSwitchGuard.Cancel' in flow
+    assert '"$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel' not in flow
     assert '"$AX_DRIVER" key "$APP_PID" escape' not in flow
 
 

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -94,6 +94,8 @@ def test_active_switch_selects_the_fresh_native_menu_item_by_identifier():
         'case "set-scroll-value":', 1
     )[0]
     assert "findFreshElement(identifier: itemIdentifier)" in selection
+    assert "freshRoots = attribute(" in selection
+    assert "application, kAXChildrenAttribute" in selection
     assert "AXUIElementPerformAction(menuItem, kAXPressAction" in selection
     assert "menu item identifier not found after opening" in selection
     assert "selected_title" not in selection


### PR DESCRIPTION
## Why

Release dogfood exposed two false-success paths in the active-request model-switch journey. The native menu helper reported success after posting title/Return events even when no row was activated, and the cancellation step reported success after posting Escape even when the confirmation dialog stayed open. This made a healthy product path look broken and could also let future regressions escape diagnosis.

## What

- Replace title typing with a semantic native-menu action that opens the menu, resolves the requested row from the fresh AX tree, and presses its stable accessibility identifier.
- Fail closed when the menu row is absent or AXPress fails.
- Exercise the confirmation dialog through its actual semantic Cancel button.
- Pin both contracts in focused preflight tests.

## Scope / non-goals

Scope is limited to the Desktop GUI dogfood driver, the active-request journey, and focused static contracts. It does not change product UI, model switching, engine lifecycle, or server behavior.

## Design precedent

The driver follows the repositorys established accessibility-first automation pattern: address controls by stable semantic identifiers, resolve transient controls only after presentation, invoke the controls advertised native action, and treat an unavailable action as a failure rather than inferring success from input delivery.

## Verification

- python3.12 -m pytest -q tests/test_gui_preflight_contract.py tests/test_gui_walk_completeness.py tests/test_gui_golden_ci_coverage.py: 33 passed
- swiftc apps/rapid-mac/scripts/rapid-ax.swift -o /tmp/vector-rapid-ax-2624
- bash -n apps/rapid-mac/scripts/gui-golden-flows.sh
- ruff check/format and git diff --check: clean
- Isolated model-switch-active-request journey: PASS; confirmation shown, Cancel restored fake-alias, original 570-chunk stream completed, and no load/replacement event occurred

Fixes #2624