### PR TITLE
Fix MTP request lifecycle isolation

### DIFF
--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1375,6 +1375,7 @@ class _StubBatchGen:
         # call — the "next sampled token." Tests can override.
         self._orig_next_sample = mx.array([999], dtype=mx.uint32)
         self._orig_next_logprob = mx.array([0.0])
+        self.next_responses: list = []
 
     def _step(self):
         """Model-side ``mlx_lm.generate.GenerationBatch._step`` mimic.
@@ -1401,6 +1402,10 @@ class _StubBatchGen:
         self._next_logprobs = [self._orig_next_logprob]
         _ = mx.eval  # noqa: F841 — imported to keep parity with real path
         return current_list, self._next_logprobs
+
+    def next(self):
+        """Minimal completion boundary used by lifecycle-hook tests."""
+        return list(self.next_responses)
 
 
 class _StubModel:
@@ -1665,26 +1670,8 @@ def test_install_mtp_vendored_initial_skip_log_is_deduplicated_on_uid_reuse(
     assert gb.orig_step_calls == 2
 
 
-def test_install_mtp_vendored_falls_back_to_orig_step_on_batch_size_growth(monkeypatch):
-    """Codex round-A blocker #3 + round-L BLOCKING #2 regression
-    guard.
-
-    Two contracts under test:
-
-    * Round-A: a uid that ran MTP for a while then transitions to a
-      B>1 batch closes its generator (side-effect observable).
-
-    * Round-L: prior round-H revision raised ``RuntimeError`` when
-      B>1 arrived after MTP had emitted tokens, killing the request.
-      That is hostile to a multi-request server where B>1 is the
-      norm. Round-L flips the behavior: the MTP generator is
-      closed, the uid is disabled, and the wrapper delegates to
-      ``_orig_step()`` — the request continues on plain decode with
-      a bounded stream artifact (see :func:`_log_mtp_mid_stream_
-      handoff_once` for the rationale).
-
-    The historical B>1 raise from round-H is intentionally gone.
-    """
+def test_install_mtp_vendored_fails_closed_on_batch_size_growth(monkeypatch):
+    """A defensive B>1 violation must never emit a stale baseline token."""
     from types import SimpleNamespace
 
     import mlx.core as mx
@@ -1737,112 +1724,34 @@ def test_install_mtp_vendored_falls_back_to_orig_step_on_batch_size_growth(monke
     gb._step()
     assert fake_gen_calls["closed"] == 0
 
-    # Now transition to B=2. Round-L BLOCKING #2: uid=7 has state,
-    # but the wrapper MUST NOT raise. It MUST close the stale
-    # generator (round-A), delegate to _orig_step (round-L), and
-    # increment the mid-stream handoff counter (operator-visible
-    # via stats).
+    # Production admission keeps MTP at B=1. Simulate a broken admission
+    # boundary and prove the wrapper terminates before _orig_step can consume
+    # the last-emitted placeholder as a new model input.
     orig_step_before = gb.orig_step_calls
     gb.uids = [1, 2]
-    result = gb._step()
+    with pytest.raises(RuntimeError, match="admission invariant violated"):
+        gb._step()
 
-    # Round-L: fall through to _orig_step, not raise.
-    assert result is not None, (
-        "codex round-L BLOCKING #2 regression: B>1 mid-stream must "
-        "return _orig_step()'s tuple, not None. The wrapper is "
-        "expected to hand off silently, not abort."
-    )
-    assert gb.orig_step_calls == orig_step_before + 1, (
-        "codex round-L BLOCKING #2 regression: B>1 mid-stream did "
-        "NOT delegate to _orig_step. The request would have been "
-        "killed by a RuntimeError under the round-H invariant that "
-        "round-L relaxed."
-    )
+    assert gb.orig_step_calls == orig_step_before
     stats = batch_gen._mtp_vendored_stats
     assert stats["ft_batch_size"] >= 1
-    assert stats["ft_mid_stream_handoff"] >= 1, (
-        "codex round-L BLOCKING #2 regression: mid-stream handoff "
-        "counter did not fire. Operator loses observability of the "
-        "MTP → plain decode transition."
+    assert stats["invariant_violations"] == 1
+    assert fake_gen_calls["closed"] == 1
+
+
+def test_mtp_running_limit_serializes_requests_without_changing_queue_capacity():
+    from vllm_mlx.scheduler import SchedulerConfig, _max_running_sequences
+
+    mtp = SchedulerConfig(
+        spec_decode="mtp",
+        max_num_seqs=256,
+        max_concurrent_requests=256,
     )
-    assert fake_gen_calls["closed"] >= 1, (
-        "codex round-A blocker #3 regression: B>1 handoff path did "
-        "not close the stale generator on the way out."
-    )
+    assert _max_running_sequences(mtp) == 1
+    assert mtp.max_concurrent_requests == 256
 
-
-def test_install_mtp_vendored_b_gt_1_handoff_keeps_yielding_tokens(monkeypatch):
-    """Codex round-L BLOCKING #2 positive test.
-
-    Once the mid-stream B>1 handoff has fired, subsequent _step
-    calls (still under B>1) MUST keep calling _orig_step — the
-    request stays on plain decode until it completes. The disable
-    marker on the affected uid ensures we don't accidentally re-arm
-    MTP mid-request.
-    """
-    from types import SimpleNamespace
-
-    import mlx.core as mx
-
-    from vllm_mlx.scheduler import _install_mtp_vendored
-    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
-
-    fake_gen_calls = {"constructed": 0, "closed": 0}
-
-    class _FakeGen:
-        def __init__(self):
-            fake_gen_calls["constructed"] += 1
-            self._n = 0
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            self._n += 1
-            return (self._n + 1000, mx.array([0.0]), False)
-
-        def close(self):
-            fake_gen_calls["closed"] += 1
-
-    monkeypatch.setattr(_gen_mod, "mtp_generate_step", lambda *a, **kw: _FakeGen())
-
-    batch_gen, gb = _make_batch_gen_with_gb()
-    gb.uids = [7]
-    request_stub = SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0))
-    ok = _install_mtp_vendored(
-        batch_gen,
-        model=_StubModel(),
-        requests={"req-7": request_stub},
-        uid_to_request_id={7: "req-7"},
-    )
-    assert ok is True
-
-    gb._next_tokens = mx.array([500], dtype=mx.uint32)
-    gb._next_logprobs = [mx.array([0.0])]
-
-    # Prime MTP with one successful call, then trigger B>1 handoff.
-    gb._step()  # FIRST-call: MTP primed
-    gb.uids = [1, 2]
-    gb._step()  # handoff fires
-    # Handoff happened via _record_terminal_disable, so uid=7 is
-    # now in _disabled_uids (accessible via the state map keyed by
-    # uid). But the wrapper is now installed at B>1, and the
-    # disable gate only fires when len(gb.uids)==1. The B>1 gate
-    # in _mtp_step should keep firing for every subsequent step
-    # while B>1 — the request never re-enters MTP even if the
-    # batch later returns to B=1 for THIS uid because it's
-    # disabled.
-
-    orig_before = gb.orig_step_calls
-    for _ in range(5):
-        gb._step()
-    assert gb.orig_step_calls == orig_before + 5, (
-        "codex round-L BLOCKING #2 regression: post-handoff _step "
-        "calls did not consistently delegate to _orig_step. The "
-        "request must continue on plain decode after the handoff."
-    )
-    stats = batch_gen._mtp_vendored_stats
-    assert stats["ft_batch_size"] >= 5
+    plain = SchedulerConfig(spec_decode="none", max_num_seqs=17)
+    assert _max_running_sequences(plain) == 17
 
 
 def test_install_mtp_vendored_b_gt_1_soft_fallthrough_when_no_state():
@@ -1875,6 +1784,113 @@ def test_install_mtp_vendored_b_gt_1_soft_fallthrough_when_no_state():
     stats = batch_gen._mtp_vendored_stats
     assert stats["ft_batch_size"] >= 1
     assert gb.orig_step_calls == 1
+
+
+@pytest.mark.parametrize("departure", ["finish", "remove"])
+def test_install_mtp_vendored_reaps_request_state_on_departure(
+    monkeypatch,
+    departure,
+):
+    """Normal completion and cancellation both release generator caches."""
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    closed: list[int] = []
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (1001, mx.array([0.0]), False)
+
+        def close(self):
+            closed.append(7)
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", lambda *a, **kw: _FakeGen())
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    present = {7}
+    batch_gen._find_uids = lambda uids: {
+        uid: (2, index) for index, uid in enumerate(sorted(present)) if uid in set(uids)
+    }
+
+    def remove(uids, return_prompt_caches=False):
+        present.difference_update(uids)
+        return {} if return_prompt_caches else None
+
+    batch_gen.remove = remove
+    gb.uids = [7]
+    ok = _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={
+            "req-7": SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0))
+        },
+        uid_to_request_id={7: "req-7"},
+    )
+    assert ok is True
+
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    gb._step()
+    assert set(gb._mtp_vendored_state) == {7}
+
+    if departure == "finish":
+        gb.next_responses = [SimpleNamespace(uid=7, finish_reason="stop")]
+        gb.next()
+    else:
+        batch_gen.remove([7])
+
+    assert closed == [7]
+    assert gb._mtp_vendored_state == {}
+    assert gb._mtp_vendored_disabled_uids == {}
+
+
+def test_install_mtp_vendored_partial_remove_reaps_only_departed_uid():
+    """A failed multi-uid remove must retain state for members still live."""
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    present = {7, 8}
+    batch_gen._find_uids = lambda uids: {
+        uid: (2, index) for index, uid in enumerate(sorted(present)) if uid in set(uids)
+    }
+
+    def partial_remove(uids, return_prompt_caches=False):
+        present.remove(uids[0])
+        raise RuntimeError("simulated partial remove")
+
+    batch_gen.remove = partial_remove
+    assert _install_mtp_vendored(batch_gen, model=_StubModel()) is True
+
+    closed: list[int] = []
+
+    class _Closable:
+        def __init__(self, uid):
+            self.uid = uid
+
+        def close(self):
+            closed.append(self.uid)
+
+    gb._mtp_vendored_state.update(
+        {
+            7: {"gen": _Closable(7), "queue": []},
+            8: {"gen": _Closable(8), "queue": []},
+        }
+    )
+    gb._mtp_vendored_disabled_uids.update({7: "req-7", 8: "req-8"})
+
+    with pytest.raises(RuntimeError, match="partial remove"):
+        batch_gen.remove([7, 8])
+
+    assert closed == [7]
+    assert set(gb._mtp_vendored_state) == {8}
+    assert gb._mtp_vendored_disabled_uids == {8: "req-8"}
 
 
 def test_install_mtp_vendored_first_call_construction_failure_does_not_double_book(
@@ -2230,18 +2246,8 @@ def test_install_mtp_vendored_cleanup_does_not_clear_disabled_uids(monkeypatch):
     )
 
 
-def test_install_mtp_vendored_stop_iteration_disables_uid_before_raise(monkeypatch):
-    """Codex round-G BLOCKING #2 regression guard (StopIteration branch).
-
-    On ``StopIteration`` mid-stream, the wrapper must:
-    (a) record the current request_id in ``_disabled_uids`` so any
-        retry short-circuits to plain decode; and
-    (b) raise ``RuntimeError`` so mlx-lm surfaces the failure.
-
-    Earlier revision called ``_cleanup_uid`` which cleared the
-    disable, meaning a retry on the same uid+request_id would re-
-    enter FIRST-call construction and hit the same bug.
-    """
+def test_install_mtp_vendored_stop_iteration_latches_terminal_uid(monkeypatch):
+    """A broken generator cannot retry through stale plain-decode state."""
     from types import SimpleNamespace
 
     import mlx.core as mx
@@ -2282,8 +2288,7 @@ def test_install_mtp_vendored_stop_iteration_disables_uid_before_raise(monkeypat
     gb._step()
 
     # Second call — draining the queue is empty, pulls from _EmptyGen
-    # which raises StopIteration. Wrapper must record 88 in
-    # _disabled_uids (with req-88 as the marker) before raising.
+    # which raises StopIteration. Wrapper must record a terminal marker.
     try:
         gb._step()
     except RuntimeError as e:
@@ -2292,25 +2297,16 @@ def test_install_mtp_vendored_stop_iteration_disables_uid_before_raise(monkeypat
             or "stopiteration" in str(e).lower()
             or "before mlx-lm hit" in str(e).lower()
         )
-        # Simulate a retry: if mlx-lm re-enters _mtp_step with the
-        # same uid+request_id, the disable marker MUST fire and
-        # short-circuit to _orig_step (not re-enter construction).
-        # This can happen if the caller uses the exception as
-        # "back off then retry" rather than propagating.
+        # A retry on the same uid must fail closed again. It may not enter
+        # ordinary decode with the last-emitted token as its next input.
         gb._next_tokens = mx.array([500], dtype=mx.uint32)
         gb._next_logprobs = [mx.array([0.0])]
         gb.uids = [88]
         pre_retry_orig_step_calls = gb.orig_step_calls
-        gb._step()
-        # The wrapper hit the disable short-circuit and called
-        # _orig_step. NOT a fresh construction attempt.
-        assert gb.orig_step_calls == pre_retry_orig_step_calls + 1, (
-            "codex round-G BLOCKING #2 regression: retry on the same "
-            "uid+request_id after a StopIteration failure did NOT hit "
-            "the disable short-circuit."
-        )
-        stats = batch_gen._mtp_vendored_stats
-        assert stats.get("ft_disabled", 0) >= 1
+        with pytest.raises(RuntimeError, match="refusing to retry terminal"):
+            gb._step()
+        assert gb.orig_step_calls == pre_retry_orig_step_calls
+        assert gb._mtp_vendored_terminal_uids == {88: "req-88"}
         return
     raise AssertionError(
         "codex round-G BLOCKING #2 regression: wrapper did NOT raise "
@@ -2318,23 +2314,10 @@ def test_install_mtp_vendored_stop_iteration_disables_uid_before_raise(monkeypat
     )
 
 
-def test_install_mtp_vendored_non_greedy_mid_stream_falls_back_to_orig_step(
+def test_install_mtp_vendored_non_greedy_mid_stream_fails_closed(
     monkeypatch,
 ):
-    """Codex round-L BLOCKING #3 regression guard.
-
-    Prior round-H revision raised ``RuntimeError`` when sampling
-    switched to non-greedy after MTP had already emitted tokens.
-    That killed the request whenever an operator adjusted sampling
-    params mid-stream.
-
-    Round-L flip: the wrapper closes the MTP generator, marks the
-    uid disabled, delegates to ``_orig_step()``, and logs a WARN
-    for the operator. Subsequent steps stay on plain decode via
-    the disable short-circuit. Same bounded stream-artifact
-    tradeoff as the B>1 handoff (see :func:`_log_mtp_mid_stream_
-    handoff_once`).
-    """
+    """A changed sampling contract cannot cross to stale plain state."""
     from types import SimpleNamespace
 
     import mlx.core as mx
@@ -2379,60 +2362,27 @@ def test_install_mtp_vendored_non_greedy_mid_stream_falls_back_to_orig_step(
     # First call — MTP primed. _state[55] populated.
     gb._step()
 
-    # Mid-stream switch to temp > 0 — round-L handoff branch.
+    # Mid-stream switch to temp > 0 must terminate before ordinary decode.
     orig_before = gb.orig_step_calls
     sp.temperature = 0.7
-    result = gb._step()
+    with pytest.raises(RuntimeError, match="sampling parameters changed"):
+        gb._step()
 
-    assert result is not None, (
-        "codex round-L BLOCKING #3 regression: non-greedy mid-stream "
-        "must delegate to _orig_step, not raise. The wrapper hands "
-        "off silently and lets the request continue on plain decode."
-    )
-    assert gb.orig_step_calls == orig_before + 1, (
-        "codex round-L BLOCKING #3 regression: non-greedy mid-stream "
-        "did NOT delegate to _orig_step. Under round-H the request "
-        "would have been killed by a RuntimeError; round-L relaxes "
-        "that to a fallback."
-    )
+    assert gb.orig_step_calls == orig_before
     stats = batch_gen._mtp_vendored_stats
     assert stats["ft_non_greedy"] >= 1
-    assert stats["ft_mid_stream_handoff"] >= 1, (
-        "codex round-L BLOCKING #3 regression: mid-stream handoff "
-        "counter did not fire on non-greedy transition."
-    )
-    assert fake_gen_calls["closed"] >= 1, (
-        "codex round-L BLOCKING #3: non-greedy handoff MUST close "
-        "the stale MTP generator so nothing dangles across the "
-        "request tail."
-    )
+    assert stats["invariant_violations"] == 1
+    assert fake_gen_calls["closed"] == 1
 
-    # Subsequent steps stay on plain decode (uid=55 is now disabled).
-    gb._next_tokens = mx.array([301], dtype=mx.uint32)
-    gb._next_logprobs = [mx.array([0.0])]
-    pre = gb.orig_step_calls
-    gb._step()
-    assert gb.orig_step_calls == pre + 1, (
-        "codex round-L BLOCKING #3 regression: post-handoff retry "
-        "did not hit the disable short-circuit; a new MTP generator "
-        "would be constructed and the fallback design regressed."
-    )
+    with pytest.raises(RuntimeError, match="refusing to retry terminal"):
+        gb._step()
+    assert gb.orig_step_calls == orig_before
 
 
-def test_install_mtp_vendored_logits_processors_mid_stream_falls_back_to_orig_step(
+def test_install_mtp_vendored_logits_processors_mid_stream_fails_closed(
     monkeypatch,
 ):
-    """Codex round-L BLOCKING #4 regression guard.
-
-    Prior round-H revision raised ``RuntimeError`` when a logits
-    processor was added after MTP had already emitted. That killed
-    the request whenever an operator wired a guided-decoding
-    grammar (or similar per-request processor) mid-stream.
-
-    Round-L flip: close the MTP generator, mark uid disabled,
-    delegate to ``_orig_step`` and log a WARN. Subsequent steps
-    stay on plain decode via the disable short-circuit.
-    """
+    """A newly added stateful processor cannot cross a stale handoff."""
     from types import SimpleNamespace
 
     import mlx.core as mx
@@ -2475,41 +2425,21 @@ def test_install_mtp_vendored_logits_processors_mid_stream_falls_back_to_orig_st
     # First call — MTP primed.
     gb._step()
 
-    # Mid-stream: install a truthy logits processor — round-L handoff branch.
+    # Mid-stream: install a truthy logits processor and fail before fallback.
     gb.logits_processors = [[lambda tokens, logits: logits]]
     orig_before = gb.orig_step_calls
-    result = gb._step()
+    with pytest.raises(RuntimeError, match="sampling contract changed"):
+        gb._step()
 
-    assert result is not None, (
-        "codex round-L BLOCKING #4 regression: mid-stream logits "
-        "processor MUST delegate to _orig_step, not raise."
-    )
-    assert gb.orig_step_calls == orig_before + 1, (
-        "codex round-L BLOCKING #4 regression: logits-processor "
-        "mid-stream did NOT delegate to _orig_step. The request "
-        "would have been killed by a RuntimeError under the "
-        "round-H invariant that round-L relaxed."
-    )
+    assert gb.orig_step_calls == orig_before
     stats = batch_gen._mtp_vendored_stats
     assert stats["ft_logits_processors"] >= 1
-    assert stats["ft_mid_stream_handoff"] >= 1, (
-        "codex round-L BLOCKING #4 regression: mid-stream handoff "
-        "counter did not fire on lp transition."
-    )
-    assert fake_gen_calls["closed"] >= 1, (
-        "codex round-L BLOCKING #4: lp handoff MUST close the "
-        "stale MTP generator on the way out."
-    )
+    assert stats["invariant_violations"] == 1
+    assert fake_gen_calls["closed"] == 1
 
-    # Subsequent step stays on plain decode (uid=33 disabled).
-    gb._next_tokens = mx.array([401], dtype=mx.uint32)
-    gb._next_logprobs = [mx.array([0.0])]
-    pre = gb.orig_step_calls
-    gb._step()
-    assert gb.orig_step_calls == pre + 1, (
-        "codex round-L BLOCKING #4 regression: post-handoff retry "
-        "did not hit the disable short-circuit."
-    )
+    with pytest.raises(RuntimeError, match="refusing to retry terminal"):
+        gb._step()
+    assert gb.orig_step_calls == orig_before
 
 
 def test_install_mtp_vendored_seeded_before_state_soft_fallthrough(monkeypatch):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -2084,6 +2084,78 @@ def test_install_mtp_vendored_partial_remove_reaps_only_departed_uid():
     assert gb._mtp_vendored_disabled_uids == {8: "req-8"}
 
 
+@pytest.mark.parametrize("finder_shape", ["missing", "raises"])
+def test_install_mtp_vendored_partial_remove_keeps_state_when_departure_unknown(
+    finder_shape,
+):
+    """An unobservable partial removal cannot justify reaping live state."""
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+
+    def partial_remove(_uids, return_prompt_caches=False):
+        raise RuntimeError("simulated partial remove")
+
+    batch_gen.remove = partial_remove
+    if finder_shape == "raises":
+
+        def broken_finder(_uids):
+            raise RuntimeError("finder unavailable")
+
+        batch_gen._find_uids = broken_finder
+
+    assert _install_mtp_vendored(batch_gen, model=_StubModel()) is True
+    gb._mtp_vendored_state[7] = {"gen": None, "queue": []}
+
+    with pytest.raises(RuntimeError, match="partial remove"):
+        batch_gen.remove([7])
+
+    assert set(gb._mtp_vendored_state) == {7}
+
+
+@pytest.mark.parametrize(
+    ("returned_caches", "expected_cache"),
+    [
+        ({}, None),
+        ({7: (["cache"], [1, 2])}, (["cache"], [1, 2])),
+    ],
+)
+def test_scheduler_stop_retirement_preserves_only_committed_plain_cache(
+    returned_caches,
+    expected_cache,
+):
+    """Plain decode keeps committed cache; a missing cache stays absent."""
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.scheduler import Scheduler
+
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.spec_decode_runtime_method = None
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = returned_caches
+    response = SimpleNamespace(uid=7)
+
+    scheduler._retire_scheduler_finished_uid(response)
+
+    scheduler.batch_generator.remove.assert_called_once_with(
+        [7], return_prompt_caches=True
+    )
+    if expected_cache is None:
+        assert not hasattr(response, "prompt_cache")
+    else:
+        assert (response.prompt_cache, response.all_tokens) == expected_cache
+
+
+def test_scheduler_stop_retirement_requires_live_batch_generator():
+    from vllm_mlx.scheduler import Scheduler
+
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = None
+
+    with pytest.raises(RuntimeError, match="without a BatchGenerator"):
+        scheduler._retire_scheduler_finished_uid(SimpleNamespace(uid=7))
+
+
 def test_install_mtp_vendored_first_call_construction_failure_does_not_double_book(
     monkeypatch,
 ):
@@ -2463,11 +2535,13 @@ def test_install_mtp_vendored_stop_iteration_latches_terminal_uid(monkeypatch):
     batch_gen, gb = _make_batch_gen_with_gb()
     gb.uids = [88]
     request_stub = SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0))
+    requests = {"req-88": request_stub}
+    uid_to_request_id = {88: "req-88"}
     ok = _install_mtp_vendored(
         batch_gen,
         model=_StubModel(),
-        requests={"req-88": request_stub},
-        uid_to_request_id={88: "req-88"},
+        requests=requests,
+        uid_to_request_id=uid_to_request_id,
     )
     assert ok is True
 
@@ -2498,6 +2572,16 @@ def test_install_mtp_vendored_stop_iteration_latches_terminal_uid(monkeypatch):
             gb._step()
         assert gb.orig_step_calls == pre_retry_orig_step_calls
         assert gb._mtp_vendored_terminal_uids == {88: "req-88"}
+
+        # mlx-lm may reuse the integer uid after the failed request is removed.
+        # A different authoritative request id proves this is a new owner and
+        # clears the terminal latch before constructing its fresh generator.
+        uid_to_request_id[88] = "req-89"
+        requests["req-89"] = request_stub
+        gb._next_tokens = mx.array([600], dtype=mx.uint32)
+        gb._next_logprobs = [mx.array([0.0])]
+        gb._step()
+        assert gb._mtp_vendored_terminal_uids == {}
         return
     raise AssertionError(
         "codex round-G BLOCKING #2 regression: wrapper did NOT raise "

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1740,18 +1740,79 @@ def test_install_mtp_vendored_fails_closed_on_batch_size_growth(monkeypatch):
 
 
 def test_mtp_running_limit_serializes_requests_without_changing_queue_capacity():
-    from vllm_mlx.scheduler import SchedulerConfig, _max_running_sequences
+    from types import SimpleNamespace
 
-    mtp = SchedulerConfig(
-        spec_decode="mtp",
-        max_num_seqs=256,
-        max_concurrent_requests=256,
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SchedulerConfig(
+        spec_decode="mtp", max_num_seqs=256, max_concurrent_requests=256
     )
-    assert _max_running_sequences(mtp) == 1
-    assert mtp.max_concurrent_requests == 256
+    scheduler.spec_decode_runtime_attempted = False
+    scheduler.spec_decode_runtime_method = None
+    assert scheduler._max_running_sequences() == 1
+    assert scheduler.config.max_concurrent_requests == 256
 
-    plain = SchedulerConfig(spec_decode="none", max_num_seqs=17)
-    assert _max_running_sequences(plain) == 17
+    scheduler.spec_decode_runtime_attempted = True
+    scheduler.spec_decode_runtime_method = "mtp"
+    assert scheduler._max_running_sequences() == 1
+
+    # A definitive MTP gate miss means this generator is ordinary decode;
+    # restore the configured batch width instead of serializing forever.
+    scheduler.spec_decode_runtime_method = None
+    assert scheduler._max_running_sequences() == 256
+
+    scheduler.config = SimpleNamespace(spec_decode="none", max_num_seqs=17)
+    assert scheduler._max_running_sequences() == 17
+
+
+def test_mtp_install_gate_miss_restores_plain_batch_width_in_same_schedule_tick():
+    """An unsupported MTP runtime must not serialize ordinary decoding."""
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.request import Request, SamplingParams
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda _text: [1]
+    scheduler = Scheduler(
+        MagicMock(),
+        tokenizer,
+        SchedulerConfig(spec_decode="mtp", max_num_seqs=4),
+    )
+    for index in range(2):
+        scheduler.waiting.append(
+            Request(
+                f"req-{index}",
+                "prompt",
+                SamplingParams(max_tokens=4),
+                prompt_token_ids=[1, 2],
+            )
+        )
+
+    batch_generator = MagicMock()
+    batch_generator.insert.side_effect = [[7], [8]]
+    scheduler.batch_generator = batch_generator
+    scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+    scheduler._register_uid_processors = MagicMock()
+
+    install_checks = 0
+
+    def ensure_after_failed_install(_sampling_params):
+        nonlocal install_checks
+        install_checks += 1
+        if install_checks == 1:
+            scheduler.spec_decode_runtime_attempted = True
+            scheduler.spec_decode_runtime_method = None
+        return True
+
+    scheduler._ensure_batch_generator = ensure_after_failed_install
+
+    scheduled = scheduler._schedule_waiting()
+
+    assert [request.request_id for request in scheduled] == ["req-0", "req-1"]
+    assert list(scheduler.running) == ["req-0", "req-1"]
+    assert batch_generator.insert.call_count == 2
 
 
 def test_install_mtp_vendored_b_gt_1_soft_fallthrough_when_no_state():
@@ -1849,6 +1910,130 @@ def test_install_mtp_vendored_reaps_request_state_on_departure(
     assert closed == [7]
     assert gb._mtp_vendored_state == {}
     assert gb._mtp_vendored_disabled_uids == {}
+
+
+def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
+    """A scheduler-side text stop must free the B=1 MTP slot immediately.
+
+    mlx-lm cannot see user-supplied text stop strings, so its response has no
+    finish reason and its GenerationBatch row remains live.  The scheduler
+    must remove that row through the same lifecycle hook as cancellation
+    before admitting the next queued request; otherwise the next request makes
+    the vendored verifier observe B=2 with stale request-local state.
+    """
+    from unittest.mock import MagicMock
+
+    import mlx.core as mx
+
+    from vllm_mlx.request import Request, RequestStatus, SamplingParams
+    from vllm_mlx.scheduler import (
+        Scheduler,
+        SchedulerConfig,
+        _install_mtp_vendored,
+    )
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (1001, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", lambda *a, **kw: _FakeGen())
+
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda _text: [1]
+    scheduler = Scheduler(
+        MagicMock(),
+        tokenizer,
+        SchedulerConfig(spec_decode="mtp", max_num_seqs=4),
+    )
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    present = {7}
+
+    def find_uids(uids):
+        return {
+            uid: (2, index)
+            for index, uid in enumerate(sorted(present))
+            if uid in set(uids)
+        }
+
+    def remove(uids, return_prompt_caches=False):
+        removed = [uid for uid in uids if uid in present]
+        present.difference_update(removed)
+        gb.uids = [uid for uid in gb.uids if uid in present]
+        if return_prompt_caches:
+            return {uid: (None, []) for uid in removed}
+        return None
+
+    batch_gen._find_uids = find_uids
+    batch_gen.remove = remove
+    scheduler.batch_generator = batch_gen
+
+    first = Request(
+        "req-7",
+        "prompt",
+        SamplingParams(max_tokens=100, temperature=0.0, stop=["STOP"]),
+    )
+    first.status = RequestStatus.RUNNING
+    first.num_prompt_tokens = 1
+    first.batch_uid = 7
+    first._decoder = MagicMock()
+    first._decoder.add_token.return_value = " STOP"
+    first._decoder.get_full_text.return_value = "prefix STOP"
+    first._decoder.prev_text = "prefix "
+    scheduler.running[first.request_id] = first
+    scheduler.uid_to_request_id[7] = first.request_id
+    scheduler.request_id_to_uid[first.request_id] = 7
+
+    gb.uids = [7]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests=scheduler.running,
+        uid_to_request_id=scheduler.uid_to_request_id,
+    )
+    gb._step()
+    assert set(gb._mtp_vendored_state) == {7}
+
+    response = SimpleNamespace(
+        uid=7,
+        token=501,
+        finish_reason=None,
+        logprobs=None,
+    )
+    outputs, finished = scheduler._process_batch_responses([response])
+    assert outputs[0].finish_reason == "stop"
+    assert finished == {first.request_id}
+    assert present == set()
+    assert gb._mtp_vendored_state == {}
+
+    scheduler._cleanup_finished(finished)
+    second = Request(
+        "req-8",
+        "next",
+        SamplingParams(max_tokens=100, temperature=0.0),
+    )
+    second.status = RequestStatus.RUNNING
+    second.batch_uid = 8
+    scheduler.running[second.request_id] = second
+    scheduler.uid_to_request_id[8] = second.request_id
+    scheduler.request_id_to_uid[second.request_id] = 8
+    present.add(8)
+    gb.uids = [8]
+    gb.tokens = [[]]
+    gb._next_tokens = mx.array([600], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+
+    gb._step()
+    assert set(gb._mtp_vendored_state) == {8}
 
 
 def test_install_mtp_vendored_partial_remove_reaps_only_departed_uid():

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1955,6 +1955,7 @@ def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
 
     batch_gen, gb = _make_batch_gen_with_gb()
     present = {7}
+    cache_return_requests: list[bool] = []
 
     def find_uids(uids):
         return {
@@ -1964,6 +1965,7 @@ def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
         }
 
     def remove(uids, return_prompt_caches=False):
+        cache_return_requests.append(return_prompt_caches)
         removed = [uid for uid in uids if uid in present]
         present.difference_update(removed)
         gb.uids = [uid for uid in gb.uids if uid in present]
@@ -1974,6 +1976,8 @@ def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
     batch_gen._find_uids = find_uids
     batch_gen.remove = remove
     scheduler.batch_generator = batch_gen
+    scheduler.spec_decode_runtime_attempted = True
+    scheduler.spec_decode_runtime_method = "mtp"
 
     first = Request(
         "req-7",
@@ -2014,6 +2018,8 @@ def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
     assert finished == {first.request_id}
     assert present == set()
     assert gb._mtp_vendored_state == {}
+    assert not hasattr(response, "prompt_cache")
+    assert cache_return_requests == [False]
 
     scheduler._cleanup_finished(finished)
     second = Request(

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -24,7 +24,10 @@ def _scheduler() -> Scheduler:
     tokenizer = MagicMock()
     tokenizer.encode = lambda text: list(range(len(text.split())))
     tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
-    return Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2))
+    scheduler = Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2))
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
+    return scheduler
 
 
 def test_detects_long_exact_periodic_suffix():

--- a/tests/test_scheduler_stop_decoder_surface.py
+++ b/tests/test_scheduler_stop_decoder_surface.py
@@ -35,7 +35,10 @@ def _make_scheduler() -> Scheduler:
     model = MagicMock()
     tokenizer = MagicMock()
     tokenizer.encode = lambda s: list(range(len(s.split())))
-    return Scheduler(model, tokenizer, SchedulerConfig(max_num_seqs=4))
+    scheduler = Scheduler(model, tokenizer, SchedulerConfig(max_num_seqs=4))
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
+    return scheduler
 
 
 def _make_request_with_decoder(

--- a/tests/test_stop_string_enforcement.py
+++ b/tests/test_stop_string_enforcement.py
@@ -35,7 +35,10 @@ def _make_scheduler() -> Scheduler:
     tokenizer = MagicMock()
     tokenizer.encode = lambda s: list(range(len(s.split())))
     config = SchedulerConfig(max_num_seqs=4)
-    return Scheduler(model, tokenizer, config)
+    scheduler = Scheduler(model, tokenizer, config)
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
+    return scheduler
 
 
 def _make_request(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -624,20 +624,6 @@ class SchedulerConfig:
         self.pflash_config = self.pflash_config.validate()
 
 
-def _max_running_sequences(config: SchedulerConfig) -> int:
-    """Return the live decode width supported by the selected runtime.
-
-    The vendored MTP path has a request-local verifier/cache transaction and
-    currently supports one sequence. Admission therefore serializes running
-    MTP requests while leaving ``max_concurrent_requests`` as the independent
-    queue/backpressure capacity. Other runtimes retain the operator's batch
-    width unchanged.
-    """
-    if config.spec_decode == "mtp":
-        return 1
-    return config.max_num_seqs
-
-
 @dataclass
 class SchedulerOutput:
     """
