### PR TITLE
fix: publish promoted desktop candidates

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -567,7 +567,16 @@ jobs:
     needs: desktop-ready
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: startsWith(github.ref, 'refs/tags/')
+    # A provenance-bound promotion dispatch is the canonical auto-release lane.
+    # GitHub does not reliably expose its selected tag through ``github.ref``
+    # in job-level expressions, so key publication eligibility to the two
+    # required promotion inputs as well. An input-free manual dispatch remains
+    # a non-publishing dry run.
+    if: >-
+      startsWith(github.ref, 'refs/tags/')
+      || (github.event_name == 'workflow_dispatch'
+          && inputs.promote_run_id != ''
+          && inputs.promote_sha != '')
     steps:
       - name: Download the notarised DMG artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -702,7 +711,11 @@ jobs:
     runs-on: ubuntu-latest
     # Includes the turnstyle queue plus final updater/Release publication.
     timeout-minutes: 120
-    if: startsWith(github.ref, 'refs/tags/')
+    if: >-
+      startsWith(github.ref, 'refs/tags/')
+      || (github.event_name == 'workflow_dispatch'
+          && inputs.promote_run_id != ''
+          && inputs.promote_sha != '')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -52,7 +52,10 @@ struct ReleaseManifestWorkflowTests {
     @Test("missing distribution config fails instead of silently skipping")
     func missingConfigFailsClosed() throws {
         let job = Self.mirrorJob
-        #expect(job.contains("if: startsWith(github.ref, 'refs/tags/')"))
+        #expect(job.contains("startsWith(github.ref, 'refs/tags/')"))
+        #expect(job.contains("github.event_name == 'workflow_dispatch'"))
+        #expect(job.contains("inputs.promote_run_id != ''"))
+        #expect(job.contains("inputs.promote_sha != ''"))
         #expect(job.contains("tagged releases require updater fallback publishing"))
         #expect(!job.contains("skipping the optional CDN mirror"))
         for requiredSetting in [

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -185,6 +185,19 @@ lacks "$PROMOTE" 'desktop-releasable' \
 lacks "$PROMOTE" 'notarize.sh' \
   "promotion lane never re-notarizes or repacks"
 
+MIRROR_JOB=$(sed -n '/^  mirror-dist:/,/^  publish-updater-fallback:/p' "$RAPID_RELEASE")
+PUBLISH_JOB=$(sed -n '/^  publish-updater-fallback:/,$p' "$RAPID_RELEASE")
+for JOB in "$MIRROR_JOB" "$PUBLISH_JOB"; do
+  contains "$JOB" "startsWith(github.ref, 'refs/tags/')" \
+    "tag-triggered Desktop releases publish"
+  contains "$JOB" "github.event_name == 'workflow_dispatch'" \
+    "promotion dispatches are recognized as publishing lanes"
+  contains "$JOB" "inputs.promote_run_id != ''" \
+    "publishing promotion requires an exact producer run"
+  contains "$JOB" "inputs.promote_sha != ''" \
+    "publishing promotion requires an exact source SHA"
+done
+
 # A same-SHA tag claim may no-op after a prior failed/missed Desktop workflow.
 # The engine must therefore wait for exact tagged Desktop publication evidence,
 # not treat ref identity alone as proof that the DMG shipped.

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -103,10 +103,7 @@ def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
         "&& inputs.promote_sha != '')"
     )
     assert " ".join(jobs["mirror-dist"]["if"].split()) == publish_condition
-    assert (
-        " ".join(jobs["publish-updater-fallback"]["if"].split())
-        == publish_condition
-    )
+    assert " ".join(jobs["publish-updater-fallback"]["if"].split()) == publish_condition
 
 
 def test_release_preflight_is_dispatch_only_and_exact_head_bound():

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -96,6 +96,17 @@ def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
         "desktop-ready",
         "mirror-dist",
     ]
+    publish_condition = (
+        "startsWith(github.ref, 'refs/tags/') "
+        "|| (github.event_name == 'workflow_dispatch' "
+        "&& inputs.promote_run_id != '' "
+        "&& inputs.promote_sha != '')"
+    )
+    assert " ".join(jobs["mirror-dist"]["if"].split()) == publish_condition
+    assert (
+        " ".join(jobs["publish-updater-fallback"]["if"].split())
+        == publish_condition
+    )
 
 
 def test_release_preflight_is_dispatch_only_and_exact_head_bound():


### PR DESCRIPTION
## Why

The exact Desktop candidate promotion lane could finish green while both publication jobs were skipped. Auto-release dispatches the Desktop workflow with a provenance-bound producer run and source SHA, but the publication jobs only recognized tag-triggered refs. The parent release then failed waiting for a GitHub Release that the child never created.

## What

- Treat an exact promotion dispatch (`promote_run_id` and `promote_sha` both present) as a publishing lane for `mirror-dist` and `publish-updater-fallback`.
- Preserve tag-triggered publication.
- Preserve input-free manual dispatch as a non-publishing dry run.
- Lock all three modes into Python and shell workflow-contract tests.

## Design precedent

GitHub Actions supports typed `workflow_dispatch` inputs as explicit workflow contracts. Publication eligibility now follows the same authenticated, provenance-verified inputs that select the promotion lane, rather than inferring dispatch intent only from ref formatting. The downstream `desktop-ready` dependency still requires the exact tag, producer run, source SHA, signing, notarization, and artifact checks to pass before any publication job can start.

## Verification

- `python3 -m pytest -q tests/test_release_candidate_workflows.py` (10 passed)
- `bash tests/release/test_desktop_release_promotion.sh` (114 passed)
- `git diff --check`

Fixes #2774