### PR TITLE
fix(mac): preserve empty GUI golden arguments

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -110,9 +110,13 @@ if [[ -n "${GUI_FLOWS:-}" && "$FLOW" != all ]]; then
     fi
 fi
 
-if [[ "${RAPID_HOST_PRECHECK_HELD:-0}" != "1" && "${CI:-}" != "true" ]]; then
+# The helper-contract tests source this file to exercise the shell guards. Host
+# admission belongs to the executable entry point, not to library-style use.
+if [[ "${BASH_SOURCE[0]}" == "$0" && "${RAPID_HOST_PRECHECK_HELD:-0}" != "1" && "${CI:-}" != "true" ]]; then
     export RAPID_HOST_PRECHECK_HELD=1
-    exec "$ROOT/scripts/dogfood-host-precheck.sh" -- "$0" "${ORIGINAL_ARGS[@]}"
+    # macOS Bash 3.2 treats an empty array expansion as unbound under `set -u`.
+    exec "$ROOT/scripts/dogfood-host-precheck.sh" -- "$0" \
+        ${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}
 fi
 
 log() { printf '[gui-golden] %s\n' "$*"; }

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -14,9 +14,9 @@ behavioural reason (#2494). Each guard below now asserts the structural
   (`pull` lifecycle, machine aliases, watchdog events);
 * the flow is gated in CI and its failures leave usable evidence (parsed
   structurally from the workflow YAML, mirroring ``test_gui_golden_ci_coverage``);
-* the only deliberately retained single-anchor source checks are the two sides
-  of a cross-language request-body contract (Swift default <-> shell request),
-  where no behavioural proxy exists — see ``test_image_generation_...``.
+* the deliberately retained source anchors cover contracts with no portable
+  behavioural proxy: the two sides of a cross-language request body and the
+  Bash 3.2 empty-array syntax that Ubuntu's newer Bash accepts either way.
 
 The guarantees here are behaviour; the anchors are precise and loud about why
 they exist when they break.
@@ -102,6 +102,16 @@ def _run_harness_helper(tmp_path: Path, helper: str, *args: str):
         text=True,
         check=False,
     )
+
+
+def test_host_precheck_uses_bash32_safe_empty_array_expansion():
+    """Ubuntu must reject syntax that would regress macOS Bash 3.2."""
+    source = HARNESS.read_text()
+    precheck_block = source.split("dogfood-host-precheck.sh", 1)[1].split("fi", 1)[0]
+    argument_lines = {line.strip() for line in precheck_block.splitlines()}
+
+    assert '${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}' in argument_lines
+    assert '"${ORIGINAL_ARGS[@]}"' not in argument_lines
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -104,6 +104,57 @@ def _run_harness_helper(tmp_path: Path, helper: str, *args: str):
     )
 
 
+@pytest.mark.parametrize(
+    "original_args",
+    [(), ("--flow", "fresh install", "--keep")],
+)
+def test_host_precheck_preserves_original_argv_on_system_bash(
+    tmp_path: Path, original_args: tuple[str, ...]
+):
+    """Direct execution preserves zero args and whitespace on macOS Bash 3.2."""
+    rapid_root = tmp_path / "rapid-mac"
+    scripts = rapid_root / "scripts"
+    scripts.mkdir(parents=True)
+
+    copied_harness = scripts / HARNESS.name
+    copied_harness.write_bytes(HARNESS.read_bytes())
+    copied_harness.chmod(0o755)
+
+    captured_argv = tmp_path / "precheck-argv.json"
+    precheck = scripts / "dogfood-host-precheck.sh"
+    precheck.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "with open(os.environ['RAPID_PRECHECK_ARGV_OUT'], 'w') as handle:\n"
+        "    json.dump(sys.argv[1:], handle)\n"
+    )
+    precheck.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CI": "false",
+            "RAPID_HOST_PRECHECK_HELD": "0",
+            "RAPID_PRECHECK_ARGV_OUT": str(captured_argv),
+        }
+    )
+    result = subprocess.run(
+        ["/bin/bash", str(copied_harness), *original_args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(captured_argv.read_text()) == [
+        "--",
+        str(copied_harness),
+        *original_args,
+    ]
+
+
 def _assert_in_order(body: str, *anchors: str) -> None:
     positions = [body.index(anchor) for anchor in anchors]
     assert positions == sorted(positions), (


### PR DESCRIPTION
## Intention

Keep the Desktop golden harness runnable under the Bash 3.2 shipped with macOS, including when its helper guards are sourced with no positional arguments.

Fixes #2634

## Scope

- run host admission only from the executable entry point
- forward an empty original-argument array safely under `set -u`
- directly test zero-argument and whitespace-preserving host-precheck forwarding

## Non-goals

- no journey, product assertion, workflow, runner-routing, or Desktop product changes
- no weakening of strict shell mode or host admission

## Design precedent

The existing macOS release scripts guard optional arrays before expansion under Bash strict mode. This applies the same compatibility contract and the standard executable-entry-point boundary so library-style helper use cannot trigger process admission.

## Acceptance

- sourced helper contracts do not execute host admission
- direct execution retains host admission and preserves zero or more original arguments
- GUI control and coverage contract tests pass

## Verification

- target shell: GNU Bash 3.2.57 on arm64 Apple Darwin
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `32 passed`: GUI control behavior + golden CI coverage
- ruff check + format check
- `git diff --check`