### PR TITLE
ci: verify mini GUI runner acceptance at 2e17121f

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -211,6 +211,7 @@ jobs:
             tests/test_gui_app_artifact.py \
             tests/test_gui_golden_ci_coverage.py \
             tests/test_gui_flow_routing.py \
+            tests/test_self_hosted_mac_runner.py \
             -q
 
       - name: Fake sidecar catalog contract

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -383,7 +383,7 @@ jobs:
           codesign --verify --deep --strict "$app"
           mkdir -p "$ARTIFACT_DIR"
           ditto -c -k --keepParent "$app" "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip"
-          python ../../scripts/gui_app_artifact.py create \
+          python3 ../../scripts/gui_app_artifact.py create \
             --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
             --source-sha "$GITHUB_SHA" \
             --output "$ARTIFACT_DIR/manifest.json"
@@ -485,7 +485,7 @@ jobs:
           ARTIFACT_DIR: ${{ runner.temp }}/gui-app-artifact
         run: |
           set -euo pipefail
-          python ../../scripts/gui_app_artifact.py verify \
+          python3 ../../scripts/gui_app_artifact.py verify \
             --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
             --manifest "$ARTIFACT_DIR/manifest.json" \
             --expected-source-sha "$GITHUB_SHA"

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -299,17 +299,69 @@ jobs:
       - name: verify chat timeout contract
         run: swift scripts/verify-chat-timeout.swift
 
+  # Resolve the GUI execution host before the artifact build starts. External
+  # heads are unconditionally hosted: public fork code must never reach
+  # project-owned hardware. Same-repository heads may use the logged-in mini
+  # only while the repository runner API reports an exact online label match.
+  # Missing/read-denied credentials and an offline runner fail safe to hosted
+  # macOS.
+  gui-runner:
+    needs: changes
+    if: >-
+      needs.changes.outputs.desktop == 'true' &&
+      needs.changes.outputs.full_gate == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on: ${{ steps.select.outputs.runs_on }}
+      runner_kind: ${{ steps.select.outputs.runner_kind }}
+    steps:
+      - name: Select GUI runner
+        id: select
+        env:
+          IS_TRUSTED_HEAD: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          MINI_GUI_RUNNER_READ_TOKEN: ${{ secrets.MINI_GUI_RUNNER_READ_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          selected='["macos-15"]'
+          kind=hosted
+
+          if [ "$IS_TRUSTED_HEAD" != true ]; then
+            echo "External head: using hosted macOS"
+          elif [ -z "$MINI_GUI_RUNNER_READ_TOKEN" ]; then
+            echo "::warning::MINI_GUI_RUNNER_READ_TOKEN is unavailable; falling back to hosted macOS"
+          elif ! runners=$(GH_TOKEN="$MINI_GUI_RUNNER_READ_TOKEN" \
+            gh api "repos/${REPO}/actions/runners?per_page=100"); then
+            echo "::warning::Runner status lookup failed; falling back to hosted macOS"
+          elif [ "$(jq '[.runners[] | select(
+              .status == "online" and
+              any(.labels[]; .name == "self-hosted") and
+              any(.labels[]; .name == "macOS") and
+              any(.labels[]; .name == "mini-gui")
+            )] | length' <<< "$runners")" -gt 0 ]; then
+            selected='["self-hosted","macOS","mini-gui"]'
+            kind=mini-gui
+            echo "Online mini-gui runner found"
+          else
+            echo "No online mini-gui runner; falling back to hosted macOS"
+          fi
+
+          echo "runs_on=$selected" >> "$GITHUB_OUTPUT"
+          echo "runner_kind=$kind" >> "$GITHUB_OUTPUT"
+
   # Build the release-shaped, sidecar-free app exactly once for every full
   # Desktop gate. GUI consumers must use this commit-bound artifact instead of
   # compiling their own copy. Keeping this as a dedicated producer makes the
   # next step (parallel journey shards) cheap without trusting a cache as test
   # evidence: the archive and its manifest are immutable outputs of this run.
   gui-app-build:
-    needs: changes
+    needs:
+      - changes
+      - gui-runner
     if: >-
       needs.changes.outputs.desktop == 'true' &&
       needs.changes.outputs.full_gate == 'true'
-    runs-on: macos-15
+    runs-on: ${{ fromJSON(needs.gui-runner.outputs.runs_on) }}
     timeout-minutes: 20
     defaults:
       run:
@@ -367,12 +419,13 @@ jobs:
     needs:
       - changes
       - gui-app-build
+      - gui-runner
     if: >-
       needs.changes.outputs.desktop == 'true' &&
       needs.changes.outputs.full_gate == 'true'
-    # macos-15 for the same reason as the build job: Package.swift is
-    # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
-    runs-on: macos-15
+    # The selector keeps forks on hosted macOS and sends eligible internal
+    # integration heads to the interactive mini when it is online.
+    runs-on: ${{ fromJSON(needs.gui-runner.outputs.runs_on) }}
     strategy:
       # A failure in one product journey must not cancel independent evidence
       # from the other selected groups. The stable desktop-tests facade still

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -334,17 +334,15 @@ jobs:
           elif ! runners=$(GH_TOKEN="$MINI_GUI_RUNNER_READ_TOKEN" \
             gh api "repos/${REPO}/actions/runners?per_page=100"); then
             echo "::warning::Runner status lookup failed; falling back to hosted macOS"
-          elif [ "$(jq '[.runners[] | select(
-              .status == "online" and
-              any(.labels[]; .name == "self-hosted") and
-              any(.labels[]; .name == "macOS") and
-              any(.labels[]; .name == "mini-gui")
-            )] | length' <<< "$runners")" -gt 0 ]; then
-            selected='["self-hosted","macOS","mini-gui"]'
-            kind=mini-gui
-            echo "Online mini-gui runner found"
           else
