### PR TITLE
test: enforce text and multimodal lane parity

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -328,13 +328,39 @@ jobs:
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
 
-          # The version being released is not on PyPI yet (publish.yml runs after
-          # the tag), so build it from the checked-out source into a fresh venv.
+          # Build the candidate wheel once, then exercise those exact bytes in
+          # both the fresh text-lane venv and the shipped reduced Desktop
+          # sidecar. Installing the source separately in each lane could let a
+          # wheel-packaging omission escape the release gate.
           V="$RUNNER_TEMP/gate-venv-$VERSION"
           rm -rf "$V"
           /opt/homebrew/opt/python@3.12/bin/python3.12 -m venv "$V"
           "$V/bin/pip" install -q --upgrade pip
-          "$V/bin/pip" install -q .
+
+          WHEEL_DIR="$RUNNER_TEMP/gate-wheel-$VERSION"
+          rm -rf "$WHEEL_DIR"
+          mkdir -p "$WHEEL_DIR"
+          "$V/bin/pip" wheel \
+            --no-deps --wheel-dir "$WHEEL_DIR" .
+          shopt -s nullglob
+          WHEELS=("$WHEEL_DIR"/rapid_mlx-*.whl)
+          if [ "${#WHEELS[@]}" -ne 1 ]; then
+            echo "Expected exactly one rapid-mlx candidate wheel; found ${#WHEELS[@]}" >&2
+            exit 1
+          fi
+          CANDIDATE_WHEEL="${WHEELS[0]}"
+          CONSTRAINTS="$RUNNER_TEMP/sidecar-constraints-$VERSION.txt"
+          /opt/homebrew/opt/python@3.12/bin/python3.12 \
+            apps/rapid-mac/scripts/check-sidecar-distributions.py \
+            --emit-constraints > "$CONSTRAINTS"
+
+          "$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"
+          "$V/bin/pip" check
+          SITE_PACKAGES=$("$V/bin/python3.12" -c \
+            'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+          "$V/bin/python3.12" \
+            apps/rapid-mac/scripts/check-sidecar-distributions.py \
+            "$SITE_PACKAGES"
           echo "gate venv → $("$V/bin/rapid-mlx" --version) (releasing v$VERSION)"
 
           RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh qwen3.6-35b-8bit
@@ -344,7 +370,8 @@ jobs:
           # production schedulers and HTTP routes. Every normal auto-release is
           # blocked by a missing immutable snapshot, incompatible reduced
           # dependency set, or failed media request.
-          HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh \
+          HF_HUB_OFFLINE=1 RAPID_MLX_WHEEL="$CANDIDATE_WHEEL" \
+            bash apps/rapid-mac/scripts/build-sidecar.sh \
             --out "$RUNNER_TEMP/desktop-vision-sidecar-$VERSION"
 
           # The reduced dependency-set exception covers both Qwen and Gemma

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -59,10 +59,13 @@ struct SidecarBuildScriptTests {
     @Test("Desktop vision stack is exact-pinned and metadata-validated")
     func visionStackIsReproducibleAndCompatible() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+        let constraints = try String(contentsOf: Self.constraintsURL, encoding: .utf8)
 
-        #expect(script.contains("'mlx-vlm==0.6.16'"))
+        #expect(constraints.contains("mlx-vlm==0.6.16"))
         #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
                 "The no-deps sidecar install must never float within a range.")
+        #expect(script.contains(#"--constraint "$SIDECAR_CONSTRAINTS""#),
+                "Every install must consume the shared release constraint set.")
         #expect(script.contains("$REPO_ROOT/scripts/check-sidecar-distributions.py"),
                 "Every sidecar build must execute the tested metadata-coherence gate.")
         #expect(script.contains("SIDECAR_VISION_SMOKE_MODEL"))
@@ -99,8 +102,9 @@ struct SidecarBuildScriptTests {
     @Test("Desktop image stack is pinned and its torch-free proof fails closed")
     func imageStackIsPinnedAndProvenTorchFree() throws {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+        let constraints = try String(contentsOf: Self.constraintsURL, encoding: .utf8)
 
-        #expect(script.contains("'mflux==0.19.0'"),
+        #expect(constraints.contains("mflux==0.19.0"),
                 "The no-deps sidecar install must never float within a range.")
         // The Images tab is only shippable because mflux's module-level
         // `import torch` is deferred into the three torch-only loading modes —
@@ -142,8 +146,10 @@ struct SidecarBuildScriptTests {
                 "The bounded desktop audio dependency group must remain separately installable.")
         #expect(pyproject.contains(#""mlx-audio>=0.2.9,<0.4.4""#))
         #expect(pyproject.contains(#""soundfile>=0.12.0""#))
-        #expect(script.contains(#""${RAPID_MLX_SOURCE}[audio-desktop]""#),
+        #expect(script.contains(#""${RAPID_MLX_INSTALL_TARGET}[audio-desktop]""#),
                 "The desktop sidecar must install the bounded desktop audio dependency set.")
+        #expect(script.contains(#"RAPID_MLX_WHEEL="${RAPID_MLX_WHEEL:-}""#),
+                "Release builds must be able to promote the exact candidate wheel into the sidecar.")
         #expect(script.contains("from mlx_audio.stt.utils import load_model"),
                 "The build smoke must import the transcription loader, not only mlx_audio's package root.")
         #expect(script.contains("from transformers.models.whisper.feature_extraction_whisper import WhisperFeatureExtractor"),
