### PR TITLE
fix(cli): resolve the unique complete snapshot offline

### DIFF
--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -906,6 +906,24 @@ def test_local_snapshot_leaves_a_cold_repo_untouched(monkeypatch):
     assert tok._local_snapshot_if_cached("org/cold-repo") == "org/cold-repo"
 
 
+def test_local_snapshot_uses_unique_complete_offline_revision(monkeypatch):
+    """The loader receives the same verified local path the CLI admitted."""
+    from vllm_mlx.utils import tokenizer as tok
+
+    complete = "/cache/models--org--model/snapshots/complete"
+    monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", lambda _name: False)
+    monkeypatch.setattr(
+        "vllm_mlx.model_metadata.resolve_unreferenced_cached_snapshot",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_metadata.resolve_offline_cached_snapshot",
+        lambda _name: Path(complete),
+    )
+
+    assert tok._local_snapshot_if_cached("org/model") == complete
+
+
 def test_local_snapshot_falls_back_when_the_local_resolve_fails(monkeypatch):
     """If the completeness probe says cached but the offline resolve raises
     (unexpected cache state), return the bare id so the normal path can still

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -72,6 +72,20 @@ def test_offline_hub_mode_detects_env_switches(monkeypatch):
     assert cli._offline_hub_mode_active() is False
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("YES", True),
+        ("true", True),
+        ("0", False),
+        (None, False),
+    ],
+)
+def test_cli_env_flag_wrapper_preserves_shared_truth_table(raw, expected):
+    """The compatibility wrapper must exercise the shared parser directly."""
+    assert cli._env_flag_active(raw) is expected
+
+
 def test_offline_uncached_serve_refuses_before_download(monkeypatch, capsys):
     """Offline + uncached must exit(1) with one actionable message and NOT
     attempt the download/mirror path (no repeated "First-time download")."""

--- a/tests/test_cli_offline_serve.py
+++ b/tests/test_cli_offline_serve.py
@@ -134,6 +134,59 @@ def test_offline_cached_repo_is_noop_not_refused(monkeypatch, capsys):
     assert "is not cached" not in capsys.readouterr().err
 
 
+def test_offline_unique_complete_snapshot_is_noop_not_refused(monkeypatch, capsys):
+    """An incomplete main ref may use one verified complete local revision."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(cli, "_cache_runnability", lambda name: False)
+    monkeypatch.setattr(
+        cli,
+        "_offline_complete_cached_snapshot",
+        lambda name: "/cache/models--acme--model/snapshots/complete",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_check_disk_space",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("offline cached snapshot must not enter download")
+        ),
+    )
+
+    cli._ensure_model_downloaded("acme/model")
+    assert "is not cached" not in capsys.readouterr().err
+
+
+def test_offline_unique_complete_snapshot_is_runnable_in_inventory(monkeypatch):
+    """Serve admission and cached-model inventory share one verdict."""
+    monkeypatch.setattr(
+        "vllm_mlx.audio.registry.resolve_audio_alias", lambda _repo: None
+    )
+    monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", lambda _repo: False)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate._snapshot_is_complete_split_model",
+        lambda _repo: False,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate._snapshot_is_complete_mflux_model",
+        lambda _repo: False,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate._snapshot_is_complete_wan_model",
+        lambda _repo: False,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_metadata.resolve_unreferenced_cached_snapshot",
+        lambda _repo: None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_metadata.resolve_offline_cached_snapshot",
+        lambda _repo: "/cache/models--acme--model/snapshots/complete",
+    )
+    monkeypatch.setattr("vllm_mlx.video.wan.WAN_REVISIONS", {})
+
+    assert cli._cache_runnability("acme/model") is True
+    assert cli._cache_entry_is_runnable("acme/model") is True
+
+
 def test_offline_cached_mflux_is_noop_not_refused(monkeypatch, capsys):
     """A fully-cached mflux checkpoint (no root ``model*.safetensors``, so a
     text-only ``is_repo_cached`` read misses it) must NOT be refused — the
@@ -318,6 +371,49 @@ def test_gate_does_not_refuse_when_wan_local_dir_set(monkeypatch, capsys, tmp_pa
     assert "is not cached and the network is unavailable" not in out.err
     assert confirmed != []  # the refusal was skipped; the confirm path ran
     assert dispatched != []  # … and serve still dispatched the Wan model
+
+
+def test_gate_dispatches_unique_complete_offline_snapshot_without_confirm(
+    monkeypatch, capsys
+):
+    """The interactive entry gate agrees with the loader's offline fallback."""
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda _name: False)
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _name: False)
+    monkeypatch.setattr(cli.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(
+        cli,
+        "_offline_complete_cached_snapshot",
+        lambda _name: "/cache/models--publisher--model/snapshots/complete",
+    )
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr(
+        gate,
+        "estimate_download_size_bytes",
+        lambda _name: (_ for _ in ()).throw(
+            AssertionError("offline cache hit must not estimate a download")
+        ),
+    )
+    monkeypatch.setattr(
+        gate,
+        "confirm_or_abort",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("offline cache hit must not ask to download")
+        ),
+    )
+
+    dispatched = []
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "publisher/model"]),
+        patch.object(cli, "serve_command", side_effect=dispatched.append),
+    ):
+        cli.main()
+
+    assert dispatched != []
+    assert "is not cached" not in capsys.readouterr().err
 
 
 def test_gate_wan_dir_set_does_not_exempt_text_model(monkeypatch, capsys, tmp_path):

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -423,6 +423,44 @@ def test_offline_resolver_rejects_weight_link_outside_repo(monkeypatch, tmp_path
     assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
 
 
+def test_offline_resolver_rejects_invalid_ref_and_complete_selected_revision(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshots = repo_root / "snapshots"
+    selected = snapshots / "selected-revision"
+    selected.mkdir(parents=True)
+    _write_json(selected / "config.json", {"model_type": "qwen3_5"})
+    (selected / "model.safetensors").write_bytes(b"complete")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    main_ref = refs / "main"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+    main_ref.write_text("../selected-revision", encoding="utf-8")
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
+
+    main_ref.write_text("selected-revision", encoding="utf-8")
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
+
+
+def test_complete_cached_checkpoint_rejects_snapshot_symlink(monkeypatch, tmp_path):
+    repo_root = tmp_path / "models--publisher--model"
+    real_snapshot = repo_root / "real-snapshot"
+    real_snapshot.mkdir(parents=True)
+    snapshot_link = repo_root / "snapshots" / "linked-revision"
+    snapshot_link.parent.mkdir()
+    snapshot_link.symlink_to(real_snapshot, target_is_directory=True)
+
+    assert (
+        metadata._complete_cached_checkpoint(
+            repo_root, snapshot_link, "publisher/model"
+        )
+        is None
+    )
+
+
 def test_unreferenced_snapshot_rejects_weight_link_outside_repo(monkeypatch, tmp_path):
     repo_root = tmp_path / "models--publisher--model"
     snapshot = repo_root / "snapshots" / "immutable-revision"

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -347,6 +347,82 @@ def test_unreferenced_snapshot_does_not_override_existing_main_ref(
     assert metadata.resolve_unreferenced_cached_snapshot("publisher/model") is None
 
 
+def test_offline_resolver_uses_unique_complete_snapshot_when_main_is_incomplete(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshots = repo_root / "snapshots"
+    incomplete = snapshots / "new-revision"
+    incomplete.mkdir(parents=True)
+    complete = snapshots / "old-revision"
+    complete.mkdir()
+    _write_json(complete / "config.json", {"model_type": "qwen3_5"})
+    (complete / "model.safetensors").write_bytes(b"complete")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("new-revision", encoding="utf-8")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(
+        metadata,
+        "_cached_file",
+        lambda _name, filename: None,
+    )
+
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") == complete
+    routed = metadata.read_cached_model_metadata("publisher/model")
+    assert routed is not None
+    assert routed.snapshot_dir == complete
+    assert routed.config == {"model_type": "qwen3_5"}
+
+
+def test_offline_resolver_rejects_online_and_ambiguous_complete_revisions(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshots = repo_root / "snapshots"
+    incomplete = snapshots / "new-revision"
+    incomplete.mkdir(parents=True)
+    _write_json(incomplete / "config.json", {"model_type": "qwen3_5"})
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("new-revision", encoding="utf-8")
+    for revision in ("complete-a", "complete-b"):
+        snapshot = snapshots / revision
+        snapshot.mkdir()
+        _write_json(snapshot / "config.json", {"model_type": "qwen3_5"})
+        (snapshot / "model.safetensors").write_bytes(b"complete")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "0")
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
+
+
+def test_offline_resolver_rejects_weight_link_outside_repo(monkeypatch, tmp_path):
+    repo_root = tmp_path / "models--publisher--model"
+    snapshots = repo_root / "snapshots"
+    incomplete = snapshots / "new-revision"
+    incomplete.mkdir(parents=True)
+    _write_json(incomplete / "config.json", {"model_type": "qwen3_5"})
+    escaped = snapshots / "escaped-revision"
+    escaped.mkdir()
+    _write_json(escaped / "config.json", {"model_type": "qwen3_5"})
+    outside = tmp_path / "outside-model.safetensors"
+    outside.write_bytes(b"complete")
+    (escaped / "model.safetensors").symlink_to(outside)
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("new-revision", encoding="utf-8")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+    assert metadata.resolve_offline_cached_snapshot("publisher/model") is None
+
+
 def test_unreferenced_snapshot_rejects_weight_link_outside_repo(monkeypatch, tmp_path):
     repo_root = tmp_path / "models--publisher--model"
     snapshot = repo_root / "snapshots" / "immutable-revision"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1718,7 +1718,9 @@ def _env_flag_active(raw: str | None) -> bool:
     ``0``/``false``/empty leave it off) without depending on the library's
     private ``constants._is_true`` helper, whose return type is untyped.
     """
-    return raw is not None and str(raw).lower() in {"1", "on", "yes", "true"}
+    from vllm_mlx.model_metadata import env_flag_active
+
+    return env_flag_active(raw)
 
 
 def _offline_hub_mode_active() -> bool:
@@ -1730,9 +1732,16 @@ def _offline_hub_mode_active() -> bool:
     ``HF_HUB_OFFLINE=0`` mask ``TRANSFORMERS_OFFLINE=1`` (or vice-versa), which
     the download layer does not do.
     """
-    return _env_flag_active(os.environ.get("HF_HUB_OFFLINE")) or _env_flag_active(
-        os.environ.get("TRANSFORMERS_OFFLINE")
-    )
+    from vllm_mlx.model_metadata import hub_offline_mode_active
+
+    return hub_offline_mode_active()
+
+
+def _offline_complete_cached_snapshot(model_name: str):
+    """Resolve the unique verified local revision allowed in offline mode."""
+    from vllm_mlx.model_metadata import resolve_offline_cached_snapshot
+
+    return resolve_offline_cached_snapshot(model_name)
 
 
 def _offline_uncached_error(model_name: str) -> str:
@@ -1798,6 +1807,12 @@ def _ensure_model_downloaded(
     # couldn't establish) — it falls through to the normal online path.
     cachedness = _cache_runnability(model_name)
     if cachedness is True:
+        return
+
+    if (
+        _offline_hub_mode_active()
+        and _offline_complete_cached_snapshot(model_name) is not None
+    ):
         return
 
     # Offline + uncached refusal (#2357): reaching this point means the model is
@@ -5847,7 +5862,10 @@ def _cache_runnability(repo: str) -> bool | None:
             is_repo_cached,
         )
         from vllm_mlx.audio.registry import resolve_audio_alias
-        from vllm_mlx.model_metadata import resolve_unreferenced_cached_snapshot
+        from vllm_mlx.model_metadata import (
+            resolve_offline_cached_snapshot,
+            resolve_unreferenced_cached_snapshot,
+        )
         from vllm_mlx.video.wan import WAN_REVISIONS
 
         audio_entry = resolve_audio_alias(repo)
@@ -5872,6 +5890,7 @@ def _cache_runnability(repo: str) -> bool | None:
             or _snapshot_is_complete_mflux_model(repo)
             or _snapshot_is_complete_wan_model(repo)
             or resolve_unreferenced_cached_snapshot(repo) is not None
+            or resolve_offline_cached_snapshot(repo) is not None
         )
     except (OSError, KeyError, ValueError, TypeError, AttributeError) as exc:
         import logging
@@ -8592,7 +8611,10 @@ def chat_command(args):
                     is_repo_cached,
                 )
 
-                if not is_repo_cached(resolved):
+                if (
+                    not is_repo_cached(resolved)
+                    and _offline_complete_cached_snapshot(resolved) is None
+                ):
                     # Offline + uncached (/model swap): refuse BEFORE the size
                     # estimate + confirm, so the user sees the one actionable
                     # offline reason instead of an "About to download" notice
@@ -12196,7 +12218,10 @@ def main():
                 is_repo_cached,
             )
 
