### PR TITLE
feat(mac): add failure diagnostics shortcut

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -401,6 +401,10 @@ enum DevSnapshot {
                 .frame(width: 900, alignment: .leading)
                 .background(RapidTheme.surfaceCanvas)
                 .tint(RapidTheme.brandAmber)
+                // Failure banners now expose diagnostics, which reads the
+                // server from the environment; keep the standalone matrix
+                // capture alive across every readiness state.
+                .environment(server)
             )
         }
         let matrixSize = CGSize(width: 900, height: 900)

--- a/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
@@ -29,6 +29,8 @@ struct ReadinessBanner: View {
     var attentionToken: Int = 0
     var onAction: (ModelReadiness.Action) -> Void
 
+    @Environment(ServerManager.self) private var server
+
     // Reduce Motion is handled inside the pieces this composes:
     // ``PulsingStateDot`` suppresses its own breathing loop, and
     // ``rapidAnimation`` resolves to an instant change. The emphasis
@@ -74,6 +76,17 @@ struct ReadinessBanner: View {
                     ))
                     .fixedSize()
                     .accessibilityIdentifier("Readiness.Action")
+                }
+
+                if readiness.isFailure {
+                    QuietIconButton(
+                        symbol: "stethoscope",
+                        label: "Export diagnostics…",
+                        help: "Export a privacy-scrubbed diagnostics bundle for support"
+                    ) {
+                        DiagnosticsBundle.exportViaSavePanel(server: server)
+                    }
+                    .accessibilityIdentifier("Readiness.ExportDiagnostics")
                 }
             }
 

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -531,6 +531,7 @@ struct CoreWorkspaceVisualFoundationTests {
             ],
             "Sources/Rapid/UI/ReadinessBanner.swift": [
                 "Readiness.Action",
+                "Readiness.ExportDiagnostics",
             ],
         ]
         for (path, identifiers) in expectations {

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -59,6 +59,7 @@ struct ImageGenerationResolutionTests {
             rootView: ImagesView(viewModel: viewModel, server: server)
                 .environment(SettingsRouter())
                 .environment(downloads)
+                .environment(server)
         )
         host.layoutSubtreeIfNeeded()
 


### PR DESCRIPTION
## Summary
- Adds a quiet diagnostics export action to the readiness banner, shown only while readiness is failing.
- Registers the action in the existing accessibility identifier inventory.
- Supplies the newly required server environment to the existing Images test host.

## Validation
- [x] `./scripts/desktop-test-timeout.sh`
- [x] `SKIP_SIDECAR=1 bash apps/rapid-mac/scripts/build.sh`
- [x] `pr_validate` full unit suite: 19856 passed, MERGE-SAFE
- [x] Focused Codex review: no findings

## Review contract
- User-visible goal: failed readiness states provide a direct path to export a privacy-scrubbed diagnostics bundle.
- Allowed scope: readiness banner action placement, accessibility identifier inventory, snapshot/test environment, and focused tests.
- Non-goals: diagnostics-generation changes, scrubbing changes, backend changes, telemetry, or other UI surfaces.