### PR TITLE
fix(mac): sweep dual-stack tcp46 listeners

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -389,7 +389,7 @@ enum PortSweep {
 
             guard let ownerColumn,
                   fields.count > 5,
-                  fields[0] == "tcp4" || fields[0] == "tcp6",
+                  fields[0] == "tcp4" || fields[0] == "tcp6" || fields[0] == "tcp46",
                   fields[5] == "LISTEN",
                   fields[3].hasSuffix(portSuffix) else { continue }
 

--- a/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortSweepTests.swift
@@ -27,6 +27,17 @@ struct PortSweepTests {
         #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 0).isEmpty)
     }
 
+    @Test("Current socket-table parser includes dual-stack tcp46 listeners")
+    func currentSocketTableParserIncludesDualStackListeners() {
+        let output = """
+        Active Internet connections (including servers)
+        Proto Recv-Q Send-Q  Local Address Foreign Address (state) rxbytes txbytes rhiwat shiwat process:pid state
+        tcp46 0 0 *.48844 *.* LISTEN 0 0 131072 131072 Python:77187 00000
+        """
+
+        #expect(PortSweep.parseListeningPIDs(Data(output.utf8), port: 48_844) == [77_187])
+    }
+
     @Test("Legacy socket-table parser reads the separate numeric pid column")
     func legacySocketTableParserReadsNumericPIDColumn() {
         let output = """


### PR DESCRIPTION
Fixes #2460.

## Why

macOS reports a listener bound to both IPv4 and IPv6 as `tcp46`. Desktop’s socket-table parser accepted only `tcp4` and `tcp6`, so an otherwise sweep-eligible orphan on a dual-stack port was invisible.

## What changed

- admit `tcp46` rows in the existing header-derived, listener-only parser
- add a regression fixture captured from a real dual-stack macOS listener
- preserve exact-port matching, PID parsing, ownership verification, and signal policy unchanged

## Verification

- runtime repro: `AF_INET6` + `IPV6_V6ONLY=0` appeared as `tcp46 *.48844 LISTEN`
- regression test failed before the parser change and passes after it
- focused PortSweep/PortAllocator suites: 32 passed
- adjacent ownership/process-lifecycle suites: 100 passed
- `git diff --check`; scope/generated-file/credential audit clean

## Non-goals

No server/API changes, port allocation policy changes, unrelated process cleanup, deploy, or release action.