### PR TITLE
docs: stage 0.13.2 release notes

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -157,8 +157,9 @@ can actually understand.
 ### Known issues
 
 - Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
-  abort a request at a window boundary. Disable suffix decoding for these
-  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
+  abort a request at a window boundary. Remove `--suffix-decoding`, or start
+  the server with `--no-spec-decode`, for these models as a workaround.
+  ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
 
 ## [0.13.1] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -67,6 +67,11 @@ can actually understand.
   105,881,983 bytes (43.53% smaller); the measured Finder copy became slower,
   from 5.94 seconds to 17.80 seconds.
   ([#2668](https://github.com/raullenchai/Rapid-MLX/pull/2668))
+- **A GitHub invitation waits for demonstrated value.** After 35 successful
+  chats, dictations, or generated images, established Desktop users may see a
+  quiet, nonmodal project invitation. Dismissal starts a three-day cooldown and
+  a progressively larger local workload threshold; no account or star-status
+  lookup is performed. ([#2675](https://github.com/raullenchai/Rapid-MLX/pull/2675))
 
 ### Fixed
 
@@ -131,6 +136,19 @@ can actually understand.
   listing, pull admission, or chat model switching.
   ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- **Oversized vision inputs fit the request budget automatically.** Images are
+  reduced against the model's patch-aware token ceiling before preprocessing,
+  with one measured retry for processor rounding and a clear error only when
+  the minimum aligned image still cannot fit.
+  ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
+- **Forced assistant prefixes no longer wait for the first decoded token.** The
+  prefix is emitted after scheduler admission, while empty, failed, and
+  cancelled streams clean up their pending admission work.
+  ([#2674](https://github.com/raullenchai/Rapid-MLX/pull/2674))
+- **Suffix decoding respects sliding-window rollback boundaries.** The engine
+  preflights the full verify-forward cache growth and falls back to ordinary
+  decoding when advancing would make rollback unsafe, rather than aborting the
+  request. ([#2682](https://github.com/raullenchai/Rapid-MLX/pull/2682))
 
 ### Security
 
@@ -153,13 +171,6 @@ can actually understand.
   release notes instead of rebuilding different bytes after the tag.
   ([#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
   [#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530))
-
-### Known issues
-
-- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
-  abort a request at a window boundary. Remove `--suffix-decoding`, or start
-  the server with `--no-spec-decode`, for these models as a workaround.
-  ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
 
 ## [0.13.1] — 2026-08-26
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -138,8 +138,9 @@ can actually understand.
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
 - **Oversized vision inputs fit the request budget automatically.** Images are
   reduced against the model's patch-aware token ceiling before preprocessing,
-  with one measured retry for processor rounding and a clear error only when
-  the minimum aligned image still cannot fit.
+  with one measured retry for processor rounding. If the minimum aligned image
+  remains over budget, the server warns and leaves the existing downstream
+  prefill-cap guard as the final rejection boundary.
   ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
 - **Forced assistant prefixes no longer wait for the first decoded token.** The
   prefix is emitted after scheduler admission, while empty, failed, and

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -103,10 +103,12 @@ can actually understand.
   [#2543](https://github.com/raullenchai/Rapid-MLX/pull/2543),
   [#2619](https://github.com/raullenchai/Rapid-MLX/pull/2619))
 - **Desktop lifecycle recovery no longer blocks shared workers.** Exited server
-  leaders are reaped after the kernel exit event, and a stopped dictation model
-  reloads on the next hotkey instead of during foreground activation.
+  leaders are reaped after the kernel exit event, dual-stack `tcp46` listeners
+  are recognized when clearing a stale server port, and a stopped dictation
+  model reloads on the next hotkey instead of during foreground activation.
   ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
-  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593))
+  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593),
+  [#2663](https://github.com/raullenchai/Rapid-MLX/pull/2663))
 - **Settings and photo guidance describe the actual state.** Tools shows
   whether the selected search key is present without exposing it; dictation no
   longer guesses that every preparation failure is a memory problem; photo

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,147 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.2] — 2026-08-29
+
+### Added
+
+- **Opt-in native MTP for Qwen3.8 Flash-Next.** The engine can use the
+  checkpoint's one-layer prediction head with target verification and atomic
+  rollback. On the measured 128-token through 32K-context workloads, decode
+  rose from 21.16–25.17 tok/s to 28.82–34.85 tok/s with 76.41% proposal
+  acceptance. Desktop's normal temperature and penalty settings are supported;
+  seeded or stateful constrained requests continue on ordinary decoding.
+  ([#2572](https://github.com/raullenchai/Rapid-MLX/pull/2572),
+  [#2655](https://github.com/raullenchai/Rapid-MLX/pull/2655))
+- **Consented Desktop activation milestones.** Rapid can report the first
+  successful chat reply, dictation, and generated image after explicit opt-in.
+  Successful Messages and Completions requests also carry privacy-bounded
+  surface and client attribution; raw user-agent text is never emitted.
+  ([#2428](https://github.com/raullenchai/Rapid-MLX/pull/2428),
+  [#2436](https://github.com/raullenchai/Rapid-MLX/pull/2436))
+
+### Changed
+
+- **Long-context Flash-Next prefills are faster.** Batched QSA index-cache
+  construction reduced measured 2K, 8K, and 32K time to first token by
+  28.9–32.5% without changing decode speed or cache precision. A follow-up
+  evaluation boundary keeps a completed 32K request from corrupting the next
+  request in the same process. ([#2574](https://github.com/raullenchai/Rapid-MLX/pull/2574),
+  [#2596](https://github.com/raullenchai/Rapid-MLX/pull/2596))
+- **Repeated Flash-Next prompts reuse their prefix.** Semantic snapshot
+  boundaries now follow the exact rendered request, including request-local
+  template options, and preserve the model-specific recurrent cache through
+  batching and persistence. In the measured 5,288-token prompt, a warm request
+  reused 5,273 tokens and completed in 0.539 seconds instead of 6.497 seconds;
+  native MTP remained active after the hit.
+  ([#2588](https://github.com/raullenchai/Rapid-MLX/pull/2588),
+  [#2644](https://github.com/raullenchai/Rapid-MLX/pull/2644))
+- **The installer recommends a faster first-chat model that fits the Mac.**
+  Fresh installs below 16 GB suggest `lfm2.5-1b-4bit`; larger Macs suggest
+  `qwen3.5-4b-4bit`, while an eligible cached curated model remains preferred.
+  ([#2426](https://github.com/raullenchai/Rapid-MLX/pull/2426))
+- **Release-candidate builds can see final-version updates.** Passive version
+  notices order `rcN` below the matching final release and now appear in
+  `pull`, `ps`, `info`, `bench`, and `doctor`. Automatic upgrade prompts remain
+  disabled for development, RC, and local builds.
+  ([#2431](https://github.com/raullenchai/Rapid-MLX/pull/2431))
+- **The Desktop download is substantially smaller.** Release packaging uses
+  LZMA and removes only build-time or dependency-proven-unused sidecar files.
+  The signed and notarized comparison artifact fell from 187,505,002 bytes to
+  105,881,983 bytes (43.53% smaller); the measured Finder copy became slower,
+  from 5.94 seconds to 17.80 seconds.
+  ([#2668](https://github.com/raullenchai/Rapid-MLX/pull/2668))
+
+### Fixed
+
+- **Kokoro pulls are complete before the machine goes offline.** `rapid-mlx
+  pull` now fetches the voice assets and prepares the English G2P requirement
+  alongside the checkpoint. Inference never downloads or installs a missing
+  runtime component from inside a request; it returns an actionable readiness
+  error instead. ([#2648](https://github.com/raullenchai/Rapid-MLX/pull/2648),
+  [#2664](https://github.com/raullenchai/Rapid-MLX/pull/2664))
+- **Qwen3.8 tool calls use the checkpoint's native wire format.** Required and
+  named tool calls return OpenAI-compatible JSON arguments, and malformed
+  required arguments fail with a client error instead of looking executable.
+  ([#2660](https://github.com/raullenchai/Rapid-MLX/pull/2660))
+- **Explicit multimodal selection stays explicit.** `--mllm` takes precedence
+  over automatic architecture, cache, and runtime fallbacks. The measured
+  vision-memory floor still fails closed, and speculative decoding continues
+  to select its supported text lane.
+  ([#2643](https://github.com/raullenchai/Rapid-MLX/pull/2643),
+  [#2669](https://github.com/raullenchai/Rapid-MLX/pull/2669))
+- **Photo attachments have bounded, recoverable behavior.** A message accepts
+  at most four images and 6 MiB of aggregate encoded image data, reports which
+  limit rejected the remainder, and cannot resend one permanently failing
+  image forever. Generated-image deletion uses an app-owned confirmation sheet
+  whose safe Keep action remains pressable and whose Return key cannot delete.
+  ([#2541](https://github.com/raullenchai/Rapid-MLX/pull/2541),
+  [#2585](https://github.com/raullenchai/Rapid-MLX/pull/2585),
+  [#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387),
+  [#2578](https://github.com/raullenchai/Rapid-MLX/pull/2578))
+- **Model changes preserve active Desktop work.** Switching away from a busy
+  model asks before replacement, Cancel keeps the response alive, and the
+  shared measured footprint keeps recommendation, review, and engine admission
+  aligned. Already-resident models remain servable through the safe replacement
+  path. ([#2430](https://github.com/raullenchai/Rapid-MLX/pull/2430),
+  [#2543](https://github.com/raullenchai/Rapid-MLX/pull/2543),
+  [#2619](https://github.com/raullenchai/Rapid-MLX/pull/2619))
+- **Desktop lifecycle recovery no longer blocks shared workers.** Exited server
+  leaders are reaped after the kernel exit event, and a stopped dictation model
+  reloads on the next hotkey instead of during foreground activation.
+  ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
+  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593))
+- **Settings and photo guidance describe the actual state.** Tools shows
+  whether the selected search key is present without exposing it; dictation no
+  longer guesses that every preparation failure is a memory problem; photo
+  remedies use the engine's real serving-lane reasons and point to the correct
+  action. ([#2514](https://github.com/raullenchai/Rapid-MLX/pull/2514),
+  [#2523](https://github.com/raullenchai/Rapid-MLX/pull/2523),
+  [#2602](https://github.com/raullenchai/Rapid-MLX/pull/2602),
+  [#2607](https://github.com/raullenchai/Rapid-MLX/pull/2607))
+- **OpenAI-compatible request behavior is more predictable.** Explicit
+  `timeout: 0` means the server default, request-local `chat_template_kwargs`
+  reach the tokenizer, cancellations are no longer mislabeled as max-length
+  completion, and orphaned streaming reservations cannot leave model changes
+  busy until restart. ([#2583](https://github.com/raullenchai/Rapid-MLX/pull/2583),
+  [#2614](https://github.com/raullenchai/Rapid-MLX/pull/2614),
+  [#2625](https://github.com/raullenchai/Rapid-MLX/pull/2625),
+  [#2636](https://github.com/raullenchai/Rapid-MLX/pull/2636))
+- **Pull and cache recovery fail locally without losing the fast path.** An
+  explicit `--bits` or `--format` selection remains eligible for the mirror,
+  and malformed or interrupted cache metadata no longer crashes cached-model
+  listing, pull admission, or chat model switching.
+  ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
+  [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+
+### Security
+
+- **Embedded API credentials have explicit safe lifetimes.** Per-launch, daily,
+  and manual-rotation policies store the bearer in a code-identity-scoped
+  Keychain item; preferences contain only non-secret metadata. Unavailable or
+  malformed persisted credentials degrade to a one-time key and are surfaced
+  in Settings. ([#2639](https://github.com/raullenchai/Rapid-MLX/pull/2639))
+- **Desktop web browsing pins the validated destination.** Every DNS answer is
+  checked by the existing SSRF policy, then the socket connects directly to
+  the selected address while retaining the original hostname for TLS and
+  certificate validation. This closes the DNS-rebinding window without
+  weakening redirect, body-size, or timeout limits.
+  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645))
+
+### Release engineering
+
+- Signed Desktop candidates identify their exact source commit, and protected
+  publication promotes the already reviewed DMG, Sparkle archive, appcast, and
+  release notes instead of rebuilding different bytes after the tag.
+  ([#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
+  [#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530))
+
+### Known issues
+
+- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
+  abort a request at a window boundary. Disable suffix decoding for these
+  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
+
 ## [0.13.1] — 2026-08-26
 
 ### Added
@@ -3378,7 +3519,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...HEAD
+[0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2
 [0.13.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.0...rapid-mac-v0.13.1
 [0.5.16]: https://github.com/machinefi/rapid-desktop/compare/v0.5.15...v0.5.16
 [0.5.15]: https://github.com/machinefi/rapid-desktop/compare/v0.5.14...v0.5.15

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -1,0 +1,152 @@
+Rapid-MLX 0.13.2 makes long-running local assistants faster and more
+dependable: Qwen3.8 Flash-Next gains opt-in native MTP and faster long-context
+prefill, repeated prompts recover their prefix cache, offline speech pulls
+include their runtime requirements, and Desktop tightens attachment, credential,
+and web-browsing safety.
+
+## Highlights
+
+**Qwen3.8 Flash-Next gains native MTP** — The engine can opt into the
+checkpoint's one-layer prediction head while the target model verifies every
+proposal and all recurrent, QSA, and KV state rolls back atomically. The
+measured fixed-K1 workload accepted 76.41% of proposals.
+([#2572](https://github.com/raullenchai/Rapid-MLX/pull/2572),
+[#2655](https://github.com/raullenchai/Rapid-MLX/pull/2655))
+
+| Context | Serial decode | Native MTP | Change |
+| ------: | ------------: | ---------: | -----: |
+|     128 | 25.17 tok/s | 34.85 tok/s | +38.5% |
+|      2K | 23.64 tok/s | 33.53 tok/s | +41.8% |
+|      8K | 22.82 tok/s | 32.20 tok/s | +41.1% |
+|     32K | 21.16 tok/s | 28.82 tok/s | +36.2% |
+
+Desktop's normal temperature, top-p, top-k, min-p, and penalty settings can use
+the lane. Seeded requests and stateful grammar, tool, reasoning, or suppression
+processors continue on ordinary decoding rather than silently weakening their
+contract. The measured MTP path used up to 6.6 GB more active memory, and 192 GB
+remains the recommended hardware tier for this experimental checkpoint.
+
+**Faster long-context prefill and reusable prompts** — QSA index-cache work is
+batched across eligible prefills, reducing measured time to first token by
+28.9–32.5% while decode speed and cache precision remain unchanged. A completed
+32K request can no longer poison the next request in the same process.
+([#2574](https://github.com/raullenchai/Rapid-MLX/pull/2574),
+[#2596](https://github.com/raullenchai/Rapid-MLX/pull/2596))
+
+| Prompt | Previous TTFT | Batched TTFT | Change |
+| -----: | ------------: | -----------: | -----: |
+|     2K | 3.346 s | 2.262 s | -32.4% |
+|     8K | 13.689 s | 9.236 s | -32.5% |
+|    32K | 62.851 s | 44.659 s | -28.9% |
+
+Semantic prefix snapshots now follow the exact rendered prompt and preserve the
+Flash-Next recurrent cache through batching and persistence. A measured
+5,288-token warm request reused 5,273 tokens and completed in 0.539 seconds
+instead of 6.497 seconds; native MTP continued proposing after the hit.
+([#2588](https://github.com/raullenchai/Rapid-MLX/pull/2588),
+[#2644](https://github.com/raullenchai/Rapid-MLX/pull/2644))
+
+**Kokoro is ready before the machine goes offline** — `rapid-mlx pull` now
+fetches the voice assets and prepares the English G2P requirement as part of
+the pull transaction. The clean-cache validation downloaded 54 voice files and
+generated speech with networking disabled. If a runtime requirement is missing,
+an inference request returns an actionable readiness error instead of trying to
+download or install software on demand.
+([#2648](https://github.com/raullenchai/Rapid-MLX/pull/2648),
+[#2664](https://github.com/raullenchai/Rapid-MLX/pull/2664))
+
+**A smaller, byte-identical-to-approved Desktop release path** — LZMA packaging
+and dependency-proven pruning reduced the signed and notarized comparison DMG
+from 187,505,002 to 105,881,983 bytes, a 43.53% reduction. The tradeoff is a
+slower one-time Finder copy on the measured host: 17.80 seconds instead of 5.94
+seconds. Candidate builds now identify their source commit, and protected
+publication promotes the exact approved DMG and updater payloads instead of
+rebuilding different bytes after the tag.
+([#2668](https://github.com/raullenchai/Rapid-MLX/pull/2668),
+[#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
+[#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530))
+
+## Desktop safety and workflow corrections
+
+- A chat message accepts up to four images and 6 MiB of aggregate encoded image
+  data, preserves selection order, and explains whether count or size rejected
+  the remainder. A repeatedly failing image gets one bounded follow-up retry
+  instead of contaminating every later text turn.
+  ([#2541](https://github.com/raullenchai/Rapid-MLX/pull/2541),
+  [#2585](https://github.com/raullenchai/Rapid-MLX/pull/2585))
+- Generated-image deletion uses an app-owned confirmation sheet: Keep remains
+  pressable in native GUI automation, Escape is safe, and Return cannot delete
+  an image. ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387),
+  [#2578](https://github.com/raullenchai/Rapid-MLX/pull/2578))
+- Switching away from a busy model asks first; Cancel preserves the live model
+  and in-flight response. Recommendation, review, and engine admission use one
+  measured footprint for known models, and already-resident models remain
+  usable through the safe replacement path.
+  ([#2430](https://github.com/raullenchai/Rapid-MLX/pull/2430),
+  [#2543](https://github.com/raullenchai/Rapid-MLX/pull/2543),
+  [#2619](https://github.com/raullenchai/Rapid-MLX/pull/2619))
+- The installer recommends `lfm2.5-1b-4bit` below 16 GB and
+  `qwen3.5-4b-4bit` on larger Macs, while preferring an eligible cached model
+  from the same memory tier. ([#2426](https://github.com/raullenchai/Rapid-MLX/pull/2426))
+- Exited server leaders are reaped without blocking a shared worker. A stopped
+  dictation model reloads when the user next presses the hotkey instead of
+  during foreground activation. ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
+  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593))
+- Tools settings resolve the selected search key's real Keychain state without
+  exposing it, dictation errors no longer guess at an unproven memory cause,
+  and photo guidance names the remedy for the engine's actual serving-lane
+  reason. ([#2514](https://github.com/raullenchai/Rapid-MLX/pull/2514),
+  [#2523](https://github.com/raullenchai/Rapid-MLX/pull/2523),
+  [#2602](https://github.com/raullenchai/Rapid-MLX/pull/2602),
+  [#2607](https://github.com/raullenchai/Rapid-MLX/pull/2607))
+
+## Engine, API, and CLI reliability
+
+- Qwen3.8 27B required and named tool calls use the checkpoint-native format
+  and return OpenAI-compatible JSON arguments. Invalid required arguments fail
+  with a client error instead of appearing executable.
+  ([#2660](https://github.com/raullenchai/Rapid-MLX/pull/2660))
+- Explicit `--mllm` selection wins over automatic architecture, cache, and
+  runtime fallback. The measured vision-memory floor remains mandatory, and
+  speculative decoding still uses its supported text lane.
+  ([#2643](https://github.com/raullenchai/Rapid-MLX/pull/2643),
+  [#2669](https://github.com/raullenchai/Rapid-MLX/pull/2669))
+- Explicit `timeout: 0` means the server default, request-local
+  `chat_template_kwargs` reach the tokenizer, cancellations are distinct from
+  max-length completion, and orphaned streaming reservations cannot keep model
+  replacement busy until restart.
+  ([#2583](https://github.com/raullenchai/Rapid-MLX/pull/2583),
+  [#2614](https://github.com/raullenchai/Rapid-MLX/pull/2614),
+  [#2625](https://github.com/raullenchai/Rapid-MLX/pull/2625),
+  [#2636](https://github.com/raullenchai/Rapid-MLX/pull/2636))
+- Explicit `--bits` and `--format` pulls remain eligible for the mirror.
+  Malformed or interrupted cache metadata no longer crashes cached-model
+  listing, pull admission, or chat model switching.
+  ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
+  [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- Passive version checks correctly order `rcN` below the matching final and now
+  cover `pull`, `ps`, `info`, `bench`, and `doctor`; automatic upgrade prompts
+  remain off for development, RC, and local builds.
+  ([#2431](https://github.com/raullenchai/Rapid-MLX/pull/2431))
+
+## Privacy and security
+
+- Desktop activation milestones are created and sent only after explicit
+  telemetry consent. Request attribution uses an allowlisted client bucket;
+  raw user-agent text never enters the payload.
+  ([#2428](https://github.com/raullenchai/Rapid-MLX/pull/2428),
+  [#2436](https://github.com/raullenchai/Rapid-MLX/pull/2436))
+- Embedded API bearer credentials support per-launch, daily, and manual
+  rotation. The bearer stays in a code-identity-scoped Keychain item while
+  preferences contain only non-secret metadata.
+  ([#2639](https://github.com/raullenchai/Rapid-MLX/pull/2639))
+- Desktop web browsing validates every DNS answer, then pins the socket to the
+  selected address while preserving hostname-based TLS verification. Redirect,
+  body-size, and timeout limits remain fail closed.
+  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645))
+
+## Known issues
+
+- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
+  abort a request at a window boundary. Disable suffix decoding for these
+  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -88,10 +88,13 @@ rebuilding different bytes after the tag.
 - The installer recommends `lfm2.5-1b-4bit` below 16 GB and
   `qwen3.5-4b-4bit` on larger Macs, while preferring an eligible cached model
   from the same memory tier. ([#2426](https://github.com/raullenchai/Rapid-MLX/pull/2426))
-- Exited server leaders are reaped without blocking a shared worker. A stopped
-  dictation model reloads when the user next presses the hotkey instead of
-  during foreground activation. ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
-  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593))
+- Exited server leaders are reaped without blocking a shared worker, and stale
+  dual-stack `tcp46` listeners are recognized when Desktop clears a server
+  port. A stopped dictation model reloads when the user next presses the hotkey
+  instead of during foreground activation.
+  ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
+  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593),
+  [#2663](https://github.com/raullenchai/Rapid-MLX/pull/2663))
 - Tools settings resolve the selected search key's real Keychain state without
   exposing it, dictation errors no longer guess at an unproven memory cause,
   and photo guidance names the remedy for the engine's actual serving-lane

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -134,8 +134,9 @@ rebuilding different bytes after the tag.
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
 - Oversized vision images are automatically reduced to the model's patch-aware
   token budget before preprocessing. Multiple images share that budget, and a
-  measured retry handles processor rounding; requests still fail clearly when
-  even the minimum aligned image cannot fit.
+  measured retry handles processor rounding. If the minimum aligned image
+  remains over budget, the server warns and leaves the existing downstream
+  prefill-cap guard as the final rejection boundary.
   ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
 - Forced assistant prefixes become visible as soon as the scheduler admits the
   request instead of waiting for the first decoded token. Empty, failed, and

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -151,5 +151,6 @@ rebuilding different bytes after the tag.
 ## Known issues
 
 - Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
-  abort a request at a window boundary. Disable suffix decoding for these
-  models as a workaround. ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))
+  abort a request at a window boundary. Remove `--suffix-decoding`, or start
+  the server with `--no-spec-decode`, for these models as a workaround.
+  ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -102,6 +102,11 @@ rebuilding different bytes after the tag.
   [#2523](https://github.com/raullenchai/Rapid-MLX/pull/2523),
   [#2602](https://github.com/raullenchai/Rapid-MLX/pull/2602),
   [#2607](https://github.com/raullenchai/Rapid-MLX/pull/2607))
+- After 35 successful chats, dictations, or generated images, established
+  Desktop users may see a quiet, nonmodal invitation to visit the project on
+  GitHub. Dismissing it starts a three-day cooldown and a progressively larger
+  local usage threshold; Rapid performs no account or star-status lookup.
+  ([#2675](https://github.com/raullenchai/Rapid-MLX/pull/2675))
 
 ## Engine, API, and CLI reliability
 
@@ -127,6 +132,19 @@ rebuilding different bytes after the tag.
   listing, pull admission, or chat model switching.
   ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- Oversized vision images are automatically reduced to the model's patch-aware
+  token budget before preprocessing. Multiple images share that budget, and a
+  measured retry handles processor rounding; requests still fail clearly when
+  even the minimum aligned image cannot fit.
+  ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
+- Forced assistant prefixes become visible as soon as the scheduler admits the
+  request instead of waiting for the first decoded token. Empty, failed, and
+  cancelled streams retire their pending admission work cleanly.
+  ([#2674](https://github.com/raullenchai/Rapid-MLX/pull/2674))
+- Suffix decoding now checks the full verify-forward cache growth before
+  advancing a sliding-window cache. At a rollback-unsafe boundary it falls
+  back to ordinary decoding instead of aborting the request.
+  ([#2682](https://github.com/raullenchai/Rapid-MLX/pull/2682))
 - Passive version checks correctly order `rcN` below the matching final and now
   cover `pull`, `ps`, `info`, `bench`, and `doctor`; automatic upgrade prompts
   remain off for development, RC, and local builds.
@@ -147,10 +165,3 @@ rebuilding different bytes after the tag.
   selected address while preserving hostname-based TLS verification. Redirect,
   body-size, and timeout limits remain fail closed.
   ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645))
-
-## Known issues
-
-- Suffix decoding with sliding-window models such as Gemma 4 and GPT-OSS can
-  abort a request at a window boundary. Remove `--suffix-decoding`, or start
-  the server with `--no-spec-decode`, for these models as a workaround.
-  ([#2463](https://github.com/raullenchai/Rapid-MLX/issues/2463))


### PR DESCRIPTION
## Why

Stage an accurate, user-facing 0.13.2 Desktop CHANGELOG and curated release-note page before the version bump. Every product and performance claim is bound to a pull request already merged into `main@9418e03f`; dogfood fixes that have not landed are intentionally absent and will receive a final delta audit before the bump.

## What

- Add `## [0.13.2]` to `apps/rapid-mac/CHANGELOG.md`, including compare links.
- Add `docs/release-notes/v0.13.2.md` with user-facing highlights, measured performance tables, explicit tradeoffs, privacy/security changes, and the still-open suffix-decoding workaround.
- Cover the landed inventory across Qwen3.8 native MTP/QSA/prefix caching, offline Kokoro readiness, Desktop attachments and lifecycle, API/CLI reliability, release artifact provenance, and DMG size reduction.

## Scope

Documentation only. No version bump, product/workflow change, dogfood, tag, release, updater mutation, or publication. #2673 remains independently owned and is not changed here.

## Source audit

Every cited PR is merged and its merge commit is an ancestor of `origin/main@9418e03f`. Performance and size numbers are copied from exact-head real-model or signed/notarized artifact evidence on the cited PRs. The final release transaction must repeat the inventory audit for any dogfood fixes merged after this source snapshot.

## Verification

- `tests/release/test_build_release_notes.sh`: 63 passed
- `tests/release/test_release_preflight_subject.sh`: 16 passed
- `tests/release/test_auto_release_dry_run.sh`: 32 passed
- All 40 cited PR merge commits verified as ancestors of `origin/main@9418e03f`
- Independent Codex review round 1: sole #2663 omission accepted, fixed, and dispositioned; no second round under the one-round quota
- `pr_validate` on Python 3.12: MERGE-SAFE; 19,718 passed, 104 skipped, 22 deselected, 6 xfailed, 1 xpassed
- Final delta audit added #2674, #2675, #2682, and #2694; removed the #2463 workaround after its fix landed
- `git diff --check`: passed

## AI assistance disclosure

Codex assembled and source-audited the release prose. Claims were checked against landed PR contracts and exact-head evidence; no unpublished dogfood result is represented as shipped.