### PR TITLE
feat(mac): persist embedded API bearer with safe lifetimes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/BearerSecret.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BearerSecret.swift
@@ -49,8 +49,10 @@ import Security
 /// stdin / a unix-socket pair instead of leaking it through the
 /// process environment) or NSXPC. Tracked in issue #303 / #305.
 ///
-/// The secret rotates on every launch / restart, so a leak via
-/// memory dump or log scrub miss is bounded to the current session.
+/// By default the secret rotates on every launch / restart, so a leak via
+/// memory dump or log scrub miss is bounded to the current session. The user
+/// may opt into a Keychain-backed daily or explicit lifetime; unavailable or
+/// malformed persisted credentials always fall back to a one-time secret.
 /// ``LogScrubber`` already redacts ``Authorization: Bearer`` and
 /// ``--api-key=`` shapes before they reach the log tail.
 enum BearerSecret {

--- a/apps/rapid-mac/Sources/Rapid/Server/EmbeddedBearerCredential.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/EmbeddedBearerCredential.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+/// How long a Desktop-managed embedded-engine bearer remains usable.
+enum EmbeddedBearerLifetime: String, CaseIterable, Equatable, Sendable {
+    case perLaunch
+    case daily
+    case explicit
+
+    var storageKey: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .perLaunch: return "Every start"
+        case .daily: return "Daily"
+        case .explicit: return "Until I rotate"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .perLaunch:
+            return "Generate a one-time key for every model start. Nothing is stored in the Keychain."
+        case .daily:
+            return "Keep one Keychain-backed key for 24 hours across model starts and app restarts."
+        case .explicit:
+            return "Keep one Keychain-backed key until you rotate it or change this setting."
+        }
+    }
+}
+
+/// A non-secret policy record. The bearer secret itself never enters
+/// UserDefaults.
+struct EmbeddedBearerCredentialMetadata: Equatable, Codable, Sendable {
+    let lifetime: String
+    let rotatedAt: Date
+}
+
+struct EmbeddedBearerCredential: Equatable, Sendable {
+    let secret: String
+    let rotatedAt: Date
+    let lifetime: EmbeddedBearerLifetime
+}
+
+enum EmbeddedBearerStorageResult: Equatable, Sendable {
+    case found(EmbeddedBearerCredential)
+    case missing
+    case corrupted
+    case unavailable
+}
+
+enum EmbeddedBearerStorageIssue: Equatable, Sendable {
+    case generationFailed
+    case missingSecret
+    case corruptedCredential
+    case unavailableKeychain
+    case writeFailed
+}
+
+/// One start-time materialization of an embedded API credential. A persisted
+/// secret is already in the Keychain; one-time material is never written to
+/// any local store.
+struct EmbeddedBearerMaterial: Equatable, Sendable {
+    let secret: String
+    let rotatedAt: Date?
+    let isPersisted: Bool
+    let issue: EmbeddedBearerStorageIssue?
+}
+
+/// Observable, secret-free credential state for Settings.
+enum EmbeddedBearerStatus: Equatable, Sendable {
+    case notMaterialized
+    case materialized(
+        rotatedAt: Date?,
+        isPersisted: Bool,
+        issue: EmbeddedBearerStorageIssue?
+    )
+}
+
+protocol EmbeddedBearerCredentialStoring: Sendable {
+    func loadCredential() -> EmbeddedBearerStorageResult
+    func hasPersistedCredential() -> Bool
+    @discardableResult func save(_ credential: EmbeddedBearerCredential) -> Bool
+    @discardableResult func clear() -> Bool
+}
+
+/// ``UserDefaults`` is thread-safe for these small metadata reads/writes but
+/// does not expose Sendable conformance in this SDK.
+struct EmbeddedBearerCredentialStore: EmbeddedBearerCredentialStoring, @unchecked Sendable {
+    private static let account = "embedded-engine.bearer.v1"
+    private static let metadataKey = "rapid.embeddedBearer.credential.v1"
+    private static let hasPersistedKey = "rapid.embeddedBearer.hasPersistedCredential.v1"
+    private static let secretLength = 64
+
+    private let defaults: UserDefaults
+    private let keychain: KeychainStoring
+
+    init(defaults: UserDefaults, keychain: KeychainStoring) {
+        self.defaults = defaults
+        self.keychain = keychain
+    }
+
+    func loadCredential() -> EmbeddedBearerStorageResult {
+        let keychainResult = keychain.readWithoutUserInteraction(account: Self.account)
+        switch keychainResult {
+        case .unavailable:
+            return .unavailable
+        case .missing:
+            return .missing
+        case .found(let secret):
+            guard Self.isValidSecret(secret) else {
+                clear()
+                return .corrupted
+            }
+        }
+
+        guard let data = defaults.data(forKey: Self.metadataKey),
+              let metadata = try? JSONDecoder().decode(
+                  EmbeddedBearerCredentialMetadata.self,
+                  from: data
+              ),
+              EmbeddedBearerLifetime(rawValue: metadata.lifetime) != nil,
+              metadata.rotatedAt <= Date().addingTimeInterval(60) else {
+            clear()
+            return .corrupted
+        }
+
+        guard case .found(let secret) = keychainResult else {
+            return .missing
+        }
+        return .found(
+            EmbeddedBearerCredential(
+                secret: secret,
+                rotatedAt: metadata.rotatedAt,
+                lifetime: EmbeddedBearerLifetime(rawValue: metadata.lifetime)!
+            )
+        )
+    }
+
+    func hasPersistedCredential() -> Bool {
+        defaults.bool(forKey: Self.hasPersistedKey)
+    }
+
+    @discardableResult
+    func save(_ credential: EmbeddedBearerCredential) -> Bool {
+        guard Self.isValidSecret(credential.secret) else { return false }
+        guard keychain.write(account: Self.account, secret: credential.secret) else {
+            return false
+        }
+
+        let metadata = EmbeddedBearerCredentialMetadata(
+            lifetime: credential.lifetime.storageKey,
+            rotatedAt: credential.rotatedAt
+        )
+        guard let data = try? JSONEncoder().encode(metadata) else {
+            clear()
+            return false
+        }
+        defaults.set(data, forKey: Self.metadataKey)
+        defaults.set(true, forKey: Self.hasPersistedKey)
+        return true
+    }
+
+    @discardableResult
+    func clear() -> Bool {
+        defaults.removeObject(forKey: Self.metadataKey)
+        defaults.removeObject(forKey: Self.hasPersistedKey)
+        return keychain.delete(account: Self.account)
+    }
+
+    static func isValidSecret(_ secret: String) -> Bool {
+        secret.count == secretLength
+            && secret.allSatisfy { character in
+                character.isHexDigit && character.isASCII
+            }
+    }
+}
+
+enum EmbeddedBearerMaterialResolver {
+    static func resolve(
+        lifetime: EmbeddedBearerLifetime,
+        store: EmbeddedBearerCredentialStoring,
+        now: Date,
+        generateSecret: () -> String?
+    ) -> EmbeddedBearerMaterial {
+        let generatedSecret = generateSecret()
+        guard let generatedSecret else {
+            return EmbeddedBearerMaterial(
+                secret: "",
+                rotatedAt: nil,
+                isPersisted: false,
+                issue: .generationFailed
+            )
+        }
+
+        switch lifetime {
+        case .perLaunch:
+            store.clear()
+            return EmbeddedBearerMaterial(
+                secret: generatedSecret,
+                rotatedAt: now,
+                isPersisted: false,
+                issue: nil
+            )
+        case .daily:
+            switch store.loadCredential() {
+            case .missing where store.hasPersistedCredential():
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .missingSecret
+                )
+            case .found(let credential) where credential.lifetime == .daily:
+                if now.timeIntervalSince(credential.rotatedAt) < 24 * 60 * 60 {
+                    return EmbeddedBearerMaterial(
+                        secret: credential.secret,
+                        rotatedAt: credential.rotatedAt,
+                        isPersisted: true,
+                        issue: nil
+                    )
+                }
+            case .corrupted:
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .corruptedCredential
+                )
+            case .unavailable:
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .unavailableKeychain
+                )
+            default:
+                break
+            }
+        case .explicit:
+            switch store.loadCredential() {
+            case .missing where store.hasPersistedCredential():
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .missingSecret
+                )
+            case .found(let credential) where credential.lifetime == .explicit:
+                return EmbeddedBearerMaterial(
+                    secret: credential.secret,
+                    rotatedAt: credential.rotatedAt,
+                    isPersisted: true,
+                    issue: nil
+                )
+            case .corrupted:
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .corruptedCredential
+                )
+            case .unavailable:
+                return EmbeddedBearerMaterial(
+                    secret: generatedSecret,
+                    rotatedAt: now,
+                    isPersisted: false,
+                    issue: .unavailableKeychain
+                )
+            default:
+                break
+            }
+        }
+
+        let credential = EmbeddedBearerCredential(
+            secret: generatedSecret,
+            rotatedAt: now,
+            lifetime: lifetime
+        )
+        guard store.save(credential) else {
+            return EmbeddedBearerMaterial(
+                secret: generatedSecret,
+                rotatedAt: now,
+                isPersisted: false,
+                issue: .writeFailed
+            )
+        }
+        return EmbeddedBearerMaterial(
+            secret: credential.secret,
+            rotatedAt: credential.rotatedAt,
+            isPersisted: true,
+            issue: nil
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -643,8 +643,8 @@ final class ServerManager {
     /// client URL.
     private(set) var activePort: Int = PortSweep.defaultPort
 
-    /// Issue #17 desktop-half: per-launch bearer secret. Generated
-    /// fresh by ``start()`` and handed to the child via the
+    /// Issue #17 desktop-half: active bearer secret. Generated or restored
+    /// by ``start()`` under the user's lifetime policy and handed to the child via the
     /// ``RAPID_MLX_API_KEY`` env (NOT argv); cleared by
     /// ``handleChildExit`` / ``terminateChild`` so a stale value
     /// can't survive into the next launch.
@@ -656,6 +656,15 @@ final class ServerManager {
     /// or in the (rare) RNG-failure case "we refused to start
     /// without auth", which surfaces as ``.crashed`` to the user.
     private(set) var activeBearer: String?
+
+    /// Issue #2599: how the next ``start()`` materializes the embedded
+    /// bearer. The default deliberately remains per-launch rotation.
+    private(set) var embeddedBearerLifetime: EmbeddedBearerLifetime = .perLaunch
+
+    /// Non-secret presentation state for the last materialized credential.
+    /// The bearer itself stays in ``activeBearer`` and, when persisted, in
+    /// the Keychain—not in UserDefaults or this struct.
+    private(set) var embeddedBearerStatus = EmbeddedBearerStatus.notMaterialized
 
     /// Supplies the `--mcp-config` path for the next spawn, or `nil` to launch
     /// with the MCP subsystem entirely absent.
@@ -1026,6 +1035,9 @@ final class ServerManager {
     @ObservationIgnored
     private weak var downloads: DownloadManager?
 
+    @ObservationIgnored
+    private let bearerCredentialStore: any EmbeddedBearerCredentialStoring
+
     // MARK: - Construction
 
     init() {
@@ -1034,6 +1046,11 @@ final class ServerManager {
         self.binaryPath = resolution?.binary
         self.state = (resolution == nil) ? .missing : .idle
         self.sessionDefaults = .standard
+        self.bearerCredentialStore = EmbeddedBearerCredentialStore(
+            defaults: .standard,
+            keychain: SystemKeychain()
+        )
+        self.embeddedBearerLifetime = Self.loadBearerLifetime(from: .standard)
     }
 
     /// Wire the app's ``DownloadManager`` so ``start(alias:)`` can
@@ -1058,16 +1075,73 @@ final class ServerManager {
         binaryPath: URL? = nil,
         residency: ModelResidencySnapshot = .empty,
         activeBearer: String? = nil,
-        sessionDefaults: UserDefaults? = nil
+        sessionDefaults: UserDefaults? = nil,
+        bearerCredentialStore: (any EmbeddedBearerCredentialStoring)? = nil
     ) {
         self.state = testingState
         self.activeBearer = activeBearer
         self.binaryPath = binaryPath
         self.residency = residency
         self.sessionDefaults = sessionDefaults
+        self.bearerCredentialStore = bearerCredentialStore ?? EmbeddedBearerCredentialStore(
+            defaults: UserDefaults(),
+            keychain: InMemoryKeychain()
+        )
+        self.embeddedBearerLifetime = Self.loadBearerLifetime(
+            from: sessionDefaults ?? UserDefaults()
+        )
         self.binaryResolution = binaryPath.map {
             ServerLocator.Resolution(binary: $0, source: .unknown, version: nil)
         }
+    }
+
+    private static func loadBearerLifetime(
+        from defaults: UserDefaults
+    ) -> EmbeddedBearerLifetime {
+        guard let raw = defaults.string(forKey: "rapid.embeddedBearer.lifetime.v1"),
+              let lifetime = EmbeddedBearerLifetime(rawValue: raw) else {
+            return .perLaunch
+        }
+        return lifetime
+    }
+
+    func setEmbeddedBearerLifetime(_ lifetime: EmbeddedBearerLifetime) {
+        embeddedBearerLifetime = lifetime
+        sessionDefaults?.set(lifetime.rawValue, forKey: "rapid.embeddedBearer.lifetime.v1")
+    }
+
+    /// Persist a replacement under the current lifetime. A running child
+    /// continues accepting its old bearer until restart; the UI must say so.
+    @discardableResult
+    func rotateEmbeddedBearerNow(now: Date = Date()) -> Bool {
+        guard let secret = BearerSecret.generate() else {
+            embeddedBearerStatus = .materialized(
+                rotatedAt: now,
+                isPersisted: false,
+                issue: .unavailableKeychain
+            )
+            return false
+        }
+        let credential = EmbeddedBearerCredential(
+            secret: secret,
+            rotatedAt: now,
+            lifetime: embeddedBearerLifetime
+        )
+        guard embeddedBearerLifetime != .perLaunch,
+              bearerCredentialStore.save(credential) else {
+            embeddedBearerStatus = .materialized(
+                rotatedAt: now,
+                isPersisted: false,
+                issue: embeddedBearerLifetime == .perLaunch ? nil : .writeFailed
+            )
+            return false
+        }
+        embeddedBearerStatus = .materialized(
+            rotatedAt: now,
+            isPersisted: true,
+            issue: nil
+        )
+        return true
     }
 
     /// codex r1 BLOCKING #3 test seam — install a stub
@@ -2491,7 +2565,13 @@ final class ServerManager {
         // Authorization header. SecRandomCopyBytes failing is
         // pathological (kernel-level RNG starvation); we surface as
         // .crashed rather than silently spawning unauthenticated.
-        guard let bearer = BearerSecret.generate() else {
+        let bearerMaterial = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: embeddedBearerLifetime,
+            store: bearerCredentialStore,
+            now: Date(),
+            generateSecret: BearerSecret.generate
+        )
+        guard !bearerMaterial.secret.isEmpty else {
             isOperating = false
             state = .crashed(
                 alias: trimmedAlias,
@@ -2499,6 +2579,11 @@ final class ServerManager {
             )
             return
         }
+        embeddedBearerStatus = .materialized(
+            rotatedAt: bearerMaterial.rotatedAt,
+            isPersisted: bearerMaterial.isPersisted,
+            issue: bearerMaterial.issue
+        )
         // Codex r1 P3 (#17): hold the bearer in a local until the
         // spawn succeeds, then publish to ``activeBearer``. The
         // previous shape published BEFORE the spawn, so a thrown
@@ -2650,7 +2735,7 @@ final class ServerManager {
                 // exported in their shell (ANTHROPIC_API_KEY etc.)
                 // never enter the sidecar's address space.
                 environmentAdditions: Self.serveEnvironmentAdditions(
-                    bearer: bearer,
+                    bearer: bearerMaterial.secret,
                     ambient: ProcessInfo.processInfo.environment,
                     // Issue #1412: the engine's server-oriented default may
                     // retain up to 20% of RAM in prefix-cache entries. The
@@ -2713,7 +2798,7 @@ final class ServerManager {
         self.launchedPerformanceFlags = performanceFlags
         // Codex r1 P3 (#17): only publish the bearer after the spawn
         // has succeeded — see comment at the bearer guard above.
-        setActiveServerSession(bearer: bearer)
+        setActiveServerSession(bearer: bearerMaterial.secret)
         self.stdoutPipe = stdoutPipe
         self.stderrPipe = stderrPipe
         // #20: persist ownership before startMonitor() so a crash

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -15,6 +15,7 @@ struct SettingsToolsPanel: View {
     @Environment(ChatViewModel.self) private var chat
     @Environment(WebSearchConfig.self) private var webSearch
     @Environment(BrowseApprovalStore.self) private var browseApproval
+    @Environment(ServerManager.self) private var server
 
     /// Draft of the API key field. Committed on Return or Save so we don't
     /// write to the Keychain on every keystroke.
@@ -45,6 +46,7 @@ struct SettingsToolsPanel: View {
             toolsSection
             webSearchSection
             browseSection
+            embeddedAPISection
         }
     }
 
@@ -461,6 +463,105 @@ struct SettingsToolsPanel: View {
             get: { browseApproval.mode == .autoApproveAll },
             set: { browseApproval.mode = $0 ? .autoApproveAll : .ask }
         )
+    }
+
+    // MARK: - Embedded API security
+
+    private var embeddedAPISection: some View {
+        SettingsSection(
+            "Embedded API security",
+            subtitle: "The Desktop engine always requires a bearer key and stays bound to 127.0.0.1. Choose when that key rotates."
+        ) {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                RapidSegmentedControl(
+                    selection: Binding(
+                        get: { server.embeddedBearerLifetime },
+                        set: { server.setEmbeddedBearerLifetime($0) }
+                    ),
+                    options: [
+                        .init(
+                            value: .perLaunch,
+                            title: "Every start",
+                            identifier: "Settings.Tools.EmbeddedAPI.PerLaunch"
+                        ),
+                        .init(
+                            value: .daily,
+                            title: "Daily",
+                            identifier: "Settings.Tools.EmbeddedAPI.Daily"
+                        ),
+                        .init(
+                            value: .explicit,
+                            title: "Until I rotate",
+                            identifier: "Settings.Tools.EmbeddedAPI.Explicit"
+                        ),
+                    ],
+                    accessibilityLabel: "Embedded API key rotation"
+                )
+                .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.Lifetime")
+
+                Text(server.embeddedBearerLifetime.summary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                statusCopy
+
+                if server.embeddedBearerLifetime != .perLaunch {
+                    Button("Rotate now") {
+                        server.rotateEmbeddedBearerNow()
+                    }
+                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.RotateNow")
+
+                    if case .ready = server.state {
+                        Text("Restart the model to make a newly rotated key active.")
+                            .font(RapidFont.caption)
+                            .foregroundStyle(RapidTheme.textSecondary)
+                            .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.RestartNotice")
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusCopy: some View {
+        switch server.embeddedBearerStatus {
+        case .notMaterialized:
+            EmptyView()
+        case .materialized(_, let isPersisted, let issue):
+            if let issue {
+                Text(Self.issueCopy(issue))
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.statusError)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.DegradedNotice")
+            } else if isPersisted {
+                Text("The current key is stored in your Keychain.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.PersistedNotice")
+            } else {
+                Text("This model is using a one-time key.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.OneTimeNotice")
+            }
+        }
+    }
+
+    private static func issueCopy(_ issue: EmbeddedBearerStorageIssue) -> String {
+        switch issue {
+        case .generationFailed:
+            return "Secure key generation failed, so the model was not started."
+        case .missingSecret:
+            return "No usable saved key was found, so this model started with a one-time key."
+        case .corruptedCredential:
+            return "The saved credential was malformed, so this model started with a one-time key."
+        case .unavailableKeychain:
+            return "The Keychain is unavailable, so this model started with a one-time key."
+        case .writeFailed:
+            return "The Keychain couldn’t store a new key, so this model started with a one-time key. Restart the model to try again."
+        }
     }
 
     // MARK: - Shared layout

--- a/apps/rapid-mac/Tests/RapidTests/EmbeddedBearerCredentialTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/EmbeddedBearerCredentialTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Embedded bearer credential persistence (issue #2599)")
+struct EmbeddedBearerCredentialTests {
+    private let now = Date(timeIntervalSince1970: 1_760_000_000)
+
+    private func secret(seed: UInt8) -> String {
+        String(repeating: String(format: "%02x", seed), count: 32)
+    }
+
+    private func store(
+        suiteName: String,
+        keychain: KeychainStoring = InMemoryKeychain()
+    ) -> EmbeddedBearerCredentialStore {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return EmbeddedBearerCredentialStore(defaults: defaults, keychain: keychain)
+    }
+
+    @Test("Generated one-time material has the canonical bearer shape")
+    func generatedMaterialShape() {
+        let material = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .perLaunch,
+            store: store(suiteName: "bearer-shape"),
+            now: now,
+            generateSecret: { self.secret(seed: 1) }
+        )
+
+        #expect(material.secret.count == 64)
+        #expect(material.secret.allSatisfy { $0.isHexDigit && $0.isASCII })
+        #expect(!material.isPersisted)
+        #expect(material.issue == nil)
+    }
+
+    @Test("Per-launch material rotates and never persists either layer")
+    func perLaunchRotation() {
+        let suiteName = "bearer-per-launch"
+        let credentialStore = store(suiteName: suiteName)
+        var seed: UInt8 = 1
+
+        let first = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .perLaunch,
+            store: credentialStore,
+            now: now,
+            generateSecret: { seed += 1; return self.secret(seed: seed) }
+        )
+        let second = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .perLaunch,
+            store: credentialStore,
+            now: now.addingTimeInterval(1),
+            generateSecret: { seed += 1; return self.secret(seed: seed) }
+        )
+
+        #expect(first.secret != second.secret)
+        #expect(!first.isPersisted)
+        #expect(!second.isPersisted)
+        #expect(credentialStore.loadCredential() == .missing)
+    }
+
+    @Test("Daily material reuses until expiry, then rotates in the Keychain")
+    func dailyRotation() {
+        let credentialStore = store(suiteName: "bearer-daily")
+        let first = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .daily,
+            store: credentialStore,
+            now: now,
+            generateSecret: { self.secret(seed: 2) }
+        )
+        let reused = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .daily,
+            store: credentialStore,
+            now: now.addingTimeInterval(24 * 60 * 60 - 1),
+            generateSecret: { self.secret(seed: 99) }
+        )
+        let rotated = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .daily,
+            store: credentialStore,
+            now: now.addingTimeInterval(24 * 60 * 60 + 1),
+            generateSecret: { self.secret(seed: 3) }
+        )
+
+        #expect(first.isPersisted)
+        #expect(reused.secret == first.secret)
+        #expect(rotated.secret != first.secret)
+        #expect(rotated.issue == nil)
+    }
+
+    @Test("Explicit material survives restarts and only the user rotates it")
+    func explicitRotation() {
+        let credentialStore = store(suiteName: "bearer-explicit")
+        let first = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .explicit,
+            store: credentialStore,
+            now: now,
+            generateSecret: { self.secret(seed: 4) }
+        )
+        let reused = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .explicit,
+            store: credentialStore,
+            now: now.addingTimeInterval(10 * 24 * 60 * 60),
+            generateSecret: { self.secret(seed: 98) }
+        )
+        let rotated = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .explicit,
+            store: credentialStore,
+            now: now.addingTimeInterval(10 * 24 * 60 * 60 + 1),
+            generateSecret: { self.secret(seed: 5) }
+        )
+
+        #expect(reused.secret == first.secret)
+        #expect(rotated.secret == first.secret)
+    }
+
+    @Test("Malformed saved credential fails safe to a one-time key")
+    func malformedCredentialFailsSafe() {
+        let credentialStore = store(
+            suiteName: "bearer-corrupted",
+            keychain: FixedResultKeychain(readResult: .found("not-a-canonical-bearer"))
+        )
+
+        let material = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .daily,
+            store: credentialStore,
+            now: now.addingTimeInterval(1),
+            generateSecret: { self.secret(seed: 6) }
+        )
+
+        #expect(!material.isPersisted)
+        #expect(material.issue == .corruptedCredential)
+    }
+
+    @Test("Unavailable Keychain fails safe to a one-time key")
+    func unavailableKeychainFailsSafe() {
+        let material = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .daily,
+            store: store(
+                suiteName: "bearer-unavailable",
+                keychain: FixedResultKeychain(readResult: .unavailable)
+            ),
+            now: now,
+            generateSecret: { self.secret(seed: 7) }
+        )
+
+        #expect(!material.isPersisted)
+        #expect(material.issue == .unavailableKeychain)
+    }
+
+    @Test("Keychain write failure keeps the new bearer out of persistence")
+    func writeFailureDegradesToOneTime() {
+        let material = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .explicit,
+            store: store(
+                suiteName: "bearer-write-failed",
+                keychain: FixedResultKeychain(readResult: .missing, writeSucceeds: false)
+            ),
+            now: now,
+            generateSecret: { self.secret(seed: 8) }
+        )
+
+        #expect(!material.isPersisted)
+        #expect(material.issue == .writeFailed)
+    }
+
+    @Test("Secret storage is separate from UserDefaults policy storage")
+    func storageSeparation() {
+        let suiteName = "bearer-storage-separation"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let secret = secret(seed: 9)
+        let credentialStore = EmbeddedBearerCredentialStore(
+            defaults: defaults,
+            keychain: InMemoryKeychain()
+        )
+        let saved = credentialStore.save(
+            EmbeddedBearerCredential(
+                secret: secret,
+                rotatedAt: now,
+                lifetime: .explicit
+            )
+        )
+
+        let serializedDefaults = defaults.dictionaryRepresentation()
+            .values
+            .compactMap { value in
+                (value as? Data).flatMap { String(data: $0, encoding: .utf8) }
+            }
+
+        #expect(saved)
+        #expect(serializedDefaults.allSatisfy { !$0.contains(secret) })
+        #expect(credentialStore.loadCredential() != .missing)
+    }
+}
+
+private final class FixedResultKeychain: KeychainStoring, @unchecked Sendable {
+    private let readResult: KeychainReadResult
+    private let writeSucceeds: Bool
+
+    init(readResult: KeychainReadResult, writeSucceeds: Bool = true) {
+        self.readResult = readResult
+        self.writeSucceeds = writeSucceeds
+    }
+
+    func read(account: String) -> String? {
+        guard case .found(let secret) = readResult else { return nil }
+        return secret
+    }
+
+    func readWithoutUserInteraction(account: String) -> KeychainReadResult {
+        readResult
+    }
+
+    @discardableResult
+    func write(account: String, secret: String) -> Bool {
+        writeSucceeds
+    }
+
+    @discardableResult
+    func delete(account: String) -> Bool {
+        true
+    }
+}
+
+@MainActor
+@Suite("ServerManager embedded bearer policy (issue #2599)")
+struct ServerManagerEmbeddedBearerTests {
+    @Test("Lifetime selection persists separately from the secret")
+    func lifetimeSelectionPersists() {
+        let suiteName = "server-bearer-lifetime"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let credentialStore = RecordingCredentialStore()
+        let server = ServerManager(
+            testingState: .idle,
+            sessionDefaults: defaults,
+            bearerCredentialStore: credentialStore
+        )
+
+        server.setEmbeddedBearerLifetime(.daily)
+
+        #expect(server.embeddedBearerLifetime == .daily)
+        #expect(defaults.string(forKey: "rapid.embeddedBearer.lifetime.v1") == "daily")
+    }
+
+    @Test("Manual rotation persists only for persisted lifetimes")
+    func manualRotation() {
+        let dailyCredentialStore = RecordingCredentialStore()
+        let dailyServer = ServerManager(
+            testingState: .ready(alias: "model"),
+            activeBearer: "active-secret",
+            sessionDefaults: UserDefaults(suiteName: "server-bearer-daily")!,
+            bearerCredentialStore: dailyCredentialStore
+        )
+        dailyServer.setEmbeddedBearerLifetime(.daily)
+        let dailyRotated = dailyServer.rotateEmbeddedBearerNow(now: Date(timeIntervalSince1970: 10))
+
+        #expect(dailyRotated)
+        #expect(dailyServer.activeBearer == "active-secret")
+        #expect(dailyServer.embeddedBearerStatus == .materialized(
+            rotatedAt: Date(timeIntervalSince1970: 10),
+            isPersisted: true,
+            issue: nil
+        ))
+
+        let perLaunchCredentialStore = RecordingCredentialStore()
+        let perLaunchServer = ServerManager(
+            testingState: .ready(alias: "model"),
+            activeBearer: "active-secret",
+            sessionDefaults: UserDefaults(suiteName: "server-bearer-per-launch")!,
+            bearerCredentialStore: perLaunchCredentialStore
+        )
+        let perLaunchRotated = perLaunchServer.rotateEmbeddedBearerNow(now: Date(timeIntervalSince1970: 20))
+
+        #expect(!perLaunchRotated)
+        #expect(perLaunchCredentialStore.saved.isEmpty)
+    }
+}
+
+private final class RecordingCredentialStore: EmbeddedBearerCredentialStoring, @unchecked Sendable {
+    private(set) var saved: [EmbeddedBearerCredential] = []
+    private(set) var cleared = false
+
+    func loadCredential() -> EmbeddedBearerStorageResult {
+        .missing
+    }
+
+    func hasPersistedCredential() -> Bool {
+        !saved.isEmpty
+    }
+
+    @discardableResult
+    func save(_ credential: EmbeddedBearerCredential) -> Bool {
+        saved.append(credential)
+        return true
+    }
+
+    @discardableResult
+    func clear() -> Bool {
+        cleared = true
+        return true
+    }
+}


### PR DESCRIPTION
Closes #2599

## User-visible goal

Let Desktop users keep the embedded engine's API bearer across model restarts, while retaining per-launch rotation as the secure default and never offering unauthenticated access.

## Approach

- Add per-launch, daily, and explicit-rotation lifetimes.
- Keep only non-secret metadata in `UserDefaults`; keep the bearer in a code-identity-scoped Keychain item.
- Reuse a valid persisted credential for the selected lifetime and rotate it at the chosen boundary.
- Treat missing, malformed, or unavailable persisted credentials as a fail-safe one-time key and surface the degradation in Settings.
- Preserve loopback binding, existing CORS behavior, environment allowlisting, and client bearer identity.

## Testing

- Focused credential, policy, environment, accessibility, and bearer-client suites: 93 passed.
- Full Desktop suite had two unrelated timing-sensitive failures that pass in isolation on clean `main`; the targeted versions of both suites also pass.
- `git diff --check`
