### PR TITLE
ci(release): gate publication on real FLUX generation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -271,15 +271,18 @@ jobs:
     # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
     # (warm/cold) — the budget is for the pathological retry path, not the
     # expected one.
-    # 165, not 125: the release-shaped Desktop sidecar build and two-model,
-    # positive/negative real-image checks now follow the agent gate. The agent
-    # path retains its documented ~121-minute worst case; each model is bounded
-    # to 4 minutes of startup plus two 4-minute requests (24 minutes total), and
-    # the measured clean sidecar build gets 15 minutes of fail-closed headroom.
-    # 121 + 24 + 15 = 160, rounded to 165 for setup and cleanup. This outer cap
-    # is not a substitute for the per-request bounds: it only prevents healthy
-    # checks near their individual budgets from being guillotined by the job.
-    timeout-minutes: 165
+    # 175, not 125: the release-shaped Desktop sidecar build, two-model
+    # positive/negative chat-photo checks, and FLUX image-generation check now
+    # follow the agent gate. The agent
+    # path retains its documented ~121-minute worst case. The two chat-photo
+    # models each get 4 minutes of startup plus two 4-minute requests (24
+    # minutes total); FLUX gets 4 minutes of startup plus one 5-minute render;
+    # and the measured clean sidecar build gets 15 minutes of fail-closed
+    # headroom. 121 + 24 + 9 + 15 = 169, rounded to 175 for setup and cleanup.
+    # This outer cap is not a substitute for the per-request bounds: it only
+    # prevents healthy checks near their individual budgets from being
+    # guillotined by the job.
+    timeout-minutes: 175
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:
@@ -319,6 +322,8 @@ jobs:
           SIDECAR_VISION_SMOKE_REVISION: ${{ steps.sidecar-pins.outputs.qwen_revision }}
           SIDECAR_GEMMA_SMOKE_MODEL: ${{ steps.sidecar-pins.outputs.gemma_model }}
           SIDECAR_GEMMA_SMOKE_REVISION: ${{ steps.sidecar-pins.outputs.gemma_revision }}
+          SIDECAR_IMAGE_SMOKE_MODEL: ${{ steps.sidecar-pins.outputs.flux_model }}
+          SIDECAR_IMAGE_SMOKE_REVISION: ${{ steps.sidecar-pins.outputs.flux_revision }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
@@ -334,10 +339,11 @@ jobs:
 
           RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh qwen3.6-35b-8bit
 
-          # Build the exact Desktop sidecar recipe and require a real PNG to
-          # traverse its production scheduler + HTTP route. Every normal
-          # auto-release is blocked by a missing immutable snapshot,
-          # incompatible reduced dependency set, or failed image request.
+          # Build the exact Desktop sidecar recipe and require real chat-photo
+          # classification plus a real generated PNG to traverse their separate
+          # production schedulers and HTTP routes. Every normal auto-release is
+          # blocked by a missing immutable snapshot, incompatible reduced
+          # dependency set, or failed media request.
           HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
             --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
 

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -121,7 +121,7 @@ struct SidecarBuildScriptTests {
                 "The bundle build must prove qwen-image itself imports without torch.")
         #expect(script.contains("SIDECAR_IMAGE_SMOKE_MODEL"),
                 "Release-candidate builds must opt into a real image-generation model.")
-        #expect(script.contains("$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py"),
+        #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-image.py"),
                 "The image runtime needs a real generated-PNG gate, not only an import probe.")
         let visionSmoke = script.range(of: "smoke-sidecar-vision.py")?.lowerBound
         let imageSmoke = script.range(of: "smoke-sidecar-image.py")?.lowerBound

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -119,6 +119,18 @@ struct SidecarBuildScriptTests {
                 "The Qwen Image import path must defer PiD's optional torch checkpoint converter.")
         #expect(script.contains(#"importlib.import_module("mflux.models.qwen.variants.txt2img.qwen_image")"#),
                 "The bundle build must prove qwen-image itself imports without torch.")
+        #expect(script.contains("SIDECAR_IMAGE_SMOKE_MODEL"),
+                "Release-candidate builds must opt into a real image-generation model.")
+        #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-image.py"),
+                "The image runtime needs a real generated-PNG gate, not only an import probe.")
+        let visionSmoke = script.range(of: "smoke-sidecar-vision.py")?.lowerBound
+        let imageSmoke = script.range(of: "smoke-sidecar-image.py")?.lowerBound
+        #expect(visionSmoke != nil)
+        #expect(imageSmoke != nil)
+        if let visionSmoke, let imageSmoke {
+            #expect(visionSmoke < imageSmoke,
+                    "Real Metal model loads must remain serialized on the release host.")
+        }
     }
 
     @Test("Desktop sidecar bundles and smokes both audio lanes")

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -121,7 +121,7 @@ struct SidecarBuildScriptTests {
                 "The bundle build must prove qwen-image itself imports without torch.")
         #expect(script.contains("SIDECAR_IMAGE_SMOKE_MODEL"),
                 "Release-candidate builds must opt into a real image-generation model.")
-        #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-image.py"),
+        #expect(script.contains("$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py"),
                 "The image runtime needs a real generated-PNG gate, not only an import probe.")
         let visionSmoke = script.range(of: "smoke-sidecar-vision.py")?.lowerBound
         let imageSmoke = script.range(of: "smoke-sidecar-image.py")?.lowerBound

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1049,7 +1049,7 @@ if [[ -n "${SIDECAR_IMAGE_SMOKE_MODEL:-}" ]]; then
     fi
     PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
         "$STAGE/python/bin/python3.12" \
-        "$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py" \
+        "$REPO_ROOT/scripts/smoke-sidecar-image.py" \
         "${SIDECAR_IMAGE_SMOKE_ARGS[@]}"
 else
     echo "==> real image-generation smoke: not configured (set SIDECAR_IMAGE_SMOKE_MODEL for release candidates)"

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1049,7 +1049,7 @@ if [[ -n "${SIDECAR_IMAGE_SMOKE_MODEL:-}" ]]; then
     fi
     PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
         "$STAGE/python/bin/python3.12" \
