### PR TITLE
fix: prove MTP metrics before residency sequence

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -226,8 +226,8 @@ run_load_sequences() {
 Modes:
   --mode std        drive every mtp: none sequence against --base.
   --mode mtp        drive the single mtp != none sequence named by --only-seq
-                    against --base (the dedicated MTP serve), then scrape its
-                    /metrics and evaluate its metrics_expected.
+                    against --base (the dedicated MTP serve), proving its
+                    metrics_expected before the residency transitions.
   --mtp-plans-out F write the MTP boot plan (one JSON object per line) to F
                     and exit — bash uses it to boot each MTP serve.
 Exits 0 iff every required step (respecting per-step + per-sequence budgets)
@@ -627,8 +627,8 @@ PY
   fi
 
   # 2) MTP sequences: one dedicated MTP serve per sequence, own port, own boot
-  #    and cleanup. Produce the boot plan, then cycle boot -> drive -> scrape
-  #    -> teardown.
+  #    and cleanup. Produce the boot plan, then cycle boot -> prove MTP metrics
+  #    -> drive residency transitions -> teardown.
   local plans="$WORK/mtp_plans.jsonl"
   : > "$plans"
   "$VENV/bin/python" "$WORK/seq_driver.py" --yaml "$yaml" --mtp-plans-out "$plans"

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -500,6 +500,42 @@ def _drive(spec, args):
         seq_to = seq.get("timeout_seconds") or (DEFAULT_SEQ_TO_MTP if mode == "mtp" else DEFAULT_SEQ_TO_STD)
         seq_deadline = min(time.time() + seq_to, deadline)
         print(f"  sequence {name} (budget {seq_to}s):")
+        if mode == "mtp":
+            # #2421 contract: prove engagement while the freshly booted MTP
+            # primary is still resident. The load sequence below deliberately
+            # replaces that primary, and /v1/models/load cannot restore its
+            # boot-only speculative configuration.
+            scrape_to = int(max(10, seq_deadline - time.time()))
+            try:
+                pre_map = _parse_series(_scrape_metrics(args["base"], args["auth"], scrape_to))
+            except Exception as e:
+                print(f"    pre-metrics scrape error: {e} [FAIL]")
+                failed += 1
+                pre_map = {}
+            canonical_model = seq.get("serve_alias")
+            chat_st, nonempty = _chat(
+                args["base"], canonical_model, args["auth"],
+                int(max(10, seq_deadline - time.time())),
+            )
+            chat_ok = chat_st == 200 and nonempty
+            print(
+                f"    canonical MTP chat {{model={canonical_model}}} -> HTTP "
+                f"{chat_st} content={'OK' if nonempty else 'EMPTY'} "
+                f"[{'PASS' if chat_ok else 'FAIL'}]"
+            )
+            if not chat_ok:
+                failed += 1
+            try:
+                post_map = _parse_series(_scrape_metrics(args["base"], args["auth"], scrape_to))
+            except Exception as e:
+                print(f"    post-metrics scrape error: {e} [FAIL]")
+                failed += 1
+                post_map = {}
+            mm = _eval_metrics(seq, pre_map, post_map)
+            for mf in mm:
+                print(f"    METRIC-FAIL: {mf}")
+            if mm:
+                failed += len(mm)
         for i, step in enumerate(seq.get("steps", []), start=1):
             remaining = seq_deadline - time.time()
             if remaining <= 5:
@@ -537,41 +573,6 @@ def _drive(spec, args):
             )
             if not (load_ok and chat_ok):
                 failed += 1
