### PR TITLE
Add validated DNS address fallback

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
@@ -68,10 +68,22 @@ enum BrowseSSRFGuard {
         _ = try await validatedAddress(url)
     }
 
-    /// Validate a URL and return the concrete address used for the pinned
-    /// transport. For DNS names, the first resolver answer is selected only
-    /// after every answer has passed the same public-address checks.
+    /// Validate a URL and return the first concrete address used for the
+    /// pinned transport. For DNS names, the first resolver answer is selected
+    /// only after every answer has passed the same public-address checks.
     static func validatedAddress(_ url: URL) async throws -> ParsedIP {
+        guard let host = url.host, !host.isEmpty else { throw Rejection.noHost }
+        let addresses = try await validatedAddresses(url)
+        guard let address = addresses.first else {
+            throw Rejection.unresolvable(host)
+        }
+        return address
+    }
+
+    /// Validate a URL and return every concrete address selected by DNS, in
+    /// resolver order. All returned addresses passed the same range checks, so
+    /// the caller can fall back to a later address without resolving DNS again.
+    static func validatedAddresses(_ url: URL) async throws -> [ParsedIP] {
         guard let scheme = url.scheme?.lowercased() else { throw Rejection.badURL }
         guard allowedSchemes.contains(scheme) else { throw Rejection.blockedScheme(scheme) }
         guard let host = url.host, !host.isEmpty else { throw Rejection.noHost }
@@ -88,7 +100,7 @@ enum BrowseSSRFGuard {
             if literal.isBlocked {
                 throw Rejection.blockedAddress(host: host, address: literal.canonical)
             }
-            return literal
+            return [literal]
         }
 
         let addresses = try await resolve(bareHost)
@@ -96,7 +108,7 @@ enum BrowseSSRFGuard {
         for ip in addresses where ip.isBlocked {
             throw Rejection.blockedAddress(host: host, address: ip.canonical)
         }
-        return addresses[0]
+        return addresses
     }
 
     /// Resolve a hostname to every A / AAAA address. Runs `getaddrinfo` off the

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -232,16 +232,18 @@ enum BrowseTool {
         while true {
             // Validate (incl. DNS) BEFORE connecting to this hop's host, then
             // pin the socket to the exact validated address.
-            let validatedAddress = try await BrowseSSRFGuard.validatedAddress(current)
+            let validatedAddresses = try await BrowseSSRFGuard.validatedAddresses(current)
             let hopURL = current
 
             // Hard wall-clock ceiling per hop — see ``requestTimeout``.
             let raw = try await withDeadline(requestTimeout) {
-                try await IPPinnedHTTPTransport.fetch(
-                    url: hopURL,
-                    address: validatedAddress,
-                    byteLimit: maxResponseBytes
-                )
+                try await firstSuccessful(addresses: validatedAddresses) { address in
+                    try await IPPinnedHTTPTransport.fetch(
+                        url: hopURL,
+                        address: address,
+                        byteLimit: maxResponseBytes
+                    )
+                }
             }
             let http = raw.response
             if (300..<400).contains(http.statusCode), let loc = http.value(forHTTPHeaderField: "Location") {
@@ -299,6 +301,28 @@ enum BrowseTool {
             }
             return result
         }
+    }
+
+    /// Try each already-validated address until one fetch succeeds. This keeps
+    /// the pinned-socket security model while restoring address fallback lost by
+    /// pinning; outer cancellation remains immediate and never moves to the
+    /// next address.
+    static func firstSuccessful<T: Sendable>(
+        addresses: [ParsedIP],
+        attempt: @escaping @Sendable (ParsedIP) async throws -> T
+    ) async throws -> T {
+        var lastError: Error?
+        for address in addresses {
+            do {
+                return try await attempt(address)
+            } catch {
+                if Task.isCancelled || error is CancellationError {
+                    throw error
+                }
+                lastError = error
+            }
+        }
+        throw lastError ?? simpleError("no validated addresses")
     }
 
     // MARK: - Render

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -135,6 +135,44 @@ struct WebToolsHardeningTests {
         #expect(address == ParsedIP("93.184.216.34"))
     }
 
+    @Test("Validated address fallback tries the next address after a failure")
+    func validatedAddressFallbackTriesNextAddress() async throws {
+        let addresses = [
+            try #require(ParsedIP("2001:db8::1")),
+            try #require(ParsedIP("2001:db8::2")),
+        ]
+        let recorder = AddressAttemptRecorder()
+
+        let result = try await BrowseTool.firstSuccessful(addresses: addresses) { address in
+            await recorder.record(address)
+            if address == addresses[0] {
+                throw TestNetworkFailure()
+            }
+            return address.canonical
+        }
+
+        #expect(result == "2001:db8::2")
+        #expect(await recorder.addresses == addresses)
+    }
+
+    @Test("Cancellation during an address attempt does not try the next address")
+    func cancellationStopsAddressFallback() async throws {
+        let addresses = [try #require(ParsedIP("2001:db8::1"))]
+        let recorder = AddressAttemptRecorder()
+
+        do {
+            _ = try await BrowseTool.firstSuccessful(addresses: addresses) { address in
+                await recorder.record(address)
+                throw CancellationError()
+            }
+            Issue.record("fallback should not swallow cancellation")
+        } catch {
+            #expect(error is CancellationError)
+        }
+
+        #expect(await recorder.addresses == addresses)
+    }
+
     @Test("resolve yields empty for an NXDOMAIN reserved TLD")
     func resolveEmptyForInvalidTLD() async throws {
         // RFC 6761 guarantees ``.invalid`` never resolves; getaddrinfo returns
@@ -160,5 +198,15 @@ struct WebToolsHardeningTests {
         """#.utf8)
         let hit = WeatherTool.parseGeocodingResponse(json, location: "Springfield")
         #expect(hit == nil)
+    }
+}
+
+private struct TestNetworkFailure: Error {}
+
+private actor AddressAttemptRecorder {
+    private(set) var addresses: [ParsedIP] = []
+
+    func record(_ address: ParsedIP) {
+        addresses.append(address)
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #2645. DNS validation returned every validated address but fetch selected only the first, so a CDN returning an unreachable first address would fail without trying an otherwise healthy address. This removed the address fallback users normally get with multiple DNS results.

## Scope

- Return all validated DNS addresses in resolver order.
- Try the next already-validated address after a connection attempt fails.
- Keep one 12-second per-hop deadline across all address attempts.
- Stop immediately on cancellation and never resolve DNS again.

## Non-goals

- No changes to DNS validation rules, approval policy, redirect handling, proxy support, Happy Eyeballs parallel racing, or per-address timeouts.

## Acceptance

- A failing non-cancellation attempt moves to the next validated address.
- Cancellation does not try additional addresses.
- A blocked DNS answer still fails closed before any connection.

## Verification

- `swift test --package-path apps/rapid-mac --no-parallel --filter "IPPinnedHTTPTransportTests|WebToolsHardeningTests"` — 25 tests passed.
- `git diff --check` passed.

## Behaviour delta

Browse fetches can use the second or later validated DNS address when the first attempt fails, within the existing per-hop deadline.

## AI assistance disclosure

- Codex implemented address collection/fallback and focused tests.
- I reviewed the fallback and cancellation behavior and ran the focused test command above.
