### PR TITLE
Downscale oversized vision inputs to token budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,7 @@ jobs:
             tests/test_paged_cache.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_batch_generator.py \
+            tests/test_mllm_corrupt_image.py \
             tests/test_mllm_penalty_passthrough.py \
             tests/test_guided.py \
             tests/test_chat_streaming_guided.py \

--- a/tests/test_mllm_corrupt_image.py
+++ b/tests/test_mllm_corrupt_image.py
@@ -46,11 +46,15 @@ import pytest
 pytest.importorskip("mlx")
 pytestmark = pytest.mark.requires_mlx
 
+import mlx.core as mx
 
 from vllm_mlx.mllm_batch_generator import (
+    ClientRequestError,
     MLLMBatchGenerator,
     MLLMBatchRequest,
     _temporary_vision_pixel_bounds,
+    _vision_patch_unit,
+    _vision_pixel_ceiling,
 )
 
 
@@ -92,6 +96,21 @@ def _make_request(images: list[str] | None) -> MLLMBatchRequest:
     )
 
 
+class _QwenLikeModel:
+    def __init__(self):
+        self.language_model = object()
+
+        class VisionConfig:
+            patch_size = 14
+            spatial_merge_size = 2
+
+        class Config:
+            image_token_index = None
+            vision_config = VisionConfig()
+
+        self.config = Config()
+
+
 def _bypass_process_image(monkeypatch):
     """Skip the base64/url decode step so the test exercises
     ``prepare_inputs`` directly without hitting tempfile I/O.
@@ -122,6 +141,170 @@ def _install_prepare_inputs_stub(monkeypatch, raiser):
     monkeypatch.setattr(mlx_vlm_utils, "prepare_inputs", raiser)
     if hasattr(gen_mod, "prepare_inputs"):
         monkeypatch.setattr(gen_mod, "prepare_inputs", raiser)
+
+
+def test_vision_pixel_ceiling_uses_patch_geometry():
+    processor = type("Processor", (), {})()
+    assert _vision_pixel_ceiling(_QwenLikeModel().config, processor, 8192, 1) == (
+        8192 * (14 * 2) ** 2
+    )
+    assert _vision_pixel_ceiling(_QwenLikeModel().config, processor, 8192, 2) == (
+        4096 * (14 * 2) ** 2
+    )
+
+
+def test_vision_patch_unit_supports_merge_size_and_missing_geometry():
+    class MergeSize:
+        patch_size = 14
+        merge_size = 2
+
+    class NoGeometry:
+        pass
+
+    class NoMerge:
+        patch_size = 14
+
+    assert _vision_patch_unit(MergeSize(), object()) == 28
+    assert _vision_patch_unit(NoMerge(), object()) == 14
+    assert _vision_patch_unit(NoGeometry(), object()) == 0
+
+
+def test_preprocess_request_applies_budget_pixel_cap(monkeypatch, tmp_path):
+    image_path = tmp_path / "image.png"
+    from PIL import Image
+
+    Image.new("RGB", (16, 16), "red").save(image_path)
+
+    class ImageProcessor:
+        min_pixels = 4
+        max_pixels = 20_000_000
+
+    class Processor:
+        def __init__(self):
+            self.image_processor = ImageProcessor()
+
+    processor = Processor()
+    observed = []
+
+    def prepare_inputs(current_processor, **_kwargs):
+        observed.append(current_processor.image_processor.max_pixels)
+        return {
+            "input_ids": mx.zeros((1, 100)),
+            "pixel_values": mx.zeros((1, 3, 4, 4)),
+        }
+
+    _bypass_process_image(monkeypatch)
+    _install_prepare_inputs_stub(monkeypatch, prepare_inputs)
+    gen = _make_generator(processor=processor)
+    gen.model = _QwenLikeModel()
+
+    gen._preprocess_request(_make_request([str(image_path)]))
+
+    assert observed == [8192 * (14 * 2) ** 2]
+    assert processor.image_processor.min_pixels == 4
+    assert processor.image_processor.max_pixels == 20_000_000
+
+
+def test_preprocess_request_retries_with_measured_token_ratio(monkeypatch, tmp_path):
+    image_path = tmp_path / "image.png"
+    from PIL import Image
+
+    Image.new("RGB", (16, 16), "red").save(image_path)
+
+    class ImageProcessor:
+        min_pixels = 4
+        max_pixels = 20_000_000
+
+    class Processor:
+        def __init__(self):
+            self.image_processor = ImageProcessor()
+
+    processor = Processor()
+    observed = []
+
+    def prepare_inputs(current_processor, **_kwargs):
+        observed.append(current_processor.image_processor.max_pixels)
+        token_count = 9000 if len(observed) == 1 else 8000
+        return {
+            "input_ids": mx.zeros((1, token_count)),
+            "pixel_values": mx.zeros((1, 3, 4, 4)),
+        }
+
+    _bypass_process_image(monkeypatch)
+    _install_prepare_inputs_stub(monkeypatch, prepare_inputs)
+    gen = _make_generator(processor=processor)
+    gen.model = _QwenLikeModel()
+
+    gen._preprocess_request(_make_request([str(image_path)]))
+
+    initial = 8192 * (14 * 2) ** 2
+    assert observed == [initial, int(initial * 8192 / 9000)]
+
+
+def test_preprocess_request_rejects_minimum_pixels_over_budget(monkeypatch, tmp_path):
+    image_path = tmp_path / "image.png"
+    from PIL import Image
+
+    Image.new("RGB", (16, 16), "red").save(image_path)
+
+    class ImageProcessor:
+        min_pixels = 4
+        max_pixels = 20_000_000
+
+    class Processor:
+        def __init__(self):
+            self.image_processor = ImageProcessor()
+
+    _bypass_process_image(monkeypatch)
+    _install_prepare_inputs_stub(
+        monkeypatch, lambda *args, **kwargs: {"input_ids": mx.zeros((1, 100))}
+    )
+    gen = _make_generator(vision_min_pixels=20_000_000, processor=Processor())
+    gen.model = _QwenLikeModel()
+
+    with pytest.raises(ClientRequestError, match="exceeds the vision token budget"):
+        gen._preprocess_request(_make_request([str(image_path)]))
+
+
+def test_preprocess_request_warns_when_minimum_patch_does_not_fit(
+    monkeypatch, tmp_path, caplog
+):
+    image_path = tmp_path / "image.png"
+    from PIL import Image
+
+    Image.new("RGB", (16, 16), "red").save(image_path)
+
+    class ImageProcessor:
+        min_pixels = 4
+        max_pixels = 20_000_000
+
+    class Processor:
+        def __init__(self):
+            self.image_processor = ImageProcessor()
+
+    class OnePixelPatchModel:
+        def __init__(self):
+            self.language_model = object()
+
+            class Config:
+                image_token_index = None
+                patch_size = 1
+                spatial_merge_size = 1
+
+            self.config = Config()
+
+    _bypass_process_image(monkeypatch)
+    _install_prepare_inputs_stub(
+        monkeypatch, lambda *args, **kwargs: {"input_ids": mx.zeros((1, 2))}
+    )
+    gen = _make_generator(processor=Processor())
+    gen.model = OnePixelPatchModel()
+    gen.vision_prefill_token_budget = 1
+
+    with caplog.at_level("WARNING"):
+        gen._preprocess_request(_make_request([str(image_path)]))
+
+    assert "remained over its 1-token budget" in caplog.text
 
 
 def test_preprocess_forwards_opt_in_dynamic_resolution_bounds(monkeypatch):

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -136,6 +136,30 @@ def _temporary_vision_pixel_bounds(processor: Any, min_pixels: int, max_pixels: 
         image_processor.size = original
 
 
+def _vision_patch_unit(config: Any, processor: Any) -> int:
+    vision_config = getattr(config, "vision_config", None)
+    for source in (vision_config, config, getattr(processor, "image_processor", None)):
+        patch_size = getattr(source, "patch_size", None)
+        if isinstance(patch_size, int) and patch_size > 0:
+            merge_size = getattr(source, "spatial_merge_size", None)
+            if not (isinstance(merge_size, int) and merge_size > 0):
+                merge_size = getattr(source, "merge_size", None)
+            if not (isinstance(merge_size, int) and merge_size > 0):
+                merge_size = 1
+            return patch_size * merge_size
+    return 0
+
+
+def _vision_pixel_ceiling(
+    config: Any, processor: Any, token_budget: int, image_count: int
+) -> int:
+    patch_unit = _vision_patch_unit(config, processor)
+    if patch_unit <= 0 or token_budget <= 0:
+        return 0
+    budget_per_image = max(1, token_budget // max(image_count, 1))
+    return max(patch_unit**2, budget_per_image * patch_unit**2)
+
+
 # Upper bound on the per-forward chunk size used when prefilling a long
 # text-only prompt on the MLLM path (issue #1187, Problem B). The actual
 # chunk is ``min(prefill_step_size, _MLLM_PREFILL_CHUNK_TOKENS)`` so an
@@ -1056,17 +1080,63 @@ class MLLMBatchGenerator:
         # ``RuntimeError`` / arbitrary ``Exception``) MUST keep
         # propagating as server errors so the caller sees HTTP 500
         # instead of a misleading HTTP 400 "Failed to process image".
-        try:
-            with _temporary_vision_pixel_bounds(
+        auto_pixel_cap = (
+            _vision_pixel_ceiling(
+                getattr(self.model, "config", None),
                 self.processor,
-                self.vision_min_pixels,
-                self.vision_max_pixels,
-            ):
-                inputs = prepare_inputs(
+                self.vision_prefill_token_budget,
+                len(all_images),
+            )
+            if all_images
+            else 0
+        )
+        pixel_cap = self.vision_max_pixels
+        if auto_pixel_cap:
+            pixel_cap = min(pixel_cap, auto_pixel_cap) if pixel_cap else auto_pixel_cap
+        if pixel_cap and self.vision_min_pixels and self.vision_min_pixels > pixel_cap:
+            raise ClientRequestError(
+                "Failed to process image: --vision-min-pixels exceeds the "
+                "vision token budget"
+            )
+
+        patch_unit = _vision_patch_unit(
+            getattr(self.model, "config", None), self.processor
+        )
+        try:
+            for _ in range(2):
+                with _temporary_vision_pixel_bounds(
                     self.processor,
-                    images=all_images if all_images else None,
-                    prompts=request.prompt,
-                    image_token_index=image_token_index,
+                    self.vision_min_pixels,
+                    pixel_cap,
+                ):
+                    inputs = prepare_inputs(
+                        self.processor,
+                        images=all_images if all_images else None,
+                        prompts=request.prompt,
+                        image_token_index=image_token_index,
+                    )
+                token_count = getattr(inputs.get("input_ids"), "size", None)
+                if (
+                    not pixel_cap
+                    or not isinstance(token_count, int)
+                    or token_count <= self.vision_prefill_token_budget
+                ):
+                    break
+                reduced_cap = int(
+                    pixel_cap * self.vision_prefill_token_budget / token_count
+                )
+                if reduced_cap < patch_unit**2:
+                    break
+                pixel_cap = reduced_cap
+            token_count = getattr(inputs.get("input_ids"), "size", None)
+            if isinstance(token_count, int) and (
+                token_count > self.vision_prefill_token_budget
+            ):
+                logger.warning(
+                    "Vision request %s remained over its %d-token budget after "
+                    "automatic downscaling",
+                    request.request_id,
+                    self.vision_prefill_token_budget,
                 )
         except (OSError, ValueError) as e:
             # Do not reflect decoder text: PIL / mlx-vlm messages can contain


### PR DESCRIPTION
## Intention

Closes #2473.

A vision request that exceeds the per-request token budget is now resized before preprocessing instead of being rejected. The resize ceiling is derived from the vision token budget and the model patch geometry. If processor rounding or prompt text still pushes the request over budget, preprocessing retries with a measured token-ratio reduction.

## Scope

- MLLM image preprocessing only.
- Preserve aspect ratio through the existing dynamic-vision processor bounds.
- Apply the budget cap across multiple images in one request.
- Keep the existing HTTP 400 for images that cannot fit at the minimum patch-aligned size.
- Surface a server warning if the final preprocessed request remains over budget; successful downscaling is reflected in the reported prompt-token count.

## Non-goals

- No video policy changes.
- No Desktop-side image handling changes.
- No model selection or residency behavior changes.
- No public API schema changes.
- No capacity-policy redesign.

## Verification

- `tests/test_mllm_corrupt_image.py tests/test_mllm_batch_generator.py tests/test_chat_route_vlm_image.py`: 74 passed.
- Ruff lint and format checks passed.
- Changed-lines coverage is 100% locally.
