### PR TITLE
fix: preserve source canvas for image edits

### DIFF
--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -545,12 +545,13 @@ class _FakeImageEngine:
         seed,
         guidance,
         negative_prompt,
-        width=None,
-        height=None,
+        width=1024,
+        height=1024,
         image_paths=None,
     ):
-        # The edit route omits width/height (the engine derives them from the
-        # input image); the generations route always supplies them.
+        # Match the real engine's text-to-image defaults so route tests catch a
+        # missing explicit ``None`` on edits. The generations route always
+        # supplies concrete dimensions.
         self.seeds.append(seed)
         self.image_paths_seen.append(image_paths)
         self.dims_seen.append((width, height))

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -619,8 +619,8 @@ class ImageGenerationEngine:
         self,
         *,
         prompt: str,
-        width: int = 1024,
-        height: int = 1024,
+        width: int | None = 1024,
+        height: int | None = 1024,
         num_inference_steps: int = 4,
         seed: int = 0,
         guidance: float | None = None,
@@ -687,6 +687,10 @@ class ImageGenerationEngine:
                         ),
                     )
                 elif editing:
+                    # FLUX.2's edit pipeline resolves ``None`` against its
+                    # primary reference image (including aspect ratio). The
+                    # route deliberately selects that behavior; explicit
+                    # dimensions remain available to direct engine callers.
                     result = model.generate_image(
                         image_paths=image_paths,
                         height=height,

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -419,13 +419,16 @@ def _generate_edit_one(
 ) -> bytes:
     """Blocking single instruction-edit render — runs off the event loop.
 
-    No width/height is threaded through the API. Each edit engine chooses its
-    compatible default: FLUX.2 uses 1024×1024, while Qwen derives a canvas from
-    the input image. The request ``size`` is accepted for OpenAI compatibility
-    but deliberately not honored.
+    Explicit ``None`` dimensions tell every built-in edit engine to derive its
+    compatible canvas from the input image. Omitting these keywords is not
+    equivalent: the engine's text-to-image defaults are 1024×1024, which would
+    silently resize smaller or non-square edit inputs. The request ``size`` is
+    accepted for OpenAI compatibility but deliberately not honored.
     """
     return img_engine.generate(
         prompt=prompt,
+        width=None,
+        height=None,
         num_inference_steps=steps
         if steps is not None
         else getattr(img_engine, "default_edit_steps", _DEFAULT_EDIT_STEPS),


### PR DESCRIPTION
## Why

A real 512×512 `/v1/images/edits` request on the 0.13.2 release path returned a 1024×1024 image. The route omitted dimensions, which unintentionally selected the engine’s text-to-image defaults instead of asking the edit backend to derive its canvas from the source. This increased latency and memory use and could alter aspect ratios.

## What changed

- pass explicit `None` dimensions from the edit route so edit backends derive the canvas from the uploaded image
- make the engine’s optional dimension contract explicit in its type annotations
- make the route fake use the real engine’s 1024 defaults, so omission regresses the test instead of false-greening

## Design precedent

Established image-edit pipelines resolve an unspecified output canvas from the primary reference image and align it internally to their latent-grid constraints. This change adopts that backend-owned sizing contract while preserving explicit dimensions for direct engine callers and leaving text-to-image sizing unchanged.

## Verification

- `python3.12 -m pytest -q tests/test_image_lane.py` — 88 passed
- `python3.12 -m ruff check vllm_mlx/routes/images.py vllm_mlx/image/engine.py tests/test_image_lane.py`
- `git diff --check`
- Mini, exact head `4bc7d1374`: real FLUX.2 Klein edit of a 512×512 PNG returned a valid 512×512 PNG in 27 s; visual inspection confirmed the requested blue star was added and the source scene remained intact

## Non-goals

No changes to text-to-image defaults, explicit engine sizing, denoise quality, model selection, upload limits, or the public compatibility `size` field.

Closes #2758