### PR TITLE
test: restore Harmony terminal lifecycle fixture

### DIFF
--- a/tests/test_harmony_stop_final_channel_only.py
+++ b/tests/test_harmony_stop_final_channel_only.py
@@ -193,6 +193,8 @@ def _make_harmony_scheduler() -> Scheduler:
     }
     tokenizer.name_or_path = "mlx-community/gpt-oss-20b-MXFP4-Q8"
     scheduler = Scheduler(model, tokenizer, SchedulerConfig(max_num_seqs=4))
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
     assert scheduler._is_harmony_family is True, (
         "Scheduler should have detected the mock harmony vocab."
     )
@@ -210,6 +212,8 @@ def _make_non_harmony_scheduler() -> Scheduler:
     tokenizer.get_vocab = lambda: {"hello": 1, "world": 2}
     tokenizer.name_or_path = "mlx-community/Qwen3-4B-4bit"
     scheduler = Scheduler(model, tokenizer, SchedulerConfig(max_num_seqs=4))
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
     assert scheduler._is_harmony_family is False
     return scheduler
 
@@ -279,6 +283,7 @@ def test_scheduler_harmony_ignores_analysis_channel_stop_mention():
     )
     assert output.finished is False
     assert finished == set()
+    scheduler.batch_generator.remove.assert_not_called()
 
 
 def test_scheduler_harmony_stops_on_final_channel_marker():
@@ -304,6 +309,9 @@ def test_scheduler_harmony_stops_on_final_channel_marker():
     assert output.finish_reason == "stop"
     assert output.finished is True
     assert "rB" in finished
+    scheduler.batch_generator.remove.assert_called_once_with(
+        [0], return_prompt_caches=True
+    )
     # The trimmed text must retain the analysis-channel usage of
     # ``</execute_ipython>`` (that's part of the CoT surface, not the
     # user-visible final content) and cut off at the FINAL channel's
@@ -332,6 +340,9 @@ def test_scheduler_non_harmony_stops_on_raw_stream_unchanged():
     output, _ = _run_step(scheduler, req)
     assert output.finish_reason == "stop"
     assert output.output_text == "hello world "
+    scheduler.batch_generator.remove.assert_called_once_with(
+        [0], return_prompt_caches=True
+    )
 
 
 def test_scheduler_harmony_without_stop_param_unaffected():
@@ -350,6 +361,7 @@ def test_scheduler_harmony_without_stop_param_unaffected():
     output, _ = _run_step(scheduler, req)
     assert output.finish_reason is None
     assert output.finished is False
+    scheduler.batch_generator.remove.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The full validation suite on current `main` fails in two direct Harmony scheduler tests. Their fixtures put a request in `Scheduler.running` but do not install the `BatchGenerator` that owns terminal row retirement. Since the production scheduler now fails closed when a terminal response lacks that lifecycle owner, the tests abort before checking their stop-string contract.

Closes #2755

## What

- Give both Harmony and non-Harmony scheduler fixtures a mocked batch lifecycle, matching neighboring scheduler tests.
- Assert terminal stop responses retire UID 0 with cache retention.
- Assert non-terminal paths do not remove a batch row.

## Design precedent

Scheduler tests should preserve the same request ownership boundary as production: a running row belongs to a batch lifecycle, and terminal processing retires it through that owner. This adapts the existing fixture pattern already used by the stop-string, decoder-surface, and repetition-guard suites rather than bypassing the production guard.

## Scope and non-goals

Test fixtures only. No scheduler, generation, stop matching, cache, model, dependency, or release behavior changes.

## Verification

- `python3.12 -m pytest -q tests/test_harmony_stop_final_channel_only.py tests/test_scheduler_stop_decoder_surface.py tests/test_stop_string_enforcement.py tests/test_repetition_guard.py` (47 passed)
- `python3.12 -m ruff check tests/test_harmony_stop_final_channel_only.py`
- `python3.12 -m ruff format --check tests/test_harmony_stop_final_channel_only.py`
- `git diff --check`

## AI assistance disclosure

Codex diagnosed the stale fixture through the release-notes full validation run, implemented the focused test correction, and ran the local checks.