### PR TITLE
fix(mac): show per-request MTP availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
+            tests/test_speculative_request_policy.py \
             tests/test_deepseek_v4_vendored.py \
             tests/test_dspark_scheduler.py \
             tests/test_prefix_cache_persistence.py \

--- a/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
@@ -42,6 +42,46 @@
         }
       }
     },
+    "speculative_status.pending" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 正在启动"
+          }
+        }
+      }
+    },
+    "speculative_status.pending.help" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已配置。Rapid-MLX 将在生成开始时确认运行状态。"
+          }
+        }
+      }
+    },
+    "speculative_status.unavailable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不可用"
+          }
+        }
+      }
+    },
+    "speculative_status.unavailable.help" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已被请求，但无法安装其运行时挂钩。此模型正使用普通解码。"
+          }
+        }
+      }
+    },
     "Send a message…" : {
       "localizations" : {
         "zh-Hans" : {

--- a/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
@@ -2,6 +2,46 @@
   "sourceLanguage" : "en",
   "version" : "1.0",
   "strings" : {
+    "speculative_status.ready" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 可用"
+          }
+        }
+      }
+    },
+    "speculative_status.ready.help" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 可以加速本次请求。"
+          }
+        }
+      }
+    },
+    "speculative_status.paused_tools" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已暂停"
+          }
+        }
+      }
+    },
+    "speculative_status.paused_tools.help" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已配置，但工具请求需要使用普通解码。请在“设置”→“工具”中关闭工具以使用它。"
+          }
+        }
+      }
+    },
     "Send a message…" : {
       "localizations" : {
         "zh-Hans" : {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
@@ -1,5 +1,90 @@
 import Foundation
 
+/// Live speculative-decoding state returned by the resident engine.
+///
+/// Configuration and per-request eligibility are deliberately separate: a
+/// method can be attached to the model while one supported request feature
+/// asks the scheduler to use ordinary decoding for correctness.
+struct ServerSpeculativeDecoding: Codable, Sendable, Equatable {
+    let configured: Bool
+    let method: String?
+    let requestFallbackFeatures: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case configured
+        case method
+        case requestFallbackFeatures = "request_fallback_features"
+    }
+}
+
+/// Composer-facing interpretation of ``ServerSpeculativeDecoding`` for the
+/// exact request shape the Desktop is about to send.
+struct SpeculativeDecodingAvailability: Equatable, Sendable {
+    enum State: Equatable, Sendable {
+        case ready
+        case pausedByTools
+    }
+
+    let methodDisplayName: String
+    let state: State
+
+    static func resolve(
+        profile: ServerModelProfile?,
+        sendsTools: Bool
+    ) -> SpeculativeDecodingAvailability? {
+        guard let speculative = profile?.speculativeDecoding,
+              speculative.configured,
+              let method = speculative.method?.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ),
+              !method.isEmpty
+        else { return nil }
+
+        let state: State = sendsTools
+            && speculative.requestFallbackFeatures.contains("tools")
+            ? .pausedByTools
+            : .ready
+        return SpeculativeDecodingAvailability(
+            methodDisplayName: method.uppercased(),
+            state: state
+        )
+    }
+
+    func label(in bundle: Bundle = .main) -> String {
+        let key: String
+        let fallback: String
+        switch state {
+        case .ready:
+            key = "speculative_status.ready"
+            fallback = "%@ ready"
+        case .pausedByTools:
+            key = "speculative_status.paused_tools"
+            fallback = "%@ paused"
+        }
+        return String(
+            format: bundle.localizedString(forKey: key, value: fallback, table: nil),
+            methodDisplayName
+        )
+    }
+
+    func help(in bundle: Bundle = .main) -> String {
+        let key: String
+        let fallback: String
+        switch state {
+        case .ready:
+            key = "speculative_status.ready.help"
+            fallback = "%@ can accelerate this request."
+        case .pausedByTools:
+            key = "speculative_status.paused_tools.help"
+            fallback = "%@ is configured, but tools require ordinary decoding. Turn off tools in Settings → Tools to use it."
+        }
+        return String(
+            format: bundle.localizedString(forKey: key, value: fallback, table: nil),
+            methodDisplayName
+        )
+    }
+}
+
 /// Per-alias profile data returned by Rapid-MLX `/v1/models/{id}` as
 /// vendor-extension fields on top of the OpenAI-canonical shape.
 /// Mirrors the server's ``vllm_mlx.api.models.ModelInfo`` extension
@@ -94,6 +179,9 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
     /// the server, so the value the desktop trusts for sliders
     /// lines up with the cap the server will actually enforce.
     let contextWindow: Int?
+    /// Live speculative-decoding configuration and the request features that
+    /// retain ordinary decoding. Nil on older sidecars and unloaded aliases.
+    let speculativeDecoding: ServerSpeculativeDecoding?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -113,6 +201,7 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         // Issue #363 — snake_case mirrors the rapid-mlx
         // ``ModelInfo.context_window`` wire shape.
         case contextWindow = "context_window"
+        case speculativeDecoding = "speculative_decoding"
     }
 
     /// Explicit memberwise init with defaults for the FU-3 floor
@@ -134,7 +223,8 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         modality: String? = nil,
         reasoningChatFloor: Int? = nil,
         reasoningToolsFloor: Int? = nil,
