### PR TITLE
fix: compare MTP ratio at exported precision

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -423,10 +423,14 @@ def _eval_metrics(seq, pre_map, post_map):
             cum_c = post_c[1] if post_c is not None else None
             if cum_a is not None and cum_a > 0 and cum_c is not None:
                 expect = cum_c / cum_a
-                if abs(expect - ratio) > 1e-6:
+                # The Prometheus exporter intentionally rounds this gauge to
+                # four decimals. Compare at that wire precision; a tighter
+                # epsilon rejects healthy fractions such as 162/166 because
+                # 0.9759 differs from the unrounded value by ~3.6e-6.
+                if ratio != round(expect, 4):
                     failures.append(
                         f"{name}.metrics_expected[{i}]: accept_ratio={ratio} "
-                        f"inconsistent with cumulative accepts/attempts "
+                        f"inconsistent with rounded cumulative accepts/attempts "
                         f"({cum_c}/{cum_a}={expect})"
                     )
             # The per-window ratio must be strictly positive.

--- a/tests/test_top10_sequences_schema.py
+++ b/tests/test_top10_sequences_schema.py
@@ -205,6 +205,49 @@ def test_mtp_probe_requests_deterministic_sustained_decode() -> None:
     assert "1 through 100" in prompt
 
 
+def test_mtp_ratio_consistency_uses_prometheus_wire_precision() -> None:
+    """The exported gauge is rounded to four decimals; counters are exact."""
+    namespace = {"__name__": "sequence_driver_contract_test"}
+    exec(
+        compile(_sequence_driver_source(), str(_AGENT_SMOKE_FILE), "exec"),
+        namespace,
+    )
+    parse = namespace["_parse_series"]
+    evaluate = namespace["_eval_metrics"]
+    labels = 'family="qwen3.8-27b-4bit",method="mtp"'
+    pre = parse(
+        f"rapid_mlx_spec_decode_attempts_total{{{labels}}} 0\n"
+        f"rapid_mlx_spec_decode_accepts_total{{{labels}}} 0\n"
+        f"rapid_mlx_spec_decode_accept_ratio{{{labels}}} 0.0\n"
+    )
+    counters = (
+        f"rapid_mlx_spec_decode_attempts_total{{{labels}}} 166\n"
+        f"rapid_mlx_spec_decode_accepts_total{{{labels}}} 162\n"
+    )
+    seq = {
+        "name": "mtp-ratio",
+        "metrics_expected": [
+            {
+                "metric": "rapid_mlx_spec_decode_accept_ratio",
+                "family": "qwen3.8-27b-4bit",
+                "method": "mtp",
+            }
+        ],
+    }
+
+    rounded = parse(
+        counters + f"rapid_mlx_spec_decode_accept_ratio{{{labels}}} 0.9759\n"
+    )
+    assert evaluate(seq, pre, rounded) == []
+
+    inconsistent = parse(
+        counters + f"rapid_mlx_spec_decode_accept_ratio{{{labels}}} 0.9758\n"
+    )
+    failures = evaluate(seq, pre, inconsistent)
+    assert len(failures) == 1
+    assert "inconsistent with rounded cumulative" in failures[0]
+
+
 @pytest.fixture(scope="module")
 def spec() -> dict:
     assert _SEQUENCES_FILE.is_file(), f"missing {_SEQUENCES_FILE}"


### PR DESCRIPTION
## Why

The sustained RC1 MTP probe proved healthy engagement (166 attempts, 162 accepts), but the gate compared the four-decimal Prometheus gauge `0.9759` with the unrounded counter fraction `162/166 = 0.975903614…` using a `1e-6` tolerance. The valid exporter rounding difference (~3.6e-6) falsely failed the release after every functional check passed.

## Scope

- compare the accept-ratio gauge with the exact counters after applying the exporter's documented four-decimal wire precision
- add the exact 162/166 RC regression and a nearby inconsistent negative control

## Non-goals

- no engine, scheduler, metric exporter, threshold, model, or workflow changes
- no weakening of attempts/accepts/tokens-saved engagement requirements

## Design precedent

A verifier must compare a derived gauge at the precision actually exported on the wire. Exact counters remain authoritative; rounding them through the same representation distinguishes expected serialization loss from a genuinely inconsistent gauge.

## Verification

- RC evidence: HTTP 200, 166 attempts, 162 accepts, exported ratio 0.9759; all residency steps passed
- `bash -n tests/integrations/agent_smoke.sh`
- `/opt/homebrew/bin/python3.12 -m pytest -q tests/test_top10_sequences_schema.py tests/test_release_candidate_workflows.py` (25 passed)
- negative control `0.9758` remains rejected
- `git diff --check`

Fixes #2421