### PR TITLE
fix(audio): align Parakeet v3 language metadata

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -281,8 +281,8 @@ final class AudioViewModel {
         case "parakeet-v3", "parakeet-tdt-0.6b-v3":
             return .init(
                 displayName: "Parakeet TDT v3",
-                badge: "English",
-                summary: "Fast English transcription with improved accuracy over v2 and automatic punctuation.",
+                badge: "25 languages",
+                summary: "Fast transcription across 25 European languages with automatic language detection. Chinese is not supported.",
                 isRecommended: false
             )
         case "parakeet", "parakeet-tdt-0.6b", "parakeet-tdt-0.6b-v2":

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -61,10 +61,10 @@ struct AudioCatalogTests {
             family: "parakeet"
         )
         #expect(parakeet.displayName == "Parakeet TDT v3")
-        #expect(parakeet.badge == "English")
-        #expect(parakeet.summary.contains("English"))
-        #expect(!parakeet.summary.contains("25"))
-        #expect(parakeet.summary.contains("punctuation"))
+        #expect(parakeet.badge == "25 languages")
+        #expect(parakeet.summary.contains("25 European languages"))
+        #expect(parakeet.summary.contains("automatic language detection"))
+        #expect(parakeet.summary.contains("Chinese is not supported"))
 
         let qwen = AudioViewModel.transcriptionDetails(
             alias: "qwen3-asr",

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -799,6 +799,7 @@ Tested on Apple M2 Max (32GB).
 | Use Case | Recommended Model | Why |
 |----------|------------------|-----|
 | Fast English STT | `parakeet` | 40x RTF, low memory |
+| European-language STT | `parakeet-v3` | Automatic detection across 25 languages |
 | Multilingual STT | `whisper-large-v3` | 99+ languages |
 | Low-latency STT | `whisper-small` | 30x RTF, quick load |
 | General TTS | `kokoro` | 17x RTF, good quality |
@@ -806,7 +807,7 @@ Tested on Apple M2 Max (32GB).
 
 ## Performance Tips
 
-1. **Use Parakeet for English** - 40x faster than real-time
+1. **Use Parakeet v2 for English or v3 for 25 European languages** - 40x faster than real-time
 2. **Use 4-bit models** for lower memory usage
 3. **Use SAM-Audio small** for faster voice separation
 4. **Cache models** - engines are lazy-loaded and cached

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -807,11 +807,12 @@ Tested on Apple M2 Max (32GB).
 
 ## Performance Tips
 
-1. **Use Parakeet v2 for English or v3 for 25 European languages** - 40x faster than real-time
-2. **Use 4-bit models** for lower memory usage
-3. **Use SAM-Audio small** for faster voice separation
-4. **Cache models** - engines are lazy-loaded and cached
-5. **Pre-download models** to avoid first-run latency
+1. **Use Parakeet v2 for English** - measured at 40x faster than real-time
+2. **Use Parakeet v3 for 25 European languages** with automatic language detection
+3. **Use 4-bit models** for lower memory usage
+4. **Use SAM-Audio small** for faster voice separation
+5. **Cache models** - engines are lazy-loaded and cached
+6. **Pre-download models** to avoid first-run latency
 
 ## Troubleshooting
 

--- a/tests/test_audio_alias_metadata.py
+++ b/tests/test_audio_alias_metadata.py
@@ -10,19 +10,48 @@ import pytest
 ALIASES_PATH = (
     Path(__file__).resolve().parents[1] / "vllm_mlx" / "audio" / "aliases.json"
 )
+PARAKEET_V3_LANGUAGES = {
+    "bg",
+    "cs",
+    "da",
+    "de",
+    "el",
+    "en",
+    "es",
+    "et",
+    "fi",
+    "fr",
+    "hr",
+    "hu",
+    "it",
+    "lt",
+    "lv",
+    "mt",
+    "nl",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sk",
+    "sl",
+    "sv",
+    "uk",
+}
 
 
 @pytest.mark.parametrize(
     "alias,expected_languages",
     [
-        ("parakeet", "en"),
-        ("parakeet-tdt-0.6b-v2", "en"),
-        ("parakeet-v3", "25 European languages"),
-        ("parakeet-tdt-0.6b-v3", "25 European languages"),
+        ("parakeet", {"en"}),
+        ("parakeet-tdt-0.6b-v2", {"en"}),
+        ("parakeet-v3", PARAKEET_V3_LANGUAGES),
+        ("parakeet-tdt-0.6b-v3", PARAKEET_V3_LANGUAGES),
     ],
 )
 def test_parakeet_language_metadata_distinguishes_v2_and_v3(
-    alias: str, expected_languages: str
+    alias: str, expected_languages: set[str]
 ) -> None:
     aliases = json.loads(ALIASES_PATH.read_text(encoding="utf-8"))
-    assert aliases[alias]["languages"] == expected_languages
+    languages = aliases[alias]["languages"].split(",")
+    assert set(languages) == expected_languages
+    assert all(len(language) == 2 and language.isalpha() for language in languages)

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -291,14 +291,14 @@
     "type": "stt",
     "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
     "family": "parakeet",
-    "languages": "25 European languages",
+    "languages": "en,es,fr,de,bg,hr,cs,da,nl,et,fi,el,hu,it,lv,lt,mt,pl,pt,ro,sk,sl,sv,ru,uk",
     "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
   },
   "parakeet-tdt-0.6b-v3": {
     "type": "stt",
     "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
     "family": "parakeet",
-    "languages": "25 European languages",
+    "languages": "en,es,fr,de,bg,hr,cs,da,nl,et,fi,el,hu,it,lv,lt,mt,pl,pt,ro,sk,sl,sv,ru,uk",
     "notes": "Parakeet TDT 0.6B v3 with automatic language detection. Chinese is not supported."
   },
   "qwen3-asr": {


### PR DESCRIPTION
## Summary

- follow the merged contributor correction in #2680 by storing Parakeet v3 support as the registry contract requires: a comma-separated list of all 25 ISO language codes
- make the Desktop picker describe the same 25-language, auto-detected capability instead of labeling v3 as English-only
- pin the registry schema and Desktop presentation with focused regression tests

## Design precedent

The canonical checkpoint metadata enumerates supported languages as ISO codes, while Rapid-MLX already defines audio `languages` as either `multilingual` or a comma-separated ISO list. This change follows that existing typed metadata boundary and derives human-facing summaries from the same capability, rather than introducing a second schema or free-form parser.

## Scope and non-goals

Scope is the Parakeet v2/v3 audio metadata introduced by #2680, related operator documentation, the Desktop audio catalog description, and focused data/presentation tests. No STT inference behavior, model loading, dependency, route, or CI changes.

## Verification

- `python3.12 -m pytest -q tests/test_audio_alias_metadata.py tests/test_audio_alias_registry.py` — 132 passed
- `swift test --no-parallel --filter AudioCatalogTests` — 19 passed
- `ruff check vllm_mlx/audio/stt.py tests/test_audio_alias_metadata.py`
- `ruff format --check vllm_mlx/audio/stt.py tests/test_audio_alias_metadata.py`
- `git diff --check`

## AI assistance disclosure

Codex reviewed #2680, implemented the two in-scope consistency fixes, and ran the focused verification.