### PR TITLE
fix: honor explicit MLLM lane selection

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1249,7 +1249,7 @@ class TestResolveServingLane:
             "local/qwen35", vision_min_memory_gb=32.0
         ) == utils_mod.ServingLaneDecision(True, "vision_hybrid_runtime_supported")
 
-    def test_explicit_vision_precedes_automatic_memory_fallback(self, monkeypatch):
+    def test_explicit_vision_honors_measured_memory_floor(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
         self._patch_probes(
@@ -1264,7 +1264,9 @@ class TestResolveServingLane:
             "local/qwen35",
             force_mllm=True,
             vision_min_memory_gb=32.0,
-        ) == utils_mod.ServingLaneDecision(True, "vision_lane_forced")
+        ) == utils_mod.ServingLaneDecision(
+            False, "vision_memory_insufficient", auto_text_fallback=True
+        )
 
     def test_automatic_vision_still_honors_measured_memory_floor(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
@@ -1305,7 +1307,7 @@ class TestResolveServingLane:
             utils_mod, "mllm_backbone_cache_mode", lambda _name: cache_mode
         )
         monkeypatch.setattr(utils_mod, "mllm_hybrid_runtime_supported", lambda: False)
-        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 64.0)
 
         assert utils_mod.resolve_serving_lane_decision(
             "local/checkpoint",

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1249,7 +1249,7 @@ class TestResolveServingLane:
             "local/qwen35", vision_min_memory_gb=32.0
         ) == utils_mod.ServingLaneDecision(True, "vision_hybrid_runtime_supported")
 
-    def test_explicit_vision_honors_measured_memory_floor(self, monkeypatch):
+    def test_explicit_vision_precedes_automatic_memory_fallback(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
         self._patch_probes(
@@ -1264,11 +1264,9 @@ class TestResolveServingLane:
             "local/qwen35",
             force_mllm=True,
             vision_min_memory_gb=32.0,
-        ) == utils_mod.ServingLaneDecision(
-            False, "vision_memory_insufficient", auto_text_fallback=True
-        )
+        ) == utils_mod.ServingLaneDecision(True, "vision_lane_forced")
 
