### PR TITLE
fix: align Qwen3.8 tool-call wire format

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -122,6 +122,17 @@ def test_qwen38_flash_next_alias_is_experimental_and_memory_gated() -> None:
     assert detect_model_config(profile.hf_path) == profile
 
 
+def test_qwen38_27b_aliases_pin_the_native_named_xml_tool_contract() -> None:
+    """Both shipped 27B quants use the same native XML tool template."""
+
+    profiles = list_profiles()
+    for alias in ("qwen3.8-27b-4bit", "qwen3.8-27b-mixed-3.5bpw"):
+        profile = profiles[alias]
+        assert profile.tool_call_parser == "qwen3_coder_xml"
+        assert detect_model_config(alias) == profile
+        assert detect_model_config(profile.hf_path) == profile
+
+
 @pytest.mark.parametrize("bad_value", [0, 1, "true", None])
 def test_experimental_alias_flag_requires_a_boolean(bad_value) -> None:
     from vllm_mlx.model_aliases import _coerce

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -43,6 +43,7 @@ can silently drift from production.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -739,6 +740,84 @@ def test_t3_chat_route_recovers_args_when_possible():
         assert leak not in reasoning, (
             f"recoverable-args path leaked {leak!r} into reasoning: {reasoning!r}"
         )
+
+
+_REQUIRED_ADD_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add_numbers",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    }
+]
+
+
+def test_required_named_xml_call_returns_schema_valid_arguments():
+    """The Qwen3.8 native wire reaches clients as ordinary JSON arguments."""
+    raw = (
+        "<tool_call>\n"
+        "<function=add_numbers>\n"
+        "<parameter=a>\n2\n</parameter>\n"
+        "<parameter=b>\n3\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+
+    class _ValidNamedXmlEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    client = _make_client(_ValidNamedXmlEngine(), tool_call_parser="qwen3_coder_xml")
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add two numbers"}],
+            "tools": _REQUIRED_ADD_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    call = resp.json()["choices"][0]["message"]["tool_calls"][0]["function"]
+    assert call["name"] == "add_numbers"
+    assert json.loads(call["arguments"]) == {"a": 2, "b": 3}
+
+
+def test_required_named_xml_call_with_missing_required_arg_fails_closed():
+    """A parser drift must not surface an executable-looking malformed 200."""
+
+    raw = "<tool_call>\n<function=add_numbers>\n</function>\n</tool_call>"
+
+    class _MissingRequiredArgEngine(_RecordingEngine):
+        def __init__(self):
+            super().__init__(text=raw, raw_text=raw)
+
+    client = _make_client(
+        _MissingRequiredArgEngine(), tool_call_parser="qwen3_coder_xml"
+    )
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "add two numbers"}],
+            "tools": _REQUIRED_ADD_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 64,
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "missing required argument" in resp.text
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -1603,6 +1603,39 @@ class TestQwen3XmlAlias:
             "qwen3_coder_xml must remain bound to the Coder parser"
         )
 
