### PR TITLE
fix(audio): make Kokoro pulls offline-ready

### DIFF
--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -807,7 +807,7 @@ class TestKokoroMisakiGate:
 
         Drives the REAL create_speech → require_kokoro_runtime →
         _ensure_kokoro_g2p_model_ready chain through the FastAPI route (only the
-        subprocess-installing probe is stubbed to a deterministic failure), so
+        local-only readiness probe is stubbed to a deterministic failure), so
         the test breaks if the route ever stops invoking the gate or downgrades
         its 503 to a 500.
         """
@@ -830,7 +830,7 @@ class TestKokoroMisakiGate:
         monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
         _install_fake_mlx_audio(monkeypatch)
         # espeak gate passes (it runs first); the spaCy-model probe then fails
-        # deterministically (no real subprocess) — its 503 must reach the client.
+        # deterministically — its 503 must reach the client.
         monkeypatch.setattr(probe_mod, "_ensure_kokoro_g2p_ready", lambda: None)
         monkeypatch.setattr(
             probe_mod,

--- a/tests/test_kokoro_g2p_bootstrap.py
+++ b/tests/test_kokoro_g2p_bootstrap.py
@@ -1,108 +1,72 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression tests for #1254 — Kokoro TTS first ``/v1/audio/speech`` request
-returns HTTP 500 when the spaCy G2P model (``en_core_web_sm``) is missing and
-gets auto-downloaded by ``misaki`` under a launcher with no active venv
-(uv-tool / bare console script).
+"""Kokoro G2P preparation and inference-boundary contracts."""
 
-Root cause: ``misaki/en.py`` calls ``spacy.cli.download("en_core_web_sm")`` on
-first generate; spaCy's installer is ``sys.executable -m pip`` when ``pip`` is
-importable, else ``uv pip`` (the uv-tool case). ``uv pip`` aborts with
-``SystemExit`` — "No virtual environment found" — which is NOT caught by the
-route's ``except Exception`` → an opaque 500.
-
-Fix: the Kokoro route-boundary gate (``require_kokoro_runtime``) pre-resolves
-the model in a contained subprocess with a launcher-independent env, and on
-failure raises a clean ``HTTPException(503)`` the route re-raises verbatim —
-never a ``RuntimeError`` (→ generic 500) nor a ``SystemExit``.
-
-Two properties these tests pin, both codex-caught:
-  * BLOCKING — the failure surfaces as ``HTTPException(status_code=503)``, so
-    the user actually sees the actionable 503, not the route's catch-all 500.
-  * MAJOR — the installer always targets THIS interpreter (``VIRTUAL_ENV`` is
-    forced to ``sys.prefix``, overriding an inherited outer-shell value), and a
-    post-install re-check verifies the model is importable here — otherwise a
-    child ``uv pip`` could "succeed" into the wrong env and leave misaki's
-    SystemExit-y runtime download reachable.
-
-Hermetic: spaCy and the subprocess are faked, so these run without the
-``[audio]`` extra installed.
-"""
+from __future__ import annotations
 
 import importlib.util
+import os
+import signal
 import subprocess
 import sys
 import types
 
 import pytest
 
-from vllm_mlx.audio import probe
+from vllm_mlx.audio import probe, runtime_requirements
 from vllm_mlx.audio.probe import (
     _KOKORO_G2P_SPACY_MODEL,
     _ensure_kokoro_g2p_model_ready,
-    _g2p_installer_env,
     _kokoro_voice_needs_en_g2p,
     _probe_kokoro_g2p_model,
     _reset_g2p_model_state,
     require_kokoro_runtime,
 )
+from vllm_mlx.audio.registry import AudioRuntimeRequirement
+from vllm_mlx.audio.runtime_requirements import (
+    AudioRuntimePreparationError,
+    _installer_env,
+    prepare_runtime_requirement,
+)
 
 
 @pytest.fixture(autouse=True)
 def _fresh_verdict():
-    # The readiness verdict is cached per-process; reset it around every test
-    # so caching-specific tests start clean and don't leak into their peers.
     _reset_g2p_model_state()
     yield
     _reset_g2p_model_state()
 
 
-# --- MAJOR fix: the installer must target the RUNNING interpreter's env ------
-
-
-def test_env_forces_virtualenv_over_inherited_mismatch():
-    # The #1254 MAJOR: an outer activated shell exports VIRTUAL_ENV=/other, but
-    # the model must land in THIS interpreter's env (/opt/venv). Force it.
-    env = _g2p_installer_env(
-        {"VIRTUAL_ENV": "/other", "PATH": "/bin"}, "/opt/venv", prefix_is_venv=True
-    )
-    assert env["VIRTUAL_ENV"] == "/opt/venv"
-    assert env["PATH"] == "/bin"  # unrelated keys preserved
-
-
-def test_env_sets_virtualenv_when_venv_and_unset():
-    env = _g2p_installer_env({"PATH": "/bin"}, "/opt/venv", prefix_is_venv=True)
-    assert env["VIRTUAL_ENV"] == "/opt/venv"
-
-
-def test_env_skips_non_venv_prefix():
-    env = _g2p_installer_env({}, "/usr", prefix_is_venv=False)
-    assert "VIRTUAL_ENV" not in env  # system Python → don't fabricate a venv
-
-
-def test_env_non_venv_drops_inherited_virtualenv():
-    # Not a venv interpreter → DROP an inherited VIRTUAL_ENV so a child `uv pip`
-    # can't install the model into that unrelated outer env (with no venv it
-    # errors cleanly → our caught failure → 503, instead of silent pollution).
-    env = _g2p_installer_env(
-        {"VIRTUAL_ENV": "/outer", "PATH": "/bin"}, "/usr", prefix_is_venv=False
-    )
-    assert "VIRTUAL_ENV" not in env
-    assert env["PATH"] == "/bin"  # unrelated keys preserved
-
-
-def test_env_does_not_mutate_input():
-    src = {"A": "1"}
-    _g2p_installer_env(src, "/opt/venv", prefix_is_venv=True)
-    assert src == {"A": "1"}
-
-
-# --- the probe (fake spaCy so no [audio] extra is required) ------------------
+@pytest.mark.parametrize(
+    "source,prefix,is_venv,expected",
+    [
+        (
+            {"VIRTUAL_ENV": "/other", "PATH": "/bin"},
+            "/opt/venv",
+            True,
+            {"VIRTUAL_ENV": "/opt/venv", "PATH": "/bin"},
+        ),
+        (
+            {"PATH": "/bin"},
+            "/opt/venv",
+            True,
+            {"PATH": "/bin", "VIRTUAL_ENV": "/opt/venv"},
+        ),
+        ({}, "/usr", False, {}),
+        (
+            {"VIRTUAL_ENV": "/outer", "PATH": "/bin"},
+            "/usr",
+            False,
+            {"PATH": "/bin"},
+        ),
+    ],
+)
+def test_installer_env_targets_running_interpreter(source, prefix, is_venv, expected):
+    original = dict(source)
+    assert _installer_env(source, prefix, is_venv) == expected
+    assert source == original
 
 
 def _fake_spacy(monkeypatch, state):
-    """Install a fake ``spacy.util`` whose ``is_package`` reflects a mutable
-    ``state['installed']`` flag, so the pre-check and the post-install re-check
-    can observe different values within one probe run."""
     util = types.ModuleType("spacy.util")
     util.is_package = lambda name: bool(state.get("installed"))
     spacy = types.ModuleType("spacy")
@@ -111,220 +75,158 @@ def _fake_spacy(monkeypatch, state):
     monkeypatch.setitem(sys.modules, "spacy.util", util)
 
 
-def test_probe_noop_when_model_present(monkeypatch):
+def _requirement() -> AudioRuntimeRequirement:
+    return AudioRuntimeRequirement(kind="spacy_pipeline", name=_KOKORO_G2P_SPACY_MODEL)
+
+
+def test_pull_preparer_noops_when_pipeline_present(monkeypatch):
     _fake_spacy(monkeypatch, {"installed": True})
     calls = []
-    monkeypatch.setattr(probe, "_spacy_download_subprocess", lambda *a: calls.append(a))
-    assert _probe_kokoro_g2p_model() == (True, None)
-    assert calls == []  # already installed → never shells out (fast happy path)
+    monkeypatch.setattr(
+        runtime_requirements, "_run_installer", lambda *args: calls.append(args)
+    )
+
+    prepare_runtime_requirement(_requirement())
+
+    assert calls == []
 
 
-def test_probe_installs_absent_model_then_verifies(monkeypatch):
+def test_pull_preparer_installs_absent_pipeline_then_verifies(monkeypatch):
     state = {"installed": False}
     _fake_spacy(monkeypatch, state)
     seen = {}
 
     def fake_install(cmd, env, timeout):
-        seen["cmd"] = cmd
-        seen["env"] = env
-        seen["timeout"] = timeout
-        state["installed"] = True  # the install makes the model importable
+        seen.update(cmd=cmd, env=env, timeout=timeout)
+        state["installed"] = True
 
