### PR TITLE
fix(release): install vision runtime for top-10 gate

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -371,6 +371,15 @@ jobs:
 
           "$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"
           "$V/bin/pip" check
+
+          # The top-10 residency roster below includes Gemma 4. Give this
+          # fresh candidate venv the same release-tested reduced vision
+          # runtime as the Desktop sidecar: mlx-vlm's model classes + Pillow,
+          # without its unused torch/cv2 dependency cascade. The canonical
+          # constraints and metadata checker below pin and validate the one
+          # intentional Transformers compatibility exception.
+          "$V/bin/pip" install -q --no-deps --constraint "$CONSTRAINTS" \
+            'mlx-vlm' 'Pillow>=10.0'
           SITE_PACKAGES=$("$V/bin/python3.12" -c \
             'import sysconfig; print(sysconfig.get_paths()["purelib"])')
           "$V/bin/python3.12" \

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -370,6 +370,11 @@ jobs:
             --emit-constraints > "$CONSTRAINTS"
 
           "$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"
+          # Validate the ordinary dependency graph before adding the deliberate
+          # reduced-runtime exception below. A second generic `pip check` would
+          # reject mlx-vlm's intentionally omitted torch/cv2 extras; the
+          # release-specific checker after that install validates the exact
+          # supported exception, and the live Gemma roster proves it works.
           "$V/bin/pip" check
 
           # The top-10 residency roster below includes Gemma 4. Give this

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -57,12 +57,17 @@ def test_tier1_candidate_installs_reduced_vision_runtime_for_multimodal_roster()
 
     assert "gemma-4-26b-4bit" in roster["top_10_aliases"]
     assert (
-        '"$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"'
-        in gate
+        '"$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"' in gate
     )
-    assert '"$V/bin/pip" install -q --no-deps --constraint "$CONSTRAINTS"' in gate
+    reduced_install = gate.index(
+        '"$V/bin/pip" install -q --no-deps --constraint "$CONSTRAINTS"'
+    )
+    distribution_check = gate.index("check-sidecar-distributions.py", reduced_install)
+    roster_run = gate.index(
+        'RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh'
+    )
+    assert reduced_install < distribution_check < roster_run
     assert "'mlx-vlm' 'Pillow>=10.0'" in gate
-    assert "check-sidecar-distributions.py" in gate
 
 
 def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -48,6 +48,23 @@ def test_auto_release_stages_one_sha_labelled_complete_desktop_bundle():
     assert "rapid-mlx-desktop-pre-tag-candidate-${{ github.sha }}" in upload
 
 
+def test_tier1_candidate_installs_reduced_vision_runtime_for_multimodal_roster():
+    workflow = AUTO_RELEASE.read_text(encoding="utf-8")
+    gate = _step(workflow, "Re-verify Tier-1 agents against the release source")
+    roster = yaml.safe_load(
+        (ROOT / "tests/integrations/top10_sequences.yaml").read_text(encoding="utf-8")
+    )
+
+    assert "gemma-4-26b-4bit" in roster["top_10_aliases"]
+    assert (
+        '"$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"'
+        in gate
+    )
+    assert '"$V/bin/pip" install -q --no-deps --constraint "$CONSTRAINTS"' in gate
+    assert "'mlx-vlm' 'Pillow>=10.0'" in gate
+    assert "check-sidecar-distributions.py" in gate
+
+
 def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
     workflow = yaml.load(DESKTOP_WORKFLOW.read_text(), Loader=yaml.BaseLoader)
     inputs = workflow["on"]["workflow_dispatch"]["inputs"]

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -56,9 +56,10 @@ def test_tier1_candidate_installs_reduced_vision_runtime_for_multimodal_roster()
     )
 
     assert "gemma-4-26b-4bit" in roster["top_10_aliases"]
-    assert (
-        '"$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"' in gate
+    candidate_install = gate.index(
+        '"$V/bin/pip" install -q --constraint "$CONSTRAINTS" "$CANDIDATE_WHEEL"'
     )
+    pip_check = gate.index('"$V/bin/pip" check')
     reduced_install = gate.index(
         '"$V/bin/pip" install -q --no-deps --constraint "$CONSTRAINTS"'
     )
@@ -66,7 +67,13 @@ def test_tier1_candidate_installs_reduced_vision_runtime_for_multimodal_roster()
     roster_run = gate.index(
         'RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh'
     )
-    assert reduced_install < distribution_check < roster_run
+    assert (
+        candidate_install
+        < pip_check
+        < reduced_install
+        < distribution_check
+        < roster_run
+    )
     assert "'mlx-vlm' 'Pillow>=10.0'" in gate
 
 


### PR DESCRIPTION
## Why

The RC Tier-1 gate drives a checked-in residency roster that includes `gemma-4-26b-4bit`, but its fresh candidate-wheel venv omitted the optional model classes required to load Gemma. That made `/v1/models/load` deterministically return HTTP 500 / `ImportError` even with a complete pinned snapshot.

## Intention

Install the same release-tested reduced vision runtime used by the shipped Desktop sidecar into the fresh Tier-1 candidate venv before the roster runs. The candidate wheel remains the exact wheel built by the gate.

## Scope

- Add pinned, `--no-deps` `mlx-vlm` + Pillow to the Tier-1 gate venv.
- Keep the canonical sidecar constraints and compatibility checker authoritative.
- Add a workflow contract test coupling the multimodal roster to that install.

## Non-goals

- No engine, model-routing, dependency-bound, or publishing behavior changes.
- No change to the Desktop sidecar recipe.
- No tag or release mutation.

## Design precedent

This reuses the repository’s existing reduced-runtime pattern: install only the architecture classes and eager import dependency needed by the exercised model families, retain the release-tested dependency pins, and validate the intentional metadata exception explicitly. It avoids pulling the unused large vision dependency cascade into the gate.

## Verification

- Fresh candidate base-wheel venv reproduced Gemma load as HTTP 500 / `ImportError`.
- After the reduced runtime install, the exact candidate venv loads the same pinned Gemma snapshot with HTTP 200.
- `python3.12 -m pytest -q tests/test_release_candidate_workflows.py tests/test_top10_sequences_schema.py` — 22 passed.
- Custom distribution checker — PASS.
- Workflow YAML parse — PASS.
- `git diff --check` — PASS.

Release-plumbing hotfix; squash-merge after exact-head review and required checks.

Fixes #2767
