### PR TITLE
fix(mac): clear saved bearer when selecting Every start

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/EmbeddedBearerCredential.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/EmbeddedBearerCredential.swift
@@ -19,7 +19,7 @@ enum EmbeddedBearerLifetime: String, CaseIterable, Equatable, Sendable {
     var summary: String {
         switch self {
         case .perLaunch:
-            return "Generate a one-time key for every model start. Nothing is stored in the Keychain."
+            return "Generate a one-time key for every model start instead of reusing a saved key."
         case .daily:
             return "Keep one Keychain-backed key for 24 hours across model starts and app restarts."
         case .explicit:
@@ -54,6 +54,7 @@ enum EmbeddedBearerStorageIssue: Equatable, Sendable {
     case corruptedCredential
     case unavailableKeychain
     case writeFailed
+    case deleteFailed
 }
 
 /// One start-time materialization of an embedded API credential. A persisted
@@ -194,12 +195,12 @@ enum EmbeddedBearerMaterialResolver {
 
         switch lifetime {
         case .perLaunch:
-            store.clear()
+            let clearedPersistedCredential = store.clear()
             return EmbeddedBearerMaterial(
                 secret: generatedSecret,
                 rotatedAt: now,
                 isPersisted: false,
-                issue: nil
+                issue: clearedPersistedCredential ? nil : .deleteFailed
             )
         case .daily:
             switch store.loadCredential() {

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1128,6 +1128,32 @@ final class ServerManager {
     func setEmbeddedBearerLifetime(_ lifetime: EmbeddedBearerLifetime) {
         embeddedBearerLifetime = lifetime
         sessionDefaults?.set(lifetime.rawValue, forKey: "rapid.embeddedBearer.lifetime.v1")
+        if lifetime == .perLaunch {
+            retryEmbeddedBearerCleanup()
+        }
+    }
+
+    /// Make the per-launch storage promise true immediately, without changing
+    /// the bearer already held by a running child. A failed deletion remains a
+    /// visible, retryable state and the per-launch policy stays selected so the
+    /// next model start will never reuse the persisted credential.
+    @discardableResult
+    func retryEmbeddedBearerCleanup() -> Bool {
+        guard embeddedBearerLifetime == .perLaunch else { return false }
+        let cleared = bearerCredentialStore.clear()
+        let lastRotation: Date?
+        switch embeddedBearerStatus {
+        case .notMaterialized:
+            lastRotation = nil
+        case .materialized(let rotatedAt, _, _):
+            lastRotation = rotatedAt
+        }
+        embeddedBearerStatus = .materialized(
+            rotatedAt: lastRotation,
+            isPersisted: !cleared,
+            issue: cleared ? nil : .deleteFailed
+        )
+        return cleared
     }
 
     /// Persist a replacement under the current lifetime. A running child

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -530,11 +530,26 @@ struct SettingsToolsPanel: View {
             EmptyView()
         case .materialized(_, let isPersisted, let issue):
             if let issue {
-                Text(Self.issueCopy(issue))
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                    Text(Self.embeddedBearerIssueCopy(issue))
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.statusError)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.DegradedNotice")
+
+                    if issue == .deleteFailed,
+                       server.embeddedBearerLifetime == .perLaunch {
+                        Button("Retry Keychain cleanup") {
+                            server.retryEmbeddedBearerCleanup()
+                        }
+                        .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.RetryCleanup")
+                    }
+                }
+            } else if server.embeddedBearerLifetime == .perLaunch {
+                Text("No embedded API key is stored in your Keychain.")
                     .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.statusError)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.DegradedNotice")
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .accessibilityIdentifier("Settings.Tools.EmbeddedAPI.ClearedNotice")
             } else if isPersisted {
                 Text("The current key is stored in your Keychain.")
                     .font(RapidFont.caption)
@@ -549,7 +564,7 @@ struct SettingsToolsPanel: View {
         }
     }
 
-    private static func issueCopy(_ issue: EmbeddedBearerStorageIssue) -> String {
+    static func embeddedBearerIssueCopy(_ issue: EmbeddedBearerStorageIssue) -> String {
         switch issue {
         case .generationFailed:
             return "Secure key generation failed, so the model was not started."
@@ -561,6 +576,8 @@ struct SettingsToolsPanel: View {
             return "The Keychain is unavailable, so this model started with a one-time key."
         case .writeFailed:
             return "The Keychain couldn’t store a new key, so this model started with a one-time key. Restart the model to try again."
+        case .deleteFailed:
+            return "The saved key couldn’t be removed from your Keychain. Retry cleanup before relying on Every start storage."
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/EmbeddedBearerCredentialTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/EmbeddedBearerCredentialTests.swift
@@ -163,6 +163,22 @@ struct EmbeddedBearerCredentialTests {
         #expect(material.issue == .writeFailed)
     }
 
+    @Test("Per-launch material reports a persisted credential cleanup failure")
+    func perLaunchCleanupFailureIsVisible() {
+        let credentialStore = RecordingCredentialStore(clearResults: [false])
+
+        let material = EmbeddedBearerMaterialResolver.resolve(
+            lifetime: .perLaunch,
+            store: credentialStore,
+            now: now,
+            generateSecret: { self.secret(seed: 10) }
+        )
+
+        #expect(!material.isPersisted)
+        #expect(material.issue == .deleteFailed)
+        #expect(credentialStore.clearCount == 1)
+    }
+
     @Test("Secret storage is separate from UserDefaults policy storage")
     func storageSeparation() {
         let suiteName = "bearer-storage-separation"
@@ -241,6 +257,76 @@ struct ServerManagerEmbeddedBearerTests {
 
         #expect(server.embeddedBearerLifetime == .daily)
         #expect(defaults.string(forKey: "rapid.embeddedBearer.lifetime.v1") == "daily")
+        #expect(credentialStore.clearCount == 0)
+    }
+
+    @Test("Selecting Every start clears persisted storage without replacing the active bearer")
+    func selectingPerLaunchClearsPersistedStorage() {
+        let suiteName = "server-bearer-select-per-launch"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let credentialStore = RecordingCredentialStore()
+        let server = ServerManager(
+            testingState: .ready(alias: "model"),
+            activeBearer: "active-secret",
+            sessionDefaults: defaults,
+            bearerCredentialStore: credentialStore
+        )
+        server.setEmbeddedBearerLifetime(.daily)
+        _ = server.rotateEmbeddedBearerNow(now: Date(timeIntervalSince1970: 10))
+
+        server.setEmbeddedBearerLifetime(.perLaunch)
+
+        #expect(server.embeddedBearerLifetime == .perLaunch)
+        #expect(defaults.string(forKey: "rapid.embeddedBearer.lifetime.v1") == "perLaunch")
+        #expect(credentialStore.clearCount == 1)
+        #expect(server.activeBearer == "active-secret")
+        #expect(server.embeddedBearerStatus == .materialized(
+            rotatedAt: Date(timeIntervalSince1970: 10),
+            isPersisted: false,
+            issue: nil
+        ))
+    }
+
+    @Test("Failed Every start cleanup stays visible and can be retried")
+    func failedPerLaunchCleanupCanBeRetried() {
+        let suiteName = "server-bearer-retry-per-launch"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let credentialStore = RecordingCredentialStore(clearResults: [false, true])
+        let server = ServerManager(
+            testingState: .ready(alias: "model"),
+            activeBearer: "active-secret",
+            sessionDefaults: defaults,
+            bearerCredentialStore: credentialStore
+        )
+        server.setEmbeddedBearerLifetime(.daily)
+
+        server.setEmbeddedBearerLifetime(.perLaunch)
+
+        #expect(server.embeddedBearerLifetime == .perLaunch)
+        #expect(defaults.string(forKey: "rapid.embeddedBearer.lifetime.v1") == "perLaunch")
+        #expect(server.activeBearer == "active-secret")
+        #expect(server.embeddedBearerStatus == .materialized(
+            rotatedAt: nil,
+            isPersisted: true,
+            issue: .deleteFailed
+        ))
+        #expect(server.retryEmbeddedBearerCleanup())
+        #expect(credentialStore.clearCount == 2)
+        #expect(server.embeddedBearerStatus == .materialized(
+            rotatedAt: nil,
+            isPersisted: false,
+            issue: nil
+        ))
+    }
+
+    @Test("Settings explains failed embedded bearer cleanup without claiming success")
+    func cleanupFailureCopy() {
+        let copy = SettingsToolsPanel.embeddedBearerIssueCopy(.deleteFailed)
+
+        #expect(copy.contains("couldn’t be removed"))
+        #expect(copy.contains("Retry cleanup"))
     }
 
     @Test("Manual rotation persists only for persisted lifetimes")
@@ -279,7 +365,12 @@ struct ServerManagerEmbeddedBearerTests {
 
 private final class RecordingCredentialStore: EmbeddedBearerCredentialStoring, @unchecked Sendable {
     private(set) var saved: [EmbeddedBearerCredential] = []
-    private(set) var cleared = false
+    private(set) var clearCount = 0
+    private var clearResults: [Bool]
+
+    init(clearResults: [Bool] = [true]) {
+        self.clearResults = clearResults
+    }
 
     func loadCredential() -> EmbeddedBearerStorageResult {
         .missing
@@ -297,7 +388,8 @@ private final class RecordingCredentialStore: EmbeddedBearerCredentialStoring, @
 
     @discardableResult
     func clear() -> Bool {
-        cleared = true
-        return true
+        let index = min(clearCount, clearResults.count - 1)
+        clearCount += 1
+        return clearResults[index]
     }
 }


### PR DESCRIPTION
## Summary
- clear any persisted embedded API bearer as soon as **Every start** is selected
- keep the bearer of an already-running model unchanged until its next start
- surface Keychain deletion failures honestly and provide a retry action

## Scope
Settings and embedded bearer credential lifecycle only.

## Non-goals
- changing daily or explicit rotation semantics
- restarting a running model
- changing embedded API authentication behavior

## Verification
- `swift test --no-parallel --filter EmbeddedBearerCredential` (14 tests passed)
- `swift test --no-parallel --filter AccessibilityIdentifierInventoryTests` (21 tests passed)
- `git diff --check`

Fixes #2716