@@ -188,6 +194,10 @@ struct SidecarBuildScriptTests {
 
     private static var appBuildScriptURL: URL {
         scriptURL.deletingLastPathComponent().appendingPathComponent("build.sh")
+    }
+
+    private static var constraintsURL: URL {
+        scriptURL.deletingLastPathComponent().appendingPathComponent("sidecar-constraints.txt")
     }
 
     private static var pyprojectURL: URL {

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -129,6 +129,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"   # = apps/rapid-mac
 # CI or dev layouts that put the engine somewhere else.
 ENGINE_ROOT="${RAPID_MLX_ENGINE_ROOT:-$(cd "${REPO_ROOT}/../.." && pwd)}"
 RAPID_MLX_SOURCE="${RAPID_MLX_SOURCE:-${ENGINE_ROOT}}"
+# Release jobs set this to the exact candidate wheel already exercised by the
+# fresh text-lane venv. Local builds retain the source-tree fallback.
+RAPID_MLX_WHEEL="${RAPID_MLX_WHEEL:-}"
+SIDECAR_CONSTRAINTS="${REPO_ROOT}/scripts/sidecar-constraints.txt"
 OUT_DIR="${OUT_DIR:-${REPO_ROOT}/build/sidecar-stage}"
 DEVELOPER_ID="${DEVELOPER_ID:--}"
 SKIP_CODESIGN=0
@@ -167,6 +171,15 @@ require shasum
 
 if [ ! -f "$ENTITLEMENTS" ] && [ "$SKIP_CODESIGN" != "1" ]; then
     echo "ERR: entitlements file missing at $ENTITLEMENTS" >&2
+    exit 1
+fi
+
+if [ ! -f "$SIDECAR_CONSTRAINTS" ]; then
+    echo "ERR: sidecar constraints missing at $SIDECAR_CONSTRAINTS" >&2
+    exit 1
+fi
+if [ -n "$RAPID_MLX_WHEEL" ] && [ ! -f "$RAPID_MLX_WHEEL" ]; then
+    echo "ERR: RAPID_MLX_WHEEL does not exist: $RAPID_MLX_WHEEL" >&2
     exit 1
 fi
 
@@ -243,6 +256,11 @@ if [ ! -d "$RAPID_MLX_SOURCE" ] || [ ! -f "$RAPID_MLX_SOURCE/pyproject.toml" ]; 
     echo "     checkout of the rapid-mlx engine." >&2
     exit 1
 fi
+RAPID_MLX_INSTALL_TARGET="$RAPID_MLX_SOURCE"
+if [ -n "$RAPID_MLX_WHEEL" ]; then
+    RAPID_MLX_INSTALL_TARGET="$RAPID_MLX_WHEEL"
+    echo "==> using candidate wheel: $RAPID_MLX_WHEEL"
+fi
 # Drive dependency resolution with the pinned interpreter extracted above.
 # Its pip is present during assembly and stripped only after both installs,
 # keeping wheel selection tied to the exact ABI that ships in the bundle.
@@ -265,9 +283,10 @@ fi
     --no-warn-script-location \
     --no-compile \
     --upgrade \
-    "${RAPID_MLX_SOURCE}[audio-desktop]" \
-    'mlx==0.32.2' \
-    'transformers==5.12.1'
+    --constraint "$SIDECAR_CONSTRAINTS" \
+    "${RAPID_MLX_INSTALL_TARGET}[audio-desktop]" \
+    'mlx' \
+    'transformers'
 
 # pip normally selects wheels for the BUILD host. A sidecar assembled on
 # macOS 26 therefore receives mlx / mlx-metal's macosx_26 wheels even though
@@ -334,7 +353,8 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    'mlx-vlm==0.6.16' \
+    --constraint "$SIDECAR_CONSTRAINTS" \
+    'mlx-vlm' \
     'Pillow>=10.0'
 
 # ----- step 2.6: bundle mflux --no-deps (Images tab image-gen lane) ----
@@ -380,7 +400,8 @@ echo "==> bundling mflux --no-deps + platformdirs/piexif/toml (Images tab image-
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    'mflux==0.19.0' \
+    --constraint "$SIDECAR_CONSTRAINTS" \
+    'mflux' \
     'platformdirs>=4.0,<5.0' \
     'piexif>=1.1.3,<2.0' \
     'toml>=0.10.2,<1.0'

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import argparse
 from importlib import metadata
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
+if TYPE_CHECKING:
+    from packaging.requirements import Requirement
 
 SIDECAR_CONSTRAINTS_FILE = Path(__file__).with_name("sidecar-constraints.txt")
 
@@ -35,6 +36,8 @@ def is_validated_compatibility_exception(
     hard error.
     """
 
+    from packaging.utils import canonicalize_name
+
     return (
         canonicalize_name(owner) == "mlx-vlm"
         and owner_version == "0.6.16"
@@ -45,6 +48,9 @@ def is_validated_compatibility_exception(
 
 
 def find_errors(site_packages: Path) -> list[str]:
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
     distributions = list(metadata.distributions(path=[str(site_packages)]))
     if not distributions:
         return [f"no installed distributions found in {site_packages}"]

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -10,6 +10,14 @@ from pathlib import Path
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
+SIDECAR_CONSTRAINTS_FILE = Path(__file__).with_name("sidecar-constraints.txt")
+
+
+def emit_constraints() -> str:
+    """Return the canonical pip constraints used by release-shaped installs."""
+
+    return SIDECAR_CONSTRAINTS_FILE.read_text()
+
 
 def is_validated_compatibility_exception(
     *, owner: str, owner_version: str, requirement: Requirement, actual: str
@@ -75,8 +83,20 @@ def find_errors(site_packages: Path) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("site_packages", type=Path)
+    parser.add_argument("site_packages", type=Path, nargs="?")
+    parser.add_argument(
+        "--emit-constraints",
+        action="store_true",
+        help="write the release-tested pip constraint set to stdout",
+    )
     args = parser.parse_args()
+    if args.emit_constraints:
+        if args.site_packages is not None:
+            parser.error("site_packages cannot be combined with --emit-constraints")
+        print(emit_constraints(), end="")
+        return 0
+    if args.site_packages is None:
+        parser.error("site_packages is required unless --emit-constraints is used")
     if not args.site_packages.is_dir():
         parser.error(f"site-packages directory does not exist: {args.site_packages}")
     errors = find_errors(args.site_packages)

--- a/apps/rapid-mac/scripts/sidecar-constraints.txt
+++ b/apps/rapid-mac/scripts/sidecar-constraints.txt
@@ -1,0 +1,5 @@
+# Release-tested versions shared by candidate-wheel and Desktop sidecar builds.
+mlx==0.32.2
+transformers==5.12.1
+mlx-vlm==0.6.16
+mflux==0.19.0

--- a/tests/test_lane_parity_contract.py
+++ b/tests/test_lane_parity_contract.py
@@ -9,6 +9,7 @@ keep intentional differences explicit instead of hiding them behind skips.
 
 from __future__ import annotations
 
+import sys
 import threading
 from types import SimpleNamespace
 from typing import Any
@@ -398,7 +399,8 @@ def test_forced_tool_thinking_schema_bundle_is_lane_independent(
 class _TextScheduler:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
-        self.engine = None
+        self.config = SimpleNamespace(max_concurrent_requests=256)
+        self.engine = SimpleNamespace(scheduler=self)
 
     async def generate(self, **kwargs):
         self.calls.append(("generate", kwargs))
@@ -545,7 +547,7 @@ def _assert_shared_semantics(
 @pytest.mark.parametrize("is_mllm", [False, True], ids=["text", "multimodal"])
 @pytest.mark.parametrize("stream", [False, True], ids=["generate", "stream"])
 async def test_engine_dispatch_preserves_shared_request_semantics(
-    is_mllm: bool, stream: bool
+    monkeypatch, is_mllm: bool, stream: bool
 ) -> None:
     """Named #2447 guard: processors, stops, lifecycle and outputs survive.
 
@@ -553,6 +555,16 @@ async def test_engine_dispatch_preserves_shared_request_semantics(
     dropping any processor or shared sampling field on either generate path
     fails one diagnostic row.
     """
+
+    # ``check_admission`` imports only the scheduler's error type, but the
+    # production scheduler module imports MLX at module load. Keep this
+    # dispatch contract runnable on Linux CI, where MLX is intentionally not
+    # installed, without bypassing the real admission/reservation lifecycle.
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_mlx.scheduler",
+        SimpleNamespace(BackpressureError=RuntimeError),
+    )
 
     engine, scheduler = _engine(is_mllm=is_mllm)
     kwargs, processors = _request_semantics()

--- a/tests/test_lane_parity_contract.py
+++ b/tests/test_lane_parity_contract.py
@@ -1,0 +1,623 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-lane request-semantics contract for text and multimodal serving.
+
+The two schedulers intentionally have different capabilities, but shared
+request semantics must not disappear merely because a vision-capable model was
+selected. These tests exercise the engine boundary used by every HTTP route and
+keep intentional differences explicit instead of hiding them behind skips.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.api import utils as api_utils
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.engine.batched import (
+    _LANE_PARITY_PROCESSOR_KEYS,
+    _LANE_PARITY_SAMPLING_KEYS,
+    _TEXT_ONLY_SAMPLING_KEYS,
+    BatchedEngine,
+)
+from vllm_mlx.middleware.exception_handlers import (
+    install_exception_handlers,
+)
+
+# Explicit capability data: shared fields are asserted on both schedulers;
+# lane-specific fields remain visible here so adding parity is an intentional
+# contract change rather than a test skip.
+LANE_CAPABILITIES = {
+    "media": {"text": False, "multimodal": True},
+    "speculative_decode": {"text": True, "multimodal": False},
+    "top_k": {"text": True, "multimodal": False},
+    "min_p": {"text": True, "multimodal": False},
+    "seed": {"text": True, "multimodal": False},
+    "prefix_cache_usage": {"text": True, "multimodal": False},
+    "cached_tokens_usage": {"text": True, "multimodal": False},
+}
+
+
+class _RouteRecordingEngine:
+    preserve_native_tool_format = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    def __init__(self, *, is_mllm: bool) -> None:
+        self.is_mllm = is_mllm
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def build_prompt(self, messages, **_kwargs):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append(("generate", kwargs))
+        text = "ok"
+        if kwargs.get("tools"):
+            text = (
+                '<tool_call>\n{"name":"emit_value",'
+                '"arguments":{"value":"ok"}}</tool_call>'
+            )
+        return GenerationOutput(
+            text=text,
+            new_text=text,
+            tokens=[1],
+            prompt_tokens=2,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            matched_stop="END",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        self.calls.append(("stream", kwargs))
+        yield GenerationOutput(
+            text="ok",
+            new_text="ok",
+            tokens=[1],
+            prompt_tokens=2,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            matched_stop="END",
+        )
+
+
+def _route_client(surface: str, engine: _RouteRecordingEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "lane-parity-test"
+    cfg.model_path = "lane-parity-test"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.tool_parser = None
+    cfg.tool_call_parser = None
+
+    if surface == "chat":
+        from vllm_mlx.routes.chat import router
+    elif surface == "responses":
+        from vllm_mlx.routes.responses import router
+    else:
+        from vllm_mlx.routes.anthropic import router
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _route_request(surface: str, *, stream: bool) -> tuple[str, dict[str, Any]]:
+    common = {"model": "lane-parity-test", "stream": stream}
+    if surface == "chat":
+        return "/v1/chat/completions", {
+            **common,
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 23,
+            "temperature": 0.2,
+            "top_p": 0.8,
+            "stop": ["END", "HALT"],
+            "repetition_penalty": 1.4,
+            "presence_penalty": 0.3,
+            "frequency_penalty": -0.2,
+        }
+    if surface == "responses":
+        return "/v1/responses", {
+            **common,
+            "input": "hello",
+            "max_output_tokens": 23,
+            "temperature": 0.2,
+            "top_p": 0.8,
+        }
+    return "/v1/messages", {
+        **common,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 23,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "stop_sequences": ["END", "HALT"],
+    }
+
+
+@pytest.mark.parametrize("surface", ["chat", "responses", "anthropic"])
+@pytest.mark.parametrize("is_mllm", [False, True], ids=["text", "multimodal"])
+@pytest.mark.parametrize("stream", [False, True], ids=["generate", "stream"])
+def test_routes_normalize_sampling_before_lane_dispatch(
+    surface: str, is_mllm: bool, stream: bool
+) -> None:
+    """Every public chat surface sends the same supported semantics per lane."""
+
+    engine = _RouteRecordingEngine(is_mllm=is_mllm)
+    path, payload = _route_request(surface, stream=stream)
+    client = _route_client(surface, engine)
+
+    if stream:
+        with client.stream("POST", path, json=payload) as response:
+            assert response.status_code == 200, response.text
+            list(response.iter_lines())
+    else:
+        response = client.post(path, json=payload)
+        assert response.status_code == 200, response.text
+
+    method, kwargs = engine.calls[-1]
+    assert method == ("stream" if stream else "generate")
+    assert kwargs["max_tokens"] == 23
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["top_p"] == 0.8
+    if surface in {"chat", "anthropic"}:
+        assert kwargs["stop"] == ["END", "HALT"]
+    if surface == "chat":
+        assert kwargs["repetition_penalty"] == 1.4
+        assert kwargs["presence_penalty"] == 0.3
+        assert kwargs["frequency_penalty"] == -0.2
+
+    reset_config()
+
+
+@pytest.mark.parametrize(
+    (
+        "is_checkpoint_mllm",
+        "cache_mode",
+        "runtime_version",
+        "force_mllm",
+        "force_text",
+        "memory_gb",
+        "spec_decode",
+        "expected",
+    ),
+    [
+        (
+            False,
+            None,
+            "0.6.17",
+            False,
+            False,
+            64.0,
+            "none",
+            (False, "text_checkpoint", False),
+        ),
+        (
+            True,
+            None,
+            "0.6.17",
+            False,
+            False,
+            64.0,
+            "none",
+            (True, "vision_supported", False),
+        ),
+        (
+            True,
+            "arrays",
+            "0.6.3",
+            False,
+            False,
+            64.0,
+            "none",
+            (False, "vision_hybrid_runtime_unsupported", True),
+        ),
+        (
+            True,
+            "arrays",
+            "0.6.16",
+            False,
+            False,
+            64.0,
+            "none",
+            (True, "vision_hybrid_runtime_supported", False),
+        ),
+        (
+            True,
+            "arrays",
+            "0.6.17",
+            False,
+            False,
+            64.0,
+            "none",
+            (True, "vision_hybrid_runtime_supported", False),
+        ),
+        (
+            True,
+            "arrays",
+            "0.6.17",
+            True,
+            False,
+            8.0,
+            "none",
+            (False, "vision_memory_insufficient", True),
+        ),
+        (
+            True,
+            "arrays",
+            "0.6.3",
+            True,
+            False,
+            64.0,
+            "none",
+            (True, "vision_lane_forced", False),
+        ),
+        (
+            True,
+            None,
+            "0.6.17",
+            True,
+            True,
+            64.0,
+            "none",
+            (False, "text_lane_forced", False),
+        ),
+        (
+            True,
+            None,
+            "0.6.17",
+            True,
+            False,
+            64.0,
+            "mtp",
+            (False, "text_lane_speculative_decode", True),
+        ),
+    ],
+    ids=[
+        "text-checkpoint",
+        "plain-vision",
+        "hybrid-old-runtime",
+        "hybrid-min-runtime",
+        "hybrid-new-runtime",
+        "memory-floor-before-force",
+        "force-vision-before-runtime-fallback",
+        "force-text-precedence",
+        "spec-decode-precedence",
+    ],
+)
+def test_lane_selection_precedence_and_runtime_matrix(
+    monkeypatch,
+    is_checkpoint_mllm: bool,
+    cache_mode: str | None,
+    runtime_version: str,
+    force_mllm: bool,
+    force_text: bool,
+    memory_gb: float,
+    spec_decode: str,
+    expected: tuple[bool, str, bool],
+) -> None:
+    """Named #2472 guard: one decision owns lane, reason and fallback."""
+
+    monkeypatch.setattr(api_utils, "is_mllm_model", lambda _name: is_checkpoint_mllm)
+    monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda _name: cache_mode)
+    monkeypatch.setattr(api_utils, "physical_ram_gb", lambda: memory_gb)
+    monkeypatch.setattr(api_utils, "version", lambda _name: runtime_version)
+    monkeypatch.setattr(
+        api_utils,
+        "mllm_arch_unsupported_but_text_vendored",
+        lambda _name: False,
+    )
+
+    decision = api_utils.resolve_serving_lane_decision(
+        "checkpoint",
+        force_mllm=force_mllm,
+        force_text=force_text,
+        vision_min_memory_gb=16.0,
+        requested_spec_decode=spec_decode,
+    )
+    assert (decision.is_mllm, decision.reason, decision.auto_text_fallback) == expected
+
+
+@pytest.mark.parametrize("is_mllm", [False, True], ids=["text", "multimodal"])
+def test_forced_tool_thinking_schema_bundle_is_lane_independent(
+    monkeypatch, is_mllm: bool
+) -> None:
+    """#2447 coupled request keeps grammar + reasoning on both lanes."""
+
+    from vllm_mlx.routes import chat as chat_route
+
+    grammar = SimpleNamespace(reasoning_gate_id=None)
+    budget = object()
+
+    async def _grammar(*_args, **_kwargs):
+        return grammar
+
+    monkeypatch.setattr(chat_route, "_offload_tool_grammar_build", _grammar)
+    monkeypatch.setattr(
+        chat_route,
+        "_build_reasoning_budget_processor",
+        lambda *_args, **_kwargs: budget,
+    )
+    monkeypatch.setattr(
+        chat_route, "enforce_context_length_for_messages", lambda *_args, **_kwargs: 4
+    )
+
+    engine = _RouteRecordingEngine(is_mllm=is_mllm)
+    client = _route_client("chat", engine)
+    from vllm_mlx.config import get_config
+
+    get_config().tool_call_parser = "hermes"
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "lane-parity-test",
+            "messages": [{"role": "user", "content": "return a value"}],
+            "max_tokens": 32,
+            "enable_thinking": True,
+            "reasoning_max_tokens": 8,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "emit_value",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                            "required": ["value"],
+                        },
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "emit_value"},
+            },
+            "response_format": {"type": "json_object"},
+        },
+    )
+    assert response.status_code == 200, response.text
+    _, kwargs = engine.calls[-1]
+    assert kwargs["grammar_logits_processor"] is grammar
+    assert kwargs["reasoning_budget_logits_processor"] is budget
+    assert "forced_assistant_prefix" not in kwargs
+    assert kwargs["requires_prompt_integrity"] is True
+    reset_config()
+
+
+class _TextScheduler:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.engine = None
+
+    async def generate(self, **kwargs):
+        self.calls.append(("generate", kwargs))
+        kwargs["on_request_committed"]()
+        return SimpleNamespace(
+            output_text="text-result",
+            output_token_ids=[],
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason="stop",
+            cached_tokens=1,
+            matched_stop="END",
+        )
+
+    async def add_request(self, **kwargs):
+        self.calls.append(("stream", kwargs))
+        kwargs["on_request_committed"]()
+        return kwargs["request_id"] or "text-request"
+
+    async def stream_outputs(self, _request_id):
+        yield SimpleNamespace(
+            output_text="text-result",
+            new_text="text-result",
+            new_token_ids=[7],
+            prompt_tokens=3,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            logprobs=[{"token": "text-result"}],
+            cached_tokens=1,
+            matched_stop="END",
+        )
+
+    def abort_request(self, _request_id) -> None:
+        return None
+
+
+class _MultimodalScheduler:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.config = SimpleNamespace(max_concurrent_requests=256)
+
+    async def generate(self, **kwargs):
+        self.calls.append(("generate", kwargs))
+        kwargs["on_request_committed"]()
+        return SimpleNamespace(
+            output_text="vision-result",
+            output_token_ids=[8],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finish_reason="stop",
+            matched_stop="END",
+        )
+
+    async def add_request_async(self, **kwargs):
+        self.calls.append(("stream", kwargs))
+        kwargs["on_request_committed"]()
+        return kwargs["request_id"] or "vision-request"
+
+    async def stream_outputs(self, _request_id):
+        yield SimpleNamespace(
+            output_text="vision-result",
+            new_text="vision-result",
+            new_token_ids=[8],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+            logprobs=[{"token": "vision-result"}],
+            matched_stop="END",
+        )
+
+
+def _engine(*, is_mllm: bool) -> tuple[BatchedEngine, Any]:
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._loaded = True
+    engine._is_mllm = is_mllm
+    engine._model_name = "lane-parity-test"
+    engine._is_muse_wire = False
+    engine._scheduler_config = SimpleNamespace(max_concurrent_requests=256)
+    engine._admission_lock = threading.Lock()
+    engine._admission_reservations = 0
+    engine._admission_tokens = set()
+    engine._admission_tasks = {}
+    engine._admission_owner_done_at = {}
+    engine._lifecycle_aborted_tasks = set()
+    if is_mllm:
+        scheduler = _MultimodalScheduler()
+        engine._mllm_scheduler = scheduler
+        engine._engine = None
+    else:
+        scheduler = _TextScheduler()
+        engine._engine = scheduler
+        engine._mllm_scheduler = None
+    return engine, scheduler
+
+
+def _request_semantics() -> tuple[dict[str, Any], tuple[object, object, object]]:
+    processors = (object(), object(), object())
+    kwargs = {
+        "repetition_penalty": 1.4,
+        "presence_penalty": 0.3,
+        "frequency_penalty": -0.2,
+        "grammar_logits_processor": processors[0],
+        "reasoning_budget_logits_processor": processors[1],
+        "suppressed_tokens_logits_processor": processors[2],
+        "top_k": 17,
+        "min_p": 0.08,
+        "seed": 42,
+    }
+    return kwargs, processors
+
+
+def _assert_shared_semantics(
+    *, lane: str, captured: dict[str, Any], processors: tuple[object, ...]
+) -> None:
+    if lane == "multimodal":
+        assert captured["logits_processors"] == list(processors)
+        assert {key: captured[key] for key in _LANE_PARITY_SAMPLING_KEYS} == {
+            "repetition_penalty": 1.4,
+            "presence_penalty": 0.3,
+            "frequency_penalty": -0.2,
+        }
+        for key in _TEXT_ONLY_SAMPLING_KEYS:
+            assert key not in captured
+        return
+
+    params = captured["sampling_params"]
+    assert {key: getattr(params, key) for key in _LANE_PARITY_SAMPLING_KEYS} == {
+        "repetition_penalty": 1.4,
+        "presence_penalty": 0.3,
+        "frequency_penalty": -0.2,
+    }
+    assert {key: getattr(params, key) for key in _TEXT_ONLY_SAMPLING_KEYS} == {
+        "top_k": 17,
+        "min_p": 0.08,
+        "seed": 42,
+    }
+    for key, processor in zip(_LANE_PARITY_PROCESSOR_KEYS, processors, strict=True):
+        assert captured[key] is processor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_mllm", [False, True], ids=["text", "multimodal"])
+@pytest.mark.parametrize("stream", [False, True], ids=["generate", "stream"])
+async def test_engine_dispatch_preserves_shared_request_semantics(
+    is_mllm: bool, stream: bool
+) -> None:
+    """Named #2447 guard: processors, stops, lifecycle and outputs survive.
+
+    This is deliberately one coupled request rather than a Cartesian product:
+    dropping any processor or shared sampling field on either generate path
+    fails one diagnostic row.
+    """
+
+    engine, scheduler = _engine(is_mllm=is_mllm)
+    kwargs, processors = _request_semantics()
+    common = {
+        "prompt": "prompt",
+        "max_tokens": 23,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "stop": ["END", "HALT"],
+        **kwargs,
+    }
+    if not stream:
+        common["_assistant_text_prefix"] = "<tool-prefix>"
+
+    if stream:
+        outputs = [
+            output
+            async for output in engine.stream_generate(
+                request_id="public-request", **common
+            )
+        ]
+    else:
+        outputs = [await engine.generate(**common)]
+
+    method, captured = scheduler.calls[-1]
+    assert method == ("stream" if stream else "generate")
+    if is_mllm:
+        assert captured["max_tokens"] == 23
+        assert captured["temperature"] == 0.2
+        assert captured["top_p"] == 0.8
+        assert captured["stop"] == ["END", "HALT"]
+    else:
+        sampling_params = captured["sampling_params"]
+        assert sampling_params.max_tokens == 23
+        assert sampling_params.temperature == 0.2
+        assert sampling_params.top_p == 0.8
+        assert sampling_params.stop == ["END", "HALT"]
+    assert captured["lifecycle_admission_token"]
+    _assert_shared_semantics(
+        lane="multimodal" if is_mllm else "text",
+        captured=captured,
+        processors=processors,
+    )
+
+    result = outputs[-1]
+    assert result.finish_reason == "stop"
+    assert result.matched_stop == "END"
+    if not stream:
+        assert result.raw_text.startswith("<tool-prefix>")
+    if stream:
+        assert result.logprobs == [
+            {"token": "vision-result" if is_mllm else "text-result"}
+        ]
+    assert engine._admission_reservations == 0
+
+
+def test_intentional_lane_differences_are_explicit_and_complete() -> None:
+    assert set(LANE_CAPABILITIES) == {
+        "media",
+        "speculative_decode",
+        "top_k",
+        "min_p",
+        "seed",
+        "prefix_cache_usage",
+        "cached_tokens_usage",
+    }
+    assert all(set(row) == {"text", "multimodal"} for row in LANE_CAPABILITIES.values())
+    assert all(row["text"] != row["multimodal"] for row in LANE_CAPABILITIES.values())

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -9,7 +9,6 @@ and the attestation check.
 from __future__ import annotations
 
 import importlib.util
