### PR TITLE
test(gui): await sidecar exit before persona cleanup

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -154,6 +154,58 @@ require_observed_phase() {
     [[ "$observed" == 1 ]] || die "required $phase phase was not observed"
 }
 
+recorded_fake_sidecar_is_live() {
+    local fake_pid="$1" fake_alias="$2" command
+    command="$(ps -p "$fake_pid" -o command= 2>/dev/null || true)"
+    [[ "$command" == *"serve $fake_alias"* ]]
+}
+
+stop_recorded_fake_sidecar() {
+    local fake_pid="$1" fake_alias="$2"
+    recorded_fake_sidecar_is_live "$fake_pid" "$fake_alias" || return 0
+
+    # Follow the server lifecycle used by the engine: request a graceful stop,
+    # wait for it to finish releasing its resources, then force only the exact
+    # recorded process if it ignores the deadline. Merely sending SIGTERM and
+    # immediately deleting the persona races Python's final cache writes.
+    kill "$fake_pid" 2>/dev/null || true
+    local attempt
+    for attempt in {1..40}; do
+        recorded_fake_sidecar_is_live "$fake_pid" "$fake_alias" || return 0
+        sleep 0.05
+    done
+
+    # Re-check the command immediately before SIGKILL. A recycled pid or a
+    # process whose argv no longer names the recorded alias is not ours.
+    recorded_fake_sidecar_is_live "$fake_pid" "$fake_alias" || return 0
+    kill -KILL "$fake_pid" 2>/dev/null || true
+    for attempt in {1..40}; do
+        recorded_fake_sidecar_is_live "$fake_pid" "$fake_alias" || return 0
+        sleep 0.05
+    done
+
+    printf '[gui-golden] owned fake sidecar pid=%s alias=%s did not exit\n' \
+        "$fake_pid" "$fake_alias" >&2
+    return 1
+}
+
+cleanup_fake_sidecars() {
+    local status=0 fake_pid fake_alias
+    if [[ -n "$OUT" && -f "$OUT/fake-events.jsonl" ]]; then
+        # Pair each pid with the alias it was started for, and require the live
+        # command to still name THAT alias. This is both the ownership boundary
+        # and the recycled-pid guard; operator processes remain untouched.
+        while IFS=$'\t' read -r fake_pid fake_alias; do
+            [[ "$fake_pid" =~ ^[0-9]+$ ]] || continue
+            [[ -n "$fake_alias" && "$fake_alias" != "null" ]] || continue
+            stop_recorded_fake_sidecar "$fake_pid" "$fake_alias" || status=1
+        done < <(jq -r 'select(.event == "server_started")
+                        | "\(.pid)\t\(.alias // "")"' \
+                     "$OUT/fake-events.jsonl" 2>/dev/null | sort -u)
+    fi
+    return "$status"
+}
+
 # When sourced, expose only the executable contract helpers above. Return
 # before cleanup traps, app launch, filesystem mutation, or tool preflight.
 # Direct execution cannot be bypassed with an environment variable.
@@ -222,9 +274,15 @@ cleanup_persona() {
         wait "$APP_PID" 2>/dev/null || true
     fi
     APP_PID=""
-    cleanup_fake_sidecars
+    local sidecars_stopped=1
+    cleanup_fake_sidecars || sidecars_stopped=0
     if [[ "$KEEP" == 0 && -n "$BUNDLE_ID" ]]; then
         defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ "$sidecars_stopped" == 0 ]]; then
+        printf '[gui-golden] preserving persona because an owned sidecar is still live: %s\n' \
+            "$PERSONA" >&2
+        return 1
     fi
     if [[ "$KEEP" == 0 && -n "$PERSONA" && -d "$PERSONA" ]]; then
         rm -rf "$PERSONA"