+    def test_qwen38_native_named_xml_round_trips_arguments(self):
+        """Qwen3.8's template emits the same named XML parameter body."""
+        parser = ToolParserManager.get_tool_parser("qwen3_coder_xml")(tokenizer=None)
+        text = (
+            "<tool_call>\n"
+            "<function=get_weather>\n"
+            "<parameter=city>\nParis\n</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ]
+        }
+
+        result = parser.extract_tool_calls(text, request)
+
+        assert result.tools_called
+        assert result.content in (None, "")
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"city": "Paris"}
+
     def test_qwen3_xml_streaming_emits_tool_call(self):
         """Streaming path: feed reasoning-model output token-by-token through qwen3_xml.
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -384,7 +384,7 @@
   },
   "qwen3.8-27b-4bit": {
     "hf_path": "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
@@ -393,7 +393,7 @@
   },
   "qwen3.8-27b-mixed-3.5bpw": {
     "hf_path": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5868,9 +5868,23 @@ async def _create_chat_completion_impl(
                     if _repair_err:
                         raise HTTPException(status_code=422, detail=_repair_err)
 
+    # Required and named tool choices are executable contracts, not best-effort
+    # extraction. Decoder constraints normally make these calls schema-valid;
+    # fail closed if a future template/parser mismatch still reaches this
+    # boundary instead of returning malformed arguments as a successful call.
+    _normalized_tool_choice = _normalize_tool_choice_for_grammar(request.tool_choice)
+    _is_forced_choice = bool(
+        _normalized_tool_choice
+        and _normalized_tool_choice.get("mode") in ("required", "named")
+    )
+
     # Validate tool call parameter values against schemas
     if tool_calls and request.tools:
-        _validate_tool_call_params(tool_calls, request.tools)
+        _validate_tool_call_params(
+            tool_calls,
+            request.tools,
+            enforce_required=_is_forced_choice,
+        )
 
     # D-TOOLCHOICE-R1 T3: scrub wire-marker leftovers from the
     # response text. Two trigger conditions:
@@ -5913,11 +5927,6 @@ async def _create_chat_completion_impl(
     # model ignores ``tool_choice="required"`` and emits ordinary
     # prose. Scrub only when the visible text contains STRUCTURAL
     # parser-wire residue, not merely a literal token mention.
-    _normalized_tool_choice = _normalize_tool_choice_for_grammar(request.tool_choice)
-    _is_forced_choice = bool(
-        _normalized_tool_choice
-        and _normalized_tool_choice.get("mode") in ("required", "named")
-    )
     _raw_text_for_reasoning = output.raw_text or output.text
     _raw_has_structural_wire = _contains_structural_tool_wire_leak(
         _raw_text_for_reasoning

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -135,10 +135,12 @@ def _convert_param_value(
 @ToolParserManager.register_module(["qwen3_coder_xml"])
 class Qwen3CoderToolParser(ToolParser):
     """
-    Tool call parser for Qwen3-Coder models using XML format.
+    Tool call parser for Qwen3-family models using named XML format.
 
     Supports the XML-based tool call format with <tool_call>/<function=...>
-    tags and type conversion from tool schema.
+    tags and type conversion from tool schema. The parser name is retained for
+    CLI compatibility; routing is based on the checkpoint's wire format, which
+    is also used by Qwen3.8 27B.
 
     Used when --enable-auto-tool-choice --tool-call-parser qwen3_coder_xml are set.
     """


### PR DESCRIPTION
## Summary

- route both shipped Qwen3.8 27B aliases through their checkpoint-native named-XML tool-call parser and grammar
- fail closed when a required or named chat tool call reaches response assembly without valid JSON-object arguments or required fields
- pin alias, parser round-trip, valid route, invalid route, streaming, and schema regressions

## User impact

A required single-tool request to Qwen3.8 27B now returns one OpenAI-compatible call whose arguments parse as JSON, rather than a mixed JSON/XML payload that agents cannot execute. If parser/template drift produces incomplete required arguments in the future, the non-streaming route returns a typed client error instead of a successful executable-looking response.

## Scope

- Qwen3.8 27B alias metadata
- the existing named-XML parser documentation
- required/named chat response validation
- focused parser/router contracts

Non-goals: MTP changes, model/release/dependency bumps, Flash-Next routing, or a broader tool-parser redesign.

## Design precedent

Production inference servers enforce required and named tool selection with schema-constrained decoding tied to each model family's native wire format, then validate structured arguments before exposing them to clients. This change adapts that established boundary by reusing Rapid-MLX's existing named-XML grammar/parser and retaining post-parse validation as defense in depth.

## Verification

- `3289 passed, 2 skipped`: tool-choice enforcement, forced-choice empty arguments, schema enforcement, parser content safety, named-XML grammar, and alias contracts
- `137 passed`: parser streaming/non-streaming parity plus focused schema and alias contracts
- `114 passed`: exact final focused suite after documentation alignment
- ruff, format check, and `git diff --check` clean
- real cached `rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX`, offline, local source build on Studio:
  - non-streaming required `get_weather(city=Paris)`: HTTP 200, one call, JSON arguments exactly `{"city":"Paris"}`
  - streaming required request: one assembled call, same parsed arguments, terminal `finish_reason=tool_calls`
  - tool-result continuation: HTTP 200 normal final answer
  - malformed required named-XML call missing required fields: HTTP 400

Fixes #2656