-        contextWindow: Int? = nil
+        contextWindow: Int? = nil,
+        speculativeDecoding: ServerSpeculativeDecoding? = nil
     ) {
         self.id = id
         self.recommendedSampling = recommendedSampling
@@ -149,6 +239,7 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
         self.reasoningChatFloor = reasoningChatFloor
         self.reasoningToolsFloor = reasoningToolsFloor
         self.contextWindow = contextWindow
+        self.speculativeDecoding = speculativeDecoding
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
@@ -6,13 +6,21 @@ import Foundation
 /// method can be attached to the model while one supported request feature
 /// asks the scheduler to use ordinary decoding for correctness.
 struct ServerSpeculativeDecoding: Codable, Sendable, Equatable {
+    enum RuntimeState: String, Codable, Sendable, Equatable {
+        case pending
+        case active
+        case unavailable
+    }
+
     let configured: Bool
     let method: String?
+    let runtimeState: RuntimeState
     let requestFallbackFeatures: [String]
 
     enum CodingKeys: String, CodingKey {
         case configured
         case method
+        case runtimeState = "runtime_state"
         case requestFallbackFeatures = "request_fallback_features"
     }
 }
@@ -23,6 +31,8 @@ struct SpeculativeDecodingAvailability: Equatable, Sendable {
     enum State: Equatable, Sendable {
         case ready
         case pausedByTools
+        case pending
+        case unavailable
     }
 
     let methodDisplayName: String
@@ -40,10 +50,21 @@ struct SpeculativeDecodingAvailability: Equatable, Sendable {
               !method.isEmpty
         else { return nil }
 
-        let state: State = sendsTools
+        let state: State
+        if speculative.runtimeState == .unavailable {
+            state = .unavailable
+        } else if sendsTools
             && speculative.requestFallbackFeatures.contains("tools")
-            ? .pausedByTools
-            : .ready
+        {
+            // Even before the lazy BatchGenerator runs its install gate, this
+            // exact request is known to use ordinary decoding because tools
+            // activate stateful processors.
+            state = .pausedByTools
+        } else if speculative.runtimeState == .active {
+            state = .ready
+        } else {
+            state = .pending
+        }
         return SpeculativeDecodingAvailability(
             methodDisplayName: method.uppercased(),
             state: state
@@ -60,6 +81,12 @@ struct SpeculativeDecodingAvailability: Equatable, Sendable {
         case .pausedByTools:
             key = "speculative_status.paused_tools"
             fallback = "%@ paused"
+        case .pending:
+            key = "speculative_status.pending"
+            fallback = "%@ starting"
+        case .unavailable:
+            key = "speculative_status.unavailable"
+            fallback = "%@ unavailable"
         }
         return String(
             format: bundle.localizedString(forKey: key, value: fallback, table: nil),
@@ -77,6 +104,12 @@ struct SpeculativeDecodingAvailability: Equatable, Sendable {
         case .pausedByTools:
             key = "speculative_status.paused_tools.help"
             fallback = "%@ is configured, but tools require ordinary decoding. Turn off tools in Settings → Tools to use it."
+        case .pending:
+            key = "speculative_status.pending.help"
+            fallback = "%@ is configured. Rapid-MLX will confirm the runtime when generation starts."
+        case .unavailable:
+            key = "speculative_status.unavailable.help"
+            fallback = "%@ was requested, but its runtime hook could not be installed. This model is using ordinary decoding."
         }
         return String(
             format: bundle.localizedString(forKey: key, value: fallback, table: nil),
@@ -182,6 +215,13 @@ struct ServerModelProfile: Codable, Sendable, Equatable {
     /// Live speculative-decoding configuration and the request features that
     /// retain ordinary decoding. Nil on older sidecars and unloaded aliases.
     let speculativeDecoding: ServerSpeculativeDecoding?
+
+    /// A lazy speculative runtime may not know whether its generator hook can
+    /// install until generation begins. Keep polling only that non-terminal
+    /// state; active and unavailable remain stable for the generator lifetime.
+    var needsLiveProfileRefresh: Bool {
+        speculativeDecoding?.runtimeState == .pending
+    }
 
     enum CodingKeys: String, CodingKey {
         case id

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -769,6 +769,16 @@ struct ChatView: View {
                 .id(viewModel.activeConversationID)
             }
             Spacer(minLength: 0)
+            if let speculativeAvailability {
+                MetricChip(
+                    label: speculativeAvailability.label(),
+                    level: speculativeAvailability.state == .ready ? .ok : .warning
+                )
+                .help(speculativeAvailability.help())
+                .accessibilityLabel(speculativeAvailability.label())
+                .accessibilityHint(speculativeAvailability.help())
+                .accessibilityIdentifier("ChatView.SpeculativeDecodingStatus")
+            }
             ModelPickerBar(
                 server: server,
                 downloads: downloads,
@@ -779,6 +789,25 @@ struct ChatView: View {
             )
             sendOrStopButton
         }
+    }
+
+    /// Resolve status from the engine's live policy and the exact tool list the
+    /// request builder will put on the wire. This intentionally shares
+    /// ``wireDefinitions`` with ``runToolLoop`` so a catalog-level tool quirk
+    /// cannot make the badge and the request disagree.
+    private var speculativeAvailability: SpeculativeDecodingAvailability? {
+        let profile = server.activeModelProfile
+        guard profile?.id.caseInsensitiveCompare(alias) == .orderedSame else {
+            return nil
+        }
+        let sendsTools = !ChatViewModel.wireDefinitions(
+            forAlias: alias,
+            enabled: viewModel.enabledDefinitions
+        ).isEmpty
+        return SpeculativeDecodingAvailability.resolve(
+            profile: profile,
+            sendsTools: sendsTools
+        )
     }
 
     /// Send / stop. v1.0 gives the send action the amber hierarchy:

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -345,10 +345,16 @@ struct ContentView: View {
                 try? await Task.sleep(for: .seconds(5))
                 guard !Task.isCancelled else { return }
                 // Reuse the existing local residency cadence as recovery for
-                // a transient profile timeout/non-2xx. A successful profile
-                // remains authoritative for this bearer session; only a
-                // missing/mismatched profile needs another request.
-                if server.activeModelProfile?.id.caseInsensitiveCompare(alias) != .orderedSame {
+                // a transient profile timeout/non-2xx. A pending speculative
+                // runtime is also intentionally refreshed: the BatchGenerator
+                // is lazy, so its install gate may finish only when the first
+                // request starts. Active/unavailable are terminal for this
+                // generator; a replacement clears the whole profile via the
+                // existing bearer/session lifecycle.
+                let profile = server.activeModelProfile
+                let mismatched = profile?.id.caseInsensitiveCompare(alias) != .orderedSame
+                let speculativePending = profile?.needsLiveProfileRefresh == true
+                if mismatched || speculativePending {
                     await refreshSelectedModelProfile(for: alias)
                 }
             }

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -50,6 +50,7 @@ final class ServerModelProfileTests {
           "speculative_decoding": {
             "configured": true,
             "method": "mtp",
+            "runtime_state": "active",
             "request_fallback_features": ["tools"]
           },
           "modality": "text"
@@ -73,8 +74,10 @@ final class ServerModelProfileTests {
         #expect(profile.speculativeDecoding == ServerSpeculativeDecoding(
             configured: true,
             method: "mtp",
+            runtimeState: .active,
             requestFallbackFeatures: ["tools"]
         ))
+        #expect(!profile.needsLiveProfileRefresh)
         #expect(profile.modality == "text")
     }
 
@@ -113,6 +116,7 @@ final class ServerModelProfileTests {
                 speculativeDecoding: ServerSpeculativeDecoding(
                     configured: true,
                     method: "mtp",
+                    runtimeState: .active,
                     requestFallbackFeatures: ["tools"]
                 )
             ),
@@ -131,6 +135,7 @@ final class ServerModelProfileTests {
                 speculativeDecoding: ServerSpeculativeDecoding(
                     configured: true,
                     method: "mtp",
+                    runtimeState: .active,
                     requestFallbackFeatures: ["tools"]
                 )
             ),
@@ -148,6 +153,7 @@ final class ServerModelProfileTests {
                 speculativeDecoding: ServerSpeculativeDecoding(
                     configured: true,
                     method: "future",
+                    runtimeState: .active,
                     requestFallbackFeatures: []
                 )
             ),
@@ -168,11 +174,67 @@ final class ServerModelProfileTests {
                 speculativeDecoding: ServerSpeculativeDecoding(
                     configured: false,
                     method: "mtp",
+                    runtimeState: .active,
                     requestFallbackFeatures: ["tools"]
                 )
             ),
             sendsTools: true
         ) == nil)
+    }
+
+    @Test("A lazy plain runtime is pending without claiming acceleration")
+    func speculativeStatusPendingBeforeInstall() {
+        let profile = ServerModelProfile(
+            id: "model",
+            speculativeDecoding: ServerSpeculativeDecoding(
+                configured: true,
+                method: "mtp",
+                runtimeState: .pending,
+                requestFallbackFeatures: ["tools"]
+            )
+        )
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: profile,
+            sendsTools: false
+        )
+        #expect(availability?.state == .pending)
+        #expect(profile.needsLiveProfileRefresh)
+    }
+
+    @Test("A failed runtime install says unavailable, not ready")
+    func speculativeStatusUnavailableAfterInstallMiss() {
+        let profile = ServerModelProfile(
+            id: "model",
+            speculativeDecoding: ServerSpeculativeDecoding(
+                configured: true,
+                method: "mtp",
+                runtimeState: .unavailable,
+                requestFallbackFeatures: ["tools"]
+            )
+        )
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: profile,
+            sendsTools: false
+        )
+        #expect(availability?.state == .unavailable)
+        #expect(!profile.needsLiveProfileRefresh)
+    }
+
+    @Test("Tools announce ordinary decode even before lazy MTP install")
+    func speculativeStatusPendingToolsArePaused() {
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(
+                id: "model",
+                speculativeDecoding: ServerSpeculativeDecoding(
+                    configured: true,
+                    method: "mtp",
+                    runtimeState: .pending,
+                    requestFallbackFeatures: ["tools"]
+                )
+            ),
+            sendsTools: true
+        )
+        #expect(availability?.state == .pausedByTools)
     }
 
     @Test("Live text lane overrides a vision-capable catalog and explains why")
@@ -383,6 +445,13 @@ final class ServerModelProfileTests {
                 range: residencyRefresh.lowerBound..<source.endIndex
             )
         )
