### PR TITLE
fix: make MTP release probe exercise sustained decode

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -182,10 +182,11 @@ fi
 #     exist on a serve booted with the speculative config. The driver:
 #       - boots the MTP serve (own-PID ownership only; never a port sweep),
 #       - drives the sequence (load + post-load completion per step) against it,
-#       - issues ONE canonical temp=0 chat on the freshly booted MTP primary and
-#         evaluates the #2421 contract as deltas between a pre- and post-chat
-#         /metrics scrape, for the exact (family, method) label pair
-#         (reviewer B1 — no uncalibrated floor),
+#       - issues ONE canonical temp=0 engagement chat with enough decode work
+#         for the freshly booted MTP primary to propose drafts, then evaluates
+#         the #2421 contract as deltas between a pre- and post-chat /metrics
+#         scrape, for the exact (family, method) label pair (reviewer B1 — no
+#         uncalibrated floor),
 #       - tears the serve down (TERM -> wait -> KILL, own PID only).
 #     On current main these must be GREEN; on a pre-#2441 sha (62a038c7) the
 #     post-load completion of the MTP-primary step must go RED — that red is
@@ -274,12 +275,21 @@ def _post(base, path, body, auth, timeout):
         return e.code, (e.read().decode("utf-8", "replace") if e.fp else "")
 
 
-def _chat(base, model, auth, timeout):
-    """Short completion exercising the generate path (the #2438 surface)."""
+def _chat(base, model, auth, timeout, *, mtp_probe=False):
+    """Exercise generation; optionally require enough decode for MTP drafts."""
+    if mtp_probe:
+        prompt = (
+            "Write the integers from 1 through 100 in order, separated by "
+            "single spaces. Output only the integers and spaces; do not stop early."
+        )
+        max_tokens = 256
+    else:
+        prompt = "Reply with the single word OK."
+        max_tokens = 8
     body = {
         "model": model,
-        "messages": [{"role": "user", "content": "Reply with the single word OK."}],
-        "max_tokens": 8,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
         "temperature": 0,
     }
     st, text = _post(base, "/v1/chat/completions", body, auth, timeout)
@@ -516,6 +526,7 @@ def _drive(spec, args):
             chat_st, nonempty = _chat(
                 args["base"], canonical_model, args["auth"],
                 int(max(10, seq_deadline - time.time())),
+                mtp_probe=True,
             )
             chat_ok = chat_st == 200 and nonempty
             print(

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -129,8 +129,8 @@ def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
         events.append("scrape")
         return next(scrapes)
 
-    def chat(_base, model, _auth, _timeout) -> tuple[int, bool]:
-        events.append(f"chat:{model}")
+    def chat(_base, model, _auth, _timeout, *, mtp_probe=False) -> tuple[int, bool]:
+        events.append(f"chat:{model}:{'mtp' if mtp_probe else 'short'}")
         return 200, True
 
     def post(_base, path, body, _auth, _timeout) -> tuple[int, str]:
@@ -174,11 +174,35 @@ def test_mtp_engagement_is_proved_before_the_primary_is_replaced() -> None:
     assert namespace["_drive"](spec, args) == 0
     assert events == [
         "scrape",
-        "chat:primary",
+        "chat:primary:mtp",
         "scrape",
         "load:secondary",
-        "chat:secondary",
+        "chat:secondary:short",
     ]
+
+
+def test_mtp_probe_requests_deterministic_sustained_decode() -> None:
+    """A two-token ``OK`` response cannot prove speculative engagement."""
+    namespace = {"__name__": "sequence_driver_contract_test"}
+    exec(
+        compile(_sequence_driver_source(), str(_AGENT_SMOKE_FILE), "exec"),
+        namespace,
+    )
+    posted: dict = {}
+
+    def post(_base, path, body, _auth, _timeout) -> tuple[int, str]:
+        posted.update(path=path, body=body)
+        return 200, json.dumps({"choices": [{"message": {"content": "1 2 3 4"}}]})
+
+    namespace["_post"] = post
+    assert namespace["_chat"](
+        "http://test.invalid", "primary", None, 60, mtp_probe=True
+    ) == (200, True)
+    assert posted["path"] == "/v1/chat/completions"
+    assert posted["body"]["temperature"] == 0
+    assert posted["body"]["max_tokens"] == 256
+    prompt = posted["body"]["messages"][0]["content"]
+    assert "1 through 100" in prompt
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Why

The RC1 release gate asked the MTP model to reply with the single word `OK`. That response finishes after two tokens, before the speculative outer loop can propose a draft, so a healthy MTP serve reports zero attempts and the engagement gate falsely fails. On the exact RC candidate, the short probe produced 0 attempts / 0 accepts; a deterministic sustained-decode probe on the same process produced 181 attempts / 178 accepts (98.34%) while returning HTTP 200.

## Scope

- use a deterministic 256-token sequence-generation request only for the canonical MTP metrics probe
- retain the existing 8-token chat for every post-load residency assertion
- behaviorally pin both the sustained MTP request and the metrics-before-residency call order

## Non-goals

- no engine, scheduler, controller, metric threshold, model roster, or release workflow changes
- no performance-floor claim; the gate still checks only engagement and observability

## Design precedent

An engagement smoke must keep the optimized decode path active long enough to observe at least one proposal. The probe uses deterministic, repetitive output so it is bounded, reproducible, and strongly accept-friendly, while the independent residency checks remain short.

## Verification

- real qwen3.8-27b-4bit MTP process on the release SHA: short probe = 0/0; sustained probe = 181 attempts, 178 accepts, ratio 0.9834, HTTP 200 with 256 completion tokens
- `bash -n tests/integrations/agent_smoke.sh`
- `/opt/homebrew/bin/python3.12 -m pytest -q tests/test_top10_sequences_schema.py tests/test_release_candidate_workflows.py` (24 passed)
- `git diff --check`

Fixes #2421