### PR TITLE
docs: finalize 0.13.2-rc1 release notes

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -158,6 +158,10 @@ can actually understand.
   remains over budget, the server warns and leaves the existing downstream
   prefill-cap guard as the final rejection boundary.
   ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
+- **Image edits preserve the source canvas.** Editing an uploaded image derives
+  the output dimensions from that image instead of silently selecting the
+  text-to-image 1024×1024 default. Square and non-square FLUX.2 Klein edits
+  retain their original dimensions. ([#2759](https://github.com/raullenchai/Rapid-MLX/pull/2759))
 - **Forced assistant prefixes no longer wait for the first decoded token.** The
   prefix is emitted after scheduler admission, while empty, failed, and
   cancelled streams clean up their pending admission work.

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -3564,8 +3564,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...HEAD
-[0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...HEAD
+[0.13.2-rc1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2-rc1
 [0.13.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.0...rapid-mac-v0.13.1
 [0.5.16]: https://github.com/machinefi/rapid-desktop/compare/v0.5.15...v0.5.16
 [0.5.15]: https://github.com/machinefi/rapid-desktop/compare/v0.5.14...v0.5.15

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,7 +17,7 @@ can actually understand.
 
 ## [Unreleased]
 
-## [0.13.2] — 2026-08-30
+## [0.13.2-rc1] — 2026-08-30
 
 ### Added
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,7 +17,7 @@ can actually understand.
 
 ## [Unreleased]
 
-## [0.13.2] — 2026-08-29
+## [0.13.2] — 2026-08-30
 
 ### Added
 
@@ -35,6 +35,11 @@ can actually understand.
   surface and client attribution; raw user-agent text is never emitted.
   ([#2428](https://github.com/raullenchai/Rapid-MLX/pull/2428),
   [#2436](https://github.com/raullenchai/Rapid-MLX/pull/2436))
+- **Conversation titles and next-step suggestions.** After the first completed
+  exchange, Desktop can derive one short local title without overwriting a user
+  rename. Settled text answers can also offer three optional follow-up prompts;
+  malformed, duplicate, or incomplete suggestions remain hidden.
+  ([#2698](https://github.com/raullenchai/Rapid-MLX/pull/2698))
 
 ### Changed
 
@@ -81,6 +86,10 @@ can actually understand.
   runtime component from inside a request; it returns an actionable readiness
   error instead. ([#2648](https://github.com/raullenchai/Rapid-MLX/pull/2648),
   [#2664](https://github.com/raullenchai/Rapid-MLX/pull/2664))
+- **Parakeet v3 reports its complete language support.** Registry metadata and
+  the Desktop picker now agree on all 25 supported ISO languages and automatic
+  language detection instead of describing the checkpoint as English-only.
+  ([#2729](https://github.com/raullenchai/Rapid-MLX/pull/2729))
 - **Qwen3.8 tool calls use the checkpoint's native wire format.** Required and
   named tool calls return OpenAI-compatible JSON arguments, and malformed
   required arguments fail with a client error instead of looking executable.
@@ -136,6 +145,13 @@ can actually understand.
   listing, pull admission, or chat model switching.
   ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- **Pulled variants resolve consistently on serve.** Pulling an explicit
+  `--bits` or `--format` variant records the selected subfolder so `serve`
+  loads the same checkpoint instead of the repository root. Catalog aliases
+  retain precedence over the pull marker, and mirror-backed pulls now commit
+  the same selection as fallback downloads.
+  ([#2558](https://github.com/raullenchai/Rapid-MLX/pull/2558),
+  [#2750](https://github.com/raullenchai/Rapid-MLX/pull/2750))
 - **Oversized vision inputs fit the request budget automatically.** Images are
   reduced against the model's patch-aware token ceiling before preprocessing,
   with one measured retry for processor rounding. If the minimum aligned image
@@ -150,6 +166,10 @@ can actually understand.
   preflights the full verify-forward cache growth and falls back to ordinary
   decoding when advancing would make rollback unsafe, rather than aborting the
   request. ([#2682](https://github.com/raullenchai/Rapid-MLX/pull/2682))
+- **Terminal MTP responses cannot publish speculative cache state.** When a
+  response finishes before every verified draft token is emitted, Rapid drops
+  that response's reusable cache rather than exposing state ahead of the
+  visible output. ([#2751](https://github.com/raullenchai/Rapid-MLX/pull/2751))
 
 ### Security
 
@@ -161,17 +181,23 @@ can actually understand.
 - **Desktop web browsing pins the validated destination.** Every DNS answer is
   checked by the existing SSRF policy, then the socket connects directly to
   the selected address while retaining the original hostname for TLS and
-  certificate validation. This closes the DNS-rebinding window without
-  weakening redirect, body-size, or timeout limits.
-  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645))
+  certificate validation. Validated IPv4 and IPv6 destinations are raced with
+  a short stagger, so one black-holed route cannot consume the whole browse
+  deadline. This closes the DNS-rebinding window without weakening redirect,
+  body-size, or timeout limits.
+  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645),
+  [#2747](https://github.com/raullenchai/Rapid-MLX/pull/2747))
 
 ### Release engineering
 
 - Signed Desktop candidates identify their exact source commit, and protected
   publication promotes the already reviewed DMG, Sparkle archive, appcast, and
-  release notes instead of rebuilding different bytes after the tag.
+  release notes instead of rebuilding different bytes after the tag. The same
+  candidate wheel is installed in Tier 1 and promoted into the Desktop sidecar,
+  while text and multimodal lanes share an explicit request-contract matrix.
   ([#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
-  [#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530))
+  [#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530),
+  [#2726](https://github.com/raullenchai/Rapid-MLX/pull/2726))
 
 ## [0.13.1] — 2026-08-26
 

--- a/docs/release-notes/v0.13.2-rc1.md
+++ b/docs/release-notes/v0.13.2-rc1.md
@@ -1,4 +1,4 @@
-Rapid-MLX 0.13.2 makes long-running local assistants faster and more
+Rapid-MLX 0.13.2-rc1 makes long-running local assistants faster and more
 dependable: Qwen3.8 Flash-Next gains opt-in native MTP and faster long-context
 prefill, repeated prompts recover their prefix cache, offline speech pulls
 include their runtime requirements, and Desktop tightens attachment, credential,

--- a/docs/release-notes/v0.13.2-rc1.md
+++ b/docs/release-notes/v0.13.2-rc1.md
@@ -2,7 +2,8 @@ Rapid-MLX 0.13.2 makes long-running local assistants faster and more
 dependable: Qwen3.8 Flash-Next gains opt-in native MTP and faster long-context
 prefill, repeated prompts recover their prefix cache, offline speech pulls
 include their runtime requirements, and Desktop tightens attachment, credential,
-and web-browsing safety.
+and web-browsing safety. This first release candidate is published for
+validation and deliberately does not replace the stable updater feed.
 
 ## Highlights
 

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -151,6 +151,10 @@ multimodal request behavior aligned.
   remains over budget, the server warns and leaves the existing downstream
   prefill-cap guard as the final rejection boundary.
   ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
+- Image edits derive their output canvas from the uploaded source instead of
+  silently falling back to the text-to-image 1024×1024 default. Square and
+  non-square FLUX.2 Klein edits now preserve the source dimensions.
+  ([#2759](https://github.com/raullenchai/Rapid-MLX/pull/2759))
 - Forced assistant prefixes become visible as soon as the scheduler admits the
   request instead of waiting for the first decoded token. Empty, failed, and
   cancelled streams retire their pending admission work cleanly.

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -61,13 +61,20 @@ from 187,505,002 to 105,881,983 bytes, a 43.53% reduction. The tradeoff is a
 slower one-time Finder copy on the measured host: 17.80 seconds instead of 5.94
 seconds. Candidate builds now identify their source commit, and protected
 publication promotes the exact approved DMG and updater payloads instead of
-rebuilding different bytes after the tag.
+rebuilding different bytes after the tag. Tier 1 and Desktop now install the
+same candidate wheel, with a shared contract matrix keeping text and
+multimodal request behavior aligned.
 ([#2668](https://github.com/raullenchai/Rapid-MLX/pull/2668),
 [#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
-[#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530))
+[#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530),
+[#2726](https://github.com/raullenchai/Rapid-MLX/pull/2726))
 
 ## Desktop safety and workflow corrections
 
+- After the first completed exchange, Desktop can derive one short local title
+  without replacing a user rename. Settled text answers can also offer three
+  optional follow-up prompts; malformed, duplicate, wrong-script, or incomplete
+  suggestions stay hidden. ([#2698](https://github.com/raullenchai/Rapid-MLX/pull/2698))
 - A chat message accepts up to four images and 6 MiB of aggregate encoded image
   data, preserves selection order, and explains whether count or size rejected
   the remainder. A repeatedly failing image gets one bounded follow-up retry
@@ -132,6 +139,12 @@ rebuilding different bytes after the tag.
   listing, pull admission, or chat model switching.
   ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
   [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- Explicit variant pulls persist their selected subfolder, so a later
+  `serve` command resolves the pulled checkpoint instead of the repository
+  root. Catalog aliases retain precedence over this pull marker, and
+  mirror-backed pulls now persist the same selection as fallback downloads.
+  ([#2558](https://github.com/raullenchai/Rapid-MLX/pull/2558),
+  [#2750](https://github.com/raullenchai/Rapid-MLX/pull/2750))
 - Oversized vision images are automatically reduced to the model's patch-aware
   token budget before preprocessing. Multiple images share that budget, and a
   measured retry handles processor rounding. If the minimum aligned image
@@ -146,6 +159,14 @@ rebuilding different bytes after the tag.
   advancing a sliding-window cache. At a rollback-unsafe boundary it falls
   back to ordinary decoding instead of aborting the request.
   ([#2682](https://github.com/raullenchai/Rapid-MLX/pull/2682))
+- A terminal MTP response that has verified farther than its visible output no
+  longer publishes that advanced state as a reusable prefix cache. Ordinary
+  completed-response cache reuse is unchanged.
+  ([#2751](https://github.com/raullenchai/Rapid-MLX/pull/2751))
+- Parakeet v3 metadata and the Desktop picker now agree on all 25 supported ISO
+  languages and automatic language detection instead of describing the
+  checkpoint as English-only.
+  ([#2729](https://github.com/raullenchai/Rapid-MLX/pull/2729))
 - Passive version checks correctly order `rcN` below the matching final and now
   cover `pull`, `ps`, `info`, `bench`, and `doctor`; automatic upgrade prompts
   remain off for development, RC, and local builds.
@@ -163,6 +184,9 @@ rebuilding different bytes after the tag.
   preferences contain only non-secret metadata.
   ([#2639](https://github.com/raullenchai/Rapid-MLX/pull/2639))
 - Desktop web browsing validates every DNS answer, then pins the socket to the
-  selected address while preserving hostname-based TLS verification. Redirect,
-  body-size, and timeout limits remain fail closed.
-  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645))
+  selected address while preserving hostname-based TLS verification. Validated
+  IPv4 and IPv6 destinations are raced with a short stagger so one black-holed
+  route cannot consume the whole deadline. Redirect, body-size, and timeout
+  limits remain fail closed.
+  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645),
+  [#2747](https://github.com/raullenchai/Rapid-MLX/pull/2747))

--- a/scripts/check_release_notes.py
+++ b/scripts/check_release_notes.py
@@ -53,23 +53,44 @@ def check_release_notes(version: str, changelog: Path, notes_dir: Path) -> None:
             f"{changelog} has an empty '## [{version}]' section; add the Desktop release notes"
         )
 
-    references = {
-        match.group(1): match.group(2)
-        for line in changelog_lines
-        if (match := CHANGELOG_REFERENCE_RE.match(line))
-    }
-    desktop_tag = f"rapid-mac-v{version}"
-    version_reference = references.get(version, "")
-    if not version_reference.endswith(f"...{desktop_tag}"):
+    if section_end == len(changelog_lines) or not (
+        previous_match := CHANGELOG_HEADING_RE.match(changelog_lines[section_end])
+    ):
         raise ValueError(
-            f"{changelog} has no exact '[{version}]' comparison ending at "
-            f"{desktop_tag}; update the changelog reference links"
+            f"{changelog} has no release section after '## [{version}]'; "
+            "the comparison base cannot be derived"
         )
-    unreleased_reference = references.get("Unreleased", "")
-    if not unreleased_reference.endswith(f"/compare/{desktop_tag}...HEAD"):
+    previous_version = previous_match.group(1)
+
+    references: dict[str, list[str]] = {}
+    for line in changelog_lines:
+        if match := CHANGELOG_REFERENCE_RE.match(line):
+            references.setdefault(match.group(1), []).append(match.group(2))
+
+    for label in ("Unreleased", version):
+        count = len(references.get(label, []))
+        if count != 1:
+            raise ValueError(
+                f"{changelog} must define exactly one '[{label}]' comparison; "
+                f"found {count}"
+            )
+
+    compare_root = "https://github.com/raullenchai/Rapid-MLX/compare/"
+    desktop_tag = f"rapid-mac-v{version}"
+    previous_tag = f"rapid-mac-v{previous_version}"
+    version_reference = references[version][0]
+    expected_version_reference = f"{compare_root}{previous_tag}...{desktop_tag}"
+    if version_reference != expected_version_reference:
         raise ValueError(
-            f"{changelog} '[Unreleased]' does not compare {desktop_tag} to HEAD; "
-            "update the changelog reference links"
+            f"{changelog} '[{version}]' must be exactly "
+            f"{expected_version_reference}; update the changelog reference links"
+        )
+    unreleased_reference = references["Unreleased"][0]
+    expected_unreleased_reference = f"{compare_root}{desktop_tag}...HEAD"
+    if unreleased_reference != expected_unreleased_reference:
+        raise ValueError(
+            f"{changelog} '[Unreleased]' must be exactly "
+            f"{expected_unreleased_reference}; update the changelog reference links"
         )
 
     notes = notes_dir / f"v{version}.md"

--- a/scripts/check_release_notes.py
+++ b/scripts/check_release_notes.py
@@ -14,6 +14,7 @@ except ModuleNotFoundError:  # imported by tests as ``scripts.*`` from repo root
     from scripts.release_version import VERSION_RE
 
 CHANGELOG_HEADING_RE = re.compile(r"^## \[([^]]+)](?:\s|$)")
+CHANGELOG_REFERENCE_RE = re.compile(r"^\[([^]]+)]:\s+(\S+)\s*$")
 
 
 def check_release_notes(version: str, changelog: Path, notes_dir: Path) -> None:
@@ -50,6 +51,25 @@ def check_release_notes(version: str, changelog: Path, notes_dir: Path) -> None:
     if not "\n".join(changelog_lines[section_start:section_end]).strip():
         raise ValueError(
             f"{changelog} has an empty '## [{version}]' section; add the Desktop release notes"
+        )
+
+    references = {
+        match.group(1): match.group(2)
+        for line in changelog_lines
+        if (match := CHANGELOG_REFERENCE_RE.match(line))
+    }
+    desktop_tag = f"rapid-mac-v{version}"
+    version_reference = references.get(version, "")
+    if not version_reference.endswith(f"...{desktop_tag}"):
+        raise ValueError(
+            f"{changelog} has no exact '[{version}]' comparison ending at "
+            f"{desktop_tag}; update the changelog reference links"
+        )
+    unreleased_reference = references.get("Unreleased", "")
+    if not unreleased_reference.endswith(f"/compare/{desktop_tag}...HEAD"):
+        raise ValueError(
+            f"{changelog} '[Unreleased]' does not compare {desktop_tag} to HEAD; "
+            "update the changelog reference links"
         )
 
     notes = notes_dir / f"v{version}.md"

--- a/tests/test_check_release_notes.py
+++ b/tests/test_check_release_notes.py
@@ -9,7 +9,9 @@ from scripts.check_release_notes import check_release_notes, main
 def _inputs(tmp_path: Path, version: str = "0.13.2") -> tuple[Path, Path]:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(
-        f"# Changelog\n\n## [{version}] — 2026-08-27\n\nDesktop changes.\n",
+        f"# Changelog\n\n## [{version}] — 2026-08-27\n\nDesktop changes.\n\n"
+        f"[Unreleased]: https://example.test/compare/rapid-mac-v{version}...HEAD\n"
+        f"[{version}]: https://example.test/compare/rapid-mac-v0.0.0...rapid-mac-v{version}\n",
         encoding="utf-8",
     )
     notes_dir = tmp_path / "release-notes"
@@ -57,6 +59,28 @@ def test_empty_version_bound_notes_file_is_rejected(tmp_path: Path) -> None:
     (notes_dir / "v0.13.2.md").write_text(" \n", encoding="utf-8")
     with pytest.raises(ValueError, match="add curated release notes"):
         check_release_notes("0.13.2", changelog, notes_dir)
+
+
+def test_missing_version_comparison_is_rejected(tmp_path: Path) -> None:
+    changelog, notes_dir = _inputs(tmp_path)
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace("[0.13.2]:", "[0.13.1]:"),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="comparison ending at rapid-mac-v0.13.2"):
+        check_release_notes("0.13.2", changelog, notes_dir)
+
+
+def test_unreleased_comparison_must_start_at_current_tag(tmp_path: Path) -> None:
+    changelog, notes_dir = _inputs(tmp_path, "0.14.0-rc1")
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace(
+            "rapid-mac-v0.14.0-rc1...HEAD", "rapid-mac-v0.14.0...HEAD"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="does not compare rapid-mac-v0.14.0-rc1"):
+        check_release_notes("0.14.0-rc1", changelog, notes_dir)
 
 
 @pytest.mark.parametrize("version", ["0.13", "0.13.2-rc0", "../0.13.2"])

--- a/tests/test_check_release_notes.py
+++ b/tests/test_check_release_notes.py
@@ -7,11 +7,13 @@ from scripts.check_release_notes import check_release_notes, main
 
 
 def _inputs(tmp_path: Path, version: str = "0.13.2") -> tuple[Path, Path]:
+    previous_version = "0.0.0"
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(
         f"# Changelog\n\n## [{version}] — 2026-08-27\n\nDesktop changes.\n\n"
-        f"[Unreleased]: https://example.test/compare/rapid-mac-v{version}...HEAD\n"
-        f"[{version}]: https://example.test/compare/rapid-mac-v0.0.0...rapid-mac-v{version}\n",
+        f"## [{previous_version}] — 2026-08-26\n\nPrevious release.\n\n"
+        f"[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v{version}...HEAD\n"
+        f"[{version}]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v{previous_version}...rapid-mac-v{version}\n",
         encoding="utf-8",
     )
     notes_dir = tmp_path / "release-notes"
@@ -67,7 +69,7 @@ def test_missing_version_comparison_is_rejected(tmp_path: Path) -> None:
         changelog.read_text(encoding="utf-8").replace("[0.13.2]:", "[0.13.1]:"),
         encoding="utf-8",
     )
-    with pytest.raises(ValueError, match="comparison ending at rapid-mac-v0.13.2"):
+    with pytest.raises(ValueError, match=r"exactly one '\[0.13.2\]' comparison"):
         check_release_notes("0.13.2", changelog, notes_dir)
 
 
@@ -79,8 +81,46 @@ def test_unreleased_comparison_must_start_at_current_tag(tmp_path: Path) -> None
         ),
         encoding="utf-8",
     )
-    with pytest.raises(ValueError, match="does not compare rapid-mac-v0.14.0-rc1"):
+    with pytest.raises(ValueError, match=r"'\[Unreleased\]' must be exactly"):
         check_release_notes("0.14.0-rc1", changelog, notes_dir)
+
+
+@pytest.mark.parametrize("label", ["Unreleased", "0.13.2"])
+def test_duplicate_comparison_definition_is_rejected(
+    tmp_path: Path, label: str
+) -> None:
+    changelog, notes_dir = _inputs(tmp_path)
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8")
+        + f"[{label}]: https://github.com/raullenchai/Rapid-MLX/compare/duplicate\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must define exactly one"):
+        check_release_notes("0.13.2", changelog, notes_dir)
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        "https://example.invalid/compare/rapid-mac-v0.0.0...rapid-mac-v0.13.2",
+        "https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.0.1...rapid-mac-v0.13.2",
+        "https://github.com/raullenchai/Rapid-MLX/releases/rapid-mac-v0.13.2",
+    ],
+)
+def test_version_comparison_requires_exact_repository_and_previous_tag(
+    tmp_path: Path, replacement: str
+) -> None:
+    changelog, notes_dir = _inputs(tmp_path)
+    expected = (
+        "https://github.com/raullenchai/Rapid-MLX/compare/"
+        "rapid-mac-v0.0.0...rapid-mac-v0.13.2"
+    )
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace(expected, replacement),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=r"'\[0.13.2\]' must be exactly"):
+        check_release_notes("0.13.2", changelog, notes_dir)
 
 
 @pytest.mark.parametrize("version", ["0.13", "0.13.2-rc0", "../0.13.2"])


### PR DESCRIPTION
## Why

The staged 0.13.2 notes predated the final release-blocker batch. This synchronizes the changelog and long-form notes with the exact user-facing and release-path delta now intended for `0.13.2-rc1`, so the release candidate does not omit shipped behavior or masquerade as the later stable release.

## Final delta audit

- Adds local conversation titles and optional follow-up suggestions from #2698.
- Records Parakeet v3 language metadata from #2729.
- Completes pulled-variant consistency across mirror and fallback paths with #2558 and #2750.
- Records the terminal MTP cache boundary from #2751 and dual-stack validated DNS fallback from #2747.
- Records the build-once lane-parity release contract from #2726.
- Records source-canvas preservation for image edits from landed #2759.
- Binds the changelog section, curated note filename, version compare link, and Unreleased baseline to the exact `0.13.2-rc1` Desktop tag; the release-note guard now checks those links.
- Leaves unrelated internal-only fixes out of user-facing sections.

## Design precedent

The release notes follow the existing curated changelog contract: user-visible behavior is grouped by outcome, related fixes are consolidated into one narrative, prereleases get their own immutable version-bound entry, and release engineering details are included only when they change artifact identity or release confidence. Version-bound compare links are validated at the same boundary as the section and note filename. Duplicate labels, wrong repositories, malformed ranges, and a previous-tag mismatch all fail closed so an RC cannot publish broken changelog navigation.

## Verification

- `python3 scripts/check_release_notes.py --version 0.13.2-rc1 --changelog apps/rapid-mac/CHANGELOG.md --notes-dir docs/release-notes`
- `python3 -m pytest -q tests/test_check_release_notes.py` (18 passed)
- `bash tests/release/test_build_release_notes.sh` (63 passed)
- `python3 -m ruff check scripts/check_release_notes.py tests/test_check_release_notes.py`
- `python3 -m ruff format --check scripts/check_release_notes.py tests/test_check_release_notes.py`
- `git diff --check`

## AI assistance disclosure

Codex performed the final merged-delta audit, updated the documentation and release-note guard, and ran the release-note checks.

Closes #2678