### PR TITLE
Preflight suffix decode cache growth

### DIFF
--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -464,6 +464,19 @@ class TestInstallSuffixDecoding:
         with pytest.raises(RuntimeError, match="rollback violated its preflight"):
             gb._step()
 
+    def test_sliding_window_boundary_falls_through_before_verify(self, monkeypatch):
+        """A rejected verify cannot push a rotating cache past rollback safety."""
+        from mlx_lm.models.cache import BatchRotatingKVCache
+
+        _bg, gb = self._install_verify_fixture(monkeypatch, [0, 0, 0], trim_result=2)
+        cache = BatchRotatingKVCache(max_size=8, left_padding=[0])
+        cache._offset = 5
+        gb.prompt_cache = [cache]
+
+        assert gb._step() == ([], [])
+        assert cache._offset == 5
+        assert gb._suffix_stats["ft_non_trimmable_cache"] == 1
+
     def test_terminal_pending_emit_rollback_fails_closed(self, monkeypatch):
         _bg, gb = self._install_verify_fixture(
             monkeypatch,

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -477,6 +477,20 @@ class TestInstallSuffixDecoding:
         assert cache._offset == 5
         assert gb._suffix_stats["ft_non_trimmable_cache"] == 1
 
+    @pytest.mark.parametrize("bad_size", ["not-an-int", "0x10"])
+    def test_advance_rejects_unconvertible_cache_size(self, bad_size):
+        from types import SimpleNamespace
+
+        from vllm_mlx.cache_rollback import can_advance
+
+        cache = SimpleNamespace(
+            can_trim=lambda _n: True,
+            max_size=8,
+            size=lambda: bad_size,
+        )
+
+        assert not can_advance(cache, 2)
+
     def test_terminal_pending_emit_rollback_fails_closed(self, monkeypatch):
         _bg, gb = self._install_verify_fixture(
             monkeypatch,

--- a/vllm_mlx/cache_rollback.py
+++ b/vllm_mlx/cache_rollback.py
@@ -68,6 +68,23 @@ def can_trim(cache: Any, n: int) -> bool:
         return False
 
 
+def can_advance(cache: Any, n: int) -> bool:
+    """Return whether a forward can append ``n + 1`` tokens and still roll back."""
+    if not can_trim(cache, n):
+        return False
+    for leaf in _leaf_caches(cache):
+        max_size = getattr(leaf, "max_size", None)
+        size = getattr(leaf, "size", None)
+        if max_size is None or not callable(size):
+            continue
+        try:
+            if int(size()) + n + 1 >= int(max_size):
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
 def trim_all(caches: Iterable[Any], n: int) -> bool:
     """Preflight and transactionally trim every composite cache leaf."""
     if n <= 0:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2600,9 +2600,9 @@ def _install_suffix_decoding(
         # Preflight the maximum possible rollback amount before the verify
         # forward mutates anything. Composite caches are checked recursively,
         # so one side-cache cannot refuse after its sibling already trimmed.
-        from .cache_rollback import can_trim
+        from .cache_rollback import can_advance
 
-        if not all(can_trim(c, K) for c in gb.prompt_cache):
+        if not all(can_advance(c, K) for c in gb.prompt_cache):
             _stats["fallthrough_steps"] += 1
             _stats["ft_non_trimmable_cache"] += 1
             _counter.record_fallthrough("non_trimmable_cache")


### PR DESCRIPTION
## Summary
- Check that sliding-window cache leaves can absorb the full verify-forward growth before suffix decoding.
- Fall through to normal decoding when a rejected draft could no longer be rolled back.
- Add a real rotating-cache boundary regression test.

Closes #2463.

## Verification
- `pytest tests/test_suffix_decoding.py tests/test_dspark_scheduler.py -q`
- `ruff check` and `ruff format --check`
- `scripts/check_mypy_error_budget.py`