### PR TITLE
Bound chunked response parsing safely

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -202,17 +202,15 @@ enum IPHTTPResponseParser {
             if size == 0 {
                 return output
             }
-            let chunkEnd = input.index(offset, offsetBy: size)
-            guard chunkEnd <= input.endIndex else {
+            guard
+                let chunkEnd = input.index(offset, offsetBy: size, limitedBy: input.endIndex),
+                let terminator = input.index(chunkEnd, offsetBy: 2, limitedBy: input.endIndex),
+                input[chunkEnd] == 0x0D,
+                input[input.index(after: chunkEnd)] == 0x0A
+            else {
                 throw IPPinnedHTTPTransport.transportError("truncated HTTP chunked response")
             }
             output.append(contentsOf: input[offset..<chunkEnd])
-            let terminator = input.index(chunkEnd, offsetBy: 2)
-            guard terminator <= input.endIndex,
-                  input[chunkEnd] == 0x0D,
-                  input[input.index(after: chunkEnd)] == 0x0A else {
-                throw IPPinnedHTTPTransport.transportError("invalid HTTP chunk terminator")
-            }
             offset = terminator
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -99,6 +99,40 @@ struct IPPinnedHTTPTransportTests {
 
         #expect(hostHeader == "[2001:db8::1]")
     }
+
+    @Test("A chunk size larger than the remaining body fails closed")
+    func oversizedChunkFailsClosed() throws {
+        let url = try #require(URL(string: "http://pinned-name.test/page"))
+        let raw = Data("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n100\r\nabc".utf8)
+
+        #expect(throws: Error.self) {
+            _ = try IPHTTPResponseParser.parse(data: raw, url: url)
+        }
+    }
+
+    @Test("A chunk missing terminator bytes fails closed")
+    func missingChunkTerminatorFailsClosed() throws {
+        let url = try #require(URL(string: "http://pinned-name.test/page"))
+        let missingBoth = Data("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc".utf8)
+        let missingOne = Data("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r".utf8)
+
+        #expect(throws: Error.self) {
+            _ = try IPHTTPResponseParser.parse(data: missingBoth, url: url)
+        }
+        #expect(throws: Error.self) {
+            _ = try IPHTTPResponseParser.parse(data: missingOne, url: url)
+        }
+    }
+
+    @Test("A parseable Int-sized chunk with no body fails closed")
+    func maxIntChunkFailsClosed() throws {
+        let url = try #require(URL(string: "http://pinned-name.test/page"))
+        let raw = Data("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n7FFFFFFFFFFFFFFF\r\n".utf8)
+
+        #expect(throws: Error.self) {
+            _ = try IPHTTPResponseParser.parse(data: raw, url: url)
+        }
+    }
 }
 
 private struct TestWatchdogDeadline: Error {}


### PR DESCRIPTION
## Why

Follow-up to #2645. Chunked HTTP parsing could trap the desktop process because it advanced `Data` by an attacker-controlled chunk size before validating the remaining byte count.

## Scope

- Use bounded `Data` index advancement for chunk payloads and terminators.
- Add fail-closed tests for oversized chunks, missing terminator bytes, and an `Int.max` chunk size.

## Non-goals

- No changes to response headers, body caps, transport cancellation, redirects, or approval policy.

## Acceptance

- A chunk larger than the remaining response fails closed.
- Missing one or both CRLF terminator bytes fails closed.
- A parseable `Int.max` chunk size fails closed instead of trapping.

## Verification

- `swift test --package-path apps/rapid-mac --no-parallel --filter IPPinnedHTTPTransportTests` — 7 tests passed.
- `git diff --check` passed.

## Behaviour delta

Malformed chunked responses now throw a browse error instead of crashing the desktop process.

## AI assistance disclosure

- Codex implemented the bounded parser change and focused tests.
- I reviewed the byte-boundary logic and ran the focused test command above.