-        if mode == "mtp":
-            # #2421 contract: one canonical temp=0, HTTP-200, non-empty chat on
-            # the freshly booted MTP primary, bracketed by a pre/post /metrics
-            # scrape, then evaluated as deltas for the exact family+method.
-            scrape_to = int(max(10, seq_deadline - time.time()))
-            try:
-                pre_map = _parse_series(_scrape_metrics(args["base"], args["auth"], scrape_to))
-            except Exception as e:
-                print(f"    pre-metrics scrape error: {e} [FAIL]")
-                failed += 1
-                pre_map = {}
-            canonical_model = seq.get("serve_alias")
-            chat_st, nonempty = _chat(
-                args["base"], canonical_model, args["auth"],
-                int(max(10, seq_deadline - time.time())),
-            )
-            chat_ok = chat_st == 200 and nonempty
-            print(
-                f"    canonical MTP chat {{model={canonical_model}}} -> HTTP "
-                f"{chat_st} content={'OK' if nonempty else 'EMPTY'} "
-                f"[{'PASS' if chat_ok else 'FAIL'}]"
-            )
-            if not chat_ok:
-                failed += 1
-            try:
-                post_map = _parse_series(_scrape_metrics(args["base"], args["auth"], scrape_to))
-            except Exception as e:
-                print(f"    post-metrics scrape error: {e} [FAIL]")
-                failed += 1
-                post_map = {}
-            mm = _eval_metrics(seq, pre_map, post_map)
-            for mf in mm:
-                print(f"    METRIC-FAIL: {mf}")
-            if mm:
-                failed += len(mm)
     return failed
 
 

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -111,12 +111,21 @@ def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
     drive_end = smoke.index("\ndef main(argv):", drive_start)
     drive = smoke[drive_start:drive_end]
 
-    metric_proof = drive.index("# #2421 contract: prove engagement")
+    pre_scrape = drive.index('pre_map = _parse_series(_scrape_metrics(')
+    canonical_chat = drive.index('canonical_model = seq.get("serve_alias")')
+    post_scrape = drive.index('post_map = _parse_series(_scrape_metrics(')
+    metric_evaluation = drive.index("mm = _eval_metrics(seq, pre_map, post_map)")
     residency_sequence = drive.index(
         'for i, step in enumerate(seq.get("steps", []), start=1):'
     )
 
