### PR TITLE
test(gui): deliver real Settings smoke clicks

### DIFF
--- a/apps/rapid-mac/scripts/gui-ax-smoke.sh
+++ b/apps/rapid-mac/scripts/gui-ax-smoke.sh
@@ -2,9 +2,9 @@
 # AX-first Rapid-Mac GUI smoke using Peekaboo.
 #
 # This deliberately avoids model startup and mutable controls. It validates
-# that the running app exposes stable semantic selectors, opens Settings via
-# the application menu, navigates with AXPress, and records structured trees
-# plus screenshots for diagnosis.
+# that the running app exposes stable semantic selectors, opens Settings with
+# synthesized user clicks, and records structured trees plus screenshots for
+# diagnosis.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -45,7 +45,8 @@ observe_app() {
 
 press_identifier() {
     local tree="$1" identifier="$2" output="$3"
-    local coords
+    local coords click_help
+    local -a click_args
     coords="$(jq -r --arg id "$identifier" \
         '.data.ui_elements[] | select(.identifier == $id) | .bounds |
          "\((.x + (.width / 2)) | floor),\((.y + (.height / 2)) | floor)"' \
@@ -57,16 +58,21 @@ press_identifier() {
     # path as a user's click while retaining semantic identifier lookup.  A
     # coordinate also avoids passing a daemon-owned snapshot to the local input
     # host, where it cannot be resolved.
-    if peekaboo click --help 2>&1 | grep -q -- --global-coords; then
-        pb click --coords "$coords" --global-coords \
-            --input-strategy synthOnly --foreground --json > "$output"
-    else
-        # Peekaboo 3.0 interprets coordinates globally by default and predates
-        # the flags that make the newer input path explicit.
-        pb click --coords "$coords" --json > "$output"
+    click_help="$(peekaboo click --help 2>&1)"
+    click_args=(click --coords "$coords")
+    if grep -q -- --global-coords <<< "$click_help"; then
+        click_args+=(--global-coords)
     fi
+    if grep -q -- --input-strategy <<< "$click_help"; then
+        click_args+=(--input-strategy synthOnly)
+    fi
+    if grep -q -- --foreground <<< "$click_help"; then
+        click_args+=(--foreground)
+    fi
+    pb "${click_args[@]}" --json > "$output"
 }
 