-    monkeypatch.setattr(probe, "_spacy_download_subprocess", fake_install)
-    assert _probe_kokoro_g2p_model() == (True, None)
-    # runs spaCy's OWN resolver via THIS interpreter (not a bare `spacy`/`uv`)
-    assert seen["cmd"][:3] == [sys.executable, "-m", "spacy"]
-    assert seen["cmd"][-1] == _KOKORO_G2P_SPACY_MODEL
+    monkeypatch.setattr(runtime_requirements, "_run_installer", fake_install)
+
+    prepare_runtime_requirement(_requirement())
+
+    assert seen["cmd"] == [
+        sys.executable,
+        "-m",
+        "spacy",
+        "download",
+        _KOKORO_G2P_SPACY_MODEL,
+    ]
     assert seen["timeout"] == 300
-    # a launcher-independent env dict was built (its exact VIRTUAL_ENV logic is
-    # pinned by the _g2p_installer_env branch-table tests above)
     assert seen["env"] is not None
 
 
-def test_probe_reports_failure_on_subprocess_error(monkeypatch, caplog):
+def test_pull_preparer_sanitizes_installer_failure(monkeypatch, caplog):
     _fake_spacy(monkeypatch, {"installed": False})
-    secret = "https://user:token@internal.pkgs.example/simple  (host=build-07)"
+    secret = "https://user:token@internal.pkgs.example/simple"
 
-    def boom(cmd, env, timeout):
-        raise subprocess.CalledProcessError(1, cmd, stderr=secret)
+    def fail(cmd, env, timeout):
+        raise subprocess.CalledProcessError(7, cmd, stderr=secret)
 
-    monkeypatch.setattr(probe, "_spacy_download_subprocess", boom)
-    with caplog.at_level("ERROR"):
-        ready, reason = _probe_kokoro_g2p_model()
-    assert ready is False
-    # actionable hint (model + a recovery command), but NO raw installer stderr
-    assert _KOKORO_G2P_SPACY_MODEL in reason
-    assert "spacy download" in reason
-    # pr_validate BLOCKING: the raw stderr (index URLs / hosts / creds) must
-    # NEVER reach the client-facing 503 body OR the server log (secret-in-logs).
-    for sink in (reason, caplog.text):
-        assert secret not in sink
-        assert "internal.pkgs.example" not in sink
-    # the log still records the failure SHAPE for the operator
-    assert "CalledProcessError" in caplog.text
+    monkeypatch.setattr(runtime_requirements, "_run_installer", fail)
+    with (
+        caplog.at_level("ERROR"),
+        pytest.raises(
+            AudioRuntimePreparationError, match=_KOKORO_G2P_SPACY_MODEL
+        ) as excinfo,
+    ):
+        prepare_runtime_requirement(_requirement())
+
+    assert secret not in str(excinfo.value)
+    assert secret not in caplog.text
+    assert "CalledProcessError (exit 7)" in caplog.text
 
 
-def test_probe_fails_when_install_succeeds_but_model_invisible(monkeypatch):
-    # A child `uv pip` honouring a mismatched VIRTUAL_ENV can exit 0 while the
-    # wheel lands in the WRONG env — the model is still not importable here.
-    # Fail closed (503), don't declare ready.
-    _fake_spacy(monkeypatch, {"installed": False})  # stays False after "install"
-    monkeypatch.setattr(probe, "_spacy_download_subprocess", lambda cmd, env, t: None)
-    ready, reason = _probe_kokoro_g2p_model()
-    assert ready is False
-    assert _KOKORO_G2P_SPACY_MODEL in reason
-
-
-def test_probe_contains_missing_executable(monkeypatch):
+def test_pull_preparer_fails_when_pipeline_remains_invisible(monkeypatch):
     _fake_spacy(monkeypatch, {"installed": False})
-
-    def missing(cmd, env, timeout):
-        raise FileNotFoundError()
-
-    monkeypatch.setattr(probe, "_spacy_download_subprocess", missing)
-    ready, reason = _probe_kokoro_g2p_model()
-    assert ready is False and _KOKORO_G2P_SPACY_MODEL in reason
-
-
-def test_probe_never_raises_when_is_package_errors(monkeypatch):
-    # pr_validate BLOCKING: the probe's contract is "never raise" — even if
-    # spacy.util.is_package itself throws (corrupt dist metadata), the outer
-    # guard converts it to a (False, hint) verdict, not an opaque route 500.
-    util = types.ModuleType("spacy.util")
-
-    def _boom(name):
-        raise RuntimeError("corrupt en_core_web_sm-*.dist-info METADATA")
-
-    util.is_package = _boom
-    spacy = types.ModuleType("spacy")
-    spacy.util = util
-    monkeypatch.setitem(sys.modules, "spacy", spacy)
-    monkeypatch.setitem(sys.modules, "spacy.util", util)
-    ready, reason = _probe_kokoro_g2p_model()
-    assert ready is False
-    assert _KOKORO_G2P_SPACY_MODEL in reason
-
-
-# --- unimportable spaCy fails CLOSED (past the misaki gate, spaCy is required) -
-
-
-def test_probe_unimportable_spacy_fails_closed(monkeypatch):
-    # Reached only past the misaki-present gate, and misaki hard-depends on
-    # spaCy — so an unimportable spaCy (here a torn ``spacy.util``) is a broken
-    # install: fail closed (503), never shell out, never claim ready. Masking
-    # it as ready would resurface as the opaque 500 this fix prevents.
-    monkeypatch.setitem(sys.modules, "spacy", None)  # → ModuleNotFoundError(spacy.util)
-    called = []
     monkeypatch.setattr(
-        probe, "_spacy_download_subprocess", lambda *a: called.append(a)
+        runtime_requirements, "_run_installer", lambda *args, **kwargs: None
     )
-    ready, reason = _probe_kokoro_g2p_model()
-    assert ready is False
-    assert _KOKORO_G2P_SPACY_MODEL in reason
-    assert called == []  # never attempts an install on a broken interpreter
+
+    with pytest.raises(AudioRuntimePreparationError, match="reported success"):
+        prepare_runtime_requirement(_requirement())
 
 
-# --- BLOCKING fix: failure surfaces as HTTPException(503), never 500 ----------
+def test_pull_preparer_sanitizes_post_install_import_failure(monkeypatch):
+    calls = 0
 
+    def availability(_package):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return False
+        raise ImportError("/private/secret/path/broken.dylib")
 
-def test_ensure_raises_503_httpexception_not_500(monkeypatch):
-    from fastapi import HTTPException
-
+    monkeypatch.setattr(runtime_requirements, "spacy_pipeline_available", availability)
     monkeypatch.setattr(
-        probe, "_probe_kokoro_g2p_model", lambda: (False, "boom, install me")
+        runtime_requirements, "_run_installer", lambda *args, **kwargs: None
     )
-    with pytest.raises(HTTPException) as excinfo:
-        _ensure_kokoro_g2p_model_ready()
-    # the whole point of #1254: the caller (route) sees a 503, not the
-    # catch-all 500 a bare RuntimeError would collapse into.
-    assert excinfo.value.status_code == 503
-    assert excinfo.value.detail == "boom, install me"
+
+    with pytest.raises(AudioRuntimePreparationError) as excinfo:
+        prepare_runtime_requirement(_requirement())
+
+    assert "/private/secret/path" not in str(excinfo.value)
 
 
-def test_ensure_noop_when_ready(monkeypatch):
-    monkeypatch.setattr(probe, "_probe_kokoro_g2p_model", lambda: (True, None))
-    _ensure_kokoro_g2p_model_ready()  # must not raise
-
-
-def test_ensure_caches_verdict(monkeypatch):
+def test_inference_probe_is_check_only_when_pipeline_missing(monkeypatch):
     calls = []
-
-    def counting_probe():
-        calls.append(1)
-        return (True, None)
-
-    monkeypatch.setattr(probe, "_probe_kokoro_g2p_model", counting_probe)
-    _ensure_kokoro_g2p_model_ready()
-    _ensure_kokoro_g2p_model_ready()
-    assert len(calls) == 1  # one-time install, coalesced across requests
-
-
-def test_ensure_transient_503_when_install_in_flight(monkeypatch):
-    # pr_validate BLOCKING: a request that finds the install already in flight
-    # must NOT block a worker thread on the lock for the whole 300 s window —
-    # it returns a transient, retryable 503 and never runs the probe itself.
-    from fastapi import HTTPException
-
-    ran = []
     monkeypatch.setattr(
-        probe, "_probe_kokoro_g2p_model", lambda: ran.append(1) or (True, None)
+        runtime_requirements,
+        "spacy_pipeline_available",
+        lambda name: calls.append(name) or False,
     )
-    # simulate another request mid-install by holding the single-flight lock
-    assert probe._G2P_MODEL_LOCK.acquire(blocking=False)
-    try:
-        with pytest.raises(HTTPException) as excinfo:
-            _ensure_kokoro_g2p_model_ready()
-        assert excinfo.value.status_code == 503
-        assert "retry" in excinfo.value.detail.lower()
-        assert ran == []  # never contended on the probe under lock pressure
-    finally:
-        probe._G2P_MODEL_LOCK.release()
+    monkeypatch.setattr(
+        runtime_requirements,
+        "_run_installer",
+        lambda *args: pytest.fail("inference must not install packages"),
+    )
+
+    ready, reason = _probe_kokoro_g2p_model()
+
+    assert ready is False
+    assert calls == [_KOKORO_G2P_SPACY_MODEL]
+    assert "rapid-mlx pull kokoro" in reason
 
 
-def test_ensure_retries_failed_verdict_after_cooldown(monkeypatch):
-    # pr_validate BLOCKING: a FAILED verdict is cached only for a cooldown, so a
-    # transient outage doesn't disable Kokoro until restart — after the window
-    # we re-probe, and a now-present dependency caches success (no restart).
-    import time
+def test_inference_probe_accepts_prepared_pipeline(monkeypatch):
+    monkeypatch.setattr(
+        runtime_requirements, "spacy_pipeline_available", lambda name: True
+    )
+    assert _probe_kokoro_g2p_model() == (True, None)
 