-    assert metric_proof < residency_sequence
+    assert (
+        pre_scrape
+        < canonical_chat
+        < post_scrape
+        < metric_evaluation
+        < residency_sequence
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -104,28 +104,81 @@ printf '%s\\n' "$SEQUENCES_YAML"
     assert Path(result.stdout.strip()) == sequence_file
 
 
-def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
-    """The MTP counters belong to the boot-configured primary, not a reload."""
+def _sequence_driver_source() -> str:
     smoke = _AGENT_SMOKE_FILE.read_text(encoding="utf-8")
-    drive_start = smoke.index("def _drive(spec, args):")
-    drive_end = smoke.index("\ndef main(argv):", drive_start)
-    drive = smoke[drive_start:drive_end]
+    marker = "cat > \"$WORK/seq_driver.py\" <<'PY'\n"
+    return smoke.split(marker, 1)[1].split("\nPY\n", 1)[0]
 
-    pre_scrape = drive.index("pre_map = _parse_series(_scrape_metrics(")
-    canonical_chat = drive.index('canonical_model = seq.get("serve_alias")')
-    post_scrape = drive.index("post_map = _parse_series(_scrape_metrics(")
-    metric_evaluation = drive.index("mm = _eval_metrics(seq, pre_map, post_map)")
-    residency_sequence = drive.index(
-        'for i, step in enumerate(seq.get("steps", []), start=1):'
+
+def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
+    """Exercise the production driver with network calls replaced by a ledger."""
+    namespace = {"__name__": "sequence_driver_contract_test"}
+    exec(
+        compile(_sequence_driver_source(), str(_AGENT_SMOKE_FILE), "exec"),
+        namespace,
+    )
+    events: list[str] = []
+    scrapes = iter(
+        (
+            'rapid_mlx_spec_decode_attempts_total{family="primary",method="mtp"} 0',
+            'rapid_mlx_spec_decode_attempts_total{family="primary",method="mtp"} 1',
+        )
     )
 
-    assert (
-        pre_scrape
-        < canonical_chat
-        < post_scrape
-        < metric_evaluation
-        < residency_sequence
-    )
+    def scrape(*_args) -> str:
+        events.append("scrape")
+        return next(scrapes)
+
+    def chat(_base, model, _auth, _timeout) -> tuple[int, bool]:
+        events.append(f"chat:{model}")
+        return 200, True
+
+    def post(_base, path, body, _auth, _timeout) -> tuple[int, str]:
+        assert path == "/v1/models/load"
+        events.append(f"load:{body['model']}")
+        return 200, ""
+
+    namespace["_scrape_metrics"] = scrape
+    namespace["_chat"] = chat
+    namespace["_post"] = post
+    spec = {
+        "sequences": [
+            {
+                "name": "mtp-order",
+                "mtp": "first",
+                "serve_alias": "primary",
+                "metrics_expected": [
+                    {
+                        "metric": "rapid_mlx_spec_decode_attempts_total",
+                        "family": "primary",
+                        "method": "mtp",
+                    }
+                ],
+                "steps": [
+                    {
+                        "model": "secondary",
+                        "expected_status": 200,
+                    }
+                ],
+            }
+        ]
+    }
+    args = {
+        "mode": "mtp",
+        "only_seq": "mtp-order",
+        "base": "http://test.invalid",
+        "auth": None,
+        "block_to": 60,
+    }
+
+    assert namespace["_drive"](spec, args) == 0
+    assert events == [
+        "scrape",
+        "chat:primary",
+        "scrape",
+        "load:secondary",
+        "chat:secondary",
+    ]
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -111,9 +111,9 @@ def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
     drive_end = smoke.index("\ndef main(argv):", drive_start)
     drive = smoke[drive_start:drive_end]
 
-    pre_scrape = drive.index('pre_map = _parse_series(_scrape_metrics(')
+    pre_scrape = drive.index("pre_map = _parse_series(_scrape_metrics(")
     canonical_chat = drive.index('canonical_model = seq.get("serve_alias")')
-    post_scrape = drive.index('post_map = _parse_series(_scrape_metrics(')
+    post_scrape = drive.index("post_map = _parse_series(_scrape_metrics(")
     metric_evaluation = drive.index("mm = _eval_metrics(seq, pre_map, post_map)")
     residency_sequence = drive.index(
         'for i, step in enumerate(seq.get("steps", []), start=1):'

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -104,6 +104,21 @@ printf '%s\\n' "$SEQUENCES_YAML"
     assert Path(result.stdout.strip()) == sequence_file
 
 
+def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
+    """The MTP counters belong to the boot-configured primary, not a reload."""
+    smoke = _AGENT_SMOKE_FILE.read_text(encoding="utf-8")
+    drive_start = smoke.index("def _drive(spec, args):")
+    drive_end = smoke.index("\ndef main(argv):", drive_start)
+    drive = smoke[drive_start:drive_end]
+
+    metric_proof = drive.index("# #2421 contract: prove engagement")
+    residency_sequence = drive.index(
+        'for i, step in enumerate(seq.get("steps", []), start=1):'
+    )
+
+    assert metric_proof < residency_sequence
+
+
 @pytest.fixture(scope="module")
 def spec() -> dict:
     assert _SEQUENCES_FILE.is_file(), f"missing {_SEQUENCES_FILE}"


### PR DESCRIPTION
## Why

The 0.13.2-rc1 Tier-1 gate successfully served the boot-configured MTP primary, but then replaced it through the A→B→A residency sequence before measuring MTP engagement. `/v1/models/load` cannot restore boot-only speculative configuration, so the later canonical chat correctly produced zero MTP deltas and falsely blocked the release.

## Scope

- bracket the canonical MTP chat with metrics while the boot-configured MTP primary is still resident
- run the existing residency sequence afterward with all load/chat assertions unchanged
- pin the ordering with a pure-CPU contract test

## Non-goals

- no engine, scheduler, timeout, model roster, or metric-threshold changes
- no weakening or skipping of the MTP engagement contract

## Design precedent

Release probes validate configuration-bound behavior before any lifecycle transition that intentionally destroys that configuration. The existing boot configuration remains the source of truth; this change only orders the independent engagement and residency proofs around that lifecycle boundary.

## Verification

- `bash -n tests/integrations/agent_smoke.sh`
- `python3 -m pytest -q tests/test_top10_sequences_schema.py tests/test_release_candidate_workflows.py` (23 passed)
- `git diff --check`
- full RC gate will be dispatched from the exact merged main SHA

Fixes #2769