-            echo "No online mini-gui runner; falling back to hosted macOS"
+            online_count=$(jq '[.runners[] | select(.status == "online" and any(.labels[]; .name == "self-hosted") and any(.labels[]; .name == "macOS") and any(.labels[]; .name == "mini-gui"))] | length' <<< "$runners")
+            if [ "$online_count" -gt 0 ]; then
+              selected='["self-hosted","macOS","mini-gui"]'
+              kind=mini-gui
+              echo "Online mini-gui runner found"
+            else
+              echo "No online mini-gui runner; falling back to hosted macOS"
+            fi
           fi
 
           echo "runs_on=$selected" >> "$GITHUB_OUTPUT"

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -278,6 +279,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1268,18 +1268,10 @@ open_settings() {
         pb menu click --app "PID:$APP_PID" --item 'Settings…' --json > "$OUT/open-settings.json"
     else
         # Settings persistence is deliberately part of the unattended,
-        # AX-only suite. Use the standard macOS shortcut so that flow does
-        # not quietly depend on Peekaboo just to open the window.
-        osascript - "$APP_PID" > "$OUT/open-settings.json" <<'APPLESCRIPT'
-on run argv
-    set targetPID to (item 1 of argv) as integer
-    tell application "System Events"
-        set frontmost of first application process whose unix id is targetPID to true
-        keystroke "," using command down
-    end tell
-    return "{\"success\":true,\"method\":\"command-comma\"}"
-end run
-APPLESCRIPT
+        # AX-only suite. Send the standard macOS shortcut directly to the
+        # activated target app so the flow does not quietly depend on Peekaboo
+        # or a separate System Events Automation grant.
+        "$AX_DRIVER" key "$APP_PID" command-comma > "$OUT/open-settings.json"
     fi
     local probe=2 opened=0
     for _ in {1..40}; do

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -392,16 +392,32 @@ if command == "dump" {
 
 // Keyboard shortcuts are interaction contracts, not AXPress aliases. Post the
 // real key to the activated app so unattended golden flows can prove native
-// cancel semantics without taking a dependency on a screen-recording bridge.
+// keyboard behavior without taking a dependency on a screen-recording bridge
+// or on System Events Automation permission.
 if command == "key" {
-    guard wanted == "escape" else { fail("key supports only escape") }
-    guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 53, keyDown: true),
-          let up = CGEvent(keyboardEventSource: nil, virtualKey: 53, keyDown: false)
-    else { fail("could not create Escape key events") }
+    let virtualKey: CGKeyCode
+    let flags: CGEventFlags
+    switch wanted {
+    case "escape":
+        virtualKey = 53
+        flags = []
+    case "command-comma":
+        virtualKey = 43
+        flags = .maskCommand
+    default:
+        fail("key supports only escape and command-comma")
+    }
+    guard let down = CGEvent(
+              keyboardEventSource: nil, virtualKey: virtualKey, keyDown: true),
+          let up = CGEvent(
+              keyboardEventSource: nil, virtualKey: virtualKey, keyDown: false)
+    else { fail("could not create \(wanted ?? "requested") key events") }
+    down.flags = flags
+    up.flags = flags
     down.postToPid(pid)
     up.postToPid(pid)
     usleep(150_000)
-    print("{\"success\":true,\"key\":\"escape\",\"action\":\"key\"}")
+    print("{\"success\":true,\"key\":\"\(wanted ?? "")\",\"action\":\"key\"}")
     exit(0)
 }
 

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -33,4 +33,8 @@ xcodebuild test \
     -destination 'platform=macOS' \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
-    CODE_SIGNING_ALLOWED=NO
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGNING_ALLOWED=YES \
+    CODE_SIGNING_REQUIRED=YES \
+    CODE_SIGN_IDENTITY=- \
+    DEVELOPMENT_TEAM=

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
 APP="$ROOT/build/Rapid-MLX Desktop.app"
 RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
+DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:-${RESULT_BUNDLE%.xcresult}-DerivedData}"
 ONLY_TESTING="${RAPID_XCUI_ONLY_TESTING:-}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
