### PR TITLE
Yield forced assistant prefix after admission

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1201,7 +1201,8 @@ class TestStreamingModels:
         async def _stream_generate(**kwargs):
             kwargs["request_admitted_event"].set()
             await asyncio.sleep(0)
-            yield None  # pragma: no cover
+            if False:
+                yield None  # pragma: no cover
 
         engine.stream_generate = _stream_generate
         stream = engine.stream_chat(
@@ -1247,6 +1248,124 @@ class TestStreamingModels:
 
         with pytest.raises(RuntimeError, match="engine failed"):
             await anext(stream)
+
+    @pytest.mark.asyncio
+    async def test_forced_prefix_preserves_output_before_admission_fallback(
+        self,
+    ):
+        """A legacy engine output does not come after the synthetic prefix."""
+        import asyncio
+
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+        admitted = asyncio.Event()
+
+        async def _stream_generate(**kwargs):
+            yield GenerationOutput(
+                text="answer",
+                new_text="answer",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+            )
+            kwargs["request_admitted_event"].set()
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
+        )
+
+        outputs = [output async for output in stream]
+
+        assert [output.new_text for output in outputs] == ["<tool_call>", "answer"]
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_without_prefix_yields_nothing(self):
+        """Non-forced streams retain their empty-engine behavior."""
+        import asyncio
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            await asyncio.sleep(0)
+            if False:
+                yield None  # pragma: no cover
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            request_admitted_event=asyncio.Event(),
+        )
+
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+
+    @pytest.mark.asyncio
+    async def test_stream_without_prefix_preserves_all_engine_outputs(self):
+        """Non-forced streams retain engine output and continuation order."""
+        import asyncio
+
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            for index, new_text in enumerate(("one", "two")):
+                yield GenerationOutput(
+                    text=new_text,
+                    new_text=new_text,
+                    prompt_tokens=1,
+                    completion_tokens=index + 1,
+                    finished=index == 1,
+                    finish_reason="stop" if index == 1 else None,
+                )
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            request_admitted_event=asyncio.Event(),
+        )
+
+        outputs = [output async for output in stream]
+
+        assert [output.new_text for output in outputs] == ["one", "two"]
 
     @pytest.mark.asyncio
     async def test_forced_prefix_stream_close_cancels_pending_output(self):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1087,6 +1087,8 @@ class TestStreamingModels:
     @pytest.mark.asyncio
     async def test_forced_prefix_waits_for_scheduler_admission(self):
         """Synthetic tool prefixes cannot expose an unadmitted request id."""
+        import asyncio
+
         from vllm_mlx.engine.base import GenerationOutput
         from vllm_mlx.engine.batched import BatchedEngine
 
@@ -1100,11 +1102,10 @@ class TestStreamingModels:
         )
         engine._needs_prefix_boundary_snapshot = lambda: False
         engine._create_output_router = lambda: None
-        admitted = False
+        admitted = asyncio.Event()
 
-        async def _stream_generate(**_kwargs):
-            nonlocal admitted
-            admitted = True
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
             yield GenerationOutput(
                 text="answer",
                 new_text="answer",
@@ -1118,13 +1119,175 @@ class TestStreamingModels:
         stream = engine.stream_chat(
             [{"role": "user", "content": "hi"}],
             forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
         )
 
         first = await anext(stream)
 
-        assert admitted is True
+        assert admitted.is_set()
         assert first.new_text == "<tool_call>"
         await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_forced_prefix_yields_after_admission_before_first_decode(self):
+        """A blocked first decode cannot delay the forced tool-call envelope."""
+        import asyncio
+
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+        admitted = asyncio.Event()
+        release_first_output = asyncio.Event()
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            await release_first_output.wait()
+            yield GenerationOutput(
+                text="answer",
+                new_text="answer",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+            )
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
+        )
+
+        first = await asyncio.wait_for(anext(stream), timeout=0.2)
+
+        assert admitted.is_set()
+        assert first.new_text == "<tool_call>"
+        assert not release_first_output.is_set()
+
+        release_first_output.set()
+        second = await anext(stream)
+        assert second.new_text == "answer"
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_forced_prefix_empty_stream_after_admission_completes(self):
+        """Exhaustion after admission emits only the synthetic prefix."""
+        import asyncio
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+        admitted = asyncio.Event()
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            await asyncio.sleep(0)
+            yield None  # pragma: no cover
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
+        )
+
+        assert (await anext(stream)).new_text == "<tool_call>"
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+
+    @pytest.mark.asyncio
+    async def test_forced_prefix_failed_stream_after_admission_propagates(self):
+        """Engine failures after admission do not swallow the prefix or error."""
+        import asyncio
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+        admitted = asyncio.Event()
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            raise RuntimeError("engine failed")
+            yield  # pragma: no cover
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
+        )
+
+        with pytest.raises(RuntimeError, match="engine failed"):
+            await anext(stream)
+
+    @pytest.mark.asyncio
+    async def test_forced_prefix_stream_close_cancels_pending_output(self):
+        """Closing after the prefix retires the still-pending decode task."""
+        import asyncio
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._prepare_cache_stable_messages = lambda messages: (messages, None)
+        engine._apply_chat_template = lambda *_args, **_kwargs: "prompt"
+        engine._prepare_harmony_no_thinking_prompt = lambda prompt, **_kwargs: (
+            prompt,
+            None,
+        )
+        engine._needs_prefix_boundary_snapshot = lambda: False
+        engine._create_output_router = lambda: None
+        admitted = asyncio.Event()
+        output_cancelled = asyncio.Event()
+
+        async def _stream_generate(**kwargs):
+            kwargs["request_admitted_event"].set()
+            try:
+                await asyncio.Event().wait()
+                yield None  # pragma: no cover
+            except asyncio.CancelledError:
+                output_cancelled.set()
+                raise
+
+        engine.stream_generate = _stream_generate
+        stream = engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            forced_assistant_prefix="<tool_call>",
+            request_admitted_event=admitted,
+        )
+
+        first = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert first.new_text == "<tool_call>"
+        await stream.aclose()
+        await asyncio.wait_for(output_cancelled.wait(), timeout=0.2)
 
     @pytest.mark.asyncio
     async def test_role_frame_waits_for_admission_not_first_token(self):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -3586,26 +3586,73 @@ class BatchedEngine(BaseEngine):
         # forced prefix were yielded first, an immediate cancel could race the
         # scheduler registration and return 404 for a live request.
         routed_stream = self._stream_with_output_router(stream, router)
