### PR TITLE
perf(mac): shrink the release DMG safely with LZMA

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -150,8 +150,53 @@ struct SidecarBuildScriptTests {
                 "Only model-family directories outside Qwen3 TTS may be removed.")
         #expect(!script.contains(#"rm -rf "$STAGE/site-packages/mlx_audio/tts/models""#),
                 "The trim must never remove the complete TTS model directory.")
-        #expect(script.contains(#"MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}""#),
-                "The signing baseline must match the measured post-audio bundle.")
+        #expect(script.contains(#"MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-172}""#),
+                "The signing baseline must match the measured post-audio bundle, less the orphaned libpython dylib dropped in step 3.")
+    }
+
+    /// The interpreter strip must stay ABOVE the signing loop.
+    ///
+    /// `strip` rewrites the Mach-O, which invalidates any signature already
+    /// attached to it. Sinking the strip below step 5 would still produce a
+    /// bundle locally — the breakage only surfaces as a `codesign --verify`
+    /// failure on the user's Mac (and a notarisation reject in CI), so pin
+    /// the relative order here rather than trusting a comment.
+    @Test("The interpreter is stripped before the Mach-O signing pass")
+    func stripsInterpreterBeforeSigning() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+
+        guard let strip = script.range(of: #"strip -x "$STAGE/python/bin/python3.12""#) else {
+            Issue.record("The interpreter strip step is missing; the bundle regains ~1.6 MB of symbol table.")
+            return
+        }
+        guard let signing = script.range(of: "step 5: count + sign Mach-Os") else {
+            Issue.record("Could not locate the Mach-O signing step to order against.")
+            return
+        }
+        #expect(strip.lowerBound < signing.lowerBound,
+                "strip invalidates signatures, so it must run before the Mach-Os are signed.")
+    }
+
+    /// `strip -x` keeps external symbols; a bare `strip` does not.
+    ///
+    /// The distinction matters beyond size: native wheels resolve Python's
+    /// exported symbols out of the interpreter at dlopen time, so a full
+    /// strip breaks `import mlx.core` at runtime rather than at build time.
+    @Test("The interpreter strip keeps external symbols")
+    func stripsInterpreterNonDestructively() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+
+        #expect(!script.contains(#"strip "$STAGE/python/bin/python3.12""#),
+                "A bare strip removes exported symbols the native wheels dlopen against; -x is required.")
+    }
+
+    /// The orphaned embedder dylib must stay out of the bundle.
+    @Test("The unreferenced libpython dylib is dropped")
+    func dropsOrphanedLibpython() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+
+        #expect(script.contains(#"rm -f "$STAGE/python/lib/libpython3.12.dylib""#),
+                "python-build-standalone ships a statically-linked interpreter, so its separate libpython dylib is 18 MB nothing links against.")
     }
 
     private static var scriptURL: URL {

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -154,49 +154,16 @@ struct SidecarBuildScriptTests {
                 "The signing baseline must match the measured post-audio bundle, less the orphaned libpython dylib dropped in step 3.")
     }
 
