### PR TITLE
fix(mtp): discard cache after terminal verify

### DIFF
--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1912,6 +1912,107 @@ def test_install_mtp_vendored_reaps_request_state_on_departure(
     assert gb._mtp_vendored_disabled_uids == {}
 
 
+def test_install_mtp_vendored_discards_finished_cache_after_partial_round(
+    monkeypatch,
+):
+    """A terminal response cannot publish verifier state past emitted tokens.
+
+    Pulling the first item from the real MTP generator can verify and accept a
+    multi-token draft round, advancing the cache through every accepted
+    position while only one token reaches ``GenerationBatch.next``.  Model
+    that boundary here: the response carries the advanced cache, then finishes
+    before the generator's second accepted token can be emitted.
+    """
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    advanced_cache = [object()]
+    closed: list[bool] = []
+
+    class _AcceptedRound:
+        def __init__(self):
+            self.tokens = iter(
+                [
+                    (1001, mx.array([0.0]), True),
+                    (1002, mx.array([0.0]), True),
+                ]
+            )
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self.tokens)
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(
+        _gen_mod,
+        "mtp_generate_step",
+        lambda *args, **kwargs: _AcceptedRound(),
+    )
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [7]
+    gb.prompt_cache = advanced_cache
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    response = SimpleNamespace(
+        uid=7,
+        finish_reason="length",
+        prompt_cache=advanced_cache,
+        all_tokens=[500, 1001],
+    )
+    gb.next_responses = [response]
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests={
+            "req-7": SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0))
+        },
+        uid_to_request_id={7: "req-7"},
+    )
+
+    gb._step()
+    assert set(gb._mtp_vendored_state) == {7}
+    assert gb.next() == [response]
+
+    assert response.prompt_cache is None
+    assert closed == [True]
+    assert gb._mtp_vendored_state == {}
+
+
+def test_install_mtp_vendored_preserves_plain_finished_cache():
+    """Installing the wrapper must not disable ordinary prefix-cache reuse."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+
+    plain_cache = [object()]
+    response = SimpleNamespace(
+        uid=8,
+        finish_reason="stop",
+        prompt_cache=plain_cache,
+    )
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.next_responses = [response]
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests=None,
+        uid_to_request_id=None,
+    )
+    assert gb.next() == [response]
+    assert response.prompt_cache is plain_cache
+
+
 def test_scheduler_text_stop_retires_mtp_state_before_next_request(monkeypatch):
     """A scheduler-side text stop must free the B=1 MTP slot immediately.
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1587,10 +1587,20 @@ def _install_mtp_vendored(
     _orig_next = gb.next
 
     def _mtp_next(*args, **kwargs):
-        """Reap request-owned MTP state at the normal finish boundary."""
+        """Reap request-owned MTP state at the normal finish boundary.
+
+        A verifier step may have advanced ``gb.prompt_cache`` through several
+        accepted draft positions even though ``GenerationBatch.next`` finishes
+        the response after emitting only the first one (for example at EOS or
+        ``max_tokens``).  That cache is ahead of ``response.all_tokens`` and
+        must never be published as a reusable prefix.  Plain/fallthrough rows
+        have no entry in ``_state`` and retain mlx-lm's normal cache behavior.
+        """
         responses = _orig_next(*args, **kwargs)
         for response in responses:
             if getattr(response, "finish_reason", None) is not None:
+                if response.uid in _state and hasattr(response, "prompt_cache"):
+                    response.prompt_cache = None
                 _reap_uid(response.uid)
         return responses
 


### PR DESCRIPTION
## Why

An MTP verification round can advance KV/SSM cache state through several accepted draft positions while `GenerationBatch.next` emits only one token. If EOS, a stop condition, or `max_tokens` finishes the request at that boundary, publishing the advanced cache under the shorter emitted token sequence can poison a later prefix-cache hit and produce incorrect output.

This replaces #2742, which GitHub could not reopen after its closed branch was rebased onto current `main`.

Fixes #2739

## What

- Discard the finished response cache only when that response still owns live MTP verifier state.
- Reap the verifier generator and markers through the existing lifecycle hook.
- Preserve ordinary/fallthrough prefix-cache behavior.
- Add deterministic coverage for completion after the first emitted token of a partially accepted speculative round.

## Design precedent

Mature speculative schedulers separate verified positions from committed output positions and publish cache state only at the committed boundary. This change adapts that invariant at Rapid-MLX's lifecycle seam: when the verifier has advanced beyond what the terminal response can prove was emitted, the response fails closed by publishing no reusable cache instead of attaching mismatched state.

## Scope and non-goals

Scope is the terminal MTP response/cache boundary and focused lifecycle tests. No scheduler admission, speculative depth, sampling, model, dependency, prefix-cache format, or default-policy changes.

## Acceptance criteria

- [x] A terminal response that stops mid-verification publishes no MTP cache.
- [x] Generator/cache and marker state are still reaped.
- [x] Plain finished responses retain normal prefix-cache reuse.

## Verification

- [x] `pytest tests/test_mtp_cli_wiring.py tests/test_mtp_stream_contract.py tests/test_mtp_lossless.py` (96 passed)
- [x] `pytest tests/test_mtp_spec_decode.py tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_cli_wiring.py` (240 passed)
- [x] `ruff check` and `ruff format --check` on changed files
- [x] `git diff --check`
