### PR TITLE
fix(desktop): clarify memory-limited photo mode

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
@@ -645,13 +645,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This model's vision mode needs more memory than this Mac has. Choose a different vision-capable model to add photos."
+            "value" : "Text chat is ready with this model. Photo mode needs more memory than this Mac has. Choose a vision model with lower memory requirements to add photos."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+            "value" : "此模型的文字聊天可以正常使用。照片模式需要的内存超过这台 Mac 的容量；如需添加照片，请选择内存需求更低的视觉模型。"
           }
         }
       }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerModelProfile.swift
@@ -315,7 +315,7 @@ struct ImageInputAvailability: Equatable, Sendable {
             case .speculativeDecode:
                 "This model is running text-only because speculative decoding is on. Turn it off in Settings → Performance to add photos."
             case .visionMemoryInsufficient:
-                "This model's vision mode needs more memory than this Mac has. Choose a different vision-capable model to add photos."
+                "Text chat is ready with this model. Photo mode needs more memory than this Mac has. Choose a vision model with lower memory requirements to add photos."
             case .visionRuntimeUnsupported:
                 "This model is running text-only because its vision runtime isn't supported here. Choose a different vision-capable model to add photos."
             case .visionFeaturesUnavailable:

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -170,6 +170,39 @@ private func copySanitizedToPasteboard(_ raw: String) {
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(ChatTextSanitizer.sanitizeForPasteboard(raw), forType: .string)
 }
+
+/// Transient guidance created by a rejected photo attempt.
+///
+/// The availability snapshot prevents a message about an old serving lane
+/// from surviving a same-alias restart onto a different lane. Alias and
+/// conversation changes still dismiss explicitly because they are navigation
+/// even when the two contexts happen to expose identical capabilities.
+struct PhotoCapabilityNotice: Equatable {
+    struct Availability: Equatable {
+        let supportsImageInput: Bool
+        let unavailableMessage: String?
+    }
+
+    private(set) var message: String?
+    private var presentedAvailability: Availability?
+
+    mutating func present(_ message: String, availability: Availability) {
+        self.message = message
+        presentedAvailability = availability
+    }
+
+    mutating func reconcile(with availability: Availability) {
+        guard let presentedAvailability,
+              presentedAvailability != availability else { return }
+        dismiss()
+    }
+
+    mutating func dismiss() {
+        message = nil
+        presentedAvailability = nil
+    }
+}
+
 /// Main chat surface. ChatGPT Desktop's layout: messages scroll the
 /// top region, the compose bar is pinned at the bottom. Streaming
 /// responses pin the scroll to the trailing edge so the user sees
@@ -226,7 +259,7 @@ struct ChatView: View {
     /// failure. Keep it outside the conversation-keyed attachment draft so it
     /// can use an informational treatment and disappear as soon as the user
     /// continues with text, another conversation, or another model.
-    @State private var imageInputNotice: String?
+    @State private var photoCapabilityNotice = PhotoCapabilityNotice()
     @State private var isAttachmentDropTarget = false
     @State private var composeFocusToken: Int = 0
     /// Incremented every time the user tries to send while gated. Drives
@@ -257,6 +290,12 @@ struct ChatView: View {
     private var attachmentDraft: ChatAttachmentDraft {
         get { attachmentDrafts[viewModel.activeConversationID] }
         nonmutating set { attachmentDrafts[viewModel.activeConversationID] = newValue }
+    }
+    private var photoAvailability: PhotoCapabilityNotice.Availability {
+        PhotoCapabilityNotice.Availability(
+            supportsImageInput: supportsImageInput,
+            unavailableMessage: imageInputUnavailableMessage
+        )
     }
 
     var body: some View {
@@ -307,12 +346,13 @@ struct ChatView: View {
         .onChange(of: viewModel.conversations.map(\.id)) { _, _ in pruneAttachmentDrafts() }
         .onChange(of: viewModel.activeConversationID) { _, _ in
             pruneAttachmentDrafts()
-            imageInputNotice = nil
+            photoCapabilityNotice.dismiss()
         }
-        .onChange(of: alias) { _, _ in imageInputNotice = nil }
-        .onChange(of: draft) { _, newDraft in
-            if !newDraft.isEmpty { imageInputNotice = nil }
+        .onChange(of: alias) { _, _ in photoCapabilityNotice.dismiss() }
+        .onChange(of: photoAvailability) { _, availability in
+            photoCapabilityNotice.reconcile(with: availability)
         }
+        .onChange(of: draft) { _, _ in photoCapabilityNotice.dismiss() }
     }
 
     // MARK: - Transcript
@@ -635,8 +675,8 @@ struct ChatView: View {
                 InlineNotice(message: attachmentNotice, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
-            } else if let imageInputNotice {
-                InlineNotice(message: imageInputNotice, tone: .info)
+            } else if let message = photoCapabilityNotice.message {
+                InlineNotice(message: message, tone: .info)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
             }
@@ -929,7 +969,7 @@ struct ChatView: View {
         // flashes and VoiceOver speaks the same sentence the Send
         // tooltip carries.
         guard acknowledgeIfNotReady() else { return }
-        imageInputNotice = nil
+        photoCapabilityNotice.dismiss()
         draft = ""
         let submission = attachmentDraft.takeSubmission()
         composeFocusToken &+= 1
@@ -1053,7 +1093,7 @@ struct ChatView: View {
     @discardableResult
     private func addAttachmentURLs(_ urls: [URL]) -> Bool {
         guard !attachmentDraft.isImportingFiles else { return false }
-        imageInputNotice = nil
+        photoCapabilityNotice.dismiss()
         // Filter before splitting, so images and documents get the same
         // answer to "is this already here". Re-attaching is not merely
         // redundant for a document: the per-message character budget is split
@@ -1275,9 +1315,14 @@ struct ChatView: View {
     }
 
     private func rejectImageInputForCurrentModel() {
-        imageInputNotice = imageInputUnavailableMessage
+        let message = imageInputUnavailableMessage
             ?? "This model doesn't support photos. Choose a vision-capable model to add one."
-        VoiceOverAnnouncer.announce(imageInputNotice ?? "This model doesn't support images.")
+        // The newest attempt owns the single notice slot. Leaving an older
+        // attachment error in place would make VoiceOver announce one fact
+        // while sighted users keep seeing another.
+        attachmentDraft.notice = nil
+        photoCapabilityNotice.present(message, availability: photoAvailability)
+        VoiceOverAnnouncer.announce(message)
     }
 
     /// The shared lifecycle gate for every path that would start a turn:

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -474,6 +474,7 @@ struct ChatView: View {
                             // could kick off a turn the Send button is refusing
                             // to allow one row below.
                             guard acknowledgeIfNotReady() else { return false }
+                            photoCapabilityNotice.dismiss()
                             return viewModel.editUserMessage(
                                 id: message.id,
                                 newContent: newContent,
@@ -483,6 +484,7 @@ struct ChatView: View {
                         },
                         onRetry: {
                             guard acknowledgeIfNotReady() else { return false }
+                            photoCapabilityNotice.dismiss()
                             return viewModel.retryAssistantMessage(
                                 id: message.id,
                                 alias: alias,
@@ -997,6 +999,7 @@ struct ChatView: View {
     private func sendSuggestion(_ text: String) {
         guard !viewModel.isStreaming, !attachmentDraft.isImportingFiles else { return }
         guard acknowledgeIfNotReady() else { return }
+        photoCapabilityNotice.dismiss()
         composeFocusToken &+= 1
         viewModel.send(text, alias: alias, supportsImageInput: supportsImageInput)
     }
@@ -1069,6 +1072,7 @@ struct ChatView: View {
     }
 
     private func choosePhotos() {
+        photoCapabilityNotice.dismiss()
         let panel = NSOpenPanel()
         // ImageIO normalizes native still-image formats at the shared draft
         // boundary; the picker must expose the same contract as paste/drop.
@@ -1081,6 +1085,7 @@ struct ChatView: View {
     }
 
     private func chooseFiles() {
+        photoCapabilityNotice.dismiss()
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.pdf, .commaSeparatedText, .plainText]
         panel.allowsMultipleSelection = true

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -222,6 +222,11 @@ struct ChatView: View {
 
     @State private var draft: String = ""
     @State private var attachmentDrafts = ChatAttachmentDraftStore()
+    /// A rejected photo is a capability explanation, not an attachment
+    /// failure. Keep it outside the conversation-keyed attachment draft so it
+    /// can use an informational treatment and disappear as soon as the user
+    /// continues with text, another conversation, or another model.
+    @State private var imageInputNotice: String?
     @State private var isAttachmentDropTarget = false
     @State private var composeFocusToken: Int = 0
     /// Incremented every time the user tries to send while gated. Drives
@@ -300,7 +305,14 @@ struct ChatView: View {
             composeFocusToken &+= 1
         }
         .onChange(of: viewModel.conversations.map(\.id)) { _, _ in pruneAttachmentDrafts() }
-        .onChange(of: viewModel.activeConversationID) { _, _ in pruneAttachmentDrafts() }
+        .onChange(of: viewModel.activeConversationID) { _, _ in
+            pruneAttachmentDrafts()
+            imageInputNotice = nil
+        }
+        .onChange(of: alias) { _, _ in imageInputNotice = nil }
+        .onChange(of: draft) { _, newDraft in
+            if !newDraft.isEmpty { imageInputNotice = nil }
+        }
     }
 
     // MARK: - Transcript
@@ -623,6 +635,10 @@ struct ChatView: View {
                 InlineNotice(message: attachmentNotice, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
+            } else if let imageInputNotice {
+                InlineNotice(message: imageInputNotice, tone: .info)
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
             // One input, not a pill containing a second pill.
             //
@@ -913,6 +929,7 @@ struct ChatView: View {
         // flashes and VoiceOver speaks the same sentence the Send
         // tooltip carries.
         guard acknowledgeIfNotReady() else { return }
+        imageInputNotice = nil
         draft = ""
         let submission = attachmentDraft.takeSubmission()
         composeFocusToken &+= 1
@@ -1036,6 +1053,7 @@ struct ChatView: View {
     @discardableResult
     private func addAttachmentURLs(_ urls: [URL]) -> Bool {
         guard !attachmentDraft.isImportingFiles else { return false }
+        imageInputNotice = nil
         // Filter before splitting, so images and documents get the same
         // answer to "is this already here". Re-attaching is not merely
         // redundant for a document: the per-message character budget is split
@@ -1257,9 +1275,9 @@ struct ChatView: View {
     }
 
     private func rejectImageInputForCurrentModel() {
-        attachmentDraft.notice = imageInputUnavailableMessage
+        imageInputNotice = imageInputUnavailableMessage
             ?? "This model doesn't support photos. Choose a vision-capable model to add one."
-        VoiceOverAnnouncer.announce(attachmentDraft.notice ?? "This model doesn't support images.")
+        VoiceOverAnnouncer.announce(imageInputNotice ?? "This model doesn't support images.")
     }
 
     /// The shared lifecycle gate for every path that would start a turn:

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -490,8 +490,33 @@ struct ChatAttachmentDraftTests {
         #expect(stripped.contains(
             "attachmentDrafts.finishFileImport(request:importRequest,outcome.0,notice:notice)"
         ))
-        #expect(stripped.contains(".onChange(of:viewModel.activeConversationID){_,_inpruneAttachmentDrafts()}"))
+        #expect(stripped.contains(
+            ".onChange(of:viewModel.activeConversationID){_,_inpruneAttachmentDrafts()imageInputNotice=nil}"
+        ))
         #expect(stripped.contains(".onChange(of:viewModel.conversations.map(\\.id)){_,_inpruneAttachmentDrafts()}"))
+    }
+
+    @Test("Photo capability notices stay informational and transient")
+    func photoCapabilityNoticeWiring() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/Rapid/UI/ChatView.swift"),
+            encoding: .utf8
+        )
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(source)
+
+        #expect(stripped.contains("@StateprivatevarimageInputNotice:String?"))
+        #expect(stripped.contains("InlineNotice(message:imageInputNotice,tone:.info)"))
+        #expect(stripped.contains("InlineNotice(message:attachmentNotice,tone:.error)"))
+        #expect(stripped.contains("imageInputNotice=imageInputUnavailableMessage??"))
+        #expect(!stripped.contains("attachmentDraft.notice=imageInputUnavailableMessage??"))
+        #expect(stripped.contains(".onChange(of:alias){_,_inimageInputNotice=nil}"))
+        #expect(stripped.contains("if!newDraft.isEmpty{imageInputNotice=nil}"))
+        #expect(stripped.contains("guardacknowledgeIfNotReady()else{return}imageInputNotice=nil"))
     }
 
     private func makeImage(name: String, bytes: Int = 4) throws -> ChatImageAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -491,7 +491,7 @@ struct ChatAttachmentDraftTests {
             "attachmentDrafts.finishFileImport(request:importRequest,outcome.0,notice:notice)"
         ))
         #expect(stripped.contains(
-            ".onChange(of:viewModel.activeConversationID){_,_inpruneAttachmentDrafts()imageInputNotice=nil}"
+            ".onChange(of:viewModel.activeConversationID){_,_inpruneAttachmentDrafts()photoCapabilityNotice.dismiss()}"
         ))
         #expect(stripped.contains(".onChange(of:viewModel.conversations.map(\\.id)){_,_inpruneAttachmentDrafts()}"))
     }
@@ -509,14 +509,41 @@ struct ChatAttachmentDraftTests {
         let stripped = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(source)
 
-        #expect(stripped.contains("@StateprivatevarimageInputNotice:String?"))
-        #expect(stripped.contains("InlineNotice(message:imageInputNotice,tone:.info)"))
+        #expect(stripped.contains("@StateprivatevarphotoCapabilityNotice=PhotoCapabilityNotice()"))
+        #expect(stripped.contains("InlineNotice(message:message,tone:.info)"))
         #expect(stripped.contains("InlineNotice(message:attachmentNotice,tone:.error)"))
-        #expect(stripped.contains("imageInputNotice=imageInputUnavailableMessage??"))
+        #expect(stripped.contains("attachmentDraft.notice=nilphotoCapabilityNotice.present(message,availability:photoAvailability)"))
         #expect(!stripped.contains("attachmentDraft.notice=imageInputUnavailableMessage??"))
-        #expect(stripped.contains(".onChange(of:alias){_,_inimageInputNotice=nil}"))
-        #expect(stripped.contains("if!newDraft.isEmpty{imageInputNotice=nil}"))
-        #expect(stripped.contains("guardacknowledgeIfNotReady()else{return}imageInputNotice=nil"))
+        #expect(stripped.contains(".onChange(of:alias){_,_inphotoCapabilityNotice.dismiss()}"))
+        #expect(stripped.contains(".onChange(of:photoAvailability){_,availabilityinphotoCapabilityNotice.reconcile(with:availability)}"))
+        #expect(stripped.contains(".onChange(of:draft){_,_inphotoCapabilityNotice.dismiss()}"))
+        #expect(stripped.contains("guardacknowledgeIfNotReady()else{return}photoCapabilityNotice.dismiss()"))
+    }
+
+    @Test("Photo capability guidance expires when same-alias availability changes")
+    func photoCapabilityNoticeReconcilesAvailability() {
+        let textOnly = PhotoCapabilityNotice.Availability(
+            supportsImageInput: false,
+            unavailableMessage: "Photo mode needs more memory."
+        )
+        var notice = PhotoCapabilityNotice()
+        notice.present("Text chat is ready.", availability: textOnly)
+
+        notice.reconcile(with: textOnly)
+        #expect(notice.message == "Text chat is ready.")
+
+        notice.reconcile(with: PhotoCapabilityNotice.Availability(
+            supportsImageInput: true,
+            unavailableMessage: nil
+        ))
+        #expect(notice.message == nil)
+
+        notice.present("Old remedy", availability: textOnly)
+        notice.reconcile(with: PhotoCapabilityNotice.Availability(
+            supportsImageInput: false,
+            unavailableMessage: "A new lane-specific remedy"
+        ))
+        #expect(notice.message == nil)
     }
 
     private func makeImage(name: String, bytes: Int = 4) throws -> ChatImageAttachment {

--- a/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatAttachmentDraftTests.swift
@@ -518,6 +518,11 @@ struct ChatAttachmentDraftTests {
         #expect(stripped.contains(".onChange(of:photoAvailability){_,availabilityinphotoCapabilityNotice.reconcile(with:availability)}"))
         #expect(stripped.contains(".onChange(of:draft){_,_inphotoCapabilityNotice.dismiss()}"))
         #expect(stripped.contains("guardacknowledgeIfNotReady()else{return}photoCapabilityNotice.dismiss()"))
+        #expect(stripped.contains("guardacknowledgeIfNotReady()else{returnfalse}photoCapabilityNotice.dismiss()returnviewModel.editUserMessage"))
+        #expect(stripped.contains("guardacknowledgeIfNotReady()else{returnfalse}photoCapabilityNotice.dismiss()returnviewModel.retryAssistantMessage"))
+        #expect(stripped.contains("privatefuncsendSuggestion(_text:String){guard!viewModel.isStreaming,!attachmentDraft.isImportingFileselse{return}guardacknowledgeIfNotReady()else{return}photoCapabilityNotice.dismiss()"))
+        #expect(stripped.contains("privatefuncchoosePhotos(){photoCapabilityNotice.dismiss()letpanel=NSOpenPanel()"))
+        #expect(stripped.contains("privatefuncchooseFiles(){photoCapabilityNotice.dismiss()letpanel=NSOpenPanel()"))
     }
 
     @Test("Photo capability guidance expires when same-alias availability changes")

--- a/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalizationTests.swift
@@ -194,7 +194,7 @@ struct LocalizationTests {
         )
         #expect(
             memory.unavailableMessage
-                == "此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+                == "此模型的文字聊天可以正常使用。照片模式需要的内存超过这台 Mac 的容量；如需添加照片，请选择内存需求更低的视觉模型。"
         )
 
         let legacy = ImageInputAvailability.resolve(

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -320,7 +320,8 @@ final class ServerModelProfileTests {
         // not model size: a smaller quant of the same model hits the identical
         // floor and freeing memory changes nothing. The only remedy the user
         // can apply is a different vision-capable model.
-        #expect(message.contains("different vision-capable model"))
+        #expect(message.hasPrefix("Text chat is ready"))
+        #expect(message.contains("lower memory requirements"))
         #expect(message != Self.genericLaneCopy)
     }
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4132,7 +4132,7 @@ flow_localized_photo_hint() {
     dismiss_first_run
     start_model
 
-    local expected="此模型的视觉模式需要的内存超过这台 Mac 的容量。要添加照片，请选择另一个支持视觉的模型。"
+    local expected="此模型的文字聊天可以正常使用。照片模式需要的内存超过这台 Mac 的容量；如需添加照片，请选择内存需求更低的视觉模型。"
     local localized=0
     for _ in {1..40}; do
         see_main "$OUT/zh-main.json"
@@ -4156,6 +4156,24 @@ flow_localized_photo_hint() {
            | select(.identifier == "ContentView.Settings" and .description == "设置")' \
         "$OUT/zh-menu.json" >/dev/null \
         || die "the release-shaped app did not load its compiled zh-Hans resources"
+
+    # The disabled menu row explains the capability before an attempt; paste
+    # proves the mounted chat surface treats the same fact as a transient
+    # capability notice while keeping text chat usable.
+    press "$OUT/zh-menu.json" ChatView.AddAttachments "$OUT/zh-menu-close.json"
+    local fixture="$ROOT/Tests/RapidTests/__Snapshots__/cheetah-logo-28.png"
+    "$AX_DRIVER" paste-file "$APP_PID" rapid.chat.compose "$fixture" \
+        > "$OUT/zh-photo-paste.json"
+    wait_tree_text "$expected" "$OUT/zh-photo-notice.json" 40
+    send_prompt "Text chat remains available" zh-text-after-photo
+    wait_send_idle "$OUT/zh-text-after-photo-complete.json"
+    jq -e --arg expected "$expected" '
+        [.data.ui_elements[]?
+         | select([(.title // ""), (.value // ""), (.description // "")]
+                  | join(" ") | contains($expected))]
+        | length == 0
+    ' "$OUT/zh-text-after-photo-complete.json" >/dev/null \
+        || die "the photo capability notice persisted after a successful text turn"
 
     cleanup_persona
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4167,6 +4167,8 @@ flow_localized_photo_hint() {
     wait_tree_text "$expected" "$OUT/zh-photo-notice.json" 40
     send_prompt "Text chat remains available" zh-text-after-photo
     wait_send_idle "$OUT/zh-text-after-photo-complete.json"
+    assert_tree_text "$OUT/zh-text-after-photo-complete.json" "Text chat remains available"
+    assert_tree_text "$OUT/zh-text-after-photo-complete.json" "deterministic content"
     jq -e --arg expected "$expected" '
         [.data.ui_elements[]?
          | select([(.title // ""), (.value // ""), (.description // "")]


### PR DESCRIPTION
## Why

On lower-memory Macs, a vision-capable model can remain fully usable for text while its photo lane is unavailable. The current red attachment error makes the entire model appear broken and leaves users unsure whether text chat still works.

## What

- lead the memory-limited photo copy with the available path: text chat is ready
- render rejected-photo capability guidance as an informational notice, while preserving error styling for genuine attachment failures
- keep visible and VoiceOver guidance synchronized when a newer attachment action replaces an older error
- clear transient guidance across typing, send, suggestion, Edit/Retry, picker, conversation, model, and same-alias serving-lane transitions
- update English and Simplified Chinese catalog values
- extend the GUI journey to prove a rejected photo does not block a completed text turn

## Design precedent

The composer already separates readiness guidance from turn failures and uses the shared informational notice treatment for non-destructive state explanations. This change applies the same pattern to photo capability: available functionality first, a precise limitation second, and a concrete recovery path, without conflating capability with failure.

## Non-goals

- changing the engine vision-memory floor
- enabling photos when the engine reports a text-only serving lane
- changing model scheduling, loading, or inference behavior

## Verification

- `swift test --package-path apps/rapid-mac --filter ServerModelProfileTests` (46 passed)
- `swift test --package-path apps/rapid-mac --filter ChatAttachmentDraftTests` (23 passed)
- `swift test --package-path apps/rapid-mac --filter LocalizationTests` (5 passed)
- `python3.12 -m scripts.pr_validate 2778` (MERGE-SAFE: 19,903 passed, 116 skipped, no failures)
- independent Codex review round 3: LGTM
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `jq empty apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings`
- `git diff --check`

Fixes #2777