-    /// The interpreter strip must stay ABOVE the signing loop.
-    ///
-    /// `strip` rewrites the Mach-O, which invalidates any signature already
-    /// attached to it. Sinking the strip below step 5 would still produce a
-    /// bundle locally — the breakage only surfaces as a `codesign --verify`
-    /// failure on the user's Mac (and a notarisation reject in CI), so pin
-    /// the relative order here rather than trusting a comment.
-    @Test("The interpreter is stripped before the Mach-O signing pass")
-    func stripsInterpreterBeforeSigning() throws {
+    /// The shared libpython optimization must stay behind the tested guard.
+    @Test("The unreferenced libpython dylib uses the fail-closed guard")
+    func guardsOrphanedLibpythonRemoval() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
 
-        guard let strip = script.range(of: #"strip -x "$STAGE/python/bin/python3.12""#) else {
-            Issue.record("The interpreter strip step is missing; the bundle regains ~1.6 MB of symbol table.")
-            return
-        }
-        guard let signing = script.range(of: "step 5: count + sign Mach-Os") else {
-            Issue.record("Could not locate the Mach-O signing step to order against.")
-            return
-        }
-        #expect(strip.lowerBound < signing.lowerBound,
-                "strip invalidates signatures, so it must run before the Mach-Os are signed.")
-    }
-
-    /// `strip -x` keeps external symbols; a bare `strip` does not.
-    ///
-    /// The distinction matters beyond size: native wheels resolve Python's
-    /// exported symbols out of the interpreter at dlopen time, so a full
-    /// strip breaks `import mlx.core` at runtime rather than at build time.
-    @Test("The interpreter strip keeps external symbols")
-    func stripsInterpreterNonDestructively() throws {
-        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
-
-        #expect(!script.contains(#"strip "$STAGE/python/bin/python3.12""#),
-                "A bare strip removes exported symbols the native wheels dlopen against; -x is required.")
-    }
-
-    /// The orphaned embedder dylib must stay out of the bundle.
-    @Test("The unreferenced libpython dylib is dropped")
-    func dropsOrphanedLibpython() throws {
-        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
-
-        #expect(script.contains(#"rm -f "$STAGE/python/lib/libpython3.12.dylib""#),
-                "python-build-standalone ships a statically-linked interpreter, so its separate libpython dylib is 18 MB nothing links against.")
+        #expect(script.contains(#""$REPO_ROOT/scripts/prune-unused-libpython.sh" "$STAGE""#))
+        #expect(!script.contains(#"rm -f "$STAGE/python/lib/libpython3.12.dylib""#),
+                "build-sidecar must not bypass the consumer scan with an unconditional deletion.")
+        #expect(!script.contains(#"strip -x "$STAGE/python/bin/python3.12""#),
+                "Local CPython symbols are required for useful native crash frames.")
     }
 
     private static var scriptURL: URL {

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -93,7 +93,19 @@ COMPILEALL_JOBS="${COMPILEALL_JOBS:-0}"
 # STT and Qwen3-TTS smoke imports passing. The non-Qwen TTS implementations
 # and SciPy subpackages outside the signal closure have already been removed
 # before this count is taken.
-MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}"
+#
+# Re-locked at 172 on 2026-08-25 (bundle slim-down): step 3 now also drops the
+# orphaned libpython3.12.dylib — exactly one Mach-O, and one we used to sign
+# rather than a new one, so no signing-safety spike re-run is needed. The
+# console-script and sysconfig trims in the same pass are shell/pure-Python
+# and Mach-O-neutral, and the step 4.5 `strip -x` rewrites the interpreter
+# without changing the count.
+#
+# NOTE: the 174 above was itself stale — a pre-change bundle measures 173, so
+# the committed baseline had drifted by one and was being masked by
+# MACHO_TOLERANCE. 172 is the directly measured post-trim count (173 - 1),
+# not 174 - 1.
+MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-172}"
 # Allow modest drift without blocking — wheel updates sometimes shift
 # 1-2 .so files. Bigger drift means a new dependency, needs review.
 # Kept at 5 across the 51 → 77 baseline rebase to give Pillow and
@@ -500,6 +512,41 @@ rm -rf \
     "$STAGE/python/lib/"thread* \
     "$STAGE/python/lib/"itcl* \
     "$STAGE/python/lib/python3.12/lib-dynload/"_tkinter*.so