-            if not is_repo_cached(args.model):
+            if (
+                not is_repo_cached(args.model)
+                and _offline_complete_cached_snapshot(args.model) is None
+            ):
                 # Offline + uncached (#2357): short-circuit BEFORE the size
                 # estimate + ``confirm_or_abort``. ``estimate_repo_size_bytes``
                 # makes a silent HF ``model_info`` round-trip that returns None

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -24,6 +24,18 @@ MAX_METADATA_FILE_BYTES = 1 * 1024 * 1024
 MAX_WEIGHT_INDEX_BYTES = 64 * 1024 * 1024
 
 
+def env_flag_active(raw: str | None) -> bool:
+    """Return Hugging Face's public truth-value semantics for env switches."""
+    return raw is not None and str(raw).lower() in {"1", "on", "yes", "true"}
+
+
+def hub_offline_mode_active() -> bool:
+    """Whether either supported Hub/Transformers offline switch is active."""
+    return env_flag_active(os.environ.get("HF_HUB_OFFLINE")) or env_flag_active(
+        os.environ.get("TRANSFORMERS_OFFLINE")
+    )
+
+
 @dataclass(frozen=True)
 class ModelMetadata:
     """Offline metadata available for a local directory or HF snapshot."""
@@ -208,47 +220,17 @@ def _cached_file(model_name: str, filename: str) -> Path | None:
     return Path(cached)
 
 