@@ -31,6 +32,7 @@ xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \
     -destination 'platform=macOS' \
+    -derivedDataPath "$DERIVED_DATA" \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
     CODE_SIGN_STYLE=Manual \

--- a/docs/development/self-hosted-mac-runner.md
+++ b/docs/development/self-hosted-mac-runner.md
@@ -77,8 +77,18 @@ started, and `caffeinate` must hold display/system assertions. The workflow's
 Accessibility preflight remains fail-closed: a locked/missing GUI session or a
 missing TCC grant is a host failure, not an application failure.
 
-Grant Accessibility to the runner's interactive parent only through macOS
-System Settings. Do not edit the TCC database directly.
+Grant Accessibility only through macOS System Settings to every executable in
+the Actions responsibility chain:
+
+- `~/actions-runner-mini-gui/bin/Runner.Listener`
+- `~/actions-runner-mini-gui/bin/Runner.Worker`
+- `/bin/bash`
+- `~/actions-runner-mini-gui/externals/node20/bin/node`
+
+Restart the idle runner service after changing a grant, then rely on the
+workflow preflight as the authoritative end-to-end check. An SSH-launched AX
+probe does not exercise the same process chain. Do not edit the TCC database
+directly.
 
 ## Dogfood coexistence
 

--- a/docs/development/self-hosted-mac-runner.md
+++ b/docs/development/self-hosted-mac-runner.md
@@ -1,0 +1,115 @@
+# Self-hosted macOS GUI runner
+
+The `mini-gui` runner supplies the logged-in Aqua session needed to build the
+Desktop test app and run its GUI golden-flow gate. It is repository-scoped and
+is not a general model or release runner. The generic Swift build,
+`test-apple-silicon`, L1 smoke, and release jobs stay hosted because the mini is
+reserved for deterministic GUI work and does not replace those lanes' build,
+GPU, performance, or release contracts.
+
+## Security boundary
+
+Rapid-MLX is public. Never run code from a fork on project hardware. The
+workflow selector sends every external head to `macos-15` before it considers
+runner status. Only same-repository integration candidates, merge groups, and
+main pushes are eligible for `mini-gui`.
+
+The selector needs a repository-scoped, fine-grained token with only this
+repository and **Administration: read** permission so it can read runner
+online state. Store it as the Actions secret `MINI_GUI_RUNNER_READ_TOKEN`.
+Missing credentials, an API error, or no online matching runner all select the
+hosted fallback. Never reuse a release or publishing token for this purpose.
+
+## One-time installation
+
+1. Log in locally as the account that owns the interactive GUI session. Keep
+   that account logged in and the screen unlocked; SSH alone does not create
+   the GUI session.
+2. In repository **Settings → Actions → Runners**, choose **New self-hosted
+   runner**, macOS, ARM64. Use only the time-limited registration command shown
+   by the web UI. Do not request a token through the API, paste it into chat,
+   save it in a file, or commit it.
+3. Install the current ARM64 runner under `~/actions-runner-mini-gui` and verify
+   the archive SHA-256 against the release asset digest before extraction.
+4. From that directory, run the UI-provided configuration command with:
+
+   ```bash
+   ./config.sh \
+     --url https://github.com/raullenchai/Rapid-MLX \
+     --name mini-gui \
+     --labels mini-gui \
+     --work _work \
+     --unattended
+   ```
+
+   Insert the UI's `--token` argument in the private shell. The runner also
+   receives the default `self-hosted`, `macOS`, and `ARM64` labels.
+5. Install the service as the logged-in user, never with `sudo`. Point the
+   official service installer at the repository's interactive template so the
+   listener holds display/system sleep assertions for its whole lifetime:
+
+   ```bash
+   cp /path/to/Rapid-MLX/scripts/actions-runner-mini-gui.plist.template \
+     ~/actions-runner-mini-gui/bin/actions.runner.mini-gui.plist.template
+   cd ~/actions-runner-mini-gui
+   export GITHUB_ACTIONS_RUNNER_SERVICE_TEMPLATE="$PWD/bin/actions.runner.mini-gui.plist.template"
+   ./svc.sh install
+   ./svc.sh start
+   ./svc.sh status
+   ```
+
+   The generated file must live in `~/Library/LaunchAgents`; a system daemon
+   cannot provide the logged-in Aqua/TCC context.
+
+## Preflight and health
+
+Before accepting GUI jobs, verify:
+
+```bash
+stat -f %Su /dev/console
+pgrep -x Dock
+cd ~/actions-runner-mini-gui && ./svc.sh status
+pmset -g assertions
+```
+
+The console user must be the runner user, Dock must exist, the service must be
+started, and `caffeinate` must hold display/system assertions. The workflow's
+Accessibility preflight remains fail-closed: a locked/missing GUI session or a
+missing TCC grant is a host failure, not an application failure.
+
+Grant Accessibility to the runner's interactive parent only through macOS
+System Settings. Do not edit the TCC database directly.
+
+## Dogfood coexistence
+
+The mini remains available for daily development. Pause the runner before
+interactive development or dogfood needs exclusive use of its GUI session:
+
+```bash
+cd ~/actions-runner-mini-gui && ./svc.sh stop
+```
+
+The next workflow evaluates the runner as offline and selects hosted macOS.
+Resume after dogfood and confirm it returns online:
+
+```bash
+cd ~/actions-runner-mini-gui && ./svc.sh start
+cd ~/actions-runner-mini-gui && ./svc.sh status
+```
+
+Pause before dispatching the candidate: host selection is made once at workflow
+start, so stopping the service after selection can leave a selected job queued
+for the mini. Stopping the service also does not cancel a job already running.
+Let that job finish or cancel the workflow through the normal CI controls before
+stopping it.
+
+## Verification and recovery
+
+For the first live proof, use an internal integration candidate and confirm both
+`gui-app-build` and every `gui-golden-flows` matrix job report runner
+`mini-gui`; the `desktop-tests` aggregate must remain green. Then stop the
+service before dispatching another internal candidate and confirm both jobs
+report hosted `macos-15`.
+
+If the mini is unhealthy, leave the service stopped and use the hosted fallback.
+Do not weaken the GUI preflight or branch/fork guard to make a run start.