-        "$REPO_ROOT/scripts/smoke-sidecar-image.py" \
+        "$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py" \
         "${SIDECAR_IMAGE_SMOKE_ARGS[@]}"
 else
     echo "==> real image-generation smoke: not configured (set SIDECAR_IMAGE_SMOKE_MODEL for release candidates)"

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1010,11 +1010,11 @@ print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>
     fi
 fi
 
-# Release-candidate builds can opt into a real image request against a cached
-# checkpoint. Once configured, this gate is fail-closed: a missing model/image,
-# failed server start, non-200 response, or implausible description aborts the
-# build. Hosted package builders do not download multi-GB model weights, so the
-# release operator supplies the immutable local snapshot explicitly.
+# Release-candidate builds can opt into a real chat-photo request against a
+# cached checkpoint. Once configured, this gate is fail-closed: a missing
+# model/image, failed server start, non-200 response, or implausible description
+# aborts the build. Hosted package builders do not download multi-GB model
+# weights, so the release operator supplies the immutable local snapshot.
 if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
     SIDECAR_VISION_SMOKE_IMAGE="${SIDECAR_VISION_SMOKE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/cheetah.png}"
     SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE="${SIDECAR_VISION_SMOKE_NEGATIVE_IMAGE:-$REPO_ROOT/Sources/Rapid/Resources/Assets.xcassets/RapidLogo.imageset/RapidLogo.png}"
@@ -1032,7 +1032,27 @@ if [[ -n "${SIDECAR_VISION_SMOKE_MODEL:-}" ]]; then
         "$REPO_ROOT/scripts/smoke-sidecar-vision.py" \
         "${SIDECAR_VISION_SMOKE_ARGS[@]}"
 else
-    echo "==> real image smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
+    echo "==> real chat-photo smoke: not configured (set SIDECAR_VISION_SMOKE_MODEL for release candidates)"
+fi
+
+# Image generation is a separate runtime and route from chat-photo vision.
+# Importing mflux above cannot prove that its reduced dependency set can load
+# the component-layout checkpoint or return a real PNG. Release candidates run
+# this after the vision process has exited, keeping Metal model loads serialized.
+if [[ -n "${SIDECAR_IMAGE_SMOKE_MODEL:-}" ]]; then
+    SIDECAR_IMAGE_SMOKE_ARGS=(
+        --sidecar-root "$STAGE"
+        --model "$SIDECAR_IMAGE_SMOKE_MODEL"
+    )
+    if [[ -n "${SIDECAR_IMAGE_SMOKE_REVISION:-}" ]]; then
+        SIDECAR_IMAGE_SMOKE_ARGS+=(--revision "$SIDECAR_IMAGE_SMOKE_REVISION")
+    fi
+    PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 \
+        "$STAGE/python/bin/python3.12" \
+        "$REPO_ROOT/scripts/smoke-sidecar-image.py" \
+        "${SIDECAR_IMAGE_SMOKE_ARGS[@]}"
+else
+    echo "==> real image-generation smoke: not configured (set SIDECAR_IMAGE_SMOKE_MODEL for release candidates)"
 fi
 
 # ----- step 7: package --------------------------------------------------

--- a/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
+++ b/apps/rapid-mac/scripts/check-sidecar-smoke-cache.py
@@ -46,8 +46,11 @@ def load_pins(path: Path) -> dict[str, tuple[str, str, tuple[str, ...]]]:
     if not isinstance(payload, dict) or payload.get("schema") != 1:
         raise PreflightError("sidecar pin manifest must be an object with schema 1")
     models = payload.get("models")
-    if not isinstance(models, dict) or set(models) != {"qwen", "gemma"}:
-        raise PreflightError("sidecar pin manifest must define exactly qwen and gemma")
+    required_models = {"qwen", "gemma", "flux"}
+    if not isinstance(models, dict) or set(models) != required_models:
+        raise PreflightError(
+            "sidecar pin manifest must define exactly qwen, gemma, and flux"
+        )
 
     result: dict[str, tuple[str, str, tuple[str, ...]]] = {}
     for key, entry in models.items():

--- a/apps/rapid-mac/scripts/sidecar-smoke-models.json
+++ b/apps/rapid-mac/scripts/sidecar-smoke-models.json
@@ -36,6 +36,24 @@
         "tokenizer.json",
         "tokenizer_config.json"
       ]
+    },
+    "flux": {
+      "repository": "Runpod/FLUX.2-klein-4B-mflux-4bit",
+      "revision": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
+      "files": [
+        "config.json",
+        "text_encoder/0.safetensors",
+        "text_encoder/1.safetensors",
+        "text_encoder/model.safetensors.index.json",
+        "tokenizer/chat_template.jinja",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "transformer/0.safetensors",
+        "transformer/1.safetensors",
+        "transformer/model.safetensors.index.json",
+        "vae/0.safetensors",
+        "vae/model.safetensors.index.json"
+      ]
     }
   }
 }

