### PR TITLE
Fix Host authority default-port handling

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/IPPinnedHTTPTransport.swift
@@ -106,7 +106,7 @@ enum IPPinnedHTTPTransport {
         let target = url.query.map { "\(path)?\($0)" } ?? path
         let headers = [
             "GET \(target) HTTP/1.1",
-            "Host: \(hostHeader(host: host, address: address, port: port))",
+            "Host: \(hostHeader(host: host, address: address, scheme: url.scheme?.lowercased() ?? "", port: port))",
             "User-Agent: \(BrowseTool.userAgent)",
             "Accept: text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8",
             "Accept-Encoding: identity",
@@ -118,6 +118,7 @@ enum IPPinnedHTTPTransport {
     static func hostHeader(
         host: String,
         address: ParsedIP,
+        scheme: String,
         port: UInt16
     ) -> String {
         let bareHost = host.hasPrefix("[") && host.hasSuffix("]")
@@ -125,7 +126,9 @@ enum IPPinnedHTTPTransport {
             : host
         let isIPv6Literal = address.family == .v6 && bareHost.contains(":")
         let hostText = isIPv6Literal ? "[\(bareHost)]" : bareHost
-        return (port == 80 || port == 443) ? hostText : "\(hostText):\(port)"
+        let isDefaultPort = (scheme == "http" && port == 80)
+            || (scheme == "https" && port == 443)
+        return isDefaultPort ? hostText : "\(hostText):\(port)"
     }
 
     fileprivate static func transportError(_ message: String) -> NSError {

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -81,6 +81,7 @@ struct IPPinnedHTTPTransportTests {
         let hostHeader = IPPinnedHTTPTransport.hostHeader(
             host: "example.com",
             address: address,
+            scheme: "https",
             port: 443
         )
 
@@ -94,6 +95,7 @@ struct IPPinnedHTTPTransportTests {
         let hostHeader = IPPinnedHTTPTransport.hostHeader(
             host: "[2001:db8::1]",
             address: address,
+            scheme: "https",
             port: 443
         )
 
@@ -108,6 +110,48 @@ struct IPPinnedHTTPTransportTests {
         #expect(throws: Error.self) {
             _ = try IPHTTPResponseParser.parse(data: raw, url: url)
         }
+    }
+
+    @Test("Explicit non-default ports remain in the Host authority")
+    func explicitNonDefaultPortsRemainInHostAuthority() throws {
+        let address = try #require(ParsedIP("2001:db8::1"))
+
+        let httpOn443 = IPPinnedHTTPTransport.hostHeader(
+            host: "example.com",
+            address: address,
+            scheme: "http",
+            port: 443
+        )
+        let httpsOn80 = IPPinnedHTTPTransport.hostHeader(
+            host: "example.com",
+            address: address,
+            scheme: "https",
+            port: 80
+        )
+
+        #expect(httpOn443 == "example.com:443")
+        #expect(httpsOn80 == "example.com:80")
+    }
+
+    @Test("Default ports are omitted from the Host authority")
+    func defaultPortsAreOmittedFromHostAuthority() throws {
+        let address = try #require(ParsedIP("2001:db8::1"))
+
+        let httpOn80 = IPPinnedHTTPTransport.hostHeader(
+            host: "example.com",
+            address: address,
+            scheme: "http",
+            port: 80
+        )
+        let httpsOn443 = IPPinnedHTTPTransport.hostHeader(
+            host: "example.com",
+            address: address,
+            scheme: "https",
+            port: 443
+        )
+
+        #expect(httpOn80 == "example.com")
+        #expect(httpsOn443 == "example.com")
     }
 
     @Test("A chunk missing terminator bytes fails closed")


### PR DESCRIPTION
## Summary
- Preserve explicit non-default ports in the Host authority.
- Omit port 80 for HTTP and port 443 for HTTPS, including IPv6 literals.
- Add focused regression coverage for cross-scheme default and non-default ports.

## Verification
- swift test --package-path apps/rapid-mac --no-parallel --filter IPPinnedHTTPTransportTests
- 11 transport tests passed.