### PR TITLE
Fix Parakeet v3 language metadata

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -337,12 +337,13 @@ stem removed. Add `--play` to audition the result without writing files.
 | `mlx-community/whisper-medium-mlx` | `whisper-medium` | 99+ | Fast | Good |
 | `mlx-community/whisper-small-mlx` | `whisper-small` | 99+ | Very Fast | OK |
 | `mlx-community/parakeet-tdt-0.6b-v2` | `parakeet` | English | Fastest | Great |
-| `mlx-community/parakeet-tdt-0.6b-v3` | `parakeet-v3` | English | Fastest | Best |
+| `mlx-community/parakeet-tdt-0.6b-v3` | `parakeet-v3` | 25 European languages | Fastest | Best |
 | `mlx-community/SenseVoiceSmall` | `sensevoice` | zh, yue, ja, ko, en | Fastest | Great (Asian) |
 
 **Recommendation:**
 - Multilingual: `whisper-large-v3`
 - English only: `parakeet` (3x faster)
+- European languages with automatic language detection: `parakeet-v3` (no Chinese)
 - Chinese / Cantonese / Japanese / Korean: `sensevoice`
 - You already have the transcript and need timings: `qwen3-aligner` (see Forced alignment below)
 

--- a/tests/test_audio_alias_metadata.py
+++ b/tests/test_audio_alias_metadata.py
@@ -1,0 +1,27 @@
+"""Pure-data contracts for audio alias metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+ALIASES_PATH = Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "aliases.json"
+
+
+@pytest.mark.parametrize(
+    "alias,expected_languages",
+    [
+        ("parakeet", "en"),
+        ("parakeet-tdt-0.6b-v2", "en"),
+        ("parakeet-v3", "25 European languages"),
+        ("parakeet-tdt-0.6b-v3", "25 European languages"),
+    ],
+)
+def test_parakeet_language_metadata_distinguishes_v2_and_v3(
+    alias: str, expected_languages: str
+) -> None:
+    aliases = json.loads(ALIASES_PATH.read_text(encoding="utf-8"))
+    assert aliases[alias]["languages"] == expected_languages

--- a/tests/test_audio_alias_metadata.py
+++ b/tests/test_audio_alias_metadata.py
@@ -7,8 +7,9 @@ from pathlib import Path
 
 import pytest
 
-
-ALIASES_PATH = Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "aliases.json"
+ALIASES_PATH = (
+    Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "aliases.json"
+)
 
 
 @pytest.mark.parametrize(

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -291,15 +291,15 @@
     "type": "stt",
     "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
     "family": "parakeet",
-    "languages": "en",
-    "notes": "Parakeet TDT 0.6B v3."
+    "languages": "25 European languages",
+    "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
   },
   "parakeet-tdt-0.6b-v3": {
     "type": "stt",
     "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
     "family": "parakeet",
-    "languages": "en",
-    "notes": "Parakeet TDT 0.6B v3."
+    "languages": "25 European languages",
+    "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
   },
   "qwen3-asr": {
     "type": "stt",

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -4,7 +4,7 @@ Speech-to-Text (STT) engine using mlx-audio.
 
 Supports:
 - Whisper (multilingual, 99+ languages)
-- Parakeet (English-focused, fast)
+- Parakeet (v2 English; v3 supports 25 European languages, fast)
 - SenseVoice (FunAudioLLM; Chinese/Cantonese/Japanese/Korean/English, very
   fast non-autoregressive CTC — a dedicated Asian-language ASR option)
 """
@@ -764,7 +764,8 @@ class STTEngine:
         # Whisper engines the value flows through to ``model.generate``
         # so the underlying decoder emits English when translating
         # and source-language text when transcribing. Parakeet engines
-        # ignore the kwarg (English-only). This kwarg was present
+        # ignore the kwarg and always transcribe in the source language.
+        # This kwarg was present
         # pre-bundle; the comment is here so the call sites are
         # discoverable from the function definition.
         task: str = "transcribe",
@@ -797,7 +798,8 @@ class STTEngine:
             language: Language code (e.g., "en", "es"). Auto-detected if None.
             task: "transcribe" or "translate" (translate to English).
                 Forwarded to ``model.generate`` for Whisper engines;
-                ignored by Parakeet (which is English-only).
+                ignored by Parakeet (v2 is English-only; v3 transcribes its
+                supported European languages without translation).
             timestamp_granularities: OpenAI ``timestamp_granularities[]``
                 values (subset of ``{"word", "segment"}``). ``"word"``
                 requests per-word timings on Whisper engines; ignored by