--- a/apps/rapid-mac/scripts/smoke-sidecar-image.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-image.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generate one real image through a freshly assembled Desktop sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+_SIZE = re.compile(r"([1-9][0-9]*)x([1-9][0-9]*)")
+
+
+def _bound_local_listener() -> socket.socket:
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    return listener
+
+
+def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data else {},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"{url} returned HTTP {response.status}")
+        body = json.load(response)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{url} returned a non-object JSON response")
+    return body
+
+
+def _wait_until_ready(base_url: str, process: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"sidecar server exited early with {process.returncode}")
+        try:
+            health = _request_json(f"{base_url}/health", None, 2)
+            if health.get("ready") is True and health.get("engine_type") == "image":
+                return
+            last_error = RuntimeError(f"unexpected health payload: {health!r}")
+        except (OSError, ValueError, RuntimeError) as exc:
+            last_error = exc
+        time.sleep(0.5)
+    raise RuntimeError(f"image sidecar was not ready after {timeout}s: {last_error}")
+
+
+def _resolve_model(model: str, revision: str | None) -> Path:
+    local_path = Path(model)
+    if local_path.exists():
+        return local_path
+    if not revision:
+        raise SystemExit(
+            "image smoke: a repository model requires --revision so the "
+            "release proof is content-addressed"
+        )
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            repo_id=model,
+            revision=revision,
+            local_files_only=True,
+        )
+    )
+
+
+def _serve_model(model: str, snapshot: Path, revision: str | None) -> str:
+    if revision is None:
+        return str(snapshot)
+
+    # Image-family routing is registry-backed. Passing snapshots/<sha> to the
+    # CLI discards that modality metadata and makes a component-layout FLUX
+    # checkpoint look like a root-sharded text model. Keep the repository ID
+    # on the wire, but first prove the production resolver will hand mflux the
+    # same content-addressed snapshot that the release manifest selected.
+    from vllm_mlx._download_gate import mflux_local_snapshot
+
+    runtime_snapshot = mflux_local_snapshot(model)
+    if runtime_snapshot is None:
+        raise RuntimeError(
+            f"image runtime cannot resolve a complete offline snapshot for {model}"
+        )
+    if Path(runtime_snapshot).resolve() != snapshot.resolve():
+        raise RuntimeError(
+            "image runtime snapshot does not match the release pin: "
+            f"runtime={runtime_snapshot}, pinned={snapshot}"
+        )
+    return model
+
+
+def _parse_size(value: str) -> tuple[int, int]:
+    match = _SIZE.fullmatch(value)
+    if not match:
+        raise argparse.ArgumentTypeError("size must be WIDTHxHEIGHT")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _validate_generated_png(body: dict, expected_size: tuple[int, int]) -> int:
+    if body.get("cancelled") is True:
+        raise RuntimeError("image request reported cancellation")
+    data = body.get("data")
+    if not isinstance(data, list) or len(data) != 1 or not isinstance(data[0], dict):
+        raise RuntimeError("image response must contain exactly one data item")
+    encoded = data[0].get("b64_json")
+    if not isinstance(encoded, str) or not encoded:
+        raise RuntimeError("image response has no non-empty b64_json")
+    try:
+        payload = base64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise RuntimeError("image response b64_json is invalid base64") from exc
+
+    from PIL import Image
+
+    try:
+        with Image.open(io.BytesIO(payload)) as image:
+            image.load()
+            if image.format != "PNG":
+                raise RuntimeError(
+                    f"image response format is {image.format}, expected PNG"
+                )
+            if image.size != expected_size:
+                raise RuntimeError(
+                    f"image response is {image.size}, expected {expected_size}"
+                )
+            extrema = image.convert("RGB").getextrema()
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("image response is not a decodable PNG") from exc
+    if not any(low < high for low, high in extrema):
+        raise RuntimeError(
+            "image response is uniform; no generated detail was produced"
+        )
+    return len(payload)
+
+
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=5)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sidecar-root", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--revision")
+    parser.add_argument("--size", type=_parse_size, default=_parse_size("512x512"))
+    parser.add_argument("--startup-timeout", type=float, default=240)
+    parser.add_argument("--request-timeout", type=float, default=300)
+    args = parser.parse_args()
+
+    executable = args.sidecar_root / "bin" / "rapid-mlx"
+    if not executable.exists():
+        raise SystemExit(f"image smoke: sidecar executable not found: {executable}")
+    snapshot = _resolve_model(args.model, args.revision)
+    serve_model = _serve_model(args.model, snapshot, args.revision)
+    size_text = f"{args.size[0]}x{args.size[1]}"
+
+    listener = _bound_local_listener()
+    base_url = f"http://127.0.0.1:{listener.getsockname()[1]}"
+    process: subprocess.Popen | None = None
+    with tempfile.NamedTemporaryFile(
+        prefix="rapid-sidecar-image-", suffix=".log", delete=False
+    ) as log:
+        log_path = Path(log.name)
+
+    try:
+        with log_path.open("ab") as log:
+            try:
+                process = subprocess.Popen(
+                    [
+                        str(executable),
+                        "serve",
+                        serve_model,
+                        "--listen-fd",
+                        str(listener.fileno()),
+                    ],
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    pass_fds=(listener.fileno(),),
+                    env={
+                        **os.environ,
+                        "HF_HUB_OFFLINE": "1",
+                        "TRANSFORMERS_OFFLINE": "1",
+                        "PYTHONNOUSERSITE": "1",
+                    },
+                )
+            finally:
+                listener.close()
+
+        _wait_until_ready(base_url, process, args.startup_timeout)
+        started = time.monotonic()
+        body = _request_json(
+            f"{base_url}/v1/images/generations",
+            {
+                "model": serve_model,
+                "prompt": (
+                    "A red sailboat on a calm alpine lake at sunrise, "
+                    "clean product illustration"
+                ),
+                "n": 1,
+                "size": size_text,
+                "response_format": "b64_json",
+                "seed": 42,
+            },
+            args.request_timeout,
+        )
+        png_bytes = _validate_generated_png(body, args.size)
+        elapsed = time.monotonic() - started
+        print(
+            f"image smoke: HTTP 200; PNG={size_text}; bytes={png_bytes}; "
+            f"elapsed={elapsed:.2f}s"
+        )
+        return 0
+    except Exception:
+        print(f"image smoke server log: {log_path}")
+        print(log_path.read_text(errors="replace"))
+        raise
+    finally:
+        listener.close()
+        if process is not None:
+            _stop_process(process)
+        log_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/rapid-mac/scripts/smoke-sidecar-image.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import contextlib
 import io
 import json
 import os
@@ -18,6 +19,28 @@ import urllib.request
 from pathlib import Path
 
 _SIZE = re.compile(r"([1-9][0-9]*)x([1-9][0-9]*)")