+
+        async def _first_engine_output() -> GenerationOutput | None:
+            try:
+                return await anext(routed_stream)
+            except StopAsyncIteration:
+                return None
+
+        first_output: GenerationOutput | None = None
+        engine_output_task: asyncio.Task[GenerationOutput | None] | None = None
+        admission_task: asyncio.Task[None] | None = None
         try:
-            first_output = await anext(routed_stream)
-        except StopAsyncIteration:
-            first_output = None
-        # On the streaming path inject the forced prefix as a synthetic
-        # first chunk so the route layer's streaming tool-call parser
-        # sees the wire envelope opener from the very first delta.
-        if forced_assistant_prefix:
-            yield GenerationOutput(
-                text=forced_assistant_prefix,
-                new_text=forced_assistant_prefix,
-                prompt_tokens=0,
-                completion_tokens=0,
-                finished=False,
-                finish_reason=None,
-            )
-        if first_output is not None:
-            yield first_output
-        async for output in routed_stream:
-            yield output
+            if forced_assistant_prefix:
+                admitted_event = kwargs.get("request_admitted_event")
+                if admitted_event is not None:
+                    # Start the engine generator so the scheduler can admit
+                    # the request, but do not wait for the first decoded
+                    # token. The prefix is valid as soon as the public ID is
+                    # addressable.
+                    engine_output_task = asyncio.create_task(_first_engine_output())
+                    admission_task = asyncio.create_task(admitted_event.wait())
+
+                    done, _ = await asyncio.wait(
+                        {engine_output_task, admission_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if engine_output_task in done:
+                        first_output = engine_output_task.result()
+                    if admission_task not in done:
+                        # The generator reached its first output without a
+                        # late admission notification. That is still
+                        # sufficient evidence that it was admitted, and the
+                        # synthetic prefix must not reorder model output.
+                        admission_task.cancel()
+            else:
+                try:
+                    first_output = await anext(routed_stream)
+                except StopAsyncIteration:
+                    first_output = None
+
+            if forced_assistant_prefix:
+                # On the streaming path inject the forced prefix as a synthetic
+                # first chunk so the route layer's streaming tool-call parser
+                # sees the wire envelope opener from the very first delta.
+                yield GenerationOutput(
+                    text=forced_assistant_prefix,
+                    new_text=forced_assistant_prefix,
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    finished=False,
+                    finish_reason=None,
+                )
+                if first_output is None and engine_output_task is not None:
+                    first_output = await engine_output_task
+                if first_output is not None:
+                    yield first_output
+            elif first_output is not None:
+                yield first_output
+
+            async for output in routed_stream:
+                yield output
+        finally:
+            # A failed, empty, or cancelled stream must not leave priming
+            # tasks attached to the current event loop.
+            if engine_output_task is not None and not engine_output_task.done():
+                engine_output_task.cancel()
+            if admission_task is not None and not admission_task.done():
+                admission_task.cancel()
 
     def get_stats(self) -> dict[str, Any]:
         """Get engine statistics."""


### PR DESCRIPTION
## Summary
- Emit a forced assistant prefix after scheduler admission instead of after the first decoded output.
- Preserve model-output ordering and cancellation identity.
- Retire pending admission/output priming tasks on empty, failed, and closed streams.
- Add deterministic tests for slow first decode, empty output, engine failure, and close-time cleanup.

Closes #2411.

## Verification
- `pytest tests/test_api_models.py tests/test_cancellation_protocol.py -q` — 189 passed
- `ruff check` and `ruff format --check`
- `scripts/check_mypy_error_budget.py`