+# Drop the orphaned libpython dylib. python-build-standalone ships BOTH a
+# statically-linked interpreter (python/bin/python3.12, __TEXT ~13 MB with
+# CPython compiled in) and the same runtime again as a standalone
+# libpython3.12.dylib for embedders. Nothing in this bundle embeds CPython:
+# an `otool -L` sweep over every .so / .dylib / the interpreter itself finds
+# zero references to it (lib-dynload extensions and every site-packages
+# native module resolve their Python symbols from the host process). 18 MB
+# and one Mach-O of pure dead weight; MACHO_BASELINE_COUNT is set to the
+# post-trim count. Verified by moving it aside and re-running the full
+# import closure (vllm_mlx, mlx_lm, transformers, scipy.signal, mlx_vlm,
+# mflux, mlx.core) plus `bin/rapid-mlx --help`.
+rm -f "$STAGE/python/lib/libpython3.12.dylib"
+# Console scripts for modules step 3 just deleted. python-build-standalone's
+# bin/ ships launchers for pip, idlelib, 2to3, pydoc and the build-time
+# sysconfig helpers; with those packages gone each one is a shell stub that
+# execs the interpreter straight into `ModuleNotFoundError` (verified: pip →
+# "No module named 'pip'", idle3.12 → "No module named 'idlelib'"). Only the
+# interpreter and its python / python3 symlinks are reachable from
+# sidecar-shim.sh. Tiny on disk, but they are signed and sealed like
+# everything else, so a user who finds one and runs it gets a traceback out
+# of an otherwise-working install.
+rm -f \
+    "$STAGE/python/bin/"pip "$STAGE/python/bin/"pip3 "$STAGE/python/bin/"pip3.12 \
+    "$STAGE/python/bin/"idle3 "$STAGE/python/bin/"idle3.12 \
+    "$STAGE/python/bin/"2to3 "$STAGE/python/bin/"2to3-3.12 \
+    "$STAGE/python/bin/"pydoc3 "$STAGE/python/bin/"pydoc3.12 \
+    "$STAGE/python/bin/"python3-config "$STAGE/python/bin/"python3.12-config
+# Build-time-only sysconfig data: pkgconfig/ and config-3.12-darwin/ exist to
+# compile C extensions against this interpreter (the latter also carries a
+# static libpython*.a), and pydoc_data backs the pydoc launcher removed just
+# above. The bundle never compiles anything at runtime.
+rm -rf \
+    "$STAGE/python/lib/pkgconfig" \
+    "$STAGE/python/lib/python3.12/config-3.12-darwin" \
+    "$STAGE/python/lib/python3.12/pydoc_data"
 find "$STAGE" -type d -name __pycache__ -prune -exec rm -rf {} +
 
 # ----- step 3.5: aggressive trim (post-strip, pre-compileall) ----------
@@ -765,6 +812,23 @@ fi
 
 cp "${REPO_ROOT}/scripts/sidecar-shim.sh" "$STAGE/bin/rapid-mlx"
 chmod +x "$STAGE/bin/rapid-mlx"
+
+# ----- step 4.5: strip the interpreter's symbol table -------------------
+#
+# python-build-standalone ships python3.12 unstripped (~42.7k symbols,
+# 18.0 MB). `strip -x` drops local symbols while keeping the exported ones
+# that lib-dynload extensions and every native wheel resolve against at
+# dlopen time — removing those would break `import mlx.core`. Saves ~1.6 MB.
+#
+# ORDER IS LOAD-BEARING: this must run BEFORE step 5 signs the Mach-Os.
+# strip rewrites the binary and invalidates any existing signature, so
+# stripping after signing would ship a bundle that fails `codesign --verify`
+# (and, post-notarisation, Gatekeeper). Keep this step above step 5.
+#
+# The interpreter is the only unstripped Mach-O worth touching: the wheel
+# .so / .dylib files arrive pre-stripped from PyPI.
+echo "==> stripping interpreter symbol table"
+strip -x "$STAGE/python/bin/python3.12"
 
 # ----- step 5: count + sign Mach-Os ------------------------------------
 

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -98,8 +98,8 @@ COMPILEALL_JOBS="${COMPILEALL_JOBS:-0}"
 # orphaned libpython3.12.dylib — exactly one Mach-O, and one we used to sign
 # rather than a new one, so no signing-safety spike re-run is needed. The
 # console-script and sysconfig trims in the same pass are shell/pure-Python
-# and Mach-O-neutral, and the step 4.5 `strip -x` rewrites the interpreter
-# without changing the count.
+# and Mach-O-neutral. The interpreter remains unstripped so native crashes
+# retain internal CPython frame names.
 #
 # NOTE: the 174 above was itself stale — a pre-change bundle measures 173, so
 # the committed baseline had drifted by one and was being masked by
@@ -512,18 +512,11 @@ rm -rf \
     "$STAGE/python/lib/"thread* \
     "$STAGE/python/lib/"itcl* \
     "$STAGE/python/lib/python3.12/lib-dynload/"_tkinter*.so
