### PR TITLE
Fix DNS-pinned browse cancellation hang

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -225,6 +225,7 @@ private final class ResponseReader: @unchecked Sendable {
     private let queue = DispatchQueue(label: "rapid.mlx.browse.ip-pinned")
     private let lock = NSLock()
     private var isFinished = false
+    private var activeCompletion: (@Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void)?
     private var bufferedData = Data()
 
     init(connection: NWConnection, request: Data, url: URL, byteLimit: Int) {
@@ -239,6 +240,9 @@ private final class ResponseReader: @unchecked Sendable {
     ) {
         lock.lock()
         let wasCancelledBeforeStart = isFinished
+        if !wasCancelledBeforeStart {
+            activeCompletion = completion
+        }
         lock.unlock()
         if wasCancelledBeforeStart {
             completion(.failure(CancellationError()))
@@ -253,15 +257,15 @@ private final class ResponseReader: @unchecked Sendable {
                     content: self.request,
                     completion: .contentProcessed { error in
                         if let error {
-                            self.finish(.failure(error), completion: completion)
+                            self.finish(.failure(error))
                         }
                     }
                 )
-                self.receive(completion: completion)
+                self.receive()
             case .failed(let error):
-                self.finish(.failure(error), completion: completion)
+                self.finish(.failure(error))
             case .cancelled:
-                self.finish(.failure(CancellationError()), completion: completion)
+                self.finish(.failure(CancellationError()))
             default:
                 break
             }
@@ -270,31 +274,30 @@ private final class ResponseReader: @unchecked Sendable {
     }
 
     func cancel() {
-        finish(.failure(CancellationError())) { _ in }
+        finish(.failure(CancellationError()))
     }
 
     private func receive(
-        completion: @escaping @Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void
     ) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
             guard let self else { return }
             if let error {
-                self.finish(.failure(error), completion: completion)
+                self.finish(.failure(error))
                 return
             }
             if let data {
                 do {
                     try self.append(data)
                 } catch {
-                    self.finish(.failure(error), completion: completion)
+                    self.finish(.failure(error))
                     return
                 }
             }
             if isComplete {
-                self.finish(self.parse(), completion: completion)
+                self.finish(self.parse())
                 return
             }
-            self.receive(completion: completion)
+            self.receive()
         }
     }
 
@@ -315,7 +318,6 @@ private final class ResponseReader: @unchecked Sendable {
 
     private func finish(
         _ result: Result<(Data, HTTPURLResponse), Error>,
-        completion: @escaping @Sendable (Result<(Data, HTTPURLResponse), Error>) -> Void
     ) {
         lock.lock()
         guard !isFinished else {
@@ -323,8 +325,10 @@ private final class ResponseReader: @unchecked Sendable {
             return
         }
         isFinished = true
+        let pendingCompletion = activeCompletion
+        activeCompletion = nil
         lock.unlock()
         connection.cancel()
-        completion(result)
+        pendingCompletion?(result)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Testing
 @testable import Rapid
 
@@ -22,6 +23,186 @@ struct IPPinnedHTTPTransportTests {
 
         #expect(throws: Error.self) {
             _ = try IPHTTPResponseParser.parse(data: Data("HTTP/1.1 200 OK\r\n".utf8), url: url)
+        }
+    }
+
+    @Test("Cancelling an open HTTP request resumes the caller")
+    func cancellingOpenRequestResumesCaller() async throws {
+        let server = try #require(HangingTCPServer())
+        defer { server.stop() }
+        let port = try #require(server.port)
+        let url = try #require(URL(string: "http://pinned-cancel.test:\(port)/request"))
+        let address = try #require(ParsedIP("127.0.0.1"))
+
+        try await raceTransportAgainstWatchdog {
+            try await IPPinnedHTTPTransport.fetch(
+                url: url,
+                address: address,
+                byteLimit: 1024 * 1024
+            )
+        } watchdogBody: { @Sendable in
+            try await Task.sleep(for: .seconds(2))
+            throw TestWatchdogDeadline()
+        } settle: {
+            await server.waitForRequest()
+            return true
+        }
+    }
+
+    @Test("An HTTP request deadline cancels the pinned transport and resumes")
+    func httpDeadlineCancelsPinnedTransportAndResumes() async throws {
+        let server = try #require(HangingTCPServer())
+        defer { server.stop() }
+        let port = try #require(server.port)
+        let url = try #require(URL(string: "http://pinned-deadline.test:\(port)/request"))
+        let address = try #require(ParsedIP("127.0.0.1"))
+
+        try await raceTransportAgainstWatchdog {
+            try await BrowseTool.withDeadline(0.2) {
+                try await IPPinnedHTTPTransport.fetch(
+                    url: url,
+                    address: address,
+                    byteLimit: 1024 * 1024
+                )
+            }
+        } watchdogBody: { @Sendable in
+            try await Task.sleep(for: .seconds(2))
+            throw TestWatchdogDeadline()
+        } settle: {
+            await server.waitForRequest()
+            return false
+        }
+    }
+}
+
+private struct TestWatchdogDeadline: Error {}
+
+private enum FetchRaceOutcome {
+    case fetch(Error)
+    case watchdog(Error)
+}
+
+/// Accepts a request and deliberately does not respond, so cancellation has
+/// to settle the checked continuation used by the pinned transport.
+private final class HangingTCPServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let requestSignal = RequestSignal()
+    private(set) var port: UInt16?
+
+    init?() {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: .ipv4(.loopback), port: .any)
+        guard let listener = try? NWListener(using: parameters) else { return nil }
+        self.listener = listener
+        port = nil
+
+        let ready = DispatchSemaphore(value: 0)
+        let requestSignal = requestSignal
+        listener.newConnectionHandler = { connection in
+            connection.start(queue: .global())
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 8 * 1024) {
+                data, _, _, _ in
+                if let data,
+                   Data(data).range(of: Data("\r\n\r\n".utf8)) != nil {
+                    requestSignal.signal()
+                }
+            }
+        }
+
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready, .failed: ready.signal()
+            default: break
+            }
+        }
+
+        listener.start(queue: .global())
+        guard ready.wait(timeout: .now() + 2) == .success else {
+            listener.cancel()
+            return nil
+        }
+        port = listener.port?.rawValue
+    }
+
+    func waitForRequest() async {
+        await requestSignal.wait()
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+}
+
+private final class RequestSignal: @unchecked Sendable {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var acknowledged = false
+    private let lock = NSLock()
+
+    func wait() async {
+        await withCheckedContinuation { pendingContinuation in
+            lock.lock()
+            if acknowledged {
+                lock.unlock()
+                pendingContinuation.resume()
+                return
+            }
+            continuation = pendingContinuation
+            lock.unlock()
+        }
+    }
+
+    func signal() {
+        lock.lock()
+        let pendingContinuation = continuation
+        continuation = nil
+        acknowledged = true
+        lock.unlock()
+        pendingContinuation?.resume()
+    }
+}
+
+private func raceTransportAgainstWatchdog(
+    fetchBody: @escaping @Sendable () async throws -> (Data, HTTPURLResponse),
+    watchdogBody: @escaping @Sendable () async throws -> Void,
+    settle: @escaping @Sendable () async -> Bool
+) async throws {
+    try await withThrowingTaskGroup(of: FetchRaceOutcome.self) { group in
+        group.addTask {
+            do {
+                _ = try await fetchBody()
+                return .fetch(TestWatchdogDeadline())
+            } catch {
+                return .fetch(error)
+            }
+        }
+        group.addTask {
+            do {
+                try await watchdogBody()
+                return .watchdog(TestWatchdogDeadline())
+            } catch {
+                return .watchdog(error)
+            }
+        }
+
+        let cancelAfterSettled = await settle()
+        if cancelAfterSettled {
+            group.cancelAll()
+        }
+
+        guard let first = try await group.next() else {
+            throw TestWatchdogDeadline()
+        }
+        group.cancelAll()
+        guard case .fetch(let error) = first else {
+            throw TestWatchdogDeadline()
+        }
+        if cancelAfterSettled {
+            #expect(error is CancellationError, "transport should surface cancellation")
+        } else {
+            #expect(
+                String(describing: error).contains("deadline"),
+                "deadline should be the first observed failure"
+            )
         }
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #2645: a cancellation or deadline could mark the IP-pinned response reader as finished before its original checked continuation was resumed. In that race, the browse fetch could remain suspended even after `cancelAll()`.

## Scope

- Preserve the transport's original completion so cancellation resumes it exactly once.
- Route connection failures, cancellation, and response completion through the same guarded finish path.
- Add real-loopback tests for explicit task cancellation and the browse deadline task-group behavior.

## Non-goals

- Changing DNS validation, redirect policy, parser behavior, approval UX, timeout values, or byte limits.

## Acceptance

- Cancelling an open IP-pinned HTTP request resumes the awaiting task with cancellation.
- A browse deadline can cancel the open transport and the outer task group returns promptly.
- Existing response parsing behavior remains unchanged.

## Verification

- `swift test --no-parallel --filter IPPinnedHTTPTransportTests` — 4 tests passed.
- `git diff --check` passed.

## Behaviour delta

Cancellation-only change: previously a raced cancel/deadline could hang the awaiting fetch; now the awaiting task is resumed.

## AI assistance disclosure

- Codex implemented `apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift` and the focused tests in `apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift`.
- I reviewed the completion lifecycle and ran the focused `swift test` command above.