@@ -232,29 +290,6 @@ cleanup_persona() {
     PERSONA=""
     BUNDLE_ID=""
     PERSONA_ENV=()
-}
-
-cleanup_fake_sidecars() {
-    if [[ -n "$OUT" && -f "$OUT/fake-events.jsonl" ]]; then
-        # Pair each pid with the alias it was started for, and require the
-        # live command to still name THAT alias. A bare `serve fake-alias`
-        # match missed `serve fake-image-alias` entirely and left the image
-        # flow's sidecar listening after the run — an orphan that then
-        # contaminates the next local run. Matching the recorded alias keeps
-        # the recycled-pid guard the substring test was there for, without
-        # having to remember to extend it for every new fixture alias.
-        while IFS=$'\t' read -r fake_pid fake_alias; do
-            [[ "$fake_pid" =~ ^[0-9]+$ ]] || continue
-            [[ -n "$fake_alias" && "$fake_alias" != "null" ]] || continue
-            local command
-            command="$(ps -p "$fake_pid" -o command= 2>/dev/null || true)"
-            if [[ "$command" == *"serve $fake_alias"* ]]; then
-                kill "$fake_pid" 2>/dev/null || true
-            fi
-        done < <(jq -r 'select(.event == "server_started")
-                        | "\(.pid)\t\(.alias // "")"' \
-                     "$OUT/fake-events.jsonl" 2>/dev/null | sort -u)
-    fi
 }
 
 cleanup_operator_server() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -154,10 +154,29 @@ require_observed_phase() {
     [[ "$observed" == 1 ]] || die "required $phase phase was not observed"
 }
 
+recorded_process_has_argv_pair() {
+    local fake_pid="$1" first="$2" second="$3" command
+    command="$(ps -ww -p "$fake_pid" -o command= 2>/dev/null || true)"
+    [[ -n "$command" ]] || return 1
+
+    # `ps` has no structured argv output on macOS. Split its untruncated
+    # rendering with glob expansion disabled and require two adjacent exact
+    # tokens rather than a substring.
+    (
+        set -f
+        local previous="" token
+        for token in $command; do
+            if [[ "$previous" == "$first" && "$token" == "$second" ]]; then
+                return 0
+            fi
+            previous="$token"
+        done
+        return 1
+    )
+}
+
 recorded_fake_sidecar_is_live() {
-    local fake_pid="$1" fake_alias="$2" command
-    command="$(ps -p "$fake_pid" -o command= 2>/dev/null || true)"
-    [[ "$command" == *"serve $fake_alias"* ]]
+    recorded_process_has_argv_pair "$1" serve "$2"
 }
 
 stop_recorded_fake_sidecar() {
@@ -190,20 +209,102 @@ stop_recorded_fake_sidecar() {
 }
 
 cleanup_fake_sidecars() {
-    local status=0 fake_pid fake_alias
+    local status=0 fake_pid fake_alias records
     if [[ -n "$OUT" && -f "$OUT/fake-events.jsonl" ]]; then
-        # Pair each pid with the alias it was started for, and require the live
-        # command to still name THAT alias. This is both the ownership boundary
-        # and the recycled-pid guard; operator processes remain untouched.
+        if ! records="$(jq -r 'select(.event == "server_started")
+                                | "\(.pid)\t\(.alias // "-")"' \
+                             "$OUT/fake-events.jsonl")"; then
+            printf '[gui-golden] could not parse fake sidecar ownership log: %s\n' \
+                "$OUT/fake-events.jsonl" >&2
+            return 1
+        fi
+        # Long-lived serves that intentionally detach from the app's process
+        # group are stopped through their exact PID+alias argv identity.
         while IFS=$'\t' read -r fake_pid fake_alias; do
             [[ "$fake_pid" =~ ^[0-9]+$ ]] || continue
-            [[ -n "$fake_alias" && "$fake_alias" != "null" ]] || continue
+            [[ "$fake_alias" != "-" ]] || { status=1; continue; }
             stop_recorded_fake_sidecar "$fake_pid" "$fake_alias" || status=1
-        done < <(jq -r 'select(.event == "server_started")
-                        | "\(.pid)\t\(.alias // "")"' \
-                     "$OUT/fake-events.jsonl" 2>/dev/null | sort -u)
+        done < <(printf '%s\n' "$records" | sort -u)
     fi
     return "$status"
+}
+
+process_is_running() {
+    local state
+    state="$(ps -p "$1" -o stat= 2>/dev/null | tr -d '[:space:]' || true)"
+    [[ -n "$state" && "$state" != Z* ]]
+}
+
+process_group_has_live_members() {
+    local expected_group="$1" group state
+    while read -r group state; do
+        if [[ "$group" == "$expected_group" && "$state" != Z* ]]; then
+            return 0
+        fi
+    done < <(ps -axo pgid=,stat= 2>/dev/null || true)
+    return 1
+}
+
+stop_app() {
+    [[ -n "$APP_PID" ]] || return 0
+    local app_pid="$APP_PID" app_group="" attempt
+    if ! process_is_running "$app_pid"; then
+        wait "$app_pid" 2>/dev/null || true
+        APP_PID=""
+        return 0
+    fi
+
+    app_group="$(ps -p "$app_pid" -o pgid= 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$app_group" != "$app_pid" ]]; then
+        # Never signal a shared or unknown process group. The launcher below
+        # establishes a session whose pgid equals the app pid; a mismatch is a
+        # broken ownership boundary, so stop only the known pid and preserve
+        # the persona for diagnosis.
+        kill "$app_pid" 2>/dev/null || true
+        for attempt in {1..20}; do
+            process_is_running "$app_pid" || break
+            sleep 0.1
+        done
+        kill -KILL "$app_pid" 2>/dev/null || true
+        wait "$app_pid" 2>/dev/null || true
+        printf '[gui-golden] app pid=%s did not own its process group (pgid=%s)\n' \
+            "$app_pid" "${app_group:-unknown}" >&2
+        return 1
+    fi
+
+    # The isolated app is the leader of a harness-owned session. Signal the
+    # whole group so catalogue probes that have not written lifecycle events
+    # yet cannot outlive their profile and recreate Python cache files during
+    # deletion.
+    kill -TERM -- "-$app_group" 2>/dev/null || true
+    for attempt in {1..20}; do
+        process_is_running "$app_pid" || break
+        sleep 0.1
+    done
+    if process_is_running "$app_pid"; then
+        kill -KILL -- "-$app_group" 2>/dev/null || true
+    fi
+    wait "$app_pid" 2>/dev/null || true
+
+    # Reaping the leader does not prove its descendants are gone. Give the
+    # remaining group a second bounded drain, then force only that owned group.
+    for attempt in {1..20}; do
+        process_group_has_live_members "$app_group" || break
+        sleep 0.1
+    done
+    if process_group_has_live_members "$app_group"; then
+        kill -KILL -- "-$app_group" 2>/dev/null || true
+        for attempt in {1..20}; do
+            process_group_has_live_members "$app_group" || break
+            sleep 0.1
+        done
+    fi
+    if process_group_has_live_members "$app_group"; then
+        printf '[gui-golden] owned app process group %s did not exit\n' \
+            "$app_group" >&2
+        return 1
+    fi
+    APP_PID=""
 }
 
 # When sourced, expose only the executable contract helpers above. Return
@@ -269,23 +370,27 @@ pb_click_coords() {
 }
 
 cleanup_persona() {
-    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
-        kill "$APP_PID" 2>/dev/null || true
-        wait "$APP_PID" 2>/dev/null || true
-    fi
-    APP_PID=""
-    local sidecars_stopped=1
+    local app_stopped=1 sidecars_stopped=1
+    stop_app || app_stopped=0
     cleanup_fake_sidecars || sidecars_stopped=0
     if [[ "$KEEP" == 0 && -n "$BUNDLE_ID" ]]; then
         defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
     fi
-    if [[ "$sidecars_stopped" == 0 ]]; then
-        printf '[gui-golden] preserving persona because an owned sidecar is still live: %s\n' \
+    if [[ "$app_stopped" == 0 || "$sidecars_stopped" == 0 ]]; then
+        printf '[gui-golden] preserving persona because an owned process is still live: %s\n' \
             "$PERSONA" >&2
         return 1
     fi
     if [[ "$KEEP" == 0 && -n "$PERSONA" && -d "$PERSONA" ]]; then
-        rm -rf "$PERSONA"
+        if ! rm -rf "$PERSONA"; then
+            # Keep the surviving tree available for ownership diagnosis and
+            # prevent the EXIT trap from turning a failed cleanup into a
+            # second, unobserved delete attempt.
+            KEEP=1
+            printf '[gui-golden] persona cleanup failed; preserving evidence: %s\n' \
+                "$PERSONA" >&2
+            return 1
+        fi
     fi
     PERSONA=""
     BUNDLE_ID=""
@@ -582,6 +687,42 @@ require_tools() {
     fi
 }
 
+launch_persona_app() {
+    local log_mode="$1"
+    shift
+    if [[ "$log_mode" == "append" ]]; then
+        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+            DOGFOOD_WORKING_SET_GB=0.1 \
+            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
+            /usr/bin/python3 -c \
+            'import os, sys; os.setsid(); os.execv(sys.argv[1], sys.argv[1:])' \
+            "$PERSONA/launch.sh" "$@" >> "$OUT/app.log" 2>&1 &
+    else
+        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+            DOGFOOD_WORKING_SET_GB=0.1 \
+            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
+            /usr/bin/python3 -c \
+            'import os, sys; os.setsid(); os.execv(sys.argv[1], sys.argv[1:])' \
+            "$PERSONA/launch.sh" "$@" > "$OUT/app.log" 2>&1 &
+    fi
+    APP_PID=$!
+
+    local app_group="" attempt
+    for attempt in {1..40}; do
+        app_group="$(ps -p "$APP_PID" -o pgid= 2>/dev/null | tr -d '[:space:]')"
+        [[ "$app_group" == "$APP_PID" ]] && return 0
+        kill -0 "$APP_PID" 2>/dev/null || break
+        sleep 0.05
+    done
+    kill "$APP_PID" 2>/dev/null || true
+    wait "$APP_PID" 2>/dev/null || true
+    printf '[gui-golden] isolated app failed to establish its owned process group\n' >&2
+    APP_PID=""
+    return 1
+}
+
 start_persona() {
     local name="$1"
     shift
@@ -624,20 +765,10 @@ start_persona() {
         mv "$updated" "$config"
     done
     if [[ -n "$app_language" ]]; then
-        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-            DOGFOOD_WORKING_SET_GB=0.1 \
-            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
-            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
-            "$PERSONA/launch.sh" -AppleLanguages "($app_language)" \
-            > "$OUT/app.log" 2>&1 &
+        launch_persona_app truncate -AppleLanguages "($app_language)"
     else
-        env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-            DOGFOOD_WORKING_SET_GB=0.1 \
-            FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
-            "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
-            "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
+        launch_persona_app truncate
     fi
-    APP_PID=$!
     wait_for_window
 }
 
@@ -648,26 +779,8 @@ relaunch_persona() {
     # #1618 the app's unsafe global port sweep hid this ownership leak by
     # killing the old fake (and potentially an operator's real server too).
     cleanup_fake_sidecars
-    env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-        DOGFOOD_WORKING_SET_GB=0.1 \
-        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
-        "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
-        "$PERSONA/launch.sh" >> "$OUT/app.log" 2>&1 &
-    APP_PID=$!
+    launch_persona_app append
     wait_for_window
-}
-
-stop_app() {
-    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
-        kill "$APP_PID" 2>/dev/null || true
-        for _ in {1..20}; do
-            kill -0 "$APP_PID" 2>/dev/null || break
-            sleep 0.1
-        done
-        kill -9 "$APP_PID" 2>/dev/null || true
-        wait "$APP_PID" 2>/dev/null || true
-    fi
-    APP_PID=""
 }
 
 refresh_main_window_id() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -307,14 +307,6 @@ stop_app() {
     APP_PID=""
 }
 
-# When sourced, expose only the executable contract helpers above. Return
-# before cleanup traps, app launch, filesystem mutation, or tool preflight.
-# Direct execution cannot be bypassed with an environment variable.
-if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
-    return 0
-fi
-
-pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
 write_result() {
     local status="$1" exit_code="$2" finished_epoch duration_seconds
     finished_epoch="$(date +%s)"
@@ -327,6 +319,37 @@ write_result() {
           duration_seconds: $duration_seconds, artifact_path: $artifact_path,
           exit_code: $exit_code}' > "$OUT_ROOT/result.json"
 }
+
+finish() {
+    local status=$? cleanup_failed=0
+    set +e
+    cleanup_persona || cleanup_failed=1
+    cleanup_operator_server || cleanup_failed=1
+    cleanup_telemetry_sink || cleanup_failed=1
+    if [[ "$status" -eq 0 && "$cleanup_failed" -ne 0 ]]; then
+        status=1
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        mkdir -p "$OUT_ROOT" 2>/dev/null || true
+        if [[ -d "$OUT_ROOT" ]]; then
+            # Cleanup failure overrides an earlier PASS result. A retained
+            # process/profile is a failed journey, never green evidence.
+            write_result fail "$status" 2>/dev/null || true
+            RESULT_WRITTEN=1
+        fi
+    fi
+    trap - EXIT
+    exit "$status"
+}
+
+# When sourced, expose only the executable contract helpers above. Return
+# before cleanup traps, app launch, filesystem mutation, or tool preflight.
+# Direct execution cannot be bypassed with an environment variable.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
+pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
 flow_requires_screen_recording() {
     case "$FLOW" in
         all) return 0 ;;
@@ -397,18 +420,37 @@ cleanup_persona() {
     PERSONA_ENV=()
 }
 
-cleanup_operator_server() {
-    if [[ -n "$OPERATOR_SERVER_PID" ]] && kill -0 "$OPERATOR_SERVER_PID" 2>/dev/null; then
-        kill "$OPERATOR_SERVER_PID" 2>/dev/null || true
-        wait "$OPERATOR_SERVER_PID" 2>/dev/null || true
+stop_tracked_child() {
+    local label="$1" child_pid="$2" attempt
+    if ! process_is_running "$child_pid"; then
+        wait "$child_pid" 2>/dev/null || true
+        return 0
     fi
+    kill "$child_pid" 2>/dev/null || true
+    for attempt in {1..20}; do
+        process_is_running "$child_pid" || break
+        sleep 0.1
+    done
+    if process_is_running "$child_pid"; then
+        kill -KILL "$child_pid" 2>/dev/null || true
+    fi
+    wait "$child_pid" 2>/dev/null || true
+    if process_is_running "$child_pid"; then
+        printf '[gui-golden] owned %s pid=%s did not exit\n' \
+            "$label" "$child_pid" >&2
+        return 1
+    fi
+}
+
+cleanup_operator_server() {
+    [[ -n "$OPERATOR_SERVER_PID" ]] || return 0
+    stop_tracked_child operator-server "$OPERATOR_SERVER_PID" || return 1
     OPERATOR_SERVER_PID=""
 }
 
 cleanup_telemetry_sink() {
-    if [[ -n "$TELEMETRY_SINK_PID" ]] && kill -0 "$TELEMETRY_SINK_PID" 2>/dev/null; then
-        kill "$TELEMETRY_SINK_PID" 2>/dev/null || true
-        wait "$TELEMETRY_SINK_PID" 2>/dev/null || true
+    if [[ -n "$TELEMETRY_SINK_PID" ]]; then
+        stop_tracked_child telemetry-sink "$TELEMETRY_SINK_PID" || return 1
     fi
     TELEMETRY_SINK_PID=""
     TELEMETRY_SINK_PORT=""
@@ -621,19 +663,6 @@ assert_share_activation_requests() {
         || die "Share did not produce exactly one valid $expected_kind Desktop activation"
 }
 
-finish() {
-    local status=$?
-    set +e
-    cleanup_persona
-    cleanup_operator_server
-    cleanup_telemetry_sink
-    if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 ]]; then
-        mkdir -p "$OUT_ROOT" 2>/dev/null || true
-        if [[ -d "$OUT_ROOT" ]]; then
-            write_result fail "$status" 2>/dev/null || true
-        fi
-    fi
-}
 trap finish EXIT
 # Signal handlers only select the conventional exit code. The EXIT handler is
 # the single owner of cleanup and final evidence, avoiding double-cleanup and

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -22,6 +22,7 @@ import json
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -283,7 +284,7 @@ def test_harness_reaps_its_own_fake_before_relaunch_without_global_sweep():
     relaunch = source.split("relaunch_persona() {", 1)[1].split("\n}", 1)[0]
     assert relaunch.index("stop_app") < relaunch.index("cleanup_fake_sidecars")
     assert relaunch.index("cleanup_fake_sidecars") < relaunch.index(
-        '"$PERSONA/launch.sh"'
+        "launch_persona_app append"
     )
 
 
@@ -293,29 +294,61 @@ def test_fake_sidecar_cleanup_waits_then_escalates_without_touching_operator(tmp
 import signal
 import sys
 import time
+from pathlib import Path
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+Path(sys.argv[1]).touch()
 while True:
     time.sleep(0.05)
 """
     stubborn_code = """
 import signal
+import sys
 import time
+from pathlib import Path
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
+Path(sys.argv[1]).touch()
 while True:
     time.sleep(0.05)
 """
+    ready_paths = [tmp_path / name for name in ("graceful", "stubborn", "operator")]
     processes = [
         subprocess.Popen(
-            [sys.executable, "-c", graceful_code, "serve", "fake-graceful"]
+            [
+                sys.executable,
+                "-c",
+                graceful_code,
+                str(ready_paths[0]),
+                "serve",
+                "fake-graceful",
+            ]
         ),
         subprocess.Popen(
-            [sys.executable, "-c", stubborn_code, "serve", "fake-stubborn"]
+            [
+                sys.executable,
+                "-c",
+                stubborn_code,
+                str(ready_paths[1]),
+                "serve",
+                "fake-stubborn",
+            ]
         ),
         subprocess.Popen(
-            [sys.executable, "-c", graceful_code, "serve", "operator-owned"]
+            [
+                sys.executable,
+                "-c",
+                graceful_code,
+                str(ready_paths[2]),
+                "serve",
+                "fake-graceful-backup",
+            ]
         ),
     ]
     graceful, stubborn, operator = processes
+    for _ in range(100):
+        if all(path.exists() for path in ready_paths):
+            break
+        time.sleep(0.01)
+    assert all(path.exists() for path in ready_paths)
     events = tmp_path / "fake-events.jsonl"
     events.write_text(
         "\n".join(
@@ -323,11 +356,13 @@ while True:
             for proc, alias in (
                 (graceful, "fake-graceful"),
                 (stubborn, "fake-stubborn"),
+                # Simulate a recycled pid whose new alias merely shares the
+                # recorded alias prefix. It is not owned by this harness run.
+                (operator, "fake-graceful"),
             )
         )
         + "\n"
     )
-
     try:
         result = subprocess.run(
             [
@@ -356,6 +391,119 @@ while True:
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait(timeout=1)
+
+
+def test_fake_sidecar_cleanup_fails_closed_on_partial_ownership_log(tmp_path):
+    ready = tmp_path / "ready"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            """
+import signal
+import sys
+import time
+from pathlib import Path
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+Path(sys.argv[1]).touch()
+while True:
+    time.sleep(0.05)
+""",
+            str(ready),
+            "serve",
+            "fake-partial",
+        ]
+    )
+    for _ in range(100):
+        if ready.exists():
+            break
+        time.sleep(0.01)
+    assert ready.exists()
+    (tmp_path / "fake-events.jsonl").write_text(
+        json.dumps(
+            {"event": "server_started", "pid": process.pid, "alias": "fake-partial"}
+        )
+        + '\n{"event":"server_started"'
+    )
+
+    try:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'harness="$1"; event_out="$2"; set --; '
+                'source "$harness"; OUT="$event_out"; cleanup_fake_sidecars',
+                "cleanup-test",
+                str(HARNESS),
+                str(tmp_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode != 0
+        assert "could not parse fake sidecar ownership log" in result.stderr
+        assert process.poll() is None
+    finally:
+        process.terminate()
+        process.wait(timeout=1)
+
+
+def test_stop_app_drains_its_owned_process_group(tmp_path):
+    """Unreported catalogue children must exit before their HOME is deleted."""
+    leader = tmp_path / "leader.py"
+    child_pid_file = tmp_path / "child.pid"
+    child_ready = tmp_path / "child.ready"
+    leader.write_text(
+        """
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+os.setsid()
+child = subprocess.Popen([
+    sys.argv[3],
+    "-c",
+    "import signal,sys,time; from pathlib import Path; "
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "Path(sys.argv[1]).touch(); time.sleep(60)",
+    sys.argv[2],
+])
+for _ in range(100):
+    if Path(sys.argv[2]).exists():
+        break
+    time.sleep(0.01)
+Path(sys.argv[1]).write_text(str(child.pid))
+while True:
+    time.sleep(1)
+"""
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'harness="$1"; leader="$2"; pid_file="$3"; ready="$4"; python="$5"; '
+            'set --; source "$harness"; '
+            '"$python" "$leader" "$pid_file" "$ready" "$python" & APP_PID=$!; '
+            'for _ in {1..100}; do test -s "$pid_file" && break; sleep 0.01; done; '
+            'test -s "$pid_file"; child_pid="$(cat "$pid_file")"; '
+            'stop_app; child_state="$(ps -p "$child_pid" -o stat= 2>/dev/null '
+            '| tr -d "[:space:]" || true)"; '
+            'test -z "$child_state" || test "${child_state#Z}" != "$child_state"',
+            "process-group-test",
+            str(HARNESS),
+            str(leader),
+            str(child_pid_file),
+            str(child_ready),
+            sys.executable,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_fresh_install_fixture_contains_the_real_starter():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -18,6 +18,10 @@ machine — it would only quietly restore the misdiagnosis on an unhealthy one.
 
 from __future__ import annotations
 
+import json
+import signal
+import subprocess
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -281,6 +285,77 @@ def test_harness_reaps_its_own_fake_before_relaunch_without_global_sweep():
     assert relaunch.index("cleanup_fake_sidecars") < relaunch.index(
         '"$PERSONA/launch.sh"'
     )
+
+
+def test_fake_sidecar_cleanup_waits_then_escalates_without_touching_operator(tmp_path):
+    """Regression for #2676: cleanup must finish before persona deletion."""
+    graceful_code = """
+import signal
+import sys
+import time
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+while True:
+    time.sleep(0.05)
+"""
+    stubborn_code = """
+import signal
+import time
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+while True:
+    time.sleep(0.05)
+"""
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", graceful_code, "serve", "fake-graceful"]
+        ),
+        subprocess.Popen(
+            [sys.executable, "-c", stubborn_code, "serve", "fake-stubborn"]
+        ),
+        subprocess.Popen(
+            [sys.executable, "-c", graceful_code, "serve", "operator-owned"]
+        ),
+    ]
+    graceful, stubborn, operator = processes
+    events = tmp_path / "fake-events.jsonl"
+    events.write_text(
+        "\n".join(
+            json.dumps({"event": "server_started", "pid": proc.pid, "alias": alias})
+            for proc, alias in (
+                (graceful, "fake-graceful"),
+                (stubborn, "fake-stubborn"),
+            )
+        )
+        + "\n"
+    )
+
+    try:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'harness="$1"; event_out="$2"; set --; '
+                'source "$harness"; OUT="$event_out"; cleanup_fake_sidecars',
+                "cleanup-test",
+                str(HARNESS),
+                str(tmp_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert graceful.wait(timeout=1) == 0
+        assert stubborn.wait(timeout=1) == -signal.SIGKILL
+        assert operator.poll() is None
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1)
 
 
 def test_fresh_install_fixture_contains_the_real_starter():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -506,6 +506,34 @@ while True:
     assert result.returncode == 0, result.stderr
 
 
+def test_exit_trap_turns_cleanup_failure_into_failed_result(tmp_path):
+    """A passing journey cannot hide a retained process or persona."""
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps({"status": "pass", "exit_code": 0}))
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'harness="$1"; out="$2"; set --; source "$harness"; '
+            'OUT_ROOT="$out"; FLOW="cleanup-contract"; APP_SOURCE="fixture.app"; '
+            "RESULT_WRITTEN=1; cleanup_persona() { return 1; }; "
+            "cleanup_operator_server() { return 0; }; "
+            "cleanup_telemetry_sink() { return 0; }; "
+            "trap finish EXIT; exit 0",
+            "finish-test",
+            str(HARNESS),
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode != 0
+    evidence = json.loads(result_path.read_text())
+    assert evidence["status"] == "fail"
+    assert evidence["exit_code"] != 0
+
+
 def test_fresh_install_fixture_contains_the_real_starter():
     """The starter assertion is meaningless if the fake catalog omits it."""
     flow = HARNESS.read_text().split("flow_fresh_install() {", 1)[1].split("\n}", 1)[0]

--- a/tests/test_gui_walk_completeness.py
+++ b/tests/test_gui_walk_completeness.py
@@ -42,10 +42,10 @@ def test_catalog_absence_checks_require_complete_walks():
 def test_empty_persona_environment_is_safe_on_macos_bash3():
     source = (ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh").read_text()
     safe = '${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}'
-    # start_persona has two mutually exclusive launch branches so a localized
-    # persona can pass -AppleLanguages, while relaunch_persona has one. The
-    # loop that persists persona config is the fourth safe expansion.
-    assert source.count(safe) == 4
+    # launch_persona_app owns the two mutually exclusive log redirections for
+    # both initial launch and relaunch. The config-persistence loop is the
+    # third safe expansion.
+    assert source.count(safe) == 3
 
     program = r"""
 set -u


### PR DESCRIPTION
## Summary

- launch each isolated app as the leader of a harness-owned process group
- wait for every app descendant and recorded detached sidecar before cleanup
- force only a still-matching recorded PID/alias after a bounded deadline
- preserve persona state instead of deleting it if an owned sidecar cannot stop
- exercise graceful exit, forced exit, and operator-process isolation

Fixes #2676

## User impact

Desktop release dogfood no longer fails between otherwise healthy GUI journeys because an exiting sidecar is still writing inside its isolated test profile. This makes repeated release certification reliable without broad process kills or hidden cleanup failures.

## Scope

Only the Desktop GUI golden-flow harness and two existing harness contract-test files change. There are no engine, sidecar product, model, UI, dependency, or CI workflow changes.

## Design precedent

Established inference process managers use an owned-process lifecycle: place descendants under one ownership boundary, request graceful termination, wait for a bounded deadline, then force only remaining owned processes. This change gives each isolated app its own session/process group and retains the recorded PID-and-alias boundary for any deliberately detached sidecar, including a final recycled-PID check before escalation.

## Verification

- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- 90 focused GUI harness/contract tests passed on Python 3.12
- Ruff check and format check passed
- `git diff --check`
- `cached-quickstart` passed twice consecutively against the exact `main@e9719e61` locally built Desktop bundle after the process-group fix
- runtime contracts prove owned-group descendant draining, graceful detached shutdown, TERM-resistant escalation, fail-closed partial logs, alias-prefix collision safety, survival of an operator-shaped process, and nonzero/failed evidence when EXIT cleanup fails