-# Drop the orphaned libpython dylib. python-build-standalone ships BOTH a
-# statically-linked interpreter (python/bin/python3.12, __TEXT ~13 MB with
-# CPython compiled in) and the same runtime again as a standalone
-# libpython3.12.dylib for embedders. Nothing in this bundle embeds CPython:
-# an `otool -L` sweep over every .so / .dylib / the interpreter itself finds
-# zero references to it (lib-dynload extensions and every site-packages
-# native module resolve their Python symbols from the host process). 18 MB
-# and one Mach-O of pure dead weight; MACHO_BASELINE_COUNT is set to the
-# post-trim count. Verified by moving it aside and re-running the full
-# import closure (vllm_mlx, mlx_lm, transformers, scipy.signal, mlx_vlm,
-# mflux, mlx.core) plus `bin/rapid-mlx --help`.
-rm -f "$STAGE/python/lib/libpython3.12.dylib"
+# python-build-standalone includes a shared libpython for embedders in
+# addition to its statically linked interpreter. The helper scans every
+# bundled Mach-O and refuses deletion if any current or future wheel links
+# the shared library; it also refuses an incomplete or broken scan.
+"$REPO_ROOT/scripts/prune-unused-libpython.sh" "$STAGE"
 # Console scripts for modules step 3 just deleted. python-build-standalone's
 # bin/ ships launchers for pip, idlelib, 2to3, pydoc and the build-time
 # sysconfig helpers; with those packages gone each one is a shell stub that
@@ -812,23 +805,6 @@ fi
 
 cp "${REPO_ROOT}/scripts/sidecar-shim.sh" "$STAGE/bin/rapid-mlx"
 chmod +x "$STAGE/bin/rapid-mlx"
-
-# ----- step 4.5: strip the interpreter's symbol table -------------------
-#
-# python-build-standalone ships python3.12 unstripped (~42.7k symbols,
-# 18.0 MB). `strip -x` drops local symbols while keeping the exported ones
-# that lib-dynload extensions and every native wheel resolve against at
-# dlopen time — removing those would break `import mlx.core`. Saves ~1.6 MB.
-#
-# ORDER IS LOAD-BEARING: this must run BEFORE step 5 signs the Mach-Os.
-# strip rewrites the binary and invalidates any existing signature, so
-# stripping after signing would ship a bundle that fails `codesign --verify`
-# (and, post-notarisation, Gatekeeper). Keep this step above step 5.
-#
-# The interpreter is the only unstripped Mach-O worth touching: the wheel
-# .so / .dylib files arrive pre-stripped from PyPI.
-echo "==> stripping interpreter symbol table"
-strip -x "$STAGE/python/bin/python3.12"
 
 # ----- step 5: count + sign Mach-Os ------------------------------------
 

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -38,23 +38,6 @@ echo "==> assembling Rapid-MLX Desktop.app"
 rm -rf "$APP"
 mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources" "$CONTENTS/Frameworks"
 cp "$ROOT/.build/$CONFIG/Rapid" "$CONTENTS/MacOS/Rapid"
-# SwiftPM emits the release binary with its full symbol table (~212k symbols,
-# 25 MB). `strip -x` removes the local symbols and takes it to ~9.4 MB.
-#
-# Crash telemetry is unaffected. ``CrashReporter``'s exception hook uploads
-# ``NSException.callStackSymbols``, which resolves frames through the dynamic
-# symbol table — and `-x` keeps exactly that, dropping only non-external
-# entries. Verified with an @inline(never) probe: the mangled Swift frame
-# name survives the strip byte-for-byte. A plain `strip` (no -x) WOULD break
-# this, as would stripping any dylib others link against; do not widen it.
-#
-# There is no dSYM to preserve first — SwiftPM's release config emits no
-# DWARF here (`dsymutil` reports "no debug symbols in executable"), so the
-# symbol table is all that ever shipped.
-#
-# ORDER: must precede the codesign pass at the end of this script, since
-# strip rewrites the Mach-O and invalidates any existing signature.
-strip -x "$CONTENTS/MacOS/Rapid"
 cp "$ROOT/Resources/Info.plist" "$CONTENTS/Info.plist"
 cp "$ROOT/Resources/AppIcon.icns" "$CONTENTS/Resources/AppIcon.icns"
 

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -38,6 +38,23 @@ echo "==> assembling Rapid-MLX Desktop.app"
 rm -rf "$APP"
 mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources" "$CONTENTS/Frameworks"
 cp "$ROOT/.build/$CONFIG/Rapid" "$CONTENTS/MacOS/Rapid"