@@ -6861,6 +6847,21 @@ class Scheduler:
             )
         return snapshot_boundary
 
+    def _max_running_sequences(self) -> int:
+        """Return the batch width supported by the live speculative runtime.
+
+        Before the lazy MTP install gate runs, admit one request so an
+        unsupported batch cannot form. A successful install keeps B=1; a
+        definitive gate miss restores the operator's ordinary-decode width.
+        """
+        if getattr(self.config, "spec_decode", "none") != "mtp":
+            return self.config.max_num_seqs
+        if not getattr(self, "spec_decode_runtime_attempted", False):
+            return 1
+        if getattr(self, "spec_decode_runtime_method", None) == "mtp":
+            return 1
+        return self.config.max_num_seqs
+
     def _schedule_waiting(self) -> list[Request]:
         """
         Move requests from waiting queue to running.
@@ -6874,8 +6875,7 @@ class Scheduler:
         # and explicitly supports B=1. Keep later requests in the ordinary
         # scheduler queue until that request departs; this preserves liveness
         # without ever attempting a lossy MTP-to-plain handoff mid-stream.
-        running_limit = _max_running_sequences(self.config)
-        while self.waiting and len(self.running) < running_limit:
+        while self.waiting and len(self.running) < self._max_running_sequences():
             request = self.waiting.popleft()
 
             # Ensure we have a batch generator. The False return means
@@ -7184,6 +7184,29 @@ class Scheduler:
 
         return scheduled
 
+    def _retire_scheduler_finished_uid(self, response: Any) -> None:
+        """Remove a uid finished by scheduler-side stop policy.
+
+        mlx-lm removes rows when its own EOS/token limit sets ``finish_reason``.
+        Text stop sequences and repetition-loop aborts are detected later by
+        Rapid-MLX, after ``GenerationBatch.next()`` returned, so that row is
+        still live. Remove it through the BatchGenerator lifecycle seam and
+        copy any returned cache onto the response before normal cache storage.
+        """
+        batch_generator = self.batch_generator
+        if batch_generator is None:
+            raise RuntimeError(
+                "scheduler generated a terminal response without a BatchGenerator"
+            )
+        caches = batch_generator.remove(
+            [response.uid],
+            return_prompt_caches=True,
+        )
+        cached = caches.get(response.uid) if isinstance(caches, dict) else None
+        if cached is None:
+            return
+        response.prompt_cache, response.all_tokens = cached
+
     def _process_batch_responses(
         self, responses: list[Any]
     ) -> tuple[list[RequestOutput], set[str]]:
@@ -7417,6 +7440,9 @@ class Scheduler:
 
             # Check if finished
             if finish_reason is not None:
+                scheduler_generated_finish = response.finish_reason is None
+                if scheduler_generated_finish:
+                    self._retire_scheduler_finished_uid(response)
                 response.finish_reason = finish_reason
                 if response.finish_reason == "stop":
                     request.set_finished(RequestStatus.FINISHED_STOPPED)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -624,6 +624,20 @@ class SchedulerConfig:
         self.pflash_config = self.pflash_config.validate()
 
 
+def _max_running_sequences(config: SchedulerConfig) -> int:
+    """Return the live decode width supported by the selected runtime.
+
+    The vendored MTP path has a request-local verifier/cache transaction and
+    currently supports one sequence. Admission therefore serializes running
+    MTP requests while leaving ``max_concurrent_requests`` as the independent
+    queue/backpressure capacity. Other runtimes retain the operator's batch
+    width unchanged.
+    """
+    if config.spec_decode == "mtp":
+        return 1
+    return config.max_num_seqs
+
+
 @dataclass
 class SchedulerOutput:
     """