-    def test_forced_and_auto_vision_share_the_memory_gate(self, monkeypatch):
+    def test_automatic_vision_still_honors_measured_memory_floor(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
         self._patch_probes(
@@ -1279,20 +1277,41 @@ class TestResolveServingLane:
         )
         monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
 
-        forced = utils_mod.resolve_serving_lane_decision(
-            "qwen3.5-4b-4bit",
-            force_mllm=True,
-            vision_min_memory_gb=32.0,
-        )
         auto = utils_mod.resolve_serving_lane_decision(
             "qwen3.5-4b-4bit",
             vision_min_memory_gb=32.0,
         )
 
-        assert forced == auto
-        assert forced == utils_mod.ServingLaneDecision(
+        assert auto == utils_mod.ServingLaneDecision(
             False, "vision_memory_insufficient", auto_text_fallback=True
         )
+
+    @pytest.mark.parametrize(
+        ("architecture_unavailable", "cache_mode"),
+        [(True, None), (False, "other"), (False, "arrays")],
+    )
+    def test_explicit_vision_precedes_automatic_capability_fallbacks(
+        self, monkeypatch, architecture_unavailable, cache_mode
+    ):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(utils_mod, "is_mllm_model", lambda _name: True)
+        monkeypatch.setattr(
+            utils_mod,
+            "mllm_arch_unsupported_but_text_vendored",
+            lambda _name: architecture_unavailable,
+        )
+        monkeypatch.setattr(
+            utils_mod, "mllm_backbone_cache_mode", lambda _name: cache_mode
+        )
+        monkeypatch.setattr(utils_mod, "mllm_hybrid_runtime_supported", lambda: False)
+        monkeypatch.setattr(utils_mod, "physical_ram_gb", lambda: 16.0)
+
+        assert utils_mod.resolve_serving_lane_decision(
+            "local/checkpoint",
+            force_mllm=True,
+            vision_min_memory_gb=32.0,
+        ) == utils_mod.ServingLaneDecision(True, "vision_lane_forced")
 
     def test_unknown_physical_memory_does_not_invent_a_fallback(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod

--- a/tests/test_routing_groups_0131.py
+++ b/tests/test_routing_groups_0131.py
@@ -293,6 +293,32 @@ def test_fix3_cli_helper_forwards_legacy_mtp_as_requested_spec_decode(monkeypatc
     assert seen["requested_spec_decode"] == "auto"
 
 
+def test_cli_explicit_mllm_precedes_automatic_architecture_fallback(monkeypatch):
+    """The public serve helper carries ``--mllm`` into the lane SSOT."""
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(utils_mod, "is_mllm_model", lambda _name: True)
+    monkeypatch.setattr(
+        utils_mod,
+        "mllm_arch_unsupported_but_text_vendored",
+        lambda _name: True,
+    )
+
+    assert (
+        cli._serve_will_run_on_mllm_lane(
+            SimpleNamespace(
+                model="/local/unsupported-vision-checkpoint",
+                mllm=True,
+                no_mllm=False,
+                spec_decode="none",
+                enable_mtp=False,
+                force_spec_decode=False,
+            )
+        )
+        is True
+    )
+
+
 @pytest.mark.parametrize(
     ("flag", "expected"),
     [("--enable-mtp", "mtp"), ("--force-spec-decode", "auto")],

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1487,8 +1487,10 @@ def resolve_serving_lane_decision(
     requested decoder is honoured) with reason ``text_lane_speculative_decode``.
 
     Precedence is explicit text, incompatible requested speculative decoding,
-    explicit MLLM, then automatic checkpoint/capability selection. Automatic
-    fallbacks must never silently override an operator-selected MLLM lane.
+    hard resource admission, explicit MLLM, then automatic capability
+    selection. Automatic capability fallbacks must never silently override an
+    operator-selected MLLM lane, while an explicit flag cannot bypass the
+    measured physical-memory floor.
     """
     if force_text:
         return ServingLaneDecision(False, "text_lane_forced")
@@ -1509,24 +1511,13 @@ def resolve_serving_lane_decision(
         return ServingLaneDecision(
             False, "text_lane_speculative_decode", auto_text_fallback=True
         )
-    # Explicit operator selection precedes every automatic capability fallback.
-    # The selected MLLM loader remains responsible for rejecting an unsupported
-    # checkpoint or an unsafe allocation loudly; silently switching lanes would
-    # violate the requested serving contract and hide the actionable failure.
-    if force_mllm:
-        return ServingLaneDecision(True, "vision_lane_forced")
-    if not is_mllm_model(model_name):
+    is_mllm_checkpoint = is_mllm_model(model_name)
+    if not is_mllm_checkpoint:
+        if force_mllm:
+            return ServingLaneDecision(True, "vision_lane_forced")
         return ServingLaneDecision(False, "text_checkpoint")
-    if mllm_arch_unsupported_but_text_vendored(model_name):
-        return ServingLaneDecision(
-            False, "vision_architecture_unavailable", auto_text_fallback=True
-        )
 
     cache_mode = mllm_backbone_cache_mode(model_name)
-    if cache_mode == "other":
-        return ServingLaneDecision(
-            False, "vision_hybrid_cache_unsupported", auto_text_fallback=True
-        )
     if cache_mode == "arrays":
         if vision_min_memory_gb is None:
             profile = resolve_profile(model_name)
@@ -1542,6 +1533,22 @@ def resolve_serving_lane_decision(
             return ServingLaneDecision(
                 False, "vision_memory_insufficient", auto_text_fallback=True
             )
+
+    # Explicit operator selection precedes automatic capability fallbacks. The
+    # selected MLLM loader rejects unsupported checkpoints loudly; silently
+    # switching lanes would violate the requested serving contract.
+    if force_mllm:
+        return ServingLaneDecision(True, "vision_lane_forced")
+    if mllm_arch_unsupported_but_text_vendored(model_name):
+        return ServingLaneDecision(
+            False, "vision_architecture_unavailable", auto_text_fallback=True
+        )
+
+    if cache_mode == "other":
+        return ServingLaneDecision(
+            False, "vision_hybrid_cache_unsupported", auto_text_fallback=True
+        )
+    if cache_mode == "arrays":
         if mllm_hybrid_runtime_supported():
             return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
         return ServingLaneDecision(

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -1485,6 +1485,10 @@ def resolve_serving_lane_decision(
     requested spec_decode would silently be dropped and throughput would regress
     vs the text lane. Route such a model back onto the text lane (where the
     requested decoder is honoured) with reason ``text_lane_speculative_decode``.
+
+    Precedence is explicit text, incompatible requested speculative decoding,
+    explicit MLLM, then automatic checkpoint/capability selection. Automatic
+    fallbacks must never silently override an operator-selected MLLM lane.
     """
     if force_text:
         return ServingLaneDecision(False, "text_lane_forced")
@@ -1505,9 +1509,13 @@ def resolve_serving_lane_decision(
         return ServingLaneDecision(
             False, "text_lane_speculative_decode", auto_text_fallback=True
         )
+    # Explicit operator selection precedes every automatic capability fallback.
+    # The selected MLLM loader remains responsible for rejecting an unsupported
+    # checkpoint or an unsafe allocation loudly; silently switching lanes would
+    # violate the requested serving contract and hide the actionable failure.
+    if force_mllm:
+        return ServingLaneDecision(True, "vision_lane_forced")
     if not is_mllm_model(model_name):
-        if force_mllm:
-            return ServingLaneDecision(True, "vision_lane_forced")
         return ServingLaneDecision(False, "text_checkpoint")
     if mllm_arch_unsupported_but_text_vendored(model_name):
         return ServingLaneDecision(
@@ -1534,15 +1542,11 @@ def resolve_serving_lane_decision(
             return ServingLaneDecision(
                 False, "vision_memory_insufficient", auto_text_fallback=True
             )
-        if force_mllm:
-            return ServingLaneDecision(True, "vision_lane_forced")
         if mllm_hybrid_runtime_supported():
             return ServingLaneDecision(True, "vision_hybrid_runtime_supported")
         return ServingLaneDecision(
             False, "vision_hybrid_runtime_unsupported", auto_text_fallback=True
         )
-    if force_mllm:
-        return ServingLaneDecision(True, "vision_lane_forced")
     return ServingLaneDecision(True, "vision_supported")
 
 


### PR DESCRIPTION
## User-visible outcome

An explicit `--mllm` request now stays on the multimodal serving lane instead of being silently changed to the text lane by automatic architecture, cache, or runtime fallback. Unsupported forced loads therefore fail loudly in the selected loader, preserving the operator's requested contract. The measured physical-memory admission floor remains mandatory, so an explicit flag cannot turn a controlled low-memory fallback into severe memory pressure.

Fixes #2667

## Design precedent

Established serving systems resolve implementation selection in a consistent order: global or explicit operator choice first, component-level override next, and automatic capability selection last. Rapid-MLX now applies that pattern in its existing typed serving-lane decision rather than adding model-name rules or a second routing mechanism.

Two existing stronger constraints remain unchanged: a requested speculative decoder selects the text lane because the MLLM lane cannot consume it, and the measured memory floor is enforced before an MLLM load. Explicit text selection retains top precedence.

## Scope

- move explicit MLLM selection ahead of automatic capability fallbacks in the serving-lane SSOT
- preserve automatic fallback behavior when no explicit force is present
- cover architecture, cache/runtime, and hard memory-admission precedence as a table
- exercise the public CLI serve helper's `--mllm` wiring

## Non-goals

- no new architecture support
- no model-name or regex routing
- no speculative-decoding policy change
- no loader, scheduler, or memory-budget changes

## Verification

- `pr_validate`: **MERGE-SAFE**; 264 targeted tests and 19,704 full-unit tests passed (104 skipped, 6 xfailed, 1 xpassed)
- independent review round 1 identified the hard memory-admission boundary; the exact head preserves that floor and no second review was requested under the one-round contract
- Ruff check and format check passed
- `git diff --check` passed
