### PR TITLE
fix(mac): pin browse sockets to validated IPs

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
@@ -13,21 +13,17 @@ import Foundation
 ///
 /// Scope of the guarantee. This layer resolves the host and rejects the request
 /// before it runs if ANY resolved address is private — for the initial URL and
-/// for every redirect hop. That confines the *hostnames the model can name* to
-/// ones whose DNS currently points at public space. It is deliberately NOT a
-/// closed IP-confinement proof, because these residuals cannot be closed at
+/// for every redirect hop. ``IPPinnedHTTPTransport`` then opens the socket to
+/// the validated address, preserving the original hostname for HTTP ``Host``
+/// and TLS name/certificate validation. Together they close the DNS-rebind
+/// time-of-check/time-of-use gap. The remaining residuals cannot be closed at
 /// this layer:
 ///
-///  1. DNS-rebind TOCTOU. We resolve and validate, then `URLSession` re-resolves
-///     when it connects; a hostile resolver can hand us a public address and the
-///     socket a private one. `URLSession` exposes no hook to pin the validated
-///     address while preserving TLS SNI / certificate validation, so the pinned
-///     connection can't be expressed here.
-///  2. System / PAC HTTP proxies. If the OS is configured with a proxy, the
+///  1. System / PAC HTTP proxies. If the OS is configured with a proxy, the
 ///     proxy resolves and connects on its own, on a path our local resolution
 ///     never sees — so a locally-public result does not prove the proxy's
 ///     connection is public.
-///  3. Network-specific NAT64 prefixes. We unwrap the well-known (`64:ff9b::/96`)
+///  2. Network-specific NAT64 prefixes. We unwrap the well-known (`64:ff9b::/96`)
 ///     and RFC 8215 local-use (`64:ff9b:1::/48`) prefixes to range-check the
 ///     embedded IPv4, but a site can deploy NAT64 under any prefix we can't know
 ///     without that network's config, so a private IPv4 tunnelled through a
@@ -38,10 +34,7 @@ import Foundation
 /// approve the exact host before the first request (and again on any
 /// cross-origin redirect), so exploitation requires the user to approve browsing
 /// an attacker-controlled domain; and the action is only a read-only GET whose