+
+
+class _RequestDeadlineExceededError(RuntimeError):
+    """The complete HTTP exchange exceeded its wall-clock budget."""
+
+
+@contextlib.contextmanager
+def _wall_clock_deadline(timeout: float):
+    """Interrupt socket reads that make progress without ever completing."""
+
+    def _expire(_signum, _frame) -> None:
+        raise _RequestDeadlineExceededError(
+            f"HTTP request exceeded {timeout:g}s wall-clock deadline"
+        )
+
+    previous_handler = signal.signal(signal.SIGALRM, _expire)
+    previous_timer = signal.setitimer(signal.ITIMER_REAL, timeout)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, *previous_timer)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _bound_local_listener() -> socket.socket:
@@ -34,7 +57,13 @@ def _request_json(url: str, payload: dict | None, timeout: float) -> dict:
         data=data,
         headers={"Content-Type": "application/json"} if data else {},
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
+    # urllib's timeout applies per socket operation. A peer that keeps sending
+    # partial bytes can therefore keep json.load() alive forever; the release
+    # gate needs a deadline for the entire render response.
+    with (
+        _wall_clock_deadline(timeout),
+        urllib.request.urlopen(request, timeout=timeout) as response,
+    ):
         if response.status != 200:
             raise RuntimeError(f"{url} returned HTTP {response.status}")
         body = json.load(response)

--- a/apps/rapid-mac/scripts/smoke-sidecar-image.py
+++ b/apps/rapid-mac/scripts/smoke-sidecar-image.py
@@ -34,13 +34,20 @@ def _wall_clock_deadline(timeout: float):
             f"HTTP request exceeded {timeout:g}s wall-clock deadline"
         )
 
+    started = time.monotonic()
     previous_handler = signal.signal(signal.SIGALRM, _expire)
     previous_timer = signal.setitimer(signal.ITIMER_REAL, timeout)
     try:
         yield
     finally:
-        signal.setitimer(signal.ITIMER_REAL, *previous_timer)
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        previous_remaining, previous_interval = previous_timer
+        if previous_remaining > 0:
+            previous_remaining = max(
+                1e-6, previous_remaining - (time.monotonic() - started)
+            )
         signal.signal(signal.SIGALRM, previous_handler)
+        signal.setitimer(signal.ITIMER_REAL, previous_remaining, previous_interval)
 
 
 def _bound_local_listener() -> socket.socket:
@@ -271,6 +278,9 @@ def main() -> int:
         )
         return 0
     except Exception:
+        if process is not None:
+            # Flush the most relevant final failure output before surfacing it.
+            _stop_process(process)
         print(f"image smoke server log: {log_path}")
         print(log_path.read_text(errors="replace"))
         raise

