### PR TITLE
fix(mtp): serve Desktop default sampling without silent fallback

### DIFF
--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -2493,7 +2493,10 @@ def test_install_mtp_vendored_passes_request_sampling_and_safe_penalty_context(
     batch_gen, gb = _make_batch_gen_with_gb()
     gb.uids = [55]
     gb.tokens = [[101, 102]]
-    gb.logits_processors = [[penalty]]
+    # mlx-lm can expose the persistent uid before the parallel processor row
+    # is populated at the prefill -> decode seam. The scheduler's uid-keyed
+    # admission state must carry the safe standard penalty through that gap.
+    gb.logits_processors = []
     gb._next_tokens = mx.array([500], dtype=mx.uint32)
     gb._next_logprobs = [mx.array([0.0])]
     request_stub = SimpleNamespace(
@@ -2512,6 +2515,7 @@ def test_install_mtp_vendored_passes_request_sampling_and_safe_penalty_context(
         model=_StubModel(),
         requests={"req-55": request_stub},
         uid_to_request_id={55: "req-55"},
+        uid_to_request_processors={55: [penalty]},
     )
     gb._step()
 
@@ -2522,6 +2526,58 @@ def test_install_mtp_vendored_passes_request_sampling_and_safe_penalty_context(
     assert seen["logits_processors"] == [penalty]
     assert seen["initial_tokens"] == [101, 102]
     assert gb.orig_step_calls == 0
+
+
+def test_install_mtp_vendored_uid_processor_source_rejects_custom_processor(
+    monkeypatch,
+):
+    """The uid-keyed seam fix must not admit an extra stateful processor."""
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    generator_calls = {"count": 0}
+
+    def _unexpected_generator(*args, **kwargs):
+        generator_calls["count"] += 1
+        raise AssertionError("custom processor must keep request on plain decode")
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", _unexpected_generator)
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [56]
+    gb.tokens = [[101, 102]]
+    gb.logits_processors = []
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    penalty = lambda tokens, logits: logits
+    custom = lambda tokens, logits: logits
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            temperature=0.7,
+            top_p=0.95,
+            top_k=40,
+            min_p=0.05,
+            seed=None,
+        ),
+        _mtp_safe_logits_processors=(penalty,),
+    )
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={"req-56": request_stub},
+        uid_to_request_id={56: "req-56"},
+        uid_to_request_processors={56: [penalty, custom]},
+    )
+    gb._step()
+
+    assert generator_calls["count"] == 0
+    assert gb.orig_step_calls == 1
+    assert batch_gen._mtp_vendored_stats["ft_logits_processors"] == 1
 
 
 def test_install_mtp_vendored_mid_stream_generator_failure_raises(monkeypatch):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1537,11 +1537,20 @@ def test_install_mtp_vendored_gate_fails_closed_on_missing_request_metadata(
                 min_p=0.0,
             )
         ),
+        SimpleNamespace(
+            sampling_params=SimpleNamespace(
+                temperature=0.7,
+                top_p=float("nan"),
+                top_k=0,
+                min_p=0.0,
+            )
+        ),
     ],
     ids=[
         "missing-sampling-params",
         "unresolved-temperature",
         "invalid-sampling-value",
+        "non-finite-sampling-value",
     ],
 )
 def test_install_mtp_vendored_sampling_metadata_shapes_fail_closed(request_stub):
@@ -1564,6 +1573,96 @@ def test_install_mtp_vendored_sampling_metadata_shapes_fail_closed(request_stub)
 
     assert batch_gen._mtp_vendored_stats["ft_non_greedy"] == 1
     assert gb.orig_step_calls == 1
+
+
+def test_install_mtp_vendored_missing_processor_history_fails_closed():
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    penalty = lambda tokens, logits: logits
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            temperature=0.7,
+            top_p=0.95,
+            top_k=20,
+            min_p=0.0,
+            seed=None,
+        ),
+        _mtp_safe_logits_processors=(penalty,),
+    )
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [44]
+    gb.tokens = []
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+
+    def plain_step():
+        gb.orig_step_calls += 1
+        return [], []
+
+    gb._step = plain_step
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={"req-44": request_stub},
+        uid_to_request_id={44: "req-44"},
+        uid_to_request_processors={44: [penalty]},
+    )
+    gb._step()
+
+    assert batch_gen._mtp_vendored_stats["ft_logits_processors"] == 1
+    assert gb.orig_step_calls == 1
+
+
+def test_install_mtp_vendored_initial_skip_log_is_deduplicated_on_uid_reuse(
+    caplog,
+):
+    import logging
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    def seeded_request():
+        return SimpleNamespace(
+            sampling_params=SimpleNamespace(
+                temperature=0.7,
+                top_p=0.95,
+                top_k=20,
+                min_p=0.0,
+                seed=7,
+            )
+        )
+
+    uid_to_request_id = {45: "req-a"}
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [45]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={"req-a": seeded_request(), "req-b": seeded_request()},
+        uid_to_request_id=uid_to_request_id,
+    )
+
+    with caplog.at_level(logging.INFO):
+        gb._step()
+        uid_to_request_id[45] = "req-b"
+        gb._step()
+
+    skip_logs = [
+        record
+        for record in caplog.records
+        if "remains on plain decode" in record.getMessage()
+    ]
+    assert len(skip_logs) == 1
+    assert gb.orig_step_calls == 2
 
 
 def test_install_mtp_vendored_falls_back_to_orig_step_on_batch_size_growth(monkeypatch):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -29,6 +29,8 @@ Deliberately out of scope (deferred to PR-B / PR-C):
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 pytestmark = pytest.mark.requires_mlx
@@ -1522,6 +1524,48 @@ def test_install_mtp_vendored_gate_fails_closed_on_missing_request_metadata(
     assert gb.orig_step_calls == 1
 
 
+@pytest.mark.parametrize(
+    "request_stub",
+    [
+        SimpleNamespace(),
+        SimpleNamespace(sampling_params=SimpleNamespace(temperature=None)),
+        SimpleNamespace(
+            sampling_params=SimpleNamespace(
+                temperature=0.7,
+                top_p=None,
+                top_k=0,
+                min_p=0.0,
+            )
+        ),
+    ],
+    ids=[
+        "missing-sampling-params",
+        "unresolved-temperature",
+        "invalid-sampling-value",
+    ],
+)
+def test_install_mtp_vendored_sampling_metadata_shapes_fail_closed(request_stub):
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [43]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={"req-43": request_stub},
+        uid_to_request_id={43: "req-43"},
+    )
+    gb._step()
+
+    assert batch_gen._mtp_vendored_stats["ft_non_greedy"] == 1
+    assert gb.orig_step_calls == 1
+
+
 def test_install_mtp_vendored_falls_back_to_orig_step_on_batch_size_growth(monkeypatch):
     """Codex round-A blocker #3 + round-L BLOCKING #2 regression
     guard.
@@ -2369,14 +2413,17 @@ def test_install_mtp_vendored_logits_processors_mid_stream_falls_back_to_orig_st
     )
 
 
-def test_install_mtp_vendored_non_greedy_before_state_soft_fallthrough(monkeypatch):
-    """Companion to round-H BLOCKING #2: when the request starts
-    non-greedy (never populated ``_state``), the wrapper soft-falls
+def test_install_mtp_vendored_seeded_before_state_soft_fallthrough(monkeypatch):
+    """A request-local seed remains outside the MTP safety boundary.
+
+    When the request starts seeded (and never populated ``_state``),
+    the wrapper soft-falls
     through to ``_orig_step()`` and marks the uid as disabled to
     prevent re-entry on the next step.
 
-    This preserves the round-A "bench harness with temp>0" path
-    working under the round-H tightening.
+    The vendored generator uses MLX's process-global RNG today. Routing
+    a seeded request through it would violate the per-request replay
+    contract even though stochastic MTP itself is distribution-safe.
     """
     from types import SimpleNamespace
 