-def resolve_unreferenced_cached_snapshot(model_name: str) -> Path | None:
-    """Return one complete cached checkpoint when no Hub ref resolves it.
-
-    ``snapshot_download(..., revision=<commit>)`` materializes
-    ``snapshots/<commit>/`` but intentionally does not update ``refs/main``.
-    That is the exact shape produced by an immutable catalog download.  The
-    normal ``try_to_load_from_cache`` lookup therefore cannot see the files,
-    even though the selected checkpoint is complete and directly loadable.
-
-    This fallback is deliberately narrow: there must be exactly one snapshot
-    directory, it must contain a valid config and a complete mlx-lm checkpoint,
-    and the checkpoint files must stay inside that repository's cache root.
-    Multiple revisions are ambiguous and return ``None``; callers then retain
-    the normal online/default-ref behavior instead of guessing which revision
-    the user intended.
-    """
-    if not _looks_like_hub_repo_id(model_name):
-        return None
+def _complete_cached_checkpoint(
+    repo_root: Path, snapshot: Path, model_name: str
+) -> Path | None:
+    """Validate one immutable snapshot and return its checkpoint directory."""
     try:
-        from huggingface_hub.constants import HF_HUB_CACHE
-
         from ._download_gate import _snapshot_is_complete
         from .model_aliases import checkpoint_prefix
 