-/// body returns to the model — no code executes, no request body is sent. A
-/// fully IP-confined fetch would need a custom transport that connects to the
-/// validated address while setting TLS SNI/Host to the original hostname; that
-/// is out of scope for this tool and tracked as future hardening.
+/// body returns to the model — no code executes, no request body is sent.
 enum BrowseSSRFGuard {
     enum Rejection: Error, Equatable {
         case badURL
@@ -72,6 +65,13 @@ enum BrowseSSRFGuard {
     /// concrete addresses (or parsed directly if it is an IP literal) and every
     /// address is range-checked. Throws ``Rejection`` on the first problem.
     static func validate(_ url: URL) async throws {
+        _ = try await validatedAddress(url)
+    }
+
+    /// Validate a URL and return the concrete address used for the pinned
+    /// transport. For DNS names, the first resolver answer is selected only
+    /// after every answer has passed the same public-address checks.
+    static func validatedAddress(_ url: URL) async throws -> ParsedIP {
         guard let scheme = url.scheme?.lowercased() else { throw Rejection.badURL }
         guard allowedSchemes.contains(scheme) else { throw Rejection.blockedScheme(scheme) }
         guard let host = url.host, !host.isEmpty else { throw Rejection.noHost }
@@ -88,7 +88,7 @@ enum BrowseSSRFGuard {
             if literal.isBlocked {
                 throw Rejection.blockedAddress(host: host, address: literal.canonical)
             }
-            return
+            return literal
         }
 
         let addresses = try await resolve(bareHost)
@@ -96,6 +96,7 @@ enum BrowseSSRFGuard {
         for ip in addresses where ip.isBlocked {
             throw Rejection.blockedAddress(host: host, address: ip.canonical)
         }
+        return addresses[0]
     }
 
     /// Resolve a hostname to every A / AAAA address. Runs `getaddrinfo` off the

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -14,16 +14,10 @@ enum BrowseTool {
     static let charBudget = 15_000
     /// Max response bytes we will download for one page.
     static let maxResponseBytes = 2 * 1024 * 1024
-    /// Hard wall-clock ceiling for a single hop's fetch (seconds). Unlike
-    /// URLSession's idle timeout — which resets on every byte and lets a server
-    /// dribble one byte per interval to hold a hop open forever — this bounds the
+    /// Hard wall-clock ceiling for a single hop's fetch (seconds). It bounds the
     /// TOTAL time one hop may take and cancels it when it expires. Applied per
     /// hop (see ``fetchFollowingRedirects``).
     static let requestTimeout: TimeInterval = 12
-    /// URLSession's own per-task resource backstop (seconds), a little above the
-    /// wall-clock ceiling so our ``withDeadline`` is the primary control and this
-    /// is defence-in-depth.
-    static let resourceTimeout: TimeInterval = 20
     /// Max redirect hops we follow (each is SSRF-validated before we connect).
     static let maxRedirects = 5
 
@@ -236,22 +230,20 @@ enum BrowseTool {
         var approvedOrigins: Set<String> = [origin(of: startURL)]
         var hop = 0
         while true {
-            // Validate (incl. DNS) BEFORE connecting to this hop's host.
-            try await BrowseSSRFGuard.validate(current)
+            // Validate (incl. DNS) BEFORE connecting to this hop's host, then
+            // pin the socket to the exact validated address.
+            let validatedAddress = try await BrowseSSRFGuard.validatedAddress(current)
+            let hopURL = current
 
-            var req = URLRequest(url: current)
-            req.timeoutInterval = requestTimeout
-            req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            req.setValue("text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8",
-                         forHTTPHeaderField: "Accept")
-            // Bind to a `let` so the @Sendable deadline closure captures an
-            // immutable value (URLRequest is a Sendable value type).
-            let request = req
             // Hard wall-clock ceiling per hop — see ``requestTimeout``.
-            let raw = try await withDeadline(requestTimeout) { try await cappedBytes(request) }
-            guard let http = raw.response as? HTTPURLResponse else {
-                throw simpleError("no HTTP response from \(current.host ?? "host")")
+            let raw = try await withDeadline(requestTimeout) {
+                try await IPPinnedHTTPTransport.fetch(
+                    url: hopURL,
+                    address: validatedAddress,
+                    byteLimit: maxResponseBytes
+                )
             }
+            let http = raw.response
             if (300..<400).contains(http.statusCode), let loc = http.value(forHTTPHeaderField: "Location") {
                 hop += 1
                 guard hop <= maxRedirects else { throw simpleError("too many redirects (> \(maxRedirects))") }
@@ -290,8 +282,7 @@ enum BrowseTool {
     }
 
     /// Run `op` with a hard wall-clock ceiling: if it hasn't finished within
-    /// `seconds`, the timer wins, `op`'s task is cancelled, and we throw. Used to
-    /// turn URLSession's resettable idle timeout into a real per-hop deadline.
+    /// `seconds`, the timer wins, `op`'s task is cancelled, and we throw.
     static func withDeadline<T: Sendable>(
         _ seconds: TimeInterval,
         _ op: @escaping @Sendable () async throws -> T
@@ -308,46 +299,6 @@ enum BrowseTool {
             }
             return result
         }
-    }
-
-    /// Dedicated, isolated session for browsing. Ephemeral + cookies and cache
-    /// fully OFF: a public-content fetch must NOT accumulate or replay cookies
-    /// (which could send one site's session token to another, or hand
-    /// authenticated content to the model) and must not persist fetched pages to
-    /// disk. The session delegate blocks automatic redirects so ``BrowseTool``
-    /// follows them itself, SSRF-checking every hop before a socket opens.
-    static let session: URLSession = {
-        let config = URLSessionConfiguration.ephemeral
-        config.httpCookieStorage = nil
-        config.httpShouldSetCookies = false
-        config.httpCookieAcceptPolicy = .never
-        config.urlCache = nil
-        config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        config.timeoutIntervalForRequest = requestTimeout
-        config.timeoutIntervalForResource = resourceTimeout
-        return URLSession(configuration: config, delegate: BrowseNoRedirectDelegate.shared, delegateQueue: nil)
-    }()
-
-    /// A fetched response body + its `URLResponse`, boxed as `Sendable` so it can
-    /// cross the ``withDeadline`` task-group boundary. `URLResponse` is safe to
-    /// hand across here: it is fully materialised and we only read it.
-    struct RawResponse: @unchecked Sendable {
-        let data: Data
-        let response: URLResponse
-    }
-
-    /// Stream a request body, aborting once it crosses ``maxResponseBytes``.
-    static func cappedBytes(_ request: URLRequest) async throws -> RawResponse {
-        let (stream, response) = try await session.bytes(for: request)
-        var data = Data()
-        data.reserveCapacity(min(maxResponseBytes, 256 * 1024))
-        for try await byte in stream {
-            if data.count >= maxResponseBytes {
-                throw simpleError("page exceeded \(maxResponseBytes / (1024 * 1024)) MB cap")
-            }
-            data.append(byte)
-        }
-        return RawResponse(data: data, response: response)
     }
 
     // MARK: - Render
@@ -513,20 +464,5 @@ enum BrowseTool {
             return "{\"error\":\"failed to encode browse result\"}"
         }
         return s
-    }
-}
-
-/// Per-task delegate that refuses every automatic redirect so ``BrowseTool``
-/// can follow them by hand, SSRF-validating each target before it connects.
-final class BrowseNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
-    static let shared = BrowseNoRedirectDelegate()
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        willPerformHTTPRedirection response: HTTPURLResponse,
-        newRequest request: URLRequest,
-        completionHandler: @escaping (URLRequest?) -> Void
-    ) {
-        completionHandler(nil)   // never auto-follow
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -1,0 +1,330 @@
+import Foundation
+import Network
+
+/// An HTTP/1.1 transport that opens sockets to an address selected by
+/// ``BrowseSSRFGuard``. A hostile DNS response cannot swap the address after
+/// validation because this transport never resolves the original hostname.
+enum IPPinnedHTTPTransport {
+    static func fetch(
+        url: URL,
+        address: ParsedIP,
+        byteLimit: Int
+    ) async throws -> (data: Data, response: HTTPURLResponse) {
+        guard let scheme = url.scheme?.lowercased() else {
+            throw transportError("URL has no scheme")
+        }
+        guard let host = url.host, !host.isEmpty else {
+            throw transportError("URL has no host")
+        }
+        guard let port = endpointPort(for: url) else {
+            throw transportError("URL has an invalid port")
+        }
+
+        let connection = try makeConnection(
+            address: address,
+            port: port,
+            secure: scheme == "https",
+            serverName: host
+        )
+        let reader = ResponseReader(
+            connection: connection,
+            request: request(for: url, address: address, host: host, port: port),
+            url: url,
+            byteLimit: byteLimit
+        )
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                reader.start { result in
+                    continuation.resume(with: result)
+                }
+            }
+        } onCancel: {
+            reader.cancel()
+        }
+    }
+
+    private static func makeConnection(
+        address: ParsedIP,
+        port: UInt16,
+        secure: Bool,
+        serverName: String
+    ) throws -> NWConnection {
+        let endpointHost: NWEndpoint.Host
+        switch address.family {
+        case .v4:
+            guard let ipv4 = IPv4Address(address.canonical) else {
+                throw transportError("invalid resolved IPv4 address")
+            }
+            endpointHost = .ipv4(ipv4)
+        case .v6:
+            guard let ipv6 = IPv6Address(address.canonical) else {
+                throw transportError("invalid resolved IPv6 address")
+            }
+            endpointHost = .ipv6(ipv6)
+        }
+        guard let endpointPort = NWEndpoint.Port(rawValue: port) else {
+            throw transportError("invalid endpoint port")
+        }
+
+        let tcpOptions = NWProtocolTCP.Options()
+        tcpOptions.connectionTimeout = 10
+        let parameters: NWParameters
+        if secure {
+            let tlsOptions = NWProtocolTLS.Options()
+            sec_protocol_options_set_tls_server_name(
+                tlsOptions.securityProtocolOptions,
+                serverName
+            )
+            parameters = NWParameters(tls: tlsOptions, tcp: tcpOptions)
+        } else {
+            parameters = NWParameters(tls: nil, tcp: tcpOptions)
+        }
+        parameters.allowLocalEndpointReuse = false
+
+        return NWConnection(
+            host: endpointHost,
+            port: endpointPort,
+            using: parameters
+        )
+    }
+
+    private static func endpointPort(for url: URL) -> UInt16? {
+        if let port = url.port {
+            return UInt16(exactly: port)
+        }
+        return url.scheme?.lowercased() == "https" ? 443 : 80
+    }
+
+    private static func request(
+        for url: URL,
+        address: ParsedIP,
+        host: String,
+        port: UInt16
+    ) -> Data {
+        let path = url.path.isEmpty ? "/" : url.path
+        let target = url.query.map { "\(path)?\($0)" } ?? path
+        let headers = [
+            "GET \(target) HTTP/1.1",
+            "Host: \(hostHeader(host: host, address: address, port: port))",
+            "User-Agent: \(BrowseTool.userAgent)",
+            "Accept: text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8",
+            "Accept-Encoding: identity",
+            "Connection: close",
+        ].joined(separator: "\r\n") + "\r\n\r\n"
+        return Data(headers.utf8)
+    }
+
+    private static func hostHeader(
+        host: String,
+        address: ParsedIP,
+        port: UInt16
+    ) -> String {
+        let bareHost = host.hasPrefix("[") && host.hasSuffix("]")
+            ? String(host.dropFirst().dropLast())
+            : host
+        let hostText = address.family == .v6 ? "[\(bareHost)]" : bareHost
+        return (port == 80 || port == 443) ? hostText : "\(hostText):\(port)"
+    }
+
+    fileprivate static func transportError(_ message: String) -> NSError {
+        NSError(
+            domain: "RapidBrowseTransport",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}
+
+/// Parses the complete HTTP/1.1 bytes collected by ``ResponseReader``.
+enum IPHTTPResponseParser {
+    static func parse(data: Data, url: URL) throws -> (Data, HTTPURLResponse) {
+        let headerSeparator = Data("\r\n\r\n".utf8)
+        guard let headerEnd = data.range(of: headerSeparator) else {
+            throw IPPinnedHTTPTransport.transportError("response ended before HTTP headers completed")
+        }
+        guard headerEnd.lowerBound <= 128 * 1024 else {
+            throw IPPinnedHTTPTransport.transportError("HTTP response headers exceeded 128 KB")
+        }
+
+        let rawHeaders = String(decoding: data[..<headerEnd.lowerBound], as: UTF8.self)
+        let lines = rawHeaders.split(separator: "\r\n", omittingEmptySubsequences: false)
+        guard let statusLine = lines.first else {
+            throw IPPinnedHTTPTransport.transportError("missing HTTP status line")
+        }
+        let statusParts = statusLine.split(separator: " ", maxSplits: 2)
+        guard statusParts.count >= 2, let statusCode = Int(statusParts[1]) else {
+            throw IPPinnedHTTPTransport.transportError("invalid HTTP status line")
+        }
+
+        var headerFields: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = String(line[..<colon]).trimmingCharacters(in: .whitespaces).lowercased()
+            let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            headerFields[name] = headerFields[name].map { "\($0), \(value)" } ?? value
+        }
+
+        let bodyData = Data(data[headerEnd.upperBound...])
+        let responseBody = if headerFields["transfer-encoding"]?
+            .lowercased()
+            .contains("chunked") == true {
+            try decodeChunked(bodyData)
+        } else {
+            bodyData
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: headerFields
+        ) else {
+            throw IPPinnedHTTPTransport.transportError("could not construct HTTP response")
+        }
+        return (responseBody, response)
+    }
+
+    private static func decodeChunked(_ input: Data) throws -> Data {
+        var output = Data()
+        var offset = input.startIndex
+
+        while true {
+            guard let lineEnd = input.range(of: Data("\r\n".utf8), in: offset..<input.endIndex) else {
+                throw IPPinnedHTTPTransport.transportError("truncated HTTP chunked response")
+            }
+            let sizeLine = String(decoding: input[offset..<lineEnd.lowerBound], as: UTF8.self)
+            let sizeText = sizeLine.split(separator: ";").first.map(String.init) ?? sizeLine
+            guard let size = Int(sizeText.trimmingCharacters(in: .whitespaces), radix: 16), size >= 0 else {
+                throw IPPinnedHTTPTransport.transportError("invalid HTTP chunk size")
+            }
+            offset = lineEnd.upperBound
+            if size == 0 {
+                return output
+            }
+            let chunkEnd = input.index(offset, offsetBy: size)
+            guard chunkEnd <= input.endIndex else {
+                throw IPPinnedHTTPTransport.transportError("truncated HTTP chunked response")
+            }
+            output.append(contentsOf: input[offset..<chunkEnd])
+            let terminator = input.index(chunkEnd, offsetBy: 2)
+            guard terminator <= input.endIndex,
+                  input[chunkEnd] == 0x0D,
+                  input[input.index(after: chunkEnd)] == 0x0A else {
+                throw IPPinnedHTTPTransport.transportError("invalid HTTP chunk terminator")
+            }
+            offset = terminator
+        }
+    }
+}
+
+private final class ResponseReader: @unchecked Sendable {
+    private let connection: NWConnection
+    private let request: Data
+    private let url: URL
+    private let byteLimit: Int
+    private let queue = DispatchQueue(label: "rapid.mlx.browse.ip-pinned")
+    private let lock = NSLock()
+    private var isFinished = false
+    private var bufferedData = Data()
+
+    init(connection: NWConnection, request: Data, url: URL, byteLimit: Int) {
+        self.connection = connection
+        self.request = request
+        self.url = url
+        self.byteLimit = byteLimit
+    }
+
+    func start(
+        completion: @escaping @Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void
+    ) {
+        lock.lock()
+        let wasCancelledBeforeStart = isFinished
+        lock.unlock()
+        if wasCancelledBeforeStart {
+            completion(.failure(CancellationError()))
+            return
+        }
+
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.connection.send(
+                    content: self.request,
+                    completion: .contentProcessed { error in
+                        if let error {
+                            self.finish(.failure(error), completion: completion)
+                        }
+                    }
+                )
+                self.receive(completion: completion)
+            case .failed(let error):
+                self.finish(.failure(error), completion: completion)
+            case .cancelled:
+                self.finish(.failure(CancellationError()), completion: completion)
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    func cancel() {
+        finish(.failure(CancellationError())) { _ in }
+    }
+
+    private func receive(
+        completion: @escaping @Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void
+    ) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let error {
+                self.finish(.failure(error), completion: completion)
+                return
+            }
+            if let data {
+                do {
+                    try self.append(data)
+                } catch {
+                    self.finish(.failure(error), completion: completion)
+                    return
+                }
+            }
+            if isComplete {
+                self.finish(self.parse(), completion: completion)
+                return
+            }
+            self.receive(completion: completion)
+        }
+    }
+
+    private func append(_ data: Data) throws {
+        bufferedData.append(data)
+        guard bufferedData.count <= byteLimit else {
+            throw IPPinnedHTTPTransport.transportError(
+                "page exceeded \(byteLimit / (1024 * 1024)) MB cap"
+            )
+        }
+    }
+
+    private func parse() -> Result<(Data, HTTPURLResponse), Error> {
+        Result {
+            try IPHTTPResponseParser.parse(data: bufferedData, url: url)
+        }
+    }
+
+    private func finish(
+        _ result: Result<(Data, HTTPURLResponse), Error>,
+        completion: @escaping @Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void
+    ) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        lock.unlock()
+        connection.cancel()
+        completion(result)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("IP-pinned browse transport")
+struct IPPinnedHTTPTransportTests {
+    @Test("Chunked HTTP/1.1 bodies are decoded once")
+    func chunkedResponseBodiesAreDecoded() throws {
+        let url = try #require(URL(string: "http://pinned-name.test/page"))
+        let raw = Data("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n4\r\n,123\r\n0\r\n\r\n".utf8)
+
+        let (body, response) = try IPHTTPResponseParser.parse(data: raw, url: url)
+
+        #expect(String(decoding: body, as: UTF8.self) == "abc,123")
+        #expect(response.statusCode == 200)
+        #expect(response.value(forHTTPHeaderField: "Transfer-Encoding") == "chunked")
+    }
+
+    @Test("A response without a complete header block fails closed")
+    func incompleteHeaderResponseFailsClosed() throws {
+        let url = try #require(URL(string: "http://pinned-name.test/page"))
+
+        #expect(throws: Error.self) {
+            _ = try IPHTTPResponseParser.parse(data: Data("HTTP/1.1 200 OK\r\n".utf8), url: url)
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -126,6 +126,15 @@ struct WebToolsHardeningTests {
         #expect(ips.allSatisfy { $0.isBlocked })
     }
 
+    @Test("validatedAddress returns an IP literal after range validation")
+    func validatedAddressReturnsPublicIPLiteral() async throws {
+        let url = try #require(URL(string: "https://93.184.216.34/page"))
+
+        let address = try await BrowseSSRFGuard.validatedAddress(url)
+
+        #expect(address == ParsedIP("93.184.216.34"))
+    }
+
     @Test("resolve yields empty for an NXDOMAIN reserved TLD")
     func resolveEmptyForInvalidTLD() async throws {
         // RFC 6761 guarantees ``.invalid`` never resolves; getaddrinfo returns


### PR DESCRIPTION
## Intention
Close the browse DNS-rebind time-of-check/time-of-use gap.

## Scope
- Validate every DNS answer with the existing SSRF guard and return the selected address.
- Open browse GET sockets directly to that address with `NWConnection`.
- Preserve the original hostname for `Host`, TLS SNI, and certificate validation.
- Keep manual per-hop redirects, the 2 MB body cap, and the 12-second deadline.

## Non-goals
- Changing approval UX or redirect policy.
- Adding proxy support or discovering proxy-resolved destinations.
- Changing non-browse networking clients.

## Acceptance
- A validated public hostname cannot later connect to a different DNS address.
- Blocked literals and ranges continue to fail closed.
- HTTPS certificate validation remains anchored to the requested hostname.
- Focused web-tool tests pass.

## Validation
- `swift build` passed.
- Focused `IPPinnedHTTPTransportTests` and `WebToolsHardeningTests` passed (16 tests).
- Full desktop CI is pending.

Closes #2012.