### PR TITLE
chore: bump version to 0.13.2-rc1

### DIFF
--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.1</string>
+	<string>0.13.2-rc1</string>
 	<key>CFBundleVersion</key>
-	<string>166</string>
+	<string>167</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.1"
+version = "0.13.2-rc1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Publish the fully reviewed and dogfooded 0.13.2 release candidate through the canonical protected release path, preserving exact source-to-artifact identity for the engine package and signed/notarized Desktop app.

## Scope

- Set the engine and Desktop versions to `0.13.2-rc1`.
- Increment the Desktop build once from `166` to `167`.
- Build on the finalized RC1 release notes at exact main SHA `e0b6b5eaeef48d2224fbfc794accd8f033e1ddf1`.

## Non-goals

- No product, model, CI, or release-workflow behavior changes.
- No stable `0.13.2` tag or stable updater-feed mutation.
- No emergency bypass, credential change, or manual artifact substitution.

## Acceptance

- Version synchronization, release contract tests, required checks, and full CI pass on the exact zero-behind head.
- The explicitly dispatched Release pre-flight binds to this PR and exact head.
- The protected release transaction publishes only `0.13.2-rc1`, with matching engine and Desktop source identity.

## Verification

- `172 passed`: focused version, subject, and release-candidate workflow tests.
- `tests/release/test_release_preflight_subject.sh`: 16 passed.
- `tests/release/test_auto_release_dry_run.sh`: 32 passed.
- `git diff --check`: clean.

Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/33314887607