@@ -2386,8 +2433,9 @@ def test_install_mtp_vendored_non_greedy_before_state_soft_fallthrough(monkeypat
 
     batch_gen, gb = _make_batch_gen_with_gb()
     gb.uids = [11]
-    # temp > 0 from the start — MTP never primes.
-    request_stub = SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.7))
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(temperature=0.7, seed=1234)
+    )
     ok = _install_mtp_vendored(
         batch_gen,
         model=_StubModel(),
@@ -2404,6 +2452,76 @@ def test_install_mtp_vendored_non_greedy_before_state_soft_fallthrough(monkeypat
     stats = batch_gen._mtp_vendored_stats
     assert stats["ft_non_greedy"] >= 1
     assert gb.orig_step_calls == 1
+
+
+def test_install_mtp_vendored_passes_request_sampling_and_safe_penalty_context(
+    monkeypatch,
+):
+    """Desktop's default sampled + repetition-penalty request engages MTP.
+
+    The processor identity marker is created alongside the scheduler's
+    standard penalty list. It is the proof that lets the wrapper forward the
+    processor and exact mlx-lm token history without accidentally admitting a
+    grammar/tool processor with mutable speculative state.
+    """
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    seen: dict[str, object] = {}
+    penalty = lambda tokens, logits: logits
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (1234, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    def _recording_generator(*args, **kwargs):
+        seen.update(kwargs)
+        return _FakeGen()
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", _recording_generator)
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [55]
+    gb.tokens = [[101, 102]]
+    gb.logits_processors = [[penalty]]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            temperature=0.7,
+            top_p=0.95,
+            top_k=40,
+            min_p=0.05,
+            seed=None,
+        ),
+        _mtp_safe_logits_processors=(penalty,),
+    )
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={"req-55": request_stub},
+        uid_to_request_id={55: "req-55"},
+    )
+    gb._step()
+
+    assert seen["temp"] == 0.7
+    assert seen["top_p"] == 0.95
+    assert seen["top_k"] == 40
+    assert seen["min_p"] == 0.05
+    assert seen["logits_processors"] == [penalty]
+    assert seen["initial_tokens"] == [101, 102]
+    assert gb.orig_step_calls == 0
 
 
 def test_install_mtp_vendored_mid_stream_generator_failure_raises(monkeypatch):

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2463,6 +2463,90 @@ def test_generator_emits_first_token_from_backbone_then_draft():
     assert snap.tokens_saved == 1
 
 
