### PR TITLE
fix(cli): retain mirrored pulled variant

### DIFF
--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -561,6 +561,64 @@ def test_successful_ordinary_mirror_pull_clears_previous_variant(marker_path):
     assert _download_gate.pulled_variant(RAW_REPO) is None
 
 
+def test_successful_variant_mirror_pull_persists_serving_choice(marker_path):
+    """The default mirror path must retain the explicit variant for serve."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits="4",
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    def mirror_success(repo_id, *, allow_patterns, out):
+        assert repo_id == RAW_REPO
+        assert allow_patterns == ["4bit/*"]
+        out["network_fetch"] = True
+        return True
+
+    with (
+        patch(
+            "huggingface_hub.HfApi.list_repo_tree",
+            return_value=_multi_variant_tree(),
+        ),
+        patch.object(cli, "_try_mirror_prefetch", side_effect=mirror_success),
+    ):
+        cli.pull_command(args)
+
+    assert _download_gate.pulled_variant(RAW_REPO) == "4bit"
+
+
+def test_runtime_asset_override_does_not_touch_model_variant(capsys, marker_path):
+    """Dependency file filters neither rewrite metadata nor emit a false warning."""
+    import argparse
+
+    from vllm_mlx import cli
+
+    _download_gate.persist_pulled_variant(RAW_REPO, "8bit")
+    args = argparse.Namespace(
+        model=RAW_REPO,
+        bits=None,
+        format=None,
+        _original_alias=RAW_REPO,
+    )
+
+    def mirror_success(repo_id, *, allow_patterns, out):
+        assert repo_id == RAW_REPO
+        assert allow_patterns == ["runtime/*"]
+        out["network_fetch"] = False
+        return True
+
+    with patch.object(cli, "_try_mirror_prefetch", side_effect=mirror_success):
+        cli._pull_repository(args, allow_patterns_override=["runtime/*"])
+
+    assert _download_gate.pulled_variant(RAW_REPO) == "8bit"
+    assert "could not record that serving choice" not in capsys.readouterr().out
+
+
 def test_ordinary_mirror_pull_survives_marker_clear_failure(capsys):
     """Cleanup metadata is best-effort on the mirror-success early return."""
     import argparse

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6899,6 +6899,46 @@ class VariantNotFoundError(Exception):
         super().__init__(f"no '{requested}' variant in {repo_id}")
 
 
+def _sync_pulled_variant_marker(repo_id: str, variant: str | None) -> None:
+    """Commit the serving choice that corresponds to a successful pull.
+
+    Every downloader success path must make the same metadata transition:
+    an explicit ``--bits/--format`` pull records its selected subfolder, while
+    an ordinary pull clears an older selection.  Keeping this after-download
+    transaction in one helper prevents the mirror early-return and the
+    HuggingFace fallback from drifting apart again.
+
+    Marker I/O is best-effort because the checkpoint download has already
+    completed.  A failed explicit update is still surfaced: without that
+    warning, a later bare-repository ``serve`` could silently reuse an older
+    or default checkpoint.
+    """
+    if variant is not None:
+        marker_updated = False
+        try:
+            from vllm_mlx._download_gate import persist_pulled_variant
+
+            marker_updated = persist_pulled_variant(repo_id, variant)
+        except Exception:
+            pass
+        if not marker_updated:
+            print(
+                f"  Warning: downloaded {variant}/, but could not "
+                "record that serving choice in the model cache. "
+                f"`rapid-mlx serve {repo_id}` may select an older or "
+                "default checkpoint. Fix the cache permissions and "
+                "re-run this pull."
+            )
+        return
+
+    try:
+        from vllm_mlx._download_gate import clear_pulled_variant
+
+        clear_pulled_variant(repo_id)
+    except Exception:
+        pass
+
+
 def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
     """Download one repository through the normal mirror/HF pipeline."""
     import time
@@ -6945,6 +6985,14 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
             "  Pick one with --bits <N> or --format <name>, or pull the repo without a selector."
         )
         sys.exit(1)
+
+    # Only a primary model pull owns serving-choice metadata. Runtime asset
+    # allow-pattern overrides select dependency files, not a checkpoint, and
+    # therefore leave any model variant marker untouched.
+    _owns_variant_marker = allow_patterns_override is None
+    _selected_variant = (
+        None if _bits is None and _fmt is None else (f"{_bits}bit" if _bits else _fmt)
+    )
 
     # The pull summary says "already cached / nothing to download" only from
     # the DOWNLOADER's own transfer account (mirror/HF bytes fetched), never
@@ -6994,15 +7042,12 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         # ``network_fetch`` is the mirror's authoritative "any bytes fetched
         # this pull" verdict (covers a fetched zero-byte file, codex #4).
         _was_cached = not _mirror_out.get("network_fetch", True)
-        # A successful ordinary pull supersedes any earlier explicit
-        # ``--bits/--format`` choice for this repo. Keep cache metadata aligned
-        # even on the mirror-success early return.
-        try:
-            from vllm_mlx._download_gate import clear_pulled_variant
-
-            clear_pulled_variant(repo_id)
-        except Exception:
-            pass
+        # Commit the same pulled-variant transition as the HF fallback before
+        # taking this early return.  The default mirror is the common path, so
+        # dropping the selection here would make a successful ``pull --bits``
+        # impossible to recover from a later bare-repository ``serve``.
+        if _owns_variant_marker:
+            _sync_pulled_variant_marker(repo_id, _selected_variant)
         _print_pull_summary(
             repo_id,
             snapshot_dir,
@@ -7103,37 +7148,11 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         )
         _after = _blob_identifier(_cache_root)
         _was_cached = (_before == _after and _before != ()) and not _mirror_fetched
-        # #2340: persist the pulled variant so a later ``serve <repo>`` can
-        # join the same subfolder. A later successful ordinary pull clears an
-        # older marker so stale cache metadata cannot override that newer
-        # choice. The pull itself is already done and valid, so metadata I/O
-        # does not turn it into a failed download; a narrowed-pull metadata
-        # failure is surfaced loudly because serving could otherwise reuse an
-        # older choice.
-        if variant_allow is not None:
-            _variant_name = f"{_bits}bit" if _bits else (_fmt or "")
-            _marker_updated = False
-            try:
-                from vllm_mlx._download_gate import persist_pulled_variant
-
-                _marker_updated = persist_pulled_variant(repo_id, _variant_name)
-            except Exception:
-                pass
-            if not _marker_updated:
-                print(
-                    f"  Warning: downloaded {_variant_name}/, but could not "
-                    "record that serving choice in the model cache. "
-                    f"`rapid-mlx serve {repo_id}` may select an older or "
-                    "default checkpoint. Fix the cache permissions and "
-                    "re-run this pull."
-                )
-        else:
-            try:
-                from vllm_mlx._download_gate import clear_pulled_variant
-
-                clear_pulled_variant(repo_id)
-            except Exception:
-                pass
+        # #2340: apply the identical successful-pull metadata transaction on
+        # both download paths. A runtime-asset allow-pattern does not own model
+        # serving-choice metadata and therefore performs no marker transition.
+        if _owns_variant_marker:
+            _sync_pulled_variant_marker(repo_id, _selected_variant)
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a


### PR DESCRIPTION
## Why

A successful `rapid-mlx pull --bits/--format` through the default model mirror downloaded the requested subfolder but then cleared the serving-choice marker on the mirror early-return path. A later bare-repository `serve` could therefore resolve the root or catalog default instead of the checkpoint the user just pulled. The fallback download path did persist the marker, so behavior depended on which backend succeeded. This is a release-blocking regression follow-up to #2558.

## What

- Apply one successful-pull marker transaction to both mirror and fallback download paths.
- Persist an explicit user-selected variant; clear an older choice only after an ordinary primary-model pull.
- Leave runtime-asset file-filter pulls out of model serving-choice metadata.
- Add no-network regressions for mirror success and runtime-asset overrides.

## Design precedent

Established content-addressed model caches update selection metadata only after the corresponding filtered snapshot succeeds. This adapts that transaction boundary and makes every successful download backend commit the same metadata transition, rather than maintaining backend-specific copies that can drift.

## Scope and non-goals

Scope is the post-download marker transition in the CLI and focused tests. No mirror transport, cache layout, alias precedence, download filtering, server routing, or model-loader behavior changes.

## Acceptance criteria

- [x] Mirror `pull --bits 4` records `4bit` for a later bare-repo serve.
- [x] Fallback pulls preserve the same behavior.
- [x] Ordinary primary pulls clear stale explicit selections.
- [x] Runtime-asset allow-pattern pulls neither rewrite model selection nor emit a false marker warning.

## Verification

- [x] `python3.12 -m ruff check vllm_mlx/cli.py tests/test_pull_variant_serve_resolution.py tests/test_pull_variant_selection.py`
- [x] `python3.12 -m pytest -q tests/test_pull_variant_serve_resolution.py tests/test_pull_variant_selection.py tests/test_resident_models.py tests/test_serve_listen_fd.py tests/test_server_load_model_order.py` (187 passed)
- [x] `git diff --check`

Fixes #2740