### PR TITLE
fix(mac): scope model pickers to the active task

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -69,9 +69,8 @@ final class AudioViewModel {
     /// with a Recommended badge may appear first), and feeding that order
     /// back into default selection silently changes the active checkpoint.
     private var transcriptionSelectionModels: [ModelEntry] {
-        let candidates = audioModels.filter {
-            $0.audioCapability?.supportsTranscription == true
-                && ModelCatalog.isDesktopAudioAliasVisible($0.alias)
+        let candidates = ModelSelectionPurpose.speechToText.entries(in: audioModels).filter {
+            ModelCatalog.isDesktopAudioAliasVisible($0.alias)
         }
         return Self.stablyDeduplicatedTranscriptionModels(candidates)
     }
@@ -81,10 +80,7 @@ final class AudioViewModel {
         // audio core, not Kokoro's spaCy/espeak language stack or F5 cloning.
         // Qwen3 CustomVoice is reference-free, has real named speakers, and
         // runs entirely on dependencies in the desktop audio extra.
-        audioModels.filter {
-            $0.audioCapability?.supportsPresetSpeech == true
-                && $0.audioFamily == "qwen3_tts"
-        }
+        ModelSelectionPurpose.textToSpeech.entries(in: audioModels)
     }
 
     var isBusy: Bool {

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -207,6 +207,13 @@ final class DictationController {
         let cached: Bool
     }
     private var catalogByAlias: [String: CatalogFacts] = [:]
+    /// Audio identities proven by Dictation's own catalog load. ContentView
+    /// needs this before AudioView mounts so a voice-lane ready transition
+    /// cannot masquerade as an unknown custom Chat model. Persisted selection
+    /// alone is deliberately not proof of capability.
+    var knownAudioAliases: Set<String> {
+        Set(catalogByAlias.keys)
+    }
     private let onProductValueDelivered: @MainActor (ProductValueKind) -> Void
 
     init(

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -146,11 +146,11 @@ final class ImageGenViewModel {
     var selectedAlias: String = ""
 
     var generationModels: [ModelEntry] {
-        imageModels.filter { $0.imageCapability?.supportsGeneration == true }
+        ModelSelectionPurpose.imageGeneration.entries(in: imageModels)
     }
 
     var editModels: [ModelEntry] {
-        imageModels.filter { $0.imageCapability?.supportsEditing == true }
+        ModelSelectionPurpose.imageEditing.entries(in: imageModels)
     }
 
     var selectableModels: [ModelEntry] {

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -52,6 +52,48 @@ enum ImageModelCapability: String, Sendable, Hashable {
     }
 }
 
+/// The product task a model picker is serving.
+///
+/// Keep this separate from ``ModelKind``: image generation and editing share
+/// one kind, as do speech input and speech output, but those operations accept
+/// different request shapes. Every picker asks this policy for its rows so an
+/// alias cannot become selectable merely because it was present in a broader
+/// catalog response.
+enum ModelSelectionPurpose: Sendable, Hashable {
+    case chat
+    case imageGeneration
+    case imageEditing
+    case speechToText
+    case textToSpeech
+
+    func accepts(_ entry: ModelEntry) -> Bool {
+        switch self {
+        case .chat:
+            return entry.kind == .chat
+        case .imageGeneration:
+            return entry.kind == .image
+                && entry.imageCapability?.supportsGeneration == true
+        case .imageEditing:
+            return entry.kind == .image
+                && entry.imageCapability?.supportsEditing == true
+        case .speechToText:
+            return entry.kind == .audio
+                && entry.audioCapability?.supportsTranscription == true
+        case .textToSpeech:
+            // The signed Desktop bundle supports the reference-free Qwen3
+            // preset-voice flow. Other TTS capabilities need inputs or
+            // dependencies this surface deliberately does not collect.
+            return entry.kind == .audio
+                && entry.audioCapability?.supportsPresetSpeech == true
+                && entry.audioFamily == "qwen3_tts"
+        }
+    }
+
+    func entries(in catalog: [ModelEntry]) -> [ModelEntry] {
+        catalog.filter(accepts)
+    }
+}
+
 /// Audited speculative-decoding preset advertised by the alias registry.
 /// `nil` on ``ModelEntry`` means the alias explicitly has no usable preset
 /// (or an older sidecar did not advertise one), so Settings fails closed.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -220,6 +220,11 @@ struct ChatView: View {
     @State private var streamingMarkdown = StreamingMarkdownStore()
     @Bindable var server: ServerManager
     @Binding var alias: String
+    /// Aliases authoritatively owned by a non-chat surface. The set may grow
+    /// after this view mounts as media catalogs finish loading, so the picker
+    /// uses it both to reject ready-state races and to normalize a stale
+    /// selection when classification arrives late.
+    var knownNonChatAliases: Set<String> = []
     /// The single readiness value for this window, resolved once by
     /// ``ContentView`` and shared with the Launch page. Both the chat
     /// hero and the composer read their copy off this, so they cannot
@@ -856,6 +861,7 @@ struct ChatView: View {
                 server: server,
                 downloads: downloads,
                 alias: $alias,
+                knownNonChatAliases: knownNonChatAliases,
                 quickstart: quickstart,
                 composerStyle: true,
                 onUserSelection: onUserModelSelection

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -32,6 +32,10 @@ struct ConnectToolsView: View {
     /// Side-channel downloader the inline picker's context menu uses
     /// ("Download in background") and its cache-state glyphs.
     @Bindable var downloads: DownloadManager
+    /// Media identities already proven by their task catalogs. The stopped
+    /// Launch page shares Chat's alias binding, so it must apply the same
+    /// cross-task guard as the composer picker.
+    var knownNonChatAliases: Set<String> = []
     /// The absolute path to the `rapid-mlx` sidecar binary this app owns
     /// (``ServerLocator`` resolution). The Desktop app deliberately does NOT
     /// install its sidecar onto the user's `PATH` (see ``ServerLocator`` —
@@ -305,6 +309,7 @@ struct ConnectToolsView: View {
                 server: server,
                 downloads: downloads,
                 alias: $alias,
+                knownNonChatAliases: knownNonChatAliases,
                 composerStyle: true
             )
             ReadinessBanner(readiness: readiness, onAction: onReadinessAction)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -1135,20 +1135,17 @@ struct ContentView: View {
 
     /// The chat catalog intentionally omits every media row, so aliases from
     /// independently loaded media catalogs close that negative-information
-    /// gap. Dictation's persisted selection is included directly: it can
+    /// gap. Dictation publishes its own catalog-proven aliases because it can
     /// start before ``AudioView`` ever mounts, which is the timing that used
-    /// to let `qwen3-asr` masquerade as an unknown custom chat model.
+    /// to let `qwen3-asr` masquerade as an unknown custom chat model. Raw
+    /// persisted selections are not included: stale preferences are not
+    /// authoritative capability evidence.
     private var knownNonChatAliases: Set<String> {
         Set(
             audio.audioModels.map(\.alias)
                 + imageGen.imageModels.map(\.alias)
-                + [
-                    audio.selectedTranscriptionAlias,
-                    audio.selectedSpeechAlias,
-                    imageGen.selectedAlias,
-                    dictation.modelAlias,
-                ]
-        ).filter { !$0.isEmpty }
+                + Array(dictation.knownAudioAliases)
+        )
     }
 
     /// True when the Quickstart sheet is up AND owns the pending

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -216,9 +216,7 @@ struct ContentView: View {
                ContentView.shouldSyncChatAlias(
                    serving: serving,
                    catalogEntries: catalogEntries,
-                   knownMediaAliases: Set(
-                       audio.audioModels.map(\.alias) + imageGen.imageModels.map(\.alias)
-                   ),
+                   knownMediaAliases: knownNonChatAliases,
                    section: section
                ) {
                 alias = serving
@@ -953,6 +951,7 @@ struct ContentView: View {
                 viewModel: chat,
                 server: server,
                 alias: $alias,
+                knownNonChatAliases: knownNonChatAliases,
                 readiness: readiness,
                 supportsImageInput: imageAvailability.isAvailable,
                 imageInputUnavailableMessage: imageAvailability.unavailableMessage,
@@ -1124,11 +1123,32 @@ struct ContentView: View {
         section: SidebarSection
     ) -> Bool {
         guard section == .chat else { return false }
-        guard !knownMediaAliases.contains(serving) else { return false }
-        guard let entry = catalogEntries.first(where: { $0.alias == serving }) else {
-            return true
+        if let entry = catalogEntries.first(where: {
+            $0.alias.caseInsensitiveCompare(serving) == .orderedSame
+        }) {
+            return ModelSelectionPurpose.chat.accepts(entry)
         }
-        return entry.kind == .chat
+        return !knownMediaAliases.contains(where: {
+            $0.caseInsensitiveCompare(serving) == .orderedSame
+        })
+    }
+
+    /// The chat catalog intentionally omits every media row, so aliases from
+    /// independently loaded media catalogs close that negative-information
+    /// gap. Dictation's persisted selection is included directly: it can
+    /// start before ``AudioView`` ever mounts, which is the timing that used
+    /// to let `qwen3-asr` masquerade as an unknown custom chat model.
+    private var knownNonChatAliases: Set<String> {
+        Set(
+            audio.audioModels.map(\.alias)
+                + imageGen.imageModels.map(\.alias)
+                + [
+                    audio.selectedTranscriptionAlias,
+                    audio.selectedSpeechAlias,
+                    imageGen.selectedAlias,
+                    dictation.modelAlias,
+                ]
+        ).filter { !$0.isEmpty }
     }
 
     /// True when the Quickstart sheet is up AND owns the pending

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -934,6 +934,7 @@ struct ContentView: View {
                 server: server,
                 downloads: downloads,
                 alias: $alias,
+                knownNonChatAliases: knownNonChatAliases,
                 readiness: readiness,
                 onReadinessAction: performReadinessAction
             )

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -53,6 +53,10 @@ struct ModelPickerBar: View {
     /// "Delete from disk" landed in v0.5.2.
     @Bindable var downloads: DownloadManager
     @Binding var alias: String
+    /// Aliases proven to belong to Image, STT, or TTS. Unknown aliases remain
+    /// valid for custom text-model compatibility; only explicit media
+    /// classification can evict a selection from Chat.
+    var knownNonChatAliases: Set<String> = []
     /// F-LWT-1: the Quickstart coordinator owns the "user is
     /// mid-Quickstart-flow" gate. The picker reads ``phase`` to
     /// (a) render a dedicated "Quickstart" section above
@@ -322,6 +326,15 @@ struct ModelPickerBar: View {
         // catalog refresh will pick it up via ``recommendedDefault``).
         .task(id: quickstartPhaseGateKey) {
             applyQuickstartSelectionMirror()
+        }
+        // Media catalogs load independently from Chat. If one of them arrives
+        // after a process-ready transition temporarily supplied its alias to
+        // the composer, converge the selection as soon as the authoritative
+        // classification becomes available. Custom text aliases are left
+        // untouched because absence from the chat catalog is not evidence of
+        // being media-only.
+        .onChange(of: knownNonChatAliases) { _, aliases in
+            reconcileKnownNonChatSelection(aliases)
         }
         .sheet(isPresented: $showCustom) {
             customAliasSheet
@@ -1024,6 +1037,38 @@ struct ModelPickerBar: View {
     /// where every recommended row would otherwise paint amber for "".
     static func roleRowIsSelected(selectedAlias: String, rowAlias: String) -> Bool {
         return !selectedAlias.isEmpty && selectedAlias == rowAlias
+    }
+
+    /// Normalize only an alias positively identified as non-chat. A chat
+    /// catalog row wins over a supplemental media set, and an unknown custom
+    /// alias remains untouched. The fallback must itself be a chat row.
+    static func normalizedChatSelection(
+        currentAlias: String,
+        catalog: [ModelEntry],
+        knownNonChatAliases: Set<String>,
+        fallbackAlias: String?
+    ) -> String {
+        let validFallback = fallbackAlias.flatMap { fallback in
+            catalog.first(where: {
+                $0.alias.caseInsensitiveCompare(fallback) == .orderedSame
+                    && ModelSelectionPurpose.chat.accepts($0)
+            })?.alias
+        }
+        if currentAlias.isEmpty {
+            return validFallback ?? ""
+        }
+        if catalog.contains(where: {
+            $0.alias.caseInsensitiveCompare(currentAlias) == .orderedSame
+                && ModelSelectionPurpose.chat.accepts($0)
+        }) {
+            return currentAlias
+        }
+        guard knownNonChatAliases.contains(where: {
+            $0.caseInsensitiveCompare(currentAlias) == .orderedSame
+        }) else {
+            return currentAlias
+        }
+        return validFallback ?? ""
     }
 
     /// The one download-state glyph for every row in the picker's
@@ -2007,16 +2052,31 @@ struct ModelPickerBar: View {
         // produce a missing row — never a selectable fake model, and
         // never a placeholder word promoted into ``alias`` by
         // ``recommendedDefault`` below.
-        let entries = loaded.filter { !ModelDisplayName.isUnresolved($0.alias) }
+        let entries = ModelSelectionPurpose.chat.entries(in: loaded).filter {
+            !ModelDisplayName.isUnresolved($0.alias)
+        }
         self.catalog = entries
         catalogGeneration = generation
-        // Default selection: only apply if the current alias is blank or
-        // not in the catalog (catalog absence still means manual pick).
-        if alias.isEmpty || !entries.contains(where: { $0.alias == alias }) {
-            if let recommended = recommendedDefault() {
-                alias = recommended
-            }
+        let normalized = Self.normalizedChatSelection(
+            currentAlias: alias,
+            catalog: entries,
+            knownNonChatAliases: knownNonChatAliases,
+            fallbackAlias: recommendedDefault()
+        )
+        if normalized != alias {
+            alias = normalized
         }
+    }
+
+    private func reconcileKnownNonChatSelection(_ aliases: Set<String>) {
+        let normalized = Self.normalizedChatSelection(
+            currentAlias: alias,
+            catalog: catalog,
+            knownNonChatAliases: aliases,
+            fallbackAlias: recommendedDefault()
+        )
+        guard normalized != alias else { return }
+        alias = normalized
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -1371,6 +1371,9 @@ struct LaunchView: View {
     /// The currently-chosen model, bound so the stopped state's inline
     /// picker can change it and the shared readiness re-derives.
     @Binding var alias: String
+    /// Catalog-proven media aliases forwarded to the stopped-state Chat model
+    /// picker so Launch and the composer enforce one task boundary.
+    var knownNonChatAliases: Set<String> = []
     /// The window's shared readiness value. Optional so the dev snapshot
     /// harness can render the page standalone; when supplied, the page
     /// describes the model lifecycle in exactly the same words the chat
@@ -1386,6 +1389,7 @@ struct LaunchView: View {
             alias: $alias,
             server: server,
             downloads: downloads,
+            knownNonChatAliases: knownNonChatAliases,
             // The sidecar binary this app owns lives off-PATH (see
             // ``ServerLocator``); pass its absolute path so the launch/agent
             // commands this page generates actually run in a terminal.

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -605,6 +605,14 @@ struct CoreWorkspaceVisualFoundationTests {
         )
     }
 
+    @Test("Every shared Chat picker receives the non-chat task boundary")
+    func sharedChatPickersKeepTaskScope() throws {
+        let chat = try strippedSource("Sources/Rapid/UI/ChatView.swift")
+        let connect = try strippedSource("Sources/Rapid/UI/ConnectToolsView.swift")
+        #expect(chat.contains("knownNonChatAliases:knownNonChatAliases"))
+        #expect(connect.contains("knownNonChatAliases:knownNonChatAliases"))
+    }
+
     // MARK: - Responsive contract
 
     /// Breakpoints belong to the view receiving the geometry: Chat's detail

--- a/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
@@ -70,4 +70,24 @@ struct LaunchMediaResidencyTests {
             section: .chat
         ))
     }
+
+    @Test("Dictation ASR cannot replace Chat before the Audio catalog mounts")
+    func persistedDictationAliasWinsUnknownFallback() {
+        #expect(!ContentView.shouldSyncChatAlias(
+            serving: "qwen3-asr",
+            catalogEntries: [entries[0]],
+            knownMediaAliases: ["qwen3-asr"],
+            section: .chat
+        ))
+    }
+
+    @Test("An authoritative Chat row wins over a stale media identity")
+    func chatCatalogWinsCollision() {
+        #expect(ContentView.shouldSyncChatAlias(
+            serving: "CHAT-MODEL",
+            catalogEntries: [entries[0]],
+            knownMediaAliases: ["chat-model"],
+            section: .chat
+        ))
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelSelectionPurposeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSelectionPurposeTests.swift
@@ -1,0 +1,153 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Task-scoped model selection")
+struct ModelSelectionPurposeTests {
+    private let chat = ModelEntry(
+        alias: "qwen3.5-4b-4bit",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true
+    )
+    private let imageGeneration = ModelEntry(
+        alias: "z-image-turbo",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .image,
+        imageCapability: .generation
+    )
+    private let imageEditing = ModelEntry(
+        alias: "flux2-edit",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .image,
+        imageCapability: .editing
+    )
+    private let imageBoth = ModelEntry(
+        alias: "flux2-klein",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .image,
+        imageCapability: .generationAndEditing
+    )
+    private let transcription = ModelEntry(
+        alias: "qwen3-asr",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .audio,
+        audioCapability: .transcription,
+        audioFamily: "qwen3_asr"
+    )
+    private let alignment = ModelEntry(
+        alias: "qwen3-aligner",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .audio,
+        audioCapability: .alignment,
+        audioFamily: "qwen3_aligner"
+    )
+    private let presetSpeech = ModelEntry(
+        alias: "qwen3-tts-4bit",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .audio,
+        audioCapability: .speech,
+        audioFamily: "qwen3_tts"
+    )
+    private let unsupportedSpeech = ModelEntry(
+        alias: "kokoro",
+        hfRepo: nil,
+        sizeOnDisk: nil,
+        cached: true,
+        kind: .audio,
+        audioCapability: .speech,
+        audioFamily: "kokoro"
+    )
+
+    private var catalog: [ModelEntry] {
+        [
+            chat,
+            imageGeneration,
+            imageEditing,
+            imageBoth,
+            transcription,
+            alignment,
+            presetSpeech,
+            unsupportedSpeech,
+        ]
+    }
+
+    @Test("Each picker receives only models accepted by its task")
+    func purposeFilters() {
+        #expect(
+            ModelSelectionPurpose.chat.entries(in: catalog).map(\.alias) == [chat.alias]
+        )
+        #expect(ModelSelectionPurpose.imageGeneration.entries(in: catalog).map(\.alias) == [
+            imageGeneration.alias,
+            imageBoth.alias,
+        ])
+        #expect(ModelSelectionPurpose.imageEditing.entries(in: catalog).map(\.alias) == [
+            imageEditing.alias,
+            imageBoth.alias,
+        ])
+        #expect(ModelSelectionPurpose.speechToText.entries(in: catalog).map(\.alias) == [
+            transcription.alias,
+        ])
+        #expect(ModelSelectionPurpose.textToSpeech.entries(in: catalog).map(\.alias) == [
+            presetSpeech.alias,
+        ])
+    }
+
+    @Test("Mounted Image, STT, and TTS view models use the shared task policy")
+    func viewModelsUsePurposePolicy() {
+        let server = ServerManager(testingState: .idle)
+        let images = ImageGenViewModel(server: server)
+        images.imageModels = catalog
+        #expect(images.generationModels.map(\.alias) == [imageGeneration.alias, imageBoth.alias])
+        #expect(images.editModels.map(\.alias) == [imageEditing.alias, imageBoth.alias])
+
+        let audio = AudioViewModel(server: server)
+        audio.audioModels = catalog
+        #expect(audio.transcriptionModels.map(\.alias) == [transcription.alias])
+        #expect(audio.speechModels.map(\.alias) == [presetSpeech.alias])
+    }
+
+    @Test("Late media classification replaces ASR in Chat but preserves custom text aliases")
+    func chatSelectionNormalization() {
+        #expect(ModelPickerBar.normalizedChatSelection(
+            currentAlias: "",
+            catalog: [chat],
+            knownNonChatAliases: [],
+            fallbackAlias: chat.alias
+        ) == chat.alias)
+        #expect(ModelPickerBar.normalizedChatSelection(
+            currentAlias: "QWEN3-ASR",
+            catalog: [chat],
+            knownNonChatAliases: ["qwen3-asr"],
+            fallbackAlias: chat.alias
+        ) == chat.alias)
+        #expect(ModelPickerBar.normalizedChatSelection(
+            currentAlias: "org/custom-text-model",
+            catalog: [chat],
+            knownNonChatAliases: ["qwen3-asr"],
+            fallbackAlias: chat.alias
+        ) == "org/custom-text-model")
+    }
+
+    @Test("An authoritative Chat row wins over supplemental media identity")
+    func chatCatalogWinsCollision() {
+        #expect(ModelPickerBar.normalizedChatSelection(
+            currentAlias: chat.alias,
+            catalog: [chat],
+            knownNonChatAliases: [chat.alias],
+            fallbackAlias: nil
+        ) == chat.alias)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ModelSelectionPurposeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSelectionPurposeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Rapid
 