+        let pendingRuntimeRetry = try #require(
+            source.range(
+                of: "profile?.needsLiveProfileRefresh == true",
+                range: residencyRefresh.lowerBound..<retry.lowerBound
+            )
+        )
+        #expect(pendingRuntimeRetry.lowerBound > residencyRefresh.lowerBound)
         #expect(retry.lowerBound > residencyRefresh.lowerBound)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -47,6 +47,11 @@ final class ServerModelProfileTests {
           "capabilities": ["text", "vision", "tools"],
           "serving_lane": "vision",
           "serving_lane_reason": "vision_hybrid_runtime_supported",
+          "speculative_decoding": {
+            "configured": true,
+            "method": "mtp",
+            "request_fallback_features": ["tools"]
+          },
           "modality": "text"
         }
         """
@@ -65,6 +70,11 @@ final class ServerModelProfileTests {
         #expect(profile.capabilities == ["text", "vision", "tools"])
         #expect(profile.servingLane == "vision")
         #expect(profile.servingLaneReason == "vision_hybrid_runtime_supported")
+        #expect(profile.speculativeDecoding == ServerSpeculativeDecoding(
+            configured: true,
+            method: "mtp",
+            requestFallbackFeatures: ["tools"]
+        ))
         #expect(profile.modality == "text")
     }
 
@@ -92,6 +102,77 @@ final class ServerModelProfileTests {
         #expect(profile.capabilities == nil)
         #expect(profile.servingLane == nil)
         #expect(profile.servingLaneReason == nil)
+        #expect(profile.speculativeDecoding == nil)
+    }
+
+    @Test("MTP is ready before a plain request")
+    func speculativeStatusReadyWithoutTools() {
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(
+                id: "model",
+                speculativeDecoding: ServerSpeculativeDecoding(
+                    configured: true,
+                    method: "mtp",
+                    requestFallbackFeatures: ["tools"]
+                )
+            ),
+            sendsTools: false
+        )
+        #expect(availability?.methodDisplayName == "MTP")
+        #expect(availability?.state == .ready)
+        #expect(availability?.label().contains("MTP") == true)
+    }
+
+    @Test("MTP says it is paused before a tools request")
+    func speculativeStatusPausedByTools() {
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(
+                id: "model",
+                speculativeDecoding: ServerSpeculativeDecoding(
+                    configured: true,
+                    method: "mtp",
+                    requestFallbackFeatures: ["tools"]
+                )
+            ),
+            sendsTools: true
+        )
+        #expect(availability?.state == .pausedByTools)
+        #expect(availability?.help().isEmpty == false)
+    }
+
+    @Test("A method that supports tools stays ready when tools are sent")
+    func speculativeStatusUsesEngineAdvertisedFallbacks() {
+        let availability = SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(
+                id: "model",
+                speculativeDecoding: ServerSpeculativeDecoding(
+                    configured: true,
+                    method: "future",
+                    requestFallbackFeatures: []
+                )
+            ),
+            sendsTools: true
+        )
+        #expect(availability?.state == .ready)
+    }
+
+    @Test("No configured live method produces no composer claim")
+    func speculativeStatusRequiresConfiguredMethod() {
+        #expect(SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(id: "model"),
+            sendsTools: true
+        ) == nil)
+        #expect(SpeculativeDecodingAvailability.resolve(
+            profile: ServerModelProfile(
+                id: "model",
+                speculativeDecoding: ServerSpeculativeDecoding(
+                    configured: false,
+                    method: "mtp",
+                    requestFallbackFeatures: ["tools"]
+                )
+            ),
+            sendsTools: true
+        ) == nil)
     }
 
     @Test("Live text lane overrides a vision-capable catalog and explains why")

--- a/tests/test_speculative_request_policy.py
+++ b/tests/test_speculative_request_policy.py
@@ -42,7 +42,11 @@ def test_other_speculative_methods_do_not_inherit_mtp_tool_policy():
 def test_model_profile_reads_policy_from_matching_live_scheduler(monkeypatch):
     from vllm_mlx.routes import models as models_route
 
-    scheduler = SimpleNamespace(spec_decode_runtime_method="mtp")
+    scheduler = SimpleNamespace(
+        config=SimpleNamespace(spec_decode="mtp"),
+        spec_decode_runtime_method="mtp",
+        spec_decode_runtime_attempted=True,
+    )
     engine = object()
     monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
     monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
@@ -52,15 +56,17 @@ def test_model_profile_reads_policy_from_matching_live_scheduler(monkeypatch):
     assert info is not None
     assert info.configured is True
     assert info.method == "mtp"
+    assert info.runtime_state == "active"
     assert info.request_fallback_features == ["tools"]
     assert info.model_dump() == {
         "configured": True,
         "method": "mtp",
+        "runtime_state": "active",
         "request_fallback_features": ["tools"],
     }
 
 
-def test_model_profile_does_not_advertise_requested_but_uninstalled_method(
+def test_model_profile_reports_pending_before_lazy_runtime_install(
     monkeypatch,
 ):
     from vllm_mlx.routes import models as models_route
@@ -68,12 +74,36 @@ def test_model_profile_does_not_advertise_requested_but_uninstalled_method(
     scheduler = SimpleNamespace(
         config=SimpleNamespace(spec_decode="mtp"),
         spec_decode_runtime_method=None,
+        spec_decode_runtime_attempted=False,
     )
     engine = object()
     monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
     monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
 
-    assert models_route._resolve_speculative_decoding("served-model") is None
+    info = models_route._resolve_speculative_decoding("served-model")
+
+    assert info is not None
+    assert info.runtime_state == "pending"
+
+
+def test_model_profile_reports_unavailable_after_runtime_install_gate_miss(
+    monkeypatch,
+):
+    from vllm_mlx.routes import models as models_route
+
+    scheduler = SimpleNamespace(
+        config=SimpleNamespace(spec_decode="mtp"),
+        spec_decode_runtime_method=None,
+        spec_decode_runtime_attempted=True,
+    )
+    engine = object()
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
+
+    info = models_route._resolve_speculative_decoding("served-model")
+
+    assert info is not None
+    assert info.runtime_state == "unavailable"
 
 
 @pytest.mark.parametrize(
@@ -120,6 +150,7 @@ def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
     scheduler.uid_to_request_id = {}
     scheduler.uid_to_request_processors = {}
     scheduler.spec_decode_runtime_method = "stale"
+    scheduler.spec_decode_runtime_attempted = True
     scheduler._get_stop_tokens = lambda: set()
     scheduler.config = SimpleNamespace(
         prefill_batch_size=1,
@@ -140,6 +171,7 @@ def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
 
     assert created is batch_generator
     assert scheduler.spec_decode_runtime_method == expected_method
+    assert scheduler.spec_decode_runtime_attempted is True
 
 
 def test_closing_batch_generator_retires_published_speculative_runtime():
@@ -149,12 +181,14 @@ def test_closing_batch_generator_retires_published_speculative_runtime():
     scheduler = scheduler_module.Scheduler.__new__(scheduler_module.Scheduler)
     scheduler.batch_generator = SimpleNamespace(close=lambda: closed.append(True))
     scheduler.spec_decode_runtime_method = "mtp"
+    scheduler.spec_decode_runtime_attempted = True
 
     scheduler._close_batch_generator()
 
     assert closed == [True]
     assert scheduler.batch_generator is None
     assert scheduler.spec_decode_runtime_method is None
+    assert scheduler.spec_decode_runtime_attempted is False
 
 
 def test_model_card_carries_live_speculative_policy(monkeypatch):
@@ -164,6 +198,7 @@ def test_model_card_carries_live_speculative_policy(monkeypatch):
     expected = SpeculativeDecodingInfo(
         configured=True,
         method="mtp",
+        runtime_state="active",
         request_fallback_features=["tools"],
     )
     monkeypatch.setattr(

--- a/tests/test_speculative_request_policy.py
+++ b/tests/test_speculative_request_policy.py
@@ -42,7 +42,7 @@ def test_other_speculative_methods_do_not_inherit_mtp_tool_policy():
 def test_model_profile_reads_policy_from_matching_live_scheduler(monkeypatch):
     from vllm_mlx.routes import models as models_route
 
-    scheduler = SimpleNamespace(config=SimpleNamespace(spec_decode="mtp"))
+    scheduler = SimpleNamespace(spec_decode_runtime_method="mtp")
     engine = object()
     monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
     monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
@@ -58,6 +58,103 @@ def test_model_profile_reads_policy_from_matching_live_scheduler(monkeypatch):
         "method": "mtp",
         "request_fallback_features": ["tools"],
     }
+
+
+def test_model_profile_does_not_advertise_requested_but_uninstalled_method(
+    monkeypatch,
+):
+    from vllm_mlx.routes import models as models_route
+
+    scheduler = SimpleNamespace(
+        config=SimpleNamespace(spec_decode="mtp"),
+        spec_decode_runtime_method=None,
+    )
+    engine = object()
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
+
+    assert models_route._resolve_speculative_decoding("served-model") is None
+
+
+@pytest.mark.parametrize(
+    ("installer_succeeds", "expected_method"),
+    [(True, "mtp"), (False, None)],
+)
+def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
+    monkeypatch,
+    installer_succeeds,
+    expected_method,
+):
+    import vllm_mlx.scheduler as scheduler_module
+    from vllm_mlx.request import SamplingParams
+
+    batch_generator = SimpleNamespace()
+    monkeypatch.setattr(
+        scheduler_module,
+        "BatchGenerator",
+        lambda *args, **kwargs: batch_generator,
+    )
+    monkeypatch.setattr(
+        scheduler_module,
+        "_install_mtp_vendored",
+        lambda *args, **kwargs: installer_succeeds,
+    )
+    monkeypatch.setattr(
+        scheduler_module,
+        "_install_dense_sampler_fastpath",
+        lambda _batch_generator: None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.singleton_cache_fastpath.install_singleton_cache_fastpath",
+        lambda: None,
+    )
+
+    scheduler = scheduler_module.Scheduler.__new__(scheduler_module.Scheduler)
+    scheduler.model = object()
+    scheduler.tokenizer = object()
+    scheduler.model_config = SimpleNamespace(
+        supports_spec_decode=True,
+        name="served-model",
+    )
+    scheduler.requests = {}
+    scheduler.uid_to_request_id = {}
+    scheduler.uid_to_request_processors = {}
+    scheduler.spec_decode_runtime_method = "stale"
+    scheduler._get_stop_tokens = lambda: set()
+    scheduler.config = SimpleNamespace(
+        prefill_batch_size=1,
+        completion_batch_size=1,
+        prefill_step_size=1,
+        kv_cache_quantization=False,
+        kv_cache_turboquant=None,
+        spec_decode="mtp",
+        mtp_model_type="qwen4_exp",
+        mtp_max_k=3,
+        mtp_disable_auto_k=False,
+        model_name="served-model",
+        mtp_sidecar=None,
+        enable_suffix_decoding=False,
+    )
+
+    created = scheduler._create_batch_generator(SamplingParams(max_tokens=8))
+
+    assert created is batch_generator
+    assert scheduler.spec_decode_runtime_method == expected_method
+
+
+def test_closing_batch_generator_retires_published_speculative_runtime():
+    import vllm_mlx.scheduler as scheduler_module
+
+    closed = []
+    scheduler = scheduler_module.Scheduler.__new__(scheduler_module.Scheduler)
+    scheduler.batch_generator = SimpleNamespace(close=lambda: closed.append(True))
+    scheduler.spec_decode_runtime_method = "mtp"
+
+    scheduler._close_batch_generator()
+
+    assert closed == [True]
+    assert scheduler.batch_generator is None
+    assert scheduler.spec_decode_runtime_method is None
 
 
 def test_model_card_carries_live_speculative_policy(monkeypatch):

--- a/tests/test_speculative_request_policy.py
+++ b/tests/test_speculative_request_policy.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live speculative configuration vs request-level fallback contract."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("method", [None, "", "none", " NONE ", 7])
+def test_disabled_speculative_methods_have_no_live_policy(method):
+    from vllm_mlx.speculative.request_policy import (
+        resolve_speculative_request_policy,
+    )
+
+    assert resolve_speculative_request_policy(method) is None
+
+
+def test_mtp_policy_reports_tools_as_safe_ordinary_decode_fallback():
+    from vllm_mlx.speculative.request_policy import (
+        resolve_speculative_request_policy,
+    )
+
+    policy = resolve_speculative_request_policy(" MTP ")
+    assert policy is not None
+    assert policy.method == "mtp"
+    assert policy.request_fallback_features == ("tools",)
+
+
+def test_other_speculative_methods_do_not_inherit_mtp_tool_policy():
+    from vllm_mlx.speculative.request_policy import (
+        resolve_speculative_request_policy,
+    )
+
+    policy = resolve_speculative_request_policy("suffix")
+    assert policy is not None
+    assert policy.method == "suffix"
+    assert policy.request_fallback_features == ()
+
+
+def test_model_profile_reads_policy_from_matching_live_scheduler(monkeypatch):
+    from vllm_mlx.routes import models as models_route
+
+    scheduler = SimpleNamespace(config=SimpleNamespace(spec_decode="mtp"))
+    engine = object()
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda candidate: scheduler)
+
+    info = models_route._resolve_speculative_decoding("served-model")
+
+    assert info is not None
+    assert info.configured is True
+    assert info.method == "mtp"
+    assert info.request_fallback_features == ["tools"]
+    assert info.model_dump() == {
+        "configured": True,
+        "method": "mtp",
+        "request_fallback_features": ["tools"],
+    }
+
+
+def test_model_card_carries_live_speculative_policy(monkeypatch):
+    from vllm_mlx.api.models import SpeculativeDecodingInfo
+    from vllm_mlx.routes import models as models_route
+
+    expected = SpeculativeDecodingInfo(
+        configured=True,
+        method="mtp",
+        request_fallback_features=["tools"],
+    )
+    monkeypatch.setattr(
+        models_route, "_resolve_speculative_decoding", lambda _model_id: expected
+    )
+    monkeypatch.setattr(models_route, "_resolve_context_window", lambda _model_id: None)
+    monkeypatch.setattr(
+        models_route,
+        "_resolve_max_model_len",
+        lambda _model_id, _native_context: None,
+    )
+    monkeypatch.setattr(models_route, "_audio_lane_snapshot", lambda: None)
+    monkeypatch.setattr(
+        models_route, "_served_lane_fields", lambda _model_id: (None, None)
+    )
+    monkeypatch.setattr(models_route, "_resolve_audio_entry", lambda _model_id: None)
+    monkeypatch.setattr(models_route, "_locked_embedding_id", lambda: None)
+    monkeypatch.setattr(
+        models_route, "_reported_hybrid", lambda _model_id, static: static
+    )
+    monkeypatch.setattr(
+        models_route,
+        "effective_parsers_for",
+        lambda _model_id, tool, reasoning: (tool, reasoning),
+    )
+    monkeypatch.setattr(
+        models_route, "_detect_capabilities", lambda *_args, **_kwargs: ["text"]
+    )
+    monkeypatch.setattr(
+        models_route,
+        "_reported_modality",
+        lambda _model_id, modality, _is_text_only=False: modality,
+    )
+
+    info = models_route._build_model_info("qwen3.8-27b-4bit")
+
+    assert info.speculative_decoding == expected
+    assert info.model_dump()["speculative_decoding"] == expected.model_dump()
+
+
+@pytest.mark.parametrize("engine,scheduler", [(None, object()), (object(), None)])
+def test_model_profile_never_advertises_unattached_runtime(
+    monkeypatch, engine, scheduler
+):
+    from vllm_mlx.routes import models as models_route
+
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: engine)
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda _engine: scheduler)
+
+    assert models_route._resolve_speculative_decoding("unloaded-model") is None

--- a/tests/test_speculative_request_policy.py
+++ b/tests/test_speculative_request_policy.py
@@ -115,6 +115,7 @@ def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
     installer_succeeds,
     expected_method,
 ):
+    pytest.importorskip("mlx")
     import vllm_mlx.scheduler as scheduler_module
     from vllm_mlx.request import SamplingParams
 
@@ -175,6 +176,7 @@ def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
 
 
 def test_closing_batch_generator_retires_published_speculative_runtime():
+    pytest.importorskip("mlx")
     import vllm_mlx.scheduler as scheduler_module
 
     closed = []

--- a/tests/test_speculative_request_policy.py
+++ b/tests/test_speculative_request_policy.py
@@ -106,29 +106,70 @@ def test_model_profile_reports_unavailable_after_runtime_install_gate_miss(
     assert info.runtime_state == "unavailable"
 
 
-@pytest.mark.parametrize(
-    ("installer_succeeds", "expected_method"),
-    [(True, "mtp"), (False, None)],
-)
-def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
-    monkeypatch,
-    installer_succeeds,
-    expected_method,
-):
-    pytest.importorskip("mlx")
-    import vllm_mlx.scheduler as scheduler_module
-    from vllm_mlx.request import SamplingParams
+def test_model_profile_reads_legacy_suffix_configuration(monkeypatch):
+    from vllm_mlx.routes import models as models_route
+
+    scheduler = SimpleNamespace(
+        config=SimpleNamespace(
+            spec_decode="none",
+            enable_suffix_decoding=True,
+        ),
+        spec_decode_runtime_method="suffix",
+        spec_decode_runtime_attempted=True,
+    )
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: object())
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda _engine: scheduler)
+
+    info = models_route._resolve_speculative_decoding("served-model")
+
+    assert info is not None
+    assert info.method == "suffix"
+    assert info.runtime_state == "active"
+
+
+def test_model_profile_omits_disabled_speculative_configuration(monkeypatch):
+    from vllm_mlx.routes import models as models_route
+
+    scheduler = SimpleNamespace(
+        config=SimpleNamespace(
+            spec_decode="none",
+            enable_suffix_decoding=False,
+        )
+    )
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: object())
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda _engine: scheduler)
+
+    assert models_route._resolve_speculative_decoding("served-model") is None
+
+
+def test_model_profile_fails_closed_when_policy_probe_raises(monkeypatch):
+    from vllm_mlx.routes import models as models_route
+    from vllm_mlx.speculative import request_policy
+
+    scheduler = SimpleNamespace(config=SimpleNamespace(spec_decode="mtp"))
+    monkeypatch.setattr(models_route, "_engine_for", lambda _model_id: object())
+    monkeypatch.setattr(models_route, "_scheduler_of", lambda _engine: scheduler)
+
+    def fail_probe(_method):
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(
+        request_policy,
+        "resolve_speculative_request_policy",
+        fail_probe,
+    )
+
+    assert models_route._resolve_speculative_decoding("served-model") is None
+
+
+def _stub_runtime_scheduler(monkeypatch, scheduler_module, **config_overrides):
+    """Build the narrow real-Scheduler seam shared by installer-state tests."""
 
     batch_generator = SimpleNamespace()
     monkeypatch.setattr(
         scheduler_module,
         "BatchGenerator",
         lambda *args, **kwargs: batch_generator,
-    )
-    monkeypatch.setattr(
-        scheduler_module,
-        "_install_mtp_vendored",
-        lambda *args, **kwargs: installer_succeeds,
     )
     monkeypatch.setattr(
         scheduler_module,
@@ -153,25 +194,91 @@ def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
     scheduler.spec_decode_runtime_method = "stale"
     scheduler.spec_decode_runtime_attempted = True
     scheduler._get_stop_tokens = lambda: set()
-    scheduler.config = SimpleNamespace(
-        prefill_batch_size=1,
-        completion_batch_size=1,
-        prefill_step_size=1,
-        kv_cache_quantization=False,
-        kv_cache_turboquant=None,
+    config = {
+        "prefill_batch_size": 1,
+        "completion_batch_size": 1,
+        "prefill_step_size": 1,
+        "kv_cache_quantization": False,
+        "kv_cache_turboquant": None,
+        "spec_decode": "none",
+        "mtp_model_type": "qwen4_exp",
+        "mtp_max_k": 3,
+        "mtp_disable_auto_k": False,
+        "model_name": "served-model",
+        "mtp_sidecar": None,
+        "dspark_num_speculative_tokens": 5,
+        "enable_suffix_decoding": False,
+        "suffix_max_draft": 8,
+        "suffix_max_suffix_len": 64,
+        "suffix_min_confidence": 0.5,
+        "suffix_min_draft_len": 2,
+    }
+    config.update(config_overrides)
+    scheduler.config = SimpleNamespace(**config)
+    return scheduler, batch_generator
+
+
+@pytest.mark.parametrize(
+    ("installer_succeeds", "expected_method"),
+    [(True, "mtp"), (False, None)],
+)
+def test_scheduler_publishes_only_a_successfully_installed_mtp_runtime(
+    monkeypatch,
+    installer_succeeds,
+    expected_method,
+):
+    pytest.importorskip("mlx")
+    import vllm_mlx.scheduler as scheduler_module
+    from vllm_mlx.request import SamplingParams
+
+    monkeypatch.setattr(
+        scheduler_module,
+        "_install_mtp_vendored",
+        lambda *args, **kwargs: installer_succeeds,
+    )
+    scheduler, batch_generator = _stub_runtime_scheduler(
+        monkeypatch,
+        scheduler_module,
         spec_decode="mtp",
-        mtp_model_type="qwen4_exp",
-        mtp_max_k=3,
-        mtp_disable_auto_k=False,
-        model_name="served-model",
-        mtp_sidecar=None,
-        enable_suffix_decoding=False,
     )
 
     created = scheduler._create_batch_generator(SamplingParams(max_tokens=8))
 
     assert created is batch_generator
     assert scheduler.spec_decode_runtime_method == expected_method
+    assert scheduler.spec_decode_runtime_attempted is True
+
+
+@pytest.mark.parametrize("method", ["dspark", "suffix"])
+def test_scheduler_publishes_other_successfully_installed_runtimes(
+    monkeypatch,
+    method,
+):
+    pytest.importorskip("mlx")
+    import vllm_mlx.scheduler as scheduler_module
+    from vllm_mlx.request import SamplingParams
+
+    monkeypatch.setattr(
+        scheduler_module,
+        "_install_dspark",
+        lambda *args, **kwargs: method == "dspark",
+    )
+    monkeypatch.setattr(
+        scheduler_module,
+        "_install_suffix_decoding",
+        lambda *args, **kwargs: method == "suffix",
+    )
+    scheduler, batch_generator = _stub_runtime_scheduler(
+        monkeypatch,
+        scheduler_module,
+        spec_decode="dspark" if method == "dspark" else "none",
+        enable_suffix_decoding=method == "suffix",
+    )
+
+    created = scheduler._create_batch_generator(SamplingParams(max_tokens=8))
+
+    assert created is batch_generator
+    assert scheduler.spec_decode_runtime_method == method
     assert scheduler.spec_decode_runtime_attempted is True
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2465,6 +2465,20 @@ class CompletionResponse(BaseModel):
 # =============================================================================
 
 
+class SpeculativeDecodingInfo(BaseModel):
+    """Live speculative-decoding state for one served model.
+
+    ``configured`` describes the engine session. Request features in
+    ``request_fallback_features`` remain fully supported, but use ordinary
+    decoding because their stateful generation constraints cannot yet cross
+    speculative verification safely.
+    """
+
+    configured: bool
+    method: str | None = None
+    request_fallback_features: list[Literal["tools"]] = Field(default_factory=list)
+
+
 class ModelInfo(BaseModel):
     """Information about an available model.
 