+def test_generator_sampled_verify_accepts_matching_draft():
+    """The probabilistic verifier is active when temperature is non-zero."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    counter = MTPAcceptCounter()
+    emitted = list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _MockedQwen35Model([7, 11, 13], [11]),
+            max_tokens=3,
+            temp=0.7,
+            top_p=0.95,
+            disable_auto_k=True,
+            accept_counter=counter,
+        )
+    )
+
+    # The scripted logits put effectively all mass on these tokens, while the
+    # non-zero temperature forces the probabilistic accept/residual branch.
+    assert [(token, drafted) for token, _lp, drafted in emitted] == [
+        (7, False),
+        (11, True),
+        (13, False),
+    ]
+    assert counter.snapshot().accepts == 1
+
+
+def test_generator_sampled_k3_draws_acceptance_independently_per_position(
+    monkeypatch,
+):
+    """K>1 rejection sampling must not correlate acceptance decisions."""
+    import vllm_mlx.spec_decode.mtp.generator as generator_mod
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    real_uniform = generator_mod.mx.random.uniform
+    shapes: list[tuple[int, ...] | None] = []
+
+    def recording_uniform(*args, **kwargs):
+        shapes.append(kwargs.get("shape"))
+        return real_uniform(*args, **kwargs)
+
+    monkeypatch.setattr(generator_mod.mx.random, "uniform", recording_uniform)
+    list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _MockedQwen35Model([7, 11, 12, 13, 14], [11, 12, 13]),
+            max_tokens=4,
+            max_k=3,
+            temp=0.7,
+            top_p=0.95,
+            disable_auto_k=True,
+            accept_counter=MTPAcceptCounter(),
+        )
+    )
+
+    assert (3,) in shapes
+
+
+def test_generator_penalty_processor_continues_existing_token_context():
+    """The first MTP target sample sees the same history as mlx-lm."""
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    observed: list[list[int]] = []
+
+    def recorder(tokens, logits):
+        observed.append(tokens.tolist())
+        return logits
+
+    list(
+        mtp_generate_step(
+            mx.array([7], dtype=mx.uint32),
+            _MockedQwen35Model([11], []),
+            max_tokens=1,
+            logits_processors=[recorder],
+            initial_tokens=[3, 5],
+            disable_auto_k=True,
+        )
+    )
+
+    assert observed == [[3, 5, 7]]
+
+
 def test_prompt_lookup_point_mass_residual_removes_proposed_token():
     from vllm_mlx.spec_decode.mtp.generator import (
         _point_mass_residual_distribution,

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2616,6 +2616,39 @@ def test_generator_penalty_processor_continues_existing_token_context():
     assert observed == [[3, 5, 7]]
 
 
+def test_generator_penalty_processor_carries_full_k3_draft_history():
+    """Each chained draft sees main_tok plus every preceding proposal."""
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    observed: list[list[int]] = []
+
+    def recorder(tokens, logits):
+        observed.append(tokens.tolist())
+        return logits
+
+    list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _MockedQwen35Model([7, 11, 12, 13, 14], [11, 12, 13]),
+            max_tokens=4,
+            max_k=3,
+            logits_processors=[recorder],
+            initial_tokens=[3, 5],
+            disable_auto_k=True,
+        )
+    )
+
+    # Cold-start target sample, then the three sequential MTP draft samples.
+    # Later entries are the batched target verification pass and are not part
+    # of the chain-local-history assertion.
+    assert observed[:4] == [
+        [3, 5, 1],
+        [3, 5, 1, 7],
+        [3, 5, 1, 7, 11],
+        [3, 5, 1, 7, 11, 12],
+    ]
+
+
 def test_prompt_lookup_point_mass_residual_removes_proposed_token():
     from vllm_mlx.spec_decode.mtp.generator import (
         _point_mass_residual_distribution,

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2491,6 +2491,75 @@ def test_generator_sampled_verify_accepts_matching_draft():
     assert counter.snapshot().accepts == 1
 
 
+def test_generator_accepted_draft_reports_target_logprobs(monkeypatch):
+    """An accepted proposal exposes p_target, never the drafter's q row."""
+    import mlx_lm.sample_utils as sample_utils
+
+    import vllm_mlx.spec_decode.mtp.generator as generator_mod
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    class _DistinctDistributionsModel(_MockedQwen35Model):
+        def _rows(self, target_ids, batch, boost):
+            rows = []
+            for token_id in target_ids:
+                row = mx.zeros((batch, self.vocab))
+                row = row + mx.where(
+                    mx.arange(self.vocab)[None, :] == token_id,
+                    mx.array(boost),
+                    mx.array(0.0),
+                )
+                rows.append(row)
+            return mx.stack(rows, axis=1)
+
+        def _logits_for_positions(self, target_ids, batch):
+            # Target p: deliberately soft so it differs materially from q.
+            return self._rows(target_ids, batch, 1.0)
+
+        def mtp_forward(self, hidden, next_token_ids, mtp_cache):
+            batch, positions = next_token_ids.shape
+            targets = []
+            for _ in range(positions):
+                if self._mtp_cursor < len(self._mtp):
+                    targets.append(self._mtp[self._mtp_cursor])
+                    self._mtp_cursor += 1
+                else:
+                    targets.append(0)
+            # Drafter q: a much sharper distribution around the same proposal.
+            return self._rows(targets, batch, 8.0)
+
+    monkeypatch.setattr(
+        sample_utils,
+        "categorical_sampling",
+        lambda logits, temp: mx.argmax(logits, axis=-1),
+    )
+    monkeypatch.setattr(
+        generator_mod.mx.random,
+        "uniform",
+        lambda *args, **kwargs: mx.zeros(kwargs.get("shape", ())),
+    )
+
+    emitted = list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _DistinctDistributionsModel([7, 11, 13], [11]),
+            max_tokens=3,
+            temp=0.7,
+            disable_auto_k=True,
+            accept_counter=MTPAcceptCounter(),
+        )
+    )
+
+    accepted_id, served_logprobs, from_draft = emitted[1]
+    assert (accepted_id, from_draft) == (11, True)
+    target_logits = mx.where(mx.arange(32) == 11, mx.array(1.0), mx.array(0.0))
+    target_logprobs = target_logits - mx.logsumexp(target_logits)
+    draft_logits = mx.where(mx.arange(32) == 11, mx.array(8.0), mx.array(0.0))
+    draft_logprobs = draft_logits - mx.logsumexp(draft_logits)
+    assert mx.allclose(served_logprobs, target_logprobs)
+    assert not mx.allclose(served_logprobs, draft_logprobs)
+
+
 def test_generator_sampled_k3_draws_acceptance_independently_per_position(
     monkeypatch,
 ):

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -710,6 +710,49 @@ class TestScheduleWaitingInsertDispatch:
         assert segments == [[[10, 20, 30], [40]]]
         batch_generator.insert.assert_not_called()
 