+# SwiftPM emits the release binary with its full symbol table (~212k symbols,
+# 25 MB). `strip -x` removes the local symbols and takes it to ~9.4 MB.
+#
+# Crash telemetry is unaffected. ``CrashReporter``'s exception hook uploads
+# ``NSException.callStackSymbols``, which resolves frames through the dynamic
+# symbol table — and `-x` keeps exactly that, dropping only non-external
+# entries. Verified with an @inline(never) probe: the mangled Swift frame
+# name survives the strip byte-for-byte. A plain `strip` (no -x) WOULD break
+# this, as would stripping any dylib others link against; do not widen it.
+#
+# There is no dSYM to preserve first — SwiftPM's release config emits no
+# DWARF here (`dsymutil` reports "no debug symbols in executable"), so the
+# symbol table is all that ever shipped.
+#
+# ORDER: must precede the codesign pass at the end of this script, since
+# strip rewrites the Mach-O and invalidates any existing signature.
+strip -x "$CONTENTS/MacOS/Rapid"
 cp "$ROOT/Resources/Info.plist" "$CONTENTS/Info.plist"
 cp "$ROOT/Resources/AppIcon.icns" "$CONTENTS/Resources/AppIcon.icns"
 

--- a/apps/rapid-mac/scripts/dmg.sh
+++ b/apps/rapid-mac/scripts/dmg.sh
@@ -76,8 +76,21 @@ hdiutil detach "$MOUNT" -quiet || hdiutil detach "$MOUNT" -force -quiet
 rmdir "$MOUNT" 2>/dev/null || true
 MOUNT=""
 
-echo "==> hdiutil convert UDRW -> UDZO ($DMG)"
-hdiutil convert "$UDRW" -format UDZO -ov -o "$DMG" >/dev/null
+echo "==> hdiutil convert UDRW -> ULMO ($DMG)"
+# ULMO (LZMA) over the historical UDZO (zlib): same .app measures 181 MB as
+# UDZO vs 111 MB as ULMO — the bundle is dominated by mlx.metallib, which is
+# highly compressible (130 MB raw → 34 MB zlib → 8 MB LZMA). ULFO (LZFSE)
+# sits in between at 149 MB. Decompression is slower than zlib, but it is
+# paid once while copying the .app out of the mounted volume.
+#
+# ULMO needs macOS 10.15+ to mount, far below the app's own 14.0 deployment
+# target, so this cannot strand a Mac that could otherwise run the app.
+#
+# The UDRW -> convert 2-step above is unrelated and load-bearing for a
+# different reason (rapid-desktop#427: the 1-step
+# `hdiutil create -srcfolder -format <compressed>` path produced an
+# unreadable BLKX table on a stapled .app) — keep it regardless of format.
+hdiutil convert "$UDRW" -format ULMO -ov -o "$DMG" >/dev/null
 rm -f "$UDRW"
 
 SIGN_IDENTITY="${CODESIGN_IDENTITY:--}"