--- a/scripts/actions-runner-mini-gui.plist.template
+++ b/scripts/actions-runner-mini-gui.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>{{SvcName}}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/bin/caffeinate</string>
+      <string>-dimsu</string>
+      <string>{{RunnerRoot}}/runsvc.sh</string>
+    </array>
+    <key>UserName</key>
+    <string>{{User}}</string>
+    <key>WorkingDirectory</key>
+    <string>{{RunnerRoot}}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{UserHome}}/Library/Logs/{{SvcName}}/stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>ACTIONS_RUNNER_SVC</key>
+      <string>1</string>
+    </dict>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>SessionCreate</key>
+    <true/>
+  </dict>
+</plist>

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -67,8 +67,8 @@ def test_ax_dump_omits_non_finite_numbers_before_json_serialization():
 def test_ax_escape_posts_a_real_key_without_answering_nonmodal_consent():
     source = DRIVER.read_text()
     key = source.split('if command == "key" {', 1)[1].split("\n}", 1)[0]
-    assert 'wanted == "escape"' in key
-    assert "virtualKey: 53" in key
+    assert 'case "escape"' in key
+    assert "virtualKey = 53" in key
     assert "down.postToPid(pid)" in key
     assert "up.postToPid(pid)" in key
 
@@ -112,6 +112,19 @@ def test_active_switch_selects_the_fresh_native_menu_item_by_identifier():
     assert '"$AX_DRIVER" click-center "$APP_PID" ModelSwitchGuard.Cancel' in flow
     assert '"$AX_DRIVER" press "$APP_PID" ModelSwitchGuard.Cancel' not in flow
     assert '"$AX_DRIVER" key "$APP_PID" escape' not in flow
