### PR TITLE
fix(mac): race validated DNS fallbacks

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -303,26 +303,89 @@ enum BrowseTool {
         }
     }
 
-    /// Try each already-validated address until one fetch succeeds. This keeps
-    /// the pinned-socket security model while restoring address fallback lost by
-    /// pinning; outer cancellation remains immediate and never moves to the
-    /// next address.
-    static func firstSuccessful<T: Sendable>(
-        addresses: [ParsedIP],
-        attempt: @escaping @Sendable (ParsedIP) async throws -> T
-    ) async throws -> T {
-        var lastError: Error?
-        for address in addresses {
-            do {
-                return try await attempt(address)
-            } catch {
-                if Task.isCancelled || error is CancellationError {
-                    throw error
-                }
-                lastError = error
+    private enum AddressAttemptOutcome<Value: Sendable>: Sendable {
+        case success(Value)
+        case failure(any Error)
+    }
+
+    /// Preserve resolver order within each family while alternating families
+    /// after the first preferred address. A broken family must not occupy every
+    /// early attempt slot before the other family gets a chance.
+    private static func interleavedAddressFamilies(_ addresses: [ParsedIP]) -> [ParsedIP] {
+        guard let preferredFamily = addresses.first?.family else { return [] }
+        let preferred = addresses.filter { $0.family == preferredFamily }
+        let alternate = addresses.filter { $0.family != preferredFamily }
+        var result: [ParsedIP] = []
+        result.reserveCapacity(addresses.count)
+        var preferredIndex = 0
+        var alternateIndex = 0
+
+        while preferredIndex < preferred.count || alternateIndex < alternate.count {
+            if preferredIndex < preferred.count {
+                result.append(preferred[preferredIndex])
+                preferredIndex += 1
+            }
+            if alternateIndex < alternate.count {
+                result.append(alternate[alternateIndex])
+                alternateIndex += 1
             }
         }
-        throw lastError ?? simpleError("no validated addresses")
+        return result
+    }
+
+    /// Race already-validated addresses with a small stagger until one fetch
+    /// succeeds. This keeps the pinned-socket security model while avoiding a
+    /// black-holed first address consuming almost the entire per-hop deadline.
+    /// The 250 ms default follows the established dual-stack connection-attempt
+    /// delay: the first address keeps its preference, later addresses receive a
+    /// meaningful chance in parallel, and the first success cancels all losers.
+    /// Outer cancellation remains immediate and cannot advance to a new address.
+    static func firstSuccessful<T: Sendable>(
+        addresses: [ParsedIP],
+        attemptDelayNanoseconds: UInt64 = 250_000_000,
+        attempt: @escaping @Sendable (ParsedIP) async throws -> T
+    ) async throws -> T {
+        guard !addresses.isEmpty else {
+            throw simpleError("no validated addresses")
+        }
+
+        return try await withThrowingTaskGroup(of: AddressAttemptOutcome<T>.self) { group in
+            for (index, address) in interleavedAddressFamilies(addresses).enumerated() {
+                group.addTask {
+                    do {
+                        if index > 0 {
+                            let (delay, overflow) = attemptDelayNanoseconds
+                                .multipliedReportingOverflow(by: UInt64(index))
+                            guard !overflow else {
+                                throw simpleError("address fallback delay overflow")
+                            }
+                            try await Task.sleep(nanoseconds: delay)
+                        }
+                        try Task.checkCancellation()
+                        return .success(try await attempt(address))
+                    } catch {
+                        return .failure(error)
+                    }
+                }
+            }
+
+            var lastError: (any Error)?
+            while let outcome = try await group.next() {
+                switch outcome {
+                case .success(let value):
+                    try Task.checkCancellation()
+                    group.cancelAll()
+                    return value
+                case .failure(let error):
+                    if Task.isCancelled || error is CancellationError {
+                        group.cancelAll()
+                        throw error
+                    }
+                    lastError = error
+                }
+            }
+            throw lastError ?? simpleError("no validated addresses")
+        }
     }
 
     // MARK: - Render

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -306,6 +306,7 @@ enum BrowseTool {
     private enum AddressAttemptOutcome<Value: Sendable>: Sendable {
         case success(Value)
         case failure(any Error)
+        case staggerElapsed(Int)
     }
 
     /// Preserve resolver order within each family while alternating families
@@ -349,27 +350,30 @@ enum BrowseTool {
             throw simpleError("no validated addresses")
         }
 
+        let orderedAddresses = interleavedAddressFamilies(addresses)
         return try await withThrowingTaskGroup(of: AddressAttemptOutcome<T>.self) { group in
-            for (index, address) in interleavedAddressFamilies(addresses).enumerated() {
+            var nextAddressIndex = 1
+            var activeAttempts = 1
+            var staggerGeneration = 0
+            var lastError: (any Error)?
+
+            group.addTask {
+                do {
+                    try Task.checkCancellation()
+                    return .success(try await attempt(orderedAddresses[0]))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            if nextAddressIndex < orderedAddresses.count {
+                staggerGeneration += 1
+                let generation = staggerGeneration
                 group.addTask {
-                    do {
-                        if index > 0 {
-                            let (delay, overflow) = attemptDelayNanoseconds
-                                .multipliedReportingOverflow(by: UInt64(index))
-                            guard !overflow else {
-                                throw simpleError("address fallback delay overflow")
-                            }
-                            try await Task.sleep(nanoseconds: delay)
-                        }
-                        try Task.checkCancellation()
-                        return .success(try await attempt(address))
-                    } catch {
-                        return .failure(error)
-                    }
+                    try await Task.sleep(nanoseconds: attemptDelayNanoseconds)
+                    return .staggerElapsed(generation)
                 }
             }
 
-            var lastError: (any Error)?
             while let outcome = try await group.next() {
                 switch outcome {
                 case .success(let value):
@@ -382,6 +386,53 @@ enum BrowseTool {
                         throw error
                     }
                     lastError = error
+                    activeAttempts -= 1
+                    if nextAddressIndex < orderedAddresses.count {
+                        let address = orderedAddresses[nextAddressIndex]
+                        nextAddressIndex += 1
+                        activeAttempts += 1
+                        group.addTask {
+                            do {
+                                try Task.checkCancellation()
+                                return .success(try await attempt(address))
+                            } catch {
+                                return .failure(error)
+                            }
+                        }
+                        staggerGeneration += 1
+                        if nextAddressIndex < orderedAddresses.count {
+                            let generation = staggerGeneration
+                            group.addTask {
+                                try await Task.sleep(nanoseconds: attemptDelayNanoseconds)
+                                return .staggerElapsed(generation)
+                            }
+                        }
+                    } else if activeAttempts == 0 {
+                        group.cancelAll()
+                        throw lastError ?? simpleError("no validated addresses")
+                    }
+                case .staggerElapsed(let generation):
+                    guard generation == staggerGeneration,
+                          nextAddressIndex < orderedAddresses.count else { continue }
+                    let address = orderedAddresses[nextAddressIndex]
+                    nextAddressIndex += 1
+                    activeAttempts += 1
+                    group.addTask {
+                        do {
+                            try Task.checkCancellation()
+                            return .success(try await attempt(address))
+                        } catch {
+                            return .failure(error)
+                        }
+                    }
+                    staggerGeneration += 1
+                    if nextAddressIndex < orderedAddresses.count {
+                        let nextGeneration = staggerGeneration
+                        group.addTask {
+                            try await Task.sleep(nanoseconds: attemptDelayNanoseconds)
+                            return .staggerElapsed(nextGeneration)
+                        }
+                    }
                 }
             }
             throw lastError ?? simpleError("no validated addresses")

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -34,7 +34,7 @@ struct IPPinnedHTTPTransportTests {
         let url = try #require(URL(string: "http://pinned-cancel.test:\(port)/request"))
         let address = try #require(ParsedIP("127.0.0.1"))
 
-        try await raceTransportAgainstWatchdog {
+        try await raceTransportAgainstWatchdog(expected: .cancellation) {
             try await IPPinnedHTTPTransport.fetch(
                 url: url,
                 address: address,
@@ -57,7 +57,7 @@ struct IPPinnedHTTPTransportTests {
         let url = try #require(URL(string: "http://pinned-deadline.test:\(port)/request"))
         let address = try #require(ParsedIP("127.0.0.1"))
 
-        try await raceTransportAgainstWatchdog {
+        try await raceTransportAgainstWatchdog(expected: .deadline) {
             try await BrowseTool.withDeadline(0.2) {
                 try await IPPinnedHTTPTransport.fetch(
                     url: url,
@@ -201,6 +201,11 @@ struct IPPinnedHTTPTransportTests {
 
 private struct TestWatchdogDeadline: Error {}
 
+private enum FetchRaceExpectation {
+    case cancellation
+    case deadline
+}
+
 private enum FetchRaceOutcome: @unchecked Sendable {
     case fetch(Error)
     case watchdog(Error)
@@ -322,6 +327,7 @@ private final class RequestSignal: @unchecked Sendable {
 }
 
 private func raceTransportAgainstWatchdog(
+    expected: FetchRaceExpectation,
     fetchBody: @escaping @Sendable () async throws -> (Data, HTTPURLResponse),
     watchdogBody: @escaping @Sendable () async throws -> Void,
     settle: @escaping @Sendable () async -> Bool
@@ -357,11 +363,13 @@ private func raceTransportAgainstWatchdog(
     guard case .fetch(let error) = first else {
         throw TestWatchdogDeadline()
     }
-    if error is CancellationError {
-        return
+    switch expected {
+    case .cancellation:
+        #expect(error is CancellationError, "transport should surface cancellation")
+    case .deadline:
+        #expect(
+            !(error is CancellationError) && String(describing: error).contains("deadline"),
+            "deadline should be the first observed failure"
+        )
     }
-    #expect(
-        String(describing: error).contains("deadline"),
-        "deadline should be the first observed failure"
-    )
 }

--- a/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IPPinnedHTTPTransportTests.swift
@@ -201,9 +201,45 @@ struct IPPinnedHTTPTransportTests {
 
 private struct TestWatchdogDeadline: Error {}
 
-private enum FetchRaceOutcome {
+private enum FetchRaceOutcome: @unchecked Sendable {
     case fetch(Error)
     case watchdog(Error)
+}
+
+/// First-result latch for the transport/watchdog race. The fetch must be
+/// cancelled independently after the server observes its request; cancelling
+/// a shared task group also cancels the watchdog and lets that cancellation
+/// win nondeterministically.
+private final class FetchRaceSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcome: FetchRaceOutcome?
+    private var continuation: CheckedContinuation<FetchRaceOutcome, Never>?
+
+    func wait() async -> FetchRaceOutcome {
+        await withCheckedContinuation { pendingContinuation in
+            lock.lock()
+            if let outcome {
+                lock.unlock()
+                pendingContinuation.resume(returning: outcome)
+                return
+            }
+            continuation = pendingContinuation
+            lock.unlock()
+        }
+    }
+
+    func signal(_ outcome: FetchRaceOutcome) {
+        lock.lock()
+        guard self.outcome == nil else {
+            lock.unlock()
+            return
+        }
+        self.outcome = outcome
+        let pendingContinuation = continuation
+        continuation = nil
+        lock.unlock()
+        pendingContinuation?.resume(returning: outcome)
+    }
 }
 
 /// Accepts a request and deliberately does not respond, so cancellation has
@@ -290,43 +326,42 @@ private func raceTransportAgainstWatchdog(
     watchdogBody: @escaping @Sendable () async throws -> Void,
     settle: @escaping @Sendable () async -> Bool
 ) async throws {
-    try await withThrowingTaskGroup(of: FetchRaceOutcome.self) { group in
-        group.addTask {
-            do {
-                _ = try await fetchBody()
-                return .fetch(TestWatchdogDeadline())
-            } catch {
-                return .fetch(error)
-            }
-        }
-        group.addTask {
-            do {
-                try await watchdogBody()
-                return .watchdog(TestWatchdogDeadline())
-            } catch {
-                return .watchdog(error)
-            }
-        }
-
-        let cancelAfterSettled = await settle()
-        if cancelAfterSettled {
-            group.cancelAll()
-        }
-
-        guard let first = try await group.next() else {
-            throw TestWatchdogDeadline()
-        }
-        group.cancelAll()
-        guard case .fetch(let error) = first else {
-            throw TestWatchdogDeadline()
-        }
-        if cancelAfterSettled {
-            #expect(error is CancellationError, "transport should surface cancellation")
-        } else {
-            #expect(
-                String(describing: error).contains("deadline"),
-                "deadline should be the first observed failure"
-            )
+    let signal = FetchRaceSignal()
+    let fetchTask = Task {
+        do {
+            _ = try await fetchBody()
+            signal.signal(.fetch(TestWatchdogDeadline()))
+        } catch {
+            signal.signal(.fetch(error))
         }
     }
+    let watchdogTask = Task {
+        do {
+            try await watchdogBody()
+            signal.signal(.watchdog(TestWatchdogDeadline()))
+        } catch {
+            signal.signal(.watchdog(error))
+        }
+    }
+    let settleTask = Task {
+        if await settle() {
+            fetchTask.cancel()
+        }
+    }
+
+    let first = await signal.wait()
+    fetchTask.cancel()
+    watchdogTask.cancel()
+    settleTask.cancel()
+
+    guard case .fetch(let error) = first else {
+        throw TestWatchdogDeadline()
+    }
+    if error is CancellationError {
+        return
+    }
+    #expect(
+        String(describing: error).contains("deadline"),
+        "deadline should be the first observed failure"
+    )
 }

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -157,11 +157,18 @@ struct WebToolsHardeningTests {
 
     @Test("Cancellation during an address attempt does not try the next address")
     func cancellationStopsAddressFallback() async throws {
-        let addresses = [try #require(ParsedIP("2001:db8::1"))]
+        let addresses = [
+            try #require(ParsedIP("2001:db8::1")),
+            try #require(ParsedIP("2001:db8::2")),
+            try #require(ParsedIP("192.0.2.1")),
+        ]
         let recorder = AddressAttemptRecorder()
 
         do {
-            _ = try await BrowseTool.firstSuccessful(addresses: addresses) { address in
+            _ = try await BrowseTool.firstSuccessful(
+                addresses: addresses,
+                attemptDelayNanoseconds: 20_000_000
+            ) { address in
                 await recorder.record(address)
                 throw CancellationError()
             }
@@ -170,7 +177,59 @@ struct WebToolsHardeningTests {
             #expect(error is CancellationError)
         }
 
-        #expect(await recorder.addresses == addresses)
+        #expect(await recorder.addresses == [addresses[0]])
+    }
+
+    @Test("A black-holed first address does not starve a working fallback")
+    func blackHoledFirstAddressDoesNotStarveFallback() async throws {
+        let addresses = [
+            try #require(ParsedIP("2001:db8::1")),
+            try #require(ParsedIP("2001:db8::2")),
+            try #require(ParsedIP("192.0.2.1")),
+        ]
+        let recorder = AddressAttemptRecorder()
+        let started = ContinuousClock.now
+
+        let result = try await BrowseTool.firstSuccessful(
+            addresses: addresses,
+            attemptDelayNanoseconds: 20_000_000
+        ) { address in
+            await recorder.record(address)
+            if address.family == .v6 {
+                try await Task.sleep(for: .seconds(2))
+                throw TestNetworkFailure()
+            }
+            return address.canonical
+        }
+
+        #expect(result == addresses[2].canonical)
+        #expect(await recorder.addresses == [addresses[0], addresses[2]])
+        #expect(started.duration(to: .now) < .seconds(1))
+    }
+
+    @Test("Address fallback reports failure after every candidate fails")
+    func addressFallbackReportsFailureAfterEveryCandidateFails() async throws {
+        let addresses = [
+            try #require(ParsedIP("2001:db8::1")),
+            try #require(ParsedIP("192.0.2.1")),
+        ]
+        let recorder = AddressAttemptRecorder()
+
+        do {
+            _ = try await BrowseTool.firstSuccessful(
+                addresses: addresses,
+                attemptDelayNanoseconds: 1_000_000
+            ) { address in
+                await recorder.record(address)
+                throw TestNetworkFailure()
+            }
+            Issue.record("Expected every address attempt to fail")
+        } catch {
+            #expect(error is TestNetworkFailure)
+        }
+
+        let attempted = await recorder.addresses.map(\.canonical).sorted()
+        #expect(attempted == addresses.map(\.canonical).sorted())
     }
 
     @Test("resolve yields empty for an NXDOMAIN reserved TLD")

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -207,6 +207,33 @@ struct WebToolsHardeningTests {
         #expect(started.duration(to: .now) < .seconds(1))
     }
 
+    @Test("Fast failures advance immediately instead of waiting for each stagger")
+    func fastFailuresAdvanceImmediately() async throws {
+        let addresses = [
+            try #require(ParsedIP("2001:db8::1")),
+            try #require(ParsedIP("192.0.2.1")),
+            try #require(ParsedIP("2001:db8::2")),
+            try #require(ParsedIP("192.0.2.2")),
+        ]
+        let recorder = AddressAttemptRecorder()
+
+        let result = try await BrowseTool.withDeadline(1) {
+            try await BrowseTool.firstSuccessful(
+                addresses: addresses,
+                attemptDelayNanoseconds: 5_000_000_000
+            ) { address in
+                await recorder.record(address)
+                if address != addresses.last {
+                    throw TestNetworkFailure()
+                }
+                return address.canonical
+            }
+        }
+
+        #expect(result == addresses.last?.canonical)
+        #expect(await recorder.addresses == addresses)
+    }
+
     @Test("Address fallback reports failure after every candidate fails")
     func addressFallbackReportsFailureAfterEveryCandidateFails() async throws {
         let addresses = [


### PR DESCRIPTION
## Why

A validated DNS result can contain several addresses. Sequentially spending most of the hop deadline on a black-holed preferred-family address starves a reachable fallback and makes Browse fail for users whose first IPv6 route is broken.

The current cancellation regression test also races the cancelled watchdog against the transport result. Candidate run 33295834399 exposed that race: the watchdog cancellation won in `IPPinnedHTTPTransportTests` even though the same transport code passed its exact-head gate. A release gate must not depend on result ordering after cancelling every child.

## What

- Preserve resolver order within each address family while alternating families.
- Stagger validated IP-pinned attempts by 250 ms and return the first success.
- Cancel losing attempts and preserve immediate parent cancellation.
- Give the transport fetch and watchdog independent cancellation handles so the watchdog remains a real deadline instead of becoming a competing cancellation result.
- Add deterministic black-hole, all-fail, multi-address cancellation, and transport cancellation coverage.

## Design precedent

Modern dual-stack connection scheduling preserves the preferred first address, starts the alternate family after a short delay, and cancels losing attempts after the first success. This adapts that established connection-racing pattern without weakening the existing validated-IP pinning boundary. The test harness follows the same ownership rule: cancel the operation under test independently while keeping its deadline observer alive.

## Scope

No DNS allow/deny policy, redirect approval, response parsing, request timeout value, or Browse UI changes.

## Verification

- `swift test --no-parallel --filter IPPinnedHTTPTransportTests`
- 30 consecutive `swift test --skip-build --no-parallel --filter IPPinnedHTTPTransportTests`
- `swift test --skip-build --no-parallel --filter WebToolsHardeningTests`
- prior full Swift suite: 3105/3105
- `git diff --check`

Fixes #2738