@@ -2584,6 +2598,11 @@ class ModelInfo(BaseModel):
     # install missing ``misaki``, etc.). Values:
     # ``"ok"``, ``"degraded"``, ``"missing"``, ``"unknown"``.
     audio_lanes: dict[str, str] | None = None
+    # Live engine speculative-decoding state. ``None`` means no matching
+    # resident engine is configured for speculative decoding. A non-null value
+    # separates process configuration from request eligibility so clients do
+    # not infer "active for this request" from a launch flag alone.
+    speculative_decoding: SpeculativeDecodingInfo | None = None
 
 
 class ModelsResponse(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2468,7 +2468,9 @@ class CompletionResponse(BaseModel):
 class SpeculativeDecodingInfo(BaseModel):
     """Live speculative-decoding state for one served model.
 
-    ``configured`` describes the engine session. Request features in
+    ``configured`` describes the engine session. ``runtime_state`` separates
+    a lazy generator that has not run its install gate from a successfully
+    attached hook and a definitive gate miss. Request features in
     ``request_fallback_features`` remain fully supported, but use ordinary
     decoding because their stateful generation constraints cannot yet cross
     speculative verification safely.
@@ -2476,6 +2478,7 @@ class SpeculativeDecodingInfo(BaseModel):
 
     configured: bool
     method: str | None = None
+    runtime_state: Literal["pending", "active", "unavailable"]
     request_fallback_features: list[Literal["tools"]] = Field(default_factory=list)
 
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -128,13 +128,14 @@ def _resolve_max_model_len(model_id: str, native_context: int | None) -> int | N
 def _resolve_speculative_decoding(
     model_id: str,
 ) -> SpeculativeDecodingInfo | None:
-    """Return live speculative configuration and request fallback features.
+    """Return configured speculative policy and its live runtime state.
 
-    The matching scheduler config is the source of truth. Discovery-only
-    aliases and engines whose scheduler is not yet attached return ``None``;
-    clients must never mistake a saved launch preference for live capability.
-    Any malformed or future runtime value degrades to ``None`` rather than
-    making model discovery fail.
+    The matching scheduler is the source of truth. Its configured method says
+    what the operator requested; the runtime method is published only after
+    the current BatchGenerator's installer succeeds. Discovery-only aliases
+    and engines whose scheduler is not yet attached return ``None``. Any
+    malformed or future value degrades to ``None`` rather than making model
+    discovery fail.
     """
 
     engine = _engine_for(model_id)
@@ -148,9 +149,13 @@ def _resolve_speculative_decoding(
             resolve_speculative_request_policy,
         )
 
-        policy = resolve_speculative_request_policy(
-            getattr(scheduler, "spec_decode_runtime_method", None)
-        )
+        config = getattr(scheduler, "config", None)
+        configured_method = getattr(config, "spec_decode", None)
+        if configured_method in (None, "none") and getattr(
+            config, "enable_suffix_decoding", False
+        ):
+            configured_method = "suffix"
+        policy = resolve_speculative_request_policy(configured_method)
     except Exception as exc:  # noqa: BLE001
         logger.debug(
             "speculative request policy probe failed for %s: %s",
@@ -161,9 +166,18 @@ def _resolve_speculative_decoding(
         return None
     if policy is None:
         return None
+    runtime_method = getattr(scheduler, "spec_decode_runtime_method", None)
+    attempted = getattr(scheduler, "spec_decode_runtime_attempted", False)
+    if runtime_method == policy.method:
+        runtime_state = "active"
+    elif attempted:
+        runtime_state = "unavailable"
+    else:
+        runtime_state = "pending"
     return SpeculativeDecodingInfo(
         configured=True,
         method=policy.method,
+        runtime_state=runtime_state,
         request_fallback_features=list(policy.request_fallback_features),
     )
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -12,6 +12,7 @@ on ``qwen3.5-9b-4bit`` doesn't have to hand-tune sliders.
 """
 
 import logging
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -168,6 +169,7 @@ def _resolve_speculative_decoding(
         return None
     runtime_method = getattr(scheduler, "spec_decode_runtime_method", None)
     attempted = getattr(scheduler, "spec_decode_runtime_attempted", False)
+    runtime_state: Literal["pending", "active", "unavailable"]
     if runtime_method == policy.method:
         runtime_state = "active"
     elif attempted:

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -148,9 +148,8 @@ def _resolve_speculative_decoding(
             resolve_speculative_request_policy,
         )
 
-        config = getattr(scheduler, "config", None)
         policy = resolve_speculative_request_policy(
-            getattr(config, "spec_decode", None)
+            getattr(scheduler, "spec_decode_runtime_method", None)
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug(

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -16,7 +16,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..agents.codex_catalog import build_codex_model_info
-from ..api.models import ModelInfo, ModelsResponse
+from ..api.models import ModelInfo, ModelsResponse, SpeculativeDecodingInfo
 from ..api.utils import is_mllm_model
 from ..config import get_config
 from ..middleware.auth import verify_api_key
@@ -123,6 +123,50 @@ def _resolve_max_model_len(model_id: str, native_context: int | None) -> int | N
     if isinstance(native_context, int) and native_context > 0:
         value = min(value, native_context)
     return value
+
+
+def _resolve_speculative_decoding(
+    model_id: str,
+) -> SpeculativeDecodingInfo | None:
+    """Return live speculative configuration and request fallback features.
+
+    The matching scheduler config is the source of truth. Discovery-only
+    aliases and engines whose scheduler is not yet attached return ``None``;
+    clients must never mistake a saved launch preference for live capability.
+    Any malformed or future runtime value degrades to ``None`` rather than
+    making model discovery fail.
+    """
+
+    engine = _engine_for(model_id)
+    if engine is None:
+        return None
+    scheduler = _scheduler_of(engine)
+    if scheduler is None:
+        return None
+    try:
+        from ..speculative.request_policy import (
+            resolve_speculative_request_policy,
+        )
+
+        config = getattr(scheduler, "config", None)
+        policy = resolve_speculative_request_policy(
+            getattr(config, "spec_decode", None)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "speculative request policy probe failed for %s: %s",
+            model_id,
+            exc,
+            exc_info=False,
+        )
+        return None
+    if policy is None:
+        return None
+    return SpeculativeDecodingInfo(
+        configured=True,
+        method=policy.method,
+        request_fallback_features=list(policy.request_fallback_features),
+    )
 
 
 def _resolve_context_window(model_id: str) -> int | None:
@@ -927,6 +971,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # (which would require a separate dry-run per audio alias).
     audio_lanes = _audio_lane_snapshot()
     serving_lane, serving_lane_reason = _served_lane_fields(model_id)
+    speculative_decoding = _resolve_speculative_decoding(model_id)
 
     # R11-B-F4 (Bo 0.8.12 dogfood): audio aliases get an audio-shaped
     # ModelInfo regardless of whether the registry has a text profile
@@ -952,6 +997,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             modality="audio",
             capabilities=audio_caps,
             audio_lanes=audio_lanes,
+            speculative_decoding=speculative_decoding,
         )
 
     locked = _locked_embedding_id()
@@ -971,6 +1017,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                 context_window=context_window,
                 max_model_len=max_model_len,
                 audio_lanes=audio_lanes,
+                speculative_decoding=speculative_decoding,
             )
         sampling = (
             dict(profile.recommended_sampling)
@@ -992,6 +1039,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             context_window=context_window,
             max_model_len=max_model_len,
             audio_lanes=audio_lanes,
+            speculative_decoding=speculative_decoding,
         )
 
     if profile is None:
@@ -1038,6 +1086,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                     audio_lanes=audio_lanes,
                     serving_lane=serving_lane,
                     serving_lane_reason=serving_lane_reason,
+                    speculative_decoding=speculative_decoding,
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -1052,6 +1101,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             audio_lanes=audio_lanes,
             serving_lane=serving_lane,
             serving_lane_reason=serving_lane_reason,
+            speculative_decoding=speculative_decoding,
         )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
@@ -1096,6 +1146,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         audio_lanes=audio_lanes,
         serving_lane=serving_lane,
         serving_lane_reason=serving_lane_reason,
+        speculative_decoding=speculative_decoding,
     )
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2231,7 +2231,7 @@ def _install_suffix_decoding(
     requests: dict[str, Any],
     uid_to_request_id: dict[int, str],
     min_draft_len: int = 2,
-) -> None:
+) -> bool:
     """Monkey-patch BatchGenerator's GenerationBatch to add SuffixDecoding.
 
     Drafter-free spec-decode: a suffix-tree index over prompt + emitted
@@ -2276,7 +2276,7 @@ def _install_suffix_decoding(
             "to step-update on recurrent layers. See "
             "evals/results/SUFFIX_POC_REPORT.md."
         )
-        return
+        return False
 
     # mlx-lm 0.31+ moved the actual generation step from BatchGenerator
     # to GenerationBatch. The _generation_batch instance is created once
@@ -2288,7 +2288,7 @@ def _install_suffix_decoding(
             "[SuffixDecoding] disabled: BatchGenerator has no _generation_batch "
             "attribute (mlx-lm version mismatch — expected ≥0.31)."
         )
-        return
+        return False
 
     _orig_step = gb._step
     _orig_next = gb.next
@@ -3019,6 +3019,7 @@ def _install_suffix_decoding(
         max_suffix_len,
         min_confidence,
     )
+    return True
 
 
 class Scheduler:
@@ -3199,6 +3200,12 @@ class Scheduler:
         # BatchGenerator - the actual batching engine
         self.batch_generator: BatchGenerator | None = None
         self._current_sampler_params: tuple | None = None
+        # Successfully installed speculative runtime for the current
+        # BatchGenerator. The configured selector alone is not proof that the
+        # model/runtime hooks passed their install gates. Model-profile clients
+        # read this live value so they never advertise an acceleration path that
+        # silently fell back to ordinary decoding.
+        self.spec_decode_runtime_method: str | None = None
 
         # Sampler cache: interns ``make_sampler`` results keyed on
         # ``(temp, top_p, min_p, top_k)``. Homogeneous concurrent
@@ -3752,6 +3759,9 @@ class Scheduler:
         self, sampling_params: SamplingParams
     ) -> BatchGenerator:
         """Create a BatchGenerator with the given sampling parameters."""
+        # Publish nothing until one installer below has successfully attached
+        # its runtime hooks to this exact generator.
+        self.spec_decode_runtime_method = None
         sampler = make_sampler(
             temp=sampling_params.temperature,
             top_p=sampling_params.top_p,
@@ -3855,7 +3865,7 @@ class Scheduler:
                     mtp_model_type,
                 )
             else:
-                _install_mtp_vendored(
+                mtp_installed = _install_mtp_vendored(
                     bg,
                     model=self.model,
                     requests=self.requests,
@@ -3879,19 +3889,22 @@ class Scheduler:
                         getattr(self.config, "mtp_sidecar", None),
                     ),
                 )
+                if mtp_installed:
+                    self.spec_decode_runtime_method = "mtp"
 
         if getattr(self.config, "spec_decode", "none") == "dspark":
-            _install_dspark(
+            if _install_dspark(
                 bg,
                 model=self.model,
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,
                 max_draft=getattr(self.config, "dspark_num_speculative_tokens", 5),
-            )
+            ):
+                self.spec_decode_runtime_method = "dspark"
 
         # Install SuffixDecoding (drafter-free spec-decode).
         if self.config.enable_suffix_decoding:
-            _install_suffix_decoding(
+            if _install_suffix_decoding(
                 bg,
                 model=self.model,
                 profile=self.model_config,
@@ -3901,7 +3914,8 @@ class Scheduler:
                 min_draft_len=self.config.suffix_min_draft_len,
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,
-            )
+            ):
+                self.spec_decode_runtime_method = "suffix"
 
         # Install batched-sampler fast path. Must run AFTER MTP /
         # SuffixDecoding since they may replace _step on the
@@ -4194,6 +4208,10 @@ class Scheduler:
             except Exception as e:
                 logger.debug(f"Error closing BatchGenerator: {e}")
             self.batch_generator = None
+        # The hook lives on the closed generator. Clear its published runtime
+        # state even when close() raised; a replacement will republish only
+        # after its own installer succeeds.
+        self.spec_decode_runtime_method = None
 
     def _ensure_batch_generator(self, sampling_params: SamplingParams) -> bool:
         """Ensure BatchGenerator exists with compatible stop token configuration.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3206,6 +3206,10 @@ class Scheduler:
         # read this live value so they never advertise an acceleration path that
         # silently fell back to ordinary decoding.
         self.spec_decode_runtime_method: str | None = None
+        # False until the current BatchGenerator has run the configured
+        # install gate. This distinguishes a lazy generator that has not been
+        # created yet from a definitive gate miss on an incompatible runtime.
+        self.spec_decode_runtime_attempted = False
 
         # Sampler cache: interns ``make_sampler`` results keyed on
         # ``(temp, top_p, min_p, top_k)``. Homogeneous concurrent
@@ -3762,6 +3766,7 @@ class Scheduler:
         # Publish nothing until one installer below has successfully attached
         # its runtime hooks to this exact generator.
         self.spec_decode_runtime_method = None
+        self.spec_decode_runtime_attempted = False
         sampler = make_sampler(
             temp=sampling_params.temperature,
             top_p=sampling_params.top_p,
@@ -3891,6 +3896,7 @@ class Scheduler:
                 )
                 if mtp_installed:
                     self.spec_decode_runtime_method = "mtp"
+            self.spec_decode_runtime_attempted = True
 
         if getattr(self.config, "spec_decode", "none") == "dspark":
             if _install_dspark(
@@ -3901,6 +3907,7 @@ class Scheduler:
                 max_draft=getattr(self.config, "dspark_num_speculative_tokens", 5),
             ):
                 self.spec_decode_runtime_method = "dspark"
+            self.spec_decode_runtime_attempted = True
 
         # Install SuffixDecoding (drafter-free spec-decode).
         if self.config.enable_suffix_decoding:
@@ -3916,6 +3923,7 @@ class Scheduler:
                 uid_to_request_id=self.uid_to_request_id,
             ):
                 self.spec_decode_runtime_method = "suffix"
+            self.spec_decode_runtime_attempted = True
 
         # Install batched-sampler fast path. Must run AFTER MTP /
         # SuffixDecoding since they may replace _step on the
@@ -4212,6 +4220,7 @@ class Scheduler:
         # state even when close() raised; a replacement will republish only
         # after its own installer succeeds.
         self.spec_decode_runtime_method = None
+        self.spec_decode_runtime_attempted = False
 
     def _ensure_batch_generator(self, sampling_params: SamplingParams) -> bool:
         """Ensure BatchGenerator exists with compatible stop token configuration.

--- a/vllm_mlx/speculative/request_policy.py
+++ b/vllm_mlx/speculative/request_policy.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-level compatibility policy for speculative decoding.
+
+Speculative decoding is configured once when an engine starts, but some
+request features can require the scheduler to use ordinary decoding for that
+request.  Keep that distinction in the engine package so API clients can
+report the effective request path without reproducing scheduler internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpeculativeRequestPolicy:
+    """Configured method and request features that trigger safe fallback."""
+
+    method: str
+    request_fallback_features: tuple[str, ...] = ()
+
+
+def resolve_speculative_request_policy(
+    method: object,
+) -> SpeculativeRequestPolicy | None:
+    """Return the policy for one configured method, or ``None`` when off.
+
+    MTP verifies tokens through the target model, but its current request-local
+    sampler contract admits only the scheduler's standard penalty processors.
+    Tool requests add grammar and agent-loop processors, so the scheduler
+    deliberately keeps those requests on ordinary decoding.  Advertising that
+    fact is additive; it does not weaken the fail-closed processor identity
+    check in the decode loop.
+    """
+
+    if not isinstance(method, str):
+        return None
+    normalized = method.strip().lower()
+    if normalized in ("", "none"):
+        return None
+    fallback_features = ("tools",) if normalized == "mtp" else ()
+    return SpeculativeRequestPolicy(
+        method=normalized,
+        request_fallback_features=fallback_features,
+    )

--- a/vllm_mlx/speculative/request_policy.py
+++ b/vllm_mlx/speculative/request_policy.py
@@ -10,6 +10,9 @@ report the effective request path without reproducing scheduler internals.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
+
+SpeculativeRequestFallbackFeature = Literal["tools"]
 
 
 @dataclass(frozen=True)
@@ -17,7 +20,7 @@ class SpeculativeRequestPolicy:
     """Configured method and request features that trigger safe fallback."""
 
     method: str
-    request_fallback_features: tuple[str, ...] = ()
+    request_fallback_features: tuple[SpeculativeRequestFallbackFeature, ...] = ()
 
 
 def resolve_speculative_request_policy(
@@ -38,7 +41,9 @@ def resolve_speculative_request_policy(
     normalized = method.strip().lower()
     if normalized in ("", "none"):
         return None
-    fallback_features = ("tools",) if normalized == "mtp" else ()
+    fallback_features: tuple[SpeculativeRequestFallbackFeature, ...] = (
+        ("tools",) if normalized == "mtp" else ()
+    )
     return SpeculativeRequestPolicy(
         method=normalized,
         request_fallback_features=fallback_features,


### PR DESCRIPTION
## User-visible goal

Tell Desktop users before they send whether the configured speculative decoder will accelerate the exact request, while preserving tools and the engine's correctness-first ordinary-decode fallback.

Fixes #2658

## What changed

- expose live speculative-decoding configuration, `pending → active | unavailable` runtime state, and request fallback features in each resident model's typed profile
- keep request compatibility policy engine-owned instead of inferring it from model names or launch arguments
- show `MTP ready` only after the runtime hook installs, `MTP paused` when the outgoing request advertises tools, and honest starting/unavailable states around the lazy install gate
- derive the UI status from the same filtered tool definitions used to build the request
- refresh only a pending runtime on the existing residency cadence, so the first request's install result reaches the composer without polling terminal states
- retain backward compatibility with older sidecars and unloaded aliases

## Design precedent

Mature serving runtimes separate process-level speculative configuration from request-local eligibility and observed activity. This change adopts that boundary: the resident engine publishes typed applicability metadata, while existing attempts, accepts, and tokens-saved metrics continue to describe actual work. The client consumes that contract and does not reproduce scheduler processor rules.

A process-global configured gauge was intentionally not added: it could become stale after unload or model replacement. The live per-model profile and existing activity counters remain authoritative across lifecycle transitions.

## Scope / non-goals

This PR changes only the model profile contract, the engine-owned request policy, the Desktop composer status, localization, focused tests, and enrollment of the real-Scheduler policy test in the existing Apple coverage roster. It does not weaken grammar or tool-loop processors, remove tools, enable speculative execution for stateful processors, change model defaults, or bump dependencies/releases.

## Verification

- Python/API/scheduler focused suite: 162 passed
- Desktop profile suite: 46 passed
- Desktop localization/accessibility/profile subset: 71 passed
- exact runtime-policy + CI-roster contracts: 42 passed; every line reported by the first hosted changed-lines union is covered
- Ruff check + format check + `git diff --check`: clean
- full local `pr_validate`: MERGE-SAFE, 492 targeted and 19,738 full-unit tests passed
- exact production-tree release bundle built and ad-hoc signed (`candidate-55ecd098`; the final commit changes tests/coverage roster only)
- real Desktop, cached `qwen3.8-27b-4bit`, MTP K=3:
  - tools on: UI showed `MTP paused`, exact response correct, attempts/accepts/tokens-saved stayed 0/0/0
  - tools off through Settings: UI showed `MTP ready`, correct Python response, metrics reached 140/114/114
  - tools restored through Settings; status returned to `MTP paused`; app and owned sidecar exited cleanly

## Risk and compatibility

The wire field is additive and optional. Older Desktop builds ignore it; this Desktop build treats a missing field as no claim. Any malformed runtime probe degrades to no status rather than failing model discovery.