+
+def test_inference_probe_fails_closed_on_broken_spacy(monkeypatch):
+    def broken(_name):
+        raise ImportError("private dylib path")
+
+    monkeypatch.setattr(runtime_requirements, "spacy_pipeline_available", broken)
+    ready, reason = _probe_kokoro_g2p_model()
+    assert ready is False
+    assert _KOKORO_G2P_SPACY_MODEL in reason
+
+
+def test_ensure_missing_pipeline_is_503_and_failure_is_not_cached(monkeypatch):
     from fastapi import HTTPException
-
-    clock = {"t": 1000.0}
-    monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
 
     calls = []
 
     def probe_fn():
         calls.append(1)
-        return (False, "install boom") if len(calls) == 1 else (True, None)
+        return (False, "run pull") if len(calls) == 1 else (True, None)
 
     monkeypatch.setattr(probe, "_probe_kokoro_g2p_model", probe_fn)
-
-    # 1st attempt fails → 503, cached with a cooldown
-    with pytest.raises(HTTPException) as e1:
+    with pytest.raises(HTTPException) as excinfo:
         _ensure_kokoro_g2p_model_ready()
-    assert e1.value.status_code == 503 and e1.value.detail == "install boom"
-    assert len(calls) == 1
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "run pull"
 
-    # within the cooldown → served from cache, probe NOT re-run
-    with pytest.raises(HTTPException):
-        _ensure_kokoro_g2p_model_ready()
-    assert len(calls) == 1
-
-    # after the cooldown → re-probe; dependency now present → ready (no restart)
-    clock["t"] += probe._G2P_MODEL_RETRY_COOLDOWN_S + 1
-    _ensure_kokoro_g2p_model_ready()  # must not raise
+    _ensure_kokoro_g2p_model_ready()
+    _ensure_kokoro_g2p_model_ready()
     assert len(calls) == 2
-
-
-# --- route-boundary wiring: the gate propagates the 503, doesn't swallow it --
 
 
 def test_require_kokoro_runtime_propagates_model_503(monkeypatch):
     from fastapi import HTTPException
 
-    # misaki present (extra installed), espeak fine — but the spaCy model can't
-    # be resolved. require_kokoro_runtime must let that 503 out untouched.
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
     monkeypatch.setattr(probe, "_ensure_kokoro_g2p_ready", lambda: None)
     monkeypatch.setattr(
@@ -340,41 +242,21 @@ def test_require_kokoro_runtime_propagates_model_503(monkeypatch):
     assert excinfo.value.detail == "model missing"
 
 
-# --- gate COVERAGE: the route must gate every model the engine treats as -----
-# --- Kokoro, not just names containing "kokoro" (the engine defaults unknown --
-# --- names to Kokoro, so a substring gate would miss them → SystemExit 500). --
-
-
 def test_is_kokoro_family_covers_explicit_and_default():
     from vllm_mlx.audio.tts import is_kokoro_family_model
 
-    # registered kokoro model → gated
     assert is_kokoro_family_model("mlx-community/Kokoro-82M-bf16") is True
-    # unregistered / renamed repo → name default is kokoro → still gated (so a
-    # renamed Kokoro repo not in the registry keeps the readiness check)
     assert is_kokoro_family_model("acme/MysteryTTS-v2") is True
 
 
 def test_gate_matches_engine_family_for_every_registered_tts_model():
-    # The route gate MUST agree with the family the ENGINE actually loads /
-    # generates with — otherwise the route could skip the Kokoro runtime check
-    # for a model the engine still runs through the Kokoro path (or vice-versa).
-    # This includes Dia, which the engine's name fallthrough runs as Kokoro
-    # (there is no separate 'dia' generate branch), so the gate treats it as
-    # Kokoro too. Consistency > cleverness.
     from vllm_mlx.audio.registry import tts_aliases
     from vllm_mlx.audio.tts import TTSEngine, is_kokoro_family_model
 
     for alias, hf_id in tts_aliases().items():
-        engine_family = TTSEngine(hf_id)._detect_family(hf_id)
-        expect_gated = engine_family == "kokoro"
-        # both the resolved HF id AND the short alias must classify the same
-        assert is_kokoro_family_model(hf_id) is expect_gated, (
-            alias,
-            hf_id,
-            engine_family,
-        )
-        assert is_kokoro_family_model(alias) is expect_gated, (alias, engine_family)
+        expect_gated = TTSEngine(hf_id)._detect_family(hf_id) == "kokoro"
+        assert is_kokoro_family_model(hf_id) is expect_gated
+        assert is_kokoro_family_model(alias) is expect_gated
 
 
 def test_detect_family_method_matches_module_ssot():
@@ -388,13 +270,7 @@ def test_detect_family_method_matches_module_ssot():
         assert TTSEngine(name)._detect_family(name) == detect_tts_family(name)
 
 
-# --- startup deep probe must CONTAIN misaki's SystemExit, never abort boot ----
-
-
 def test_dry_run_tts_contains_systemexit(monkeypatch):
-    # #1254: misaki's spaCy download shells out to `uv pip`, which sys.exit()s
-    # under a uv-tool launcher. That SystemExit (a BaseException) must NOT abort
-    # a RAPID_MLX_AUDIO_DEEP_PROBE startup — the dry-run reports degraded.
     from vllm_mlx.audio import tts as tts_mod
 
     class _FakeEngine:
@@ -404,52 +280,46 @@ def test_dry_run_tts_contains_systemexit(monkeypatch):
         def load(self):
             pass
 
-        def generate(self, *a, **k):
+        def generate(self, *args, **kwargs):
             raise SystemExit("No virtual environment found")
 
     monkeypatch.setattr(tts_mod, "TTSEngine", _FakeEngine)
     ok, reason = probe._dry_run_tts("mlx-community/Kokoro-82M-bf16")
     assert ok is False
-    assert "SystemExit" in reason  # contained + reported, not propagated
-
-
-# --- the English-only en_core_web_sm gate is gated by VOICE language ----------
+    assert "SystemExit" in reason
 
 
 def test_voice_language_gate_classifies():
-    # American / British English voices use misaki.en → need en_core_web_sm.
     assert _kokoro_voice_needs_en_g2p("af_heart") is True
     assert _kokoro_voice_needs_en_g2p("bm_george") is True
-    # other languages use their own tokenizers, NOT spaCy-English.
-    for v in ("jf_alpha", "zf_xiaobei", "ef_dora", "ff_siwis", "if_sara", "pf_dora"):
-        assert _kokoro_voice_needs_en_g2p(v) is False
-    # omitted/unknown → default English (canonical default af_heart is English)
+    for voice in (
+        "jf_alpha",
+        "zf_xiaobei",
+        "ef_dora",
+        "ff_siwis",
+        "if_sara",
+        "pf_dora",
+    ):
+        assert _kokoro_voice_needs_en_g2p(voice) is False
     assert _kokoro_voice_needs_en_g2p(None) is True
     assert _kokoro_voice_needs_en_g2p("") is True
 
 
-def test_require_kokoro_runtime_skips_en_model_for_non_english_voice(monkeypatch):
-    # pr_validate BLOCKING: a Japanese Kokoro voice must NOT be forced through
-    # the spaCy-English gate (misaki.ja doesn't use en_core_web_sm).
+def test_require_kokoro_runtime_skips_english_pipeline_for_other_voices(monkeypatch):
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
     monkeypatch.setattr(probe, "_ensure_kokoro_g2p_ready", lambda: None)
-    ran = []
-    monkeypatch.setattr(probe, "_ensure_kokoro_g2p_model_ready", lambda: ran.append(1))
+    calls = []
+    monkeypatch.setattr(
+        probe, "_ensure_kokoro_g2p_model_ready", lambda: calls.append(1)
+    )
 
-    require_kokoro_runtime("jf_alpha")  # Japanese → skip the en gate
-    assert ran == []
-    require_kokoro_runtime("af_heart")  # English → run the en gate
-    assert ran == [1]
+    require_kokoro_runtime("jf_alpha")
+    assert calls == []
+    require_kokoro_runtime("af_heart")
+    assert calls == [1]
 
 
-# --- installer runs in its own process group; timeout reaps the WHOLE tree ----
-
-
-def test_spacy_download_kills_process_group_on_timeout(monkeypatch):
-    import os
-    import signal
-    import subprocess as _sp
-
+def test_installer_kills_process_group_on_timeout(monkeypatch):
     killed = {}
 
     class _FakeProc:
@@ -458,47 +328,38 @@ def test_spacy_download_kills_process_group_on_timeout(monkeypatch):
         stdout = stderr = stdin = None
 
         def communicate(self, timeout=None):
-            raise _sp.TimeoutExpired(cmd="spacy", timeout=timeout)
+            raise subprocess.TimeoutExpired(cmd="spacy", timeout=timeout)
 
         def kill(self):
             killed["direct"] = True
 
-        def wait(self, timeout=None):
-            return 0
-
     popen_kwargs = {}
 
-    def _fake_popen(*a, **k):
-        popen_kwargs.update(k)
+    def fake_popen(*args, **kwargs):
+        popen_kwargs.update(kwargs)
         return _FakeProc()
 
-    monkeypatch.setattr(_sp, "Popen", _fake_popen)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
     monkeypatch.setattr(os, "getpgid", lambda pid: pid)
     monkeypatch.setattr(
         os, "killpg", lambda pgid, sig: killed.__setitem__("pgid", (pgid, sig))
     )
-    with pytest.raises(_sp.TimeoutExpired):
-        probe._spacy_download_subprocess(["x"], {}, timeout=1)
-    # MUST start its own session/group — otherwise killpg(getpgid(child)) would
-    # signal the SERVER's own process group. This assertion is what makes the
-    # killpg check below meaningful (it fails if start_new_session is dropped).
-    assert popen_kwargs.get("start_new_session") is True
-    # the WHOLE group is SIGKILLed, not just the direct child (no orphaned pip)
+    with pytest.raises(subprocess.TimeoutExpired):
+        runtime_requirements._run_installer(["x"], {}, timeout=1)
+    assert popen_kwargs["start_new_session"] is True
     assert killed["pgid"] == (4321, signal.SIGKILL)
-    assert "direct" not in killed  # killpg succeeded → no single-child fallback
+    assert "direct" not in killed
 
 
-def test_spacy_download_raises_calledprocesserror_on_nonzero_exit(monkeypatch):
-    import subprocess as _sp
-
+def test_installer_raises_on_nonzero_exit(monkeypatch):
     class _FakeProc:
         pid = 1
         returncode = 7
 
         def communicate(self, timeout=None):
-            return ("", "boom stderr")
+            return "", "boom stderr"
 
-    monkeypatch.setattr(_sp, "Popen", lambda *a, **k: _FakeProc())
-    with pytest.raises(_sp.CalledProcessError) as e:
-        probe._spacy_download_subprocess(["x"], {}, timeout=1)
-    assert e.value.returncode == 7
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: _FakeProc())
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        runtime_requirements._run_installer(["x"], {}, timeout=1)
+    assert excinfo.value.returncode == 7