+
+
+def test_settings_shortcut_uses_ax_driver_without_system_events_automation():
+    driver = DRIVER.read_text()
+    key = driver.split('if command == "key" {', 1)[1].split("\n}", 1)[0]
+    assert 'case "command-comma"' in key
+    assert "virtualKey = 43" in key
+    assert "flags = .maskCommand" in key
+
+    settings = HARNESS.read_text().split("open_settings() {", 1)[1].split("\n}", 1)[0]
+    assert '"$AX_DRIVER" key "$APP_PID" command-comma' in settings
+    assert "osascript" not in settings
+    assert 'tell application "System Events"' not in settings
 
 
 def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert 'DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:' in runner
+    assert "${RESULT_BUNDLE%.xcresult}-DerivedData" in runner
+    assert '-derivedDataPath "$DERIVED_DATA"' in runner
     assert "CODE_SIGN_STYLE=Manual" in runner
     assert "CODE_SIGNING_ALLOWED=YES" in runner
     assert "CODE_SIGNING_REQUIRED=YES" in runner

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -1,3 +1,4 @@
+import plistlib
 from pathlib import Path
 
 import yaml
@@ -154,6 +155,17 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert "isExecutableFile" in source
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
+
+
+def test_xcui_runner_can_reserve_its_loopback_listener():
+    project = (
+        MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
+    ).read_text()
+    entitlements_path = MAC / "Tests/RapidUITests/RapidUITests.entitlements"
+    entitlements = plistlib.loads(entitlements_path.read_bytes())
+
+    assert project.count("CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;") == 2
+    assert entitlements == {"com.apple.security.network.server": True}
 
 
 def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,11 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert "CODE_SIGN_STYLE=Manual" in runner
+    assert "CODE_SIGNING_ALLOWED=YES" in runner
+    assert "CODE_SIGNING_REQUIRED=YES" in runner
+    assert "CODE_SIGN_IDENTITY=-" in runner
+    assert "CODE_SIGNING_ALLOWED=NO" not in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1

