### PR TITLE
macOS: ask for a GitHub star after a value moment

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -79,6 +79,12 @@ enum DevSnapshot {
             recordDecision: { _ in },
             startTelemetrySession: {}
         )
+        let snapshotStarDefaults = UserDefaults(suiteName: "rapid.dev-snapshot.github-star")!
+        snapshotStarDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.github-star")
+        let snapshotStarPrompt = GitHubStarPromptCoordinator(
+            defaults: snapshotStarDefaults,
+            quietWindow: .zero
+        )
         snapshotPerfDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.perf")
         let snapshotPerfConfig = ModelPerfConfigStore(defaults: snapshotPerfDefaults)
 
@@ -103,6 +109,7 @@ enum DevSnapshot {
                     .environment(snapshotSparkleUpdater)
                     .environment(quickstart)
                     .environment(snapshotConsent)
+                    .environment(snapshotStarPrompt)
                     .environment(dockPromptStore)
                     .environment(browseApproval)
                     .environment(imageGen)
@@ -240,6 +247,31 @@ enum DevSnapshot {
         // ViewThatFits rather than squeezing them to ellipses, and the version
         // pill must stay on one line. Only a width this small exercises it.
         render(contentView(width: 380, height: 560), to: "\(dir)/content-narrow.png")
+
+        // Focused proof of the post-value card at the minimum supported
+        // window. Drive the real workload gate, then complete it immediately
+        // after capture so it cannot leak into the rest of the snapshot
+        // matrix below.
+        snapshotStarDefaults.set(
+            GitHubStarPromptCoordinator.initialWorkloadThreshold - 1,
+            forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions
+        )
+        snapshotStarPrompt.productValueDelivered(.chatReply)
+        render(
+            AnyView(
+                ZStack(alignment: .bottomTrailing) {
+                    RapidTheme.surfaceCanvas
+                    GitHubStarPromptCard()
+                        .padding(.trailing, 16)
+                        .padding(.bottom, 40)
+                }
+                .environment(snapshotStarPrompt)
+                .frame(width: 720, height: 560)
+            ),
+            to: "\(dir)/github-star-value-moment.png"
+        )
+        snapshotStarPrompt.repositoryOpened()
+
         // Images tab (empty state — no results, catalog not yet resolved).
         render(imagesView(width: 700, height: 640), to: "\(dir)/images-empty.png")
         // Narrow composer: the canvas controls wrap to the two-row

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -83,7 +83,8 @@ enum DevSnapshot {
         snapshotStarDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.github-star")
         let snapshotStarPrompt = GitHubStarPromptCoordinator(
             defaults: snapshotStarDefaults,
-            quietWindow: .zero
+            quietWindow: .zero,
+            presentationActive: true
         )
         snapshotPerfDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.perf")
         let snapshotPerfConfig = ModelPerfConfigStore(defaults: snapshotPerfDefaults)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -99,6 +99,9 @@ struct RapidApp: App {
     /// App-owned owner of the one-time invitation that follows the first
     /// successful product outcome. Feature models only publish typed success.
     @State private var deferredTelemetryConsent: DeferredTelemetryConsentCoordinator
+    /// Local-only post-value GitHub invitation. It shares the typed success
+    /// seam above but owns independent quiet-window and backoff policy.
+    @State private var githubStarPrompt: GitHubStarPromptCoordinator
     /// Side-car downloader — spawns ``rapid-mlx pull <alias>`` jobs.
     @State private var downloads: DownloadManager
     /// Detects the "Finder Replace into /Applications silently failed
@@ -143,6 +146,7 @@ struct RapidApp: App {
         // handled by the post-value consent coordinator.
         TelemetryConsent.synchronizeExistingDecision()
         let consentCoordinator = DeferredTelemetryConsentCoordinator()
+        let starPromptCoordinator = GitHubStarPromptCoordinator()
         // Sweep orphan rapid-mlx processes from previous sessions BEFORE
         // anything else looks at our serve port.
         //
@@ -260,8 +264,9 @@ struct RapidApp: App {
             sampling: samplingConfig,
             customInstructions: customInstructionsConfig,
             server: manager,
-            onProductValueDelivered: { [weak consentCoordinator] kind in
+            onProductValueDelivered: { [weak consentCoordinator, weak starPromptCoordinator] kind in
                 consentCoordinator?.productValueDelivered(kind)
+                starPromptCoordinator?.productValueDelivered(kind)
             }
         )
         // Deterministic AX fixture for the otherwise release-only state where
@@ -308,8 +313,9 @@ struct RapidApp: App {
             server: manager,
             testingReadiness: fixtureReadiness,
             testingHotkeyStart: fixtureHotkeyStart,
-            onProductValueDelivered: { [weak consentCoordinator] kind in
+            onProductValueDelivered: { [weak consentCoordinator, weak starPromptCoordinator] kind in
                 consentCoordinator?.productValueDelivered(kind)
+                starPromptCoordinator?.productValueDelivered(kind)
             }
         )
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
@@ -324,8 +330,9 @@ struct RapidApp: App {
         AppDelegate.shared.dockPromptStore = dockPrompt
         _chatViewModel = State(initialValue: chat)
         let imageGenViewModel = ImageGenViewModel(server: manager)
-        imageGenViewModel.observeProductValue { [weak consentCoordinator] kind in
+        imageGenViewModel.observeProductValue { [weak consentCoordinator, weak starPromptCoordinator] kind in
             consentCoordinator?.productValueDelivered(kind)
+            starPromptCoordinator?.productValueDelivered(kind)
         }
         _imageGen = State(initialValue: imageGenViewModel)
         _audio = State(initialValue: AudioViewModel(server: manager))
@@ -337,6 +344,7 @@ struct RapidApp: App {
         _appearance = State(initialValue: appearanceConfig)
         _settingsRouter = State(initialValue: SettingsRouter())
         _deferredTelemetryConsent = State(initialValue: consentCoordinator)
+        _githubStarPrompt = State(initialValue: starPromptCoordinator)
         // Hand the live singletons to the delegate so the shutdown hook
         // and the AppKit menu-bar tray can reach them without rebuilding
         // the SwiftUI environment.
@@ -369,6 +377,7 @@ struct RapidApp: App {
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(deferredTelemetryConsent)
+                .environment(githubStarPrompt)
                 .environment(installTracker)
                 .environment(quickstart)
                 .environment(dockPromptStore)

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
@@ -43,6 +43,7 @@ struct RapidPrimaryButtonStyle: ButtonStyle {
     /// Fill the available width — for full-width CTAs in cards/sheets.
     var expands: Bool
     var height: CGFloat
+    var font: Font
 
     /// Default height is ``ControlHeight/medium`` (32) — the SAME
     /// regular-command height as ``RapidSecondaryButtonStyle`` and
@@ -53,9 +54,14 @@ struct RapidPrimaryButtonStyle: ButtonStyle {
     /// out 32/36 and visibly stepped. Emphasis is carried by the FILL,
     /// not by being 4pt taller. The hero, full-width case keeps 36 via
     /// ``rapidPrimaryWide``.
-    init(expands: Bool = false, height: CGFloat = RapidTheme.ControlHeight.medium) {
+    init(
+        expands: Bool = false,
+        height: CGFloat = RapidTheme.ControlHeight.medium,
+        font: Font = RapidFont.bodyEmphasis
+    ) {
         self.expands = expands
         self.height = height
+        self.font = font
     }
 
     func makeBody(configuration: Configuration) -> some View {
@@ -64,6 +70,7 @@ struct RapidPrimaryButtonStyle: ButtonStyle {
             isEnabled: isEnabled,
             expands: expands,
             height: height,
+            font: font,
             foreground: RapidTheme.primaryActionLabel,
             fill: RapidTheme.primaryActionFill,
             stroke: nil
@@ -86,6 +93,7 @@ struct RapidSecondaryButtonStyle: ButtonStyle {
     var utility: Bool
     var expands: Bool
     var height: CGFloat
+    var font: Font
     /// Explicit label colour, overriding every default. Needed where a
     /// button signals transient state through colour (Copy → Copied
     /// flips to the ready green) — an outer `.foregroundStyle` can't
@@ -96,11 +104,13 @@ struct RapidSecondaryButtonStyle: ButtonStyle {
         utility: Bool = false,
         expands: Bool = false,
         height: CGFloat = RapidTheme.ControlHeight.medium,
+        font: Font = RapidFont.bodyEmphasis,
         foreground: Color? = nil
     ) {
         self.utility = utility
         self.expands = expands
         self.height = height
+        self.font = font
         self.foreground = foreground
     }
 
@@ -110,6 +120,7 @@ struct RapidSecondaryButtonStyle: ButtonStyle {
             isEnabled: isEnabled,
             expands: expands,
             height: height,
+            font: font,
             foreground: foreground ?? RapidTheme.secondaryActionLabel,
             hoverForeground: (foreground == nil && utility)
                 ? RapidTheme.utilityActionHover
@@ -141,6 +152,7 @@ struct RapidTertiaryButtonStyle: ButtonStyle {
             isEnabled: isEnabled,
             expands: false,
             height: height,
+            font: RapidFont.bodyEmphasis,
             foreground: link ? RapidTheme.linkLabel : .primary,
             hoverForeground: link ? nil : RapidTheme.utilityActionHover,
             fill: .clear,
@@ -168,6 +180,7 @@ struct RapidDestructiveButtonStyle: ButtonStyle {
             isEnabled: isEnabled,
             expands: expands,
             height: height,
+            font: RapidFont.bodyEmphasis,
             foreground: RapidTheme.destructiveActionLabel,
             fill: RapidTheme.destructiveActionFill,
             stroke: nil
@@ -185,6 +198,7 @@ private struct RapidButtonSurface: View {
     let isEnabled: Bool
     let expands: Bool
     let height: CGFloat
+    let font: Font
     let foreground: Color
     /// Label colour under the pointer. ``nil`` keeps ``foreground``.
     /// This is how utility controls earn steel blue on hover without
@@ -203,7 +217,7 @@ private struct RapidButtonSurface: View {
 
     var body: some View {
         configuration.label
-            .font(RapidFont.bodyEmphasis)
+            .font(font)
             .foregroundStyle(resolvedForeground)
             // Icons inside a Label track the text size rather than the
             // SF Symbol default, so a `Label("Copy", systemImage:)`

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -81,6 +81,7 @@ struct ContentView: View {
     @Environment(MCPCatalog.self) private var mcpCatalog
     @Environment(MCPToolApprovalStore.self) private var mcpApproval
     @Environment(DeferredTelemetryConsentCoordinator.self) private var deferredTelemetryConsent
+    @Environment(GitHubStarPromptCoordinator.self) private var githubStarPrompt
     @Environment(\.openWindow) private var openWindow
 
     @State private var alias: String = ""
@@ -312,6 +313,14 @@ struct ContentView: View {
         // the browse sheet above — an MCP server is an arbitrary local process,
         // so "may the model run this" is a decision that belongs on screen.
         .modifier(MCPToolApprovalDialog(store: mcpApproval))
+        .onAppear {
+            githubStarPrompt.startMonitoringUserActivity()
+            githubStarPrompt.updatePresentationContext(starPromptPresentationContext)
+        }
+        .onDisappear { githubStarPrompt.stopMonitoringUserActivity() }
+        .onChange(of: starPromptPresentationContext) { _, context in
+            githubStarPrompt.updatePresentationContext(context)
+        }
         .task { await restorePersistedSession() }
         // Keyed exactly as the picker's own catalog task: re-fetch when
         // the engine binary appears and whenever the set of models on
@@ -525,6 +534,36 @@ struct ContentView: View {
             }
             statusFooter
         }
+        .overlay(alignment: .bottomTrailing) {
+            if githubStarPrompt.isPresented {
+                GitHubStarPromptCard()
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 40)
+                    .zIndex(20)
+            }
+        }
+    }
+
+    private var starPromptPresentationContext: GitHubStarPromptCoordinator.PresentationContext {
+        let dictationIsBusy: Bool = switch dictation.phase {
+        case .preparingModel, .starting, .recording, .transcribing: true
+        case .off, .idle: false
+        }
+        let campaignIsVisible = campaign.map {
+            !UserDefaults.standard.bool(forKey: $0.dismissalKey)
+        } ?? false
+
+        return .init(
+            isBusy: chat.isStreaming || imageGen.isGenerating || dictationIsBusy,
+            hasBlockingSurface: quickstartVisible
+                || deferredTelemetryConsent.isPresented
+                || campaignIsVisible
+                || showConversationSearch
+                || server.pendingMemoryWarning != nil
+                || server.pendingModelSwitch != nil
+                || browseApproval.pendingRequest != nil
+                || mcpApproval.pendingRequest != nil
+        )
     }
 
     private var conversationSearchOverlay: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -38,3 +38,95 @@ struct GitHubStarButton: View {
         .accessibilityHint("Opens the Rapid-MLX repository in your browser")
     }
 }
+
+/// A quiet, nonmodal value-moment card. It sits above the workspace instead
+/// of reflowing it, takes no focus, and remains until the user chooses.
+struct GitHubStarPromptCard: View {
+    @Environment(GitHubStarPromptCoordinator.self) private var prompt
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
+            Image(systemName: "star.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(RapidTheme.amberDeep)
+                .frame(width: 22, height: 22)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                    Text("Enjoying Rapid-MLX?")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(RapidTheme.textPrimary)
+
+                    Text("Rapid-MLX is open source. If it helped today, a GitHub star helps other developers find it.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .lineSpacing(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.trailing, 28)
+
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Button {
+                        openURL(GitHubCommunity.repositoryURL) { accepted in
+                            guard accepted else { return }
+                            prompt.repositoryOpened()
+                        }
+                    } label: {
+                        HStack(spacing: RapidTheme.Space.xs) {
+                            Text("Open GitHub")
+                            Image(systemName: "arrow.up.right")
+                                .font(.system(size: 10, weight: .semibold))
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(RapidPrimaryButtonStyle(
+                        expands: true,
+                        height: RapidTheme.ControlHeight.medium,
+                        font: .system(size: 14, weight: .medium)
+                    ))
+                    .frame(maxWidth: .infinity, minHeight: RapidTheme.ControlHeight.medium)
+                    .accessibilityHint("Opens the Rapid-MLX repository in your browser")
+                    .accessibilityIdentifier("GitHub.Star.ValueMoment.Open")
+
+                    Button("Later") { prompt.deferPrompt() }
+                        .buttonStyle(RapidSecondaryButtonStyle(
+                            height: RapidTheme.ControlHeight.medium,
+                            font: .system(size: 14, weight: .medium)
+                        ))
+                        .frame(width: 84, height: RapidTheme.ControlHeight.medium)
+                        .accessibilityIdentifier("GitHub.Star.ValueMoment.Later")
+                }
+            }
+
+        }
+        .padding(14)
+        .frame(width: 360)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(RapidTheme.card)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(RapidTheme.hairline.opacity(0.8), lineWidth: 1)
+        )
+        .overlay(alignment: .topTrailing) {
+            Button { prompt.deferPrompt() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(RapidTheme.textSecondary)
+            .help("Later")
+            .accessibilityLabel("Show the GitHub invitation later")
+            .accessibilityIdentifier("GitHub.Star.ValueMoment.Close")
+            .padding(10)
+        }
+        .shadow(color: Color.black.opacity(0.08), radius: 10, y: 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("GitHub.Star.ValueMoment.Card")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -34,19 +34,27 @@ final class GitHubStarPromptCoordinator {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let quietWindow: Duration
+    @ObservationIgnored private let waitForQuietWindow: @MainActor (Duration) async -> Void
     @ObservationIgnored private var context: PresentationContext = .ready
     @ObservationIgnored private var presentationPending = false
     @ObservationIgnored private var presentationTask: Task<Void, Never>?
     @ObservationIgnored private var keyboardMonitor: Any?
+    @ObservationIgnored private var presentationActive: Bool
 
     init(
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
-        quietWindow: Duration = GitHubStarPromptCoordinator.quietWindow
+        quietWindow: Duration = GitHubStarPromptCoordinator.quietWindow,
+        presentationActive: Bool = false,
+        waitForQuietWindow: @escaping @MainActor (Duration) async -> Void = { duration in
+            try? await Task.sleep(for: duration)
+        }
     ) {
         self.defaults = defaults
         self.now = now
         self.quietWindow = quietWindow
+        self.presentationActive = presentationActive
+        self.waitForQuietWindow = waitForQuietWindow
     }
 
     /// Records one delivered chat reply, dictation transcript, or generated
@@ -88,17 +96,28 @@ final class GitHubStarPromptCoordinator {
     }
 
     func startMonitoringUserActivity() {
-        guard keyboardMonitor == nil else { return }
-        keyboardMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
-            self?.noteUserActivity()
-            return event
+        presentationActive = true
+        if keyboardMonitor == nil {
+            keyboardMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+                self?.noteUserActivity()
+                return event
+            }
         }
+        if presentationPending { schedulePresentationCheck() }
     }
 
     func stopMonitoringUserActivity() {
-        guard let keyboardMonitor else { return }
-        NSEvent.removeMonitor(keyboardMonitor)
-        self.keyboardMonitor = nil
+        presentationActive = false
+        presentationTask?.cancel()
+        presentationTask = nil
+        if isPresented {
+            isPresented = false
+            presentationPending = true
+        }
+        if let keyboardMonitor {
+            NSEvent.removeMonitor(keyboardMonitor)
+            self.keyboardMonitor = nil
+        }
     }
 
     /// Close and Later are intentionally equivalent: both respect the user's
@@ -140,7 +159,10 @@ final class GitHubStarPromptCoordinator {
 
     private func schedulePresentationCheck() {
         presentationTask?.cancel()
-        guard presentationPending, !context.isBusy, !context.hasBlockingSurface else {
+        guard presentationActive,
+              presentationPending,
+              !context.isBusy,
+              !context.hasBlockingSurface else {
             presentationTask = nil
             return
         }
@@ -150,8 +172,8 @@ final class GitHubStarPromptCoordinator {
             return
         }
 
-        presentationTask = Task { [weak self, quietWindow] in
-            try? await Task.sleep(for: quietWindow)
+        presentationTask = Task { [weak self, quietWindow, waitForQuietWindow] in
+            await waitForQuietWindow(quietWindow)
             guard !Task.isCancelled else { return }
             self?.presentIfReady()
         }
@@ -161,6 +183,7 @@ final class GitHubStarPromptCoordinator {
         presentationTask = nil
         guard presentationPending,
               !isPresented,
+              presentationActive,
               !context.isBusy,
               !context.hasBlockingSurface,
               !defaults.bool(forKey: Keys.completed),

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -1,0 +1,171 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Owns the local-only, post-value invitation to visit Rapid-MLX on GitHub.
+///
+/// The prompt is deliberately workload-based rather than launch-based: it is
+/// eligible only after successful product outcomes, waits for a quiet window,
+/// and backs off exponentially when the user asks to see it later.
+@MainActor
+@Observable
+final class GitHubStarPromptCoordinator {
+    struct PresentationContext: Equatable {
+        var isBusy: Bool
+        var hasBlockingSurface: Bool
+
+        static let ready = PresentationContext(isBusy: false, hasBlockingSurface: false)
+    }
+
+    enum Keys {
+        static let completed = "Rapid.githubStar.completed.v1"
+        static let totalSuccessfulActions = "Rapid.githubStar.totalSuccessfulActions.v1"
+        static let baselineSuccessfulActions = "Rapid.githubStar.baselineSuccessfulActions.v1"
+        static let nextWorkloadThreshold = "Rapid.githubStar.nextWorkloadThreshold.v1"
+        static let deferredUntil = "Rapid.githubStar.deferredUntil.v1"
+    }
+
+    static let initialWorkloadThreshold = 35
+    static let deferralInterval: TimeInterval = 3 * 24 * 60 * 60
+    static let quietWindow: Duration = .milliseconds(1_200)
+
+    private(set) var isPresented = false
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let now: () -> Date
+    @ObservationIgnored private let quietWindow: Duration
+    @ObservationIgnored private var context: PresentationContext = .ready
+    @ObservationIgnored private var presentationPending = false
+    @ObservationIgnored private var presentationTask: Task<Void, Never>?
+    @ObservationIgnored private var keyboardMonitor: Any?
+
+    init(
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init,
+        quietWindow: Duration = GitHubStarPromptCoordinator.quietWindow
+    ) {
+        self.defaults = defaults
+        self.now = now
+        self.quietWindow = quietWindow
+    }
+
+    /// Records one delivered chat reply, dictation transcript, or generated
+    /// image. No prompt state, content, or GitHub account data leaves the Mac.
+    func productValueDelivered(_ kind: ProductValueKind) {
+        guard !defaults.bool(forKey: Keys.completed) else { return }
+
+        let previousTotal = defaults.integer(forKey: Keys.totalSuccessfulActions)
+        let total = previousTotal == Int.max ? Int.max : previousTotal + 1
+        defaults.set(total, forKey: Keys.totalSuccessfulActions)
+
+        guard !isPresented, !presentationPending, isWorkloadEligible(total: total) else { return }
+        presentationPending = true
+        schedulePresentationCheck()
+    }
+
+    /// Keeps the prompt out of active generation and competing dialogs. A
+    /// pending invitation is retained and retried once the workspace is calm.
+    func updatePresentationContext(_ newContext: PresentationContext) {
+        guard context != newContext else { return }
+        context = newContext
+        if newContext.isBusy || newContext.hasBlockingSurface {
+            presentationTask?.cancel()
+            presentationTask = nil
+            if isPresented {
+                isPresented = false
+                presentationPending = true
+            }
+        } else if presentationPending {
+            schedulePresentationCheck()
+        }
+    }
+
+    /// Restarts the quiet window after a local key press without consuming or
+    /// intercepting the event. This prevents the card arriving mid-sentence.
+    func noteUserActivity() {
+        guard presentationPending, !isPresented else { return }
+        schedulePresentationCheck()
+    }
+
+    func startMonitoringUserActivity() {
+        guard keyboardMonitor == nil else { return }
+        keyboardMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            self?.noteUserActivity()
+            return event
+        }
+    }
+
+    func stopMonitoringUserActivity() {
+        guard let keyboardMonitor else { return }
+        NSEvent.removeMonitor(keyboardMonitor)
+        self.keyboardMonitor = nil
+    }
+
+    /// Close and Later are intentionally equivalent: both respect the user's
+    /// timing, establish a three-day floor, and double the next workload gate.
+    func deferPrompt() {
+        guard isPresented else { return }
+        isPresented = false
+        presentationPending = false
+
+        let total = defaults.integer(forKey: Keys.totalSuccessfulActions)
+        let currentThreshold = workloadThreshold
+        let (doubled, overflow) = currentThreshold.multipliedReportingOverflow(by: 2)
+        defaults.set(total, forKey: Keys.baselineSuccessfulActions)
+        defaults.set(overflow ? Int.max : doubled, forKey: Keys.nextWorkloadThreshold)
+        defaults.set(now().addingTimeInterval(Self.deferralInterval), forKey: Keys.deferredUntil)
+    }
+
+    /// A successfully handed-off browser open completes this invitation for
+    /// the install. Rapid does not probe the user's GitHub account to verify it.
+    func repositoryOpened() {
+        guard isPresented else { return }
+        isPresented = false
+        presentationPending = false
+        defaults.set(true, forKey: Keys.completed)
+    }
+
+    private var workloadThreshold: Int {
+        let stored = defaults.integer(forKey: Keys.nextWorkloadThreshold)
+        return stored > 0 ? stored : Self.initialWorkloadThreshold
+    }
+
+    private func isWorkloadEligible(total: Int) -> Bool {
+        let baseline = defaults.integer(forKey: Keys.baselineSuccessfulActions)
+        let completedWork = max(0, total - baseline)
+        guard completedWork >= workloadThreshold else { return false }
+        guard let deferredUntil = defaults.object(forKey: Keys.deferredUntil) as? Date else { return true }
+        return now() >= deferredUntil
+    }
+
+    private func schedulePresentationCheck() {
+        presentationTask?.cancel()
+        guard presentationPending, !context.isBusy, !context.hasBlockingSurface else {
+            presentationTask = nil
+            return
+        }
+
+        if quietWindow == .zero {
+            presentIfReady()
+            return
+        }
+
+        presentationTask = Task { [weak self, quietWindow] in
+            try? await Task.sleep(for: quietWindow)
+            guard !Task.isCancelled else { return }
+            self?.presentIfReady()
+        }
+    }
+
+    private func presentIfReady() {
+        presentationTask = nil
+        guard presentationPending,
+              !isPresented,
+              !context.isBusy,
+              !context.hasBlockingSurface,
+              !defaults.bool(forKey: Keys.completed),
+              isWorkloadEligible(total: defaults.integer(forKey: Keys.totalSuccessfulActions)) else { return }
+        presentationPending = false
+        isPresented = true
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -24,6 +24,20 @@ import Testing
 @Suite("Accessibility identifier inventory")
 struct AccessibilityIdentifierInventoryTests {
 
+    @Test("The GitHub value-moment card names every control")
+    func githubStarValueMomentIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""GitHub.Star.ValueMoment.Card""#,
+                #""GitHub.Star.ValueMoment.Open""#,
+                #""GitHub.Star.ValueMoment.Later""#,
+                #""GitHub.Star.ValueMoment.Close""#,
+            ],
+            in: "Sources/Rapid/UI/GitHubStarPrompt.swift",
+            surface: "GitHub value-moment card"
+        )
+    }
+
     @Test("Model switch guard names its destructive and cancel controls")
     func modelSwitchGuardIdentifiers() throws {
         try assertDeclared(

--- a/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeferredTelemetryConsentWiringTests.swift
@@ -20,7 +20,9 @@ struct DeferredTelemetryConsentWiringTests {
         let app = try Self.source("Sources/Rapid/RapidApp.swift")
 
         #expect(app.contains("let consentCoordinator = DeferredTelemetryConsentCoordinator()"))
+        #expect(app.contains("let starPromptCoordinator = GitHubStarPromptCoordinator()"))
         #expect(app.components(separatedBy: "consentCoordinator?.productValueDelivered(kind)").count - 1 == 3)
+        #expect(app.components(separatedBy: "starPromptCoordinator?.productValueDelivered(kind)").count - 1 == 3)
     }
 
     @Test("Chat signals only a nonempty completed final turn")

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -8,7 +8,11 @@ struct GitHubStarPromptCoordinatorTests {
     @Test("The first card follows 35 successful outcomes, not app launches")
     func initialWorkloadGate() {
         let defaults = isolatedDefaults()
-        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true
+        )
 
         for _ in 0..<(GitHubStarPromptCoordinator.initialWorkloadThreshold - 1) {
             prompt.productValueDelivered(.chatReply)
@@ -24,7 +28,11 @@ struct GitHubStarPromptCoordinatorTests {
     func waitsForCalmWorkspace() {
         let defaults = isolatedDefaults()
         defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
-        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true
+        )
 
         prompt.updatePresentationContext(.init(isBusy: true, hasBlockingSurface: false))
         prompt.productValueDelivered(.dictationTranscript)
@@ -50,7 +58,8 @@ struct GitHubStarPromptCoordinatorTests {
         let prompt = GitHubStarPromptCoordinator(
             defaults: defaults,
             now: { currentDate },
-            quietWindow: .zero
+            quietWindow: .zero,
+            presentationActive: true
         )
 
         prompt.productValueDelivered(.chatReply)
@@ -76,7 +85,11 @@ struct GitHubStarPromptCoordinatorTests {
     func completionIsDurable() {
         let defaults = isolatedDefaults()
         defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
-        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true
+        )
 
         prompt.productValueDelivered(.chatReply)
         prompt.repositoryOpened()
@@ -88,10 +101,57 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions) == 35)
     }
 
+    @Test("Closing the window suspends presentation and reopening earns a new quiet window")
+    func windowLifecycleRestartsQuietWindow() async {
+        let defaults = isolatedDefaults()
+        let quietWindow = QuietWindowGate()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .seconds(1),
+            presentationActive: true,
+            waitForQuietWindow: { _ in await quietWindow.wait() }
+        )
+
+        prompt.productValueDelivered(.dictationTranscript)
+        await Task.yield()
+        #expect(quietWindow.pendingCount == 1)
+        prompt.stopMonitoringUserActivity()
+        quietWindow.releaseNext()
+        await Task.yield()
+        #expect(!prompt.isPresented, "an absent window cannot consume the quiet window offscreen")
+
+        prompt.startMonitoringUserActivity()
+        await Task.yield()
+        #expect(quietWindow.pendingCount == 1)
+        #expect(!prompt.isPresented, "reopening must start a fresh quiet window")
+        quietWindow.releaseNext()
+        await Task.yield()
+        #expect(prompt.isPresented)
+        prompt.stopMonitoringUserActivity()
+    }
+
     private func isolatedDefaults() -> UserDefaults {
         let name = "GitHubStarPromptCoordinatorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: name)!
         defaults.removePersistentDomain(forName: name)
         return defaults
+    }
+}
+
+@MainActor
+private final class QuietWindowGate {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    var pendingCount: Int { waiters.count }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func releaseNext() {
+        waiters.removeFirst().resume()
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("GitHub star value-moment policy")
+struct GitHubStarPromptCoordinatorTests {
+    @Test("The first card follows 35 successful outcomes, not app launches")
+    func initialWorkloadGate() {
+        let defaults = isolatedDefaults()
+        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+
+        for _ in 0..<(GitHubStarPromptCoordinator.initialWorkloadThreshold - 1) {
+            prompt.productValueDelivered(.chatReply)
+        }
+        #expect(!prompt.isPresented)
+
+        prompt.productValueDelivered(.generatedImage)
+        #expect(prompt.isPresented)
+        #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions) == 35)
+    }
+
+    @Test("Busy work and competing surfaces preserve the invitation until quiet")
+    func waitsForCalmWorkspace() {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+
+        prompt.updatePresentationContext(.init(isBusy: true, hasBlockingSurface: false))
+        prompt.productValueDelivered(.dictationTranscript)
+        #expect(!prompt.isPresented)
+
+        prompt.updatePresentationContext(.init(isBusy: false, hasBlockingSurface: true))
+        #expect(!prompt.isPresented)
+
+        prompt.updatePresentationContext(.ready)
+        #expect(prompt.isPresented)
+
+        prompt.updatePresentationContext(.init(isBusy: false, hasBlockingSurface: true))
+        #expect(!prompt.isPresented, "a new dialog temporarily tucks away an already-visible card")
+        prompt.updatePresentationContext(.ready)
+        #expect(prompt.isPresented)
+    }
+
+    @Test("Later applies a three-day floor and doubles subsequent workload")
+    func exponentialDeferral() {
+        var currentDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            now: { currentDate },
+            quietWindow: .zero
+        )
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+        prompt.deferPrompt()
+        #expect(!prompt.isPresented)
+        #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.baselineSuccessfulActions) == 35)
+        #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.nextWorkloadThreshold) == 70)
+
+        for _ in 0..<69 { prompt.productValueDelivered(.chatReply) }
+        currentDate.addTimeInterval(GitHubStarPromptCoordinator.deferralInterval - 1)
+        prompt.productValueDelivered(.chatReply)
+        #expect(!prompt.isPresented, "workload alone cannot bypass the cooldown")
+
+        currentDate.addTimeInterval(1)
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+        prompt.deferPrompt()
+        #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.nextWorkloadThreshold) == 140)
+    }
+
+    @Test("Opening GitHub completes the invitation without account probing")
+    func completionIsDurable() {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(defaults: defaults, quietWindow: .zero)
+
+        prompt.productValueDelivered(.chatReply)
+        prompt.repositoryOpened()
+        #expect(defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
+        #expect(!prompt.isPresented)
+
+        for _ in 0..<500 { prompt.productValueDelivered(.generatedImage) }
+        #expect(!prompt.isPresented)
+        #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions) == 35)
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let name = "GitHubStarPromptCoordinatorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Rapid
 
-@Suite("GitHub star onboarding prompt")
+@Suite("GitHub star surfaces")
 struct GitHubStarPromptTests {
     private static func source(_ name: String) throws -> String {
         let root = URL(fileURLWithPath: #filePath)
@@ -29,5 +29,36 @@ struct GitHubStarPromptTests {
         #expect(chat.contains("GitHubStarButton()"))
         #expect(!content.contains("OnboardingCompletePrompt"))
         #expect(!content.contains("showOnboardingCompletePrompt"))
+    }
+
+    @Test("The value-moment card follows the approved compact hierarchy")
+    func valueMomentVisualContract() throws {
+        let card = try Self.source("GitHubStarPrompt.swift")
+        let content = try Self.source("ContentView.swift")
+        let snapshot = try Self.source("../DevSnapshot.swift")
+
+        #expect(card.contains("Enjoying Rapid-MLX?"))
+        #expect(card.contains("Rapid-MLX is open source."))
+        #expect(card.contains(".frame(width: 360)"))
+        #expect(card.contains(".frame(width: 84, height: RapidTheme.ControlHeight.medium)"))
+        #expect(card.contains(".padding(14)"))
+        #expect(content.contains(".padding(.trailing, 16)"))
+        #expect(content.contains(".padding(.bottom, 40)"))
+        #expect(snapshot.contains("github-star-value-moment.png"))
+    }
+
+    @Test("The card is nonmodal, focus-neutral, and fully addressable")
+    func interactionContract() throws {
+        let card = try Self.source("GitHubStarPrompt.swift")
+        let coordinator = try Self.source("GitHubStarPromptCoordinator.swift")
+
+        for identifier in ["Card", "Open", "Later", "Close"] {
+            #expect(card.contains("GitHub.Star.ValueMoment.\(identifier)"))
+        }
+        #expect(!card.contains("@FocusState"))
+        #expect(!card.contains(".keyboardShortcut"))
+        #expect(!card.contains(".isModal"))
+        #expect(coordinator.contains("NSEvent.addLocalMonitorForEvents(matching: [.keyDown])"))
+        #expect(!coordinator.contains("URLSession"), "eligibility must not probe GitHub or the network")
     }
 }


### PR DESCRIPTION
Closes #2452

## Intention

Invite established Desktop users to open the Rapid-MLX GitHub page at a quiet value moment, without interrupting active work or adding account/network probing.

## Scope

- Count successful text chat replies, delivered dictation transcripts, and newly generated images locally.
- Present a compact bottom-right card after 35 successful outcomes and a 1.2-second quiet window.
- Temporarily tuck the card away during active generation, onboarding, search, consent, approval, and model-decision surfaces.
- Treat Close and Later identically: wait at least three days, then require an exponentially larger successful workload.
- Mark the invitation complete after macOS accepts the repository URL handoff.
- Add stable accessibility identifiers and a deterministic 720×560 visual proof.

## Non-goals

- No engine/server/API changes.
- No GitHub account or star-status lookup.
- No telemetry expansion or prompt/response collection.
- No onboarding, global typography, release, or deployment changes.

## Acceptance evidence

- Local-only UserDefaults state with deterministic workload, cooldown, completion, and blocking-surface tests.
- Existing chat/dictation/image success contracts remain the sole delivery triggers.
- Nonmodal and focus-neutral; no keyboard shortcut or auto-dismiss behavior.
- Primary action uses the shared high-contrast Desktop button treatment.

## Verification

- `./scripts/desktop-test-timeout.sh` — 3058 tests in 258 suites passed after rebasing onto current `main`.
- `swift build -c release` — passed after rebase.
- Focused value-moment/accessibility/wiring tests — 16 passed.
- Dev snapshot `github-star-value-moment.png` visually checked at the 720×560 window floor.