-import re
 from pathlib import Path
 
 import pytest
@@ -128,13 +127,18 @@ def test_desktop_sidecar_uses_validated_mlx_vlm_bound():
     ]
     assert len(vision_specs) == 1
 
-    sidecar = (
-        _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "build-sidecar.sh"
-    ).read_text()
-    matches = re.findall(r"['\"](mlx-vlm[^'\"]*)['\"]", sidecar)
-    assert len(matches) == 1, "expected exactly one mlx-vlm sidecar requirement"
+    scripts = _REPO_ROOT / "apps" / "rapid-mac" / "scripts"
+    sidecar = (scripts / "build-sidecar.sh").read_text()
+    constraints = [
+        Requirement(line)
+        for line in (scripts / "sidecar-constraints.txt").read_text().splitlines()
+        if line and not line.startswith("#")
+    ]
+    matches = [spec for spec in constraints if spec.name == "mlx-vlm"]
+    assert len(matches) == 1, "expected exactly one mlx-vlm sidecar constraint"
+    assert '--constraint "$SIDECAR_CONSTRAINTS"' in sidecar
 
-    desktop_spec = Requirement(matches[0])
+    desktop_spec = matches[0]
     # Both surfaces deliberately pin one validated version. A range here caused
     # fresh pip installs to backtrack to 0.6.3 while Desktop stayed on 0.6.16.
     assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.16").specifier

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -28,6 +28,17 @@ def constraints():
     return _load_module()
 
 