--- a/tests/test_kokoro_g2p_bootstrap.py
+++ b/tests/test_kokoro_g2p_bootstrap.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 import sys
 import types
+from typing import cast
 
 import pytest
 
@@ -21,7 +22,10 @@ from vllm_mlx.audio.probe import (
     _reset_g2p_model_state,
     require_kokoro_runtime,
 )
-from vllm_mlx.audio.registry import AudioRuntimeRequirement
+from vllm_mlx.audio.registry import (
+    AudioRuntimeRequirement,
+    AudioRuntimeRequirementKind,
+)
 from vllm_mlx.audio.runtime_requirements import (
     AudioRuntimePreparationError,
     _installer_env,
@@ -165,6 +169,33 @@ def test_pull_preparer_sanitizes_post_install_import_failure(monkeypatch):
         prepare_runtime_requirement(_requirement())
 
     assert "/private/secret/path" not in str(excinfo.value)
+
+
+def test_pull_preparer_fails_closed_when_spacy_runtime_is_broken(monkeypatch):
+    def broken(_package):
+        raise ImportError("/private/secret/path/broken.dylib")
+
+    monkeypatch.setattr(runtime_requirements, "spacy_pipeline_available", broken)
+    monkeypatch.setattr(
+        runtime_requirements,
+        "_run_installer",
+        lambda *args, **kwargs: pytest.fail("broken spaCy must not run installer"),
+    )
+
+    with pytest.raises(AudioRuntimePreparationError) as excinfo:
+        prepare_runtime_requirement(_requirement())
+
+    assert "spaCy runtime is not importable" in str(excinfo.value)
+    assert "/private/secret/path" not in str(excinfo.value)
+
+
+def test_preparer_rejects_unvalidated_requirement_kind():
+    requirement = AudioRuntimeRequirement(
+        kind=cast(AudioRuntimeRequirementKind, "shell"), name="payload"
+    )
+
+    with pytest.raises(AudioRuntimePreparationError, match="Unsupported"):
+        prepare_runtime_requirement(requirement)
 
 
 def test_inference_probe_is_check_only_when_pipeline_missing(monkeypatch):
@@ -349,6 +380,55 @@ def test_installer_kills_process_group_on_timeout(monkeypatch):
     assert popen_kwargs["start_new_session"] is True
     assert killed["pgid"] == (4321, signal.SIGKILL)
     assert "direct" not in killed
+
+
+def test_installer_timeout_falls_back_and_closes_every_pipe(monkeypatch):
+    killed = {}
+
+    class _Pipe:
+        def __init__(self, *, fail=False):
+            self.fail = fail
+            self.closed = 0
+
+        def close(self):
+            self.closed += 1
+            if self.fail:
+                raise OSError("already closed")
+
+    class _FakeProc:
+        pid = 4321
+        returncode = None
+        stdout = _Pipe()
+        stderr = _Pipe(fail=True)
+        stdin = _Pipe()
+
+        def __init__(self):
+            self.communications = 0
+
+        def communicate(self, timeout=None):
+            self.communications += 1
+            if self.communications == 1:
+                raise subprocess.TimeoutExpired(cmd="spacy", timeout=timeout)
+            return "", ""
+
+        def kill(self):
+            killed["direct"] = True
+
+    proc = _FakeProc()
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        os, "killpg", lambda pgid, sig: (_ for _ in ()).throw(PermissionError())
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runtime_requirements._run_installer(["x"], {}, timeout=1)
+
+    assert killed == {"direct": True}
+    assert proc.communications == 2
+    assert proc.stdout.closed == 1
+    assert proc.stderr.closed == 1
+    assert proc.stdin.closed == 1
 
 
 def test_installer_raises_on_nonzero_exit(monkeypatch):

--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -157,7 +158,7 @@ def test_runtime_asset_failure_does_not_report_successful_pull(monkeypatch) -> N
 
 
 def test_runtime_requirement_failure_does_not_report_successful_pull(
-    monkeypatch,
+    monkeypatch, capsys
 ) -> None:
     activations = 0
 
@@ -166,7 +167,9 @@ def test_runtime_requirement_failure_does_not_report_successful_pull(
         runtime_requirements,
         "prepare_runtime_requirement",
         lambda requirement: (_ for _ in ()).throw(
-            RuntimeError("requirement preparation failed")
+            runtime_requirements.AudioRuntimePreparationError(
+                "required pipeline is unavailable"
+            )
         ),
     )
 
@@ -176,10 +179,50 @@ def test_runtime_requirement_failure_does_not_report_successful_pull(
 
     monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
 
-    with pytest.raises(RuntimeError, match="requirement preparation failed"):
+    with pytest.raises(SystemExit) as excinfo:
         cli.pull_command(argparse.Namespace(model="mlx-community/Kokoro-82M-bf16"))
 
+    assert excinfo.value.code == 1
     assert activations == 0
+    output = capsys.readouterr().out
+    assert "Could not prepare audio runtime" in output
+    assert "rapid-mlx[audio]" in output
+    assert "rapid-mlx pull mlx-community/Kokoro-82M-bf16" in output
+
+
+def test_main_pull_requirement_failure_is_actionable_without_traceback(
+    monkeypatch, capsys
+) -> None:
+    requirement = registry.AudioRuntimeRequirement(
+        kind="spacy_pipeline", name="en_core_web_sm"
+    )
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "1")
+    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "--no-telemetry", "pull", "kokoro"])
+    monkeypatch.setattr(cli, "_pull_repository", lambda *args, **kwargs: None)
+    monkeypatch.setattr(registry, "runtime_assets_for", lambda _name: ())
+    monkeypatch.setattr(
+        registry, "runtime_requirements_for", lambda _name: (requirement,)
+    )
+    monkeypatch.setattr(
+        runtime_requirements,
+        "prepare_runtime_requirement",
+        lambda _requirement: (_ for _ in ()).throw(
+            runtime_requirements.AudioRuntimePreparationError(
+                "Could not prepare required spaCy pipeline 'en_core_web_sm'"
+            )
+        ),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 1
+    output = capsys.readouterr().out
+    assert "Could not prepare audio runtime for 'kokoro'" in output
+    assert "rapid-mlx pull kokoro" in output
+    assert "rapid-mlx[audio]" in output
+    assert "Traceback" not in output
 
 
 def test_runtime_asset_uses_normal_filtered_download_pipeline(

--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from vllm_mlx import cli
-from vllm_mlx.audio import registry
+from vllm_mlx.audio import registry, runtime_requirements
 
 
 def test_kokoro_alias_and_hf_id_declare_voice_assets() -> None:
@@ -29,9 +29,23 @@ def test_kokoro_alias_and_hf_id_declare_voice_assets() -> None:
     assert registry.runtime_assets_for("not-an-audio-model") == ()
 
 
+def test_kokoro_alias_and_hf_id_declare_g2p_requirement() -> None:
+    expected = (
+        registry.AudioRuntimeRequirement(kind="spacy_pipeline", name="en_core_web_sm"),
+    )
+
+    assert registry.runtime_requirements_for("kokoro") == expected
+    assert (
+        registry.runtime_requirements_for("mlx-community/Kokoro-82M-bf16") == expected
+    )
+    assert registry.runtime_requirements_for("whisper-small") == ()
+    assert registry.runtime_requirements_for("not-an-audio-model") == ()
+
+
 def test_pull_downloads_primary_then_declared_runtime_assets(monkeypatch) -> None:
     calls: list[tuple[str, list[str] | None, str | None, str | None]] = []
     activations = 0
+    preparations = []
 
     def fake_pull_repository(args, *, allow_patterns_override=None):
         calls.append(
@@ -49,6 +63,11 @@ def test_pull_downloads_primary_then_declared_runtime_assets(monkeypatch) -> Non
 
     monkeypatch.setattr(cli, "_pull_repository", fake_pull_repository)
     monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
+    monkeypatch.setattr(
+        runtime_requirements,
+        "prepare_runtime_requirement",
+        lambda requirement: preparations.append(requirement),
+    )
     args = argparse.Namespace(
         model="mlx-community/Kokoro-82M-bf16",
         _original_alias="kokoro",
@@ -68,6 +87,9 @@ def test_pull_downloads_primary_then_declared_runtime_assets(monkeypatch) -> Non
         ),
     ]
     assert activations == 1
+    assert preparations == [
+        registry.AudioRuntimeRequirement(kind="spacy_pipeline", name="en_core_web_sm")
+    ]
     assert args.model == "mlx-community/Kokoro-82M-bf16"
     assert args._original_alias == "kokoro"
 
@@ -129,6 +151,32 @@ def test_runtime_asset_failure_does_not_report_successful_pull(monkeypatch) -> N
     monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
 
     with pytest.raises(RuntimeError, match="asset download failed"):
+        cli.pull_command(argparse.Namespace(model="mlx-community/Kokoro-82M-bf16"))
+
+    assert activations == 0
+
+
+def test_runtime_requirement_failure_does_not_report_successful_pull(
+    monkeypatch,
+) -> None:
+    activations = 0
+
+    monkeypatch.setattr(cli, "_pull_repository", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runtime_requirements,
+        "prepare_runtime_requirement",
+        lambda requirement: (_ for _ in ()).throw(
+            RuntimeError("requirement preparation failed")
+        ),
+    )
+
+    def fake_activation() -> None:
+        nonlocal activations
+        activations += 1
+
+    monkeypatch.setattr(cli, "_emit_pull_activation", fake_activation)
+
+    with pytest.raises(RuntimeError, match="requirement preparation failed"):
         cli.pull_command(argparse.Namespace(model="mlx-community/Kokoro-82M-bf16"))
 
     assert activations == 0
@@ -217,6 +265,62 @@ def test_runtime_asset_registry_rejects_malformed_metadata(
     monkeypatch.setattr(registry, "_REGISTRY", None)
     monkeypatch.setattr(registry, "_HF_ID_INDEX", {})
     monkeypatch.setattr(registry, "_RUNTIME_ASSETS", {})
+
+    with pytest.raises(ValueError, match=re.escape(error)):
+        registry._load_registry()
+
+
+@pytest.mark.parametrize(
+    "runtime_requirements_metadata,error",
+    [
+        ([], "_runtime_requirements must be an object"),
+        ({"": []}, "family keys must be non-empty strings"),
+        ({"kokoro": {}}, "_runtime_requirements.kokoro must be an array"),
+        ({"kokoro": ["bad"]}, "_runtime_requirements.kokoro[0] must be an object"),
+        (
+            {"kokoro": [{"kind": "shell", "name": "anything"}]},
+            "kind must be 'spacy_pipeline'",
+        ),
+        (
+            {"kokoro": [{"kind": "spacy_pipeline", "name": "bad-name"}]},
+            "name must be a Python package identifier",
+        ),
+        (
+            {
+                "kokoro": [
+                    {"kind": "spacy_pipeline", "name": "en_core_web_sm"},
+                    {"kind": "spacy_pipeline", "name": "en_core_web_sm"},
+                ]
+            },
+            "duplicate runtime requirement",
+        ),
+        (
+            {"unknown": [{"kind": "spacy_pipeline", "name": "en_core_web_sm"}]},
+            "runtime requirements declared for unknown family",
+        ),
+    ],
+)
+def test_runtime_requirement_registry_rejects_malformed_metadata(
+    monkeypatch, tmp_path, runtime_requirements_metadata, error
+) -> None:
+    registry_file = tmp_path / "aliases.json"
+    registry_file.write_text(
+        json.dumps(
+            {
+                "_runtime_requirements": runtime_requirements_metadata,
+                "kokoro": {
+                    "type": "tts",
+                    "hf_id": "owner/kokoro",
+                    "family": "kokoro",
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(registry, "_registry_path", lambda: str(registry_file))
+    monkeypatch.setattr(registry, "_REGISTRY", None)
+    monkeypatch.setattr(registry, "_HF_ID_INDEX", {})
+    monkeypatch.setattr(registry, "_RUNTIME_ASSETS", {})
+    monkeypatch.setattr(registry, "_RUNTIME_REQUIREMENTS", {})
 
     with pytest.raises(ValueError, match=re.escape(error)):
         registry._load_registry()

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -10,6 +10,15 @@
     ]
   },
 
+  "_runtime_requirements": {
+    "kokoro": [
+      {
+        "kind": "spacy_pipeline",
+        "name": "en_core_web_sm"
+      }
+    ]
+  },
+
   "kokoro": {
     "type": "tts",
     "hf_id": "mlx-community/Kokoro-82M-bf16",

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -612,148 +612,31 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
 
 
 # ---------------------------------------------------------------------------
-# F-K-KOKORO-SPACY (#1254): misaki's English G2P tokenizer needs the spaCy
-# ``en_core_web_sm`` model, which misaki downloads LAZILY on the first
-# ``generate`` via ``spacy.cli.download``. spaCy's installer shells out to
-# ``sys.executable -m pip`` when ``pip`` is importable, else ``uv pip`` (the
-# uv-tool / bundled console-script case). ``uv pip`` aborts with a
-# ``SystemExit`` — "No virtual environment found" — when no venv is active,
-# which the route's ``except Exception`` cannot catch → an opaque HTTP 500 on
-# the FIRST speech request. We pre-resolve the model at the route boundary
-# (offloaded to a worker thread, like the espeak sweep) so a missing model
-# 503s cleanly BEFORE weight load and can never reach misaki's SystemExit-y
-# runtime download. Cached + lock-coalesced: the one-time install runs once
-# per process even under concurrent cold-start requests.
+# Kokoro's English G2P tokenizer needs ``en_core_web_sm``. The explicit model
+# pull workflow prepares it from catalog metadata; inference is check-only so a
+# request never mutates the Python environment or reaches the downstream lazy
+# downloader. A successful check is cached for the process lifetime. Failures
+# are not cached because an operator may prepare the dependency while the
+# server remains up.
 _KOKORO_G2P_SPACY_MODEL = "en_core_web_sm"
-
-# Per-process readiness cache + single-flight lock. rapid-mlx serves from a
-# SINGLE uvicorn worker (``server.py`` calls ``uvicorn.run(app)`` with no
-# ``workers=``), so a process-local lock fully coalesces the one-time install;
-# a hypothetical multi-worker deployment would need a cross-process lock, but
-# that isn't a supported topology here.
-#
-# SUCCESS is cached for the process lifetime; a FAILURE is cached only for a
-# short cooldown (``_G2P_MODEL_RETRY_COOLDOWN_S``) so a transient index outage
-# or timeout doesn't disable Kokoro until restart — after the window we
-# re-probe, and once the dependency is present we cache success.
 _G2P_MODEL_READY: bool | None = None
-_G2P_MODEL_REASON: str | None = None
-_G2P_MODEL_RETRY_AFTER: float = 0.0
-_G2P_MODEL_RETRY_COOLDOWN_S = 60.0
-_G2P_MODEL_LOCK = threading.Lock()
 
 
 def _g2p_model_install_hint() -> str:
-    """Fixed, operator-facing 503 message.
-
-    Carries NO subprocess output and no interpreter path: raw installer stderr
-    can leak authenticated package-index URLs, internal hostnames, usernames,
-    and filesystem paths, so it is logged server-side and NEVER returned in the
-    HTTP response. The recovery text covers both a normal venv and the uv-tool
-    / no-venv launcher (where a bare ``spacy download`` can't resolve a target)
-    by pointing at a venv reinstall of the audio extras.
-    """
+    """Fixed operator-facing recovery text with no environment details."""
     return (
         f"Kokoro TTS needs the spaCy G2P model '{_KOKORO_G2P_SPACY_MODEL}', "
-        "which could not be prepared automatically. Reinstall the audio extras "
-        "with 'pip install \"rapid-mlx[audio]\"' inside a virtual environment "
-        f"(or run 'python -m spacy download {_KOKORO_G2P_SPACY_MODEL}' against "
-        "the server's interpreter), then retry — the server re-checks "
-        "automatically; restart only if it still can't find the model."
+        "which is not prepared in this environment. Run 'rapid-mlx pull kokoro' "
+        "while online with the server's interpreter, then retry."
     )
-
-
-def _g2p_installer_env(
-    environ: dict[str, str], prefix: str, prefix_is_venv: bool
-) -> dict[str, str]:
-    """Env for a child spaCy-model install so it targets THIS interpreter.
-
-    spaCy's ``uv pip`` fallback installs into ``$VIRTUAL_ENV``. Two cases:
-
-    * The running interpreter IS a venv (the uv-tool / bundled-sidecar case):
-      force ``VIRTUAL_ENV`` to ``prefix`` — even if one is already set —
-      because an inherited ``VIRTUAL_ENV`` from an outer activated shell can
-      point at a DIFFERENT environment; installing the model there would leave
-      it invisible to the running spaCy and keep misaki's SystemExit-y runtime
-      download reachable.
-    * The running interpreter is NOT a venv (system Python): DROP any inherited
-      ``VIRTUAL_ENV`` rather than let a child ``uv pip`` install into that
-      unrelated outer env. With no venv, ``uv pip`` errors cleanly (→ our
-      caught failure → 503) instead of silently polluting the wrong env.
-
-    Harmless for the ``pip`` path either way (pip installs into
-    ``sys.executable`` regardless of ``VIRTUAL_ENV``). Pure + no FS access →
-    unit-testable.
-    """
-    env = dict(environ)
-    if prefix_is_venv:
-        env["VIRTUAL_ENV"] = prefix
-    else:
-        env.pop("VIRTUAL_ENV", None)
-    return env
-
-
-def _spacy_download_subprocess(
-    cmd: list[str], env: dict[str, str], timeout: int
-) -> None:
-    """Run the spaCy-model install in its OWN process group; kill the WHOLE
-    group on timeout.
-
-    ``subprocess.run(timeout=...)`` SIGKILLs only the direct child, so a pip/uv
-    grandchild would survive a timeout, keep mutating the environment after the
-    single-flight lock is released, and race a later retry. ``start_new_session``
-    makes the child a group leader whose grandchildren inherit the group, so one
-    ``killpg`` reaps the whole tree. Raises ``CalledProcessError`` on non-zero
-    exit (stderr on the exception only) or ``TimeoutExpired`` on timeout — both
-    already handled by the caller, which logs a sanitized shape, never raw text.
-    """
-    import os
-    import signal
-    import subprocess
-
-    proc = subprocess.Popen(
-        cmd,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
-    try:
-        _, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
-            proc.kill()  # fall back to killing at least the direct child
-        # BOUNDED best-effort reap: SIGKILL is uncatchable so this normally
-        # returns at once; cap it so a wedged descendant still holding a pipe
-        # can't hang the worker past the timeout. Close our pipe ends regardless
-        # so we never leak fds; any residual process is reaped by the subprocess
-        # module's own cleanup on the next ``Popen``.
-        try:
-            proc.communicate(timeout=10)
-        except Exception:  # noqa: BLE001 — never mask the timeout re-raised below
-            pass
-        for _pipe in (proc.stdout, proc.stderr, proc.stdin):
-            if _pipe is not None:
-                try:
-                    _pipe.close()
-                except Exception:  # noqa: BLE001
-                    pass
-        raise
-    if proc.returncode != 0:
-        raise subprocess.CalledProcessError(proc.returncode, cmd, stderr=stderr)
 
 
 def _probe_kokoro_g2p_model() -> tuple[bool, str | None]:
-    """Ensure misaki's spaCy G2P model is importable; install it once if not.
+    """Check that misaki's pull-prepared spaCy G2P model is importable.
 
     Returns ``(ready, reason)`` and NEVER raises — its contract is that ANY
-    failure (a spaCy import error, ``spacy.util.is_package`` raising on corrupt
-    metadata, a subprocess or ``SystemExit`` from the installer) becomes a
-    clean 503 verdict, not an exception the route would collapse into the
-    opaque 500 this fix exists to prevent.
+    failure becomes a clean 503 verdict, not an exception the route would
+    collapse into an opaque 500. This path never downloads or installs.
     """
     try:
         return _probe_kokoro_g2p_model_impl()
@@ -768,156 +651,40 @@ def _probe_kokoro_g2p_model() -> tuple[bool, str | None]:
 
 
 def _probe_kokoro_g2p_model_impl() -> tuple[bool, str | None]:
-    import importlib
-    import os
-    import subprocess
-    import sys
+    from vllm_mlx.audio.runtime_requirements import spacy_pipeline_available
 
     try:
-        import spacy.util
+        available = spacy_pipeline_available(_KOKORO_G2P_SPACY_MODEL)
     except Exception as e:  # noqa: BLE001
-        # Reached only for a Kokoro request past the misaki-present gate, and
-        # misaki hard-depends on spaCy — so an unimportable spaCy (absent, torn
-        # submodule, or broken C-ext) is a broken install. Fail closed with a
-        # 503 rather than mask it as ready (which would resurface as the opaque
-        # 500 this fix prevents). Log only the exception TYPE (a broken-C-ext
-        # ImportError repr can carry a dylib path); never return it.
         logger.error(
             "Kokoro TTS: spaCy G2P runtime is not importable: %s", type(e).__name__
         )
         return False, _g2p_model_install_hint()
-    # ``is_package`` is misaki's OWN download predicate — misaki/en.py does
-    # ``if not spacy.util.is_package(name): spacy.cli.download(name)`` then
-    # ``spacy.load(name)``. Matching that predicate exactly is what makes this
-    # gate sufficient: when it's True, misaki's ``if not is_package`` is False,
-    # so misaki NEVER reaches ``spacy.cli.download`` and the uv-pip SystemExit
-    # cannot fire. (A corrupt-but-installed model would fail later in
-    # ``spacy.load`` as a normal ``OSError`` — a plain Exception the route 500s
-    # cleanly — never the #1254 SystemExit, because misaki gates the download
-    # on presence, not on load success.)
-    if spacy.util.is_package(_KOKORO_G2P_SPACY_MODEL):
+    if available:
         return True, None
-
-    env = _g2p_installer_env(
-        dict(os.environ),
-        sys.prefix,
-        os.path.exists(os.path.join(sys.prefix, "pyvenv.cfg")),
-    )
-    logger.info(
-        "Kokoro TTS: installing spaCy G2P model %s (first-use bootstrap)…",
-        _KOKORO_G2P_SPACY_MODEL,
-    )
-    try:
-        _spacy_download_subprocess(
-            [sys.executable, "-m", "spacy", "download", _KOKORO_G2P_SPACY_MODEL],
-            env,
-            300,
-        )
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-        OSError,
-    ) as e:
-        # Log only the failure SHAPE (exception type + exit status) — never the
-        # raw installer stderr, which can echo authenticated package-index URLs,
-        # credentials, hostnames, and paths (secret-in-logs). The operator
-        # reproduces with the exact command surfaced in the 503 hint.
-        rc = getattr(e, "returncode", None)
-        logger.error(
-            "Kokoro TTS: spaCy G2P model install failed: %s%s",
-            type(e).__name__,
-            f" (exit {rc})" if rc is not None else "",
-        )
-        return False, _g2p_model_install_hint()
-
-    importlib.invalidate_caches()
-    # Verify the model is importable in THIS interpreter. A child ``uv pip``
-    # honouring a mismatched ``VIRTUAL_ENV`` (or any silent no-op) could report
-    # success while the wheel landed elsewhere; without this re-check misaki
-    # would still hit its runtime download. Fail closed → clean 503, never 500.
-    if not spacy.util.is_package(_KOKORO_G2P_SPACY_MODEL):
-        logger.error(
-            "Kokoro TTS: spaCy G2P model install reported success but '%s' is "
-            "still not importable in this interpreter (%s)",
-            _KOKORO_G2P_SPACY_MODEL,
-            sys.prefix,
-        )
-        return False, _g2p_model_install_hint()
-    return True, None
+    return False, _g2p_model_install_hint()
 
 
 def _ensure_kokoro_g2p_model_ready() -> None:
-    """Raise a clean 503 if misaki's spaCy G2P model can't be made available.
-
-    Single-flight, NON-blocking: the first cold request acquires
-    ``_G2P_MODEL_LOCK`` and runs the one-time install (up to the subprocess's
-    300 s timeout); concurrent cold requests do NOT block waiting on the lock.
-    Because the ``/v1/audio/speech`` route offloads this to the shared route
-    thread pool, a first-use burst that all blocked here would tie up worker
-    threads for the whole install window and stall unrelated endpoints — so a
-    request that finds the install already in flight returns a transient 503
-    ("retry shortly") and frees its worker immediately.
-
-    SUCCESS is cached for the process lifetime; a FAILURE is cached only for
-    ``_G2P_MODEL_RETRY_COOLDOWN_S`` so a transient index outage / timeout can
-    recover WITHOUT a server restart (re-probe after the cooldown; cache
-    success once the dependency is present).
-    """
-    global _G2P_MODEL_READY, _G2P_MODEL_REASON, _G2P_MODEL_RETRY_AFTER
-
-    import time
+    """Raise 503 unless the pull-prepared pipeline is locally available."""
+    global _G2P_MODEL_READY
 
     from fastapi import HTTPException
 
     if _G2P_MODEL_READY:
         return  # success is sticky for the process lifetime
 
-    # A recent failure is served from cache until its cooldown expires — don't
-    # re-run the (up to 300 s) install on every request while it's still broken.
-    if _G2P_MODEL_REASON is not None and time.monotonic() < _G2P_MODEL_RETRY_AFTER:
-        raise HTTPException(status_code=503, detail=_G2P_MODEL_REASON)
-
-    if _G2P_MODEL_LOCK.acquire(blocking=False):
-        try:
-            # Re-check under the lock: another request may have just resolved it
-            # or set a fresh cooldown while we were racing to acquire.
-            if not _G2P_MODEL_READY and time.monotonic() >= _G2P_MODEL_RETRY_AFTER:
-                ready, reason = _probe_kokoro_g2p_model()
-                if ready:
-                    _G2P_MODEL_READY, _G2P_MODEL_REASON = True, None
-                else:
-                    _G2P_MODEL_REASON = reason
-                    _G2P_MODEL_RETRY_AFTER = (
-                        time.monotonic() + _G2P_MODEL_RETRY_COOLDOWN_S
-                    )
-        finally:
-            _G2P_MODEL_LOCK.release()
-    else:
-        # Another request holds the lock and is running the install; don't
-        # occupy a worker thread blocked on it. Fail fast + retryable.
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                f"Kokoro TTS is preparing its spaCy G2P model "
-                f"('{_KOKORO_G2P_SPACY_MODEL}', one-time first-use setup). "
-                "Retry in a few seconds."
-            ),
-        )
-
-    if _G2P_MODEL_READY:
+    ready, reason = _probe_kokoro_g2p_model()
+    if ready:
+        _G2P_MODEL_READY = True
         return
-    raise HTTPException(
-        status_code=503, detail=_G2P_MODEL_REASON or _g2p_model_install_hint()
-    )
+    raise HTTPException(status_code=503, detail=reason or _g2p_model_install_hint())
 
 
 def _reset_g2p_model_state() -> None:
     """Test hook: forget the cached spaCy-G2P-model readiness verdict."""
-    global _G2P_MODEL_READY, _G2P_MODEL_REASON, _G2P_MODEL_RETRY_AFTER
+    global _G2P_MODEL_READY
     _G2P_MODEL_READY = None
-    _G2P_MODEL_REASON = None
-    _G2P_MODEL_RETRY_AFTER = 0.0
 
 
 def _ensure_kokoro_g2p_ready() -> None:
@@ -993,10 +760,11 @@ def require_kokoro_runtime(voice: str | None = None) -> None:
     F-K-KOKORO-SPACY (#1254): misaki's English G2P tokenizer needs the
     spaCy ``en_core_web_sm`` model, which it downloads lazily on the
     first ``generate`` in a way that ``SystemExit``s under uv-tool /
-    console-script launchers (an opaque 500). This pre-resolves it here
-    (installed once, in a contained subprocess) so a missing model 503s
-    cleanly instead. Gated on ``voice`` — only ENGLISH voices use
-    ``misaki.en``; Japanese/Mandarin/etc. voices don't need this model.
+    console-script launchers (an opaque 500). ``rapid-mlx pull`` prepares the
+    catalog-declared pipeline; this request boundary only verifies local
+    availability and returns a clean 503 if preparation is incomplete. Gated
+    on ``voice`` — only ENGLISH voices use ``misaki.en``;
+    Japanese/Mandarin/etc. voices don't need this model.
 
     F-K-KOKORO-ESPEAK: beyond the missing-extra check, this also
     validates that misaki's espeak-ng G2P backend can actually
@@ -1018,9 +786,8 @@ def require_kokoro_runtime(voice: str | None = None) -> None:
             status_code=503,
             detail=f"{_KOKORO_EXTRA_HINT}",
         )
-    # Run the CHEAP espeak readiness check first (a ~1-2 s subprocess self-test)
-    # so a host missing espeak fails fast, BEFORE the spaCy model bootstrap —
-    # which can spend up to 300 s on a network install.
+    # Run the espeak readiness check first. The following spaCy check is
+    # local-only and never mutates the environment.
     _ensure_kokoro_g2p_ready()
     # F-K-KOKORO-SPACY (#1254): misaki's English G2P also needs the spaCy
     # ``en_core_web_sm`` model, downloaded lazily on first ``generate`` in a

--- a/vllm_mlx/audio/registry.py
+++ b/vllm_mlx/audio/registry.py
@@ -40,6 +40,7 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 AudioType = Literal["tts", "stt"]
+AudioRuntimeRequirementKind = Literal["spacy_pipeline"]
 
 
 @dataclass(frozen=True)
@@ -55,6 +56,19 @@ class AudioRuntimeAsset:
 
     repo_id: str
     allow_patterns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AudioRuntimeRequirement:
+    """One typed environment requirement prepared by ``rapid-mlx pull``.
+
+    The catalog stores data, not commands.  A closed ``kind`` set keeps the
+    preparation surface auditable and prevents model metadata from becoming an
+    arbitrary package-install hook.
+    """
+
+    kind: AudioRuntimeRequirementKind
+    name: str
 
 
 @dataclass(frozen=True)
@@ -98,6 +112,7 @@ _REGISTRY: dict[str, AudioAliasEntry] | None = None
 # ids the same way it answers for short aliases.
 _HF_ID_INDEX: dict[str, str] = {}
 _RUNTIME_ASSETS: dict[str, tuple[AudioRuntimeAsset, ...]] = {}
+_RUNTIME_REQUIREMENTS: dict[str, tuple[AudioRuntimeRequirement, ...]] = {}
 _REGISTRY_LOCK = threading.Lock()
 
 
@@ -180,6 +195,50 @@ def _load_registry_uncached() -> dict[str, AudioAliasEntry]:
             parsed.append(AudioRuntimeAsset(repo_id, tuple(patterns)))
         runtime_assets[family] = tuple(parsed)
 
+    runtime_requirements: dict[str, tuple[AudioRuntimeRequirement, ...]] = {}
+    raw_runtime_requirements = raw.get("_runtime_requirements", {})
+    if not isinstance(raw_runtime_requirements, dict):
+        raise ValueError("audio aliases.json: _runtime_requirements must be an object")
+    for family, requirements in raw_runtime_requirements.items():
+        if not isinstance(family, str) or not family:
+            raise ValueError(
+                "audio aliases.json: _runtime_requirements family keys must be "
+                "non-empty strings"
+            )
+        if not isinstance(requirements, list):
+            raise ValueError(
+                f"audio aliases.json: _runtime_requirements.{family} must be an array"
+            )
+        parsed_requirements: list[AudioRuntimeRequirement] = []
+        seen_requirements: set[tuple[str, str]] = set()
+        for index, requirement in enumerate(requirements):
+            if not isinstance(requirement, dict):
+                raise ValueError(
+                    f"audio aliases.json: _runtime_requirements.{family}[{index}] "
+                    "must be an object"
+                )
+            kind = requirement.get("kind")
+            name = requirement.get("name")
+            if kind != "spacy_pipeline":
+                raise ValueError(
+                    f"audio aliases.json: _runtime_requirements.{family}[{index}]."
+                    "kind must be 'spacy_pipeline'"
+                )
+            if not isinstance(name, str) or not name.isidentifier():
+                raise ValueError(
+                    f"audio aliases.json: _runtime_requirements.{family}[{index}]."
+                    "name must be a Python package identifier"
+                )
+            key = (kind, name)
+            if key in seen_requirements:
+                raise ValueError(
+                    f"audio aliases.json: duplicate runtime requirement {kind}:{name} "
+                    f"for family {family!r}"
+                )
+            seen_requirements.add(key)
+            parsed_requirements.append(AudioRuntimeRequirement(kind=kind, name=name))
+        runtime_requirements[family] = tuple(parsed_requirements)
+
     entries: dict[str, AudioAliasEntry] = {}
     for key, value in raw.items():
         if key.startswith("_"):
@@ -220,13 +279,19 @@ def _load_registry_uncached() -> dict[str, AudioAliasEntry]:
             notes=value.get("notes", ""),
         )
 
-    unknown_families = set(runtime_assets) - {
-        entry.family for entry in entries.values()
-    }
-    if unknown_families:
-        names = ", ".join(sorted(unknown_families))
+    known_families = {entry.family for entry in entries.values()}
+    unknown_asset_families = set(runtime_assets) - known_families
+    if unknown_asset_families:
+        names = ", ".join(sorted(unknown_asset_families))
         raise ValueError(
             f"audio aliases.json: runtime assets declared for unknown family: {names}"
+        )
+    unknown_requirement_families = set(runtime_requirements) - known_families
+    if unknown_requirement_families:
+        names = ", ".join(sorted(unknown_requirement_families))
+        raise ValueError(
+            "audio aliases.json: runtime requirements declared for unknown family: "
+            f"{names}"
         )
     # Reverse index keyed on the lowercased HF id so ``serve_command``
     # can route a request like ``rapid-mlx serve mlx-community/Kokoro-
@@ -242,6 +307,8 @@ def _load_registry_uncached() -> dict[str, AudioAliasEntry]:
     _HF_ID_INDEX.update(hf_id_index)
     _RUNTIME_ASSETS.clear()
     _RUNTIME_ASSETS.update(runtime_assets)
+    _RUNTIME_REQUIREMENTS.clear()
+    _RUNTIME_REQUIREMENTS.update(runtime_requirements)
     _REGISTRY = entries
     return entries
 
@@ -317,6 +384,17 @@ def runtime_assets_for(name: str | None) -> tuple[AudioRuntimeAsset, ...]:
     if entry is None:
         return ()
     return _RUNTIME_ASSETS.get(entry.family, ())
+
+
+def runtime_requirements_for(
+    name: str | None,
+) -> tuple[AudioRuntimeRequirement, ...]:
+    """Return typed environment requirements declared for an audio name."""
+
+    entry = resolve_audio_alias(name)
+    if entry is None:
+        return ()
+    return _RUNTIME_REQUIREMENTS.get(entry.family, ())
 
 
 def stt_aliases() -> dict[str, str]:

--- a/vllm_mlx/audio/runtime_requirements.py
+++ b/vllm_mlx/audio/runtime_requirements.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare catalog-declared audio runtime requirements.
+
+Model servers should enter inference with every external artifact already
+materialized.  This module keeps that preparation in the explicit
+``rapid-mlx pull`` workflow and leaves request handling local-only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import signal
+import subprocess
+import sys
+
+from vllm_mlx.audio.registry import AudioRuntimeRequirement
+
+logger = logging.getLogger(__name__)
+
+
+class AudioRuntimePreparationError(RuntimeError):
+    """A declared runtime requirement could not be prepared safely."""
+
+
+def spacy_pipeline_available(package: str) -> bool:
+    """Return whether ``package`` is installed for this interpreter.
+
+    ``spacy.util.is_package`` is also the predicate used by the downstream G2P
+    runtime before it attempts its own download, so matching it prevents a
+    hidden first-request network path.
+    """
+
+    import spacy.util
+
+    return bool(spacy.util.is_package(package))
+
+
+def _installer_env(
+    environ: dict[str, str], prefix: str, prefix_is_venv: bool
+) -> dict[str, str]:
+    """Return a child environment targeting the running interpreter."""
+
+    env = dict(environ)
+    if prefix_is_venv:
+        env["VIRTUAL_ENV"] = prefix
+    else:
+        env.pop("VIRTUAL_ENV", None)
+    return env
+
+
+def _run_installer(cmd: list[str], env: dict[str, str], timeout: int) -> None:
+    """Run an installer in its own process group and reap it on timeout."""
+
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        _, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+        try:
+            proc.communicate(timeout=10)
+        except Exception:  # noqa: BLE001 - preserve the original timeout
+            pass
+        for pipe in (proc.stdout, proc.stderr, proc.stdin):
+            if pipe is not None:
+                try:
+                    pipe.close()
+                except Exception:  # noqa: BLE001
+                    pass
+        raise
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, stderr=stderr)
+
+
+def _prepare_spacy_pipeline(package: str) -> None:
+    try:
+        if spacy_pipeline_available(package):
+            return
+    except Exception as exc:  # noqa: BLE001 - normalize broken environments
+        raise AudioRuntimePreparationError(
+            f"spaCy runtime is not importable while preparing '{package}'"
+        ) from exc
+
+    env = _installer_env(
+        dict(os.environ),
+        sys.prefix,
+        os.path.exists(os.path.join(sys.prefix, "pyvenv.cfg")),
+    )
+    try:
+        _run_installer(
+            [sys.executable, "-m", "spacy", "download", package], env, timeout=300
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ) as exc:
+        status = getattr(exc, "returncode", None)
+        logger.error(
+            "Audio runtime preparation failed for spaCy pipeline %s: %s%s",
+            package,
+            type(exc).__name__,
+            f" (exit {status})" if status is not None else "",
+        )
+        raise AudioRuntimePreparationError(
+            f"Could not prepare required spaCy pipeline '{package}'"
+        ) from exc
+
+    importlib.invalidate_caches()
+    try:
+        available = spacy_pipeline_available(package)
+    except Exception as exc:  # noqa: BLE001 - keep CLI errors path-safe
+        raise AudioRuntimePreparationError(
+            f"spaCy pipeline '{package}' was installed but cannot be imported"
+        ) from exc
+    if not available:
+        raise AudioRuntimePreparationError(
+            f"spaCy reported success but pipeline '{package}' is not available "
+            "to the rapid-mlx interpreter"
+        )
+
+
+def prepare_runtime_requirement(requirement: AudioRuntimeRequirement) -> None:
+    """Materialize one validated catalog requirement for offline inference."""
+
+    if requirement.kind == "spacy_pipeline":
+        _prepare_spacy_pipeline(requirement.name)
+        return
+    raise AudioRuntimePreparationError(
+        f"Unsupported audio runtime requirement kind: {requirement.kind}"
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7097,7 +7097,10 @@ def pull_command(args):
     import copy
 
     from vllm_mlx.audio.registry import runtime_assets_for, runtime_requirements_for
-    from vllm_mlx.audio.runtime_requirements import prepare_runtime_requirement
+    from vllm_mlx.audio.runtime_requirements import (
+        AudioRuntimePreparationError,
+        prepare_runtime_requirement,
+    )
 
     primary_repo = args.model
     _pull_repository(args)
@@ -7116,7 +7119,17 @@ def pull_command(args):
         )
     for requirement in runtime_requirements_for(primary_repo):
         print(f"\n  Runtime requirement: {requirement.kind} {requirement.name}")
-        prepare_runtime_requirement(requirement)
+        try:
+            prepare_runtime_requirement(requirement)
+        except AudioRuntimePreparationError as exc:
+            shown = getattr(args, "_original_alias", primary_repo)
+            print(f"\n  Error: Could not prepare audio runtime for '{shown}'.")
+            print(f"  {exc}")
+            print(
+                "  Install 'rapid-mlx[audio]' in this environment, then rerun "
+                f"'rapid-mlx pull {shown}'."
+            )
+            sys.exit(1)
     _emit_pull_activation()
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7092,11 +7092,12 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
 
 
 def pull_command(args):
-    """Download a model and every catalog-declared runtime repository."""
+    """Download a model and prepare every catalog-declared requirement."""
 
     import copy
 
-    from vllm_mlx.audio.registry import runtime_assets_for
+    from vllm_mlx.audio.registry import runtime_assets_for, runtime_requirements_for
+    from vllm_mlx.audio.runtime_requirements import prepare_runtime_requirement
 
     primary_repo = args.model
     _pull_repository(args)
@@ -7113,6 +7114,9 @@ def pull_command(args):
             dependency_args,
             allow_patterns_override=list(asset.allow_patterns),
         )
+    for requirement in runtime_requirements_for(primary_repo):
+        print(f"\n  Runtime requirement: {requirement.kind} {requirement.name}")
+        prepare_runtime_requirement(requirement)
     _emit_pull_activation()
 
 


### PR DESCRIPTION
## Summary

- declare Kokoro's English G2P pipeline as a closed, typed audio-catalog runtime requirement
- have `rapid-mlx pull` prepare and verify every declared requirement before recording a successful pull
- make the inference boundary local-only: it checks the prepared pipeline and returns an actionable 503 instead of downloading or installing from a request
- preserve the existing checkpoint/voice-asset mirror, fallback, and activation accounting flow

Fixes #2659

## Design precedent

Production serving keeps artifact acquisition separate from inference: operators prepare model/runtime artifacts explicitly, then serving resolves local state and honors offline mode without mutating its environment. The pipeline provider likewise treats trained pipelines as package dependencies and supplies its own compatibility resolver. This change adapts that pattern to Rapid-MLX's existing catalog-driven pull flow.

A direct wheel URL was not added to published dependency metadata because public package indexes do not support direct references in uploaded distributions. The catalog contains a validated requirement type and package identifier, never a command; the generic preparer invokes the dependency's compatibility resolver through the running interpreter.

## Scope

- audio runtime-requirement metadata and validation
- generic pull-time preparation
- Kokoro request-time local readiness check
- focused pull, registry, route, failure-sanitization, and process-lifecycle tests

## Non-goals

- no model or dependency version bump
- no unrelated audio-family redesign
- no Desktop sidecar change
- no request-time package installation fallback

## User walk

A wheel built from this head was installed as `rapid-mlx[audio]` in a fresh Python 3.12 environment.

1. Before pull: `spacy.util.is_package("en_core_web_sm") == False`.
2. `rapid-mlx pull kokoro` prepared the checkpoint, 54 voice assets, and compatible `en_core_web_sm 3.8.0`.
3. The server was then started with Hugging Face/Transformers offline mode and every external proxy pointed at an unreachable loopback port.
4. The first default `af_heart` request returned HTTP 200 and a real PCM WAV: mono, 16-bit, 24 kHz, 103,800 frames (4.325 s). Server logs contained local load/synthesis only.

## Verification

- 543 passed, 3 skipped: complete audio/Kokoro/pull-audio test set in the fresh `[audio]` environment
- 234 passed: pull, alias-subfolder, and mirror regression set
- 235 passed: focused catalog/pull/route set
- mypy error budget: 707 grandfathered errors, no growth
- Ruff check and format, plus `git diff --check`: clean