-        repo_root = Path(HF_HUB_CACHE) / ("models--" + model_name.replace("/", "--"))
-        # This path is only for commit-pinned downloads that deliberately do
-        # not publish a default ref. If ``main`` exists, the Hub resolver owns
-        # revision selection and we must never substitute a different snapshot.
-        if os.path.lexists(repo_root / "refs" / "main"):
+        if snapshot.is_symlink() or not snapshot.is_dir():
             return None
-        snapshots_root = repo_root / "snapshots"
-        if snapshots_root.is_symlink() or not snapshots_root.is_dir():
-            return None
-        candidates = [
-            entry
-            for entry in snapshots_root.iterdir()
-            if entry.is_dir() and not entry.is_symlink()
-        ]
-        if len(candidates) != 1:
-            return None
-        checkpoint = candidates[0] / checkpoint_prefix(model_name)
+        checkpoint = snapshot / checkpoint_prefix(model_name)
         if checkpoint.is_symlink() or not checkpoint.is_dir():
             return None
         config_path = checkpoint / "config.json"
@@ -272,6 +254,90 @@ def resolve_unreferenced_cached_snapshot(model_name: str) -> Path | None:
         return None
 
 
+def resolve_unreferenced_cached_snapshot(model_name: str) -> Path | None:
+    """Return one complete cached checkpoint when no Hub ref resolves it.
+
+    ``snapshot_download(..., revision=<commit>)`` materializes
+    ``snapshots/<commit>/`` but intentionally does not update ``refs/main``.
+    That is the exact shape produced by an immutable catalog download.  The
+    normal ``try_to_load_from_cache`` lookup therefore cannot see the files,
+    even though the selected checkpoint is complete and directly loadable.
+
+    This fallback is deliberately narrow: there must be exactly one snapshot
+    directory, it must contain a valid config and a complete mlx-lm checkpoint,
+    and the checkpoint files must stay inside that repository's cache root.
+    Multiple revisions are ambiguous and return ``None``; callers then retain
+    the normal online/default-ref behavior instead of guessing which revision
+    the user intended.
+    """
+    if not _looks_like_hub_repo_id(model_name):
+        return None
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = Path(HF_HUB_CACHE) / ("models--" + model_name.replace("/", "--"))
+        # This path is only for commit-pinned downloads that deliberately do
+        # not publish a default ref. If ``main`` exists, the Hub resolver owns
+        # revision selection and we must never substitute a different snapshot.
+        if os.path.lexists(repo_root / "refs" / "main"):
+            return None
+        snapshots_root = repo_root / "snapshots"
+        if snapshots_root.is_symlink() or not snapshots_root.is_dir():
+            return None
+        candidates = [
+            entry
+            for entry in snapshots_root.iterdir()
+            if entry.is_dir() and not entry.is_symlink()
+        ]
+        if len(candidates) != 1:
+            return None
+        return _complete_cached_checkpoint(repo_root, candidates[0], model_name)
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+
+
+def resolve_offline_cached_snapshot(model_name: str) -> Path | None:
+    """Return the sole complete local revision behind an incomplete main ref.
+
+    This is intentionally narrower than ordinary Hub resolution. It is active
+    only in explicit offline mode, requires ``refs/main`` to select an
+    incomplete snapshot, never mutates that ref, and refuses ambiguity when
+    more than one complete immutable revision remains in the cache.
+    """
+    if not hub_offline_mode_active() or not _looks_like_hub_repo_id(model_name):
+        return None
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = Path(HF_HUB_CACHE) / ("models--" + model_name.replace("/", "--"))
+        snapshots_root = repo_root / "snapshots"
+        main_ref = repo_root / "refs" / "main"
+        if (
+            main_ref.is_symlink()
+            or not main_ref.is_file()
+            or snapshots_root.is_symlink()
+            or not snapshots_root.is_dir()
+        ):
+            return None
+        selected_sha = main_ref.read_text(encoding="utf-8").strip()
+        if not selected_sha or Path(selected_sha).name != selected_sha:
+            return None
+        selected = snapshots_root / selected_sha
+        if _complete_cached_checkpoint(repo_root, selected, model_name) is not None:
+            return None
+
+        complete = []
+        for snapshot in snapshots_root.iterdir():
+            checkpoint = _complete_cached_checkpoint(repo_root, snapshot, model_name)
+            if checkpoint is not None:
+                complete.append(checkpoint)
+                if len(complete) > 1:
+                    return None
+        return complete[0] if len(complete) == 1 else None
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+
+
 def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
     """Read metadata for a cached HF repository, never triggering download.
 
@@ -284,8 +350,21 @@ def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
     from .model_aliases import checkpoint_prefix
 
     prefix = checkpoint_prefix(model_name)
-    config_path = _cached_file(model_name, f"{prefix}config.json")
-    snapshot_dir = config_path.parent if config_path is not None else None
+    # In explicit offline mode the serve gate and loader may select the sole
+    # verified-complete immutable revision behind an incomplete ``refs/main``.
+    # Route from that same checkpoint; mixing main-ref metadata with fallback
+    # weights can choose an incompatible architecture or serving lane.
+    snapshot_dir = resolve_offline_cached_snapshot(model_name)
+    config_path = (
+        _cached_file(model_name, f"{prefix}config.json")
+        if snapshot_dir is None
+        else None
+    )
+    snapshot_dir = (
+        config_path.parent
+        if snapshot_dir is None and config_path is not None
+        else snapshot_dir
+    )
     if snapshot_dir is None:
         template_path = _cached_file(model_name, f"{prefix}chat_template.jinja")
         snapshot_dir = template_path.parent if template_path is not None else None

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -975,10 +975,15 @@ def _local_snapshot_if_cached(model_name: str) -> str:
     """
     try:
         from .._download_gate import is_repo_cached
