### PR TITLE
Prevent request-target header injection

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -28,7 +28,7 @@ enum IPPinnedHTTPTransport {
         )
         let reader = ResponseReader(
             connection: connection,
-            request: request(for: url, address: address, host: host, port: port),
+            request: try request(for: url, address: address, host: host, port: port),
             url: url,
             byteLimit: byteLimit
         )
@@ -101,9 +101,9 @@ enum IPPinnedHTTPTransport {
         address: ParsedIP,
         host: String,
         port: UInt16
-    ) -> Data {
-        let path = url.path.isEmpty ? "/" : url.path
-        let target = url.query.map { "\(path)?\($0)" } ?? path
+    ) throws -> Data {
+        let target = try requestTarget(for: url)
+        try validateNoControlCharacters(host)
         let headers = [
             "GET \(target) HTTP/1.1",
             "Host: \(hostHeader(host: host, address: address, scheme: url.scheme?.lowercased() ?? "", port: port))",
@@ -113,6 +113,27 @@ enum IPPinnedHTTPTransport {
             "Connection: close",
         ].joined(separator: "\r\n") + "\r\n\r\n"
         return Data(headers.utf8)
+    }
+
+    static func requestTarget(for url: URL) throws -> String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw transportError("invalid request URL")
+        }
+        let path = components.percentEncodedPath.isEmpty ? "/" : components.percentEncodedPath
+        let query = components.percentEncodedQuery
+        let target = query.map { "\(path)?\($0)" } ?? path
+        try validateNoControlCharacters(target)
+        return target
+    }
+
+    private static func validateNoControlCharacters(_ value: String) throws {
+        guard value.allSatisfy({ character in
+            character.unicodeScalars.allSatisfy { scalar in
+                scalar.value >= 0x20 && scalar.value != 0x7F
+            }
+        }) else {
+            throw transportError("request contains forbidden control characters")
+        }
     }
 
     static func hostHeader(

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -177,6 +177,26 @@ struct IPPinnedHTTPTransportTests {
             _ = try IPHTTPResponseParser.parse(data: raw, url: url)
         }
     }
+
+    @Test("Percent-encoded path and query remain encoded in request-target")
+    func percentEncodedRequestTargetRemainsEncoded() throws {
+        let url = try #require(URL(string: "http://approved.example/a%20b?q=a%20b"))
+
+        let target = try IPPinnedHTTPTransport.requestTarget(for: url)
+
+        #expect(target == "/a%20b?q=a%20b")
+    }
+
+    @Test("Encoded control characters stay encoded in request-target")
+    func encodedControlCharactersRemainEncodedInRequestTarget() throws {
+        let url = try #require(URL(string: "http://approved.example/%0D%0AHost:%20other.internal"))
+
+        let target = try IPPinnedHTTPTransport.requestTarget(for: url)
+
+        #expect(target == "/%0D%0AHost:%20other.internal")
+        #expect(!target.contains("\r"))
+        #expect(!target.contains("\n"))
+    }
 }
 
 private struct TestWatchdogDeadline: Error {}


### PR DESCRIPTION
## Why

Follow-up to #2645. Building the request from the decoded `URL.path` could turn `%0D%0A` into real CRLF bytes and let an approved origin inject headers or an additional HTTP request.

## Scope

- Build HTTP/1.1 request-targets from the percent-encoded path and query.
- Reject control characters in the serialized request-target and host.
- Add tests proving encoded path/query remain encoded and injected sequences cannot expand to raw CRLF.

## Non-goals

- No changes to redirects, DNS validation, chunked parsing, transport cancellation, approval policy, or timeouts.

## Acceptance

- Percent-encoded path and query data remain encoded in the request-target.
- Encoded CRLF sequences cannot become raw header separators.
- Control characters in the request-target or host fail closed.

## Verification

- `swift test --package-path apps/rapid-mac --no-parallel --filter IPPinnedHTTPTransportTests` — 6 tests passed.
- `git diff --check` passed.

## Behaviour delta

Maliciously encoded request paths no longer produce a raw request-line/header injection.

## AI assistance disclosure

- Codex implemented the request-target hardening and focused tests.
- I reviewed the request serialization and ran the focused test command above.