--- a/apps/rapid-mac/scripts/prune-unused-libpython.sh
+++ b/apps/rapid-mac/scripts/prune-unused-libpython.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Remove python-build-standalone's shared libpython only after proving that no
+# bundled Mach-O links it. A dependency update must fail the build rather than
+# turn this size optimization into a runtime import failure.
+set -euo pipefail
+
+STAGE="${1:?usage: prune-unused-libpython.sh <sidecar-stage>}"
+LIBPYTHON="$STAGE/python/lib/libpython3.12.dylib"
+
+[[ -f "$LIBPYTHON" ]] || exit 0
+
+FILE_LIST="$(mktemp "${TMPDIR:-/tmp}/rapid-libpython-files.XXXXXX")"
+MACHO_LIST="$(mktemp "${TMPDIR:-/tmp}/rapid-libpython-machos.XXXXXX")"
+CONSUMERS="$(mktemp "${TMPDIR:-/tmp}/rapid-libpython-consumers.XXXXXX")"
+trap 'rm -f "$FILE_LIST" "$MACHO_LIST" "$CONSUMERS"' EXIT
+
+if ! find "$STAGE" -type f -print0 > "$FILE_LIST"; then
+    echo "::error::could not enumerate the sidecar while checking libpython consumers" >&2
+    exit 1
+fi
+
+scanned=0
+while IFS= read -r -d '' candidate; do
+    [[ "$candidate" == "$LIBPYTHON" ]] && continue
+    if ! description="$(file -b "$candidate")"; then
+        echo "::error::could not classify $candidate while checking libpython consumers" >&2
+        exit 1
+    fi
+    case "$description" in
+        *Mach-O*)
+            printf '%s\0' "$candidate" >> "$MACHO_LIST"
+            scanned=$((scanned + 1))
+            ;;
+    esac
+done < "$FILE_LIST"
+
+# A production sidecar contains hundreds of Mach-Os. Requiring at least two
+# makes an empty, truncated, or misclassified fixture fail closed without
+# coupling this guard to the separate release signing baseline.
+if [[ "$scanned" -lt 2 ]]; then
+    echo "::error::libpython consumer scan found only $scanned bundled Mach-Os; refusing to trim on an incomplete scan" >&2
+    exit 1
+fi
+
+while IFS= read -r -d '' candidate; do
+    if ! dependencies="$(otool -L "$candidate")"; then
+        echo "::error::otool failed for $candidate while checking libpython consumers" >&2
+        exit 1
+    fi
+    if grep -q 'libpython3\.12\.dylib' <<< "$dependencies"; then
+        printf '%s\n' "$candidate" >> "$CONSUMERS"
+    fi
+done < "$MACHO_LIST"
+
+if [[ -s "$CONSUMERS" ]]; then
+    echo "::error::libpython3.12.dylib is linked by bundled Mach-Os; refusing to drop it:" >&2
+    cat "$CONSUMERS" >&2
+    exit 1
+fi
+
+echo "==> dropping unused libpython3.12.dylib ($(du -m "$LIBPYTHON" | cut -f1) MB)"
+rm -f "$LIBPYTHON"