+def test_emitted_constraints_are_stable_and_complete(constraints) -> None:
+    emitted = constraints.emit_constraints().splitlines()
+    assert emitted[0].startswith("# Release-tested versions")
+    assert emitted[1:] == [
+        "mlx==0.32.2",
+        "transformers==5.12.1",
+        "mlx-vlm==0.6.16",
+        "mflux==0.19.0",
+    ]
+
+
 def test_exact_reduced_vision_runtime_is_allowed(constraints) -> None:
     assert constraints.is_validated_compatibility_exception(
         owner="mlx-vlm",

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -37,6 +39,16 @@ def test_emitted_constraints_are_stable_and_complete(constraints) -> None:
         "mlx-vlm==0.6.16",
         "mflux==0.19.0",
     ]
+
+
+def test_emit_constraints_needs_only_the_python_standard_library() -> None:
+    result = subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), "--emit-constraints"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "mlx-vlm==0.6.16" in result.stdout
 
 
 def test_exact_reduced_vision_runtime_is_allowed(constraints) -> None:

--- a/tests/test_sidecar_vision_smoke.py
+++ b/tests/test_sidecar_vision_smoke.py
@@ -50,7 +50,11 @@ def test_release_workflow_runs_content_addressed_real_image_gate() -> None:
     assert "steps.sidecar-pins.outputs.gemma_revision" in workflow
     assert "steps.sidecar-pins.outputs.flux_model" in workflow
     assert "steps.sidecar-pins.outputs.flux_revision" in workflow
