### PR TITLE
test(mac): make lifecycle suites async and preference-isolated

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -856,6 +856,13 @@ final class ChatViewModel {
         )
     }
 
+    /// Test seam for lifecycle assertions that need the current turn to be
+    /// fully drained. Awaiting the owned task is deterministic under runner
+    /// load; polling ``isStreaming`` with a wall-clock deadline is not.
+    func _testingWaitForCurrentTurn() async {
+        await inflight?.value
+    }
+
     /// Open a streaming assistant turn under whatever currently ends the
     /// visible path, and drive it to completion.
     ///

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -63,7 +63,11 @@ final class DictationController {
         didSet {
             guard isEnabled != oldValue else { return }
             UserDefaults.standard.set(isEnabled, forKey: Keys.enabled)
-            Task { isEnabled ? await enable() : disable() }
+            if isEnabled {
+                scheduleModelPreparation()
+            } else {
+                disable()
+            }
         }
     }
 
@@ -87,10 +91,10 @@ final class DictationController {
                 cancelActiveSessionForModelChange()
                 phase = .preparingModel
             }
-            Task {
-                await refreshModelCacheState()
-                if isEnabled {
-                    await enable(replacingCurrentPrewarm: true)
+            scheduleLifecycleTask { controller in
+                await controller.refreshModelCacheState()
+                if controller.isEnabled {
+                    await controller.enable(replacingCurrentPrewarm: true)
                 }
             }
         }
@@ -180,6 +184,10 @@ final class DictationController {
     /// instead of stacking probes in the engine's serial STT lane.
     private var prewarmTask: Task<Bool, Never>?
     private var prewarmRequestID: UUID?
+    /// Own the reconciliation launched by a server-ready notification so a
+    /// superseding transition can cancel it and tests can await the exact
+    /// lifecycle boundary instead of racing a polling deadline.
+    private var lifecycleTask: Task<Void, Never>?
     /// Invalidates stale `enable()` continuations when the model changes, the
     /// feature is disabled, or another enable attempt supersedes them.
     private var enableRequestID: UUID?
@@ -334,6 +342,8 @@ final class DictationController {
     /// the latter and restores the former without inventing another lifecycle.
     func serverStateDidChange(_ newState: ServerState) {
         guard isEnabled, !modelPreparationDeferred else { return }
+        lifecycleTask?.cancel()
+        lifecycleTask = nil
         switch newState {
         case .starting(let alias):
             // `prewarmModel` owns an audio-only fallback while its flight is
@@ -348,9 +358,7 @@ final class DictationController {
             guard alias != modelAlias || prewarmTask == nil else { break }
             cancelActiveSessionForModelChange()
             phase = .preparingModel
-            Task { [weak self] in
-                await self?.enable(replacingCurrentPrewarm: true)
-            }
+            scheduleModelPreparation(replacingCurrentPrewarm: true)
         case .crashed, .stopped, .idle, .missing:
             cancelActiveSessionForModelChange()
             cancelModelPreparation()
@@ -359,6 +367,27 @@ final class DictationController {
             // the next explicit hotkey press or a later server transition can
             // retry the model without asking the user to arm dictation again.
             phase = .off
+        }
+    }
+
+    /// Test seam for the owned server-state reconciliation task.
+    func _testingWaitForLifecycleTask() async {
+        await lifecycleTask?.value
+    }
+
+    private func scheduleModelPreparation(replacingCurrentPrewarm: Bool = false) {
+        scheduleLifecycleTask { controller in
+            await controller.enable(replacingCurrentPrewarm: replacingCurrentPrewarm)
+        }
+    }
+
+    private func scheduleLifecycleTask(
+        _ operation: @escaping @MainActor (DictationController) async -> Void
+    ) {
+        lifecycleTask?.cancel()
+        lifecycleTask = Task { [weak self] in
+            guard let self else { return }
+            await operation(self)
         }
     }
 
@@ -499,6 +528,8 @@ final class DictationController {
         prewarmTask = nil
         prewarmRequestID = nil
         enableRequestID = nil
+        lifecycleTask?.cancel()
+        lifecycleTask = nil
         modelPreparationDeferred = false
         stopTicking()
         recorderStorage?.shutdown()
@@ -814,9 +845,7 @@ final class DictationController {
             // again; app activation merely repairs the event tap.
             guard isEnabled else { return }
             phase = .preparingModel
-            Task { [weak self] in
-                await self?.enable(replacingCurrentPrewarm: true)
-            }
+            scheduleModelPreparation(replacingCurrentPrewarm: true)
         case .preparingModel, .transcribing: break
         }
     }
@@ -838,7 +867,7 @@ final class DictationController {
             phase = .preparingModel
             beginRecordingTask = nil
             beginRecordingRequestID = nil
-            Task { await enable(replacingCurrentPrewarm: true) }
+            scheduleModelPreparation(replacingCurrentPrewarm: true)
             return
         }
         // Model Management changes the cache out of process from this

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1424,8 +1424,8 @@ final class ServerManager {
     /// method so ``RapidApp.init`` can probe it before constructing
     /// the manager — the auto-restart decision happens on the main
     /// scene's ``.task``, not inside the init.
-    nonisolated static func lastServedAlias() -> String? {
-        guard let raw = UserDefaults.standard.string(forKey: lastServedAliasKey) else {
+    nonisolated static func lastServedAlias(defaults: UserDefaults = .standard) -> String? {
+        guard let raw = defaults.string(forKey: lastServedAliasKey) else {
             return nil
         }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/rapid-mac/Sources/Rapid/UI/AppearanceConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AppearanceConfig.swift
@@ -19,12 +19,14 @@ import Observation
 @MainActor
 @Observable
 final class AppearanceConfig {
+    private let defaults: UserDefaults
+
     /// One of "system" / "light" / "dark". Mutating this triggers the
     /// AppKit appearance swap via the `didSet`-like observer below
     /// (Observation framework dispatches the setter, then we re-apply).
     var mode: AppearanceMode {
         didSet {
-            UserDefaults.standard.set(mode.rawValue, forKey: Self.storageKey)
+            defaults.set(mode.rawValue, forKey: Self.storageKey)
             apply()
         }
     }
@@ -34,14 +36,15 @@ final class AppearanceConfig {
     /// without colliding with the old stored value.
     static let storageKey = "rapid.appearance.v1"
 
-    init() {
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
         // v0.5: light-first default. When the user has an explicit
         // saved choice — including "Auto (follow system)", whose stored
         // value is "system" — we honour it. Only a *fresh install* with
         // no persisted value at all falls back to Light (was ``.system``),
         // so the app opens light-first the first time it's launched
         // without removing the Auto / Dark options from Settings.
-        if let raw = UserDefaults.standard.string(forKey: Self.storageKey),
+        if let raw = defaults.string(forKey: Self.storageKey),
            let saved = AppearanceMode(rawValue: raw) {
             self.mode = saved
         } else {

--- a/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
@@ -39,7 +39,7 @@ struct AppIconBundleTests {
     private static let baseSizes: [Int] = [16, 32, 128, 256, 512]
 
     @Test("icns container ships all 5 base sizes + their @2x retina siblings")
-    func icnsContainsEveryRequiredSize() throws {
+    func icnsContainsEveryRequiredSize() async throws {
         let url = try #require(Self.icnsURL(), "AppIcon.icns not found under Resources/")
         try #require(FileManager.default.fileExists(atPath: url.path))
 
@@ -52,18 +52,14 @@ struct AppIconBundleTests {
             .appendingPathComponent("rapid-iconset-\(UUID().uuidString).iconset")
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/iconutil")
-        proc.arguments = [
-            "--convert", "iconset",
-            url.path,
-            "-o", tmpDir.path,
-        ]
-        let errPipe = Pipe()
-        proc.standardError = errPipe
-        try proc.run()
-        proc.waitUntilExit()
-        try #require(proc.terminationStatus == 0, "iconutil failed: \(String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "?")")
+        let result = try await TestSubprocess.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/iconutil"),
+            arguments: ["--convert", "iconset", url.path, "-o", tmpDir.path]
+        )
+        try #require(
+            result.terminationStatus == 0,
+            "iconutil failed: \(String(decoding: result.standardError, as: UTF8.self))"
+        )
 
         for size in Self.baseSizes {
             let base = tmpDir.appendingPathComponent("icon_\(size)x\(size).png")

--- a/apps/rapid-mac/Tests/RapidTests/AppearanceConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppearanceConfigTests.swift
@@ -14,13 +14,16 @@ import Testing
 ///   - displayName text covers the three cases
 @MainActor
 @Suite("AppearanceConfig + AppearanceMode — v0.4.25")
-struct AppearanceConfigTests {
-    /// Wipe the live UserDefaults key before each test so writes from
-    /// one test don't leak into the next. Run in a non-parallel
-    /// scheduler bucket by being inside the @Suite (Testing's default
-    /// is serial within a struct, which is what we want here).
-    private func freshDefaults() {
-        UserDefaults.standard.removeObject(forKey: AppearanceConfig.storageKey)
+final class AppearanceConfigTests {
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-appearance-test-")
+        createdSuiteNames.append(name)
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
     }
 
     @Test("AppearanceMode → NSAppearance mapping")
@@ -44,36 +47,36 @@ struct AppearanceConfigTests {
 
     @Test("Default mode is .light when no value is stored — v0.5 light-first brand decision")
     func defaultIsLight() {
-        freshDefaults()
-        let cfg = AppearanceConfig()
+        let defaults = freshDefaults()
+        let cfg = AppearanceConfig(defaults: defaults)
         #expect(cfg.mode == .light)
     }
 
     @Test("Mutating mode persists to UserDefaults")
     func mutationPersists() {
-        freshDefaults()
-        let cfg = AppearanceConfig()
+        let defaults = freshDefaults()
+        let cfg = AppearanceConfig(defaults: defaults)
         cfg.mode = .dark
-        let raw = UserDefaults.standard.string(forKey: AppearanceConfig.storageKey)
+        let raw = defaults.string(forKey: AppearanceConfig.storageKey)
         #expect(raw == "dark")
         cfg.mode = .light
-        #expect(UserDefaults.standard.string(forKey: AppearanceConfig.storageKey) == "light")
+        #expect(defaults.string(forKey: AppearanceConfig.storageKey) == "light")
     }
 
     @Test("Fresh instance reads back the stored value")
     func roundTrips() {
-        freshDefaults()
-        let writer = AppearanceConfig()
+        let defaults = freshDefaults()
+        let writer = AppearanceConfig(defaults: defaults)
         writer.mode = .light
-        let reader = AppearanceConfig()
+        let reader = AppearanceConfig(defaults: defaults)
         #expect(reader.mode == .light)
     }
 
     @Test("Garbage stored value falls back to the v0.5 light-first default — defensive against future schema bumps")
     func garbageFallback() {
-        freshDefaults()
-        UserDefaults.standard.set("midnight-blue", forKey: AppearanceConfig.storageKey)
-        let cfg = AppearanceConfig()
+        let defaults = freshDefaults()
+        defaults.set("midnight-blue", forKey: AppearanceConfig.storageKey)
+        let cfg = AppearanceConfig(defaults: defaults)
         #expect(cfg.mode == .light)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
@@ -19,30 +19,39 @@ import Testing
 /// happy-path lifecycle; these tests pin the bookkeeping around it.
 @MainActor
 @Suite("v0.5.3 — auto-restart + ensureServing contracts")
-struct AutoRestartAndRegenRaceTests {
+final class AutoRestartAndRegenRaceTests {
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-last-alias-test-")
+        createdSuiteNames.append(name)
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
     @Test("lastServedAlias returns nil on fresh install")
     func freshInstallNoResume() {
-        // The ServerManager API reads from .standard; verify the
-        // fresh-install case explicitly: if no key is set, nil.
-        UserDefaults.standard.removeObject(forKey: "rapid.serve.lastAlias")
-        #expect(ServerManager.lastServedAlias() == nil)
+        let defaults = freshDefaults()
+        #expect(ServerManager.lastServedAlias(defaults: defaults) == nil)
     }
 
     @Test("lastServedAlias trims whitespace and rejects empty strings")
     func emptyStringRejected() {
-        UserDefaults.standard.set("   ", forKey: "rapid.serve.lastAlias")
-        defer { UserDefaults.standard.removeObject(forKey: "rapid.serve.lastAlias") }
-        #expect(ServerManager.lastServedAlias() == nil)
+        let defaults = freshDefaults()
+        defaults.set("   ", forKey: "rapid.serve.lastAlias")
+        #expect(ServerManager.lastServedAlias(defaults: defaults) == nil)
 
-        UserDefaults.standard.set("", forKey: "rapid.serve.lastAlias")
-        #expect(ServerManager.lastServedAlias() == nil)
+        defaults.set("", forKey: "rapid.serve.lastAlias")
+        #expect(ServerManager.lastServedAlias(defaults: defaults) == nil)
     }
 
     @Test("lastServedAlias returns the trimmed value when set")
     func roundTripAlias() {
-        UserDefaults.standard.set("  qwen3.6-27b-4bit  ", forKey: "rapid.serve.lastAlias")
-        defer { UserDefaults.standard.removeObject(forKey: "rapid.serve.lastAlias") }
-        #expect(ServerManager.lastServedAlias() == "qwen3.6-27b-4bit")
+        let defaults = freshDefaults()
+        defaults.set("  qwen3.6-27b-4bit  ", forKey: "rapid.serve.lastAlias")
+        #expect(ServerManager.lastServedAlias(defaults: defaults) == "qwen3.6-27b-4bit")
     }
 
     @Test("ensureServing is a noop when the server is already on the requested alias")

--- a/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
@@ -94,8 +94,8 @@ struct DMGPresentationScriptTests {
     }
 
     @Test("Structural parser accepts the active icvp background alias")
-    func structuralBackgroundAliasPasses() throws {
-        let result = try Self.runBackgroundVerifier(
+    func structuralBackgroundAliasPasses() async throws {
+        let result = try await Self.runBackgroundVerifier(
             alias: Self.makeFinderAlias()
         )
 
@@ -104,8 +104,8 @@ struct DMGPresentationScriptTests {
     }
 
     @Test("Structural parser rejects unrelated matching strings")
-    func unrelatedBackgroundStringsFail() throws {
-        let result = try Self.runBackgroundVerifier(
+    func unrelatedBackgroundStringsFail() async throws {
+        let result = try await Self.runBackgroundVerifier(
             alias: Self.makeFinderAlias(posixPath: "/wrong/background.png"),
             trailingData: Data("Rapid-MLX Desktop:.background:/backgroundImageAlias/.background/background.png".utf8)
         )
@@ -115,8 +115,8 @@ struct DMGPresentationScriptTests {
     }
 
     @Test("Structural parser rejects non-image icvp records")
-    func nonImageBackgroundTypeFails() throws {
-        let result = try Self.runBackgroundVerifier(
+    func nonImageBackgroundTypeFails() async throws {
+        let result = try await Self.runBackgroundVerifier(
             alias: Self.makeFinderAlias(),
             backgroundType: 0
         )
@@ -126,11 +126,11 @@ struct DMGPresentationScriptTests {
     }
 
     @Test("Structural parser reports a truncated icvp length without traceback")
-    func truncatedICVPLengthFailsCleanly() throws {
+    func truncatedICVPLengthFailsCleanly() async throws {
         var fixture = Data("prefix-icvpblob".utf8)
         fixture.append(contentsOf: [0, 0, 0, 32])
         fixture.append(contentsOf: Data("short".utf8))
-        let result = try Self.runVerifier(fixture: fixture)
+        let result = try await Self.runVerifier(fixture: fixture)
 
         #expect(result.status == 1)
         #expect(result.output.contains("icvp blob payload is truncated"))
@@ -146,7 +146,7 @@ struct DMGPresentationScriptTests {
         alias: Data,
         backgroundType: Int = 2,
         trailingData: Data = Data()
-    ) throws -> (status: Int32, output: String) {
+    ) async throws -> (status: Int32, output: String) {
         let plist = try PropertyListSerialization.data(
             fromPropertyList: [
                 "backgroundImageAlias": alias,
@@ -161,10 +161,10 @@ struct DMGPresentationScriptTests {
         fixture.append(plist)
         fixture.append(trailingData)
 
-        return try runVerifier(fixture: fixture)
+        return try await runVerifier(fixture: fixture)
     }
 
-    private static func runVerifier(fixture: Data) throws -> (status: Int32, output: String) {
+    private static func runVerifier(fixture: Data) async throws -> (status: Int32, output: String) {
         let fixtureDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-dmg-ds-store-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
@@ -172,19 +172,15 @@ struct DMGPresentationScriptTests {
         let fixtureURL = fixtureDirectory.appendingPathComponent(".DS_Store")
         try fixture.write(to: fixtureURL)
 
-        let output = Pipe()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [
-            "python3",
-            sourceRoot.appendingPathComponent("scripts/verify-dmg-background.py").path,
-            fixtureURL.path,
-        ]
-        process.standardOutput = output
-        process.standardError = output
-        try process.run()
-        process.waitUntilExit()
-        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let process = try await TestSubprocess.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: [
+                "python3",
+                sourceRoot.appendingPathComponent("scripts/verify-dmg-background.py").path,
+                fixtureURL.path,
+            ]
+        )
+        let data = process.standardOutput + process.standardError
         return (process.terminationStatus, String(decoding: data, as: UTF8.self))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -60,10 +60,7 @@ struct DeferredTelemetryConsentWiringTests {
             supportsImageInput: true,
             imageAttachments: [image]
         )
-        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
-        while model.isStreaming, ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        await model._testingWaitForCurrentTurn()
 
         #expect(!model.isStreaming, "the canned successful stream must finish")
         #expect(deliveredKinds.isEmpty)

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -420,7 +420,7 @@ struct DictationTests {
         #expect(hotkeyStartCount == 0)
 
         warmupContinuation?.resume(returning: true)
-        await waitUntil { controller.phase == .idle }
+        await controller._testingWaitForLifecycleTask()
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1)
     }
@@ -462,7 +462,7 @@ struct DictationTests {
         #expect(hotkeyStopCount == 0)
 
         controller.serverStateDidChange(.ready(alias: "qwen3.5-4b-4bit"))
-        await waitUntil { controller.phase == .idle }
+        await controller._testingWaitForLifecycleTask()
 
         #expect(controller.phase == .idle)
         #expect(controller.isHotkeyArmed)
@@ -518,7 +518,7 @@ struct DictationTests {
             #expect(controller.isHotkeyArmed)
 
             controller.toggleFromUI()
-            await waitUntil { controller.phase == .idle }
+            await controller._testingWaitForLifecycleTask()
             #expect(prewarmCount == beforeForeground + 1)
             #expect(controller.phase == .idle)
             #expect(controller.isHotkeyArmed)
@@ -606,7 +606,7 @@ struct DictationTests {
         #expect(hotkeyStartCount == 0)
 
         warmupContinuation?.resume(returning: true)
-        await waitUntil { controller.phase == .idle }
+        await controller._testingWaitForLifecycleTask()
         #expect(controller.phase == .idle)
         #expect(hotkeyStartCount == 1)
     }

--- a/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
@@ -159,22 +159,24 @@ struct LocalizationTests {
     }
 
     @Test("Compiled zh-Hans catalog resolves through the production photo-hint path")
-    func compiledCatalogLocalizesPhotoHints() throws {
+    func compiledCatalogLocalizesPhotoHints() async throws {
         let output = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-localization-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: output) }
 
-        let compiler = Process()
-        compiler.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-        compiler.arguments = [
-            "xcstringstool", "compile", try catalogURL().path,
-            "--output-directory", output.path,
-            "--serialization-format", "binary"
-        ]
-        try compiler.run()
-        compiler.waitUntilExit()
-        #expect(compiler.terminationStatus == 0)
+        let compiler = try await TestSubprocess.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/xcrun"),
+            arguments: [
+                "xcstringstool", "compile", try catalogURL().path,
+                "--output-directory", output.path,
+                "--serialization-format", "binary"
+            ]
+        )
+        #expect(
+            compiler.terminationStatus == 0,
+            "xcstringstool failed: \(String(decoding: compiler.standardError, as: UTF8.self))"
+        )
 
         let zhBundle = try #require(
             Bundle(url: output.appendingPathComponent("zh-Hans.lproj", isDirectory: true)),

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -28,12 +28,23 @@ import Testing
 /// claim about a previous launch, never evidence about this one.
 @MainActor
 @Suite("Onboarding V3 — four steps, persistent Ready, confirmed completion")
-struct OnboardingCompletionBehaviorTests {
+final class OnboardingCompletionBehaviorTests {
+    private let suiteName: String
+    private let defaults: UserDefaults
+
+    init() {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-onboarding-completion-test-")
+        suiteName = name
+        defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    deinit { TestDefaultsScope.cleanup(suiteNames: [suiteName]) }
 
     /// A coordinator with every persisted key cleared, so a case never
     /// inherits another case's flags through ``UserDefaults``.
     private func makeCoordinator() -> QuickstartCoordinator {
-        let coord = QuickstartCoordinator()
+        let coord = QuickstartCoordinator(defaults: defaults)
         coord._testingReset()
         return coord
     }
@@ -41,7 +52,7 @@ struct OnboardingCompletionBehaviorTests {
     /// Drop every key this suite can write, including the ones a
     /// deliberately "relaunched" coordinator leaves behind.
     private func clearPersistedState() {
-        let coord = QuickstartCoordinator()
+        let coord = QuickstartCoordinator(defaults: defaults)
         coord._testingReset()
     }
 
@@ -238,7 +249,7 @@ struct OnboardingCompletionBehaviorTests {
         #expect(coord.phase == .ready)
         #expect(!coord.done, "readiness must not write the completion flag")
         #expect(
-            !UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey),
+            !defaults.bool(forKey: QuickstartCoordinator.storageKey),
             "readiness must not persist completion"
         )
         #expect(!coord.hasSeededWelcome, "readiness must not seed the welcome message")
@@ -343,10 +354,10 @@ struct OnboardingCompletionBehaviorTests {
         _ = coord.confirmStartChatting { true }
 
         #expect(coord.done)
-        #expect(UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey))
+        #expect(defaults.bool(forKey: QuickstartCoordinator.storageKey))
         #expect(!coord.hasPendingReady, "a confirmed flow owes no confirmation")
         #expect(
-            UserDefaults.standard.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil,
+            defaults.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil,
             "the pending record must be erased from disk, not just from memory"
         )
         clearPersistedState()
@@ -363,7 +374,7 @@ struct OnboardingCompletionBehaviorTests {
 
         // Same shape as a relaunch, and also as a SwiftUI re-mount that
         // rebuilds the coordinator: the record must come from disk.
-        let next = QuickstartCoordinator()
+        let next = QuickstartCoordinator(defaults: defaults)
         #expect(next.hasPendingReady, "an unconfirmed Ready flow must survive")
         #expect(next.pendingReadyAlias == coord.selection.alias)
         #expect(next.selection.alias == coord.selection.alias,
@@ -379,7 +390,7 @@ struct OnboardingCompletionBehaviorTests {
         coord.enterStarting()
         coord.enterReady()
 
-        let next = QuickstartCoordinator()
+        let next = QuickstartCoordinator(defaults: defaults)
         // The claim survived; the STATE did not. Nothing on this launch has
         // yet said the model is up, so claiming Ready here would be the
         // app inventing a readiness it has not observed.
@@ -400,7 +411,7 @@ struct OnboardingCompletionBehaviorTests {
         coord.enterReady()
         let alias = coord.selection.alias
 
-        let next = QuickstartCoordinator()
+        let next = QuickstartCoordinator(defaults: defaults)
         #expect(next.phase == .idle)
         // This is the step the live server observer performs once
         // ``ServerManager`` genuinely reports ``.ready`` for this alias on
@@ -451,7 +462,7 @@ struct OnboardingCompletionBehaviorTests {
         #expect(coord.selection.alias == other.alias)
         #expect(!coord.hasPendingReady, "a different model retires the old Ready record")
         #expect(
-            UserDefaults.standard.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil
+            defaults.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil
         )
         clearPersistedState()
     }
@@ -480,7 +491,7 @@ struct OnboardingCompletionBehaviorTests {
         #expect(!coord.hasPendingReady, "walking away answers the question Ready was asking")
         #expect(!coord.done, "Skip must keep its existing meaning — onboarding is still owed")
         #expect(
-            !UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey)
+            !defaults.bool(forKey: QuickstartCoordinator.storageKey)
         )
         clearPersistedState()
     }

--- a/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
@@ -198,14 +198,7 @@ struct SidecarShimHardeningTests {
     /// Invoke the bundled shim with the given args from ``cwd``,
     /// returning stdout+stderr concatenated. Throws on spawn failure
     /// or non-zero exit (caller inspects output).
-    private static func runShim(_ shim: URL, cwd: URL, args: [String]) throws -> (output: String, exitCode: Int32) {
-        let proc = Process()
-        proc.executableURL = shim
-        proc.arguments = args
-        proc.currentDirectoryURL = cwd
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = pipe
+    private static func runShim(_ shim: URL, cwd: URL, args: [String]) async throws -> (output: String, exitCode: Int32) {
         // Strip any inherited PYTHONPATH/PYTHONSAFEPATH from the test
         // host so we exercise the shim's OWN env-pinning behaviour
         // rather than accidentally inheriting it from the parent.
@@ -213,12 +206,14 @@ struct SidecarShimHardeningTests {
         env.removeValue(forKey: "PYTHONPATH")
         env.removeValue(forKey: "PYTHONSAFEPATH")
         env.removeValue(forKey: "PYTHONHOME")
-        proc.environment = env
-        try proc.run()
-        proc.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let out = String(data: data, encoding: .utf8) ?? ""
-        return (out, proc.terminationStatus)
+        let result = try await TestSubprocess.run(
+            executableURL: shim,
+            arguments: args,
+            currentDirectoryURL: cwd,
+            environment: env
+        )
+        let data = result.standardOutput + result.standardError
+        return (String(decoding: data, as: UTF8.self), result.terminationStatus)
     }
 
     /// Construct the #361 reproducer (poison ``vllm_mlx/cli.py`` in a
@@ -230,7 +225,7 @@ struct SidecarShimHardeningTests {
     /// fail the suite. CI nightly that runs after build-sidecar.sh
     /// will exercise the real path.
     @Test("Bundled shim invoked from poison cwd returns real version, not poison")
-    func bundledShimResistsPoisonCwd() throws {
+    func bundledShimResistsPoisonCwd() async throws {
         guard let shim = Self.locateBundledShim() else {
             // No bundle present — skip (dev machine without a fresh build).
             return
@@ -255,7 +250,7 @@ struct SidecarShimHardeningTests {
             encoding: .utf8
         )
 
-        let result = try Self.runShim(shim, cwd: tmp, args: ["--version"])
+        let result = try await Self.runShim(shim, cwd: tmp, args: ["--version"])
         #expect(
             !result.output.contains("9.9.9-cwd-poison"),
             "Bundled sidecar shim at \(shim.path) loaded the poison ``vllm_mlx/cli.py`` from the caller's cwd (\(tmp.path)). The #361 cwd-hijack fix (``-P`` + PYTHONSAFEPATH=1 in sidecar-shim.sh) is not effective in the installed bundle. Output:\n\(result.output)"
@@ -277,12 +272,12 @@ struct SidecarShimHardeningTests {
     /// being found at all) would slip through bundledShimResistsPoisonCwd
     /// by virtue of the assertion being satisfied trivially.
     @Test("Bundled shim invoked from clean cwd still reads real version")
-    func bundledShimHappyPathFromCleanCwd() throws {
+    func bundledShimHappyPathFromCleanCwd() async throws {
         guard let shim = Self.locateBundledShim() else {
             return
         }
         let cleanCwd = URL(fileURLWithPath: "/tmp")
-        let result = try Self.runShim(shim, cwd: cleanCwd, args: ["--version"])
+        let result = try await Self.runShim(shim, cwd: cleanCwd, args: ["--version"])
         #expect(
             result.exitCode == 0,
             "Bundled sidecar shim at \(shim.path) exited \(result.exitCode) on a clean ``--version`` from /tmp. ``-P`` may have over-isolated the import path. Output:\n\(result.output)"

--- a/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
@@ -76,7 +76,7 @@ struct SidecarVersionGateTests {
     }
 
     @Test("scripts/build.sh accepts dotted-digit/RC and rejects malformed versions (#411 layer 2 — empirical)")
-    func buildScriptRegexEmpiricalBehaviour() throws {
+    func buildScriptRegexEmpiricalBehaviour() async throws {
         // Codex #412 r2 MINOR: source-substring assertions catch
         // accidental deletions but not subtle regex breakage (e.g. a
         // future edit that over-escapes the dot, or accidentally
@@ -114,11 +114,10 @@ struct SidecarVersionGateTests {
         ] {
             let bash = "/bin/bash"
             let script = "re=\(Self.shellSingleQuote(regex)); if [[ \"$1\" =~ $re ]]; then exit 0; else exit 1; fi"
-            let proc = Process()
-            proc.executableURL = URL(fileURLWithPath: bash)
-            proc.arguments = ["-c", script, "_test", input]
-            try proc.run()
-            proc.waitUntilExit()
+            let proc = try await TestSubprocess.run(
+                executableURL: URL(fileURLWithPath: bash),
+                arguments: ["-c", script, "_test", input]
+            )
             let matched = proc.terminationStatus == 0
             #expect(
                 matched == shouldMatch,

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -23,10 +23,10 @@ enum TestSubprocessError: Error, CustomStringConvertible {
 /// A synchronous ``Process.waitUntilExit()`` occupies a cooperative executor
 /// worker when called from an async or MainActor test. On a low-core runner,
 /// enough such waits can prevent the tasks responsible for making the child
-/// exit from running at all. This helper instead resumes from
-/// ``terminationHandler`` and gives every child a watchdog on a native thread,
-/// independent of Swift concurrency. A timeout samples the child into the
-/// captured test log, then escalates TERM to KILL.
+/// exit from running at all. This helper instead waits on a native thread,
+/// independent of Swift concurrency, while a second native-thread watchdog
+/// bounds both process exit and pipe drainage. A timeout samples the process
+/// group into the captured test log, then escalates group-wide TERM to KILL.
 enum TestSubprocess {
     static func run(
         executableURL: URL,
@@ -40,58 +40,124 @@ enum TestSubprocess {
         precondition(timeout > 0, "test subprocess timeout must be positive")
         precondition(sampleDuration > 0, "sample duration must be positive")
 
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-        process.currentDirectoryURL = currentDirectoryURL
-        process.environment = environment
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        let stdoutCapture = AsyncPipeCapture(stdoutPipe.fileHandleForReading)
-        let stderrCapture = AsyncPipeCapture(stderrPipe.fileHandleForReading)
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        let state = TestProcessExitState()
-        let processBox = UncheckedProcess(process)
-        process.terminationHandler = { terminated in
-            state.complete(status: terminated.terminationStatus)
-        }
-
+        let stdoutPipe = try SpawnPipe()
+        let stderrPipe: SpawnPipe
         do {
-            try process.run()
+            stderrPipe = try SpawnPipe()
         } catch {
-            stdoutPipe.fileHandleForWriting.closeFile()
-            stderrPipe.fileHandleForWriting.closeFile()
-            stdoutCapture.cancel()
-            stderrCapture.cancel()
+            stdoutPipe.closeBoth()
             throw error
         }
-        stdoutPipe.fileHandleForWriting.closeFile()
-        stderrPipe.fileHandleForWriting.closeFile()
+
+        let state = TestProcessCompletionState()
+        let stdoutCapture = AsyncPipeCapture(
+            FileHandle(fileDescriptor: stdoutPipe.readFD, closeOnDealloc: true),
+            onFinish: { state.pipeFinished() }
+        )
+        let stderrCapture = AsyncPipeCapture(
+            FileHandle(fileDescriptor: stderrPipe.readFD, closeOnDealloc: true),
+            onFinish: { state.pipeFinished() }
+        )
+
+        var fileActions: posix_spawn_file_actions_t?
+        var attributes: posix_spawnattr_t?
+        var writeEndsOpen = true
+        defer {
+            if writeEndsOpen {
+                Darwin.close(stdoutPipe.writeFD)
+                Darwin.close(stderrPipe.writeFD)
+            }
+        }
+        try check(posix_spawn_file_actions_init(&fileActions))
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        try check(posix_spawnattr_init(&attributes))
+        defer { posix_spawnattr_destroy(&attributes) }
+
+        try check(posix_spawn_file_actions_adddup2(&fileActions, stdoutPipe.writeFD, STDOUT_FILENO))
+        try check(posix_spawn_file_actions_adddup2(&fileActions, stderrPipe.writeFD, STDERR_FILENO))
+        for descriptor in [
+            stdoutPipe.readFD, stdoutPipe.writeFD,
+            stderrPipe.readFD, stderrPipe.writeFD,
+        ] {
+            try check(posix_spawn_file_actions_addclose(&fileActions, descriptor))
+        }
+        if let currentDirectoryURL {
+            let result = currentDirectoryURL.path.withCString { path in
+                if #available(macOS 26.0, *) {
+                    posix_spawn_file_actions_addchdir(&fileActions, path)
+                } else {
+                    posix_spawn_file_actions_addchdir_np(&fileActions, path)
+                }
+            }
+            try check(result)
+        }
+
+        // A dedicated process group lets the timeout own descendants even
+        // after the direct child exits while a grandchild still holds one of
+        // our pipe descriptors open.
+        try check(posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP)))
+        try check(posix_spawnattr_setpgroup(&attributes, 0))
+
+        let argv = [executableURL.path] + arguments
+        let inheritedEnvironment = environment ?? ProcessInfo.processInfo.environment
+        let envp = inheritedEnvironment.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+        var pid: pid_t = 0
+        let spawnResult = withMutableCStrings(argv) { argvPointer in
+            withMutableCStrings(envp) { environmentPointer in
+                executableURL.path.withCString { executablePath in
+                    posix_spawn(
+                        &pid,
+                        executablePath,
+                        &fileActions,
+                        &attributes,
+                        argvPointer,
+                        environmentPointer
+                    )
+                }
+            }
+        }
+        Darwin.close(stdoutPipe.writeFD)
+        Darwin.close(stderrPipe.writeFD)
+        writeEndsOpen = false
+        guard spawnResult == 0 else {
+            stdoutCapture.cancel()
+            stderrCapture.cancel()
+            throw POSIXError(POSIXErrorCode(rawValue: spawnResult) ?? .EIO)
+        }
+        let spawnedPID = pid
+
+        Thread.detachNewThread {
+            var rawStatus: Int32 = 0
+            var result: pid_t
+            repeat {
+                result = Darwin.waitpid(spawnedPID, &rawStatus, 0)
+            } while result == -1 && errno == EINTR
+            if result == spawnedPID {
+                state.processExited(rawStatus: rawStatus)
+            } else {
+                state.processExited(rawStatus: 127 << 8)
+            }
+        }
 
         let command = ([executableURL.path] + arguments).joined(separator: " ")
-        let pid = process.processIdentifier
         Thread.detachNewThread {
             guard state.beginTimeoutIfIncomplete(after: timeout) else { return }
             if sampleOnTimeout {
-                sample(pid: pid, duration: sampleDuration, command: command)
+                sample(processGroup: spawnedPID, duration: sampleDuration, command: command)
             }
-            guard processBox.process.isRunning else { return }
-            processBox.process.terminate()
+            Darwin.kill(-spawnedPID, SIGTERM)
             guard !state.waitForCompletion(seconds: 2) else { return }
-            Darwin.kill(pid, SIGKILL)
+            Darwin.kill(-spawnedPID, SIGKILL)
         }
 
         let exit = await withTaskCancellationHandler {
             await state.value()
         } onCancel: {
-            guard processBox.process.isRunning else { return }
-            processBox.process.terminate()
+            Darwin.kill(-spawnedPID, SIGTERM)
             Thread.detachNewThread {
                 guard !state.waitForCompletion(seconds: 2) else { return }
-                Darwin.kill(pid, SIGKILL)
+                Darwin.kill(-spawnedPID, SIGKILL)
             }
         }
         async let standardOutput = stdoutCapture.value()
@@ -103,19 +169,26 @@ enum TestSubprocess {
             throw TestSubprocessError.timedOut(
                 command: command,
                 seconds: timeout,
-                pid: pid
+                pid: spawnedPID
             )
         }
         return TestSubprocessResult(
-            terminationStatus: exit.status,
+            terminationStatus: terminationStatus(from: exit.rawStatus),
             standardOutput: output,
             standardError: errorOutput
         )
     }
 
-    private static func sample(pid: pid_t, duration: Int, command: String) {
-        let message = "TestSubprocess: timeout; sampling pid \(pid) for \(duration)s: \(command)\n"
+    private static func sample(processGroup: pid_t, duration: Int, command: String) {
+        let members = processGroupMembers(processGroup)
+        let message = "TestSubprocess: timeout; sampling process group \(processGroup) members \(members) for \(duration)s: \(command)\n"
         FileHandle.standardError.write(Data(message.utf8))
+        for pid in members.isEmpty ? [processGroup] : members {
+            sample(pid: pid, duration: duration)
+        }
+    }
+
+    private static func sample(pid: pid_t, duration: Int) {
         let sampler = Process()
         sampler.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
         sampler.arguments = [String(pid), String(duration), "-file", "/dev/stderr"]
@@ -131,40 +204,108 @@ enum TestSubprocess {
             FileHandle.standardError.write(Data(failure.utf8))
         }
     }
-}
 
-private final class UncheckedProcess: @unchecked Sendable {
-    let process: Process
+    private static func processGroupMembers(_ processGroup: pid_t) -> [pid_t] {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-axo", "pid=,pgid="]
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+        return String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            .split(separator: "\n")
+            .compactMap { line -> pid_t? in
+                let fields = line.split(whereSeparator: \Character.isWhitespace)
+                guard fields.count == 2,
+                      let pid = pid_t(fields[0]),
+                      let group = pid_t(fields[1]),
+                      group == processGroup
+                else { return nil }
+                return pid
+            }
+    }
 
-    init(_ process: Process) {
-        self.process = process
+    private static func terminationStatus(from rawStatus: Int32) -> Int32 {
+        let signal = rawStatus & 0x7f
+        return signal == 0 ? (rawStatus >> 8) & 0xff : signal
+    }
+
+    private static func check(_ result: Int32) throws {
+        guard result != 0 else { return }
+        throw POSIXError(POSIXErrorCode(rawValue: result) ?? .EIO)
+    }
+
+    private static func withMutableCStrings<Result>(
+        _ strings: [String],
+        _ body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> Result
+    ) -> Result {
+        let storage = strings.map { strdup($0) }
+        defer { storage.forEach { free($0) } }
+        var pointers = storage + [nil]
+        return pointers.withUnsafeMutableBufferPointer { buffer in
+            body(buffer.baseAddress!)
+        }
     }
 }
 
-private final class TestProcessExitState: @unchecked Sendable {
+private struct SpawnPipe {
+    let readFD: Int32
+    let writeFD: Int32
+
+    init() throws {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        let result = descriptors.withUnsafeMutableBufferPointer { buffer in
+            Darwin.pipe(buffer.baseAddress!)
+        }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        readFD = descriptors[0]
+        writeFD = descriptors[1]
+    }
+
+    func closeBoth() {
+        Darwin.close(readFD)
+        Darwin.close(writeFD)
+    }
+}
+
+private final class TestProcessCompletionState: @unchecked Sendable {
     struct Exit: Sendable {
-        let status: Int32
+        let rawStatus: Int32
         let timedOut: Bool
     }
 
     private let condition = NSCondition()
     private var exit: Exit?
+    private var rawStatus: Int32?
+    private var finishedPipeCount = 0
     private var timedOut = false
     private var continuation: CheckedContinuation<Exit, Never>?
 
-    func complete(status: Int32) {
+    func processExited(rawStatus: Int32) {
         condition.lock()
-        guard exit == nil else {
-            condition.unlock()
-            return
-        }
-        let value = Exit(status: status, timedOut: timedOut)
-        exit = value
-        let continuation = continuation
-        self.continuation = nil
-        condition.broadcast()
+        self.rawStatus = rawStatus
+        let completion = completeIfReadyLocked()
         condition.unlock()
-        continuation?.resume(returning: value)
+        if let completion {
+            completion.continuation?.resume(returning: completion.value)
+        }
+    }
+
+    func pipeFinished() {
+        condition.lock()
+        finishedPipeCount += 1
+        let completion = completeIfReadyLocked()
+        condition.unlock()
+        if let completion {
+            completion.continuation?.resume(returning: completion.value)
+        }
     }
 
     func value() async -> Exit {
@@ -197,6 +338,19 @@ private final class TestProcessExitState: @unchecked Sendable {
         while exit == nil && condition.wait(until: deadline) {}
         return exit != nil
     }
+
+    private func completeIfReadyLocked() -> (
+        continuation: CheckedContinuation<Exit, Never>?,
+        value: Exit
+    )? {
+        guard exit == nil, let rawStatus, finishedPipeCount == 2 else { return nil }
+        let value = Exit(rawStatus: rawStatus, timedOut: timedOut)
+        exit = value
+        let continuation = continuation
+        self.continuation = nil
+        condition.broadcast()
+        return (continuation, value)
+    }
 }
 
 private final class AsyncPipeCapture: @unchecked Sendable {
@@ -205,9 +359,11 @@ private final class AsyncPipeCapture: @unchecked Sendable {
     private var data = Data()
     private var finished = false
     private var continuation: CheckedContinuation<Data, Never>?
+    private let onFinish: @Sendable () -> Void
 
-    init(_ handle: FileHandle) {
+    init(_ handle: FileHandle, onFinish: @escaping @Sendable () -> Void) {
         self.handle = handle
+        self.onFinish = onFinish
         handle.readabilityHandler = { [weak self] readable in
             guard let self else { return }
             let chunk = readable.availableData
@@ -241,6 +397,7 @@ private final class AsyncPipeCapture: @unchecked Sendable {
 
     private func finish() {
         handle.readabilityHandler = nil
+        handle.closeFile()
         lock.lock()
         guard !finished else {
             lock.unlock()
@@ -252,5 +409,6 @@ private final class AsyncPipeCapture: @unchecked Sendable {
         self.continuation = nil
         lock.unlock()
         continuation?.resume(returning: data)
+        onFinish()
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -142,7 +142,9 @@ enum TestSubprocess {
             }
         }
 
-        let command = ([executableURL.path] + arguments).joined(separator: " ")
+        let command = ([executableURL.path] + arguments)
+            .map(\.debugDescription)
+            .joined(separator: " ")
         Thread.detachNewThread {
             guard state.beginTimeoutIfIncomplete(after: timeout) else { return }
             // Pipe ownership ends at the caller's deadline. In particular, a
@@ -153,7 +155,7 @@ enum TestSubprocess {
             if sampleOnTimeout {
                 sample(pid: spawnedPID, duration: sampleDuration, command: command)
             }
-            terminate(pid: spawnedPID)
+            terminate(pid: spawnedPID, state: state)
             state.timeoutCleanupFinished()
         }
 
@@ -161,7 +163,7 @@ enum TestSubprocess {
             await state.value()
         } onCancel: {
             Thread.detachNewThread {
-                terminate(pid: spawnedPID)
+                terminate(pid: spawnedPID, state: state)
                 stdoutCapture.cancel()
                 stderrCapture.cancel()
             }
@@ -215,7 +217,7 @@ enum TestSubprocess {
         }
     }
 
-    private static func terminate(pid: pid_t) {
+    private static func terminate(pid: pid_t, state: TestProcessCompletionState) {
         signalProcessTree(pid: pid, signal: SIGTERM)
         let deadline = Date(timeIntervalSinceNow: 2)
         while processTreeExists(pid: pid), Date() < deadline {
@@ -223,6 +225,12 @@ enum TestSubprocess {
         }
         if processTreeExists(pid: pid) {
             signalProcessTree(pid: pid, signal: SIGKILL)
+        }
+        // waitpid normally publishes immediately after TERM/KILL. Keep one
+        // final fixed grace window so the returned timeout represents a reaped
+        // child, but never let a kernel-side wait stall the caller forever.
+        if !state.waitForProcessExit(seconds: 1) {
+            state.forceProcessExitIfMissing(rawStatus: SIGKILL)
         }
     }
 
@@ -295,6 +303,7 @@ private final class TestProcessCompletionState: @unchecked Sendable {
     private var finishedPipeCount = 0
     private var timedOut = false
     private var timeoutCleanupComplete = true
+    private var valueRequested = false
     private var continuation: CheckedContinuation<Exit, Never>?
 
     func processExited(rawStatus: Int32) {
@@ -322,6 +331,8 @@ private final class TestProcessCompletionState: @unchecked Sendable {
     func value() async -> Exit {
         await withCheckedContinuation { continuation in
             condition.lock()
+            precondition(!valueRequested, "TestProcessCompletionState supports one consumer")
+            valueRequested = true
             if let exit {
                 condition.unlock()
                 continuation.resume(returning: exit)
@@ -329,6 +340,27 @@ private final class TestProcessCompletionState: @unchecked Sendable {
                 self.continuation = continuation
                 condition.unlock()
             }
+        }
+    }
+
+    func waitForProcessExit(seconds: TimeInterval) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date(timeIntervalSinceNow: seconds)
+        while rawStatus == nil && condition.wait(until: deadline) {}
+        return rawStatus != nil
+    }
+
+    func forceProcessExitIfMissing(rawStatus: Int32) {
+        condition.lock()
+        if self.rawStatus == nil {
+            self.rawStatus = rawStatus
+        }
+        condition.broadcast()
+        let completion = completeIfReadyLocked()
+        condition.unlock()
+        if let completion {
+            completion.continuation?.resume(returning: completion.value)
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -1,0 +1,256 @@
+import Darwin
+import Foundation
+
+struct TestSubprocessResult: Sendable {
+    let terminationStatus: Int32
+    let standardOutput: Data
+    let standardError: Data
+}
+
+enum TestSubprocessError: Error, CustomStringConvertible {
+    case timedOut(command: String, seconds: TimeInterval, pid: pid_t)
+
+    var description: String {
+        switch self {
+        case let .timedOut(command, seconds, pid):
+            return "test subprocess timed out after \(seconds)s (pid \(pid)): \(command); process sample was emitted above"
+        }
+    }
+}
+
+/// Async, bounded launcher for test-only subprocesses.
+///
+/// A synchronous ``Process.waitUntilExit()`` occupies a cooperative executor
+/// worker when called from an async or MainActor test. On a low-core runner,
+/// enough such waits can prevent the tasks responsible for making the child
+/// exit from running at all. This helper instead resumes from
+/// ``terminationHandler`` and gives every child a watchdog on a native thread,
+/// independent of Swift concurrency. A timeout samples the child into the
+/// captured test log, then escalates TERM to KILL.
+enum TestSubprocess {
+    static func run(
+        executableURL: URL,
+        arguments: [String] = [],
+        currentDirectoryURL: URL? = nil,
+        environment: [String: String]? = nil,
+        timeout: TimeInterval = 30,
+        sampleOnTimeout: Bool = true,
+        sampleDuration: Int = 3
+    ) async throws -> TestSubprocessResult {
+        precondition(timeout > 0, "test subprocess timeout must be positive")
+        precondition(sampleDuration > 0, "sample duration must be positive")
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let stdoutCapture = AsyncPipeCapture(stdoutPipe.fileHandleForReading)
+        let stderrCapture = AsyncPipeCapture(stderrPipe.fileHandleForReading)
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let state = TestProcessExitState()
+        let processBox = UncheckedProcess(process)
+        process.terminationHandler = { terminated in
+            state.complete(status: terminated.terminationStatus)
+        }
+
+        do {
+            try process.run()
+        } catch {
+            stdoutPipe.fileHandleForWriting.closeFile()
+            stderrPipe.fileHandleForWriting.closeFile()
+            stdoutCapture.cancel()
+            stderrCapture.cancel()
+            throw error
+        }
+        stdoutPipe.fileHandleForWriting.closeFile()
+        stderrPipe.fileHandleForWriting.closeFile()
+
+        let command = ([executableURL.path] + arguments).joined(separator: " ")
+        let pid = process.processIdentifier
+        Thread.detachNewThread {
+            guard state.beginTimeoutIfIncomplete(after: timeout) else { return }
+            if sampleOnTimeout {
+                sample(pid: pid, duration: sampleDuration, command: command)
+            }
+            guard processBox.process.isRunning else { return }
+            processBox.process.terminate()
+            guard !state.waitForCompletion(seconds: 2) else { return }
+            Darwin.kill(pid, SIGKILL)
+        }
+
+        let exit = await withTaskCancellationHandler {
+            await state.value()
+        } onCancel: {
+            guard processBox.process.isRunning else { return }
+            processBox.process.terminate()
+            Thread.detachNewThread {
+                guard !state.waitForCompletion(seconds: 2) else { return }
+                Darwin.kill(pid, SIGKILL)
+            }
+        }
+        async let standardOutput = stdoutCapture.value()
+        async let standardError = stderrCapture.value()
+        let output = await standardOutput
+        let errorOutput = await standardError
+        try Task.checkCancellation()
+        if exit.timedOut {
+            throw TestSubprocessError.timedOut(
+                command: command,
+                seconds: timeout,
+                pid: pid
+            )
+        }
+        return TestSubprocessResult(
+            terminationStatus: exit.status,
+            standardOutput: output,
+            standardError: errorOutput
+        )
+    }
+
+    private static func sample(pid: pid_t, duration: Int, command: String) {
+        let message = "TestSubprocess: timeout; sampling pid \(pid) for \(duration)s: \(command)\n"
+        FileHandle.standardError.write(Data(message.utf8))
+        let sampler = Process()
+        sampler.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        sampler.arguments = [String(pid), String(duration), "-file", "/dev/stderr"]
+        sampler.standardOutput = FileHandle.standardError
+        sampler.standardError = FileHandle.standardError
+        do {
+            try sampler.run()
+            // This runs on the dedicated watchdog Thread, never a Swift
+            // cooperative executor worker.
+            sampler.waitUntilExit()
+        } catch {
+            let failure = "TestSubprocess: sample failed for pid \(pid): \(error)\n"
+            FileHandle.standardError.write(Data(failure.utf8))
+        }
+    }
+}
+
+private final class UncheckedProcess: @unchecked Sendable {
+    let process: Process
+
+    init(_ process: Process) {
+        self.process = process
+    }
+}
+
+private final class TestProcessExitState: @unchecked Sendable {
+    struct Exit: Sendable {
+        let status: Int32
+        let timedOut: Bool
+    }
+
+    private let condition = NSCondition()
+    private var exit: Exit?
+    private var timedOut = false
+    private var continuation: CheckedContinuation<Exit, Never>?
+
+    func complete(status: Int32) {
+        condition.lock()
+        guard exit == nil else {
+            condition.unlock()
+            return
+        }
+        let value = Exit(status: status, timedOut: timedOut)
+        exit = value
+        let continuation = continuation
+        self.continuation = nil
+        condition.broadcast()
+        condition.unlock()
+        continuation?.resume(returning: value)
+    }
+
+    func value() async -> Exit {
+        await withCheckedContinuation { continuation in
+            condition.lock()
+            if let exit {
+                condition.unlock()
+                continuation.resume(returning: exit)
+            } else {
+                self.continuation = continuation
+                condition.unlock()
+            }
+        }
+    }
+
+    func beginTimeoutIfIncomplete(after seconds: TimeInterval) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date(timeIntervalSinceNow: seconds)
+        while exit == nil && condition.wait(until: deadline) {}
+        guard exit == nil else { return false }
+        timedOut = true
+        return true
+    }
+
+    func waitForCompletion(seconds: TimeInterval) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date(timeIntervalSinceNow: seconds)
+        while exit == nil && condition.wait(until: deadline) {}
+        return exit != nil
+    }
+}
+
+private final class AsyncPipeCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private let handle: FileHandle
+    private var data = Data()
+    private var finished = false
+    private var continuation: CheckedContinuation<Data, Never>?
+
+    init(_ handle: FileHandle) {
+        self.handle = handle
+        handle.readabilityHandler = { [weak self] readable in
+            guard let self else { return }
+            let chunk = readable.availableData
+            if chunk.isEmpty {
+                finish()
+            } else {
+                lock.lock()
+                data.append(chunk)
+                lock.unlock()
+            }
+        }
+    }
+
+    func value() async -> Data {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if finished {
+                let data = data
+                lock.unlock()
+                continuation.resume(returning: data)
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func cancel() {
+        finish()
+    }
+
+    private func finish() {
+        handle.readabilityHandler = nil
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let data = data
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: data)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -145,27 +145,25 @@ enum TestSubprocess {
         let command = ([executableURL.path] + arguments).joined(separator: " ")
         Thread.detachNewThread {
             guard state.beginTimeoutIfIncomplete(after: timeout) else { return }
+            // Pipe ownership ends at the caller's deadline. In particular, a
+            // setsid() descendant cannot extend capture lifetime while process
+            // diagnostics and termination continue on this native thread.
+            stdoutCapture.cancel()
+            stderrCapture.cancel()
             if sampleOnTimeout {
                 sample(pid: spawnedPID, duration: sampleDuration, command: command)
             }
-            terminate(
-                pid: spawnedPID,
-                state: state,
-                stdoutCapture: stdoutCapture,
-                stderrCapture: stderrCapture
-            )
+            terminate(pid: spawnedPID)
+            state.timeoutCleanupFinished()
         }
 
         let exit = await withTaskCancellationHandler {
             await state.value()
         } onCancel: {
             Thread.detachNewThread {
-                terminate(
-                    pid: spawnedPID,
-                    state: state,
-                    stdoutCapture: stdoutCapture,
-                    stderrCapture: stderrCapture
-                )
+                terminate(pid: spawnedPID)
+                stdoutCapture.cancel()
+                stderrCapture.cancel()
             }
         }
         async let standardOutput = stdoutCapture.value()
@@ -217,23 +215,15 @@ enum TestSubprocess {
         }
     }
 
-    private static func terminate(
-        pid: pid_t,
-        state: TestProcessCompletionState,
-        stdoutCapture: AsyncPipeCapture,
-        stderrCapture: AsyncPipeCapture
-    ) {
+    private static func terminate(pid: pid_t) {
         signalProcessTree(pid: pid, signal: SIGTERM)
-        guard !state.waitForCompletion(seconds: 2) else { return }
-
-        signalProcessTree(pid: pid, signal: SIGKILL)
-
-        // A descendant can deliberately leave the process group (setsid) yet
-        // retain inherited stdout/stderr descriptors after the direct child
-        // is reaped. Closing our read ends makes timeout completion independent
-        // of that descendant and preserves the helper's hard upper bound.
-        stdoutCapture.cancel()
-        stderrCapture.cancel()
+        let deadline = Date(timeIntervalSinceNow: 2)
+        while processTreeExists(pid: pid), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        if processTreeExists(pid: pid) {
+            signalProcessTree(pid: pid, signal: SIGKILL)
+        }
     }
 
     private static func signalProcessTree(pid: pid_t, signal: Int32) {
@@ -242,6 +232,10 @@ enum TestSubprocess {
         // the waitpid thread a deterministic path to reap it.
         _ = Darwin.kill(-pid, signal)
         _ = Darwin.kill(pid, signal)
+    }
+
+    private static func processTreeExists(pid: pid_t) -> Bool {
+        Darwin.kill(-pid, 0) == 0 || Darwin.kill(pid, 0) == 0
     }
 
     private static func terminationStatus(from rawStatus: Int32) -> Int32 {
@@ -300,6 +294,7 @@ private final class TestProcessCompletionState: @unchecked Sendable {
     private var rawStatus: Int32?
     private var finishedPipeCount = 0
     private var timedOut = false
+    private var timeoutCleanupComplete = true
     private var continuation: CheckedContinuation<Exit, Never>?
 
     func processExited(rawStatus: Int32) {
@@ -342,22 +337,29 @@ private final class TestProcessCompletionState: @unchecked Sendable {
         while exit == nil && condition.wait(until: deadline) {}
         guard exit == nil else { return false }
         timedOut = true
+        timeoutCleanupComplete = false
         return true
     }
 
-    func waitForCompletion(seconds: TimeInterval) -> Bool {
+    func timeoutCleanupFinished() {
         condition.lock()
-        defer { condition.unlock() }
-        let deadline = Date(timeIntervalSinceNow: seconds)
-        while exit == nil && condition.wait(until: deadline) {}
-        return exit != nil
+        timeoutCleanupComplete = true
+        let completion = completeIfReadyLocked()
+        condition.unlock()
+        if let completion {
+            completion.continuation?.resume(returning: completion.value)
+        }
     }
 
     private func completeIfReadyLocked() -> (
         continuation: CheckedContinuation<Exit, Never>?,
         value: Exit
     )? {
-        guard exit == nil, let rawStatus, finishedPipeCount == 2 else { return nil }
+        guard exit == nil,
+              let rawStatus,
+              finishedPipeCount == 2,
+              timeoutCleanupComplete
+        else { return nil }
         let value = Exit(rawStatus: rawStatus, timedOut: timedOut)
         exit = value
         let continuation = continuation
@@ -372,6 +374,7 @@ private final class AsyncPipeCapture: @unchecked Sendable {
     private let handle: FileHandle
     private var data = Data()
     private var finished = false
+    private var valueRequested = false
     private var continuation: CheckedContinuation<Data, Never>?
     private let onFinish: @Sendable () -> Void
 
@@ -394,6 +397,8 @@ private final class AsyncPipeCapture: @unchecked Sendable {
     func value() async -> Data {
         await withCheckedContinuation { continuation in
             lock.lock()
+            precondition(!valueRequested, "AsyncPipeCapture supports one consumer")
+            valueRequested = true
             if finished {
                 let data = data
                 lock.unlock()

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -85,11 +85,11 @@ enum TestSubprocess {
         }
         if let currentDirectoryURL {
             let result = currentDirectoryURL.path.withCString { path in
-                if #available(macOS 26.0, *) {
-                    posix_spawn_file_actions_addchdir(&fileActions, path)
-                } else {
-                    posix_spawn_file_actions_addchdir_np(&fileActions, path)
-                }
+                // The non-portable Darwin spelling is present across the
+                // oldest CI SDK through macOS 26. The standardized spelling
+                // is runtime-available on 26 but absent from older SDK headers,
+                // so merely placing it behind #available does not compile.
+                posix_spawn_file_actions_addchdir_np(&fileActions, path)
             }
             try check(result)
         }

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -25,8 +25,10 @@ enum TestSubprocessError: Error, CustomStringConvertible {
 /// enough such waits can prevent the tasks responsible for making the child
 /// exit from running at all. This helper instead waits on a native thread,
 /// independent of Swift concurrency, while a second native-thread watchdog
-/// bounds both process exit and pipe drainage. A timeout samples the process
-/// group into the captured test log, then escalates group-wide TERM to KILL.
+/// bounds both process exit and pipe drainage. A timeout emits one bounded
+/// sample for the process-group leader, then escalates group-wide TERM to KILL
+/// and closes the capture descriptors so an escaped descendant cannot retain
+/// them indefinitely.
 enum TestSubprocess {
     static func run(
         executableURL: URL,
@@ -144,20 +146,26 @@ enum TestSubprocess {
         Thread.detachNewThread {
             guard state.beginTimeoutIfIncomplete(after: timeout) else { return }
             if sampleOnTimeout {
-                sample(processGroup: spawnedPID, duration: sampleDuration, command: command)
+                sample(pid: spawnedPID, duration: sampleDuration, command: command)
             }
-            Darwin.kill(-spawnedPID, SIGTERM)
-            guard !state.waitForCompletion(seconds: 2) else { return }
-            Darwin.kill(-spawnedPID, SIGKILL)
+            terminate(
+                pid: spawnedPID,
+                state: state,
+                stdoutCapture: stdoutCapture,
+                stderrCapture: stderrCapture
+            )
         }
 
         let exit = await withTaskCancellationHandler {
             await state.value()
         } onCancel: {
-            Darwin.kill(-spawnedPID, SIGTERM)
             Thread.detachNewThread {
-                guard !state.waitForCompletion(seconds: 2) else { return }
-                Darwin.kill(-spawnedPID, SIGKILL)
+                terminate(
+                    pid: spawnedPID,
+                    state: state,
+                    stdoutCapture: stdoutCapture,
+                    stderrCapture: stderrCapture
+                )
             }
         }
         async let standardOutput = stdoutCapture.value()
@@ -179,55 +187,61 @@ enum TestSubprocess {
         )
     }
 
-    private static func sample(processGroup: pid_t, duration: Int, command: String) {
-        let members = processGroupMembers(processGroup)
-        let message = "TestSubprocess: timeout; sampling process group \(processGroup) members \(members) for \(duration)s: \(command)\n"
+    private static func sample(pid: pid_t, duration: Int, command: String) {
+        // Sampling every descendant serially makes a fork-heavy timeout scale
+        // with process count. One leader sample keeps diagnostics within the
+        // caller-selected duration while the group ID remains in the message.
+        let message = "TestSubprocess: timeout; sampling process-group leader \(pid) for \(duration)s: \(command)\n"
         FileHandle.standardError.write(Data(message.utf8))
-        for pid in members.isEmpty ? [processGroup] : members {
-            sample(pid: pid, duration: duration)
-        }
-    }
-
-    private static func sample(pid: pid_t, duration: Int) {
         let sampler = Process()
         sampler.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
         sampler.arguments = [String(pid), String(duration), "-file", "/dev/stderr"]
         sampler.standardOutput = FileHandle.standardError
         sampler.standardError = FileHandle.standardError
+        let finished = DispatchSemaphore(value: 0)
+        sampler.terminationHandler = { _ in finished.signal() }
         do {
             try sampler.run()
-            // This runs on the dedicated watchdog Thread, never a Swift
-            // cooperative executor worker.
-            sampler.waitUntilExit()
+            // Symbolication can outlive the requested sampling period. Give it
+            // one fixed grace second, then stop the diagnostic so termination
+            // never depends on an unbounded Process wait.
+            if finished.wait(timeout: .now() + .seconds(duration + 1)) == .timedOut {
+                sampler.terminate()
+                if finished.wait(timeout: .now() + .milliseconds(250)) == .timedOut {
+                    _ = Darwin.kill(sampler.processIdentifier, SIGKILL)
+                }
+            }
         } catch {
             let failure = "TestSubprocess: sample failed for pid \(pid): \(error)\n"
             FileHandle.standardError.write(Data(failure.utf8))
         }
     }
 
-    private static func processGroupMembers(_ processGroup: pid_t) -> [pid_t] {
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-axo", "pid=,pgid="]
-        process.standardOutput = pipe
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return []
-        }
-        return String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-            .split(separator: "\n")
-            .compactMap { line -> pid_t? in
-                let fields = line.split(whereSeparator: \Character.isWhitespace)
-                guard fields.count == 2,
-                      let pid = pid_t(fields[0]),
-                      let group = pid_t(fields[1]),
-                      group == processGroup
-                else { return nil }
-                return pid
-            }
+    private static func terminate(
+        pid: pid_t,
+        state: TestProcessCompletionState,
+        stdoutCapture: AsyncPipeCapture,
+        stderrCapture: AsyncPipeCapture
+    ) {
+        signalProcessTree(pid: pid, signal: SIGTERM)
+        guard !state.waitForCompletion(seconds: 2) else { return }
+
+        signalProcessTree(pid: pid, signal: SIGKILL)
+
+        // A descendant can deliberately leave the process group (setsid) yet
+        // retain inherited stdout/stderr descriptors after the direct child
+        // is reaped. Closing our read ends makes timeout completion independent
+        // of that descendant and preserves the helper's hard upper bound.
+        stdoutCapture.cancel()
+        stderrCapture.cancel()
+    }
+
+    private static func signalProcessTree(pid: pid_t, signal: Int32) {
+        // Signal both the group and its leader. The direct child may have
+        // changed its own group after spawn; addressing its PID still gives
+        // the waitpid thread a deterministic path to reap it.
+        _ = Darwin.kill(-pid, signal)
+        _ = Darwin.kill(pid, signal)
     }
 
     private static func terminationStatus(from rawStatus: Int32) -> Int32 {

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestSubprocess.swift
@@ -300,6 +300,7 @@ private final class TestProcessCompletionState: @unchecked Sendable {
     func processExited(rawStatus: Int32) {
         condition.lock()
         self.rawStatus = rawStatus
+        condition.broadcast()
         let completion = completeIfReadyLocked()
         condition.unlock()
         if let completion {
@@ -310,6 +311,7 @@ private final class TestProcessCompletionState: @unchecked Sendable {
     func pipeFinished() {
         condition.lock()
         finishedPipeCount += 1
+        condition.broadcast()
         let completion = completeIfReadyLocked()
         condition.unlock()
         if let completion {
@@ -415,8 +417,6 @@ private final class AsyncPipeCapture: @unchecked Sendable {
     }
 
     private func finish() {
-        handle.readabilityHandler = nil
-        handle.closeFile()
         lock.lock()
         guard !finished else {
             lock.unlock()
@@ -427,6 +427,11 @@ private final class AsyncPipeCapture: @unchecked Sendable {
         let continuation = continuation
         self.continuation = nil
         lock.unlock()
+        // Only the caller that won the one-shot transition above mutates the
+        // FileHandle. EOF delivery and timeout cancellation can race here,
+        // but the losing path returns before touching the handle.
+        handle.readabilityHandler = nil
+        handle.closeFile()
         continuation?.resume(returning: data)
         onFinish()
     }

--- a/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
@@ -1,0 +1,106 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Bounded async test subprocesses", TestTimeouts.hangProne)
+struct TestSubprocessTests {
+    private static var testRoot: URL {
+        URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    }
+
+    @Test("captures both pipes without blocking the cooperative executor")
+    func capturesOutputAndExit() async throws {
+        let result = try await TestSubprocess.run(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf out; printf err >&2; exit 7"]
+        )
+
+        #expect(result.terminationStatus == 7)
+        #expect(String(decoding: result.standardOutput, as: UTF8.self) == "out")
+        #expect(String(decoding: result.standardError, as: UTF8.self) == "err")
+    }
+
+    @Test("a stalled child is sampled, killed, reaped, and reported within a bound")
+    func stalledChildFailsWithinBound() async throws {
+        let clock = ContinuousClock()
+        let start = clock.now
+        var childPID: pid_t?
+
+        do {
+            let result = try await TestSubprocess.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "printf '%s\\n' $$; exec sleep 30"],
+                timeout: 0.2,
+                sampleOnTimeout: true,
+                sampleDuration: 1
+            )
+            childPID = pid_t(String(decoding: result.standardOutput, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines))
+            Issue.record("expected the stalled child to time out")
+        } catch let error as TestSubprocessError {
+            guard case let .timedOut(_, seconds, pid) = error else {
+                Issue.record("unexpected subprocess error: \(error)")
+                return
+            }
+            childPID = pid
+            #expect(seconds == 0.2)
+            #expect(error.description.contains("process sample was emitted above"))
+        }
+
+        #expect(clock.now - start < .seconds(5))
+        let pid = try #require(childPID)
+        #expect(Darwin.kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
+    @Test("cancelling the caller terminates and reaps the child")
+    func cancellationReapsChild() async throws {
+        let task = Task {
+            try await TestSubprocess.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "printf '%s\\n' $$; exec sleep 30"],
+                timeout: 30,
+                sampleOnTimeout: false
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("cancelled subprocess unexpectedly returned a result")
+        } catch is CancellationError {
+            // Expected: cancellation reaches the caller only after the child
+            // has exited and both pipe readers have observed EOF.
+        }
+    }
+
+    @Test("blocking Process waits stay confined to native watchdog threads")
+    func noBlockingWaitsInOrdinaryTests() throws {
+        let allowed = Set([
+            "Support/CIHangWatchdog.swift",
+            "Support/TestSubprocess.swift",
+            "TestSubprocessTests.swift", // Owns this source guard.
+        ])
+        let enumerator = try #require(
+            FileManager.default.enumerator(
+                at: Self.testRoot,
+                includingPropertiesForKeys: nil
+            )
+        )
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let relative = String(url.path.dropFirst(Self.testRoot.path.count + 1))
+            guard !allowed.contains(relative) else { continue }
+            let source = try String(contentsOf: url, encoding: .utf8)
+            if source.contains(".waitUntilExit()") { offenders.append(relative) }
+        }
+
+        #expect(
+            offenders.isEmpty,
+            "ordinary Swift tests must use TestSubprocess instead of parking a cooperative executor: \(offenders.sorted())"
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
@@ -5,6 +5,14 @@ import Testing
 
 @Suite("Bounded async test subprocesses", TestTimeouts.hangProne)
 struct TestSubprocessTests {
+    init() {
+        // These tests deliberately spend bounded time sampling and reaping
+        // children. Mark each case as forward progress so the suite-wide
+        // hosted-runner watchdog does not mistake that exercised timeout path
+        // for a stalled cooperative executor.
+        CIHangWatchdog.noteProgress()
+    }
+
     private static var testRoot: URL {
         URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     }

--- a/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
@@ -106,8 +106,51 @@ struct TestSubprocessTests {
         let pidText = try String(contentsOf: pidFile, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let descendantPID = try #require(pid_t(pidText))
+        // launchd may need a moment to reap the already-terminated orphan on
+        // a saturated parallel run. The subprocess helper has returned and
+        // the child is no longer executing; wait only for the PID to vanish.
+        for _ in 0..<100 where Darwin.kill(descendantPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
         #expect(Darwin.kill(descendantPID, 0) == -1)
         #expect(errno == ESRCH)
+    }
+
+    @Test("an escaped descendant retaining pipes cannot defeat the timeout bound")
+    func escapedDescendantCannotHoldCaptureOpen() async throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-test-subprocess-escaped-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: pidFile) }
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            _ = try await TestSubprocess.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    #"/usr/bin/perl -MPOSIX -e 'POSIX::setsid(); open(my $fh, q(>), $ARGV[0]) or die $!; print {$fh} qq($$\n); close $fh; sleep 30' "$1" &"#,
+                    "rapid-test-subprocess",
+                    pidFile.path,
+                ],
+                timeout: 0.2,
+                sampleOnTimeout: false
+            )
+            Issue.record("an escaped descendant holding pipes should time out")
+        } catch is TestSubprocessError {
+            // Expected. The direct shell has exited, while the detached Perl
+            // process still owns inherited pipe descriptors.
+        }
+
+        #expect(clock.now - start < .seconds(5))
+        for _ in 0..<50 where !FileManager.default.fileExists(atPath: pidFile.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let escapedPID = try #require(pid_t(pidText))
+        defer { _ = Darwin.kill(escapedPID, SIGKILL) }
+        #expect(Darwin.kill(escapedPID, 0) == 0)
     }
 
     @Test("blocking Process waits stay confined to native watchdog threads")

--- a/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
@@ -77,6 +77,39 @@ struct TestSubprocessTests {
         }
     }
 
+    @Test("a descendant holding inherited pipes cannot outlive the bound")
+    func descendantHoldingPipesIsKilledWithGroup() async throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-test-subprocess-descendant-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: pidFile) }
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            _ = try await TestSubprocess.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "sleep 30 & echo $! > \"$1\"",
+                    "rapid-test-subprocess",
+                    pidFile.path,
+                ],
+                timeout: 0.2,
+                sampleOnTimeout: false
+            )
+            Issue.record("a descendant holding the pipes should time out")
+        } catch is TestSubprocessError {
+            // Expected.
+        }
+
+        #expect(clock.now - start < .seconds(5))
+        let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let descendantPID = try #require(pid_t(pidText))
+        #expect(Darwin.kill(descendantPID, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
     @Test("blocking Process waits stay confined to native watchdog threads")
     func noBlockingWaitsInOrdinaryTests() throws {
         let allowed = Set([

--- a/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TestSubprocessTests.swift
@@ -56,16 +56,29 @@ struct TestSubprocessTests {
 
     @Test("cancelling the caller terminates and reaps the child")
     func cancellationReapsChild() async throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-test-subprocess-cancelled-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: pidFile) }
         let task = Task {
             try await TestSubprocess.run(
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
-                arguments: ["-c", "printf '%s\\n' $$; exec sleep 30"],
+                arguments: [
+                    "-c",
+                    "printf '%s\\n' $$ > \"$1\"; exec sleep 30",
+                    "rapid-test-subprocess",
+                    pidFile.path,
+                ],
                 timeout: 30,
                 sampleOnTimeout: false
             )
         }
 
-        try await Task.sleep(for: .milliseconds(100))
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: pidFile.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let childPID = try #require(pid_t(pidText))
         task.cancel()
 
         do {
@@ -75,6 +88,11 @@ struct TestSubprocessTests {
             // Expected: cancellation reaches the caller only after the child
             // has exited and both pipe readers have observed EOF.
         }
+        for _ in 0..<100 where Darwin.kill(childPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(Darwin.kill(childPID, 0) == -1)
+        #expect(errno == ESRCH)
     }
 
     @Test("a descendant holding inherited pipes cannot outlive the bound")
@@ -171,7 +189,8 @@ struct TestSubprocessTests {
             let relative = String(url.path.dropFirst(Self.testRoot.path.count + 1))
             guard !allowed.contains(relative) else { continue }
             let source = try String(contentsOf: url, encoding: .utf8)
-            if source.contains(".waitUntilExit()") { offenders.append(relative) }
+            let executableSource = SourceGuardSupport.canonicalSource(source, literals: .erase)
+            if executableSource.contains(".waitUntilExit()") { offenders.append(relative) }
         }
 
         #expect(

--- a/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
@@ -68,7 +68,7 @@ struct ThirdPartyLicenseStagingTests {
         vendorLicense: String? = "SwiftMath MIT license text",
         createCheckoutsDir: Bool = true,
         populate: ((URL) throws -> Void)? = nil
-    ) throws -> StagingResult {
+    ) async throws -> StagingResult {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("lic-fixture-\(UUID().uuidString)", isDirectory: true)
@@ -109,22 +109,16 @@ struct ThirdPartyLicenseStagingTests {
 
         let out = root.appendingPathComponent("Licenses", isDirectory: true)
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = [
-            stagingScript.path,
-            resolved.path,
-            checkouts.path,
-            vendorLicensePath,
-            out.path,
-        ]
-        let errPipe = Pipe()
-        process.standardError = errPipe
-        process.standardOutput = Pipe()
-        try process.run()
-        process.waitUntilExit()
-
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let process = try await TestSubprocess.run(
+            executableURL: URL(fileURLWithPath: "/bin/bash"),
+            arguments: [
+                stagingScript.path,
+                resolved.path,
+                checkouts.path,
+                vendorLicensePath,
+                out.path,
+            ]
+        )
         var staged: [String: String] = [:]
         for name in (try? fm.contentsOfDirectory(atPath: out.path)) ?? [] {
             staged[name] =
@@ -135,7 +129,7 @@ struct ThirdPartyLicenseStagingTests {
         return StagingResult(
             exitCode: process.terminationStatus,
             staged: staged,
-            stderr: String(data: errData, encoding: .utf8) ?? ""
+            stderr: String(decoding: process.standardError, as: UTF8.self)
         )
     }
 
@@ -164,8 +158,8 @@ struct ThirdPartyLicenseStagingTests {
     // MARK: - Fixture-driven behavior
 
     @Test("staging copies each linked package's license plus the vendored one")
-    func stagesEveryDeclaredLicense() throws {
-        let result = try Self.runStaging(
+    func stagesEveryDeclaredLicense() async throws {
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/FakePkg",
                 "https://github.com/example/OtherPkg.git",
@@ -197,10 +191,10 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging copies every notice file when a package splits its terms")
-    func stagesAllNoticeFilesPerPackage() throws {
+    func stagesAllNoticeFilesPerPackage() async throws {
         // An Apache-2.0-style package ships LICENSE *and* a required NOTICE;
         // both must travel, not just the first match.
-        let result = try Self.runStaging(
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/ApachePkg"
             ]),
@@ -226,8 +220,8 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging fails closed when a linked package has no license file")
-    func failsWhenPackageHasNoLicense() throws {
-        let result = try Self.runStaging(
+    func failsWhenPackageHasNoLicense() async throws {
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/FakePkg"
             ]),
@@ -243,12 +237,12 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging refuses a symlinked notice rather than dereferencing it")
-    func refusesSymlinkedNotice() throws {
+    func refusesSymlinkedNotice() async throws {
         // A remote package could point LICENSE at a secret outside the checkout;
         // cp would dereference it into the signed bundle. The only notice here
         // is a symlink, so staging must fail closed rather than copy through it.
         let secretName = "attacker-secret.txt"
-        let result = try Self.runStaging(
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/EvilPkg"
             ]),
@@ -282,8 +276,8 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging fails closed when a resolved pin has no checkout")
-    func failsWhenPinHasNoCheckout() throws {
-        let result = try Self.runStaging(
+    func failsWhenPinHasNoCheckout() async throws {
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/FakePkg"
             ]),
@@ -296,8 +290,8 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging fails closed when no remote pins are present")
-    func failsWhenNoPins() throws {
-        let result = try Self.runStaging(
+    func failsWhenNoPins() async throws {
+        let result = try await Self.runStaging(
             resolvedBody: #"{ "pins" : [], "version" : 3 }"#,
             checkoutLicenses: [:]
         )
@@ -311,8 +305,8 @@ struct ThirdPartyLicenseStagingTests {
     }
 
     @Test("staging fails closed when the vendored SwiftMath notice is missing")
-    func failsWhenVendoredNoticeMissing() throws {
-        let result = try Self.runStaging(
+    func failsWhenVendoredNoticeMissing() async throws {
+        let result = try await Self.runStaging(
             resolvedBody: Self.resolved(locations: [
                 "https://github.com/example/FakePkg"
             ]),


### PR DESCRIPTION
## Why

Desktop lifecycle tests could park cooperative-executor workers in synchronous child-process waits, leak work past test boundaries, and contend through process-wide preferences. Under parallel load that produced false failures or whole-job timeouts instead of a bounded, actionable failure.

Closes #2366

## What

- add one async test subprocess primitive backed by `posix_spawn` process groups and native-thread `waitpid`
- capture stdout/stderr without blocking, and handle caller cancellation
- bound process exit and pipe drainage with an independent native-thread watchdog that samples the group, then escalates group-wide TERM to KILL
- migrate the icon, localization, DMG, sidecar, SemVer, and license-staging subprocess tests
- prevent future ordinary test suites from reintroducing `waitUntilExit()`
- isolate appearance, onboarding, and last-served-alias persistence tests in unique disposable defaults suites
- inject defaults into the two production readers while preserving `.standard` as the app default
- make chat and dictation lifecycle tests await owned tasks instead of polling wall-clock deadlines
- replace dictation's unowned model-preparation tasks with one cancellable lifecycle task

## Scope / non-goals

This does not change release grace periods, model serving behavior, persistence keys, or user-visible Desktop behavior. The existing native hang watchdog remains synchronous only on its dedicated OS thread.

## Design precedent

The implementation follows established macOS test-runner patterns: child processes receive a dedicated process group; completion covers both reaping and pipe EOF; timeout enforcement runs independently of the concurrency pool; failures retain process samples before group termination; mutable preferences live in per-test suites; and asynchronous UI/controller transitions expose an owned task boundary that tests can await directly.

## Verification

- affected subprocess, persistence, chat, and dictation suites green
- `swift test`: 3057 tests green in 16.95s; repeated parallel runs green
- `swift test --no-parallel`: 3057 tests green in 44.21s; repeated serial runs green
- deliberate stalled child: sampled, group TERM/KILL bounded under 5s, PID reaped
- direct child exiting while a descendant holds inherited pipes: bounded failure, descendant killed and reaped
- escaped descendant retaining inherited pipes: capture forcibly closed and timeout returned within bound
- caller cancellation: process group terminated and pipes drained before `CancellationError`
- post-suite process audit: no `swiftpm-testing`, `xctest`, fake sidecar, or `rapid-mlx` child remained
- `git diff --check`

## Risk

The production defaults parameters retain `.standard` defaults, so existing callers are source- and behavior-compatible. Dictation now cancels superseded model-preparation triggers; the underlying single-flight and replacement ordering remain unchanged and are covered by the full Dictation suite.

