### PR TITLE
fix(engine): apply vision memory gate to forced lane loads

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -640,6 +640,20 @@ def test_vision_memory_floor_requires_a_positive_number(bad_floor) -> None:
         )
 
 
+def test_qwen35_and_qwen36_vision_aliases_carry_the_same_memory_floor() -> None:
+    """Cold start and residency must make the same lane choice for a family."""
+
+    aliases = _raw_aliases()
+    gated_aliases = {
+        name: profile
+        for name, profile in aliases.items()
+        if ("qwen3.5" in name.lower() or "qwen3.6" in name.lower())
+    }
+    assert gated_aliases
+    for name, profile in gated_aliases.items():
+        assert profile.get("vision_min_memory_gb") == 32, name
+
+
 def test_mtp_preset_requires_a_valid_drafter_and_positive_token_count() -> None:
     """MTP capability metadata is consumed by both CLI and macOS Settings."""
     from vllm_mlx.model_aliases import _coerce

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1414,6 +1414,18 @@ class TestResolveServingLane:
             False,
         )
 
+    def test_force_mllm_on_text_checkpoint_stays_text_forced(self, monkeypatch):
+        from vllm_mlx.api.utils import (
+            ServingLaneDecision,
+            resolve_serving_lane_decision,
+        )
+
+        self._patch_probes(monkeypatch, is_mllm=False, hybrid=False)
+
+        assert resolve_serving_lane_decision(
+            "local/text-model", force_mllm=True
+        ) == ServingLaneDecision(True, "vision_lane_forced")
+
 
 class TestServingLaneDecisionValidation:
     """The SSOT membership checks on ``ServingLaneDecision`` fail fast."""

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1249,16 +1249,50 @@ class TestResolveServingLane:
             "local/qwen35", vision_min_memory_gb=32.0
         ) == utils_mod.ServingLaneDecision(True, "vision_hybrid_runtime_supported")
 
-    def test_explicit_vision_overrides_measured_memory_floor(self, monkeypatch):
+    def test_explicit_vision_honors_measured_memory_floor(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
         monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
 
         assert utils_mod.resolve_serving_lane_decision(
             "local/qwen35",
             force_mllm=True,
             vision_min_memory_gb=32.0,
-        ) == utils_mod.ServingLaneDecision(True, "vision_lane_forced")
+        ) == utils_mod.ServingLaneDecision(
+            False, "vision_memory_insufficient", auto_text_fallback=True
+        )
+
+    def test_forced_and_auto_vision_share_the_memory_gate(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
+
+        forced = utils_mod.resolve_serving_lane_decision(
+            "qwen3.5-4b-4bit",
+            force_mllm=True,
+            vision_min_memory_gb=32.0,
+        )
+        auto = utils_mod.resolve_serving_lane_decision(
+            "qwen3.5-4b-4bit",
+            vision_min_memory_gb=32.0,
+        )
+
+        assert forced == auto
+        assert forced == utils_mod.ServingLaneDecision(
+            False, "vision_memory_insufficient", auto_text_fallback=True
+        )
 
     def test_unknown_physical_memory_does_not_invent_a_fallback(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
@@ -1365,7 +1399,16 @@ class TestResolveServingLane:
 
         # Explicit --mllm on a hybrid VLM keeps the MLLM lane (the engine will
         # raise its own #352 error naming --mllm — the flag the user set).
-        self._patch_probes(monkeypatch, is_mllm=True, hybrid=True)
+        self._patch_probes(
+            monkeypatch,
+            is_mllm=True,
+            hybrid=True,
+            hybrid_runtime_supported=True,
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.api.utils.physical_ram_gb",
+            lambda: 64.0,
+        )
         assert resolve_serving_lane("any/qwen36-27b", force_mllm=True) == (
             True,
             False,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -28,6 +28,7 @@
   },
   "qwen3.5-4b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-4B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -41,6 +42,7 @@
   },
   "qwen3.5-4b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-4B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -67,6 +69,7 @@
   },
   "qwen3.5-9b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -86,6 +89,7 @@
   },
   "qwen3.5-9b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -98,6 +102,7 @@
   },
   "qwen3.5-27b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -109,6 +114,7 @@
   },
   "qwen3.5-35b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -118,6 +124,7 @@
   },
   "qwen3.5-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -127,6 +134,7 @@
   },
   "qwen3.5-35b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -136,6 +144,7 @@
   },
   "qwen3.5-122b-mxfp4": {
     "hf_path": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -145,6 +154,7 @@
   },
   "qwen3.5-122b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-122B-A10B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -154,6 +164,7 @@
   },
   "qwen3.5-122b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-122B-A10B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -225,6 +236,7 @@
   },
   "qwen3.5-27b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -238,6 +250,7 @@
   },
   "qwen3.5-27b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -247,6 +260,9 @@
   },
   "qwen3.6-27b-4bit": {
     "hf_path": "mlx-community/Qwen3.6-27B-4bit",
+    "vision_min_memory_gb": 32,
+    "vision_min_memory_gb": 32,
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -258,6 +274,7 @@
   },
   "qwen3.6-27b-8bit": {
     "hf_path": "unsloth/Qwen3.6-27B-MLX-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -270,6 +287,7 @@
   },
   "qwen3.6-27b-6bit": {
     "hf_path": "lmstudio-community/Qwen3.6-27B-MLX-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -281,6 +299,7 @@
   },
   "qwen3.6-27b-ud": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -292,6 +311,9 @@
   },
   "qwen3.6-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit",