--- a/tests/test_self_hosted_mac_runner.py
+++ b/tests/test_self_hosted_mac_runner.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the repository-scoped interactive macOS GUI runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+PLIST = ROOT / "scripts/actions-runner-mini-gui.plist.template"
+DOC = ROOT / "docs/development/self-hosted-mac-runner.md"
+
+
+def _workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _selector_run() -> str:
+    return next(
+        step
+        for step in _workflow()["jobs"]["gui-runner"]["steps"]
+        if step["name"] == "Select GUI runner"
+    )["run"]
+
+
+def _execute_selector(
+    tmp_path: Path,
+    *,
+    trusted_head: bool,
+    token: str,
+    runners: dict[str, object] | None = None,
+    api_fails: bool = False,
+) -> tuple[dict[str, str], bool]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    called = tmp_path / "called"
+    payload = tmp_path / "runners.json"
+    payload.write_text(json.dumps(runners or {"total_count": 0, "runners": []}))
+    mock_gh = bin_dir / "gh"
+    mock_gh.write_text(
+        """#!/bin/bash
+set -euo pipefail
+touch "$MOCK_GH_CALLED"
+if [ "$MOCK_GH_FAILS" = true ]; then
+  exit 1
+fi
+cat "$MOCK_RUNNERS_JSON"
+"""
+    )
+    mock_gh.chmod(0o755)
+    output = tmp_path / "github-output"
+    env = os.environ | {
+        "GITHUB_OUTPUT": str(output),
+        "IS_TRUSTED_HEAD": str(trusted_head).lower(),
+        "MINI_GUI_RUNNER_READ_TOKEN": token,
+        "MOCK_GH_CALLED": str(called),
+        "MOCK_GH_FAILS": str(api_fails).lower(),
+        "MOCK_RUNNERS_JSON": str(payload),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "REPO": "test/repo",
+    }
+    subprocess.run(["bash", "-c", _selector_run()], check=True, env=env)
+    values = dict(
+        line.split("=", maxsplit=1) for line in output.read_text().splitlines()
+    )
+    return values, called.exists()
+
+
+def test_runner_selector_fails_safe_to_hosted_for_external_heads_and_api_failures():
+    job = _workflow()["jobs"]["gui-runner"]
+    step = next(step for step in job["steps"] if step["name"] == "Select GUI runner")
+    run = step["run"]
+
+    assert "head.repo.full_name == github.repository" in step["env"][
+        "IS_TRUSTED_HEAD"
+    ]
+    assert "selected='[\"macos-15\"]'" in run
+    assert 'if [ "$IS_TRUSTED_HEAD" != true ]' in run
+    assert 'if [ -z "$MINI_GUI_RUNNER_READ_TOKEN" ]' in run
+    assert 'elif ! runners=$(GH_TOKEN="$MINI_GUI_RUNNER_READ_TOKEN"' in run
+    assert 'gh api "repos/${REPO}/actions/runners?per_page=100"' in run
+    assert "falling back to hosted macOS" in run
+
+
+def test_runner_selector_executes_external_missing_token_and_api_fallbacks(tmp_path):
+    external, called = _execute_selector(
+        tmp_path / "external", trusted_head=False, token="secret"
+    )
+    assert external == {"runs_on": '["macos-15"]', "runner_kind": "hosted"}
+    assert not called
+
+    missing, called = _execute_selector(
+        tmp_path / "missing", trusted_head=True, token=""
+    )
+    assert missing == {"runs_on": '["macos-15"]', "runner_kind": "hosted"}
+    assert not called
+
+    failed, called = _execute_selector(
+        tmp_path / "failed", trusted_head=True, token="secret", api_fails=True
+    )
+    assert failed == {"runs_on": '["macos-15"]', "runner_kind": "hosted"}
+    assert called
+
+
+def test_runner_selector_requires_one_online_exact_label_match():
+    step = next(
+        step
+        for step in _workflow()["jobs"]["gui-runner"]["steps"]
+        if step["name"] == "Select GUI runner"
+    )
+    run = step["run"]
+    assert '.status == "online"' in run
+    for label in ("self-hosted", "macOS", "mini-gui"):
+        assert f'.name == "{label}"' in run
+    assert 'selected=\'["self-hosted","macOS","mini-gui"]\'' in run
+
+
+def test_runner_selector_executes_online_and_offline_routing(tmp_path):
+    labels = [
+        {"name": "self-hosted"},
+        {"name": "macOS"},
+        {"name": "ARM64"},
+        {"name": "mini-gui"},
+    ]
+    online, called = _execute_selector(
+        tmp_path / "online",
+        trusted_head=True,
+        token="secret",
+        runners={
+            "total_count": 1,
+            "runners": [{"status": "online", "busy": False, "labels": labels}],
+        },
+    )
+    assert online == {
+        "runs_on": '["self-hosted","macOS","mini-gui"]',
+        "runner_kind": "mini-gui",
+    }
+    assert called
+
+    offline, called = _execute_selector(
+        tmp_path / "offline",
+        trusted_head=True,
+        token="secret",
+        runners={
+            "total_count": 1,
+            "runners": [{"status": "offline", "busy": False, "labels": labels}],
+        },
+    )
+    assert offline == {"runs_on": '["macos-15"]', "runner_kind": "hosted"}
+    assert called
+
+
+def test_gui_jobs_use_selector_output_and_generic_build_stays_hosted():
+    jobs = _workflow()["jobs"]
+    for name in ("gui-app-build", "gui-golden-flows"):
+        job = jobs[name]
+        assert "gui-runner" in job["needs"]
+        assert job["runs-on"] == "${{ fromJSON(needs.gui-runner.outputs.runs_on) }}"
+
+    assert jobs["build"]["runs-on"] == "macos-15"
+
+
+def test_launchagent_template_is_interactive_and_holds_awake_assertions():
+    text = PLIST.read_text()
+    assert "{{RunnerRoot}}/runsvc.sh" in text
+    assert "{{User}}" in text and "{{UserHome}}" in text
+    assert "<string>/usr/bin/caffeinate</string>" in text
+    assert "<string>-dimsu</string>" in text
+    assert "<key>ProcessType</key>\n    <string>Interactive</string>" in text
+    assert "<key>SessionCreate</key>\n    <true/>" in text
+
+
+def test_operator_doc_pins_security_pause_and_recovery_contracts():
+    text = DOC.read_text()
+    assert "Never run code from a fork" in text
+    assert "MINI_GUI_RUNNER_READ_TOKEN" in text
+    assert "Administration: read" in text
+    assert "./svc.sh stop" in text
+    assert "./svc.sh start" in text
+    assert "~/Library/LaunchAgents" in text
+    assert "/Volumes/Extreme SSD" not in text

