### PR TITLE
fix(release): run promotion publishers after skipped build

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -572,11 +572,18 @@ jobs:
     # in job-level expressions, so key publication eligibility to the two
     # required promotion inputs as well. An input-free manual dispatch remains
     # a non-publishing dry run.
+    # ``desktop-ready`` deliberately depends on both mutually-exclusive source
+    # lanes, so one of its ancestors is always skipped. GitHub otherwise
+    # propagates that skip past the successful join job and silently suppresses
+    # publication. Evaluate explicitly, while still failing closed unless the
+    # join itself succeeded.
     if: >-
-      startsWith(github.ref, 'refs/tags/')
-      || (github.event_name == 'workflow_dispatch'
-          && inputs.promote_run_id != ''
-          && inputs.promote_sha != '')
+      always()
+      && needs.desktop-ready.result == 'success'
+      && (startsWith(github.ref, 'refs/tags/')
+          || (github.event_name == 'workflow_dispatch'
+              && inputs.promote_run_id != ''
+              && inputs.promote_sha != ''))
     steps:
       - name: Download the notarised DMG artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -712,10 +719,13 @@ jobs:
     # Includes the turnstyle queue plus final updater/Release publication.
     timeout-minutes: 120
     if: >-
-      startsWith(github.ref, 'refs/tags/')
-      || (github.event_name == 'workflow_dispatch'
-          && inputs.promote_run_id != ''
-          && inputs.promote_sha != '')
+      always()
+      && needs.desktop-ready.result == 'success'
+      && needs.mirror-dist.result == 'success'
+      && (startsWith(github.ref, 'refs/tags/')
+          || (github.event_name == 'workflow_dispatch'
+              && inputs.promote_run_id != ''
+              && inputs.promote_sha != ''))
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -575,10 +575,10 @@ jobs:
     # ``desktop-ready`` deliberately depends on both mutually-exclusive source
     # lanes, so one of its ancestors is always skipped. GitHub otherwise
     # propagates that skip past the successful join job and silently suppresses
-    # publication. Evaluate explicitly, while still failing closed unless the
-    # join itself succeeded.
+    # publication. Evaluate explicitly with the cancellation-safe status
+    # function, while still failing closed unless the join itself succeeded.
     if: >-
