### PR TITLE
fix(cache): restore Flash-Next prefix hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,8 @@ jobs:
             tests/test_deepseek_v4_vendored.py \
             tests/test_dspark_scheduler.py \
             tests/test_prefix_cache_persistence.py \
+            tests/test_prefix_boundary_path_parity.py \
+            tests/test_prompt_cache_snapshot.py \
             tests/test_suffix_decoding.py \
             tests/test_qwen4_exp_artifact_parity.py \
             tests/test_qwen4_exp_reference_parity.py \

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -100,7 +100,7 @@ vllm_mlx/runtime/disk_kv_checkpoint.py 1
 vllm_mlx/runtime/radix_index.py 2
 vllm_mlx/runtime/ubc_evict.py 1
 vllm_mlx/runtime/video_lane.py 4
-vllm_mlx/scheduler.py 37
+vllm_mlx/scheduler.py 35
 vllm_mlx/server.py 21
 vllm_mlx/service/helpers.py 4
 vllm_mlx/service/postprocessor.py 6

--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -94,7 +94,7 @@ def _build_engine(
     monkeypatch.setattr(
         engine,
         "_compute_prefix_boundary",
-        lambda messages, tools=None: _SENTINEL_BOUNDARY,
+        lambda messages, tools=None, **kwargs: _SENTINEL_BOUNDARY,
     )
     monkeypatch.setattr(engine, "_is_hybrid_model", lambda: is_hybrid)
     return engine, stub
@@ -146,6 +146,45 @@ def test_stream_chat_forwards_prefix_boundary(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("streaming", [False, True])
+def test_chat_boundary_receives_submitted_prompt_options(monkeypatch, streaming):
+    """Both chat paths calculate against the exact prompt sent downstream."""
+    engine, _ = _build_engine(monkeypatch)
+    captured = {}
+
+    def compute(messages, tools=None, **kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(engine, "_compute_prefix_boundary", compute)
+    messages = [{"role": "user", "content": "hello"}]
+    options = {"request_scope": "kept"}
+
+    if streaming:
+
+        async def _drain():
+            async for _ in engine.stream_chat(
+                messages=messages,
+                enable_thinking=True,
+                chat_template_kwargs=options,
+            ):
+                break
+
+        asyncio.run(_drain())
+    else:
+        asyncio.run(
+            engine.chat(
+                messages=messages,
+                enable_thinking=True,
+                chat_template_kwargs=options,
+            )
+        )
+
+    assert captured["generation_prompt"] == "prompt-stub"
+    assert captured["enable_thinking"] is True
+    assert captured["chat_template_kwargs"] is options
+
+
 def test_single_message_zero_boundary_both_paths(monkeypatch):
     """When ``_compute_prefix_boundary`` returns 0 (single-turn request),
     BOTH paths must end up at the downstream layer with the same value
@@ -160,7 +199,7 @@ def test_single_message_zero_boundary_both_paths(monkeypatch):
     engine._engine = stub
     monkeypatch.setattr(engine, "_apply_chat_template", lambda *a, **k: "prompt-stub")
     monkeypatch.setattr(
-        engine, "_compute_prefix_boundary", lambda messages, tools=None: 0
+        engine, "_compute_prefix_boundary", lambda messages, tools=None, **kwargs: 0
     )
     monkeypatch.setattr(engine, "_is_hybrid_model", lambda: True)
     messages = [{"role": "user", "content": "single"}]
@@ -296,6 +335,52 @@ def test_first_turn_saves_stable_boundary_before_generation_suffix(monkeypatch):
 
     assert boundary == len(stable) - 8
     assert 0 < boundary < len(render(messages, add_generation_prompt=True)) - 1
+
+
+def test_prefix_boundary_uses_exact_submitted_prompt_options(monkeypatch):
+    """Request-scoped template options must not produce an impossible boundary.
+
+    The Qwen4 no-thinking path exposed this with a boundary 23 tokens beyond
+    the actual scheduler prompt: the helper re-rendered with the tokenizer's
+    thinking default instead of using the prompt already submitted by chat().
+    """
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(
+        messages,
+        tools=None,
+        *,
+        add_generation_prompt=True,
+        enable_thinking=None,
+        chat_template_kwargs=None,
+        **kwargs,
+    ):
+        body = "|".join(str(message.get("content", "")) for message in messages)
+        option = "|THINKING-DEFAULT-LONG-SUFFIX" if enable_thinking is not False else ""
+        return option + body + ("|GEN" if add_generation_prompt else "")
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    messages = [{"role": "user", "content": "first turn"}]
+    submitted = render(messages, enable_thinking=False)
+
+    # Pin the repro shape: a default re-render would yield a boundary beyond
+    # the shorter no-thinking prompt actually sent to the scheduler.
+    assert engine._compute_prefix_boundary(messages) > len(submitted)
+
+    boundary = engine._compute_prefix_boundary(
+        messages,
+        generation_prompt=submitted,
+        enable_thinking=False,
+        chat_template_kwargs={"request_scope": "preserved"},
+    )
+
+    stable = render(messages, add_generation_prompt=False, enable_thinking=False)
+    assert boundary == len(stable) - 8
+    assert 0 < boundary < len(submitted)
 
 
 def test_prefix_boundary_stops_before_transient_server_priming(monkeypatch):

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -681,6 +681,35 @@ class TestScheduleWaitingInsertDispatch:
     invoking the same boundary-split branch.
     """
 
+    def test_real_schedule_uses_n_minus_one_for_impossible_boundary(self):
+        """An impossible semantic boundary must not suppress safe exact reuse."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = Request(
+            request_id="req-real-dispatch",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [101]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        scheduled = scheduler._schedule_waiting()
+
+        assert scheduled == [request]
+        assert request._cache_snapshot_boundary == 3
+        segments = batch_generator.insert_segments.call_args.args[0]
+        assert segments == [[[10, 20, 30], [40]]]
+        batch_generator.insert.assert_not_called()
+
     def _build_dispatch_args(
         self,
         prefix_boundary: int,

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -62,6 +62,40 @@ class TestPromptCacheSnapshot:
         )
         assert scheduler._prompt_cache_save_cb is None
 
+    @pytest.mark.parametrize("invalid_boundary", [4, 9])
+    def test_out_of_range_boundary_arms_internal_n_minus_one(self, invalid_boundary):
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = Request(
+            request_id="req-invalid-boundary",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.prefix_boundary = invalid_boundary
+
+        boundary = scheduler._resolve_snapshot_boundary(request)
+
+        assert boundary == 3
+        assert request._cache_snapshot_boundary == 3
+        assert request._cache_snapshot_is_internal is True
+
+    def test_valid_semantic_boundary_is_preserved(self):
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = Request(
+            request_id="req-valid-boundary",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.prefix_boundary = 2
+
+        assert scheduler._resolve_snapshot_boundary(request) == 2
+        assert not hasattr(request, "_cache_snapshot_is_internal")
+
     def test_snapshot_stores_promoted_prompt_only(self):
         scheduler = _make_scheduler_with_cache()
         prompt_tokens = [10, 20, 30, 40]

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2781,12 +2781,21 @@ class BatchedEngine(BaseEngine):
         # active where it's needed and inert where it broke things.
         if self._needs_prefix_boundary_snapshot():
             if transient_message_start is None:
-                prefix_boundary = self._compute_prefix_boundary(messages, tools)
+                prefix_boundary = self._compute_prefix_boundary(
+                    messages,
+                    tools,
+                    generation_prompt=prompt,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
+                )
             else:
                 prefix_boundary = self._compute_prefix_boundary(
                     messages,
                     tools,
                     transient_message_start=transient_message_start,
+                    generation_prompt=prompt,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
                 )
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary
@@ -2860,6 +2869,9 @@ class BatchedEngine(BaseEngine):
         tools: list[dict] | None = None,
         *,
         transient_message_start: int | None = None,
+        generation_prompt: str | list[int] | None = None,
+        enable_thinking: bool | None = None,
+        chat_template_kwargs: dict | None = None,
     ) -> int:
         """Compute the latest prefix that is stable across the next turn.
 
@@ -2884,16 +2896,28 @@ class BatchedEngine(BaseEngine):
         try:
             template_tools = convert_tools_for_template(tools) if tools else None
 
-            # Tokenize the real generation prompt and the same conversation
-            # before its transient assistant-generation marker is appended.
-            real_prompt = self._apply_chat_template(
-                messages, template_tools, add_generation_prompt=True
-            )
+            # The submitted generation prompt is the source of truth. Re-
+            # rendering it here can change tokenization when request-scoped
+            # template options (for example ``enable_thinking=False``) are in
+            # effect, producing a boundary beyond the actual scheduler prompt.
+            real_prompt = generation_prompt
+            if real_prompt is None:
+                real_prompt = self._apply_chat_template(
+                    messages,
+                    template_tools,
+                    add_generation_prompt=True,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
+                )
             tokenizer = self.tokenizer
             if hasattr(tokenizer, "tokenizer"):
                 tokenizer = tokenizer.tokenizer
 
-            real_tokens = tokenizer.encode(real_prompt)
+            real_tokens = (
+                list(real_prompt)
+                if isinstance(real_prompt, list)
+                else tokenizer.encode(real_prompt)
+            )
 
             if transient_message_start is not None:
                 future_prompt = self._apply_chat_template(
@@ -2906,6 +2930,8 @@ class BatchedEngine(BaseEngine):
                     ],
                     template_tools,
                     add_generation_prompt=False,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
                 )
                 future_tokens = tokenizer.encode(future_prompt)
                 transient_lcp = 0
@@ -2916,7 +2942,11 @@ class BatchedEngine(BaseEngine):
                 return max(0, transient_lcp - _PREFIX_BOUNDARY_REPLAY_TOKENS)
 
             stable_prompt = self._apply_chat_template(
-                messages, template_tools, add_generation_prompt=False
+                messages,
+                template_tools,
+                add_generation_prompt=False,
+                enable_thinking=enable_thinking,
+                chat_template_kwargs=chat_template_kwargs,
             )
             next_turn_prompt = self._apply_chat_template(
                 [
@@ -2928,6 +2958,8 @@ class BatchedEngine(BaseEngine):
                 ],
                 template_tools,
                 add_generation_prompt=False,
+                enable_thinking=enable_thinking,
+                chat_template_kwargs=chat_template_kwargs,
             )
 
             stable_tokens = tokenizer.encode(stable_prompt)
@@ -2959,7 +2991,12 @@ class BatchedEngine(BaseEngine):
                 **messages[last_user_idx],
                 "content": "XXXXXXXXXX",
             }
-            dummy_prompt = self._apply_chat_template(dummy_messages, template_tools)
+            dummy_prompt = self._apply_chat_template(
+                dummy_messages,
+                template_tools,
+                enable_thinking=enable_thinking,
+                chat_template_kwargs=chat_template_kwargs,
+            )
 
             dummy_tokens = tokenizer.encode(dummy_prompt)
 
@@ -3498,12 +3535,21 @@ class BatchedEngine(BaseEngine):
         # silently regress one path while keeping the other green.
         if self._needs_prefix_boundary_snapshot():
             if transient_message_start is None:
-                prefix_boundary = self._compute_prefix_boundary(messages, tools)
+                prefix_boundary = self._compute_prefix_boundary(
+                    messages,
+                    tools,
+                    generation_prompt=prompt,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
+                )
             else:
                 prefix_boundary = self._compute_prefix_boundary(
                     messages,
                     tools,
                     transient_message_start=transient_message_start,
+                    generation_prompt=prompt,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
                 )
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4077,9 +4077,21 @@ class Scheduler:
 
             states = self._extract_cache_states(cache)
             if not states:
+                logger.debug(
+                    "[boundary_snapshot] state extraction returned no complete "
+                    "cache for uid=%s layers=%d",
+                    uid,
+                    len(cache) if isinstance(cache, list) else -1,
+                )
                 continue
             reconstructed = self._reconstruct_cache_from_states(states)
             if not reconstructed:
+                logger.debug(
+                    "[boundary_snapshot] cache reconstruction returned empty "
+                    "for uid=%s states=%d",
+                    uid,
+                    len(states),
+                )
                 continue
 
             prefix_tokens = list(request.prompt_token_ids[:prefix_boundary])
@@ -6714,6 +6726,45 @@ class Scheduler:
             return request.prompt_token_ids
         return tokens_to_process
 
+    def _resolve_snapshot_boundary(self, request: Request) -> int:
+        """Return a usable prompt boundary, arming N-1 reuse when needed.
+
+        A caller-provided boundary must lie strictly inside the scheduler's
+        actual tokenized prompt.  Treat an out-of-range value as absent so it
+        cannot suppress the bounded N-1 fallback for non-trimmable caches.
+        """
+        prompt_tokens = request.prompt_token_ids or []
+        snapshot_boundary = int(getattr(request, "prefix_boundary", 0) or 0)
+        if snapshot_boundary >= len(prompt_tokens):
+            logger.debug(
+                "[boundary_snapshot] ignoring out-of-range boundary "
+                "request=%s boundary=%d prompt_tokens=%d",
+                request.request_id[:12],
+                snapshot_boundary,
+                len(prompt_tokens),
+            )
+            snapshot_boundary = 0
+
+        if (
+            snapshot_boundary <= 0
+            and self.memory_aware_cache is not None
+            and getattr(self.config, "hybrid_cache_entries", 0) > 0
+            and getattr(self.config, "non_trimmable_exact_prefix_reuse", False)
+            and not request.prompt_cache
+            and len(prompt_tokens) > 1
+        ):
+            snapshot_boundary = len(prompt_tokens) - 1
+            request._cache_snapshot_boundary = snapshot_boundary
+            request._cache_snapshot_is_internal = True
+            logger.debug(
+                "[boundary_snapshot] armed internal N-1 boundary request=%s "
+                "boundary=%d prompt_tokens=%d",
+                request.request_id[:12],
+                snapshot_boundary,
+                len(prompt_tokens),
+            )
+        return snapshot_boundary
+
     def _schedule_waiting(self) -> list[Request]:
         """
         Move requests from waiting queue to running.
@@ -6910,21 +6961,10 @@ class Scheduler:
             # lies strictly inside the tokens we're about to process —
             # otherwise there's nothing new to capture at the boundary.
             boundary_local_split: int | None = None
-            snapshot_boundary = getattr(request, "prefix_boundary", 0)
             # A non-trimmable exact hit cannot use the usual trim-one then
             # re-forward-last-token kickoff. Capture the cold prompt at N-1;
             # an identical repeat becomes a safe one-token prefix extension.
-            if (
-                snapshot_boundary <= 0
-                and self.memory_aware_cache is not None
-                and getattr(self.config, "hybrid_cache_entries", 0) > 0
-                and getattr(self.config, "non_trimmable_exact_prefix_reuse", False)
-                and not request.prompt_cache
-                and len(request.prompt_token_ids) > 1
-            ):
-                snapshot_boundary = len(request.prompt_token_ids) - 1
-                request._cache_snapshot_boundary = snapshot_boundary
-                request._cache_snapshot_is_internal = True
+            snapshot_boundary = self._resolve_snapshot_boundary(request)
             if (
                 self.memory_aware_cache is not None
                 and snapshot_boundary > 0

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4077,21 +4077,9 @@ class Scheduler:
 
             states = self._extract_cache_states(cache)
             if not states:
-                logger.debug(
-                    "[boundary_snapshot] state extraction returned no complete "
-                    "cache for uid=%s layers=%d",
-                    uid,
-                    len(cache) if isinstance(cache, list) else -1,
-                )
                 continue
             reconstructed = self._reconstruct_cache_from_states(states)
             if not reconstructed:
-                logger.debug(
-                    "[boundary_snapshot] cache reconstruction returned empty "
-                    "for uid=%s states=%d",
-                    uid,
-                    len(states),
-                )
                 continue
 
             prefix_tokens = list(request.prompt_token_ids[:prefix_boundary])


### PR DESCRIPTION
## User-visible goal

Restore reusable prefix-cache hits for Flash-Next so repeated and growing agent context does not pay full prefill TTFT on every request.

## Scope

- calculate semantic snapshot boundaries against the exact prompt and request-scoped template options submitted to the scheduler
- reject impossible/out-of-range boundaries at the scheduler boundary and retain the bounded N-1 fallback
- preserve the coupled non-trimmable cache snapshot lifecycle
- add engine/scheduler regression coverage and enroll those two MLX-native test files in the existing Apple coverage roster
- tighten the scheduler mypy baseline to the lower error count produced by this refactor

## Non-goals

- no cache eviction-policy or memory-budget changes
- no KV-cache quantization changes
- no model architecture, sampler, MTP-depth, or performance-default changes
- no broad CI routing or Apple-roster policy change

## Design precedent

The implementation follows the established serving-engine rule that reusable state is keyed only at a validated token boundary from the exact scheduled sequence. Request rendering remains an engine concern; the scheduler independently validates the boundary and fails closed to a safe semantic checkpoint instead of trusting caller metadata.

## Verification

- 49 focused engine/scheduler tests pass; focused changed-lines coverage is 20/20 (100%)
- 85 focused engine/scheduler, CI-roster, and mypy-budget contract tests pass
- Python 3.11 pinned mypy gate passes with the baseline tightened from 709 to 707 total errors (`scheduler.py` 37 to 35)
- ruff check, ruff format, actionlint, and diff-check pass
- independent Codex review round 1 found no blocking issues on the prior production head; final exact-head round remains before queueing
- real `rapid-mlx/Qwen3.8-Flash-Next-4bit` revision `dcf657e4...`, fresh editable venv, offline cache, PFlash/thinking disabled:
  - ordinary decode: cold 5,288-token prompt 6.497 s; warm cache HIT with 5,273 cached tokens in 0.539 s
  - native MTP fixed K=1: cold 7.096 s; warm cache HIT with 5,273 cached tokens in 0.531 s
  - ordinary and MTP cold/warm responses are byte-identical (`sha256 6d09de33...`)
  - MTP continued proposing/accepting on the hit (6 proposals, 4 accepts across the pair)
  - MLX active memory 103.54 GB ordinary / 105.39 GB MTP; each server stopped after proof

The first full local train-gates run is documented on the PR: the product diff passed its focused coverage and mypy checks, while the current-base no-MLX roster and a stale local Apple venv blocked a clean five-gate receipt. Exact-head hosted Linux and Apple checks are authoritative for those environments.

Fixes #2618