@@ -149,5 +150,25 @@ struct ModelSelectionPurposeTests {
             knownNonChatAliases: [chat.alias],
             fallbackAlias: nil
         ) == chat.alias)
+    }
+
+    @Test("Dictation publishes catalog truth, not its persisted selection")
+    func dictationKnownAudioAliases() async {
+        let staleSelection = "org/custom-text-model"
+        let catalogEntry = transcription
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        let dictation = DictationController(
+            server: server,
+            testingEnabled: false,
+            testingModelAlias: staleSelection,
+            audioCatalogLoader: { _ in [catalogEntry] }
+        )
+
+        #expect(!dictation.knownAudioAliases.contains(staleSelection))
+        await dictation.refreshModelCacheState()
+        #expect(dictation.knownAudioAliases == [catalogEntry.alias])
     }
 }


### PR DESCRIPTION
## User impact

Desktop model selection now stays within the current task:

- Chat shows only chat-capable models.
- Images shows only generation or editing models accepted by that operation.
- Speech to Text shows transcription models.
- Text to Speech shows supported preset-voice speech models.
- If Dictation starts before the Audio catalog mounts, its ASR alias can no longer replace the Chat selection.
- Unknown custom text-model aliases remain supported.

## Implementation

- Centralize task-to-capability filtering in one model-selection policy.
- Route the Chat, Images, STT, and TTS candidate lists through that policy.
- Reconcile late media classification without allowing process-wide ready state to leak across task boundaries.
- Keep authoritative Chat catalog rows ahead of supplemental media identity.

## Verification

- swift test --no-parallel: 3,179 tests in 269 suites passed.
- Focused model-selection, launch-residency, audio-catalog, and image suites: 47 tests passed.
- git diff --check passed.

Fixes #2784