--- a/tests/test_sidecar_libpython_prune.py
+++ b/tests/test_sidecar_libpython_prune.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PRUNER = ROOT / "apps/rapid-mac/scripts/prune-unused-libpython.sh"
+
+
+def _fixture(tmp_path: Path, *, consumer: bool = False) -> tuple[Path, dict[str, str]]:
+    stage = tmp_path / "stage"
+    libpython = stage / "python/lib/libpython3.12.dylib"
+    interpreter = stage / "python/bin/python3.12"
+    extension = stage / "site-packages/example.so"
+    for path in (libpython, interpreter, extension):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"fixture")
+
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    file_tool = tools / "file"
+    file_tool.write_text("#!/bin/sh\necho 'Mach-O 64-bit bundle arm64'\n")
+    file_tool.chmod(0o755)
+    otool = tools / "otool"
+    otool.write_text(
+        "#!/bin/sh\n"
+        'echo "$2:"\n'
+        'if [ "${FAKE_LIBPYTHON_CONSUMER:-}" = "$2" ]; then\n'
+        "  echo '    @rpath/libpython3.12.dylib (compatibility version 3.12.0)'\n"
+        "else\n"
+        "  echo '    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0)'\n"
+        "fi\n"
+    )
+    otool.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{tools}:{env['PATH']}"
+    if consumer:
+        env["FAKE_LIBPYTHON_CONSUMER"] = str(extension)
+    return stage, env
+
+
+def _run(stage: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(PRUNER), str(stage)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_pruner_removes_libpython_only_after_complete_no_consumer_scan(tmp_path):
+    stage, env = _fixture(tmp_path)
+
+    result = _run(stage, env)
+
+    assert result.returncode == 0, result.stderr
+    assert not (stage / "python/lib/libpython3.12.dylib").exists()
+
+
+def test_pruner_refuses_a_linked_libpython_and_names_the_consumer(tmp_path):
+    stage, env = _fixture(tmp_path, consumer=True)
+
+    result = _run(stage, env)
+
+    assert result.returncode != 0
+    assert "refusing to drop it" in result.stderr
+    assert "example.so" in result.stderr
+    assert (stage / "python/lib/libpython3.12.dylib").exists()
+
+
+def test_pruner_refuses_an_incomplete_macho_scan(tmp_path):
+    stage, env = _fixture(tmp_path)
+    (stage / "site-packages/example.so").unlink()
+
+    result = _run(stage, env)
+
+    assert result.returncode != 0
+    assert "incomplete scan" in result.stderr
+    assert (stage / "python/lib/libpython3.12.dylib").exists()
+
+
+def test_pruner_refuses_an_otool_failure(tmp_path):
+    stage, env = _fixture(tmp_path)
+    broken_otool = Path(env["PATH"].split(":", 1)[0]) / "otool"
+    broken_otool.write_text("#!/bin/sh\nexit 1\n")
+    broken_otool.chmod(0o755)
+
+    result = _run(stage, env)
+
+    assert result.returncode != 0
+    assert "otool failed" in result.stderr
+    assert (stage / "python/lib/libpython3.12.dylib").exists()


### PR DESCRIPTION
Supersedes #2315 for queue execution. Mergify intentionally excludes fork heads from repository-owned integration batches, so this internal PR carries the exact reviewed commit `cf099518` without changing its tree. Original implementation and commit authorship remain credited to @osdodo; maintainer hardening and artifact evidence are preserved here.

## Why

The published 0.13.1 Desktop DMG is 187,505,002 bytes. The exact signed and notarized artifact from this branch is 105,881,983 bytes, saving 81,623,019 bytes (43.53%) per download. The tradeoff is explicit: LZMA makes the one-time Finder copy slower on the measured Studio host (5.94 s to 17.80 s), while reducing network transfer by about 78 MiB.

## What

| Metric | Published 0.13.1 | Exact branch artifact |
|---|---:|---:|
| DMG download | 187,505,002 bytes | 105,881,983 bytes |
| Installed app file bytes | 509,621,417 bytes | 490,569,194 bytes |
| Finder copy on this host | 5.94 s | 17.80 s |

- Convert the staged writable image to an LZMA-compressed `ULMO` DMG instead of zlib `UDZO`.
- Remove dead console launchers and build-time-only sysconfig data from the sidecar.
- Delete `libpython3.12.dylib` only after a fail-closed dependency scan proves every bundled Mach-O is readable and none consumes it.
- Retain the Python interpreter symbol table so native sidecar crashes remain symbol-compatible with existing diagnostics.
- Keep the measured Mach-O baseline at the current 172 binaries.

## Scope and non-goals

This PR changes Desktop release packaging only. It does not remove runtime model/config modules, strip the Swift app or Python interpreter, change product behavior, publish a release, create a tag, or modify updater state.

## Design precedent

The packaging flow keeps the established writable-layout-then-convert sequence and changes only the final compression format. Runtime pruning follows a fail-closed dependency-graph pattern: every bundled Mach-O must enumerate successfully, any consumer blocks deletion, and all byte changes happen before signing.

## Verification

- Exact head: `cf0995188dfb6e234706e31c089be153aeb0a238`.
- Signed/notarized artifact-only dry run: https://github.com/raullenchai/Rapid-MLX/actions/runs/33260624721 — all build and desktop-ready jobs passed; publishing jobs were skipped.
- DMG SHA-256: `23f2dd9b107620ae2ea6bfb47620f831467f2e2d94322554b0711b7dae0a306b`.
- `hdiutil verify`, DMG `codesign --verify`, `stapler validate`, and Gatekeeper assessment passed.
- Mounted and copied app passed deep/strict code-sign verification, stapler validation, and Gatekeeper assessment as Notarized Developer ID.
- Installed sidecar launched from the copied app in an environment-stripped shell and reported `rapid-mlx 0.13.1`.
- Full sidecar build passed with 172 Mach-Os; raw bundle 455 MiB, tarball 145,612,923 bytes.
- Guard fixtures cover no-consumer, consumer-present, incomplete scan, and `otool` failure. Focused Python and Swift packaging tests, Ruff, shell syntax, and diff checks passed.