-        from ..model_metadata import resolve_unreferenced_cached_snapshot
+        from ..model_metadata import (
+            resolve_offline_cached_snapshot,
+            resolve_unreferenced_cached_snapshot,
+        )
 
         if not is_repo_cached(model_name):
             snapshot = resolve_unreferenced_cached_snapshot(model_name)
+            if snapshot is None:
+                snapshot = resolve_offline_cached_snapshot(model_name)
             return str(snapshot) if snapshot is not None else model_name
     except Exception:
         return model_name


### PR DESCRIPTION
## Intention

Let an explicitly offline user serve the one verified-complete cached checkpoint when `refs/main` has advanced to an incomplete metadata-only revision.

Fixes #2616

## Scope

- share one live offline-mode predicate across CLI and loader paths
- resolve only the unique complete immutable snapshot behind an incomplete `refs/main`
- preserve strict config, shard, subfolder, symlink, and cache-containment validation
- align CLI admission, cached inventory, route metadata, and loader path on that same snapshot
- add hermetic incomplete/ambiguous/escape/online contracts

## Non-goals

- no online revision fallback or change to Hub branch semantics
- no mutation of `refs/main` or any cached artifact
- no guessing when multiple complete revisions exist
- no model, dependency, CI, or Desktop changes

## Design precedent

Established serving loaders switch the Hub client to local-only resolution in explicit offline mode and pass a concrete local checkpoint path downstream. The Hub correctly rejects an incomplete selected snapshot; Rapid-MLX adds one platform-safe recovery boundary for its own metadata-probe cache shape: select a local path only when one complete candidate is provable, then use that exact path for admission, metadata, and loading. Online behavior and ambiguous caches remain fail-closed.

## Acceptance

- offline + incomplete main + exactly one complete revision resolves without network access
- multiple complete revisions and escaping links fail closed
- online mode retains normal Hub revision semantics
- cache inventory, routing metadata, download gate, and loader agree

## Verification

- 370 passed: model metadata, offline CLI, loader/subfolder, cached inventory, and API utility suites
- ruff check + format-check
- git diff --check
- Studio user-side dry run against the real Flash-Next cache: `dcf657e4` selected identically by inventory, metadata, download gate, and loader; online fallback disabled; no model load