+    "vision_min_memory_gb": 32,
+    "vision_min_memory_gb": 32,
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -304,6 +326,7 @@
   },
   "qwen3.6-35b-6bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -316,6 +339,7 @@
   },
   "qwen3.6-35b-8bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-8bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -328,6 +352,7 @@
   },
   "qwen3.6-35b-ud": {
     "hf_path": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -339,6 +364,7 @@
   },
   "qwen3.6-35b-dwq": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -349,6 +375,7 @@
   },
   "qwen3.6-35b-mxfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-mxfp4",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -387,6 +414,7 @@
   },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -395,6 +423,7 @@
   },
   "qwen3.6-27b": {
     "hf_path": "mlx-community/Qwen3.6-27B-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -406,6 +435,7 @@
   },
   "qwen3.6-35b": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -418,6 +448,7 @@
   },
   "qwen3.6-27b-mtp-4bit": {
     "hf_path": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -427,6 +458,7 @@
   },
   "qwen3.6-35b-mtp-4bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -436,6 +468,7 @@
   },
   "qwen3.6-27b-optiq-4bit": {
     "hf_path": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -445,6 +478,7 @@
   },
   "qwen3.6-35b-optiq-4bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
@@ -454,6 +488,7 @@
   },
   "qwen3.6-27b-ud-3bit": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-3bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
@@ -463,6 +498,7 @@
   },
   "qwen3.6-27b-ud-6bit": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-6bit",
+    "vision_min_memory_gb": 32,
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1520,23 +1520,23 @@ def resolve_serving_lane_decision(
             False, "vision_hybrid_cache_unsupported", auto_text_fallback=True
         )
     if cache_mode == "arrays":
+        if vision_min_memory_gb is None:
+            profile = resolve_profile(model_name)
+            vision_min_memory_gb = (
+                profile.vision_min_memory_gb if profile is not None else None
+            )
+        available_gb = physical_ram_gb()
+        if (
+            vision_min_memory_gb is not None
+            and available_gb > 0
+            and available_gb < vision_min_memory_gb
+        ):
+            return ServingLaneDecision(
+                False, "vision_memory_insufficient", auto_text_fallback=True
+            )
+        if force_mllm:
+            return ServingLaneDecision(True, "vision_lane_forced")
         if mllm_hybrid_runtime_supported():
-            if vision_min_memory_gb is None:
-                profile = resolve_profile(model_name)
-                vision_min_memory_gb = (
-                    profile.vision_min_memory_gb if profile is not None else None
-                )
-            available_gb = physical_ram_gb()
-            if (
-                vision_min_memory_gb is not None
-                and available_gb > 0
-                and available_gb < vision_min_memory_gb
-            ):
-                return ServingLaneDecision(
-                    False, "vision_memory_insufficient", auto_text_fallback=True
-                )
-            if force_mllm:
-                return ServingLaneDecision(True, "vision_lane_forced")
             return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
         return ServingLaneDecision(
             False, "vision_hybrid_runtime_unsupported", auto_text_fallback=True

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1505,9 +1505,9 @@ def resolve_serving_lane_decision(
         return ServingLaneDecision(
             False, "text_lane_speculative_decode", auto_text_fallback=True
         )
-    if force_mllm:
-        return ServingLaneDecision(True, "vision_lane_forced")
     if not is_mllm_model(model_name):
+        if force_mllm:
+            return ServingLaneDecision(True, "vision_lane_forced")
         return ServingLaneDecision(False, "text_checkpoint")
     if mllm_arch_unsupported_but_text_vendored(model_name):
         return ServingLaneDecision(
@@ -1535,10 +1535,14 @@ def resolve_serving_lane_decision(
                 return ServingLaneDecision(
                     False, "vision_memory_insufficient", auto_text_fallback=True
                 )
+            if force_mllm:
+                return ServingLaneDecision(True, "vision_lane_forced")
             return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
         return ServingLaneDecision(
             False, "vision_hybrid_runtime_unsupported", auto_text_fallback=True
         )
+    if force_mllm:
+        return ServingLaneDecision(True, "vision_lane_forced")
     return ServingLaneDecision(True, "vision_supported")
 
 


### PR DESCRIPTION
Closes #2520

## User-visible goal

Make the same multimodal model use the same serving lane on cold start and residency replacement. An explicit `--mllm` request now respects the vision memory floor instead of bypassing it.

## Approach

- Move the vision memory gate ahead of `force_mllm` in the shared lane contract.
- Keep explicit-vision reasons for supported loads and fail closed to the existing auto-text fallback when the floor does not fit.
- Extend the Qwen3.5/3.6 alias family to one consistent vision memory floor.
- Add lane-parity and alias-family contract tests.

## Testing

- Focused lane/server/alias/engine regression: 3200 passed; one clean-main environment failure was deselected.
- Full adjacent server/alias/routing suite: 2968 passed.
- Ruff check/format and `git diff --check`: passed.
- Pinned mypy error budget: no growth.
