### PR TITLE
test(mllm): align token accounting with cancelled status

### DIFF
--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -144,8 +144,8 @@ def test_mllm_completed_request_adds_prompt_and_completion_tokens():
     assert scheduler.num_requests_processed == 1
 
 
-def test_mllm_aborted_request_adds_prompt_tokens_without_completion_tokens():
-    """Aborted requests still account for their already-prefilled prompt."""
+def test_mllm_cancelled_request_adds_prompt_tokens_without_completion_tokens():
+    """Cancelled requests still account for their already-prefilled prompt."""
     scheduler = _bare_scheduler()
     request = MLLMRequest(request_id="req-2", prompt="hello")
     request.status = RequestStatus.RUNNING
@@ -164,4 +164,4 @@ def test_mllm_aborted_request_adds_prompt_tokens_without_completion_tokens():
 
     assert scheduler.total_prompt_tokens == 23
     assert scheduler.total_completion_tokens == 0
-    assert request.status is RequestStatus.FINISHED_ABORTED
+    assert request.status is RequestStatus.FINISHED_CANCELLED


### PR DESCRIPTION
## Intention

Restore a green local full-unit gate after the cancellation taxonomy changed active MLLM aborts to the user-visible cancelled terminal state.

Fixes #2649

## Scope

- rename one stale token-accounting regression to describe cancellation
- assert the established FINISHED_CANCELLED terminal state
- preserve the prompt/completion token-accounting assertions

## Non-goals

- no engine, scheduler, API, dependency, or CI changes
- no cancellation behavior change

## Design precedent

The test follows the existing single terminal-status contract: an explicit request cancellation has one canonical cancelled state, and accounting tests reuse that contract instead of maintaining a second legacy status expectation.

## Verification

- reproduced deterministically on current main@244849f8 and the #2648 head
- 17 focused MLLM stats and cancellation-protocol tests pass
- exact-head pr_validate is MERGE-SAFE: 19,664 passed, 104 skipped, 22 deselected, 6 xfailed, 1 xpassed
- independent Codex review round 1: LGTM
- ruff check, ruff format, and diff-check pass

## Review contract

Review only the one stale expectation and its naming. The runtime behavior and cancellation taxonomy are explicit non-goals.