@@ -773,10 +787,10 @@ def _install_mtp_vendored(
 
     Adaptive chain-of-K scope:
 
-    * Single-request only (``len(gb.uids) == 1``). Multi-request batches
-      fall through to ``_orig_step`` — Gemma 4's MTP fast-path is
-      batch=1-only (``mtp_forward`` raises on B>1) and the vendored
-      generator maintains its own per-request state.
+    * Single-request only (``len(gb.uids) == 1``). Scheduler admission keeps
+      an MTP generator at one running sequence while additional requests wait;
+      Gemma 4's MTP fast-path is batch=1-only (``mtp_forward`` raises on B>1)
+      and the vendored generator maintains its own per-request state.
 
     * Request-local temperature / top-p / top-k / min-p are passed through to
       the generator's target-distribution verifier. Seeded requests still fall
@@ -895,6 +909,10 @@ def _install_mtp_vendored(
     # (this only happens under bench harness callers, where uids are
     # not reused across requests anyway).
     _disabled_uids: dict[int, str | None] = {}
+    # Terminal failures are distinct from pre-MTP soft disables. Once MTP has
+    # emitted, retrying through ``_orig_step`` would consume a stale placeholder;
+    # the uid must keep failing closed until removal or verified uid reuse.
+    _terminal_uids: dict[int, str | None] = {}
 
     _stats = {
         "vendored_steps": 0,
@@ -905,57 +923,10 @@ def _install_mtp_vendored(
         "ft_disabled": 0,
         "gen_exhausted": 0,
         "gen_raised": 0,
-        # Codex round-L BLOCKING #2-4: track uids that have been
-        # handed off from MTP to plain decode mid-stream so subsequent
-        # fallback branches can log ONCE per uid rather than once per
-        # step. Silent degradation is per Ollama's depth-0 park
-        # behavior; but we still want the operator to see the
-        # degradation happened, without log spam if the batch stays
-        # B>1 (or non-greedy, or has an lp) for many tokens.
-        "ft_mid_stream_handoff": 0,
+        "invariant_violations": 0,
     }
 
-    # Codex round-L BLOCKING #2-4: log-once bookkeeping for mid-stream
-    # MTP → plain-decode handoffs. Keyed by (uid, reason) so the same
-    # uid can log both "B>1" and "non-greedy" if it hits both, but
-    # each reason surfaces at most once per uid lifetime.
-    _handoff_logged: set[tuple[int, str]] = set()
     _initial_skip_logged: set[tuple[int, str]] = set()
-
-    def _log_mtp_mid_stream_handoff_once(uid: int, reason: str, detail: str) -> None:
-        """Emit a WARN log for a mid-stream MTP → plain-decode handoff,
-        at most once per (uid, reason).
-
-        Codex round-L BLOCKING #2-4: the fallback design matches
-        Ollama's depth-0 park behavior — MTP silently degrades to
-        plain decode when the current step is incompatible (B>1,
-        non-greedy, or has a logits processor) instead of aborting
-        the request with a RuntimeError. But the tradeoff is real:
-        ``gb._next_tokens`` currently holds the last-MTP-emitted
-        token (see ``_sync_next_tokens_after_emit``) rather than a
-        fresh baseline sample, so ``_orig_step`` may emit a
-        duplicated token or sample from a slightly stale cache
-        position for one step before the request continues on plain
-        decode. Log the handoff so the operator can correlate the
-        potential stream artifact with the load-balancing event.
-        """
-        key = (uid, reason)
-        if key in _handoff_logged:
-            return
-        _handoff_logged.add(key)
-        logger.warning(
-            "[MTP-vendored] uid=%s handoff to plain decode (%s): %s. "
-            "The MTP generator was closed; the request continues on "
-            "baseline mlx-lm _step. gb._next_tokens still holds the "
-            "last-MTP-emitted token so the next _orig_step call may "
-            "produce a duplicated token or a token sampled from a "
-            "slightly stale cache position for one step — a bounded, "
-            "known tradeoff for not killing the request "
-            "(Ollama-style depth-0 park behavior).",
-            uid,
-            reason,
-            detail,
-        )
 
     def _log_mtp_initial_skip_once(uid: int, reason: str) -> None:
         """Surface a request that never entered MTP without log spam."""
@@ -998,6 +969,20 @@ def _install_mtp_vendored(
                 gen.close()
             except Exception:  # noqa: BLE001
                 pass
+
+    def _reap_uid(uid: int) -> None:
+        """Release every request-owned MTP object after the uid departs.
+
+        ``_cleanup_uid`` deliberately preserves the request's disable marker
+        while it is live. Completion/removal is the stronger lifecycle
+        boundary: no generator, marker, or log-once key may retain the request.
+        """
+        _cleanup_uid(uid)
+        _disabled_uids.pop(uid, None)
+        _terminal_uids.pop(uid, None)
+        _initial_skip_logged.difference_update(
+            key for key in _initial_skip_logged if key[0] == uid
+        )
 
     def _sampling_options_for_uid(uid: int) -> tuple[dict[str, Any] | None, str]:
         """Resolve the request-local MTP sampling contract, fail closed.
@@ -1131,13 +1116,11 @@ def _install_mtp_vendored(
         #     ``gb._next_tokens`` from the last MTP-emitted token,
         #     which we don't stage anywhere.
         def _record_terminal_disable(u: int) -> None:
-            """Record a terminal disable marker for uid ``u`` and
-            drop any per-generator state. Used on the "MTP already
-            emitted, fallthrough is unsafe" path."""
+            """Latch a terminal failure after MTP has emitted for ``u``."""
             _term_req_id = None
             if uid_to_request_id is not None:
                 _term_req_id = uid_to_request_id.get(u)
-            _disabled_uids[u] = _term_req_id
+            _terminal_uids[u] = _term_req_id
             _state_entry = _state.pop(u, None)
             if _state_entry is not None:
                 _gen = _state_entry.get("gen")
@@ -1195,20 +1178,11 @@ def _install_mtp_vendored(
             * ``.filter(keep)`` / ``.extend`` don't forward through
               the model — they mutate the tensor in place. No
               downstream cache interaction.
-            * Codex round-L BLOCKING #2-4 relaxed the round-H
-              terminal-raise contract: the B>1 / non-greedy /
-              logits-processor fallthrough branches now delegate to
-              ``_orig_step()`` instead of aborting the request. In
-              that handoff path, ``_orig_step()`` will read the
-              stale ``_next_tokens`` and may emit a duplicated token
-              or sample from a slightly stale cache position for one
-              step. The wrapper logs a WARN (once per uid+reason)
-              on the handoff so the operator can correlate the
-              artifact with the load-balancing event. This is the
-              accepted tradeoff for not killing the request — see
-              :func:`_log_mtp_mid_stream_handoff_once` and the
-              round-L rationale comments in the three fallthrough
-              branches.
+            * Once MTP has emitted, an ordinary-decode handoff is forbidden:
+              ``_orig_step()`` would consume this last-emitted placeholder as
+              if it were the next model input. Admission prevents B>1, and
+              defensive invariant checks fail closed instead of returning a
+              duplicate or stale token.
 
             Cache state stays under the MTP generator's control — the
             wrapper never advances ``prompt_cache`` outside a
@@ -1221,37 +1195,39 @@ def _install_mtp_vendored(
         if not gb.uids or len(gb.uids) != 1:
             _stats["fallthrough_steps"] += 1
             _stats["ft_batch_size"] += 1
-            # Codex round-L BLOCKING #2: prior round-H revision raised
-            # ``RuntimeError`` here when any uid in ``_state`` had in-
-            # flight MTP emissions. That killed the request whenever
-            # normal continuous-batching load added a second uid to
-            # the batch — hostile behavior for a multi-request server
-            # where B>1 is the norm, not the exception.
-            #
-            # Round-L fix: hand off to ``_orig_step`` regardless of
-            # whether MTP has emitted. The MTP generator is closed and
-            # the affected uid(s) are marked disabled so we don't
-            # retry MTP on subsequent steps. The stream may briefly
-            # exhibit a duplicated token or a token sampled from a
-            # slightly stale cache position (``gb._next_tokens`` still
-            # holds the last-MTP-emitted token) — a bounded, known
-            # tradeoff that matches Ollama's ``depth=0`` park behavior
-            # when speculation cannot proceed. See
-            # :func:`_log_mtp_mid_stream_handoff_once` for the operator-
-            # facing warning contract.
             if _state:
                 terminal_uids = list(_state)
-                _stats["ft_mid_stream_handoff"] += len(terminal_uids)
+                _stats["invariant_violations"] += 1
                 for stale_uid in terminal_uids:
-                    _log_mtp_mid_stream_handoff_once(
-                        stale_uid,
-                        "b_gt_1",
-                        f"batch grew to size {len(gb.uids)}",
-                    )
                     _record_terminal_disable(stale_uid)
+                raise RuntimeError(
+                    "[MTP-vendored] single-request admission invariant violated: "
+                    f"batch grew to {len(gb.uids)} after MTP emitted for "
+                    f"uids={terminal_uids}. Failing closed because plain-decode "
+                    "handoff would corrupt the output stream."
+                )
             return _orig_step()
 
         uid = gb.uids[0]
+
+        if uid in _terminal_uids:
+            terminal_req_id = _terminal_uids[uid]
+            current_req_id = (
+                uid_to_request_id.get(uid) if uid_to_request_id is not None else None
+            )
+            if (
+                terminal_req_id is not None
+                and current_req_id is not None
+                and terminal_req_id != current_req_id
+            ):
+                del _terminal_uids[uid]
+            else:
+                _stats["invariant_violations"] += 1
+                raise RuntimeError(
+                    "[MTP-vendored] refusing to retry terminal uid="
+                    f"{uid}; request removal is required before this slot can "
+                    "return to plain decode."
+                )
 
         # Codex round-D blocker #2 + round-E blocker #1: honour the
         # permanent-skip map BEFORE re-entering FIRST-call
@@ -1298,25 +1274,15 @@ def _install_mtp_vendored(
                 _stats["ft_logits_processors"] += 1
             else:
                 _stats["ft_non_greedy"] += 1
-            # Codex round-L BLOCKING #3: prior round-H revision raised
-            # ``RuntimeError`` here when sampling switched to non-
-            # greedy after MTP had already emitted. That killed the
-            # request on a legitimate runtime sampling-param change.
-            #
-            # Round-L fix: hand off to ``_orig_step`` regardless of
-            # state. The MTP generator is closed and the uid is
-            # marked disabled so subsequent steps skip MTP entirely.
-            # Same bounded stream-artifact tradeoff as the B>1 handoff
-            # above; see :func:`_log_mtp_mid_stream_handoff_once` for
-            # the operator-facing WARN contract.
             if uid in _state:
-                _stats["ft_mid_stream_handoff"] += 1
-                _log_mtp_mid_stream_handoff_once(
-                    uid,
-                    "sampling_unsupported",
-                    sampling_skip_reason,
-                )
+                _stats["invariant_violations"] += 1
                 _record_terminal_disable(uid)
+                raise RuntimeError(
+                    "[MTP-vendored] request sampling contract changed after "
+                    f"MTP emitted for uid={uid}: {sampling_skip_reason}. "
+                    "Failing closed because plain-decode handoff would corrupt "
+                    "the output stream."
+                )
             else:
                 _log_mtp_initial_skip_once(uid, sampling_skip_reason)
                 _mark_disabled(uid)
@@ -1330,14 +1296,13 @@ def _install_mtp_vendored(
         ):
             _stats["fallthrough_steps"] += 1
             _stats["ft_non_greedy"] += 1
-            _stats["ft_mid_stream_handoff"] += 1
-            _log_mtp_mid_stream_handoff_once(
-                uid,
-                "sampling_changed",
-                "request sampling parameters changed after MTP started",
-            )
+            _stats["invariant_violations"] += 1
             _record_terminal_disable(uid)
-            return _orig_step()
+            raise RuntimeError(
+                "[MTP-vendored] request sampling parameters changed after "
+                f"MTP emitted for uid={uid}. Failing closed because "
+                "plain-decode handoff would corrupt the output stream."
+            )
 
         # Codex round-K BLOCKING #1: uid reuse detection for the
         # ACTIVE (non-disabled) state map. mlx-lm reuses uid ints
@@ -1547,7 +1512,7 @@ def _install_mtp_vendored(
                 _terminal_req_id = None
                 if uid_to_request_id is not None:
                     _terminal_req_id = uid_to_request_id.get(uid)
-                _disabled_uids[uid] = _terminal_req_id
+                _terminal_uids[uid] = _terminal_req_id
                 # Generator's own state can go — nothing to close
                 # here (StopIteration means it already tore down).
                 _state.pop(uid, None)
@@ -1599,7 +1564,7 @@ def _install_mtp_vendored(
                 _terminal_req_id = None
                 if uid_to_request_id is not None:
                     _terminal_req_id = uid_to_request_id.get(uid)
-                _disabled_uids[uid] = _terminal_req_id
+                _terminal_uids[uid] = _terminal_req_id
                 # Close the (broken) generator; don't touch
                 # _disabled_uids from inside _cleanup_uid.
                 _state_entry = _state.pop(uid, None)
@@ -1633,6 +1598,42 @@ def _install_mtp_vendored(
         _sync_next_tokens_after_emit(gb, tok_int, lp_arr)
         return [tok_int], [lp_arr]
 
+    _orig_next = gb.next
+
+    def _mtp_next(*args, **kwargs):
+        """Reap request-owned MTP state at the normal finish boundary."""
+        responses = _orig_next(*args, **kwargs)
+        for response in responses:
+            if getattr(response, "finish_reason", None) is not None:
+                _reap_uid(response.uid)
+        return responses
+
+    _orig_remove = getattr(batch_gen, "remove", None)
+
+    def _departed(uid_list: list[int]) -> list[int]:
+        """Return only uids that actually left after a partial remove error."""
+        finder = getattr(batch_gen, "_find_uids", None)
+        if finder is None:
+            return []
+        try:
+            still_present = set(finder(uid_list))
+        except Exception:  # noqa: BLE001
+            return []
+        return [uid for uid in uid_list if uid not in still_present]
+
+    def _mtp_remove(uids, return_prompt_caches=False):
+        """Reap MTP state after abort/removal without dropping live requests."""
+        uid_list = list(uids)
+        try:
+            result = _orig_remove(uid_list, return_prompt_caches=return_prompt_caches)
+        except Exception:
+            for uid in _departed(uid_list):
+                _reap_uid(uid)
+            raise
+        for uid in uid_list:
+            _reap_uid(uid)
+        return result
+
     # Patch onto the persistent _generation_batch. New GenerationBatch
     # instances created inside PromptProcessingBatch.generate() use the
     # CLASS _step for their priming call (which is exactly what we want:
@@ -1641,12 +1642,23 @@ def _install_mtp_vendored(
     # persistent gb happens via .extend(), after which our patched
     # _step takes over.
     gb._step = _mtp_step
+    gb.next = _mtp_next
+    if _orig_remove is not None:
+        batch_gen.remove = _mtp_remove
+    else:
+        logger.warning(
+            "[MTP-vendored] BatchGenerator has no remove(); abort-path "
+            "state reaping is not installed (mlx-lm version mismatch?)."
+        )
     batch_gen._mtp_vendored_stats = _stats
+    gb._mtp_vendored_state = _state
+    gb._mtp_vendored_disabled_uids = _disabled_uids
+    gb._mtp_vendored_terminal_uids = _terminal_uids
 
     logger.info(
         "[MTP-vendored] installed on GenerationBatch._step "
         "(single-request adaptive chain-of-K with request-local sampling; "
-        "falls through on B>1 / seeded sampling / custom logits-processors)."
+        "request state reaped on finish/remove)."
     )
     return True
 
@@ -6858,7 +6870,12 @@ class Scheduler:
         """
         scheduled = []
 
-        while self.waiting and len(self.running) < self.config.max_num_seqs:
+        # The current vendored MTP verifier owns one request-local generator
+        # and explicitly supports B=1. Keep later requests in the ordinary
+        # scheduler queue until that request departs; this preserves liveness
+        # without ever attempting a lossy MTP-to-plain handoff mid-stream.
+        running_limit = _max_running_sequences(self.config)
+        while self.waiting and len(self.running) < running_limit:
             request = self.waiting.popleft()
 
             # Ensure we have a batch generator. The False return means

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7191,17 +7191,27 @@ class Scheduler:
         Text stop sequences and repetition-loop aborts are detected later by
         Rapid-MLX, after ``GenerationBatch.next()`` returned, so that row is
         still live. Remove it through the BatchGenerator lifecycle seam and
-        copy any returned cache onto the response before normal cache storage.
+        copy any committed cache onto the response before normal cache storage.
+
+        An MTP generator can have verified lookahead in its private cache past
+        the one token surfaced by this response. Its rollback occurs only when
+        the generator resumes, which a scheduler-side stop deliberately skips.
+        Never publish that speculative cache as a reusable conversation prefix;
+        closing the request and discarding the cache is the only lossless
+        terminal action until the verifier exposes a committed-cache boundary.
         """
         batch_generator = self.batch_generator
         if batch_generator is None:
             raise RuntimeError(
                 "scheduler generated a terminal response without a BatchGenerator"
             )
+        retain_cache = getattr(self, "spec_decode_runtime_method", None) != "mtp"
         caches = batch_generator.remove(
             [response.uid],
-            return_prompt_caches=True,
+            return_prompt_caches=retain_cache,
         )
+        if not retain_cache:
+            return
         cached = caches.get(response.uid) if isinstance(caches, dict) else None
         if cached is None:
             return


### PR DESCRIPTION
## Summary

- serialize the current request-local MTP verifier at scheduler admission while preserving the independent waiting-queue capacity
- restore ordinary batch width after a definitive MTP install-gate miss
- reap MTP generator/cache and marker state on normal completion, scheduler text stops, cancellation, removal, and partial remove failure
- discard uncommitted speculative cache on scheduler-side stops instead of publishing it as a reusable conversation prefix
- fail closed on an impossible mid-stream MTP-to-plain transition instead of returning a duplicate or stale token

Fixes #2715

## User impact

Opt-in MTP serving no longer retains per-request MLX cache state after requests depart. Concurrent clients remain serviceable through the scheduler queue, unsupported runtimes retain ordinary batching, and an internal scheduling or sampling invariant cannot silently corrupt a response or the next turn's cache.

## Scope

- text scheduler MTP admission and request-state lifecycle
- deterministic MTP concurrency, completion, text-stop, cancellation, partial-remove, install-gate, and fail-closed branch regressions

## Non-goals

- no multi-request MTP verifier implementation
- no model, dependency, CI, release-version, speculative-depth, or default-policy change
- no changes to plain decode or other speculative methods

## Design precedent

Production serving schedulers treat speculative state as request-owned state: the target verifier is the sole commit authority, unsupported batch shapes are constrained by admission, and finish/abort events close request state explicitly. This PR adopts that established boundary using Rapid-MLX's existing scheduler queue and the same finish/remove lifecycle seams already used by its other request-local drafter.

## Verification

- `442 passed`: focused MTP, speculative config/policy, scheduler text-stop, repetition-guard, and stream-contract suites
- text-stop → next-request regression proves MTP state is retired and speculative cache extraction is disabled before slot reuse
- all lifecycle fail-closed branches exercised locally, including the 9 lines identified by the first changed-lines coverage run
- clean rebase onto current main; `git range-diff` showed the reviewed implementation commits unchanged
- `ruff check` passed
- `ruff format --check` passed
- `git diff --check` passed
