### PR TITLE
fix(release): accept Sparkle item version fields

### DIFF
--- a/scripts/desktop_promotion.py
+++ b/scripts/desktop_promotion.py
@@ -136,25 +136,53 @@ def _verify_appcast(bundle: Path, *, version: str, zip_relative: str) -> None:
         root = ET.parse(appcast).getroot()
     except (OSError, ET.ParseError) as exc:
         raise ValueError(f"cannot parse Sparkle appcast: {exc}") from exc
-    enclosures = root.findall(".//enclosure")
-    if len(enclosures) != 1:
+    item_enclosures = [
+        (item, enclosure)
+        for item in root.findall(".//item")
+        for enclosure in item.findall("enclosure")
+    ]
+    if len(item_enclosures) != 1:
         raise ValueError(
-            f"Sparkle appcast must contain exactly one enclosure; found {len(enclosures)}"
+            "Sparkle appcast must contain exactly one enclosure; "
+            f"found {len(item_enclosures)}"
         )
-    enclosure = enclosures[0]
+    item, enclosure = item_enclosures[0]
     zip_path = _regular_file(bundle, zip_relative)
     url = enclosure.get("url", "")
     if url.rsplit("/", 1)[-1] != zip_path.name:
         raise ValueError("Sparkle enclosure URL does not name the promoted ZIP")
     if enclosure.get("length") != str(zip_path.stat().st_size):
         raise ValueError("Sparkle enclosure length does not match the promoted ZIP")
-    if enclosure.get(f"{{{SPARKLE_NS}}}shortVersionString") != version:
+    short_version = _sparkle_version_value(item, enclosure, "shortVersionString")
+    if short_version != version:
         raise ValueError("Sparkle short version does not match the promotion version")
-    build = enclosure.get(f"{{{SPARKLE_NS}}}version", "")
+    build = _sparkle_version_value(item, enclosure, "version")
     if not build.isdigit() or int(build) < 1:
         raise ValueError("Sparkle enclosure has no valid numeric bundle build")
     if not enclosure.get(f"{{{SPARKLE_NS}}}edSignature"):
         raise ValueError("Sparkle enclosure has no EdDSA signature")