-      always()
+      !cancelled()
       && needs.desktop-ready.result == 'success'
       && (startsWith(github.ref, 'refs/tags/')
           || (github.event_name == 'workflow_dispatch'
@@ -719,7 +719,7 @@ jobs:
     # Includes the turnstyle queue plus final updater/Release publication.
     timeout-minutes: 120
     if: >-
-      always()
+      !cancelled()
       && needs.desktop-ready.result == 'success'
       && needs.mirror-dist.result == 'success'
       && (startsWith(github.ref, 'refs/tags/')

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -188,6 +188,10 @@ lacks "$PROMOTE" 'notarize.sh' \
 MIRROR_JOB=$(sed -n '/^  mirror-dist:/,/^  publish-updater-fallback:/p' "$RAPID_RELEASE")
 PUBLISH_JOB=$(sed -n '/^  publish-updater-fallback:/,$p' "$RAPID_RELEASE")
 for JOB in "$MIRROR_JOB" "$PUBLISH_JOB"; do
+  contains "$JOB" 'always()' \
+    "publication evaluates after the mutually-exclusive source lane is skipped"
+  contains "$JOB" "needs.desktop-ready.result == 'success'" \
+    "publication fails closed unless the source-lane join succeeds"
   contains "$JOB" "startsWith(github.ref, 'refs/tags/')" \
     "tag-triggered Desktop releases publish"
   contains "$JOB" "github.event_name == 'workflow_dispatch'" \
@@ -197,6 +201,8 @@ for JOB in "$MIRROR_JOB" "$PUBLISH_JOB"; do
   contains "$JOB" "inputs.promote_sha != ''" \
     "publishing promotion requires an exact source SHA"
 done
+contains "$PUBLISH_JOB" "needs.mirror-dist.result == 'success'" \
+  "final publication fails closed unless immutable mirroring succeeds"
 
 # A same-SHA tag claim may no-op after a prior failed/missed Desktop workflow.
 # The engine must therefore wait for exact tagged Desktop publication evidence,

--- a/tests/release/test_desktop_release_promotion.sh
+++ b/tests/release/test_desktop_release_promotion.sh
@@ -188,8 +188,10 @@ lacks "$PROMOTE" 'notarize.sh' \
 MIRROR_JOB=$(sed -n '/^  mirror-dist:/,/^  publish-updater-fallback:/p' "$RAPID_RELEASE")
 PUBLISH_JOB=$(sed -n '/^  publish-updater-fallback:/,$p' "$RAPID_RELEASE")
 for JOB in "$MIRROR_JOB" "$PUBLISH_JOB"; do
-  contains "$JOB" 'always()' \
-    "publication evaluates after the mutually-exclusive source lane is skipped"
+  contains "$JOB" '!cancelled()' \
+    "publication evaluates after a skipped source lane but respects cancellation"
+  lacks "$JOB" 'always()' \
+    "publication cannot outlive an operator cancellation"
   contains "$JOB" "needs.desktop-ready.result == 'success'" \
     "publication fails closed unless the source-lane join succeeds"
   contains "$JOB" "startsWith(github.ref, 'refs/tags/')" \

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -103,8 +103,7 @@ def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
         "&& inputs.promote_sha != ''))"
     )
     assert " ".join(jobs["mirror-dist"]["if"].split()) == (
-        "!cancelled() && needs.desktop-ready.result == 'success' && "
-        + event_condition
+        "!cancelled() && needs.desktop-ready.result == 'success' && " + event_condition
     )
     assert " ".join(jobs["publish-updater-fallback"]["if"].split()) == (
         "!cancelled() && needs.desktop-ready.result == 'success' "

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -103,10 +103,11 @@ def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
         "&& inputs.promote_sha != ''))"
     )
     assert " ".join(jobs["mirror-dist"]["if"].split()) == (
-        "always() && needs.desktop-ready.result == 'success' && " + event_condition
+        "!cancelled() && needs.desktop-ready.result == 'success' && "
+        + event_condition
     )
     assert " ".join(jobs["publish-updater-fallback"]["if"].split()) == (
-        "always() && needs.desktop-ready.result == 'success' "
+        "!cancelled() && needs.desktop-ready.result == 'success' "
         "&& needs.mirror-dist.result == 'success' && " + event_condition
     )
 

--- a/tests/test_release_candidate_workflows.py
+++ b/tests/test_release_candidate_workflows.py
@@ -96,14 +96,19 @@ def test_tagged_promotion_and_standalone_build_are_mutually_exclusive():
         "desktop-ready",
         "mirror-dist",
     ]
-    publish_condition = (
-        "startsWith(github.ref, 'refs/tags/') "
+    event_condition = (
+        "(startsWith(github.ref, 'refs/tags/') "
         "|| (github.event_name == 'workflow_dispatch' "
         "&& inputs.promote_run_id != '' "
-        "&& inputs.promote_sha != '')"
+        "&& inputs.promote_sha != ''))"
     )
-    assert " ".join(jobs["mirror-dist"]["if"].split()) == publish_condition
-    assert " ".join(jobs["publish-updater-fallback"]["if"].split()) == publish_condition
+    assert " ".join(jobs["mirror-dist"]["if"].split()) == (
+        "always() && needs.desktop-ready.result == 'success' && " + event_condition
+    )
+    assert " ".join(jobs["publish-updater-fallback"]["if"].split()) == (
+        "always() && needs.desktop-ready.result == 'success' "
+        "&& needs.mirror-dist.result == 'success' && " + event_condition
+    )
 
 
 def test_release_preflight_is_dispatch_only_and_exact_head_bound():


### PR DESCRIPTION
## Why

The v0.13.2 Desktop candidate promotion run 33338756672 verified the exact signed/notarized artifacts, but GitHub Actions silently skipped both publication jobs because the mutually-exclusive standalone build lane was skipped. The parent auto-release therefore stopped before creating the engine release.

## What

- force both downstream job conditions to evaluate after the intentionally skipped source lane
- require `desktop-ready == success` before immutable mirroring
- require both `desktop-ready == success` and `mirror-dist == success` before updater/Release publication
- lock the skipped-ancestor regression into Python and shell workflow contracts

## Design precedent

The workflow follows the documented dependent-job pattern: explicitly evaluate a downstream condition after skipped dependencies, then gate on each required dependency result. This preserves the intended join while remaining fail-closed on failures and cancellations.

## Verification

- `git diff --check`
- `python3.12 -m pytest -q tests/test_release_candidate_workflows.py` (10 passed)
- `bash tests/release/test_desktop_release_promotion.sh` (119 passed)

Fixes #2781