+    def test_real_schedule_registers_standard_penalties_for_mtp_handoff(self):
+        """Admission keeps one exact penalty list for mlx-lm and MTP."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = Request(
+            request_id="req-penalty-admission",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(
+                max_tokens=4,
+                repetition_penalty=1.1,
+                presence_penalty=0.2,
+                frequency_penalty=0.3,
+            ),
+        )
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [102]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        assert scheduler._schedule_waiting() == [request]
+
+        admitted = batch_generator.insert_segments.call_args.kwargs[
+            "logits_processors"
+        ][0]
+        assert admitted
+        assert tuple(admitted) == request._mtp_safe_logits_processors
+        scheduler._register_uid_processors.assert_called_once()
+        registered = scheduler._register_uid_processors.call_args.args[2]
+        assert registered == admitted
+        assert all(
+            actual is safe
+            for actual, safe in zip(
+                registered, request._mtp_safe_logits_processors, strict=True
+            )
+        )
+
     def _build_dispatch_args(
         self,
         prefix_boundary: int,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -125,6 +125,7 @@ class TestRequest:
         assert req.num_computed_tokens == 0
         assert req.output_token_ids == []
         assert req.output_text == ""
+        assert req._mtp_safe_logits_processors == ()
 
     def test_arrival_time_set(self):
         before = time.time()

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -196,6 +196,15 @@ class Request:
     # parser state after the prompt has explicitly closed it.
     suppressed_tokens_logits_processor: Any | None = None
 
+    # Exact standard-penalty processors installed for this request. The MTP
+    # handoff accepts a processor row only when every live object is identical
+    # to this tuple; grammar, tool, reasoning, and arbitrary custom processors
+    # therefore fail closed instead of entering speculative execution without
+    # a rollback contract. Populated by Scheduler at batch admission.
+    _mtp_safe_logits_processors: tuple[Any, ...] = field(
+        default_factory=tuple, init=False, repr=False
+    )
+
     # PFlash prompt compression state. When pflash_metadata["compressed"]
     # is True, prompt_token_ids is the compressed list and
     # original_prompt_token_ids holds the pre-compression sequence so

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -742,6 +742,7 @@ def _install_mtp_vendored(
     model: Any,
     requests: dict[str, Any] | None = None,
     uid_to_request_id: dict[int, str] | None = None,
+    uid_to_request_processors: dict[int, list] | None = None,
     max_k: int = 3,
     disable_auto_k: bool = False,
     controller_key: str | None = None,
@@ -919,6 +920,7 @@ def _install_mtp_vendored(
     # uid can log both "B>1" and "non-greedy" if it hits both, but
     # each reason surfaces at most once per uid lifetime.
     _handoff_logged: set[tuple[int, str]] = set()
+    _initial_skip_logged: set[tuple[int, str]] = set()
 
     def _log_mtp_mid_stream_handoff_once(uid: int, reason: str, detail: str) -> None:
         """Emit a WARN log for a mid-stream MTP → plain-decode handoff,
@@ -953,6 +955,18 @@ def _install_mtp_vendored(
             uid,
             reason,
             detail,
+        )
+
+    def _log_mtp_initial_skip_once(uid: int, reason: str) -> None:
+        """Surface a request that never entered MTP without log spam."""
+        key = (uid, reason)
+        if key in _initial_skip_logged:
+            return
+        _initial_skip_logged.add(key)
+        logger.info(
+            "[MTP-vendored] uid=%s remains on plain decode: %s.",
+            uid,
+            reason,
         )
 
     def _cleanup_uid(uid: int) -> None:
@@ -1009,18 +1023,43 @@ def _install_mtp_vendored(
         if getattr(sp, "seed", None) is not None:
             return None, "request-local seeded RNG is not yet supported"
 
+        # The scheduler's uid-keyed map is the processor source of truth. At
+        # the PromptProcessingBatch -> persistent GenerationBatch transition,
+        # mlx-lm can expose the live uid before its positional processor row is
+        # populated. Reading only ``gb.logits_processors[0]`` at that seam made
+        # Desktop's standard repetition penalty look like a custom-processor
+        # mismatch and permanently parked the request on plain decode (#2654).
+        #
+        # Keep the positional fallback for standalone/benchmark callers that
+        # do not own scheduler admission state. Production always passes the
+        # uid map; custom, grammar, tool, and reasoning processors remain in
+        # that authoritative list and therefore still fail closed below.
         row_processors: list[Any] = []
-        all_processors = getattr(gb, "logits_processors", None)
-        if all_processors:
-            row = all_processors[0]
-            if row:
-                row_processors = list(row)
+        if uid_to_request_processors is not None:
+            row_processors = list(uid_to_request_processors.get(uid, ()))
+        else:
+            all_processors = getattr(gb, "logits_processors", None)
+            if all_processors:
+                row = all_processors[0]
+                if row:
+                    row_processors = list(row)
         safe_processors = list(getattr(req, "_mtp_safe_logits_processors", ()))
-        if len(row_processors) != len(safe_processors) or any(
-            actual is not safe
+        identities_match = len(row_processors) == len(safe_processors) and all(
+            actual is safe
             for actual, safe in zip(row_processors, safe_processors, strict=True)
-        ):
-            return None, "custom or stateful logits processor is active"
+        )
+        if not identities_match:
+            active_types = ",".join(
+                type(processor).__name__ for processor in row_processors
+            )
+            safe_types = ",".join(
+                type(processor).__name__ for processor in safe_processors
+            )
+            return None, (
+                "custom or stateful logits processor is active "
+                f"(active={len(row_processors)} [{active_types or '-'}], "
+                f"safe={len(safe_processors)} [{safe_types or '-'}])"
+            )
 
         try:
             fingerprint = (
@@ -1279,6 +1318,7 @@ def _install_mtp_vendored(
                 )
                 _record_terminal_disable(uid)
             else:
+                _log_mtp_initial_skip_once(uid, sampling_skip_reason)
                 _mark_disabled(uid)
             return _orig_step()
 
@@ -3820,6 +3860,7 @@ class Scheduler:
                     model=self.model,
                     requests=self.requests,
                     uid_to_request_id=self.uid_to_request_id,
+                    uid_to_request_processors=self.uid_to_request_processors,
                     # 0.9.13 PR-B: EV depth controller knobs.
                     max_k=getattr(self.config, "mtp_max_k", 3),
                     disable_auto_k=getattr(self.config, "mtp_disable_auto_k", False),

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -777,15 +777,16 @@ def _install_mtp_vendored(
       batch=1-only (``mtp_forward`` raises on B>1) and the vendored
       generator maintains its own per-request state.
 
-    * Greedy sampling only (temperature == 0). Non-greedy falls through
-      to ``_orig_step`` — the byte-lossless verify contract lives in the
-      generator's residual-distribution sampling on reject, which the
-      MVP does not exercise. Non-greedy support is a follow-up.
+    * Request-local temperature / top-p / top-k / min-p are passed through to
+      the generator's target-distribution verifier. Seeded requests still fall
+      through because the vendored generator does not yet accept a request-
+      local PRNG key.
 
-    * No logits processors. If any position of ``gb.logits_processors``
-      is truthy we fall through — the generator has its own logits-
-      processor plumbing but wiring the mlx-lm per-uid processor list
-      through to the generator is out of MVP scope.
+    * The standard repetition / presence / frequency penalty processors are
+      passed through with the exact mlx-lm token history at the handoff seam.
+      Custom, grammar, tool, and reasoning-budget processors still fall
+      through because their mutable state needs an explicit speculative
+      rollback contract.
 
     * On the very first ``_step`` call we short-circuit and return the
       token that mlx-lm's fresh ``GenerationBatch.__init__._step()``
@@ -984,45 +985,73 @@ def _install_mtp_vendored(
             except Exception:  # noqa: BLE001
                 pass
 
-    def _is_greedy_for_uid(uid: int) -> bool:
-        """Return True when the request behind ``uid`` sampled at temp=0.
+    def _sampling_options_for_uid(uid: int) -> tuple[dict[str, Any] | None, str]:
+        """Resolve the request-local MTP sampling contract, fail closed.
 
-        Matches the greedy contract that
-        ``vllm_mlx/spec_decode/mtp/generator.py::mtp_generate_step``
-        implements with ``temp=0.0``. Under temp>0, the vendored
-        generator can still preserve the lossless marginal via its
-        residual-distribution sample on reject — but the MVP install
-        hard-codes ``temp=0.0`` into the generator constructor, so any
-        request with temperature>0 would silently receive a
-        different sampled marginal.
-
-        Codex round-A blocker #1: fail closed on unresolvable metadata.
-        Prior revision returned ``True`` when ``uid_to_request_id`` or
-        ``requests`` were ``None`` (or the request lookup failed) —
-        that would silently apply greedy sampling to a temp>0 request
-        whose bookkeeping had just been evicted. Return ``False`` here
-        so the caller falls through to ``_orig_step()`` (which reads
-        the real sampler from ``gb.samplers[0]``) instead of applying
-        the MTP-hardcoded greedy path.
-
-        Codex round-B blocker: also fail closed when ``temperature is
-        None``. ``vllm_mlx.request.SamplingParams`` defaults
-        ``temperature=0.7`` (not zero) and ``None`` is not a normal
-        value — it typically signals "use the server / OpenAI-route
-        default," which is likewise nonzero. Treating a bare ``None``
-        as greedy would silently apply the MTP-hardcoded ``temp=0.0``
-        marginal to a request the operator meant to sample stochast-
-        ically. Only an EXPLICIT ``0.0`` passes the gate; every other
-        shape falls through to plain decode.
+        The scheduler owns the authoritative ``SamplingParams`` object and the
+        exact per-row processor list installed into mlx-lm. Only processors
+        explicitly marked as the standard penalty list at request insertion
+        may cross this seam; identity comparison prevents a future custom
+        processor with the same list length from being mistaken for a safe
+        one.
         """
         if uid_to_request_id is None or requests is None:
-            return False
+            return None, "request metadata is unavailable"
         req_id = uid_to_request_id.get(uid)
         req = requests.get(req_id) if req_id else None
-        if req is None or getattr(req, "sampling_params", None) is None:
-            return False
-        temp = getattr(req.sampling_params, "temperature", None)
-        return temp == 0.0
+        sp = getattr(req, "sampling_params", None) if req is not None else None
+        if sp is None:
+            return None, "sampling parameters are unavailable"
+
+        temp = getattr(sp, "temperature", None)
+        if temp is None:
+            return None, "temperature is unresolved"
+        if getattr(sp, "seed", None) is not None:
+            return None, "request-local seeded RNG is not yet supported"
+
+        row_processors: list[Any] = []
+        all_processors = getattr(gb, "logits_processors", None)
+        if all_processors:
+            row = all_processors[0]
+            if row:
+                row_processors = list(row)
+        safe_processors = list(getattr(req, "_mtp_safe_logits_processors", ()))
+        if len(row_processors) != len(safe_processors) or any(
+            actual is not safe
+            for actual, safe in zip(row_processors, safe_processors, strict=True)
+        ):
+            return None, "custom or stateful logits processor is active"
+
+        try:
+            fingerprint = (
+                float(temp),
+                float(getattr(sp, "top_p", 0.9)),
+                int(getattr(sp, "top_k", 0)),
+                float(getattr(sp, "min_p", 0.0)),
+            )
+        except (TypeError, ValueError, OverflowError):
+            return None, "sampling parameters are invalid"
+        if not all(math.isfinite(value) for value in fingerprint):
+            return None, "sampling parameters are invalid"
+
+        initial_tokens: list[int] | None = None
+        if row_processors:
+            try:
+                initial_tokens = list(gb.tokens[0])
+            except (IndexError, TypeError):
+                return None, "processor token history is unavailable"
+        return (
+            {
+                "temp": fingerprint[0],
+                "top_p": fingerprint[1],
+                "top_k": fingerprint[2],
+                "min_p": fingerprint[3],
+                "logits_processors": row_processors or None,
+                "initial_tokens": initial_tokens,
+                "fingerprint": fingerprint,
+            },
+            "",
+        )
 
     def _mtp_step():
         """Wrapped ``GenerationBatch._step`` for MTP speculative decoding.
@@ -1223,9 +1252,13 @@ def _install_mtp_vendored(
                 _stats["ft_disabled"] += 1
                 return _orig_step()
 
-        if not _is_greedy_for_uid(uid):
+        sampling_options, sampling_skip_reason = _sampling_options_for_uid(uid)
+        if sampling_options is None:
             _stats["fallthrough_steps"] += 1
-            _stats["ft_non_greedy"] += 1
+            if "processor" in sampling_skip_reason:
+                _stats["ft_logits_processors"] += 1
+            else:
+                _stats["ft_non_greedy"] += 1
             # Codex round-L BLOCKING #3: prior round-H revision raised
             # ``RuntimeError`` here when sampling switched to non-
             # greedy after MTP had already emitted. That killed the
@@ -1241,34 +1274,8 @@ def _install_mtp_vendored(
                 _stats["ft_mid_stream_handoff"] += 1
                 _log_mtp_mid_stream_handoff_once(
                     uid,
-                    "non_greedy",
-                    "sampling switched to temperature > 0 mid-stream",
-                )
-                _record_terminal_disable(uid)
-            else:
-                _mark_disabled(uid)
-            return _orig_step()
-
-        _lp = getattr(gb, "logits_processors", None)
-        if _lp and any(p for p in _lp if p):
-            _stats["fallthrough_steps"] += 1
-            _stats["ft_logits_processors"] += 1
-            # Codex round-L BLOCKING #4: prior round-H revision raised
-            # ``RuntimeError`` here when a logits processor was added
-            # mid-stream after MTP had already emitted. That killed
-            # the request whenever an operator toggled a per-request
-            # processor (e.g., a guided-decoding grammar) after the
-            # first tokens streamed.
-            #
-            # Round-L fix: hand off to ``_orig_step`` regardless of
-            # state. Same handoff pattern as B>1 and non-greedy: log
-            # once per uid, mark disabled, delegate.
-            if uid in _state:
-                _stats["ft_mid_stream_handoff"] += 1
-                _log_mtp_mid_stream_handoff_once(
-                    uid,
-                    "logits_processor",
-                    "logits processor appeared mid-stream",
+                    "sampling_unsupported",
+                    sampling_skip_reason,
                 )
                 _record_terminal_disable(uid)
             else:
@@ -1276,6 +1283,21 @@ def _install_mtp_vendored(
             return _orig_step()
 
         state = _state.get(uid)
+
+        if (
+            state is not None
+            and state.get("sampling_fingerprint") != sampling_options["fingerprint"]
+        ):
+            _stats["fallthrough_steps"] += 1
+            _stats["ft_non_greedy"] += 1
+            _stats["ft_mid_stream_handoff"] += 1
+            _log_mtp_mid_stream_handoff_once(
+                uid,
+                "sampling_changed",
+                "request sampling parameters changed after MTP started",
+            )
+            _record_terminal_disable(uid)
+            return _orig_step()
 
         # Codex round-K BLOCKING #1: uid reuse detection for the
         # ACTIVE (non-disabled) state map. mlx-lm reuses uid ints
@@ -1370,7 +1392,12 @@ def _install_mtp_vendored(
                     model=mtp_model,
                     max_tokens=gen_max,
                     prompt_cache=gb.prompt_cache,
-                    temp=0.0,
+                    temp=sampling_options["temp"],
+                    top_p=sampling_options["top_p"],
+                    top_k=sampling_options["top_k"],
+                    min_p=sampling_options["min_p"],
+                    logits_processors=sampling_options["logits_processors"],
+                    initial_tokens=sampling_options["initial_tokens"],
                     # 0.9.13 PR-B: EV depth controller.
                     # Fallback key derived from the model's SHAPE, not
                     # its address. ``SchedulerConfig`` carries no model
@@ -1439,6 +1466,7 @@ def _install_mtp_vendored(
                 "queue": [],
                 "primed": True,
                 "request_id": _first_call_req_id,
+                "sampling_fingerprint": sampling_options["fingerprint"],
             }
             _stats["vendored_steps"] += 1
             # Codex round-I BLOCKING #2 / round-J BLOCKING #2+#3:
@@ -1577,8 +1605,8 @@ def _install_mtp_vendored(
 
     logger.info(
         "[MTP-vendored] installed on GenerationBatch._step "
-        "(single-request greedy adaptive chain-of-K; falls through on B>1 / "
-        "non-greedy / logits-processors)."
+        "(single-request adaptive chain-of-K with request-local sampling; "
+        "falls through on B>1 / seeded sampling / custom logits-processors)."
     )
     return True
 
@@ -6894,30 +6922,30 @@ class Scheduler:
             # extension (not OpenAI-spec) and is documented as multiplicative
             # over a rolling window.
             sp = request.sampling_params
+            penalty_processors: list[Any] = []
             if (
                 sp.repetition_penalty != 1.0
                 or sp.presence_penalty != 0.0
                 or sp.frequency_penalty != 0.0
             ):
-                request_processors.extend(
-                    make_logits_processors(
-                        repetition_penalty=(
-                            sp.repetition_penalty
-                            if sp.repetition_penalty != 1.0
-                            else None
-                        ),
-                        presence_penalty=(
-                            sp.presence_penalty if sp.presence_penalty != 0.0 else None
-                        ),
-                        presence_context_size=4096,
-                        frequency_penalty=(
-                            sp.frequency_penalty
-                            if sp.frequency_penalty != 0.0
-                            else None
-                        ),
-                        frequency_context_size=4096,
-                    )
+                penalty_processors = make_logits_processors(
+                    repetition_penalty=(
+                        sp.repetition_penalty if sp.repetition_penalty != 1.0 else None
+                    ),
+                    presence_penalty=(
+                        sp.presence_penalty if sp.presence_penalty != 0.0 else None
+                    ),
+                    presence_context_size=4096,
+                    frequency_penalty=(
+                        sp.frequency_penalty if sp.frequency_penalty != 0.0 else None
+                    ),
+                    frequency_context_size=4096,
                 )
+                request_processors.extend(penalty_processors)
+            # MTP may reuse only this exact standard-penalty list. Identity
+            # (not processor count or type-name heuristics) is the fail-closed
+            # contract at the GenerationBatch handoff.
+            request._mtp_safe_logits_processors = tuple(penalty_processors)
             # Generation-time thinking-token budget (force-close </think>).
             # Appended LAST so its force-close mask (all but </think> -> -inf)
             # has final say over any penalty/grammar bias in the same step;

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -208,6 +208,7 @@ def mtp_generate_step(
     kv_group_size: int = 64,
     quantized_kv_start: int = 0,
     input_embeddings: mx.array | None = None,
+    initial_tokens: list[int] | mx.array | None = None,
     temp: float = 0.0,
     top_p: float = 0.0,
     top_k: int = 0,
@@ -335,7 +336,21 @@ def mtp_generate_step(
         if _prompt_lookup_enabled:
             generated_token_ids.append(token_id)
 
-    prev_tokens: mx.array | None = None
+    # ``BatchGenerator`` has already sampled the first generated token before
+    # the MTP wrapper takes over. Stateful-by-context processors (the standard
+    # repetition / presence / frequency penalties) must therefore start from
+    # the exact token history that mlx-lm's ``TokenBuffer`` had at that seam.
+    # Copy it into the vendored generator rather than restarting processor
+    # context at the first generated token. Callers without processors keep
+    # the old allocation-free ``None`` path.
+    if logits_processors and initial_tokens is not None:
+        prev_tokens = (
+            initial_tokens.astype(mx.uint32)
+            if isinstance(initial_tokens, mx.array)
+            else mx.array(list(initial_tokens), dtype=mx.uint32)
+        )
+    else:
+        prev_tokens = None
 
     if prompt_cache is None:
         model_cache = _cache_module.make_prompt_cache(model)
@@ -950,14 +965,12 @@ def mtp_generate_step(
                 xtc_draw=first_xtc_draw,
             )
 
-            # One shared uniform for all positions' probabilistic
-            # accept tests. Ollama uses a per-position Bernoulli draw;
-            # at greedy temp=0 the draw is ignored (accept iff argmax
-            # match), so this only matters for temp>0 where the same
-            # ``u`` biases all positions the same way — closer to
-            # Ollama's per-position draw than reusing the sampler
-            # chain's XTC cell would be.
-            u = mx.random.uniform()
+            # One independent uniform per speculative position. Reusing one
+            # scalar across K positions preserves each isolated acceptance
+            # probability but correlates the sequential accept decisions,
+            # changing the joint token distribution for K>1. Independent
+            # Bernoulli draws are required by rejection sampling.
+            u = mx.random.uniform(shape=(k_len,))
             drafts_i32 = drafts_arr.astype(mx.int32)
 
             # --------------------------------------------------------
@@ -975,7 +988,7 @@ def mtp_generate_step(
                 bonus_tok_arr = toks[k_len]
             else:
                 # Vectorized per-position log-accept over the K draft
-                # positions with a shared draw ``u``.
+                # positions with one independent draw per position.
                 v_alps = accept_lps[:k_len]  # (K, V)
                 idx = drafts_i32.reshape(-1, 1)  # (K, 1)
                 v_at = mx.take_along_axis(v_alps, idx, axis=1).squeeze(-1)

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -630,13 +630,19 @@ def mtp_generate_step(
         draft_accept_lps: list = []
         xtc_draws: list = []
         prev_tok = main_tok
+        # Processor history for draft position j must contain the confirmed
+        # prefix plus main_tok and every earlier draft in this chain. Keeping
+        # ``prev`` fixed made d2 see ``prev + d1`` (omitting main_tok), and d3
+        # see ``prev + d2`` (omitting both), which weakens repetition/presence/
+        # frequency penalties precisely when K > 1.
+        chain_prev = prev
         cur_hidden = hidden_last
         cur_commit = cache_commit
         for _k in range(K):
             d_tok, d_lp, d_alp, d_xtc, d_hidden = _step_mtp(
                 cur_hidden,
                 prev_tok,
-                prev,
+                chain_prev,
                 cache_commit=cur_commit,
                 want_hidden=_mtp_supports_hidden and K >= 2,
             )
@@ -649,6 +655,12 @@ def mtp_generate_step(
             draft_lps.append(d_lp)
             draft_accept_lps.append(d_alp)
             xtc_draws.append(d_xtc)
+            if logits_processors:
+                chain_prev = (
+                    mx.concatenate([chain_prev, prev_tok.reshape(-1)])
+                    if chain_prev is not None
+                    else prev_tok.reshape(-1)
+                )
             prev_tok = d_tok
             # Drafter-hidden cascade: swap in the drafter's own
             # ``post_projection(h)`` for the next iteration's hidden

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -940,7 +940,6 @@ def mtp_generate_step(
             # -------------------------------------------------------
             k_len = len(pending_drafts)
             draft_toks_arr = [rec[0] for rec in pending_drafts]
-            draft_lps_arr = [rec[1] for rec in pending_drafts]
             draft_alps_arr = [rec[2] for rec in pending_drafts]
             first_xtc_draw = pending_drafts[0][3]
 
@@ -1101,14 +1100,14 @@ def mtp_generate_step(
             for i in range(accepted_count):
                 accept_counter.record_accept(tokens_saved=1)
                 ntoks += 1
-                draft_lp = draft_lps_arr[i]
-                # The fused greedy drafter intentionally never builds a
-                # full-vocabulary draft logprob row.  The accepted token is
-                # also the target argmax, so its target row is the correct
-                # serving logprob surface and is already available here.
                 draft_id = int(draft_ids[i])
                 _remember_generated(draft_id)
-                yield draft_id, lps[i] if draft_lp is None else draft_lp, True
+                # Serving logprobs always describe the target model, even when
+                # the emitted token originated as a draft.  Returning the
+                # drafter row here leaks q(token) to API clients instead of the
+                # verified target p(token); the distributions legitimately
+                # differ on a probabilistically accepted proposal.
+                yield draft_id, lps[i], True
                 if ntoks >= max_tokens:
                     return
 
@@ -1159,6 +1158,11 @@ def mtp_generate_step(
 
                 ntoks += 1
                 _remember_generated(verify_tok_id)
+                # ``lps[position]`` is the full target-model logprob row, not
+                # a scalar attached to the independently pre-sampled
+                # ``toks[position]``.  Indexing this row later with the emitted
+                # residual token therefore reports its target probability,
+                # while rejection sampling preserves the target marginal.
                 yield verify_tok_id, lps[accepted_count], False
                 if ntoks >= max_tokens:
                     return


### PR DESCRIPTION
## Summary

- pass each request's temperature, top-p, top-k, and min-p into target-verified MTP instead of restricting the lane to greedy decode
- carry the exact generated-token history into the standard repetition/presence/frequency penalty processors at the MTP handoff, including every token in a K > 1 draft chain
- read processor eligibility from the scheduler's UID-keyed admission state so the prefill-to-decode transition cannot temporarily hide a safe penalty row
- preserve fail-closed behavior for request-local seeds and custom/stateful grammar, tool, reasoning, or suppression processors
- use one independent acceptance draw per speculative position and expose target-model logprobs for accepted drafts

## User impact

Desktop enables MTP at server startup, but its ordinary sampling defaults use temperature `0.7`, top-p `0.95`, and repetition penalty `1.1`. Before this change, otherwise eligible requests silently ran plain decode: the model answered correctly, while proposal/accept metrics stayed at zero and users received no MTP speedup. The same local sidecar produced proposals on a greedy control request, isolating the failure to request eligibility rather than model attachment.

After this change, plain Desktop chats and API/CLI requests using the ordinary sampling contract can use target-verified MTP. Every draft is still checked by the target model; unsupported stateful processors and seeded requests continue on ordinary decode.

Desktop's three built-in tools are enabled by default and intentionally install stateful tool processors. Those tools-enabled requests still fail closed on ordinary decode; #2658 tracks making that per-request limitation visible or providing a safe processor transaction contract. This PR does not silently remove tools or weaken their grammar to claim a speedup.

## Design precedent

Production speculative decoders preserve the target distribution by evaluating draft-token acceptance against the target and sampling from the residual distribution on rejection. They also keep per-request sampler state authoritative at the scheduler boundary and disable speculation when a request feature lacks an explicit rollback/replay contract. This change adapts those established boundaries: scheduler-owned sampling metadata, identity-checked safe processors, exact history transfer, target verification, and fail-closed fallback.

## Scope

- text scheduler MTP handoff and request bookkeeping
- vendored MTP sampling/acceptance behavior
- focused request, scheduler-wiring, and generator regressions

## Non-goals

- enabling MTP when the operator/Desktop toggle is off
- request-local seeded MTP RNG support
- speculative rollback for grammar, tool, reasoning-budget, suppression, or arbitrary custom processors
- model-loading, cache-format, Desktop UI, release, or dependency changes

## Verification

- exact head `f7fcd66a`; 305 focused tests passed across MTP wiring/generator, request contracts, scheduler admission, and cache snapshot regressions
- local changed-lines coverage executes every previously uncovered scheduler line; Ruff, format, and `git diff --check` are clean
- full local suite: 19,689 passed, 104 skipped, 22 deselected, 6 xfailed, 1 xpassed
- Qwen3.5, diffusion-Gemma, and harmony stress/agent lanes passed; Qwen3.6 stopped before load on the explicit disk guard because its 32.3 GB download exceeded available space, documented on the PR without bypass or rerun
- hosted exact-head Apple Silicon, engine contracts, type checks, validation, and Python 3.11/3.12 matrices passed; remaining exact-head jobs must be green before queueing
- full local Desktop bundle built and ad-hoc signed from production-tree head `4e188a58`; the final commit is tests-only
- five real-model spot cases passed: exact English, exact Chinese, integer math, compact valid JSON, valid Python
- 320-token sampled response with repetition penalty: proposals `5 -> 199`, accepts `2 -> 113`, cumulative ratio `0.5678`, 39.2 tok/s
- two identical seeded requests were byte-identical and proposal counters did not move
- strict JSON-schema and required-tool paths remained on ordinary decode
- exact-bundle GUI short request returned `GUI_MTP_FIXED_OK`; proposals `0 -> 2`, accepts `0 -> 1`
- exact-bundle GUI long request returned 368 tokens ending `FINAL_CHAIN_OK`; 243 proposals / 140 accepts (`0.5761`) at 39.7 tok/s
- all three built-in tools were restored after each test; App and child server shut down cleanly; no dogfood model remains resident

Closes #2654