--- a/scripts/protected_models.json
+++ b/scripts/protected_models.json
@@ -3,6 +3,7 @@
   "models": [
     {"repository": "mlx-community/Qwen3.5-9B-4bit", "revision": "8b2b98c00a6b4d291155e4890773ca8f769aee53", "sources": ["sidecar", "telemetry_top10"]},
     {"repository": "mlx-community/gemma-4-e2b-it-8bit", "revision": "03dcf209f3f549b4075e7191e77cf69b3d48e1b2", "sources": ["sidecar"]},
+    {"repository": "Runpod/FLUX.2-klein-4B-mflux-4bit", "revision": "7ee1b3aa8178a1240050490072196a57da2bf2a9", "sources": ["sidecar"]},
     {"repository": "mlx-community/Qwen3.5-4B-MLX-4bit", "sources": ["release_fleet", "telemetry_top10"]},
     {"repository": "mlx-community/Qwen3.5-35B-A3B-4bit", "sources": ["release_fleet"]},
     {"repository": "mlx-community/Qwen3.6-27B-4bit", "sources": ["release_fleet", "telemetry_top10"]},

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1842,11 +1842,18 @@ def _seed_mflux_snapshot(repo_root, sha: str, *, omit: tuple[str, str] | None = 
     _seed_refs_main(repo_root, sha)
 
 
+_UNPINNED_MFLUX_REPO = "filipstrand/Z-Image-Turbo-mflux-4bit"
+
+
+def _mflux_repo_root(cache_root, repo: str):
+    return cache_root / f"models--{repo.replace('/', '--')}"
+
+
 def test_complete_mflux_snapshot_is_runnable(tmp_path, monkeypatch):
     """A complete image-gen component layout is a cached runnable model."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "a" * 40)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1859,8 +1866,8 @@ def test_complete_mflux_snapshot_is_runnable(tmp_path, monkeypatch):
 def test_partial_mflux_snapshot_is_not_runnable(tmp_path, monkeypatch):
     """Every shard from every required mflux component must be present."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "b" * 40, omit=("transformer", "1.safetensors"))
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1873,8 +1880,8 @@ def test_mflux_missing_weights_checks_single_partial_snapshot_without_ref(
 ):
     """Interrupted first pulls can leave indexes before refs/main is written."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "e" * 40, omit=("text_encoder", "1.safetensors"))
     (repo_root / "refs" / "main").unlink()
 
@@ -1888,8 +1895,8 @@ def test_mflux_missing_weights_no_verdict_for_multiple_unpinned_snapshots(
 ):
     """Never let an old complete snapshot mask a newer partial snapshot."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "f" * 40)
     _seed_mflux_snapshot(repo_root, "0" * 40, omit=("transformer", "0.safetensors"))
     (repo_root / "refs" / "main").unlink()
@@ -1902,8 +1909,8 @@ def test_mflux_missing_weights_no_verdict_for_multiple_unpinned_snapshots(
 def test_mflux_missing_weights_names_the_absent_shard(tmp_path, monkeypatch):
     """The gate reports WHICH file is missing, so the error can be acted on."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "c" * 40, omit=("transformer", "0.safetensors"))
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1914,8 +1921,8 @@ def test_mflux_missing_weights_names_the_absent_shard(tmp_path, monkeypatch):
 def test_mflux_missing_weights_empty_when_complete(tmp_path, monkeypatch):
     """Complete is ``[]``, not ``None`` — the two must stay distinguishable."""
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "d" * 40)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1979,8 +1986,8 @@ def test_mflux_missing_weights_reports_non_string_index_without_raising(
     strings is treated as missing, exactly like a corrupt one.
     """
     cache_root = tmp_path / "hf-cache"
-    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
-    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    repo = _UNPINNED_MFLUX_REPO
+    repo_root = _mflux_repo_root(cache_root, repo)
     _seed_mflux_snapshot(repo_root, "9" * 40)
     # Corrupt one component index with a non-string (unhashable) shard value.
     bad_index = (
@@ -2065,6 +2072,25 @@ def test_mflux_local_snapshot_accepts_pinned_revision_without_refs_main(
     resolved = gate.mflux_local_snapshot(repo)
     assert resolved is not None
     assert resolved.endswith(pinned_sha)
+    assert gate.mflux_missing_weights(repo) == []
+
+
+def test_flux_smoke_pin_ignores_stale_ref_and_extra_cached_revision(
+    tmp_path, monkeypatch
+):
+    """The release FLUX alias always resolves the manifest-pinned checkpoint."""
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    pinned_sha = gate.IMAGE_MODEL_REVISIONS[repo]
+    stale_sha = "6" * 40
+    cache_root = tmp_path / "hf-cache"
+    repo_root = _mflux_repo_root(cache_root, repo)
+    _seed_mflux_snapshot(repo_root, pinned_sha)
+    _seed_mflux_snapshot(repo_root, stale_sha)
+    (repo_root / "refs" / "main").write_text(stale_sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_local_snapshot(repo) == str(repo_root / "snapshots" / pinned_sha)
     assert gate.mflux_missing_weights(repo) == []
 
 
@@ -2235,7 +2261,7 @@ def test_mflux_local_snapshot_resolves_a_complete_checkpoint(tmp_path, monkeypat
     cache_root = tmp_path / "hf-cache"
     repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
     repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
-    sha = "e" * 40
+    sha = gate.IMAGE_MODEL_REVISIONS[repo]
     _seed_mflux_snapshot(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -2253,7 +2279,8 @@ def test_mflux_local_snapshot_declines_a_partial_checkpoint(tmp_path, monkeypatc
     cache_root = tmp_path / "hf-cache"
     repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
     repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
-    _seed_mflux_snapshot(repo_root, "f" * 40, omit=("transformer", "1.safetensors"))
+    sha = gate.IMAGE_MODEL_REVISIONS[repo]
+    _seed_mflux_snapshot(repo_root, sha, omit=("transformer", "1.safetensors"))
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -145,12 +145,13 @@ def test_warm_cache_hands_mflux_a_local_directory(monkeypatch):
 
 def test_unresolvable_cache_still_hands_mflux_the_repo_id(monkeypatch):
     """No local verdict → today's behavior, so a cold pull still happens."""
-    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    repo = "filipstrand/Z-Image-Turbo-mflux-4bit"
+    engine = ImageGenerationEngine(repo)
     monkeypatch.setattr(
         "vllm_mlx._download_gate.mflux_local_snapshot", lambda repo: None
     )
 
-    assert engine._model_path_for_mflux() == "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    assert engine._model_path_for_mflux() == repo
 
 
 def test_canonical_repo_still_defers_to_model_config(monkeypatch):
@@ -202,7 +203,10 @@ def _seed_mflux_cache(tmp_path, monkeypatch, *, omit=None):
     multi-gigabyte shard absent.
     """
     repo_root = tmp_path / "hf-cache" / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
-    snap = repo_root / "snapshots" / ("e" * 40)
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    pinned_sha = IMAGE_MODEL_REVISIONS[_MFLUX_REPO]
+    snap = repo_root / "snapshots" / pinned_sha
     (snap / "tokenizer").mkdir(parents=True)
     (snap / "tokenizer" / "tokenizer.json").write_text("{}")
     for component in ("transformer", "text_encoder", "vae"):
@@ -215,6 +219,7 @@ def _seed_mflux_cache(tmp_path, monkeypatch, *, omit=None):
             if omit != (component, shard):
                 (component_dir / shard).write_bytes(b"weights")
     (repo_root / "refs").mkdir(parents=True)
+    # Deliberately stale: pinned resolution must ignore refs/main entirely.
     (repo_root / "refs" / "main").write_text("e" * 40)
     monkeypatch.setattr(
         "huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path / "hf-cache")

--- a/tests/test_serve_image_gen_completeness.py
+++ b/tests/test_serve_image_gen_completeness.py
@@ -29,8 +29,12 @@ def _seed_cache(tmp_path, monkeypatch, *, omit=None):
     ``omit`` drops one ``(component, shard)`` so the layout matches what an
     interrupted pull leaves: every small file present, one big shard absent.
     """
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    pinned_sha = IMAGE_MODEL_REVISIONS[repo]
     repo_root = tmp_path / "hf-cache" / _REPO_DIR
-    snap = repo_root / "snapshots" / ("f" * 40)
+    snap = repo_root / "snapshots" / pinned_sha
     (snap / "tokenizer").mkdir(parents=True)
     (snap / "tokenizer" / "tokenizer.json").write_text("{}")
     for component in ("transformer", "text_encoder", "vae"):
@@ -43,6 +47,8 @@ def _seed_cache(tmp_path, monkeypatch, *, omit=None):
             if omit != (component, shard):
                 (component_dir / shard).write_bytes(b"weights")
     (repo_root / "refs").mkdir(parents=True)
+    # Pinned image aliases resolve snapshots/<revision> directly, even when a
+    # stale branch ref or additional cached snapshot exists.
     (repo_root / "refs" / "main").write_text("f" * 40)
     monkeypatch.setattr(
         "huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path / "hf-cache")

--- a/tests/test_sidecar_image_smoke.py
+++ b/tests/test_sidecar_image_smoke.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import socket
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parents[1]
+_SCRIPT = _ROOT / "apps/rapid-mac/scripts/smoke-sidecar-image.py"
+_SPEC = importlib.util.spec_from_file_location("sidecar_image_smoke", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _chunk(kind: bytes, payload: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(payload))
+        + kind
+        + payload
+        + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+    )
+
+
+def _rgb_png(width: int, height: int, *, uniform: bool = False) -> bytes:
+    rows = []
+    for y in range(height):
+        row = bytearray([0])
+        for x in range(width):
+            value = 40 if uniform else (x * 67 + y * 31) % 256
+            row.extend((value, (value + 80) % 256, (value + 160) % 256))
+        rows.append(bytes(row))
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", header)
+        + _chunk(b"IDAT", zlib.compress(b"".join(rows)))
+        + _chunk(b"IEND", b"")
+    )
+
+
+def _body(payload: bytes) -> dict:
+    return {"data": [{"b64_json": base64.b64encode(payload).decode()}]}
+
+
+def test_generated_png_must_be_decodable_sized_and_non_uniform() -> None:
+    payload = _rgb_png(2, 2)
+    assert _MODULE._validate_generated_png(_body(payload), (2, 2)) == len(payload)
+
+    with pytest.raises(RuntimeError, match="uniform"):
+        _MODULE._validate_generated_png(_body(_rgb_png(2, 2, uniform=True)), (2, 2))
+    with pytest.raises(RuntimeError, match="expected"):
+        _MODULE._validate_generated_png(_body(payload), (512, 512))
+    with pytest.raises(RuntimeError, match="invalid base64"):
+        _MODULE._validate_generated_png({"data": [{"b64_json": "%%%"}]}, (2, 2))
+
+
+def test_repository_model_without_revision_fails_closed() -> None:
+    with pytest.raises(SystemExit, match="requires --revision"):
+        _MODULE._resolve_model("owner/model", None)
+
+
+def test_local_model_path_is_served_without_registry_resolution(tmp_path: Path) -> None:
+    assert _MODULE._serve_model(str(tmp_path), tmp_path, None) == str(tmp_path)
+
+
+def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
+    listener = _MODULE._bound_local_listener()
+    host, port = listener.getsockname()
+    contender = socket.socket()
+    try:
+        with pytest.raises(OSError):
+            contender.bind((host, port))
+    finally:
+        contender.close()
+        listener.close()
+
+
+_FAKE_SIDECAR = """#!/usr/bin/env python3
+import http.server
+import json
+import os
+import socket
+import sys
+
+fd = int(sys.argv[sys.argv.index("--listen-fd") + 1])
+assert os.environ["HF_HUB_OFFLINE"] == "1"
+assert os.environ["TRANSFORMERS_OFFLINE"] == "1"
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _send(self, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        assert self.path == "/health"
+        self._send({"ready": True, "engine_type": "image"})
+
+    def do_POST(self):
+        assert self.path == "/v1/images/generations"
+        length = int(self.headers["Content-Length"])
+        payload = json.loads(self.rfile.read(length))
+        assert payload["size"] == "2x2"
+        assert payload["response_format"] == "b64_json"
+        self._send({"data": [{"b64_json": os.environ["FAKE_PNG"]}]})
+
+listener = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler, bind_and_activate=False)
+server.socket = listener
+server.server_address = listener.getsockname()
+server.serve_forever()
+"""
+
+
+def test_main_executes_socket_activated_image_generation_journey(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sidecar = tmp_path / "sidecar"
+    executable = sidecar / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True)
+    executable.write_text(_FAKE_SIDECAR)
+    executable.chmod(0o755)
+    model = tmp_path / "model"
+    model.mkdir()
+    monkeypatch.setenv("FAKE_PNG", base64.b64encode(_rgb_png(2, 2)).decode())
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(_SCRIPT),
+            "--sidecar-root",
+            str(sidecar),
+            "--model",
+            str(model),
+            "--size",
+            "2x2",
+            "--startup-timeout",
+            "5",
+            "--request-timeout",
+            "5",
+        ],
+    )
+    assert _MODULE.main() == 0
+
+
+def test_release_workflow_serializes_flux_after_vision_smoke() -> None:
+    workflow = (_ROOT / ".github/workflows/auto-release.yml").read_text()
+    build = (_ROOT / "apps/rapid-mac/scripts/build-sidecar.sh").read_text()
+    assert "steps.sidecar-pins.outputs.flux_model" in workflow
+    assert "steps.sidecar-pins.outputs.flux_revision" in workflow
+    assert "SIDECAR_IMAGE_SMOKE_MODEL" in workflow
+    assert "SIDECAR_IMAGE_SMOKE_REVISION" in workflow
+    assert build.index("smoke-sidecar-vision.py") < build.index(
+        "smoke-sidecar-image.py"
+    )
+    assert '"$REPO_ROOT/scripts/smoke-sidecar-image.py"' in build
+    assert '"$SIDE/python/bin/python3.12"' in workflow
+
+
+def test_flux_pin_is_protected_from_host_hygiene() -> None:
+    protected = json.loads((_ROOT / "scripts/protected_models.json").read_text())
+    flux = [
+        model
+        for model in protected["models"]
+        if model["repository"] == "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    ]
+    assert flux == [
+        {
+            "repository": "Runpod/FLUX.2-klein-4B-mflux-4bit",
+            "revision": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
+            "sources": ["sidecar"],
+        }
+    ]

--- a/tests/test_sidecar_image_smoke.py
+++ b/tests/test_sidecar_image_smoke.py
@@ -204,7 +204,8 @@ def test_main_executes_socket_activated_image_generation_journey(
 
 def test_release_workflow_serializes_flux_after_vision_smoke() -> None:
     workflow = (_ROOT / ".github/workflows/auto-release.yml").read_text()
-    build = (_ROOT / "apps/rapid-mac/scripts/build-sidecar.sh").read_text()
+    build_script = _ROOT / "apps/rapid-mac/scripts/build-sidecar.sh"
+    build = build_script.read_text()
     assert "steps.sidecar-pins.outputs.flux_model" in workflow
     assert "steps.sidecar-pins.outputs.flux_revision" in workflow
     assert "SIDECAR_IMAGE_SMOKE_MODEL" in workflow
@@ -212,7 +213,13 @@ def test_release_workflow_serializes_flux_after_vision_smoke() -> None:
     assert build.index("smoke-sidecar-vision.py") < build.index(
         "smoke-sidecar-image.py"
     )
-    assert '"$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py"' in build
+    assert '"$REPO_ROOT/scripts/smoke-sidecar-image.py"' in build
+    # build-sidecar.sh defines REPO_ROOT as its parent directory
+    # (apps/rapid-mac), not the git root. Mirror that resolution and prove the
+    # invoked file exists instead of merely accepting a plausible string.
+    build_repo_root = build_script.parent.parent
+    assert build_repo_root / "scripts/smoke-sidecar-image.py" == _SCRIPT
+    assert _SCRIPT.is_file()
     assert '"$SIDE/python/bin/python3.12"' in workflow
 
 

--- a/tests/test_sidecar_image_smoke.py
+++ b/tests/test_sidecar_image_smoke.py
@@ -106,6 +106,29 @@ def test_request_deadline_bounds_a_never_finishing_response(monkeypatch) -> None
     assert time.monotonic() - started < 0.5
 
 
+def test_request_deadline_preserves_existing_alarm_budget(monkeypatch) -> None:
+    timer_calls = []
+    monotonic_values = iter((100.0, 102.0))
+
+    monkeypatch.setattr(_MODULE.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(_MODULE.signal, "signal", lambda *_args: "previous-handler")
+
+    def fake_setitimer(*args):
+        timer_calls.append(args)
+        return (5.0, 1.0) if len(timer_calls) == 1 else (0.0, 0.0)
+
+    monkeypatch.setattr(_MODULE.signal, "setitimer", fake_setitimer)
+
+    with _MODULE._wall_clock_deadline(10.0):
+        pass
+
+    assert timer_calls == [
+        (_MODULE.signal.ITIMER_REAL, 10.0),
+        (_MODULE.signal.ITIMER_REAL, 0),
+        (_MODULE.signal.ITIMER_REAL, 3.0, 1.0),
+    ]
+
+
 _FAKE_SIDECAR = """#!/usr/bin/env python3
 import http.server
 import json

--- a/tests/test_sidecar_image_smoke.py
+++ b/tests/test_sidecar_image_smoke.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import socket
 import struct
+import time
 import zlib
 from pathlib import Path
 
@@ -79,6 +80,30 @@ def test_bound_listener_holds_port_until_socket_activation_handoff() -> None:
     finally:
         contender.close()
         listener.close()
+
+
+def test_request_deadline_bounds_a_never_finishing_response(monkeypatch) -> None:
+    class SlowResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            while True:
+                time.sleep(0.01)
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *_args, **_kwargs: SlowResponse()
+    )
+
+    started = time.monotonic()
+    with pytest.raises(_MODULE._RequestDeadlineExceededError, match="wall-clock"):
+        _MODULE._request_json("http://127.0.0.1/stream", None, 0.05)
+    assert time.monotonic() - started < 0.5
 
 
 _FAKE_SIDECAR = """#!/usr/bin/env python3
@@ -164,7 +189,7 @@ def test_release_workflow_serializes_flux_after_vision_smoke() -> None:
     assert build.index("smoke-sidecar-vision.py") < build.index(
         "smoke-sidecar-image.py"
     )
-    assert '"$REPO_ROOT/scripts/smoke-sidecar-image.py"' in build
+    assert '"$REPO_ROOT/apps/rapid-mac/scripts/smoke-sidecar-image.py"' in build
     assert '"$SIDE/python/bin/python3.12"' in workflow
 
 

--- a/tests/test_sidecar_smoke_cache_preflight.py
+++ b/tests/test_sidecar_smoke_cache_preflight.py
@@ -30,7 +30,7 @@ def _populate(cache: Path, repository: str, revision: str) -> None:
         target.write_text("stub")
 
 
-def test_manifest_is_the_exact_two_pin_source_of_truth() -> None:
+def test_manifest_is_the_exact_three_pin_source_of_truth() -> None:
     pins = _MODULE.load_pins(_MANIFEST)
     assert pins["qwen"][:2] == (
         "mlx-community/Qwen3.5-9B-4bit",
@@ -40,12 +40,23 @@ def test_manifest_is_the_exact_two_pin_source_of_truth() -> None:
         "mlx-community/gemma-4-e2b-it-8bit",
         "03dcf209f3f549b4075e7191e77cf69b3d48e1b2",
     )
-    for _, _, files in pins.values():
+    assert pins["flux"][:2] == (
+        "Runpod/FLUX.2-klein-4B-mflux-4bit",
+        "7ee1b3aa8178a1240050490072196a57da2bf2a9",
+    )
+    for key in ("qwen", "gemma"):
+        files = pins[key][2]
         assert "config.json" in files
         assert "tokenizer.json" in files
         assert "model.safetensors.index.json" in files
         assert "model-00001-of-00002.safetensors" in files
         assert "model-00002-of-00002.safetensors" in files
+    flux_files = pins["flux"][2]
+    assert "config.json" in flux_files
+    assert "tokenizer/tokenizer.json" in flux_files
+    assert "text_encoder/model.safetensors.index.json" in flux_files
+    assert "transformer/model.safetensors.index.json" in flux_files
+    assert "vae/model.safetensors.index.json" in flux_files
 
 
 def test_cache_root_matches_hugging_face_environment_precedence(
@@ -66,7 +77,7 @@ def test_cache_root_matches_hugging_face_environment_precedence(
     assert _MODULE.default_cache_root() == xdg_cache / "huggingface" / "hub"
 
 
-@pytest.mark.parametrize("missing_key", ["qwen", "gemma"])
+@pytest.mark.parametrize("missing_key", ["qwen", "gemma", "flux"])
 def test_one_missing_pin_fails_and_names_exact_recovery(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], missing_key: str
 ) -> None:
@@ -84,19 +95,19 @@ def test_one_missing_pin_fails_and_names_exact_recovery(
     assert "No download was attempted" in error
 
 
-def test_both_missing_are_reported_together(
+def test_all_missing_are_reported_together(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert (
         _MODULE.main(["--manifest", str(_MANIFEST), "--cache-root", str(tmp_path)]) == 1
     )
     error = capsys.readouterr().err
-    assert "2 immutable snapshot(s)" in error
+    assert "3 immutable snapshot(s)" in error
     for repository, revision, _ in _MODULE.load_pins(_MANIFEST).values():
         assert f"{repository}@{revision}" in error
 
 
-def test_both_present_pass_without_reading_model_files(tmp_path: Path) -> None:
+def test_all_present_pass_without_reading_model_files(tmp_path: Path) -> None:
     for repository, revision, _ in _MODULE.load_pins(_MANIFEST).values():
         _populate(tmp_path, repository, revision)
     assert (
@@ -160,13 +171,15 @@ def test_present_pins_emit_workflow_outputs(tmp_path: Path) -> None:
         f"qwen_revision={pins['qwen'][1]}",
         f"gemma_model={pins['gemma'][0]}",
         f"gemma_revision={pins['gemma'][1]}",
+        f"flux_model={pins['flux'][0]}",
+        f"flux_revision={pins['flux'][1]}",
     ]
 
 
 def test_malformed_manifest_fails_closed(tmp_path: Path) -> None:
     manifest = tmp_path / "pins.json"
     manifest.write_text(json.dumps({"schema": 1, "models": {}}))
-    with pytest.raises(_MODULE.PreflightError, match="exactly qwen and gemma"):
+    with pytest.raises(_MODULE.PreflightError, match="exactly qwen, gemma, and flux"):
         _MODULE.load_pins(manifest)
 
 
@@ -199,6 +212,8 @@ def test_workflow_preflight_precedes_every_expensive_command() -> None:
         assert preflight < workflow.index(expensive)
     assert "steps.sidecar-pins.outputs.qwen_model" in workflow
     assert "steps.sidecar-pins.outputs.gemma_revision" in workflow
+    assert "steps.sidecar-pins.outputs.flux_model" in workflow
+    assert "steps.sidecar-pins.outputs.flux_revision" in workflow
     assert (
         "/opt/homebrew/opt/python@3.12/bin/python3.12 \\\n"
         "            apps/rapid-mac/scripts/check-sidecar-smoke-cache.py" in workflow

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -32,7 +32,7 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/auto-release.yml"
     ).read_text()
-    assert "timeout-minutes: 165" in workflow
+    assert "timeout-minutes: 175" in workflow
     manifest = json.loads(
         (
             Path(__file__).parents[1]
@@ -43,8 +43,13 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     assert (
         manifest["models"]["gemma"]["repository"] == "mlx-community/gemma-4-e2b-it-8bit"
     )
+    assert (
+        manifest["models"]["flux"]["repository"] == "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    )
     assert "steps.sidecar-pins.outputs.qwen_model" in workflow
     assert "steps.sidecar-pins.outputs.gemma_revision" in workflow
+    assert "steps.sidecar-pins.outputs.flux_model" in workflow
+    assert "steps.sidecar-pins.outputs.flux_revision" in workflow
     assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
     assert '"$SIDE/python/bin/python3.12"' in workflow
     assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1072,6 +1072,7 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
 #: behavior; one present here is refused unless the resolved snapshot
 #: matches exactly (see the check in ``_mflux_snapshot_dir``).
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
+    "Runpod/FLUX.2-klein-4B-mflux-4bit": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
 }
 


### PR DESCRIPTION
## Why

The release sidecar currently proves that mflux imports, but it never loads the image-generation runtime or calls `/v1/images/generations`. Chat-photo smokes cannot cover that separate scheduler and route. A broken packaged FLUX path could therefore reach candidate acceptance and publication.

Fixes #2687.

## What

- Add the exact FLUX.2 Klein 4B snapshot to the sidecar smoke manifest, runtime revision registry, and host-hygiene protected-model inventory.
- Fail fast before expensive release work if the pinned snapshot or any required FLUX component/shard is missing; the gate remains offline and never downloads.
- Run a bounded real generation through the freshly assembled Desktop sidecar, requiring HTTP 200 and one valid, non-uniform 512×512 PNG.
- Keep Qwen, Gemma, and FLUX model loads serialized and always terminate the smoke sidecar.
- Block the normal auto-release before candidate approval, tag, Release, appcast, or package publication when FLUX fails.

## Scope and non-goals

Release verification and revision integrity for the existing FLUX alias only. This does not change image-generation behavior, model selection, endpoints, signing, notarization, tags, updater state, or publication.

## Design precedent

Mature desktop release pipelines separate compile/package jobs from the publication job and make publication depend on exact artifact-producing gates. This adapts that pattern to local-model software: immutable model coordinates are preflighted before expensive work, the exact assembled runtime is exercised through its public API, resource-heavy smokes are serialized, and all failures stay before irreversible release boundaries.

## Verification

- Signed/notarized candidate source: `cf099518`; artifact run: https://github.com/raullenchai/Rapid-MLX/actions/runs/33260624721.
- Candidate Desktop user path on Mini: Images → `flux2-klein-4b` → Start reached Ready; Generate produced a visible Stage/Gallery result.
- New gate against the candidate bundled sidecar: HTTP 200, valid non-uniform 512×512 PNG, 297,186 bytes, 16.40 s; no process remained.
- Pinned-cache, image-lane, release-smoke, cache-preflight, vision-smoke, and host-hygiene contracts: 302 passed, including stale `refs/main` plus multiple cached revisions.
- Python release/SSOT contracts: 90 passed.
- Swift `SidecarBuildScriptTests`: 8 passed.
- Auto-release dry-run shell contract: 32 passed.
- Ruff check/format, Bash syntax, JSON parsing, action pinning, and `git diff --check` passed.
- `actionlint` reaches only two pre-existing findings: the registered `rapidmlx-studio` custom runner label is absent from its local config, and an unrelated SC2129 style warning.