### PR DESCRIPTION
## Summary\n- distinguish the English-only Parakeet v2 aliases from multilingual Parakeet v3 metadata\n- document v3's 25 European languages, automatic language detection, and lack of Chinese support\n- add a pure-data regression test that runs without MLX\n\nThe corrected coverage follows NVIDIA's upstream model card:\nhttps://huggingface.co/nvidia/parakeet-tdt-0.6b-v3\n\n## Verification\n- ============================= test session starts ==============================
platform darwin -- Python 3.11.6, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/qevan/orca/workspaces/Rapid-MLX/fix-parakeet-v3-language
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 4 items

tests/test_audio_alias_metadata.py ....                                  [100%]

============================== 4 passed in 0.04s =============================== (4 passed)\n- {
    "_comment": "R10-C1 audio alias registry. Single source of truth for short alias -> HuggingFace repo id mapping. Every entry's hf_id has been verified resolvable on https://huggingface.co/api/models/<id> at registry-introduction time. Add new entries by hand, then run tests/test_audio_alias_registry.py::test_every_hf_id_resolves locally (network-gated) to confirm before merging.",
    "_runtime_assets": {
        "kokoro": [
            {
                "repo_id": "prince-canuma/Kokoro-82M",
                "allow_patterns": [
                    "voices/*.safetensors"
                ]
            }
        ]
    },
    "_runtime_requirements": {
        "kokoro": [
            {
                "kind": "spacy_pipeline",
                "name": "en_core_web_sm"
            }
        ]
    },
    "kokoro": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-bf16",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "Default Kokoro 82M (bf16). Drop-in OpenAI-style TTS."
    },
    "kokoro-82m": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-bf16",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "Long-form alias for ``kokoro`` \u2014 same HF id."
    },
    "kokoro-82m-bf16": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-bf16",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "Explicit bf16 quant of Kokoro 82M."
    },
    "kokoro-82m-4bit": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-4bit",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "4-bit quant of Kokoro 82M \u2014 smaller download, mild quality drop."
    },
    "kokoro-82m-8bit": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-8bit",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "8-bit quant of Kokoro 82M."
    },
    "kokoro-4bit": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-4bit",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "Short-form 4-bit alias."
    },
    "kokoro-8bit": {
        "type": "tts",
        "hf_id": "mlx-community/Kokoro-82M-8bit",
        "family": "kokoro",
        "default_voice": "af_heart",
        "notes": "Short-form 8-bit alias."
    },
    "chatterbox": {
        "type": "tts",
        "hf_id": "mlx-community/chatterbox-turbo-fp16",
        "family": "chatterbox",
        "default_voice": "default",
        "notes": "Multilingual expressive TTS. Voice cloning via reference audio."
    },
    "chatterbox-4bit": {
        "type": "tts",
        "hf_id": "mlx-community/chatterbox-turbo-4bit",
        "family": "chatterbox",
        "default_voice": "default",
        "notes": "4-bit quant of Chatterbox Turbo."
    },
    "vibevoice": {
        "type": "tts",
        "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
        "family": "vibevoice",
        "default_voice": "en-Grace_woman",
        "notes": "Realtime low-latency TTS, 0.5B 4bit. Per-language voice caches; en-Grace_woman is the canonical English-female default. Full set: en-{Grace_woman,Mike_man,Carter_man,Davis_man,Frank_man,Emma_woman} + de/fr/it/jp/kr/nl/pl/pt/sp Spk0/Spk1 pairs + in-Samuel_man."
    },
    "vibevoice-realtime": {
        "type": "tts",
        "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
        "family": "vibevoice",
        "default_voice": "en-Grace_woman",
        "notes": "Long-form alias for ``vibevoice``."
    },
    "voxcpm": {
        "type": "tts",
        "hf_id": "mlx-community/VoxCPM1.5",
        "family": "voxcpm",
        "default_voice": "default",
        "notes": "English (experimental) TTS (CPM-based). WARNING: Chinese is currently BROKEN in this MLX port \u2014 Chinese input produces Thai-script gibberish plus long runaway generation, so do NOT use voxcpm for Chinese. For Chinese TTS use `f5-tts-zh` (EN+ZH, cloneable) or `qwen3-tts` (named Chinese speakers) instead. English-only is usable but best-effort; report upstream if synth fails."
    },
    "dia": {
        "type": "tts",
        "hf_id": "mlx-community/Dia-1.6B-4bit",
        "family": "dia",
        "default_voice": "default",
        "notes": "Dia 1.6B multi-speaker dialogue TTS (4-bit). Best-effort \u2014 covered by the audio probe but mlx_audio support is experimental; report bugs upstream if synth fails."
    },
    "qwen3-tts": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",
        "family": "qwen3_tts",
        "default_voice": "Serena",
        "notes": "Alibaba Qwen3-TTS 1.7B CustomVoice (bf16). Multilingual predefined speakers (Chinese: Vivian, Serena, Uncle_Fu, Dylan, Eric; English: Ryan, Aiden; Japanese: Ono_Anna; Korean: Sohee) matched case-insensitively, with emotion/style control via the OpenAI `instructions` field. The CustomVoice variant is used (not 0.6B-Base, which is voice-cloning-only and needs a reference clip)."
    },
    "f5-tts-zh": {
        "type": "tts",
        "hf_id": "lucasnewman/f5-tts-mlx",
        "family": "f5",
        "default_voice": "clone",
        "notes": "F5-TTS (pure-MLX, no torch): EN+ZH multilingual, zero-shot voice CLONING via ref_audio (24kHz clip) + ref_text. Fills the Chinese expressive/cloneable gap (Qwen3-TTS is flat, Chatterbox English-only). With no ref it uses a packaged default voice; supply a Chinese ref for a natural Chinese narrator."
    },
    "indextts": {
        "type": "tts",
        "hf_id": "mlx-community/IndexTTS-1.5",
        "family": "indextts",
        "default_voice": "clone",
        "notes": "IndexTTS 1.5 zero-shot voice cloning. Requires ref_audio; the reference transcript is not required. No predefined speakers."
    },
    "indextts-1.5": {
        "type": "tts",
        "hf_id": "mlx-community/IndexTTS-1.5",
        "family": "indextts",
        "default_voice": "clone",
        "notes": "Long-form alias for indextts \u2014 same IndexTTS 1.5 MLX checkpoint."
    },
    "qwen3-tts-clone": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16",
        "family": "qwen3_tts",
        "default_voice": "clone",
        "notes": "Alibaba Qwen3-TTS 1.7B **Base** \u2014 zero-shot Chinese/multilingual voice CLONING. Requires ref_audio (a clean 5-10s reference clip at the model's native sample rate) plus ref_text (its exact transcript); ignores predefined speakers. Lets a channel reuse ONE consistent branded narrator voice. Distinct from the CustomVoice variant (named speakers + `instruct` emotion, no cloning)."
    },
    "qwen3-tts-customvoice": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",
        "family": "qwen3_tts",
        "default_voice": "Serena",
        "notes": "Long-form alias for ``qwen3-tts`` \u2014 same HF id (1.7B CustomVoice bf16)."
    },
    "qwen3-tts-6bit": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit",
        "family": "qwen3_tts",
        "default_voice": "Serena",
        "notes": "6-bit quant of Qwen3-TTS 1.7B CustomVoice \u2014 smaller download, mild quality drop."
    },
    "qwen3-tts-4bit": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit",
        "family": "qwen3_tts",
        "default_voice": "Serena",
        "notes": "4-bit quant of Qwen3-TTS 1.7B CustomVoice \u2014 smallest download."
    },
    "qwen3-tts-voicedesign": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16",
        "family": "qwen3_tts",
        "default_voice": "describe",
        "notes": "Qwen3-TTS 1.7B VoiceDesign (bf16). The VOICE-DESIGN sibling of CustomVoice: instead of picking a named speaker, the ENTIRE voice \u2014 timbre, gender, age, accent, emotion, prosody \u2014 is described in natural language via the OpenAI `instructions` field (mapped to mlx_audio's mandatory `instruct` arg; the weights self-dispatch to `generate_voice_design`). Richer style control than CustomVoice's `instruct` (which only modulates a fixed speaker). Has NO named speakers, so `voice` is ignored \u2014 the voice surface is the single `describe` sentinel (like F5's `clone`) and `default_voice` is that sentinel so the voice-omitted path validates. Supply a description, e.g. `instructions=\"a warm, low female narrator, calm and measured\"`."
    },
    "qwen3-tts-voicedesign-8bit": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit",
        "family": "qwen3_tts",
        "default_voice": "describe",
        "notes": "8-bit quant of Qwen3-TTS 1.7B VoiceDesign \u2014 smaller download, mild quality drop."
    },
    "qwen3-tts-voicedesign-4bit": {
        "type": "tts",
        "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit",
        "family": "qwen3_tts",
        "default_voice": "describe",
        "notes": "4-bit quant of Qwen3-TTS 1.7B VoiceDesign \u2014 smallest download."
    },
    "whisper": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-large-v3-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Bare ``whisper`` -> largest-v3. Matches OpenAI's ``whisper-1`` placeholder."
    },
    "whisper-1": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-large-v3-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "OpenAI-spec id from the legacy Whisper API. Same destination as ``whisper-large-v3``."
    },
    "whisper-large-v3": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-large-v3-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper large-v3 (multilingual, 99+ languages)."
    },
    "whisper-large-v3-turbo": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-large-v3-turbo",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper large-v3 turbo (faster decode, slight quality drop)."
    },
    "whisper-medium": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-medium-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper medium."
    },
    "whisper-small": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-small-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper small."
    },
    "whisper-base": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-base-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper base."
    },
    "whisper-tiny": {
        "type": "stt",
        "hf_id": "mlx-community/whisper-tiny-mlx",
        "family": "whisper",
        "languages": "multilingual",
        "notes": "Whisper tiny (smallest, fastest, lowest accuracy)."
    },
    "qwen3-aligner": {
        "type": "stt",
        "hf_id": "mlx-community/Qwen3-ForcedAligner-0.6B-8bit",
        "family": "qwen3_aligner",
        "languages": "multilingual",
        "notes": "Forced ALIGNMENT (not ASR): given audio + the KNOWN transcript, returns per-character start/end times with zero recognition error. Use STTEngine.align(audio, text, language) or /v1/audio/transcriptions with a `text` field. Powers karaoke captions + beat-synced editing; unoccupied on MLX."
    },
    "qwen3-forced-aligner": {
        "type": "stt",
        "hf_id": "mlx-community/Qwen3-ForcedAligner-0.6B-8bit",
        "family": "qwen3_aligner",
        "languages": "multilingual",
        "notes": "Long-form alias for ``qwen3-aligner`` \u2014 same HF id."
    },
    "parakeet": {
        "type": "stt",
        "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
        "family": "parakeet",
        "languages": "en",
        "notes": "NVIDIA Parakeet TDT 0.6B v2 (English, fastest STT)."
    },
    "parakeet-tdt-0.6b": {
        "type": "stt",
        "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
        "family": "parakeet",
        "languages": "en",
        "notes": "Long-form alias for ``parakeet``."
    },
    "parakeet-tdt-0.6b-v2": {
        "type": "stt",
        "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
        "family": "parakeet",
        "languages": "en",
        "notes": "Parakeet TDT 0.6B v2."
    },
    "parakeet-v3": {
        "type": "stt",
        "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
        "family": "parakeet",
        "languages": "25 European languages",
        "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
    },
    "parakeet-tdt-0.6b-v3": {
        "type": "stt",
        "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
        "family": "parakeet",
        "languages": "25 European languages",
        "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
    },
    "qwen3-asr": {
        "type": "stt",
        "hf_id": "mlx-community/Qwen3-ASR-1.7B-5bit",
        "family": "qwen3_asr",
        "languages": "multilingual",
        "notes": "Qwen3-ASR 1.7B (5-bit). An audio LLM rather than an encoder-decoder ASR model: keeps Chinese/English code-switching straight without a decoding hint, and emits normal punctuation plus spacing between scripts. Takes hotwords as ``system_prompt`` (STTEngine maps the neutral ``context`` argument onto it). Bare ``qwen3-asr`` -> the 1.7B."
    },
    "qwen3-asr-1.7b": {
        "type": "stt",
        "hf_id": "mlx-community/Qwen3-ASR-1.7B-5bit",
        "family": "qwen3_asr",
        "languages": "multilingual",
        "notes": "Explicit long-form alias for ``qwen3-asr`` \u2014 same HF id."
    },
    "qwen3-asr-0.6b": {
        "type": "stt",
        "hf_id": "mlx-community/Qwen3-ASR-0.6B-5bit",
        "family": "qwen3_asr",
        "languages": "multilingual",
        "notes": "Smaller Qwen3-ASR. Faster than the 1.7B with a small accuracy cost."
    },
    "sensevoice": {
        "type": "stt",
        "hf_id": "mlx-community/SenseVoiceSmall",
        "family": "sensevoice",
        "languages": "zh,yue,ja,ko,en",
        "notes": "FunAudioLLM SenseVoice Small (~234M, non-autoregressive CTC). Dedicated fast Asian-language ASR (strong on Chinese/Cantonese/Japanese/Korean). Also emits per-segment emotion + audio-event tags. Bare ``sensevoice`` -> the small model."
    },
    "sensevoice-small": {
        "type": "stt",
        "hf_id": "mlx-community/SenseVoiceSmall",
        "family": "sensevoice",
        "languages": "zh,yue,ja,ko,en",
        "notes": "Explicit long-form alias for ``sensevoice`` \u2014 same HF id."
    }
}\n- 