### PR TITLE
test(mllm): align cancellation statistics status

### DIFF
--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -144,8 +144,8 @@ def test_mllm_completed_request_adds_prompt_and_completion_tokens():
     assert scheduler.num_requests_processed == 1
 
 
-def test_mllm_aborted_request_adds_prompt_tokens_without_completion_tokens():
-    """Aborted requests still account for their already-prefilled prompt."""
+def test_mllm_cancelled_request_adds_prompt_tokens_without_completion_tokens():
+    """Cancelled requests still account for their already-prefilled prompt."""
     scheduler = _bare_scheduler()
     request = MLLMRequest(request_id="req-2", prompt="hello")
     request.status = RequestStatus.RUNNING
@@ -164,4 +164,4 @@ def test_mllm_aborted_request_adds_prompt_tokens_without_completion_tokens():
 
     assert scheduler.total_prompt_tokens == 23
     assert scheduler.total_completion_tokens == 0
-    assert request.status is RequestStatus.FINISHED_ABORTED
+    assert request.status is RequestStatus.FINISHED_CANCELLED


### PR DESCRIPTION
## Intention

Restore the full unit gate after the cancellation protocol introduced a dedicated cancelled terminal status.

Fixes #2635

## Scope

- rename the MLLM statistics regression around user cancellation
- assert the canonical `FINISHED_CANCELLED` state while retaining prompt/completion accounting checks

## Non-goals

- no scheduler, route, protocol, metrics, or runtime behavior changes
- no CI workflow changes

## Design precedent

Terminal-state tests should assert the canonical lifecycle state exposed by the request contract, while accounting checks remain orthogonal. The dedicated cancelled state is already covered across the shared scheduler and protocol paths; this aligns the MLLM statistics contract with that same state machine.

## Acceptance

- user cancellation is asserted as cancelled rather than an internal abort
- prompt tokens remain accounted and completion tokens remain zero
- focused MLLM and cancellation tests pass

## Verification

- `68 passed`: MLLM statistics, cancellation protocol, and request status
- ruff check + format check
- `git diff --check`