### PR TITLE
fix(release): bind agent sequence path before cwd changes

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -861,6 +861,15 @@ unset _arg _prev_was_sequences
 # Validate a sequences file now (fail early), not mid-gate.
 if [ -n "$SEQUENCES_YAML" ]; then
   [ -f "$SEQUENCES_YAML" ] || fail "--sequences file not found: $SEQUENCES_YAML"
+  # Agent tasks run in per-agent scratch repositories and `seed_repo` changes
+  # this shell's cwd. Bind the already-validated input to an absolute path
+  # before that happens; otherwise a repository-relative path passes here but
+  # the later sequence driver opens it relative to $WORK and fails after every
+  # Tier-1 agent has already passed.
+  _sequences_dir="$(cd "$(dirname "$SEQUENCES_YAML")" && pwd -P)" \
+    || fail "cannot resolve --sequences directory: $SEQUENCES_YAML"
+  SEQUENCES_YAML="$_sequences_dir/$(basename "$SEQUENCES_YAML")"
+  unset _sequences_dir
 fi
 unset _positional
 

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -53,6 +53,7 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SEQUENCES_FILE = _REPO_ROOT / "tests" / "integrations" / "top10_sequences.yaml"
 _ALIASES_FILE = _REPO_ROOT / "vllm_mlx" / "aliases.json"
+_AGENT_SMOKE_FILE = _REPO_ROOT / "tests" / "integrations" / "agent_smoke.sh"
 
 VALID_REPLACE_MODES = frozenset({"reject", "wait", "abort"})
 VALID_ACTIONS = frozenset({"load"})
@@ -61,6 +62,21 @@ VALID_ON_ABSENT = frozenset({"fail", "pass"})
 # Aliases that, per the v3->v4 coverage mandate, must actually be LOADED by
 # some sequence step (they were listed in top_10_aliases but never loaded).
 MUST_LOAD_ALIASES = ("gemma-4-26b-4bit", "bonsai-27b-2bit")
+
+
+def test_agent_smoke_binds_sequence_path_before_agent_cwd_changes() -> None:
+    """A repo-relative sequence path must survive ``seed_repo`` changing cwd."""
+    smoke = _AGENT_SMOKE_FILE.read_text(encoding="utf-8")
+    validation = smoke.index(
+        '[ -f "$SEQUENCES_YAML" ] || fail "--sequences file not found:'
+    )
+    binding = smoke.index(
+        'SEQUENCES_YAML="$_sequences_dir/$(basename "$SEQUENCES_YAML")"'
+    )
+    cwd_change = smoke.index("seed_repo() {")
+    sequence_run = smoke.index('run_load_sequences "$SEQUENCES_YAML"')
+
+    assert validation < binding < cwd_change < sequence_run
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -45,6 +45,7 @@ What it pins (schema v4):
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -64,19 +65,43 @@ VALID_ON_ABSENT = frozenset({"fail", "pass"})
 MUST_LOAD_ALIASES = ("gemma-4-26b-4bit", "bonsai-27b-2bit")
 
 
-def test_agent_smoke_binds_sequence_path_before_agent_cwd_changes() -> None:
-    """A repo-relative sequence path must survive ``seed_repo`` changing cwd."""
+def test_agent_smoke_binds_sequence_path_before_agent_cwd_changes(
+    tmp_path: Path,
+) -> None:
+    """Execute the production binding block across a real cwd transition."""
     smoke = _AGENT_SMOKE_FILE.read_text(encoding="utf-8")
-    validation = smoke.index(
-        '[ -f "$SEQUENCES_YAML" ] || fail "--sequences file not found:'
-    )
-    binding = smoke.index(
-        'SEQUENCES_YAML="$_sequences_dir/$(basename "$SEQUENCES_YAML")"'
-    )
+    binding_start = smoke.index("# Validate a sequences file now (fail early)")
+    binding_end = smoke.index("unset _positional", binding_start)
     cwd_change = smoke.index("seed_repo() {")
     sequence_run = smoke.index('run_load_sequences "$SEQUENCES_YAML"')
+    binding_block = smoke[binding_start:binding_end]
 
-    assert validation < binding < cwd_change < sequence_run
+    assert binding_start < binding_end < cwd_change < sequence_run
+
+    fixture_dir = tmp_path / "fixture dir"
+    fixture_dir.mkdir()
+    sequence_file = fixture_dir / "top sequences.yaml"
+    sequence_file.write_text("base_schema_version: 4\n", encoding="utf-8")
+    later_cwd = tmp_path / "agent-work"
+    later_cwd.mkdir()
+
+    script = f"""
+fail() {{ echo "$*" >&2; exit 3; }}
+SEQUENCES_YAML='fixture dir/top sequences.yaml'
+{binding_block}
+cd '{later_cwd}'
+[ -f "$SEQUENCES_YAML" ]
+printf '%s\\n' "$SEQUENCES_YAML"
+"""
+    result = subprocess.run(
+        ["/bin/bash", "-c", script],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert Path(result.stdout.strip()) == sequence_file
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Why

The 0.13.2-rc1 Tier-1 release gate accepted the repository-relative top-10 sequence YAML path, then changed cwd while exercising the five agent CLIs. The later sequence driver therefore opened the same relative spelling from `~/agent-smoke-work` and failed after every model/agent/coherence/performance check had passed.

This is an authorized RC1 release-plumbing hotfix. It creates no tag or publication by itself.

## What

- Canonicalize the already-validated sequence file directory before any agent task changes cwd.
- Keep the original basename and pass the resulting absolute path to both standard and MTP sequence drivers.
- Add a pure-CPU regression contract that pins validation and path binding ahead of the cwd transition and sequence execution.

## Design precedent

The script already resolves repository-owned paths at process start because its agent functions intentionally change the parent shell cwd. This applies that same early-binding pattern to caller-supplied sequence input, keeping path ownership at the CLI boundary instead of teaching downstream drivers about the caller’s original cwd.

## Scope

- Allowed: release/Tier-1 smoke path handling and focused regression coverage.
- Non-goals: model behavior, YAML contents, residency policy, timeout changes, release authorization, or stable publication.

## Verification

- `bash -n tests/integrations/agent_smoke.sh`
- `python3.12 -m pytest -q tests/test_top10_sequences_schema.py` (12 passed)
- `python3.12 -m ruff check tests/test_top10_sequences_schema.py`
- `python3.12 -m ruff format --check tests/test_top10_sequences_schema.py`
- `git diff --check`
- Manual cwd-transition check confirmed the bound path remains readable from `/private/tmp`.

Fixes #2765