--- a/tests/test_self_hosted_mac_runner.py
+++ b/tests/test_self_hosted_mac_runner.py
@@ -163,6 +163,13 @@ def test_gui_jobs_use_selector_output_and_generic_build_stays_hosted():
     assert jobs["build"]["runs-on"] == "macos-15"
 
 
+def test_gui_artifact_helpers_use_system_python3():
+    workflow_text = WORKFLOW.read_text()
+
+    assert "python ../../scripts/gui_app_artifact.py" not in workflow_text
+    assert workflow_text.count("python3 ../../scripts/gui_app_artifact.py") == 2
+
+
 def test_launchagent_template_is_interactive_and_holds_awake_assertions():
     text = PLIST.read_text()
     assert "{{RunnerRoot}}/runsvc.sh" in text

--- a/tests/test_self_hosted_mac_runner.py
+++ b/tests/test_self_hosted_mac_runner.py
@@ -76,9 +76,7 @@ def test_runner_selector_fails_safe_to_hosted_for_external_heads_and_api_failure
     step = next(step for step in job["steps"] if step["name"] == "Select GUI runner")
     run = step["run"]
 
-    assert "head.repo.full_name == github.repository" in step["env"][
-        "IS_TRUSTED_HEAD"
-    ]
+    assert "head.repo.full_name == github.repository" in step["env"]["IS_TRUSTED_HEAD"]
     assert "selected='[\"macos-15\"]'" in run
     assert 'if [ "$IS_TRUSTED_HEAD" != true ]' in run
     assert 'if [ -z "$MINI_GUI_RUNNER_READ_TOKEN" ]' in run


### PR DESCRIPTION
## Why

Exercise PR #2580 on an internal `train/**` head so the full GUI gate runs before the workflow change is eligible for the merge queue.

## Scope

Validation-only draft. It must not merge. The expected evidence is that `gui-app-build` and all selected GUI shards run on `mini-gui`, including the Chat XCUITest loopback listener regression.

Part of #2557