### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,56 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.2] — 2026-08-30
+
+Rapid-MLX 0.13.2 makes long-running local assistants faster and more reliable,
+improves offline speech and Desktop safety, and promotes the exact signed
+Desktop candidate that passed release validation.
+
+### Added
+
+- **Opt-in native MTP for Qwen3.8 Flash-Next.** Target verification and atomic
+  recurrent-state rollback raise measured decode throughput by 36–42% across
+  128-token through 32K-context workloads while constrained requests retain
+  ordinary decoding.
+- **Conversation titles and follow-up suggestions.** Completed local chats can
+  derive a short title and offer three optional next steps without replacing a
+  user rename or displaying malformed output.
+- **Privacy-bounded activation milestones.** Desktop records the first
+  successful chat, dictation, and generated image only after explicit consent.
+
+### Changed
+
+- **Flash-Next long-context prefill is faster and reusable.** Batched QSA
+  index-cache construction reduced measured 2K, 8K, and 32K time to first token
+  by 28.9–32.5%, and semantic snapshots preserve reusable recurrent state
+  through batching and persistence.
+- **The Desktop download is smaller.** LZMA packaging and dependency-proven
+  pruning reduced the signed comparison DMG by 43.53% while retaining the
+  release contract.
+- **First-chat recommendations follow available memory.** New installs choose
+  a smaller default below 16 GB and prefer an eligible cached model in the same
+  memory tier.
+
+### Fixed
+
+- **Photo limits no longer make text chat look broken.** When a model's vision
+  lane needs more memory than the Mac has, Desktop now says that text chat is
+  still ready, recommends a lower-memory vision model, and dismisses the notice
+  after the user continues. ([#2778](https://github.com/raullenchai/Rapid-MLX/pull/2778))
+- Offline Kokoro pulls include their runtime assets, image attachments enforce
+  count and encoded-size budgets, and generated-image deletion uses a stable
+  app-owned confirmation sheet.
+- Model switching, request cancellation, required tool calls, explicit model
+  variants, oversized vision inputs, image-edit dimensions, suffix rollback,
+  MTP cache publication, and multilingual Parakeet metadata now retain their
+  validated contracts across the engine and Desktop.
+- Web browsing pins validated IPv4 and IPv6 destinations while preserving TLS
+  hostname verification, and Desktop credentials stay in Keychain-backed,
+  rotation-aware storage.
+- Protected publication promotes the exact signed and notarized Desktop
+  candidate bytes that passed pre-tag validation. ([#2775](https://github.com/raullenchai/Rapid-MLX/pull/2775))
+
 ## [0.13.2-rc1] — 2026-08-30
 
 ### Added
@@ -3564,7 +3614,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...HEAD
+[0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...rapid-mac-v0.13.2
 [0.13.2-rc1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2-rc1
 [0.13.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.0...rapid-mac-v0.13.1
 [0.5.16]: https://github.com/machinefi/rapid-desktop/compare/v0.5.15...v0.5.16

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.2-rc1</string>
+	<string>0.13.2</string>
 	<key>CFBundleVersion</key>
-	<string>167</string>
+	<string>168</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.13.2.md
+++ b/docs/release-notes/v0.13.2.md
@@ -1,0 +1,208 @@
+Rapid-MLX 0.13.2 makes long-running local assistants faster and more
+dependable: Qwen3.8 Flash-Next gains opt-in native MTP and faster long-context
+prefill, repeated prompts recover their prefix cache, offline speech pulls
+include their runtime requirements, and Desktop tightens attachment, credential,
+and web-browsing safety. This stable release also includes the fixes validated
+after rc1 and replaces the stable Desktop updater feed.
+
+## Final release validation
+
+- The protected Desktop publication path now promotes the exact signed and
+  notarized candidate bytes, including the canonical DMG and updater payloads,
+  rather than rebuilding after the release tag. ([#2775](https://github.com/raullenchai/Rapid-MLX/pull/2775))
+- On memory-constrained Macs, choosing a photo with a model whose text lane is
+  still usable now explains that text chat remains ready and recommends a
+  lower-memory vision model. The notice clears after the user continues with a
+  text turn, changes model capability, or chooses another attachment path.
+  ([#2778](https://github.com/raullenchai/Rapid-MLX/pull/2778))
+
+## Highlights
+
+**Qwen3.8 Flash-Next gains native MTP** — The engine can opt into the
+checkpoint's one-layer prediction head while the target model verifies every
+proposal and all recurrent, QSA, and KV state rolls back atomically. The
+measured fixed-K1 workload accepted 76.41% of proposals.
+([#2572](https://github.com/raullenchai/Rapid-MLX/pull/2572),
+[#2655](https://github.com/raullenchai/Rapid-MLX/pull/2655))
+
+| Context | Serial decode | Native MTP | Change |
+| ------: | ------------: | ---------: | -----: |
+|     128 | 25.17 tok/s | 34.85 tok/s | +38.5% |
+|      2K | 23.64 tok/s | 33.53 tok/s | +41.8% |
+|      8K | 22.82 tok/s | 32.20 tok/s | +41.1% |
+|     32K | 21.16 tok/s | 28.82 tok/s | +36.2% |
+
+Desktop's normal temperature, top-p, top-k, min-p, and penalty settings can use
+the lane. Seeded requests and stateful grammar, tool, reasoning, or suppression
+processors continue on ordinary decoding rather than silently weakening their
+contract. The measured MTP path used up to 6.6 GB more active memory, and 192 GB
+remains the recommended hardware tier for this experimental checkpoint.
+
+**Faster long-context prefill and reusable prompts** — QSA index-cache work is
+batched across eligible prefills, reducing measured time to first token by
+28.9–32.5% while decode speed and cache precision remain unchanged. A completed
+32K request can no longer poison the next request in the same process.
+([#2574](https://github.com/raullenchai/Rapid-MLX/pull/2574),
+[#2596](https://github.com/raullenchai/Rapid-MLX/pull/2596))
+
+| Prompt | Previous TTFT | Batched TTFT | Change |
+| -----: | ------------: | -----------: | -----: |
+|     2K | 3.346 s | 2.262 s | -32.4% |
+|     8K | 13.689 s | 9.236 s | -32.5% |
+|    32K | 62.851 s | 44.659 s | -28.9% |
+
+Semantic prefix snapshots now follow the exact rendered prompt and preserve the
+Flash-Next recurrent cache through batching and persistence. A measured
+5,288-token warm request reused 5,273 tokens and completed in 0.539 seconds
+instead of 6.497 seconds; native MTP continued proposing after the hit.
+([#2588](https://github.com/raullenchai/Rapid-MLX/pull/2588),
+[#2644](https://github.com/raullenchai/Rapid-MLX/pull/2644))
+
+**Kokoro is ready before the machine goes offline** — `rapid-mlx pull` now
+fetches the voice assets and prepares the English G2P requirement as part of
+the pull transaction. The clean-cache validation downloaded 54 voice files and
+generated speech with networking disabled. If a runtime requirement is missing,
+an inference request returns an actionable readiness error instead of trying to
+download or install software on demand.
+([#2648](https://github.com/raullenchai/Rapid-MLX/pull/2648),
+[#2664](https://github.com/raullenchai/Rapid-MLX/pull/2664))
+
+**A smaller, byte-identical-to-approved Desktop release path** — LZMA packaging
+and dependency-proven pruning reduced the signed and notarized comparison DMG
+from 187,505,002 to 105,881,983 bytes, a 43.53% reduction. The tradeoff is a
+slower one-time Finder copy on the measured host: 17.80 seconds instead of 5.94
+seconds. Candidate builds now identify their source commit, and protected
+publication promotes the exact approved DMG and updater payloads instead of
+rebuilding different bytes after the tag. Tier 1 and Desktop now install the
+same candidate wheel, with a shared contract matrix keeping text and
+multimodal request behavior aligned.
+([#2668](https://github.com/raullenchai/Rapid-MLX/pull/2668),
+[#2450](https://github.com/raullenchai/Rapid-MLX/pull/2450),
+[#2530](https://github.com/raullenchai/Rapid-MLX/pull/2530),
+[#2726](https://github.com/raullenchai/Rapid-MLX/pull/2726))
+
+## Desktop safety and workflow corrections
+
+- After the first completed exchange, Desktop can derive one short local title
+  without replacing a user rename. Settled text answers can also offer three
+  optional follow-up prompts; malformed, duplicate, wrong-script, or incomplete
+  suggestions stay hidden. ([#2698](https://github.com/raullenchai/Rapid-MLX/pull/2698))
+- A chat message accepts up to four images and 6 MiB of aggregate encoded image
+  data, preserves selection order, and explains whether count or size rejected
+  the remainder. A repeatedly failing image gets one bounded follow-up retry
+  instead of contaminating every later text turn.
+  ([#2541](https://github.com/raullenchai/Rapid-MLX/pull/2541),
+  [#2585](https://github.com/raullenchai/Rapid-MLX/pull/2585))
+- Generated-image deletion uses an app-owned confirmation sheet: Keep remains
+  pressable in native GUI automation, Escape is safe, and Return cannot delete
+  an image. ([#2387](https://github.com/raullenchai/Rapid-MLX/pull/2387),
+  [#2578](https://github.com/raullenchai/Rapid-MLX/pull/2578))
+- Switching away from a busy model asks first; Cancel preserves the live model
+  and in-flight response. Recommendation, review, and engine admission use one
+  measured footprint for known models, and already-resident models remain
+  usable through the safe replacement path.
+  ([#2430](https://github.com/raullenchai/Rapid-MLX/pull/2430),
+  [#2543](https://github.com/raullenchai/Rapid-MLX/pull/2543),
+  [#2619](https://github.com/raullenchai/Rapid-MLX/pull/2619))
+- The installer recommends `lfm2.5-1b-4bit` below 16 GB and
+  `qwen3.5-4b-4bit` on larger Macs, while preferring an eligible cached model
+  from the same memory tier. ([#2426](https://github.com/raullenchai/Rapid-MLX/pull/2426))
+- Exited server leaders are reaped without blocking a shared worker, and stale
+  dual-stack `tcp46` listeners are recognized when Desktop clears a server
+  port. A stopped dictation model reloads when the user next presses the hotkey
+  instead of during foreground activation.
+  ([#2562](https://github.com/raullenchai/Rapid-MLX/pull/2562),
+  [#2593](https://github.com/raullenchai/Rapid-MLX/pull/2593),
+  [#2663](https://github.com/raullenchai/Rapid-MLX/pull/2663))
+- Tools settings resolve the selected search key's real Keychain state without
+  exposing it, dictation errors no longer guess at an unproven memory cause,
+  and photo guidance names the remedy for the engine's actual serving-lane
+  reason. ([#2514](https://github.com/raullenchai/Rapid-MLX/pull/2514),
+  [#2523](https://github.com/raullenchai/Rapid-MLX/pull/2523),
+  [#2602](https://github.com/raullenchai/Rapid-MLX/pull/2602),
+  [#2607](https://github.com/raullenchai/Rapid-MLX/pull/2607))
+- After 35 successful chats, dictations, or generated images, established
+  Desktop users may see a quiet, nonmodal invitation to visit the project on
+  GitHub. Dismissing it starts a three-day cooldown and a progressively larger
+  local usage threshold; Rapid performs no account or star-status lookup.
+  ([#2675](https://github.com/raullenchai/Rapid-MLX/pull/2675))
+
+## Engine, API, and CLI reliability
+
+- Qwen3.8 27B required and named tool calls use the checkpoint-native format
+  and return OpenAI-compatible JSON arguments. Invalid required arguments fail
+  with a client error instead of appearing executable.
+  ([#2660](https://github.com/raullenchai/Rapid-MLX/pull/2660))
+- Explicit `--mllm` selection wins over automatic architecture, cache, and
+  runtime fallback. The measured vision-memory floor remains mandatory, and
+  speculative decoding still uses its supported text lane.
+  ([#2643](https://github.com/raullenchai/Rapid-MLX/pull/2643),
+  [#2669](https://github.com/raullenchai/Rapid-MLX/pull/2669))
+- Explicit `timeout: 0` means the server default, request-local
+  `chat_template_kwargs` reach the tokenizer, cancellations are distinct from
+  max-length completion, and orphaned streaming reservations cannot keep model
+  replacement busy until restart.
+  ([#2583](https://github.com/raullenchai/Rapid-MLX/pull/2583),
+  [#2614](https://github.com/raullenchai/Rapid-MLX/pull/2614),
+  [#2625](https://github.com/raullenchai/Rapid-MLX/pull/2625),
+  [#2636](https://github.com/raullenchai/Rapid-MLX/pull/2636))
+- Explicit `--bits` and `--format` pulls remain eligible for the mirror.
+  Malformed or interrupted cache metadata no longer crashes cached-model
+  listing, pull admission, or chat model switching.
+  ([#2610](https://github.com/raullenchai/Rapid-MLX/pull/2610),
+  [#2613](https://github.com/raullenchai/Rapid-MLX/pull/2613))
+- Explicit variant pulls persist their selected subfolder, so a later
+  `serve` command resolves the pulled checkpoint instead of the repository
+  root. Catalog aliases retain precedence over this pull marker, and
+  mirror-backed pulls now persist the same selection as fallback downloads.
+  ([#2558](https://github.com/raullenchai/Rapid-MLX/pull/2558),
+  [#2750](https://github.com/raullenchai/Rapid-MLX/pull/2750))
+- Oversized vision images are automatically reduced to the model's patch-aware
+  token budget before preprocessing. Multiple images share that budget, and a
+  measured retry handles processor rounding. If the minimum aligned image
+  remains over budget, the server warns and leaves the existing downstream
+  prefill-cap guard as the final rejection boundary.
+  ([#2694](https://github.com/raullenchai/Rapid-MLX/pull/2694))
+- Image edits derive their output canvas from the uploaded source instead of
+  silently falling back to the text-to-image 1024×1024 default. Square and
+  non-square FLUX.2 Klein edits now preserve the source dimensions.
+  ([#2759](https://github.com/raullenchai/Rapid-MLX/pull/2759))
+- Forced assistant prefixes become visible as soon as the scheduler admits the
+  request instead of waiting for the first decoded token. Empty, failed, and
+  cancelled streams retire their pending admission work cleanly.
+  ([#2674](https://github.com/raullenchai/Rapid-MLX/pull/2674))
+- Suffix decoding now checks the full verify-forward cache growth before
+  advancing a sliding-window cache. At a rollback-unsafe boundary it falls
+  back to ordinary decoding instead of aborting the request.
+  ([#2682](https://github.com/raullenchai/Rapid-MLX/pull/2682))
+- A terminal MTP response that has verified farther than its visible output no
+  longer publishes that advanced state as a reusable prefix cache. Ordinary
+  completed-response cache reuse is unchanged.
+  ([#2751](https://github.com/raullenchai/Rapid-MLX/pull/2751))
+- Parakeet v3 metadata and the Desktop picker now agree on all 25 supported ISO
+  languages and automatic language detection instead of describing the
+  checkpoint as English-only.
+  ([#2729](https://github.com/raullenchai/Rapid-MLX/pull/2729))
+- Passive version checks correctly order `rcN` below the matching final and now
+  cover `pull`, `ps`, `info`, `bench`, and `doctor`; automatic upgrade prompts
+  remain off for development, RC, and local builds.
+  ([#2431](https://github.com/raullenchai/Rapid-MLX/pull/2431))
+
+## Privacy and security
+
+- Desktop activation milestones are created and sent only after explicit
+  telemetry consent. Request attribution uses an allowlisted client bucket;
+  raw user-agent text never enters the payload.
+  ([#2428](https://github.com/raullenchai/Rapid-MLX/pull/2428),
+  [#2436](https://github.com/raullenchai/Rapid-MLX/pull/2436))
+- Embedded API bearer credentials support per-launch, daily, and manual
+  rotation. The bearer stays in a code-identity-scoped Keychain item while
+  preferences contain only non-secret metadata.
+  ([#2639](https://github.com/raullenchai/Rapid-MLX/pull/2639))
+- Desktop web browsing validates every DNS answer, then pins the socket to the
+  selected address while preserving hostname-based TLS verification. Validated
+  IPv4 and IPv6 destinations are raced with a short stagger so one black-holed
+  route cannot consume the whole deadline. Redirect, body-size, and timeout
+  limits remain fail closed.
+  ([#2645](https://github.com/raullenchai/Rapid-MLX/pull/2645),
+  [#2747](https://github.com/raullenchai/Rapid-MLX/pull/2747))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.2-rc1"
+version = "0.13.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Publish the validated 0.13.2 stable release after rc1 dogfood and the final memory-limited photo guidance fix. No open `release-blocker` issues remain.

## What

- align the engine and Desktop marketing version at `0.13.2`
- advance Desktop `CFBundleVersion` from 167 to 168
- add the stable `CHANGELOG` section and `docs/release-notes/v0.13.2.md`

## Design precedent

This uses the repository's existing single-commit version-bump transaction and protected promotion path: validate the exact parent without publication, bind the pre-flight to the exact bump head, then let the protected environment guard the immutable tag claim. No alternate tag or local publication path is introduced.

## Verification

- Release parent: `00eb18a12a68cd976dad5e1a7c6456dd63a0c9e1`
- Auto-release dry run: https://github.com/raullenchai/Rapid-MLX/actions/runs/33336718262
- Python release/version contracts: 282 passed
- Shell release contracts: 324 passed
- `python3.12 scripts/check_version_sync.py`
- `python3.12 scripts/validate_release_subject.py --subject "chore: bump version to 0.13.2"`

Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/33337372744