+main() {
 command -v peekaboo >/dev/null || die "peekaboo is not installed"
 command -v jq >/dev/null || die "jq is not installed"
 
@@ -160,3 +166,8 @@ pb image --window-id "$SETTINGS_WINDOW_ID" --path "$OUT/appearance.png" --json \
 
 log "PASS — semantic GUI smoke complete"
 log "artifacts: $OUT"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/apps/rapid-mac/scripts/gui-ax-smoke.sh
+++ b/apps/rapid-mac/scripts/gui-ax-smoke.sh
@@ -45,12 +45,20 @@ observe_app() {
 
 press_identifier() {
     local tree="$1" identifier="$2" output="$3"
-    local element snapshot
-    element="$(jq -r --arg id "$identifier" \
-        '.data.ui_elements[] | select(.identifier == $id) | .id' "$tree" | head -1)"
-    snapshot="$(jq -r '.data.snapshot_id' "$tree")"
-    [[ -n "$element" ]] || return 1
-    pb perform-action --on "$element" --action AXPress --snapshot "$snapshot" --json > "$output"
+    local coords
+    coords="$(jq -r --arg id "$identifier" \
+        '.data.ui_elements[] | select(.identifier == $id) | .bounds |
+         "\((.x + (.width / 2)) | floor),\((.y + (.height / 2)) | floor)"' \
+        "$tree" | head -1)"
+    [[ -n "$coords" ]] || return 1
+    # SwiftUI can expose AXPress and report a successful action without
+    # dispatching the control's Button closure.  Deliver a foreground mouse
+    # event at the AX-resolved element's centre instead: this follows the same
+    # path as a user's click while retaining semantic identifier lookup.  A
+    # coordinate also avoids passing a daemon-owned snapshot to the local input
+    # host, where it cannot be resolved.
+    pb click --coords "$coords" --global-coords \
+        --input-strategy synthOnly --foreground --json > "$output"
 }
 
 command -v peekaboo >/dev/null || die "peekaboo is not installed"
@@ -90,10 +98,10 @@ for identifier in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.Sen
         '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/main.json" >/dev/null \
         || die "main window missing AX identifier: $identifier"
 done
+press_identifier "$OUT/main.json" "ContentView.Settings" "$OUT/open-settings.json" \
+    || die "could not click ContentView.Settings"
 pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/main.png" --json \
     > "$OUT/main-image.json"
-
-pb menu click --app "$APP" --item 'Settings…' --json > "$OUT/open-settings.json"
 for _ in {1..20}; do
     pb list windows --app "$APP" --json > "$OUT/windows-settings.json"
     SETTINGS_WINDOW_ID="$(jq -r '.data.windows[] | select(.title == "Settings") | .window_id' \
@@ -125,10 +133,8 @@ for identifier in Settings.Models.ShowAllModelsToggle Settings.Models.AutoStartO
         || die "Models toggle is not exposed as a native AX checkbox: $identifier"
 done
 
-APPEARANCE_ID="$(jq -r '.data.ui_elements[] | select(.identifier == "Settings.Category.appearance") | .id' "$OUT/models.json")"
-SNAPSHOT="$(jq -r '.data.snapshot_id' "$OUT/models.json")"
-pb perform-action --on "$APPEARANCE_ID" --action AXPress --snapshot "$SNAPSHOT" --json \
-    > "$OUT/open-appearance.json"
+press_identifier "$OUT/models.json" "Settings.Category.appearance" "$OUT/open-appearance.json" \
+    || die "could not click Settings.Category.appearance"
 sleep 0.5
 pb see --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/appearance.json"
 

--- a/apps/rapid-mac/scripts/gui-ax-smoke.sh
+++ b/apps/rapid-mac/scripts/gui-ax-smoke.sh
@@ -57,8 +57,14 @@ press_identifier() {
     # path as a user's click while retaining semantic identifier lookup.  A
     # coordinate also avoids passing a daemon-owned snapshot to the local input
     # host, where it cannot be resolved.
-    pb click --coords "$coords" --global-coords \
-        --input-strategy synthOnly --foreground --json > "$output"
+    if peekaboo click --help 2>&1 | grep -q -- --global-coords; then
+        pb click --coords "$coords" --global-coords \
+            --input-strategy synthOnly --foreground --json > "$output"
+    else
+        # Peekaboo 3.0 interprets coordinates globally by default and predates
+        # the flags that make the newer input path explicit.
+        pb click --coords "$coords" --json > "$output"
+    fi
 }
 
 command -v peekaboo >/dev/null || die "peekaboo is not installed"

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -203,7 +203,10 @@ def test_real_dogfood_entrypoints_share_the_host_guards() -> None:
 def test_gui_ax_smoke_delivers_real_user_input() -> None:
     ax = (ROOT / "apps/rapid-mac/scripts/gui-ax-smoke.sh").read_text()
 
+    assert "peekaboo click --help" in ax
+    assert "grep -q -- --global-coords" in ax
     assert 'pb click --coords "$coords" --global-coords' in ax
+    assert 'pb click --coords "$coords" --json' in ax
     assert "--input-strategy synthOnly --foreground" in ax
     assert "pb perform-action" not in ax
     assert "pb menu click" not in ax

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -198,3 +198,21 @@ def test_real_dogfood_entrypoints_share_the_host_guards() -> None:
     assert 'exec "$SCRIPT_DIR/dogfood-host-precheck.sh"' in ax
     assert 'exec "$ROOT/scripts/dogfood-host-precheck.sh"' in golden
     assert golden.count("DOGFOOD_WORKING_SET_GB=0.1") == 2
+
+
+def test_gui_ax_smoke_delivers_real_user_input() -> None:
+    ax = (ROOT / "apps/rapid-mac/scripts/gui-ax-smoke.sh").read_text()
+
+    assert 'pb click --coords "$coords" --global-coords' in ax
+    assert "--input-strategy synthOnly --foreground" in ax
+    assert "pb perform-action" not in ax
+    assert "pb menu click" not in ax
+    assert (
+        "--snapshot"
+        not in ax.split("press_identifier()", maxsplit=1)[1].split(
+            "command -v peekaboo", maxsplit=1
+        )[0]
+    )
+    assert ax.index('press_identifier "$OUT/main.json"') < ax.index(
+        'pb image --window-id "$MAIN_WINDOW_ID"'
+    )

--- a/tests/test_host_prechecks.py
+++ b/tests/test_host_prechecks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -204,10 +205,13 @@ def test_gui_ax_smoke_delivers_real_user_input() -> None:
     ax = (ROOT / "apps/rapid-mac/scripts/gui-ax-smoke.sh").read_text()
 
     assert "peekaboo click --help" in ax
-    assert "grep -q -- --global-coords" in ax
-    assert 'pb click --coords "$coords" --global-coords' in ax
-    assert 'pb click --coords "$coords" --json' in ax
-    assert "--input-strategy synthOnly --foreground" in ax
+    assert 'grep -q -- --global-coords <<< "$click_help"' in ax
+    assert 'grep -q -- --input-strategy <<< "$click_help"' in ax
+    assert 'grep -q -- --foreground <<< "$click_help"' in ax
+    assert 'click_args=(click --coords "$coords")' in ax
+    assert "click_args+=(--global-coords)" in ax
+    assert "click_args+=(--input-strategy synthOnly)" in ax
+    assert "click_args+=(--foreground)" in ax
     assert "pb perform-action" not in ax
     assert "pb menu click" not in ax
     assert (
@@ -219,3 +223,68 @@ def test_gui_ax_smoke_delivers_real_user_input() -> None:
     assert ax.index('press_identifier "$OUT/main.json"') < ax.index(
         'pb image --window-id "$MAIN_WINDOW_ID"'
     )
+
+
+@pytest.mark.parametrize(
+    ("help_text", "expected_flags"),
+    [
+        (
+            "--global-coords\n--input-strategy\n--foreground\n",
+            ["--global-coords", "--input-strategy", "synthOnly", "--foreground"],
+        ),
+        ("--global-coords\n--foreground\n", ["--global-coords", "--foreground"]),
+        ("Peekaboo 3.0 coordinates are global by default\n", []),
+    ],
+)
+def test_gui_ax_click_helper_uses_only_supported_flags(
+    tmp_path: Path, help_text: str, expected_flags: list[str]
+) -> None:
+    tree = tmp_path / "tree.json"
+    output = tmp_path / "output.json"
+    log = tmp_path / "args.log"
+    tree.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "Test.Button",
+                            "bounds": {"x": 10, "y": 20, "width": 10, "height": 10},
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    shell = r"""
+source "$RAPID_AX_SCRIPT"
+peekaboo() {
+    if [[ "${1:-}" == click && "${2:-}" == --help ]]; then
+        printf '%s' "$RAPID_FAKE_HELP"
+        return 0
+    fi
+    printf '%s\n' "$@" > "$RAPID_FAKE_LOG"
+    printf '{"success":true}\n'
+}
+press_identifier "$RAPID_FAKE_TREE" "Test.Button" "$RAPID_FAKE_OUTPUT"
+"""
+    result = subprocess.run(
+        ["bash", "-c", shell],
+        env=dict(
+            os.environ,
+            RAPID_HOST_PRECHECK_HELD="1",
+            RAPID_GUI_OUT=str(tmp_path / "artifacts"),
+            RAPID_AX_SCRIPT=str(ROOT / "apps/rapid-mac/scripts/gui-ax-smoke.sh"),
+            RAPID_FAKE_HELP=help_text,
+            RAPID_FAKE_LOG=str(log),
+            RAPID_FAKE_TREE=str(tree),
+            RAPID_FAKE_OUTPUT=str(output),
+        ),
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    args = log.read_text().splitlines()
+    assert args[:3] == ["click", "--coords", "15,25"]
+    for flag in ("--global-coords", "--input-strategy", "synthOnly", "--foreground"):
+        assert (flag in args) is (flag in expected_flags)


### PR DESCRIPTION
## User-visible goal

Keep release GUI dogfood trustworthy: opening Settings must exercise the same synthesized mouse-input path a user takes, rather than an AXPress that can report success without running a SwiftUI Button action.

Closes #2651

## Scope

- Resolve semantic identifiers to their accessibility bounds and click the element center with foreground synthesized input.
- Use that path for Settings, onboarding/dock prompts, and Settings category navigation.
- Pin the input strategy and click-before-screenshot ordering with a focused contract test.

## Non-goals

- No product UI behavior changes.
- No CI workflow or runner-routing changes.
- No golden-flow expansion.

## Design precedent

The existing release GUI journeys already resolve accessibility elements and use foreground coordinate clicks for controls that require actual input delivery. This change applies that established boundary to the smaller AX smoke while preserving semantic identifier lookup.

## Verification

- `python3.12 -m pytest -q tests/test_host_prechecks.py` — 8 passed
- `python3.12 -m ruff check tests/test_host_prechecks.py`
- `python3.12 -m ruff format --check tests/test_host_prechecks.py`
- `shellcheck apps/rapid-mac/scripts/gui-ax-smoke.sh`
- `bash -n apps/rapid-mac/scripts/gui-ax-smoke.sh`
- `git diff --check`
- Live local-build run on Studio: semantic GUI smoke PASS, including Settings window, model-management checkbox roles, Appearance navigation, and theme semantics.

## Risk

Low and harness-only. The click still originates from the AX identifier; bounds are used only to deliver a real event across the daemon/local input-host boundary.