### PR TITLE
feat(mac): offer one-click GitHub star via gh CLI

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -75,15 +75,25 @@ struct GitHubStarPromptCard: View {
 
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button {
-                        openURL(GitHubCommunity.repositoryURL) { accepted in
-                            guard accepted else { return }
-                            prompt.repositoryOpened()
+                        Task {
+                            if await prompt.attemptDirectStar() {
+                                return
+                            }
+
+                            openURL(GitHubCommunity.repositoryURL) { accepted in
+                                guard accepted else { return }
+                                prompt.repositoryOpened()
+                            }
                         }
                     } label: {
                         HStack(spacing: RapidTheme.Space.xs) {
-                            Text("Open GitHub")
-                            Image(systemName: "arrow.up.right")
-                                .font(.system(size: 10, weight: .semibold))
+                            if prompt.isStarring {
+                                Text("Starring…")
+                            } else {
+                                Text("Open GitHub")
+                                Image(systemName: "arrow.up.right")
+                                    .font(.system(size: 10, weight: .semibold))
+                            }
                         }
                         .frame(maxWidth: .infinity)
                     }
@@ -93,7 +103,8 @@ struct GitHubStarPromptCard: View {
                         font: .system(size: 14, weight: .medium)
                     ))
                     .frame(maxWidth: .infinity, minHeight: RapidTheme.ControlHeight.medium)
-                    .accessibilityHint("Opens the Rapid-MLX repository in your browser")
+                    .disabled(prompt.isStarring)
+                    .accessibilityHint("Stars the Rapid-MLX repository, using the GitHub CLI when available")
                     .accessibilityIdentifier("GitHub.Star.ValueMoment.Open")
 
                     Button("Later") { prompt.deferPrompt() }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -92,8 +92,8 @@ struct GitHubStarPromptCard: View {
                             if prompt.isStarring {
                                 Text("Starring…")
                             } else {
-                                Text("Open GitHub")
-                                Image(systemName: "arrow.up.right")
+                                Text("Star on GitHub")
+                                Image(systemName: "star")
                                     .font(.system(size: 10, weight: .semibold))
                             }
                         }
@@ -106,7 +106,9 @@ struct GitHubStarPromptCard: View {
                     ))
                     .frame(maxWidth: .infinity, minHeight: RapidTheme.ControlHeight.medium)
                     .disabled(prompt.isStarring)
