### PR TITLE
Fix Host header for IPv6-pinned DNS names

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -115,7 +115,7 @@ enum IPPinnedHTTPTransport {
         return Data(headers.utf8)
     }
 
-    private static func hostHeader(
+    static func hostHeader(
         host: String,
         address: ParsedIP,
         port: UInt16
@@ -123,7 +123,8 @@ enum IPPinnedHTTPTransport {
         let bareHost = host.hasPrefix("[") && host.hasSuffix("]")
             ? String(host.dropFirst().dropLast())
             : host
-        let hostText = address.family == .v6 ? "[\(bareHost)]" : bareHost
+        let isIPv6Literal = address.family == .v6 && bareHost.contains(":")
+        let hostText = isIPv6Literal ? "[\(bareHost)]" : bareHost
         return (port == 80 || port == 443) ? hostText : "\(hostText):\(port)"
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -73,6 +73,32 @@ struct IPPinnedHTTPTransportTests {
             return false
         }
     }
+
+    @Test("A DNS hostname pinned to IPv6 keeps its Host header unbracketed")
+    func dnsHostnamePinnedToIPv6KeepsUnbracketedHostHeader() throws {
+        let address = try #require(ParsedIP("2001:db8::1"))
+
+        let hostHeader = IPPinnedHTTPTransport.hostHeader(
+            host: "example.com",
+            address: address,
+            port: 443
+        )
+
+        #expect(hostHeader == "example.com")
+    }
+
+    @Test("An IPv6 literal host uses the required bracket syntax")
+    func ipv6LiteralHostUsesBracketSyntax() throws {
+        let address = try #require(ParsedIP("2001:db8::1"))
+
+        let hostHeader = IPPinnedHTTPTransport.hostHeader(
+            host: "[2001:db8::1]",
+            address: address,
+            port: 443
+        )
+
+        #expect(hostHeader == "[2001:db8::1]")
+    }
 }
 
 private struct TestWatchdogDeadline: Error {}


### PR DESCRIPTION
## Why

Follow-up to #2645. When a DNS hostname resolved to IPv6, the pinned transport wrapped the hostname in brackets and produced an invalid authority such as `Host: [example.com]`, causing normal browse fetches to fail.

## Scope

- Bracket only IPv6 literal hosts, not DNS hostnames.
- Add raw-header tests for a DNS hostname pinned to IPv6 and for an IPv6 literal host.

## Non-goals

- No DNS validation, timeout, parser, redirect, approval, or request-target changes.

## Acceptance

- A DNS hostname pinned to an IPv6 address sends `Host: example.com`.
- An IPv6 literal host continues to send a bracketed authority.

## Verification

- `swift test --package-path apps/rapid-mac --no-parallel --filter IPPinnedHTTPTransportTests` — 6 tests passed.
- `git diff --check` passed.

## Behaviour delta

Browse requests to DNS names whose validated address is IPv6 now send a standards-compliant Host header.

## AI assistance disclosure

- Codex implemented the fix and focused tests.
- I reviewed the Host authority logic and ran the focused test command above.
