### PR TITLE
fix(cli): pull audio runtime assets for offline use

### DIFF
--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime-asset contracts for offline-capable audio pulls (#2646)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+
+import pytest
+
+from vllm_mlx import cli
+from vllm_mlx.audio import registry
+
+
+def test_kokoro_alias_and_hf_id_declare_voice_assets() -> None:
+    expected = (
+        registry.AudioRuntimeAsset(
+            repo_id="prince-canuma/Kokoro-82M",
+            allow_patterns=("voices/*.safetensors",),
+        ),
+    )
+
+    assert registry.runtime_assets_for("kokoro") == expected
+    assert registry.runtime_assets_for("mlx-community/Kokoro-82M-bf16") == expected
+    assert registry.runtime_assets_for("whisper-small") == ()
+    assert registry.runtime_assets_for("not-an-audio-model") == ()
+
+
+def test_pull_downloads_primary_then_declared_runtime_assets(monkeypatch) -> None:
+    calls: list[tuple[str, list[str] | None, str | None, str | None]] = []
+    activations = 0
+
+    def fake_pull_repository(args, *, allow_patterns_override=None):
+        calls.append(
+            (
+                args.model,
+                allow_patterns_override,
+                getattr(args, "bits", None),
+                getattr(args, "format", None),
+            )
+        )
+
+    def fake_activation() -> None:
+        nonlocal activations
+        activations += 1
+
+    monkeypatch.setattr(cli, "_pull_repository", fake_pull_repository)
+    monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
+    args = argparse.Namespace(
+        model="mlx-community/Kokoro-82M-bf16",
+        _original_alias="kokoro",
+        bits=None,
+        format=None,
+    )
+
+    cli.pull_command(args)
+
+    assert calls == [
+        ("mlx-community/Kokoro-82M-bf16", None, None, None),
+        (
+            "prince-canuma/Kokoro-82M",
+            ["voices/*.safetensors"],
+            None,
+            None,
+        ),
+    ]
+    assert activations == 1
+    assert args.model == "mlx-community/Kokoro-82M-bf16"
+    assert args._original_alias == "kokoro"
+
+
+def test_pull_without_runtime_assets_keeps_single_repository(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **_kwargs: calls.append(args.model),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+
+    cli.pull_command(argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit"))
+
+    assert calls == ["mlx-community/Qwen3-0.6B-4bit"]
+
+
+def test_runtime_asset_failure_does_not_report_successful_pull(monkeypatch) -> None:
+    activations = 0
+
+    def fake_pull_repository(args, **_kwargs):
+        if args.model == "prince-canuma/Kokoro-82M":
+            raise RuntimeError("asset download failed")
+
+    def fake_activation() -> None:
+        nonlocal activations
+        activations += 1
+
+    monkeypatch.setattr(cli, "_pull_repository", fake_pull_repository)
+    monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
+
+    with pytest.raises(RuntimeError, match="asset download failed"):
+        cli.pull_command(argparse.Namespace(model="mlx-community/Kokoro-82M-bf16"))
+
+    assert activations == 0
+
+
+def test_runtime_asset_uses_normal_filtered_download_pipeline(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_mirror(repo_id, *, allow_patterns=None, out=None):
+        seen["mirror"] = (repo_id, allow_patterns)
+        return False
+
+    def fake_snapshot(repo_id, *, allow_patterns=None):
+        seen["snapshot"] = (repo_id, allow_patterns)
+        return str(tmp_path)
+
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", fake_mirror)
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot)
+    monkeypatch.setattr(cli, "_blob_identifier", lambda _root: ())
+
+    cli._pull_repository(
+        argparse.Namespace(
+            model="prince-canuma/Kokoro-82M",
+            bits=None,
+            format=None,
+            json=True,
+        ),
+        allow_patterns_override=["voices/*.safetensors"],
+    )
+
+    expected = ("prince-canuma/Kokoro-82M", ["voices/*.safetensors"])
+    assert seen["mirror"] == expected
+    assert seen["snapshot"] == expected
+    assert "runtime assets declared by the audio catalog" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "runtime_assets,error",
+    [
+        ([], "_runtime_assets must be an object"),
+        ({"": []}, "family keys must be non-empty strings"),
+        ({"kokoro": {}}, "_runtime_assets.kokoro must be an array"),
+        ({"kokoro": ["bad"]}, "_runtime_assets.kokoro[0] must be an object"),
+        (
+            {"kokoro": [{"repo_id": "bad", "allow_patterns": ["*"]}]},
+            "repo_id must be a HuggingFace namespace/name",
+        ),
+        (
+            {
+                "kokoro": [
+                    {"repo_id": "owner/assets", "allow_patterns": ["*"]},
+                    {"repo_id": "owner/assets", "allow_patterns": ["*"]},
+                ]
+            },
+            "duplicate runtime asset",
+        ),
+        (
+            {"kokoro": [{"repo_id": "owner/assets", "allow_patterns": [""]}]},
+            "allow_patterns must be an array of non-empty strings",
+        ),
+        (
+            {"unknown": [{"repo_id": "owner/assets", "allow_patterns": ["*"]}]},
+            "runtime assets declared for unknown family",
+        ),
+    ],
+)
+def test_runtime_asset_registry_rejects_malformed_metadata(
+    monkeypatch, tmp_path, runtime_assets, error
+) -> None:
+    registry_file = tmp_path / "aliases.json"
+    registry_file.write_text(
+        json.dumps(
+            {
+                "_runtime_assets": runtime_assets,
+                "kokoro": {
+                    "type": "tts",
+                    "hf_id": "owner/kokoro",
+                    "family": "kokoro",
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(registry, "_registry_path", lambda: str(registry_file))
+    monkeypatch.setattr(registry, "_REGISTRY", None)
+    registry._HF_ID_INDEX.clear()
+    registry._RUNTIME_ASSETS.clear()
+
+    with pytest.raises(ValueError, match=re.escape(error)):
+        registry._load_registry()

--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -185,8 +187,73 @@ def test_runtime_asset_registry_rejects_malformed_metadata(
     )
     monkeypatch.setattr(registry, "_registry_path", lambda: str(registry_file))
     monkeypatch.setattr(registry, "_REGISTRY", None)
-    registry._HF_ID_INDEX.clear()
-    registry._RUNTIME_ASSETS.clear()
+    monkeypatch.setattr(registry, "_HF_ID_INDEX", {})
+    monkeypatch.setattr(registry, "_RUNTIME_ASSETS", {})
 
     with pytest.raises(ValueError, match=re.escape(error)):
         registry._load_registry()
+
+
+def test_concurrent_first_lookup_publishes_runtime_assets_atomically(
+    monkeypatch, tmp_path
+) -> None:
+    registry_file = tmp_path / "aliases.json"
+    registry_file.write_text(
+        json.dumps(
+            {
+                "_runtime_assets": {
+                    "kokoro": [
+                        {
+                            "repo_id": "owner/voices",
+                            "allow_patterns": ["voices/*.safetensors"],
+                        }
+                    ]
+                },
+                "kokoro": {
+                    "type": "tts",
+                    "hf_id": "owner/kokoro",
+                    "family": "kokoro",
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(registry, "_registry_path", lambda: str(registry_file))
+    monkeypatch.setattr(registry, "_REGISTRY", None)
+    monkeypatch.setattr(registry, "_HF_ID_INDEX", {})
+    monkeypatch.setattr(registry, "_RUNTIME_ASSETS", {})
+
+    first_is_parsing = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    real_json_load = json.load
+    load_calls = 0
+
+    def blocking_json_load(stream):
+        nonlocal load_calls
+        load_calls += 1
+        first_is_parsing.set()
+        assert release_first.wait(timeout=2)
+        return real_json_load(stream)
+
+    def second_lookup():
+        second_started.set()
+        return registry.runtime_assets_for("kokoro")
+
+    monkeypatch.setattr(registry.json, "load", blocking_json_load)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(registry.runtime_assets_for, "kokoro")
+        assert first_is_parsing.wait(timeout=2)
+        second = executor.submit(second_lookup)
+        assert second_started.wait(timeout=2)
+        release_first.set()
+
+        expected = (
+            registry.AudioRuntimeAsset(
+                repo_id="owner/voices",
+                allow_patterns=("voices/*.safetensors",),
+            ),
+        )
+        assert first.result(timeout=2) == expected
+        assert second.result(timeout=2) == expected
+
+    assert load_calls == 1

--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -86,6 +86,34 @@ def test_pull_without_runtime_assets_keeps_single_repository(monkeypatch) -> Non
     assert calls == ["mlx-community/Qwen3-0.6B-4bit"]
 
 
+def test_pull_does_not_download_primary_again_when_declared_as_runtime_asset(
+    monkeypatch,
+) -> None:
+    """Malformed future metadata cannot turn one pull into a duplicate pull."""
+    primary = "owner/model"
+    calls: list[str] = []
+    monkeypatch.setattr(
+        registry,
+        "runtime_assets_for",
+        lambda _repo: (
+            registry.AudioRuntimeAsset(
+                repo_id=primary,
+                allow_patterns=("voices/*.safetensors",),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **_kwargs: calls.append(args.model),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+
+    cli.pull_command(argparse.Namespace(model=primary))
+
+    assert calls == [primary]
+
+
 def test_runtime_asset_failure_does_not_report_successful_pull(monkeypatch) -> None:
     activations = 0
 

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -1,6 +1,15 @@
 {
   "_comment": "R10-C1 audio alias registry. Single source of truth for short alias -> HuggingFace repo id mapping. Every entry's hf_id has been verified resolvable on https://huggingface.co/api/models/<id> at registry-introduction time. Add new entries by hand, then run tests/test_audio_alias_registry.py::test_every_hf_id_resolves locally (network-gated) to confirm before merging.",
 
+  "_runtime_assets": {
+    "kokoro": [
+      {
+        "repo_id": "prince-canuma/Kokoro-82M",
+        "allow_patterns": ["voices/*.safetensors"]
+      }
+    ]
+  },
+
   "kokoro": {
     "type": "tts",
     "hf_id": "mlx-community/Kokoro-82M-bf16",

--- a/vllm_mlx/audio/registry.py
+++ b/vllm_mlx/audio/registry.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from typing import Literal
 
@@ -97,6 +98,7 @@ _REGISTRY: dict[str, AudioAliasEntry] | None = None
 # ids the same way it answers for short aliases.
 _HF_ID_INDEX: dict[str, str] = {}
 _RUNTIME_ASSETS: dict[str, tuple[AudioRuntimeAsset, ...]] = {}
+_REGISTRY_LOCK = threading.Lock()
 
 
 def _registry_path() -> str:
@@ -104,6 +106,17 @@ def _registry_path() -> str:
 
 
 def _load_registry() -> dict[str, AudioAliasEntry]:
+    """Return the registry, initializing its complete snapshot once."""
+
+    if _REGISTRY is not None:
+        return _REGISTRY
+    with _REGISTRY_LOCK:
+        if _REGISTRY is not None:
+            return _REGISTRY
+        return _load_registry_uncached()
+
+
+def _load_registry_uncached() -> dict[str, AudioAliasEntry]:
     """Parse ``aliases.json`` and return the alias -> entry map.
 
     The JSON file is committed alongside this module so the registry
@@ -116,8 +129,6 @@ def _load_registry() -> dict[str, AudioAliasEntry]:
     alias surface.
     """
     global _REGISTRY
-    if _REGISTRY is not None:
-        return _REGISTRY
 
     path = _registry_path()
     with open(path) as f:
@@ -217,16 +228,21 @@ def _load_registry() -> dict[str, AudioAliasEntry]:
         raise ValueError(
             f"audio aliases.json: runtime assets declared for unknown family: {names}"
         )
-    _REGISTRY = entries
     # Reverse index keyed on the lowercased HF id so ``serve_command``
     # can route a request like ``rapid-mlx serve mlx-community/Kokoro-
     # 82M-bf16`` directly back to its registry entry (HF id case varies
     # across mlx-community uploads).
-    _HF_ID_INDEX.clear()
+    hf_id_index: dict[str, str] = {}
     for alias, entry in entries.items():
-        _HF_ID_INDEX.setdefault(entry.hf_id.lower(), alias)
+        hf_id_index.setdefault(entry.hf_id.lower(), alias)
+    # Publish one coherent snapshot while holding _REGISTRY_LOCK.  Readers use
+    # _REGISTRY as the ready flag, so it must become visible only after every
+    # companion index contains the matching data.
+    _HF_ID_INDEX.clear()
+    _HF_ID_INDEX.update(hf_id_index)
     _RUNTIME_ASSETS.clear()
     _RUNTIME_ASSETS.update(runtime_assets)
+    _REGISTRY = entries
     return entries
 
 

--- a/vllm_mlx/audio/registry.py
+++ b/vllm_mlx/audio/registry.py
@@ -42,6 +42,21 @@ AudioType = Literal["tts", "stt"]
 
 
 @dataclass(frozen=True)
+class AudioRuntimeAsset:
+    """One external repository required by an audio family at inference time.
+
+    Some audio runtimes keep reusable assets (for example voice packs) in a
+    repository separate from the quantized checkpoint.  Keeping that
+    relationship in the catalog lets ``rapid-mlx pull`` prepare a genuinely
+    offline-runnable alias without teaching the downloader about individual
+    model families.
+    """
+
+    repo_id: str
+    allow_patterns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class AudioAliasEntry:
     """Resolved metadata for an audio alias.
 
@@ -81,6 +96,7 @@ _REGISTRY: dict[str, AudioAliasEntry] | None = None
 # forward index so :func:`resolve_audio_alias` can answer for full HF
 # ids the same way it answers for short aliases.
 _HF_ID_INDEX: dict[str, str] = {}
+_RUNTIME_ASSETS: dict[str, tuple[AudioRuntimeAsset, ...]] = {}
 
 
 def _registry_path() -> str:
@@ -106,6 +122,52 @@ def _load_registry() -> dict[str, AudioAliasEntry]:
     path = _registry_path()
     with open(path) as f:
         raw = json.load(f)
+
+    runtime_assets: dict[str, tuple[AudioRuntimeAsset, ...]] = {}
+    raw_runtime_assets = raw.get("_runtime_assets", {})
+    if not isinstance(raw_runtime_assets, dict):
+        raise ValueError("audio aliases.json: _runtime_assets must be an object")
+    for family, assets in raw_runtime_assets.items():
+        if not isinstance(family, str) or not family:
+            raise ValueError(
+                "audio aliases.json: _runtime_assets family keys must be non-empty strings"
+            )
+        if not isinstance(assets, list):
+            raise ValueError(
+                f"audio aliases.json: _runtime_assets.{family} must be an array"
+            )
+        parsed: list[AudioRuntimeAsset] = []
+        seen_repos: set[str] = set()
+        for index, asset in enumerate(assets):
+            if not isinstance(asset, dict):
+                raise ValueError(
+                    f"audio aliases.json: _runtime_assets.{family}[{index}] "
+                    "must be an object"
+                )
+            repo_id = asset.get("repo_id")
+            patterns = asset.get("allow_patterns")
+            if not isinstance(repo_id, str) or repo_id.count("/") != 1:
+                raise ValueError(
+                    f"audio aliases.json: _runtime_assets.{family}[{index}].repo_id "
+                    "must be a HuggingFace namespace/name"
+                )
+            if repo_id in seen_repos:
+                raise ValueError(
+                    f"audio aliases.json: duplicate runtime asset {repo_id!r} "
+                    f"for family {family!r}"
+                )
+            if (
+                not isinstance(patterns, list)
+                or not patterns
+                or not all(isinstance(pattern, str) and pattern for pattern in patterns)
+            ):
+                raise ValueError(
+                    f"audio aliases.json: _runtime_assets.{family}[{index}]."
+                    "allow_patterns must be an array of non-empty strings"
+                )
+            seen_repos.add(repo_id)
+            parsed.append(AudioRuntimeAsset(repo_id, tuple(patterns)))
+        runtime_assets[family] = tuple(parsed)
 
     entries: dict[str, AudioAliasEntry] = {}
     for key, value in raw.items():
@@ -147,6 +209,14 @@ def _load_registry() -> dict[str, AudioAliasEntry]:
             notes=value.get("notes", ""),
         )
 
+    unknown_families = set(runtime_assets) - {
+        entry.family for entry in entries.values()
+    }
+    if unknown_families:
+        names = ", ".join(sorted(unknown_families))
+        raise ValueError(
+            f"audio aliases.json: runtime assets declared for unknown family: {names}"
+        )
     _REGISTRY = entries
     # Reverse index keyed on the lowercased HF id so ``serve_command``
     # can route a request like ``rapid-mlx serve mlx-community/Kokoro-
@@ -155,6 +225,8 @@ def _load_registry() -> dict[str, AudioAliasEntry]:
     _HF_ID_INDEX.clear()
     for alias, entry in entries.items():
         _HF_ID_INDEX.setdefault(entry.hf_id.lower(), alias)
+    _RUNTIME_ASSETS.clear()
+    _RUNTIME_ASSETS.update(runtime_assets)
     return entries
 
 
@@ -215,6 +287,20 @@ def list_audio_aliases() -> list[AudioAliasEntry]:
     ``whisper*`` / ``parakeet*`` groups cluster together visually.
     """
     return sorted(_load_registry().values(), key=lambda e: e.alias)
+
+
+def runtime_assets_for(name: str | None) -> tuple[AudioRuntimeAsset, ...]:
+    """Return catalog-declared external runtime assets for an audio name.
+
+    ``name`` accepts the same short-alias and full-HF-id forms as
+    :func:`resolve_audio_alias`.  Non-audio names intentionally return an
+    empty tuple so the general pull path stays unchanged.
+    """
+
+    entry = resolve_audio_alias(name)
+    if entry is None:
+        return ()
+    return _RUNTIME_ASSETS.get(entry.family, ())
 
 
 def stt_aliases() -> dict[str, str]:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6767,12 +6767,14 @@ def _print_pull_summary(
             f"{_format_pull_duration(elapsed)}"
         )
 
+
+def _emit_pull_activation() -> None:
+    """Record one successful user pull, regardless of artifact count."""
+
     # Activation funnel (docs/telemetry-activation.md): a successful pull is
     # the ``model_pull`` milestone (an activation, NOT inference-engaged).
-    # This helper is only reached on the two success exits of ``pull_command``,
-    # so it is the single "pull succeeded" chokepoint. Fired once per install,
-    # consent-gated + ``@_safe``, so it is a no-op when telemetry is off and
-    # can never affect the pull.
+    # Runtime assets are part of the same user command, so emit only after the
+    # primary checkpoint and every declared asset have completed.
     from vllm_mlx.telemetry import emit as _telemetry_emit
     from vllm_mlx.telemetry.activation_spec import ACTIVATION_MODEL_PULL, SURFACE_CLI
 
@@ -6860,8 +6862,8 @@ class VariantNotFoundError(Exception):
         super().__init__(f"no '{requested}' variant in {repo_id}")
 
 
-def pull_command(args):
-    """Download a model to the HuggingFace cache without serving."""
+def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
+    """Download one repository through the normal mirror/HF pipeline."""
     import time
 
     from huggingface_hub import snapshot_download
@@ -6885,7 +6887,11 @@ def pull_command(args):
     _bits = getattr(args, "bits", None)
     _fmt = getattr(args, "format", None)
     try:
-        variant_allow = _resolve_variant_allow_patterns(repo_id, _bits, _fmt)
+        variant_allow = (
+            list(allow_patterns_override)
+            if allow_patterns_override is not None
+            else _resolve_variant_allow_patterns(repo_id, _bits, _fmt)
+        )
     except ValueError as e:
         print(f"\n  Error: {e}")
         sys.exit(1)
@@ -6992,7 +6998,10 @@ def pull_command(args):
         # An explicit --bits/--format selection (variant_allow) always wins over
         # the catalog-driven subfolder narrowing; otherwise fall back to the
         # catalog subfolder (one checkpoint per quantization).
-        if variant_allow is not None:
+        if allow_patterns_override is not None:
+            _allow = variant_allow
+            print("  Fetching only the runtime assets declared by the audio catalog.")
+        elif variant_allow is not None:
             _allow = variant_allow
             # Literal folder name the user asked for (e.g. "4bit"). Derived
             # from the raw selectors, NOT from the (glob-escaped) pattern, so
@@ -7080,6 +7089,31 @@ def pull_command(args):
         time.monotonic() - t0,
         was_cached=_was_cached,
     )
+
+
+def pull_command(args):
+    """Download a model and every catalog-declared runtime repository."""
+
+    import copy
+
+    from vllm_mlx.audio.registry import runtime_assets_for
+
+    primary_repo = args.model
+    _pull_repository(args)
+    for asset in runtime_assets_for(primary_repo):
+        if asset.repo_id == primary_repo:
+            continue
+        print(f"\n  Runtime assets: {asset.repo_id}")
+        dependency_args = copy.copy(args)
+        dependency_args.model = asset.repo_id
+        dependency_args._original_alias = asset.repo_id
+        dependency_args.bits = None
+        dependency_args.format = None
+        _pull_repository(
+            dependency_args,
+            allow_patterns_override=list(asset.allow_patterns),
+        )
+    _emit_pull_activation()
 
 
 def rm_command(args):


### PR DESCRIPTION
## Intention

Make `rapid-mlx pull kokoro` prepare every catalog-declared runtime asset needed for the default offline TTS path, so a successful pull is sufficient to generate speech with `HF_HUB_OFFLINE=1`.

Fixes #2646

## Scope

- add validated, family-level runtime-asset metadata to the audio catalog
- make the pull command process the primary checkpoint and each declared asset through the same mirror/HF pipeline
- filter the Kokoro runtime repository to `voices/*.safetensors` instead of duplicating its model weights
- emit the user pull activation only after all artifacts succeed
- publish the registry and its runtime-asset indexes atomically on concurrent first access
- add hermetic registry, orchestration, filtering, failure, and concurrency regressions

## Non-goals

- no audio generation/runtime changes
- no model, Python dependency, version, CI, or Desktop changes
- no special-case downloader branch for Kokoro

## Design precedent

Established serving systems model weights and separately hosted tokenizers/codecs/assets as explicit components, then resolve each component through the normal artifact loader. Rapid-MLX adapts that pattern at the audio catalog boundary: a family declares its external runtime assets and narrow file patterns as data; the generic pull orchestrator downloads each component with its existing integrity, fallback, accounting, and error semantics.

## Acceptance evidence

- fresh Python 3.12 wheel install from exact head `46df9e82`; wheel SHA-256 `863915331c448055cdc57052019d41d9b45cba79301efc274334b5ec61b228c1`
- 201 focused alias/pull/runtime-asset tests passed; ruff check, format and diff-check clean
- exact-head offline pull verified the 371.4MiB primary snapshot and the filtered 26.9MiB runtime-asset snapshot without network access
- clean-cache user walk fetched exactly 54 voice safetensors / 26.9MiB and generated a valid 132,044-byte 24kHz mono PCM WAV with `HF_HUB_OFFLINE=1`
- primary Qwen chat remained live alongside TTS and returned schema-valid JSON
- deterministic two-thread first-read regression proves all callers observe runtime assets and the catalog is parsed once

## Review contract

Please review only the catalog schema, generic pull orchestration, telemetry success boundary, atomic registry publication, and focused tests. Explicit non-goals above remain out of scope.