-                    .accessibilityHint("Stars the Rapid-MLX repository, using the GitHub CLI when available")
+                    .accessibilityHint(
+                        "Stars the Rapid-MLX repository using GitHub CLI, or opens GitHub if unavailable"
+                    )
                     .accessibilityIdentifier("GitHub.Star.ValueMoment.Open")
 
                     Button("Later") { prompt.deferPrompt() }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -76,8 +76,11 @@ struct GitHubStarPromptCard: View {
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button {
                         Task {
-                            if await prompt.attemptDirectStar() {
+                            switch await prompt.attemptDirectStar() {
+                            case .starred, .cancelled:
                                 return
+                            case .unavailable:
+                                break
                             }
 
                             guard prompt.isPresented, !prompt.isStarring else { return }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -80,7 +80,7 @@ struct GitHubStarPromptCard: View {
                                 return
                             }
 
-                            guard prompt.isPresented else { return }
+                            guard prompt.isPresented, !prompt.isStarring else { return }
 
                             openURL(GitHubCommunity.repositoryURL) { accepted in
                                 guard accepted else { return }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -117,6 +117,7 @@ struct GitHubStarPromptCard: View {
                             font: .system(size: 14, weight: .medium)
                         ))
                         .frame(width: 84, height: RapidTheme.ControlHeight.medium)
+                        .disabled(prompt.isStarring)
                         .accessibilityIdentifier("GitHub.Star.ValueMoment.Later")
 
                     Menu("Feedback") {
@@ -157,6 +158,7 @@ struct GitHubStarPromptCard: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(prompt.isStarring)
             .foregroundStyle(RapidTheme.textSecondary)
             .help("Later")
             .accessibilityLabel("Show the GitHub invitation later")

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -80,6 +80,8 @@ struct GitHubStarPromptCard: View {
                                 return
                             }
 
+                            guard prompt.isPresented else { return }
+
                             openURL(GitHubCommunity.repositoryURL) { accepted in
                                 guard accepted else { return }
                                 prompt.repositoryOpened()

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -240,6 +240,11 @@ enum GitHubStarCLIError: Error {
 /// canonical repository, so drag-and-dropped or copied URLs cannot change it.
 enum GitHubStarCLI {
     static let timeout: Duration = .seconds(8)
+    static let trustedExecutablePaths = [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+        "/usr/bin/gh"
+    ]
 
     static func star(
         _ repositoryURL: URL,
@@ -273,17 +278,8 @@ enum GitHubStarCLI {
     }
 
     static func executableURL() -> URL? {
-        let searchPaths = [
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            ProcessInfo.processInfo.environment["PATH"] ?? "",
-            "/usr/bin",
-            "/bin"
-        ]
-
-        return searchPaths
-            .flatMap { $0.split(separator: ":").map(String.init) }
-            .map { URL(fileURLWithPath: $0).appendingPathComponent("gh") }
+        trustedExecutablePaths
+            .map { URL(fileURLWithPath: $0) }
             .first { FileManager.default.isExecutableFile(atPath: $0.path) }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -156,6 +156,7 @@ final class GitHubStarPromptCoordinator {
 
         do {
             try await starExecutor(GitHubCommunity.repositoryURL)
+            guard isPresented else { return false }
             markCompleted()
             return true
         } catch {
@@ -242,6 +243,7 @@ enum GitHubStarCLI {
         process.executableURL = executable
         process.arguments = [
             "api", "--method", "PUT", "--silent",
+            "--hostname", "github.com",
             "repos/raullenchai/Rapid-MLX/starred"
         ]
         process.standardOutput = Pipe()

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -245,17 +245,13 @@ enum GitHubStarCLI {
             throw GitHubStarCLIError.executableNotFound
         }
 
-        let process = Process()
-        process.executableURL = executable
-        process.arguments = apiArguments()
+        let child = try GitHubStarChild.spawn(
+            executableURL: executable,
+            arguments: apiArguments()
+        )
+        let terminationStatus = try await waitUntilExit(child, timeout: requestedTimeout)
 
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        try process.run()
-        try await waitUntilExit(process, timeout: requestedTimeout)
-
-        guard process.terminationStatus == 0 else {
+        guard terminationStatus == 0 else {
             throw GitHubStarCLIError.commandFailed
         }
     }
@@ -283,7 +279,7 @@ enum GitHubStarCLI {
             .first { FileManager.default.isExecutableFile(atPath: $0.path) }
     }
 
-    private static func waitUntilExit(_ process: Process, timeout: Duration) async throws {
+    private static func waitUntilExit(_ child: GitHubStarChild, timeout: Duration) async throws -> Int32 {
         enum Outcome {
             case exited(Int32)
             case timedOut
@@ -291,21 +287,18 @@ enum GitHubStarCLI {
 
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
-        let termination = GitHubStarProcessTermination(process)
         let outcome = try await withTaskCancellationHandler {
             try await withThrowingTaskGroup(of: Outcome.self) { group in
                 group.addTask {
-                    await Task.detached {
-                        process.waitUntilExit()
-                    }.value
+                    let status = await child.waitUntilExit()
                     // Once the deadline has passed, timeout is authoritative even
                     // if SIGKILL makes the waiter observe a nonzero exit first.
                     guard clock.now < deadline else { return .timedOut }
-                    return .exited(process.terminationStatus)
+                    return .exited(status)
                 }
                 group.addTask {
                     try await clock.sleep(until: deadline)
-                    termination.killIfRunning()
+                    child.killIfRunning()
                     return .timedOut
                 }
 
@@ -319,30 +312,210 @@ enum GitHubStarCLI {
             // Cancelling the caller also cancels the timeout sleeper. Kill the
             // child here so the detached waiter can reap it before the task
             // group propagates CancellationError.
-            termination.killIfRunning()
+            child.killIfRunning()
         }
 
         switch outcome {
-        case .exited(0):
-            return
-        case .exited:
-            throw GitHubStarCLIError.commandFailed
+        case let .exited(status):
+            return status
         case .timedOut:
             throw GitHubStarCLIError.timedOut
         }
     }
 }
 
-private final class GitHubStarProcessTermination: @unchecked Sendable {
-    private let process: Process
+/// Owns launch, signalling, and reaping for the short-lived `gh` child.
+/// Foundation `Process.waitUntilExit()` can race a raw PID signal after the
+/// process has been reaped. This owner serializes SIGKILL with the only
+/// `waitpid`, so an exited PID cannot be reused before signalling decides.
+private final class GitHubStarChild: @unchecked Sendable {
+    private static let exitQueue = DispatchQueue(
+        label: "com.rapidmlx.desktop.github-star-exit",
+        qos: .userInitiated
+    )
 
-    init(_ process: Process) {
-        self.process = process
+    private let processIdentifier: pid_t
+    private let lock = NSLock()
+    private let reapLock = NSLock()
+    private var running = true
+    private var terminationStatus: Int32?
+    private var waiters: [CheckedContinuation<Int32, Never>] = []
+    private var exitSource: (any DispatchSourceProcess)?
+
+    private init(processIdentifier: pid_t) {
+        self.processIdentifier = processIdentifier
     }
 
     func killIfRunning() {
-        if process.isRunning {
-            _ = kill(process.processIdentifier, SIGKILL)
+        reapLock.lock()
+        lock.lock()
+        let shouldSignal = running
+        lock.unlock()
+        if shouldSignal {
+            _ = kill(-processIdentifier, SIGKILL)
         }
+        reapLock.unlock()
+    }
+
+    func waitUntilExit() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let terminationStatus {
+                lock.unlock()
+                continuation.resume(returning: terminationStatus)
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    static func spawn(executableURL: URL, arguments: [String]) throws -> GitHubStarChild {
+        var fileActions: posix_spawn_file_actions_t?
+        var attributes: posix_spawnattr_t?
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            throw GitHubStarCLIError.commandFailed
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        guard posix_spawnattr_init(&attributes) == 0 else {
+            throw GitHubStarCLIError.commandFailed
+        }
+        defer { posix_spawnattr_destroy(&attributes) }
+        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP)) == 0,
+            posix_spawnattr_setpgroup(&attributes, 0) == 0
+        else {
+            throw GitHubStarCLIError.commandFailed
+        }
+
+        guard posix_spawn_file_actions_addopen(
+            &fileActions,
+            STDIN_FILENO,
+            "/dev/null",
+            O_RDONLY,
+            0
+        ) == 0,
+            posix_spawn_file_actions_addopen(
+                &fileActions,
+                STDOUT_FILENO,
+                "/dev/null",
+                O_WRONLY,
+                0
+            ) == 0,
+            posix_spawn_file_actions_addopen(
+                &fileActions,
+                STDERR_FILENO,
+                "/dev/null",
+                O_WRONLY,
+                0
+            ) == 0
+        else {
+            throw GitHubStarCLIError.commandFailed
+        }
+
+        let argv = [executableURL.path] + arguments
+        let environment = ProcessInfo.processInfo.environment
+            .map { "\($0.key)=\($0.value)" }
+            .sorted()
+        var pid: pid_t = 0
+        let spawnResult = argv.withGitHubStarCStringArray { argvPointer in
+            environment.withGitHubStarCStringArray { environmentPointer in
+                executableURL.path.withCString { executablePath in
+                    posix_spawn(
+                        &pid,
+                        executablePath,
+                        &fileActions,
+                        &attributes,
+                        argvPointer,
+                        environmentPointer
+                    )
+                }
+            }
+        }
+        guard spawnResult == 0 else {
+            throw GitHubStarCLIError.commandFailed
+        }
+
+        let child = GitHubStarChild(processIdentifier: pid)
+        child.startExitMonitor()
+        return child
+    }
+
+    private func startExitMonitor() {
+        let source = DispatchSource.makeProcessSource(
+            identifier: processIdentifier,
+            eventMask: .exit,
+            queue: Self.exitQueue
+        )
+        source.setEventHandler { [weak self] in
+            self?.reapExitedProcess(waitOptions: 0)
+        }
+        lock.lock()
+        exitSource = source
+        lock.unlock()
+        source.activate()
+
+        // Close the very-short-lived-child race before the source is armed.
+        _ = reapExitedProcess(waitOptions: WNOHANG)
+    }
+
+    @discardableResult
+    private func reapExitedProcess(waitOptions: Int32) -> Bool {
+        reapLock.lock()
+        lock.lock()
+        guard running else {
+            lock.unlock()
+            reapLock.unlock()
+            return true
+        }
+        lock.unlock()
+
+        var waitStatus: Int32 = 0
+        var waited: pid_t
+        repeat {
+            waited = waitpid(processIdentifier, &waitStatus, waitOptions)
+        } while waited == -1 && errno == EINTR
+        guard waited == processIdentifier else {
+            reapLock.unlock()
+            return false
+        }
+
+        let statusCode = waitStatus & 0x7f
+        let status = statusCode == 0 ? (waitStatus >> 8) & 0xff : statusCode
+        lock.lock()
+        running = false
+        terminationStatus = status
+        let continuations = waiters
+        waiters.removeAll()
+        let source = exitSource
+        exitSource = nil
+        lock.unlock()
+        reapLock.unlock()
+
+        source?.cancel()
+        for continuation in continuations {
+            continuation.resume(returning: status)
+        }
+        return true
+    }
+}
+
+private extension Array where Element == String {
+    func withGitHubStarCStringArray<Result>(
+        _ body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> Result
+    ) rethrows -> Result {
+        let strings = map { strdup($0) }
+        defer {
+            for string in strings {
+                free(string)
+            }
+        }
+        let pointer = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+            .allocate(capacity: count + 1)
+        defer { pointer.deallocate() }
+        for index in indices {
+            pointer[index] = strings[index]
+        }
+        pointer[count] = nil
+        return try body(pointer)
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -291,29 +291,35 @@ enum GitHubStarCLI {
 
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
-        let outcome = try await withThrowingTaskGroup(of: Outcome.self) { group in
-            group.addTask {
-                await Task.detached {
-                    process.waitUntilExit()
-                }.value
-                // Once the deadline has passed, timeout is authoritative even
-                // if SIGKILL makes the waiter observe a nonzero exit first.
-                guard clock.now < deadline else { return .timedOut }
-                return .exited(process.terminationStatus)
-            }
-            group.addTask {
-                try await clock.sleep(until: deadline)
-                if process.isRunning {
-                    kill(process.processIdentifier, SIGKILL)
+        let termination = GitHubStarProcessTermination(process)
+        let outcome = try await withTaskCancellationHandler {
+            try await withThrowingTaskGroup(of: Outcome.self) { group in
+                group.addTask {
+                    await Task.detached {
+                        process.waitUntilExit()
+                    }.value
+                    // Once the deadline has passed, timeout is authoritative even
+                    // if SIGKILL makes the waiter observe a nonzero exit first.
+                    guard clock.now < deadline else { return .timedOut }
+                    return .exited(process.terminationStatus)
                 }
-                return .timedOut
-            }
+                group.addTask {
+                    try await clock.sleep(until: deadline)
+                    termination.killIfRunning()
+                    return .timedOut
+                }
 
-            guard let first = try await group.next() else {
-                throw GitHubStarCLIError.commandFailed
+                guard let first = try await group.next() else {
+                    throw GitHubStarCLIError.commandFailed
+                }
+                group.cancelAll()
+                return first
             }
-            group.cancelAll()
-            return first
+        } onCancel: {
+            // Cancelling the caller also cancels the timeout sleeper. Kill the
+            // child here so the detached waiter can reap it before the task
+            // group propagates CancellationError.
+            termination.killIfRunning()
         }
 
         switch outcome {
@@ -323,6 +329,20 @@ enum GitHubStarCLI {
             throw GitHubStarCLIError.commandFailed
         case .timedOut:
             throw GitHubStarCLIError.timedOut
+        }
+    }
+}
+
+private final class GitHubStarProcessTermination: @unchecked Sendable {
+    private let process: Process
+
+    init(_ process: Process) {
+        self.process = process
+    }
+
+    func killIfRunning() {
+        if process.isRunning {
+            _ = kill(process.processIdentifier, SIGKILL)
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -2,6 +2,12 @@ import AppKit
 import Foundation
 import Observation
 
+enum GitHubStarAttemptResult: Equatable {
+    case starred
+    case unavailable
+    case cancelled
+}
+
 /// Owns the local-only, post-value invitation to visit Rapid-MLX on GitHub.
 ///
 /// The prompt is deliberately workload-based rather than launch-based: it is
@@ -151,18 +157,20 @@ final class GitHubStarPromptCoordinator {
     /// Tries the GitHub CLI first so developers can complete the invitation
     /// without a browser round-trip. A missing or unauthenticated CLI is not an
     /// error surface: the caller falls back to the existing browser handoff.
-    func attemptDirectStar() async -> Bool {
-        guard isPresented, !isStarring else { return false }
+    func attemptDirectStar() async -> GitHubStarAttemptResult {
+        guard isPresented, !isStarring else { return .unavailable }
         isStarring = true
         defer { isStarring = false }
 
         do {
             try await starExecutor(GitHubCommunity.repositoryURL)
-            guard isPresented || presentationPending else { return false }
+            guard isPresented || presentationPending else { return .unavailable }
             markCompleted()
-            return true
+            return .starred
+        } catch is CancellationError {
+            return .cancelled
         } catch {
-            return false
+            return .unavailable
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -235,7 +235,8 @@ enum GitHubStarCLI {
 
     static func star(
         _ repositoryURL: URL,
-        executableURL overrideExecutableURL: URL? = nil
+        executableURL overrideExecutableURL: URL? = nil,
+        timeout requestedTimeout: Duration = timeout
     ) async throws {
         guard repositoryURL == GitHubCommunity.repositoryURL else {
             throw GitHubStarCLIError.invalidRepository
@@ -252,7 +253,7 @@ enum GitHubStarCLI {
         process.standardError = FileHandle.nullDevice
 
         try process.run()
-        try await waitUntilExit(process, timeout: timeout)
+        try await waitUntilExit(process, timeout: requestedTimeout)
 
         guard process.terminationStatus == 0 else {
             throw GitHubStarCLIError.commandFailed

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -295,13 +295,16 @@ enum GitHubStarCLI {
             try await withThrowingTaskGroup(of: Outcome.self) { group in
                 group.addTask {
                     let status = await child.waitUntilExit()
-                    // Once the deadline has passed, timeout is authoritative even
-                    // if SIGKILL makes the waiter observe a nonzero exit first.
-                    guard clock.now < deadline else { return .timedOut }
                     return .exited(status)
                 }
                 group.addTask {
                     try await clock.sleep(until: deadline)
+                    // Reap an already-exited child before declaring timeout. The
+                    // dispatch exit callback may be delayed even though `gh`
+                    // completed successfully before the deadline.
+                    if let status = child.terminationStatusIfExited() {
+                        return .exited(status)
+                    }
                     child.killIfRunning()
                     return .timedOut
                 }
@@ -372,6 +375,14 @@ private final class GitHubStarChild: @unchecked Sendable {
                 lock.unlock()
             }
         }
+    }
+
+    func terminationStatusIfExited() -> Int32? {
+        _ = reapExitedProcess(waitOptions: WNOHANG)
+        lock.lock()
+        let status = terminationStatus
+        lock.unlock()
+        return status
     }
 
     static func spawn(executableURL: URL, arguments: [String]) throws -> GitHubStarChild {

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -156,7 +156,7 @@ final class GitHubStarPromptCoordinator {
 
         do {
             try await starExecutor(GitHubCommunity.repositoryURL)
-            guard isPresented else { return false }
+            guard isPresented || presentationPending else { return false }
             markCompleted()
             return true
         } catch {
@@ -246,8 +246,8 @@ enum GitHubStarCLI {
             "--hostname", "github.com",
             "repos/raullenchai/Rapid-MLX/starred"
         ]
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
         try process.run()
         try await waitUntilExit(process, timeout: timeout)

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -30,10 +30,12 @@ final class GitHubStarPromptCoordinator {
     static let quietWindow: Duration = .milliseconds(1_200)
 
     private(set) var isPresented = false
+    private(set) var isStarring = false
 
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let quietWindow: Duration
+    @ObservationIgnored private let starExecutor: @Sendable (URL) async throws -> Void
     @ObservationIgnored private let waitForQuietWindow: @MainActor (Duration) async -> Void
     @ObservationIgnored private var context: PresentationContext = .ready
     @ObservationIgnored private var presentationPending = false
@@ -46,6 +48,7 @@ final class GitHubStarPromptCoordinator {
         now: @escaping () -> Date = Date.init,
         quietWindow: Duration = GitHubStarPromptCoordinator.quietWindow,
         presentationActive: Bool = false,
+        starExecutor: @escaping @Sendable (URL) async throws -> Void = GitHubStarCLI.star,
         waitForQuietWindow: @escaping @MainActor (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
         }
@@ -53,6 +56,7 @@ final class GitHubStarPromptCoordinator {
         self.defaults = defaults
         self.now = now
         self.quietWindow = quietWindow
+        self.starExecutor = starExecutor
         self.presentationActive = presentationActive
         self.waitForQuietWindow = waitForQuietWindow
     }
@@ -139,6 +143,27 @@ final class GitHubStarPromptCoordinator {
     /// the install. Rapid does not probe the user's GitHub account to verify it.
     func repositoryOpened() {
         guard isPresented else { return }
+        markCompleted()
+    }
+
+    /// Tries the GitHub CLI first so developers can complete the invitation
+    /// without a browser round-trip. A missing or unauthenticated CLI is not an
+    /// error surface: the caller falls back to the existing browser handoff.
+    func attemptDirectStar() async -> Bool {
+        guard isPresented, !isStarring else { return false }
+        isStarring = true
+        defer { isStarring = false }
+
+        do {
+            try await starExecutor(GitHubCommunity.repositoryURL)
+            markCompleted()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func markCompleted() {
         isPresented = false
         presentationPending = false
         defaults.set(true, forKey: Keys.completed)
@@ -190,5 +215,82 @@ final class GitHubStarPromptCoordinator {
               isWorkloadEligible(total: defaults.integer(forKey: Keys.totalSuccessfulActions)) else { return }
         presentationPending = false
         isPresented = true
+    }
+}
+
+enum GitHubStarCLIError: Error {
+    case executableNotFound
+    case invalidRepository
+    case timedOut
+    case commandFailed
+}
+
+/// Runs one narrowly-scoped GitHub CLI request. The URL is Rapid-MLX's own
+/// canonical repository, so drag-and-dropped or copied URLs cannot change it.
+enum GitHubStarCLI {
+    static let timeout: Duration = .seconds(8)
+
+    static func star(_ repositoryURL: URL) async throws {
+        guard repositoryURL == GitHubCommunity.repositoryURL else {
+            throw GitHubStarCLIError.invalidRepository
+        }
+        guard let executable = executableURL() else {
+            throw GitHubStarCLIError.executableNotFound
+        }
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = [
+            "api", "--method", "PUT", "--silent",
+            "repos/raullenchai/Rapid-MLX/starred"
+        ]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        try process.run()
+        try await waitUntilExit(process, timeout: timeout)
+
+        guard process.terminationStatus == 0 else {
+            throw GitHubStarCLIError.commandFailed
+        }
+    }
+
+    static func executableURL() -> URL? {
+        let searchPaths = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            ProcessInfo.processInfo.environment["PATH"] ?? "",
+            "/usr/bin",
+            "/bin"
+        ]
+
+        return searchPaths
+            .flatMap { $0.split(separator: ":").map(String.init) }
+            .map { URL(fileURLWithPath: $0).appendingPathComponent("gh") }
+            .first { FileManager.default.isExecutableFile(atPath: $0.path) }
+    }
+
+    private static func waitUntilExit(_ process: Process, timeout: Duration) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await Task.detached {
+                    process.waitUntilExit()
+                    if process.terminationStatus != 0 {
+                        throw GitHubStarCLIError.commandFailed
+                    }
+                }.value
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                if process.isRunning {
+                    process.terminate()
+                }
+                try Task.checkCancellation()
+                throw GitHubStarCLIError.timedOut
+            }
+
+            try await group.next()
+            group.cancelAll()
+        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -241,20 +241,15 @@ enum GitHubStarCLI {
 
         let process = Process()
         process.executableURL = executable
-        process.arguments = [
+        process.arguments = apiArguments()
+    }
+
+    static func apiArguments() -> [String] {
+        [
             "api", "--method", "PUT", "--silent",
             "--hostname", "github.com",
-            "repos/raullenchai/Rapid-MLX/starred"
+            "user/starred/raullenchai/Rapid-MLX"
         ]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        try process.run()
-        try await waitUntilExit(process, timeout: timeout)
-
-        guard process.terminationStatus == 0 else {
-            throw GitHubStarCLIError.commandFailed
-        }
     }
 
     static func executableURL() -> URL? {
@@ -285,7 +280,7 @@ enum GitHubStarCLI {
             group.addTask {
                 try await Task.sleep(for: timeout)
                 if process.isRunning {
-                    process.terminate()
+                    kill(process.processIdentifier, SIGKILL)
                 }
                 try Task.checkCancellation()
                 throw GitHubStarCLIError.timedOut

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -284,26 +284,45 @@ enum GitHubStarCLI {
     }
 
     private static func waitUntilExit(_ process: Process, timeout: Duration) async throws {
-        try await withThrowingTaskGroup(of: Void.self) { group in
+        enum Outcome {
+            case exited(Int32)
+            case timedOut
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        let outcome = try await withThrowingTaskGroup(of: Outcome.self) { group in
             group.addTask {
-                try await Task.detached {
+                await Task.detached {
                     process.waitUntilExit()
-                    if process.terminationStatus != 0 {
-                        throw GitHubStarCLIError.commandFailed
-                    }
                 }.value
+                // Once the deadline has passed, timeout is authoritative even
+                // if SIGKILL makes the waiter observe a nonzero exit first.
+                guard clock.now < deadline else { return .timedOut }
+                return .exited(process.terminationStatus)
             }
             group.addTask {
-                try await Task.sleep(for: timeout)
+                try await clock.sleep(until: deadline)
                 if process.isRunning {
                     kill(process.processIdentifier, SIGKILL)
                 }
-                try Task.checkCancellation()
-                throw GitHubStarCLIError.timedOut
+                return .timedOut
             }
 
-            try await group.next()
+            guard let first = try await group.next() else {
+                throw GitHubStarCLIError.commandFailed
+            }
             group.cancelAll()
+            return first
+        }
+
+        switch outcome {
+        case .exited(0):
+            return
+        case .exited:
+            throw GitHubStarCLIError.commandFailed
+        case .timedOut:
+            throw GitHubStarCLIError.timedOut
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPromptCoordinator.swift
@@ -48,7 +48,9 @@ final class GitHubStarPromptCoordinator {
         now: @escaping () -> Date = Date.init,
         quietWindow: Duration = GitHubStarPromptCoordinator.quietWindow,
         presentationActive: Bool = false,
-        starExecutor: @escaping @Sendable (URL) async throws -> Void = GitHubStarCLI.star,
+        starExecutor: @escaping @Sendable (URL) async throws -> Void = { url in
+            try await GitHubStarCLI.star(url)
+        },
         waitForQuietWindow: @escaping @MainActor (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
         }
@@ -231,17 +233,30 @@ enum GitHubStarCLIError: Error {
 enum GitHubStarCLI {
     static let timeout: Duration = .seconds(8)
 
-    static func star(_ repositoryURL: URL) async throws {
+    static func star(
+        _ repositoryURL: URL,
+        executableURL overrideExecutableURL: URL? = nil
+    ) async throws {
         guard repositoryURL == GitHubCommunity.repositoryURL else {
             throw GitHubStarCLIError.invalidRepository
         }
-        guard let executable = executableURL() else {
+        guard let executable = overrideExecutableURL ?? executableURL() else {
             throw GitHubStarCLIError.executableNotFound
         }
 
         let process = Process()
         process.executableURL = executable
         process.arguments = apiArguments()
+
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        try await waitUntilExit(process, timeout: timeout)
+
+        guard process.terminationStatus == 0 else {
+            throw GitHubStarCLIError.commandFailed
+        }
     }
 
     static func apiArguments() -> [String] {

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -235,7 +235,7 @@ struct GitHubStarPromptCoordinatorTests {
 
         let clock = ContinuousClock()
         let start = clock.now
-        await #expect(throws: GitHubStarCLIError.self) {
+        await #expect(throws: GitHubStarCLIError.timedOut) {
             try await GitHubStarCLI.star(
                 GitHubCommunity.repositoryURL,
                 executableURL: executable,

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -172,6 +172,30 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(!prompt.isPresented)
     }
 
+    @Test("A successful direct star completes after transient hiding")
+    func transientlyHiddenDirectStarCompletesLocally() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let promptReference = PromptReference()
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { _ in
+                await promptReference.hidePrompt()
+            }
+        )
+        promptReference.prompt = prompt
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+
+        let directStarSucceeded = await prompt.attemptDirectStar()
+        #expect(directStarSucceeded)
+        #expect(defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
+        #expect(!prompt.isPresented)
+    }
+
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
     func windowLifecycleRestartsQuietWindow() async {
         let defaults = isolatedDefaults()
@@ -244,5 +268,11 @@ private final class PromptReference: @unchecked Sendable {
 
     func deferPrompt() async {
         await MainActor.run { prompt?.deferPrompt() }
+    }
+
+    func hidePrompt() async {
+        await MainActor.run {
+            prompt?.updatePresentationContext(.init(isBusy: true, hasBlockingSurface: false))
+        }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -101,6 +101,53 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(defaults.integer(forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions) == 35)
     }
 
+    @Test("A successful gh CLI star completes the invitation without a browser handoff")
+    func directStarCompletesLocally() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let recorder = DirectStarRecorder()
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { url in
+                await recorder.record(url)
+            }
+        )
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+
+        #expect(await prompt.attemptDirectStar())
+        #expect(await recorder.recordedURL() == GitHubCommunity.repositoryURL)
+        #expect(defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
+        #expect(!prompt.isPresented)
+        #expect(!prompt.isStarring)
+    }
+
+    @Test("A failed direct star preserves the browser invitation")
+    func directStarFailureFallsBackLater() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { _ in
+                throw GitHubStarCLIError.commandFailed
+            }
+        )
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+
+        let directStarSucceeded = await prompt.attemptDirectStar()
+        #expect(!directStarSucceeded)
+        #expect(!defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
+        #expect(prompt.isPresented)
+        #expect(!prompt.isStarring)
+    }
+
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
     func windowLifecycleRestartsQuietWindow() async {
         let defaults = isolatedDefaults()
@@ -153,5 +200,17 @@ private final class QuietWindowGate {
 
     func releaseNext() {
         waiters.removeFirst().resume()
+    }
+}
+
+private actor DirectStarRecorder {
+    private var url: URL?
+
+    func record(_ newValue: URL) {
+        url = newValue
+    }
+
+    func recordedURL() -> URL? {
+        url
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -148,6 +148,30 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(!prompt.isStarring)
     }
 
+    @Test("A direct star finishing after deferral does not override cadence")
+    func deferredDirectStarDoesNotCompleteInvitation() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let promptReference = PromptReference()
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { _ in
+                await promptReference.deferPrompt()
+            }
+        )
+        promptReference.prompt = prompt
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+
+        let directStarSucceeded = await prompt.attemptDirectStar()
+        #expect(!directStarSucceeded)
+        #expect(!defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
+        #expect(!prompt.isPresented)
+    }
+
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
     func windowLifecycleRestartsQuietWindow() async {
         let defaults = isolatedDefaults()
@@ -212,5 +236,13 @@ private actor DirectStarRecorder {
 
     func recordedURL() -> URL? {
         url
+    }
+}
+
+private final class PromptReference: @unchecked Sendable {
+    var prompt: GitHubStarPromptCoordinator?
+
+    func deferPrompt() async {
+        await MainActor.run { prompt?.deferPrompt() }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -196,6 +196,15 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(!prompt.isPresented)
     }
 
+    @Test("The gh star request pins the canonical host and authenticated-user route")
+    func ghStarArgumentsAreCanonical() {
+        #expect(GitHubStarCLI.apiArguments() == [
+            "api", "--method", "PUT", "--silent",
+            "--hostname", "github.com",
+            "user/starred/raullenchai/Rapid-MLX"
+        ])
+    }
+
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
     func windowLifecycleRestartsQuietWindow() async {
         let defaults = isolatedDefaults()

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -118,7 +118,7 @@ struct GitHubStarPromptCoordinatorTests {
         prompt.productValueDelivered(.chatReply)
         #expect(prompt.isPresented)
 
-        #expect(await prompt.attemptDirectStar())
+        #expect(await prompt.attemptDirectStar() == .starred)
         #expect(await recorder.recordedURL() == GitHubCommunity.repositoryURL)
         #expect(defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
         #expect(!prompt.isPresented)
@@ -141,8 +141,8 @@ struct GitHubStarPromptCoordinatorTests {
         prompt.productValueDelivered(.chatReply)
         #expect(prompt.isPresented)
 
-        let directStarSucceeded = await prompt.attemptDirectStar()
-        #expect(!directStarSucceeded)
+        let directStarResult = await prompt.attemptDirectStar()
+        #expect(directStarResult == .unavailable)
         #expect(!defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
         #expect(prompt.isPresented)
         #expect(!prompt.isStarring)
@@ -166,8 +166,8 @@ struct GitHubStarPromptCoordinatorTests {
         prompt.productValueDelivered(.chatReply)
         #expect(prompt.isPresented)
 
-        let directStarSucceeded = await prompt.attemptDirectStar()
-        #expect(!directStarSucceeded)
+        let directStarResult = await prompt.attemptDirectStar()
+        #expect(directStarResult == .unavailable)
         #expect(!defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
         #expect(!prompt.isPresented)
     }
@@ -190,8 +190,8 @@ struct GitHubStarPromptCoordinatorTests {
         prompt.productValueDelivered(.chatReply)
         #expect(prompt.isPresented)
 
-        let directStarSucceeded = await prompt.attemptDirectStar()
-        #expect(directStarSucceeded)
+        let directStarResult = await prompt.attemptDirectStar()
+        #expect(directStarResult == .starred)
         #expect(defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
         #expect(!prompt.isPresented)
     }
@@ -312,11 +312,31 @@ struct GitHubStarPromptCoordinatorTests {
 
         let firstAttempt = Task { await prompt.attemptDirectStar() }
         await gate.waitUntilEntered()
-        #expect(await prompt.attemptDirectStar() == false)
+        #expect(await prompt.attemptDirectStar() == .unavailable)
         await gate.release()
-        let firstAttemptSucceeded = await firstAttempt.value
-        #expect(firstAttemptSucceeded)
+        let firstAttemptResult = await firstAttempt.value
+        #expect(firstAttemptResult == .starred)
         #expect(!prompt.isStarring)
+    }
+
+    @Test("Cancelling a direct star does not trigger browser fallback")
+    func directStarCancellationIsDistinctFromFailure() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { _ in throw CancellationError() }
+        )
+
+        prompt.productValueDelivered(.chatReply)
+        let result = await prompt.attemptDirectStar()
+
+        #expect(result == .cancelled)
+        #expect(prompt.isPresented)
+        #expect(!prompt.isStarring)
+        #expect(!defaults.bool(forKey: GitHubStarPromptCoordinator.Keys.completed))
     }
 
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -205,6 +205,21 @@ struct GitHubStarPromptCoordinatorTests {
         ])
     }
 
+    @Test("The default gh executor launches, waits, and reports command status")
+    func ghStarExecutorRunsTheSubprocess() async {
+        try? await GitHubStarCLI.star(
+            GitHubCommunity.repositoryURL,
+            executableURL: URL(fileURLWithPath: "/usr/bin/true")
+        )
+
+        await #expect(throws: GitHubStarCLIError.self) {
+            try await GitHubStarCLI.star(
+                GitHubCommunity.repositoryURL,
+                executableURL: URL(fileURLWithPath: "/usr/bin/false")
+            )
+        }
+    }
+
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
     func windowLifecycleRestartsQuietWindow() async {
         let defaults = isolatedDefaults()

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -207,17 +207,68 @@ struct GitHubStarPromptCoordinatorTests {
 
     @Test("The default gh executor launches, waits, and reports command status")
     func ghStarExecutorRunsTheSubprocess() async {
-        try? await GitHubStarCLI.star(
-            GitHubCommunity.repositoryURL,
-            executableURL: URL(fileURLWithPath: "/usr/bin/true")
-        )
+        await #expect(throws: Never.self) {
+            try await GitHubStarCLI.star(
+                GitHubCommunity.repositoryURL,
+                executableURL: URL(fileURLWithPath: "/usr/bin/true")
+            )
+        }
 
-        await #expect(throws: GitHubStarCLIError.self) {
+        await #expect(throws: GitHubStarCLIError.commandFailed) {
             try await GitHubStarCLI.star(
                 GitHubCommunity.repositoryURL,
                 executableURL: URL(fileURLWithPath: "/usr/bin/false")
             )
         }
+    }
+
+    @Test("A hung gh child is force-stopped at the configured timeout")
+    func ghStarTimeoutKillsHungChild() async throws {
+        let executable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-star-hung-gh-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: executable) }
+        try Data("#!/bin/sh\nsleep 30\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executable.path
+        )
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        await #expect(throws: GitHubStarCLIError.self) {
+            try await GitHubStarCLI.star(
+                GitHubCommunity.repositoryURL,
+                executableURL: executable,
+                timeout: .milliseconds(100)
+            )
+        }
+        #expect(clock.now - start < .seconds(3))
+    }
+
+    @Test("A second direct star cannot start while the first is in flight")
+    func directStarReentryIsRejected() async {
+        let defaults = isolatedDefaults()
+        defaults.set(34, forKey: GitHubStarPromptCoordinator.Keys.totalSuccessfulActions)
+        let gate = DirectStarGate()
+        let prompt = GitHubStarPromptCoordinator(
+            defaults: defaults,
+            quietWindow: .zero,
+            presentationActive: true,
+            starExecutor: { _ in
+                await gate.wait()
+            }
+        )
+
+        prompt.productValueDelivered(.chatReply)
+        #expect(prompt.isPresented)
+
+        let firstAttempt = Task { await prompt.attemptDirectStar() }
+        await gate.waitUntilEntered()
+        #expect(await prompt.attemptDirectStar() == false)
+        await gate.release()
+        let firstAttemptSucceeded = await firstAttempt.value
+        #expect(firstAttemptSucceeded)
+        #expect(!prompt.isStarring)
     }
 
     @Test("Closing the window suspends presentation and reopening earns a new quiet window")
@@ -298,5 +349,28 @@ private final class PromptReference: @unchecked Sendable {
         await MainActor.run {
             prompt?.updatePresentationContext(.init(isBusy: true, hasBlockingSurface: false))
         }
+    }
+}
+
+private actor DirectStarGate {
+    private var entered = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func waitUntilEntered() async {
+        while !entered {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -245,6 +245,48 @@ struct GitHubStarPromptCoordinatorTests {
         #expect(clock.now - start < .seconds(3))
     }
 
+    @Test("Cancelling a gh star request terminates and reaps its child")
+    func ghStarCancellationKillsHungChild() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-star-cancel-\(UUID().uuidString)")
+        let executable = directory.appendingPathComponent("gh")
+        let pidFile = directory.appendingPathComponent("pid")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("#!/bin/sh\necho $$ > '\(pidFile.path)'\nsleep 30\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executable.path
+        )
+
+        let request = Task {
+            try await GitHubStarCLI.star(
+                GitHubCommunity.repositoryURL,
+                executableURL: executable,
+                timeout: .seconds(30)
+            )
+        }
+        let clock = ContinuousClock()
+        let pidDeadline = clock.now.advanced(by: .seconds(3))
+        while !FileManager.default.fileExists(atPath: pidFile.path), clock.now < pidDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidText))
+
+        request.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await request.value
+        }
+
+        let reapDeadline = clock.now.advanced(by: .seconds(3))
+        while kill(pid, 0) == 0, clock.now < reapDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(kill(pid, 0) == -1 && errno == ESRCH)
+    }
+
     @Test("A second direct star cannot start while the first is in flight")
     func directStarReentryIsRejected() async {
         let defaults = isolatedDefaults()

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -253,7 +253,8 @@ struct GitHubStarPromptCoordinatorTests {
         let pidFile = directory.appendingPathComponent("pid")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-        try Data("#!/bin/sh\necho $$ > '\(pidFile.path)'\nsleep 30\n".utf8).write(to: executable)
+        try Data("#!/bin/sh\nsleep 30 &\necho \"$$ $!\" > '\(pidFile.path)'\nwait\n".utf8)
+            .write(to: executable)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755],
             ofItemAtPath: executable.path
@@ -273,7 +274,10 @@ struct GitHubStarPromptCoordinatorTests {
         }
         let pidText = try String(contentsOf: pidFile, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let pid = try #require(pid_t(pidText))
+        let pids = try pidText.split(separator: " ").map {
+            try #require(pid_t($0))
+        }
+        #expect(pids.count == 2)
 
         request.cancel()
         await #expect(throws: CancellationError.self) {
@@ -281,10 +285,12 @@ struct GitHubStarPromptCoordinatorTests {
         }
 
         let reapDeadline = clock.now.advanced(by: .seconds(3))
-        while kill(pid, 0) == 0, clock.now < reapDeadline {
+        while pids.contains(where: { kill($0, 0) == 0 }), clock.now < reapDeadline {
             try await Task.sleep(for: .milliseconds(10))
         }
-        #expect(kill(pid, 0) == -1 && errno == ESRCH)
+        for pid in pids {
+            #expect(kill(pid, 0) == -1 && errno == ESRCH)
+        }
     }
 
     @Test("A second direct star cannot start while the first is in flight")

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptCoordinatorTests.swift
@@ -203,6 +203,11 @@ struct GitHubStarPromptCoordinatorTests {
             "--hostname", "github.com",
             "user/starred/raullenchai/Rapid-MLX"
         ])
+        #expect(GitHubStarCLI.trustedExecutablePaths == [
+            "/opt/homebrew/bin/gh",
+            "/usr/local/bin/gh",
+            "/usr/bin/gh"
+        ])
     }
 
     @Test("The default gh executor launches, waits, and reports command status")

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -67,6 +67,10 @@ struct GitHubStarPromptTests {
         #expect(!card.contains("@FocusState"))
         #expect(!card.contains(".keyboardShortcut"))
         #expect(!card.contains(".isModal"))
+        #expect(
+            card.components(separatedBy: ".disabled(prompt.isStarring)").count - 1 == 3,
+            "Star, Later, and close must all be disabled while the external mutation is in flight"
+        )
         #expect(coordinator.contains("NSEvent.addLocalMonitorForEvents(matching: [.keyDown])"))
         #expect(!coordinator.contains("URLSession"), "eligibility must not probe GitHub or the network")
     }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -71,6 +71,8 @@ struct GitHubStarPromptTests {
             card.components(separatedBy: ".disabled(prompt.isStarring)").count - 1 == 3,
             "Star, Later, and close must all be disabled while the external mutation is in flight"
         )
+        #expect(coordinator.contains("if let status = child.terminationStatusIfExited()"))
+        #expect(!coordinator.contains("guard clock.now < deadline"))
         #expect(coordinator.contains("NSEvent.addLocalMonitorForEvents(matching: [.keyDown])"))
         #expect(!coordinator.contains("URLSession"), "eligibility must not probe GitHub or the network")
     }

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -43,6 +43,8 @@ struct GitHubStarPromptTests {
 
         #expect(card.contains("Enjoying Rapid-MLX?"))
         #expect(card.contains("Rapid-MLX is open source."))
+        #expect(card.contains("Text(\"Star on GitHub\")"))
+        #expect(!card.contains("Text(\"Open GitHub\")"))
         #expect(card.contains(".frame(width: 360)"))
         #expect(card.contains(".frame(width: 84, height: RapidTheme.ControlHeight.medium)"))
         #expect(card.contains(".padding(14)"))


### PR DESCRIPTION
## Why

After users have completed enough successful work to see the optional GitHub invitation, authenticated GitHub CLI users should be able to complete the star action without a browser round trip. Users without a usable CLI must keep the existing browser fallback.

## User-visible goal

One deliberate click on the invitation attempts to star the canonical Rapid-MLX repository through the local `gh` CLI; if that cannot be completed, the app opens the existing repository page instead.

## Scope

- Run one bounded, canonical `gh api` request with no shell interpolation.
- Preserve the browser handoff for missing, unauthenticated, failed, or timed-out CLI execution.
- Prevent duplicate in-flight attempts and preserve invitation cadence when the card is deferred or hidden.
- Add focused coordinator and subprocess lifecycle tests.

## Non-goals

- No bundled GitHub credentials, OAuth flow, account probing, telemetry change, repository URL input, or changes to when the invitation becomes eligible.
- No background star attempt without the user pressing the invitation action.

## Acceptance criteria

- The only writable target is `github.com/user/starred/raullenchai/Rapid-MLX`.
- CLI failure leaves the invitation eligible and falls back to the browser.
- A hung process is bounded and duplicate clicks cannot create concurrent requests.
- The visible and accessibility copy accurately describes the action before it mutates the user account.

## Testing

- `swift build`
- `swift test --filter "GitHubStarPromptCoordinatorTests|GitHubStarPromptTests"`
- Full focused Swift regressions completed; two unrelated local subprocess/load flakes passed on focused rerun.
- `SKIP_SIDECAR=1 bash scripts/build.sh`