-    assert "HF_HUB_OFFLINE=1 bash apps/rapid-mac/scripts/build-sidecar.sh" in workflow
+    assert 'RAPID_MLX_WHEEL="$CANDIDATE_WHEEL"' in workflow
+    assert '"$V/bin/pip" wheel' in workflow
+    assert "--emit-constraints" in workflow
+    assert '"$V/bin/pip" check' in workflow
+    assert "HF_HUB_OFFLINE=1 RAPID_MLX_WHEEL=" in workflow
     assert '"$SIDE/python/bin/python3.12"' in workflow
     assert '--model "$SIDECAR_GEMMA_SMOKE_MODEL"' in workflow
     assert (

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -114,6 +114,29 @@ _HARMONY_NO_THINKING_SUFFIX_TOKENS = (
     "<|message|>",
 )
 
+# Request semantics that both serving lanes must preserve. Keep these names
+# and their ordering in one place: the text scheduler receives the processors
+# as named request fields, while the multimodal scheduler receives the same
+# processors as an ordered list. A route or engine refactor must therefore
+# update one contract instead of four independent generate/stream branches.
+_LANE_PARITY_SAMPLING_KEYS = (
+    "repetition_penalty",
+    "presence_penalty",
+    "frequency_penalty",
+)
+_TEXT_ONLY_SAMPLING_KEYS = ("top_k", "min_p", "seed")
+_LANE_PARITY_PROCESSOR_KEYS = (
+    "grammar_logits_processor",
+    "reasoning_budget_logits_processor",
+    "suppressed_tokens_logits_processor",
+)
+
+
+def _pop_lane_parity_processors(kwargs: dict[str, Any]) -> tuple[Any | None, ...]:
+    """Pop per-request processors in the scheduler's canonical order."""
+
+    return tuple(kwargs.pop(key, None) for key in _LANE_PARITY_PROCESSOR_KEYS)
+
 
 def _resolve_hf_model_type(model_name: str) -> str | None:
     """Best-effort read of ``config.json::model_type`` for ``model_name``.
@@ -2174,19 +2197,15 @@ class BatchedEngine(BaseEngine):
             # generator. ``top_k`` / ``min_p`` / ``seed`` MLLM passthrough
             # is intentionally NOT in scope here — see #512 follow-ups.
             _mllm_penalty_kwargs = {
-                k: kwargs.pop(k)
-                for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
-                if k in kwargs
+                key: kwargs.pop(key)
+                for key in _LANE_PARITY_SAMPLING_KEYS
+                if key in kwargs
             }
-            _mllm_logits_processors = []
-            for processor_key in (
-                "grammar_logits_processor",
-                "reasoning_budget_logits_processor",
-                "suppressed_tokens_logits_processor",
-            ):
-                processor = kwargs.pop(processor_key, None)
-                if processor is not None:
-                    _mllm_logits_processors.append(processor)
+            _mllm_logits_processors = [
+                processor
+                for processor in _pop_lane_parity_processors(kwargs)
+                if processor is not None
+            ]
             try:
                 output = await self._mllm_scheduler.generate(
                     prompt=prompt,
@@ -2233,22 +2252,9 @@ class BatchedEngine(BaseEngine):
         # sampler, repetition/presence/frequency_penalty via mlx-lm's
         # make_logits_processors().
         _sp_kwargs = {
-            k: kwargs.pop(k)
-            for k in (
-                "top_k",
-                "min_p",
-                "repetition_penalty",
-                "presence_penalty",
-                "frequency_penalty",
-                # H-11: forward the per-request seed onto SamplingParams
-                # so the scheduler can build a fresh seeded sampler. Without
-                # this, the seed field on the request model is parsed,
-                # validated, and silently dropped — Tomek r3's reproduced
-                # failure mode (five calls with seed=42 → five different
-                # outputs).
-                "seed",
-            )
-            if k in kwargs
+            key: kwargs.pop(key)
+            for key in (*_LANE_PARITY_SAMPLING_KEYS, *_TEXT_ONLY_SAMPLING_KEYS)
+            if key in kwargs
         }
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
@@ -2275,13 +2281,11 @@ class BatchedEngine(BaseEngine):
         output_router_seed = kwargs.pop("_output_router_seed_token_ids", None)
         # Grammar-constrained tool calling (#558): per-request logits
         # processor forwarded to the scheduler's request_processors slot.
-        grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
-        reasoning_budget_logits_processor = kwargs.pop(
-            "reasoning_budget_logits_processor", None
-        )
-        suppressed_tokens_logits_processor = kwargs.pop(
-            "suppressed_tokens_logits_processor", None
-        )
+        (
+            grammar_logits_processor,
+            reasoning_budget_logits_processor,
+            suppressed_tokens_logits_processor,
+        ) = _pop_lane_parity_processors(kwargs)
         if output_router_seed is None and isinstance(prompt, str):
             # ``build_prompt(enable_thinking=False)`` is part of the public
             # engine contract and returns the prepared Harmony string. A
@@ -2436,17 +2440,13 @@ class BatchedEngine(BaseEngine):
             # OpenAI-spec penalty passthrough (#512) — see ``generate()``
             # MLLM branch above for the rationale.
             _mllm_penalty_kwargs = {
-                k: kwargs.pop(k)
-                for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
-                if k in kwargs
+                key: kwargs.pop(key)
+                for key in _LANE_PARITY_SAMPLING_KEYS
+                if key in kwargs
             }
             _mllm_logits_processors = [
                 processor
-                for processor in (
-                    kwargs.pop("grammar_logits_processor", None),
-                    kwargs.pop("reasoning_budget_logits_processor", None),
-                    kwargs.pop("suppressed_tokens_logits_processor", None),
-                )
+                for processor in _pop_lane_parity_processors(kwargs)
                 if processor is not None
             ]
             try:
@@ -2514,22 +2514,9 @@ class BatchedEngine(BaseEngine):
 
         # Extended sampling params (#355) — see generate() for rationale.
         _sp_kwargs = {
-            k: kwargs.pop(k)
-            for k in (
-                "top_k",
-                "min_p",
-                "repetition_penalty",
-                "presence_penalty",
-                "frequency_penalty",
-                # H-11: forward the per-request seed onto SamplingParams
-                # so the scheduler can build a fresh seeded sampler. Without
-                # this, the seed field on the request model is parsed,
-                # validated, and silently dropped — Tomek r3's reproduced
-                # failure mode (five calls with seed=42 → five different
-                # outputs).
-                "seed",
-            )
-            if k in kwargs
+            key: kwargs.pop(key)
+            for key in (*_LANE_PARITY_SAMPLING_KEYS, *_TEXT_ONLY_SAMPLING_KEYS)
+            if key in kwargs
         }
         try:
             sampling_params = SamplingParams(
@@ -2547,13 +2534,11 @@ class BatchedEngine(BaseEngine):
                 kwargs.pop("requires_prompt_integrity", False)
             )
             # Grammar-constrained tool calling (#558) — streaming parity.
-            grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
-            reasoning_budget_logits_processor = kwargs.pop(
-                "reasoning_budget_logits_processor", None
-            )
-            suppressed_tokens_logits_processor = kwargs.pop(
-                "suppressed_tokens_logits_processor", None
-            )
+            (
+                grammar_logits_processor,
+                reasoning_budget_logits_processor,
+                suppressed_tokens_logits_processor,
+            ) = _pop_lane_parity_processors(kwargs)
             request_id = await self._engine.add_request(
                 request_id=request_id,
                 prompt=prompt,


### PR DESCRIPTION
## Why\n\nA vision-capable alias can select a different scheduler without changing the request semantics the client asked for. Before this change, grammar, reasoning-budget, suppression, penalty, stop, lifecycle, and output metadata were guarded by separate tests and duplicated forwarding code, so one lane could silently drift. The release gate also installed source independently in its text and Desktop lanes, which could miss a candidate-wheel packaging defect.\n\nFixes #2495\n\n## What\n\n- Add a table-driven route and engine matrix over text/multimodal plus streaming/non-streaming paths.\n- Centralize the shared sampling and ordered logits-processor field roster used by both schedulers.\n- Make intentional lane differences explicit data: media, speculative decode, top-k/min-p/seed, prefix-cache and cached-token reporting.\n- Cover lane-selection precedence across vision-runtime versions 0.6.3, 0.6.16 and 0.6.17, memory admission, force flags and speculative decode.\n- Build one candidate wheel in auto-release, install it into the fresh Tier-1 venv, run pip check and distribution coherence, then promote the exact same wheel into the reduced Desktop sidecar.\n- Move Desktop runtime pins into one constraint file exposed through check-sidecar-distributions.py --emit-constraints.\n\n## Design precedent\n\nMature production serving stacks normalize request semantics before scheduler selection, keep capability differences explicit, and parameterize the same request lifecycle across execution backends. This adapts that pattern: one ordered field contract feeds both schedulers, while unsupported features remain declared capability data instead of permanent skips. Release verification similarly builds once and promotes the exact artifact through each consumer lane.\n\n## Scope\n\nThis PR changes contracts and release-shaped installation only. It does not implement multimodal prefix caching, alter scheduler policy, change dependency versions, or load model weights outside the existing serialized release smoke.\n\n## Verification\n\n- [x] 28 lane-parity route/engine/selection cases\n- [x] 132 focused lane, scheduler, sidecar and release tests\n- [x] 80 pin/route/sidecar regression tests after SSOT migration\n- [x] Swift SidecarBuildScriptTests: 8/8\n- [x] auto-release dry-run contract: 32/32\n- [x] Desktop promotion contract: 106/106\n- [x] release workflow Python contracts: 44/44\n- [x] ruff check + format check, bash -n, YAML parse, git diff --check\n- [x] candidate wheel build and wheel[audio-desktop] constraint resolution dry-run\n- [x] full suite: 19,826 passed; the three remaining failures are unchanged host/test-fixture baselines (one missing offline tokenizer snapshot and two scheduler fixtures missing BatchGenerator), unrelated to this diff\n\n## Rollout\n\nThe workflow change is exercised by auto-release dry_run before any future version bump. Normal publication protections remain unchanged.