### PR TITLE
test(mac): settle Launch registry before golden capture

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -39,11 +39,55 @@ AXApplication title="Rapid-MLX"
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.hermes" desc="Copy Hermes command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXButton id="Launch.Integration.Copy.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.continue-dev" desc="Copy Continue.dev command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.cursor" desc="Copy Cursor command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.hermes" desc="Copy Hermes Agent command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.kilo-code" desc="Copy Kilo Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.langchain" desc="Copy LangChain command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.opencode" desc="Copy OpenCode command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.openhands" desc="Copy OpenHands command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.pydanticai" desc="Copy PydanticAI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.qwen-code" desc="Copy Qwen Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.smolagents" desc="Copy smolagents command" help="Start a model to generate a valid key and launch command." enabled=false
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4676,6 +4676,25 @@ flow_launch_integrations() {
     press "$OUT/main.json" Sidebar.Launch "$OUT/launch.json"
     wait_tree_text "Connect your agents" "$OUT/launch.json" 40
 
+    # ``ConnectToolsView`` renders the three-entry compatibility fallback
+    # first, then replaces it with the sidecar's authoritative integration
+    # registry. The heading appears before that asynchronous load completes,
+    # so capturing immediately makes the baseline race between two valid UI
+    # states. Settle on the fake sidecar's complete 14-entry registry before
+    # asserting or recording the stopped-state structure.
+    local i count=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/launch.json"
+        count="$(jq '[.data.ui_elements[]?
+                      | (.identifier // "")
+                      | select(startswith("Launch.Integration.Copy."))]
+                     | unique | length' "$OUT/launch.json")"
+        [[ "$count" == 14 ]] && break
+        sleep 0.1
+    done
+    [[ "$count" == 14 ]] \
+        || die "Cold Launch did not settle on the 14-entry integration registry (got $count)"
+
     # Cold Launch is a beginner path, not a wall of live (copyable) commands.
     # The stopped state now stays a useful setup destination (#2297): the
     # endpoint shape and integration rows are shown as documentation, the
@@ -4685,8 +4704,6 @@ flow_launch_integrations() {
     # `Launch.Integration.Copy.*` button must be present but `.enabled == false`
     # until the endpoint/key actually exist (Copy on a placeholder is the
     # silent-failure defect the disabled-Copy gate exists to prevent).
-    count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration.Copy."))] | unique | length' "$OUT/launch.json")"
-    [[ "$count" -gt 0 ]] || die "Cold Launch hid the integration setup rows entirely"
     enabled_count="$(jq '[.data.ui_elements[]? | select(((.identifier // "") | startswith("Launch.Integration.Copy.")) and .enabled == true)] | length' "$OUT/launch.json")"
     [[ "$enabled_count" == 0 ]] || die "Cold Launch offered $enabled_count copyable commands before the endpoint/key existed"
     jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' "$OUT/launch.json" >/dev/null \
@@ -4719,7 +4736,6 @@ flow_launch_integrations() {
     press "$OUT/launch-ready.json" ConnectTools.MoreIntegrations \
         "$OUT/launch-more-press.json" \
         || die "More integrations disclosure is not pressable"
-    local i
     for ((i=0; i<80; i++)); do
         see_main "$OUT/launch-ready.json"
         ready_copies="$(jq '[.data.ui_elements[]?

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -353,6 +353,16 @@ BASELINED_AUDIT_FLOWS = ["update-state", "launch-integrations"]
 SNAPSHOT_LESS_AUDIT_FLOWS = ["no-dead-controls", "catalog-integrity"]
 
 
+def test_launch_baseline_waits_for_the_authoritative_integration_registry():
+    flow = _harness_flow_body("flow_launch_integrations")
+    settle = flow.index('[[ "$count" == 14 ]] && break')
+    require_settled = flow.index('|| die "Cold Launch did not settle')
+    capture = flow.index("baseline launch-integrations.complete")
+
+    assert settle < require_settled < capture
+    assert 'see_main "$OUT/launch.json"' in flow[:settle]
+
+
 @pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)
 def test_semantic_control_audits_are_blocking_gui_ci(flow: str):
     """Each semantic audit is gated, and its failure leaves usable evidence.


### PR DESCRIPTION
## Why

Release dogfood found a deterministic-looking golden failure caused by an asynchronous catalog race. The stopped Launch page first renders a three-entry compatibility fallback, then replaces it with the authoritative 14-entry sidecar registry. The journey waited only for the page heading, so its snapshot could capture either valid intermediate or settled state.

## What

- Wait for the complete 14-entry fake-sidecar integration registry before evaluating or recording the stopped Launch structure.
- Fail closed if that authoritative state never arrives.
- Regenerate the baseline from the settled state.
- Pin the settle-before-capture ordering in a focused contract.

## Scope / non-goals

Scope is limited to Launch Integrations golden settling, its committed snapshot, and a focused test. It does not change product UI, integration commands, engine registry, model lifecycle, or server behavior.

## Design precedent

The journey follows the repositorys established async-view testing pattern: wait for an authoritative semantic state rather than a generic page marker, assert the resolved data contract, and only then capture structural evidence. Compatibility fallback remains product behavior but is no longer mistaken for the final fixture state.

## Verification

- Isolated launch-integrations journey passed twice: once while updating the baseline and once against the committed result.
- Both runs expanded all 14 integrations and proved every enabled button copied a non-empty command.
- RAPID_HOST_PRECHECK_HELD=1 python3.12 -m pytest -q tests/test_gui_control_behavior_contract.py tests/test_gui_golden_ci_coverage.py: 30 passed.
- Ruff check/format, bash -n, and git diff --check: clean.
- Current-main local helper failures caused by empty ORIGINAL_ARGS under the newly landed host precheck are tracked separately in #2629; they reproduce outside this diff and hosted CI skips that local-only branch.

Fixes #2627