### PR TITLE
fix(ci): bound cached Quickstart readiness

### DIFF
--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -610,7 +610,15 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         path = urlsplit(self.path).path
         if path == "/healthz":
-            self._json(200, {"ok": True})
+            # The GUI golden harness verifies this identity before trusting a
+            # fake sidecar as ready.  A bare 200 could belong to an unrelated
+            # listener that won the ephemeral-port bind race after the fake
+            # recorded ``server_started`` but before it called bind().
+            self._json(200, {
+                "ok": True,
+                "pid": os.getpid(),
+                "alias": SERVED_ALIAS,
+            })
             return
         if path == "/v1/models":
             # ModelPickerBar reads this on real rapid-mlx — return

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -154,20 +154,26 @@ assert_fake_server_starts() {
 # wire-side boundary explicit so a GUI assertion can distinguish a sidecar
 # that never became reachable from a slower app state transition.
 wait_fake_sidecar_health() {
-    local expected_alias="$1" what="$2" attempts="${3:-40}" sidecar_port i
-    sidecar_port="$(jq -rs --arg alias "$expected_alias" \
+    local expected_alias="$1" what="$2" attempts="${3:-40}"
+    local sidecar_record sidecar_pid sidecar_port health_payload i
+    sidecar_record="$(jq -rs --arg alias "$expected_alias" \
         'map(select(.event == "server_started" and .alias == $alias))
-         | last | .port // empty' "$OUT/fake-events.jsonl")"
-    [[ "$sidecar_port" =~ ^[0-9]+$ ]] \
-        || die "$what did not record a valid sidecar port"
+         | last | [(.pid // ""), (.port // "")] | @tsv' \
+        "$OUT/fake-events.jsonl")"
+    IFS=$'\t' read -r sidecar_pid sidecar_port <<< "$sidecar_record"
+    [[ "$sidecar_pid" =~ ^[0-9]+$ && "$sidecar_port" =~ ^[0-9]+$ ]] \
+        || die "$what did not record a valid sidecar pid and port"
     for ((i=0; i<attempts; i++)); do
-        if curl -fsS --connect-timeout 1 --max-time 1 \
-            "http://127.0.0.1:$sidecar_port/healthz" >/dev/null 2>&1; then
+        health_payload="$(curl -fsS --connect-timeout 1 --max-time 1 \
+            "http://127.0.0.1:$sidecar_port/healthz" 2>/dev/null || true)"
+        if jq -e --argjson pid "$sidecar_pid" --arg alias "$expected_alias" \
+            '.ok == true and .pid == $pid and .alias == $alias' \
+            <<< "$health_payload" >/dev/null 2>&1; then
             return 0
         fi
         sleep 0.1
     done
-    die "$what started but never served health on :$sidecar_port"
+    die "$what pid=$sidecar_pid started but never served its own health on :$sidecar_port"
 }
 
 require_observed_phase() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -149,6 +149,27 @@ assert_fake_server_starts() {
     die "$phase could not validate the sidecar event log"
 }
 
+# A recorded spawn is intentionally weaker than readiness: the fake writes
+# ``server_started`` immediately before binding its HTTP server.  Keep the
+# wire-side boundary explicit so a GUI assertion can distinguish a sidecar
+# that never became reachable from a slower app state transition.
+wait_fake_sidecar_health() {
+    local expected_alias="$1" what="$2" attempts="${3:-40}" sidecar_port i
+    sidecar_port="$(jq -rs --arg alias "$expected_alias" \
+        'map(select(.event == "server_started" and .alias == $alias))
+         | last | .port // empty' "$OUT/fake-events.jsonl")"
+    [[ "$sidecar_port" =~ ^[0-9]+$ ]] \
+        || die "$what did not record a valid sidecar port"
+    for ((i=0; i<attempts; i++)); do
+        if curl -fsS --connect-timeout 1 --max-time 1 \
+            "http://127.0.0.1:$sidecar_port/healthz" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    die "$what started but never served health on :$sidecar_port"
+}
+
 require_observed_phase() {
     local observed="$1" phase="$2"
     [[ "$observed" == 1 ]] || die "required $phase phase was not observed"
@@ -4143,26 +4164,6 @@ wait_fake_event() {
         sleep 0.25
     done
     die "$what"
-}
-
-# A recorded spawn is intentionally weaker than readiness: the fake writes
-# ``server_started`` immediately before binding its HTTP server.  Keep the
-# wire-side boundary explicit so a GUI assertion can distinguish a sidecar
-# that never became reachable from a slower app state transition.
-wait_fake_sidecar_health() {
-    local expected_alias="$1" what="$2" sidecar_port i
-    sidecar_port="$(jq -rs --arg alias "$expected_alias" \
-        'map(select(.event == "server_started" and .alias == $alias))
-         | last | .port // empty' "$OUT/fake-events.jsonl")"
-    [[ "$sidecar_port" =~ ^[0-9]+$ ]] \
-        || die "$what did not record a valid sidecar port"
-    for ((i=0; i<40; i++)); do
-        if curl -fsS "http://127.0.0.1:$sidecar_port/healthz" >/dev/null 2>&1; then
-            return 0
-        fi
-        sleep 0.1
-    done
-    die "$what started but never served health on :$sidecar_port"
 }
 
 # Put text in the Images composer and PROVE it arrived.

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1974,18 +1974,7 @@ flow_cached_quickstart() {
               and .port >= 49152 and .port <= 65535)' \
         "$OUT/fake-events.jsonl" >/dev/null \
         || die "isolated persona did not bind its selected high port"
-    local sidecar_port
-    sidecar_port="$(jq -rs 'map(select(.event == "server_started" and .alias == "fake-alias")) | last | .port // empty' "$OUT/fake-events.jsonl")"
-    local sidecar_healthy=0
-    for _ in {1..40}; do
-        if curl -fsS "http://127.0.0.1:$sidecar_port/healthz" >/dev/null 2>&1; then
-            sidecar_healthy=1
-            break
-        fi
-        sleep 0.1
-    done
-    [[ "$sidecar_healthy" == 1 ]] \
-        || die "cached Quickstart sidecar started but never served health on :$sidecar_port"
+    wait_fake_sidecar_health "$FAKE_ALIAS" "cached Quickstart sidecar"
     # Ready is no longer completion: onboarding must hold the window until
     # the user explicitly confirms the final step. Pin both halves so a
     # future regression cannot silently restore the old auto-dismiss path.
@@ -2066,7 +2055,14 @@ flow_cached_curated_tradeup() {
         sleep 0.25
     done
     [[ "$starter_started" == 1 ]] || die "cached 16 GB starter did not start"
-    wait_identifier Quickstart.Ready.StartChatting "$OUT/ready-confirmation.json"
+    wait_fake_sidecar_health "qwen3.5-4b-4bit" "cached 16 GB starter"
+    # ``server_started`` is emitted before the fake binds HTTP, and a
+    # constrained hosted runner can spend more than the default 20-second AX
+    # budget moving from healthy sidecar to the final SwiftUI readiness step.
+    # Match the existing 60-second hosted-start budget without weakening the
+    # independent health or exact Ready-identifier requirements.
+    wait_identifier Quickstart.Ready.StartChatting \
+        "$OUT/ready-confirmation.json" 240
     press "$OUT/ready-confirmation.json" Quickstart.Ready.StartChatting \
         "$OUT/start-chatting.json"
     wait_identifier rapid.chat.compose "$OUT/ready.json"
@@ -4147,6 +4143,26 @@ wait_fake_event() {
         sleep 0.25
     done
     die "$what"
+}
+
+# A recorded spawn is intentionally weaker than readiness: the fake writes
+# ``server_started`` immediately before binding its HTTP server.  Keep the
+# wire-side boundary explicit so a GUI assertion can distinguish a sidecar
+# that never became reachable from a slower app state transition.
+wait_fake_sidecar_health() {
+    local expected_alias="$1" what="$2" sidecar_port i
+    sidecar_port="$(jq -rs --arg alias "$expected_alias" \
+        'map(select(.event == "server_started" and .alias == $alias))
+         | last | .port // empty' "$OUT/fake-events.jsonl")"
+    [[ "$sidecar_port" =~ ^[0-9]+$ ]] \
+        || die "$what did not record a valid sidecar port"
+    for ((i=0; i<40; i++)); do
+        if curl -fsS "http://127.0.0.1:$sidecar_port/healthz" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    die "$what started but never served health on :$sidecar_port"
 }
 
 # Put text in the Images composer and PROVE it arrived.

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -24,6 +24,7 @@ they exist when they break.
 
 from __future__ import annotations
 
+import http.server
 import json
 import os
 import socket
@@ -348,7 +349,14 @@ def test_sidecar_health_guard_bounds_a_connected_nonresponsive_peer(tmp_path: Pa
     events_dir = tmp_path / "evidence"
     events_dir.mkdir()
     (events_dir / "fake-events.jsonl").write_text(
-        json.dumps({"event": "server_started", "alias": "fake-alias", "port": port})
+        json.dumps(
+            {
+                "event": "server_started",
+                "alias": "fake-alias",
+                "pid": os.getpid(),
+                "port": port,
+            }
+        )
         + "\n"
     )
     try:
@@ -376,7 +384,68 @@ def test_sidecar_health_guard_bounds_a_connected_nonresponsive_peer(tmp_path: Pa
         thread.join(timeout=1)
 
     assert result.returncode == 1
-    assert "started but never served health" in result.stderr
+    assert "started but never served its own health" in result.stderr
+
+
+def test_sidecar_health_guard_rejects_a_competing_listener(tmp_path: Path):
+    """A 200 from a process other than the recorded fake is not readiness."""
+
+    class CompetingHealthHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib handler API
+            payload = json.dumps(
+                {"ok": True, "pid": os.getpid() + 1, "alias": "fake-alias"}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), CompetingHealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    events_dir = tmp_path / "evidence"
+    events_dir.mkdir()
+    (events_dir / "fake-events.jsonl").write_text(
+        json.dumps(
+            {
+                "event": "server_started",
+                "alias": "fake-alias",
+                "pid": os.getpid(),
+                "port": server.server_port,
+            }
+        )
+        + "\n"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'harness="$1"; evidence="$2"; set --; source "$harness"; '
+                'OUT="$evidence"; wait_fake_sidecar_health '
+                '"fake-alias" "test sidecar" 1',
+                "gui-contract-test",
+                str(HARNESS),
+                str(events_dir),
+            ],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert result.returncode == 1
+    assert "started but never served its own health" in result.stderr
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -387,13 +387,23 @@ def test_sidecar_health_guard_bounds_a_connected_nonresponsive_peer(tmp_path: Pa
     assert "started but never served its own health" in result.stderr
 
 
-def test_sidecar_health_guard_rejects_a_competing_listener(tmp_path: Path):
-    """A 200 from a process other than the recorded fake is not readiness."""
+@pytest.mark.parametrize(
+    ("response_pid_delta", "expected_returncode"),
+    [(0, 0), (1, 1)],
+)
+def test_sidecar_health_guard_requires_the_recorded_identity(
+    tmp_path: Path, response_pid_delta: int, expected_returncode: int
+):
+    """Matching health passes; a competing process on the port is rejected."""
 
-    class CompetingHealthHandler(http.server.BaseHTTPRequestHandler):
+    class IdentityHealthHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802 - stdlib handler API
             payload = json.dumps(
-                {"ok": True, "pid": os.getpid() + 1, "alias": "fake-alias"}
+                {
+                    "ok": True,
+                    "pid": os.getpid() + response_pid_delta,
+                    "alias": "fake-alias",
+                }
             ).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -404,7 +414,7 @@ def test_sidecar_health_guard_rejects_a_competing_listener(tmp_path: Path):
         def log_message(self, _format, *_args):
             return
 
-    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), CompetingHealthHandler)
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), IdentityHealthHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     events_dir = tmp_path / "evidence"
@@ -444,8 +454,11 @@ def test_sidecar_health_guard_rejects_a_competing_listener(tmp_path: Path):
         server.server_close()
         thread.join(timeout=1)
 
-    assert result.returncode == 1
-    assert "started but never served its own health" in result.stderr
+    assert result.returncode == expected_returncode
+    if expected_returncode:
+        assert "started but never served its own health" in result.stderr
+    else:
+        assert result.stderr == ""
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -326,6 +328,55 @@ def test_start_set_guard_fails_closed_on_partial_jsonl(tmp_path: Path):
     )
     assert result.returncode == 1
     assert "FAIL:" in result.stderr
+
+
+def test_sidecar_health_guard_bounds_a_connected_nonresponsive_peer(tmp_path: Path):
+    """A listener that accepts but never replies cannot hang the health gate."""
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+    release = threading.Event()
+
+    def hold_connection() -> None:
+        connection, _ = listener.accept()
+        with connection:
+            release.wait(timeout=5)
+
+    thread = threading.Thread(target=hold_connection, daemon=True)
+    thread.start()
+    events_dir = tmp_path / "evidence"
+    events_dir.mkdir()
+    (events_dir / "fake-events.jsonl").write_text(
+        json.dumps({"event": "server_started", "alias": "fake-alias", "port": port})
+        + "\n"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'harness="$1"; evidence="$2"; set --; source "$harness"; '
+                'OUT="$evidence"; wait_fake_sidecar_health '
+                '"fake-alias" "test sidecar" 1',
+                "gui-contract-test",
+                str(HARNESS),
+                str(events_dir),
+            ],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    finally:
+        release.set()
+        listener.close()
+        thread.join(timeout=1)
+
+    assert result.returncode == 1
+    assert "started but never served health" in result.stderr
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -217,10 +217,7 @@ def test_cached_curated_tradeup_waits_for_health_and_bounded_ui_readiness():
     source = HARNESS.read_text()
     flow = source.split("flow_cached_curated_tradeup() {", 1)[1].split("\n}", 1)[0]
 
-    assert (
-        'wait_fake_sidecar_health "qwen3.5-4b-4bit" "cached 16 GB starter"'
-        in flow
-    )
+    assert 'wait_fake_sidecar_health "qwen3.5-4b-4bit" "cached 16 GB starter"' in flow
     assert (
         'wait_identifier Quickstart.Ready.StartChatting \\\n        "$OUT/ready-confirmation.json" 240'
         in flow

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -212,6 +212,21 @@ def test_cached_curated_tradeup_confirms_the_quickstart_memory_sheet():
     assert 'identifier == "MemoryWarning.Confirm"' not in flow
 
 
+def test_cached_curated_tradeup_waits_for_health_and_bounded_ui_readiness():
+    """A spawn event is not health, and hosted UI readiness gets 60 seconds."""
+    source = HARNESS.read_text()
+    flow = source.split("flow_cached_curated_tradeup() {", 1)[1].split("\n}", 1)[0]
+
+    assert (
+        'wait_fake_sidecar_health "qwen3.5-4b-4bit" "cached 16 GB starter"'
+        in flow
+    )
+    assert (
+        'wait_identifier Quickstart.Ready.StartChatting \\\n        "$OUT/ready-confirmation.json" 240'
+        in flow
+    )
+
+
 def test_peekaboo_requirement_is_default_deny():
     """A new flow must be assumed to need peekaboo until stated otherwise.
 


### PR DESCRIPTION
## Why

The Mac merge queue reproduced `cached-curated-tradeup` timing out twice after its exact fake qwen3.5 sidecar had already emitted `server_started`. That event is written immediately before the HTTP listener binds, and this flow then used the generic 20-second AX wait even though the existing hosted model-start contract allows 60 seconds. The same base and exact candidate passed clean Mini rebuilds, isolating the failure to this under-specified hosted readiness boundary.

## What changed

- Extract the existing exact-alias `/healthz` proof into one shared helper.
- Reuse it for both cached Quickstart journeys.
- Require the curated starter to answer health before checking the UI.
- Give only the final exact Ready identifier the established bounded 60-second hosted-start budget.
- Pin both requirements in the fast GUI preflight contract.

The gate remains fail-closed: an absent/malformed port, a sidecar that never serves health, or a UI that never reaches the exact Ready action still fails.

## Design precedent

Mature end-to-end harnesses separate process creation, network readiness, and user-visible readiness into independently bounded gates. This change adopts that layered contract using the repository's existing cached Quickstart health probe and hosted-start budget instead of adding a new retry mechanism.

## Verification

- `python3.12 -m pytest tests/test_gui_*.py -q` — 86 passed
- `python3 -m pytest tests/test_gui_preflight_contract.py -q` — 21 passed
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `git diff --check`
- Exact candidate `ba77b962` on Mini: all 32 named GUI flows passed, including repeated `cached-curated-tradeup`

Fixes #2744