+
+
+def _sparkle_version_value(
+    item: ET.Element, enclosure: ET.Element, local_name: str
+) -> str:
+    """Read one Sparkle identity field without accepting contradictory copies.
+
+    Sparkle 2 emits ``version`` and ``shortVersionString`` as item-level
+    elements. Older appcasts may carry the same values as enclosure
+    attributes. Sparkle accepts either representation, so promotion must too,
+    while rejecting an appcast that supplies both with different values.
+    """
+
+    child = item.find(f"{{{SPARKLE_NS}}}{local_name}")
+    element_value = (child.text or "").strip() if child is not None else ""
+    attribute_value = enclosure.get(f"{{{SPARKLE_NS}}}{local_name}", "").strip()
+    if element_value and attribute_value and element_value != attribute_value:
+        raise ValueError(f"Sparkle {local_name} values conflict")
+    value = element_value or attribute_value
+    if not value:
+        raise ValueError(f"Sparkle appcast is missing {local_name}")
+    return value
 
 
 def create_manifest(

--- a/tests/test_desktop_promotion.py
+++ b/tests/test_desktop_promotion.py
@@ -12,21 +12,22 @@ REPO = "raullenchai/Rapid-MLX"
 WORKFLOW = ".github/workflows/auto-release.yml"
 
 
-def _bundle(tmp_path: Path) -> tuple[Path, Path]:
+def _bundle(tmp_path: Path, *, version: str = VERSION) -> tuple[Path, Path]:
+    tag = f"rapid-mac-v{version}"
     bundle = tmp_path / "candidate"
     sparkle = bundle / "sparkle"
     sparkle.mkdir(parents=True)
     dmg = bundle / "rapid-mlx-desktop.dmg"
     dmg.write_bytes(b"signed notarized dmg")
-    zip_path = sparkle / "Rapid-MLX-Desktop-0.13.2.zip"
+    zip_path = sparkle / f"Rapid-MLX-Desktop-{version}.zip"
     zip_path.write_bytes(b"signed sparkle zip")
-    (bundle / "release-notes.md").write_text("## [0.13.2]\n")
+    (bundle / "release-notes.md").write_text(f"## [{version}]\n")
     (bundle / "rapid-mlx-desktop.manifest.json").write_text(
         json.dumps(
             {
                 "source_sha": SHA,
-                "version": VERSION,
-                "app_tag": TAG,
+                "version": version,
+                "app_tag": tag,
                 "signed": True,
                 "artifacts": [
                     {
@@ -41,7 +42,7 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
         )
     )
     (sparkle / "appcast.xml").write_text(
-        f'''<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><enclosure url="https://dl.rapidmlx.com/{zip_path.name}" length="{zip_path.stat().st_size}" sparkle:version="132" sparkle:shortVersionString="{VERSION}" sparkle:edSignature="signature" /></item></channel></rss>'''
+        f'''<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>132</sparkle:version><sparkle:shortVersionString>{version}</sparkle:shortVersionString><enclosure url="https://dl.rapidmlx.com/{zip_path.name}" length="{zip_path.stat().st_size}" sparkle:edSignature="signature" /></item></channel></rss>'''
     )
     manifest = bundle / "desktop-promotion-manifest.json"
     manifest.write_text(
@@ -53,15 +54,15 @@ def _bundle(tmp_path: Path) -> tuple[Path, Path]:
                 run_id=123,
                 run_attempt=2,
                 source_sha=SHA,
-                version=VERSION,
-                app_tag=TAG,
+                version=version,
+                app_tag=tag,
             )
         )
     )
     return bundle, manifest
 
 
-def _verify(bundle: Path, manifest: Path):
+def _verify(bundle: Path, manifest: Path, *, version: str = VERSION):
     return verify_manifest(
         bundle=bundle,
         manifest_path=manifest,
@@ -70,14 +71,69 @@ def _verify(bundle: Path, manifest: Path):
         run_id=123,
         run_attempt=2,
         source_sha=SHA,
-        version=VERSION,
-        app_tag=TAG,
+        version=version,
+        app_tag=f"rapid-mac-v{version}",
     )
 
 
 def test_exact_bundle_round_trip(tmp_path: Path):
     bundle, manifest = _bundle(tmp_path)
     assert _verify(bundle, manifest)["producer"]["run_attempt"] == 2
+
+
+def test_rc_item_level_identity_round_trip(tmp_path: Path):
+    version = "0.13.2-rc1"
+    bundle, manifest = _bundle(tmp_path, version=version)
+    assert _verify(bundle, manifest, version=version)["release"]["version"] == version
+
+
+def test_legacy_enclosure_identity_is_accepted(tmp_path: Path):
+    bundle, _ = _bundle(tmp_path)
+    appcast = bundle / "sparkle/appcast.xml"
+    text = appcast.read_text()
+    text = text.replace("<sparkle:version>132</sparkle:version>", "")
+    text = text.replace(
+        f"<sparkle:shortVersionString>{VERSION}</sparkle:shortVersionString>", ""
+    )
+    text = text.replace(
+        "<enclosure ",
+        f'<enclosure sparkle:version="132" sparkle:shortVersionString="{VERSION}" ',
+    )
+    appcast.write_text(text)
+
+    manifest = create_manifest(
+        bundle=bundle,
+        repository=REPO,
+        workflow=WORKFLOW,
+        run_id=123,
+        run_attempt=2,
+        source_sha=SHA,
+        version=VERSION,
+        app_tag=TAG,
+    )
+    assert manifest["release"]["version"] == VERSION
+
+
+def test_conflicting_item_and_enclosure_identity_is_rejected(tmp_path: Path):
+    bundle, _ = _bundle(tmp_path)
+    appcast = bundle / "sparkle/appcast.xml"
+    appcast.write_text(
+        appcast.read_text().replace(
+            "<enclosure ",
+            '<enclosure sparkle:shortVersionString="0.13.3" ',
+        )
+    )
+    with pytest.raises(ValueError, match="shortVersionString values conflict"):
+        create_manifest(
+            bundle=bundle,
+            repository=REPO,
+            workflow=WORKFLOW,
+            run_id=123,
+            run_attempt=2,
+            source_sha=SHA,
+            version=VERSION,
+            app_tag=TAG,
+        )
 
 
 @pytest.mark.parametrize(
@@ -151,8 +207,8 @@ def test_appcast_identity_is_rejected_even_if_manifest_is_rehashed(tmp_path: Pat
     appcast = bundle / "sparkle/appcast.xml"
     appcast.write_text(
         appcast.read_text().replace(
-            f'sparkle:shortVersionString="{VERSION}"',
-            'sparkle:shortVersionString="0.13.3"',
+            f"<sparkle:shortVersionString>{VERSION}</sparkle:shortVersionString>",
+            "<sparkle:shortVersionString>0.13.3</sparkle:shortVersionString>",
         )
     )
     data = json.loads(manifest.read_text())


### PR DESCRIPTION
## Why

The 0.13.2-rc1 auto-release successfully built, signed, notarized, and accepted its Desktop candidate, then rejected the generated Sparkle appcast while creating promotion provenance. The verifier only read legacy enclosure attributes, while the current generator emits version identity as item-level elements.

Closes #2763

## Scope

- Read Sparkle version identity from canonical item-level elements.
- Retain compatibility with legacy enclosure attributes.
- Reject missing or contradictory duplicate identity fields.
- Add stable and RC regression coverage using the generated schema.

## Non-goals

- No product, app, updater, signing, notarization, tag, or publication behavior change.
- No gate bypass and no artifact substitution.

## Design precedent

The updater framework documents item-level `sparkle:version` and `sparkle:shortVersionString` as the current appcast representation while retaining enclosure attributes for compatibility. Promotion now applies the same precedence and fails closed when both representations disagree.

## Verification

- `python3.12 -m pytest -q tests/test_desktop_promotion.py tests/test_release_candidate_workflows.py` — 24 passed.
- `bash tests/release/test_desktop_release_promotion.sh` — 106 passed.
- Ruff check/format and `git diff --check` — clean.
- Failure evidence: auto-release run 33315934652, job 99269291564.