### PR TITLE
fix(ci): make native XCUITest bootstrap reliable

### DIFF
--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -278,6 +279,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RapidUITestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D3511FF388A5B23AA16F8D1 /* ChatAttachmentJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentJourneyTests.swift; sourceTree = "<group>"; };
 		7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RapidUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		956DE8BFE793F597BFBB4385 /* RapidUITests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RapidUITests.entitlements; sourceTree = "<group>"; };
 		981AB696C88019DDE1FC4C44 /* RapidUITestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RapidUITestHarness.swift; sourceTree = "<group>"; };
 		C125516144CFDFB692F0EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB04F3C22EF0AAABD315027F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -55,6 +56,7 @@
 		E6A84D31EDC64D755BA80792 = {
 			isa = PBXGroup;
 			children = (
+				956DE8BFE793F597BFBB4385 /* RapidUITests.entitlements */,
 				1B5A8BB0E7AD6E27D95CB510 /* Host */,
 				F27E5155342C1F7C1AFFB341 /* Tests */,
 				0227B5A18E76E11410CE7982 /* Products */,

--- a/apps/rapid-mac/Tests/RapidUITests/project.yml
+++ b/apps/rapid-mac/Tests/RapidUITests/project.yml
@@ -7,6 +7,8 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     CODE_SIGN_STYLE: Automatic
+fileGroups:
+  - RapidUITests.entitlements
 targets:
   RapidUITestHost:
     type: application
@@ -34,6 +36,7 @@ targets:
       - target: RapidUITestHost
     settings:
       base:
+        CODE_SIGN_ENTITLEMENTS: RapidUITests.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.rapidmlx.rapid-uitests
         GENERATE_INFOPLIST_FILE: YES
         TEST_TARGET_NAME: RapidUITestHost

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -11,6 +11,20 @@ Run it with full Xcode after building the app:
 ./scripts/run-xcui-tests.sh
 ```
 
+The runner needs no Apple signing identity: the script requests Xcode's local
+ad-hoc identity, verifies each run in its own DerivedData directory, and prints
+the host's Automation Mode state before launch. Do not replace that with
+`CODE_SIGNING_ALLOWED=NO`; Xcode copies and modifies its runner bundle, and an
+unsigned copy has an invalid resource seal that Gatekeeper can kill before any
+test starts.
+
+If Xcode reports `Timed out while enabling automation mode` even though
+`automationmodetool` prints `ENABLED`, treat it as a stale per-user
+`testmanagerd` service, not as a product-test failure. Stop other UI tests,
+terminate that service once (`pkill -9 -x testmanagerd`), and rerun with a new
+result-bundle path. Launchd starts a fresh service on demand. A second identical
+failure is a host blocker and must not be retried again.
+
 The target is additive; do not remove an AX journey until its semantic and
 structural assertions have equivalent native coverage.
 

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -33,4 +33,8 @@ xcodebuild test \
     -destination 'platform=macOS' \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
-    CODE_SIGNING_ALLOWED=NO
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGNING_ALLOWED=YES \
+    CODE_SIGNING_REQUIRED=YES \
+    CODE_SIGN_IDENTITY=- \
+    DEVELOPMENT_TEAM=

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -18,6 +18,9 @@ xcodebuild -version >/dev/null 2>&1 || {
     echo "error: generated Xcode project missing: $PROJECT" >&2
     exit 1
 }
+if [[ -x /usr/bin/automationmodetool ]]; then
+    /usr/bin/automationmodetool
+fi
 
 # XCUIApplication(bundleIdentifier:) resolves through LaunchServices.
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
@@ -34,7 +37,7 @@ xcodebuild test \
     -destination 'platform=macOS' \
     -derivedDataPath "$DERIVED_DATA" \
     -resultBundlePath "$RESULT_BUNDLE" \
-    "${test_selection[@]}" \
+    ${test_selection[@]+"${test_selection[@]}"} \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
 APP="$ROOT/build/Rapid-MLX Desktop.app"
 RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
+DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:-${RESULT_BUNDLE%.xcresult}-DerivedData}"
 ONLY_TESTING="${RAPID_XCUI_ONLY_TESTING:-}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
@@ -31,6 +32,7 @@ xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \
     -destination 'platform=macOS' \
+    -derivedDataPath "$DERIVED_DATA" \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
     CODE_SIGN_STYLE=Manual \

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert 'DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:' in runner
+    assert "${RESULT_BUNDLE%.xcresult}-DerivedData" in runner
+    assert '-derivedDataPath "$DERIVED_DATA"' in runner
     assert "CODE_SIGN_STYLE=Manual" in runner
     assert "CODE_SIGNING_ALLOWED=YES" in runner
     assert "CODE_SIGNING_REQUIRED=YES" in runner

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -1,3 +1,4 @@
+import plistlib
 from pathlib import Path
 
 import yaml
@@ -154,6 +155,17 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert "isExecutableFile" in source
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
+
+
+def test_xcui_runner_can_reserve_its_loopback_listener():
+    project = (
+        MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
+    ).read_text()
+    entitlements_path = MAC / "Tests/RapidUITests/RapidUITests.entitlements"
+    entitlements = plistlib.loads(entitlements_path.read_bytes())
+
+    assert project.count("CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;") == 2
+    assert entitlements == {"com.apple.security.network.server": True}
 
 
 def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,11 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert "CODE_SIGN_STYLE=Manual" in runner
+    assert "CODE_SIGNING_ALLOWED=YES" in runner
+    assert "CODE_SIGNING_REQUIRED=YES" in runner
+    assert "CODE_SIGN_IDENTITY=-" in runner
+    assert "CODE_SIGNING_ALLOWED=NO" not in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -160,12 +160,22 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
 
 
 def test_xcui_runner_can_reserve_its_loopback_listener():
+    project_source = yaml.safe_load(
+        (MAC / "Tests/RapidUITests/project.yml").read_text()
+    )
     project = (
         MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
     ).read_text()
     entitlements_path = MAC / "Tests/RapidUITests/RapidUITests.entitlements"
     entitlements = plistlib.loads(entitlements_path.read_bytes())
 
+    assert "RapidUITests.entitlements" in project_source["fileGroups"]
+    assert (
+        project_source["targets"]["RapidUITests"]["settings"]["base"][
+            "CODE_SIGN_ENTITLEMENTS"
+        ]
+        == "RapidUITests.entitlements"
+    )
     assert project.count("CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;") == 2
     assert entitlements == {"com.apple.security.network.server": True}
 

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -84,6 +84,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert "/usr/bin/automationmodetool" in runner
     assert 'DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:' in runner
     assert "${RESULT_BUNDLE%.xcresult}-DerivedData" in runner
     assert '-derivedDataPath "$DERIVED_DATA"' in runner
@@ -92,6 +93,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "CODE_SIGNING_REQUIRED=YES" in runner
     assert "CODE_SIGN_IDENTITY=-" in runner
     assert "CODE_SIGNING_ALLOWED=NO" not in runner
+    assert '${test_selection[@]+"${test_selection[@]}"}' in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1


### PR DESCRIPTION
## Why

The native macOS UI-test harness could fail before a product test began. Xcode copied and modified its runner while the script disabled signing, leaving a malformed resource seal that Gatekeeper killed. Reusing global DerivedData could then carry that broken runner into later invocations, and the ad-hoc-signed test bundle lacked the loopback-server entitlement required by its fake sidecars.

## What changed

- request Xcode's local ad-hoc signing identity instead of disabling signing
- isolate every result bundle in a matching per-run DerivedData directory
- grant only the UI-test bundle's required local network-server entitlement
- keep the optional `-only-testing` array compatible with the system Bash 3.2
- print Automation Mode state and document one bounded stale-`testmanagerd` recovery
- pin these contracts with focused tests

## Design precedent

The implementation uses Xcode's documented manual code-signing overrides and per-invocation DerivedData path instead of repairing generated bundles after the build. The host recovery is deliberately bounded: one exact infrastructure failure permits one per-user test-service reset; a repeated failure remains red and requires host investigation.

## Non-goals

- no product UI or journey assertion changes
- no retry of failed product tests
- no Developer ID, release signing, notarization, or packaging changes
- no mini-runner routing changes from the separate WIP pilot

## Test plan

- `python3 -m pytest tests/test_rapid_mac_xcui_target.py -q` — 5 passed
- `/bin/bash -n apps/rapid-mac/scripts/run-xcui-tests.sh`
- `plutil -lint apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements`
- clean `xcodebuild build-for-testing` followed by `codesign --verify --deep --strict` — valid
- `SKIP_SIDECAR=1 BUNDLE_MODEL=0 ./scripts/build.sh` — app built and sealed
- focused `ImageGenerationPixelTests` after the single diagnosed stale-service reset — 1 passed in 36.743 s; Runner, Desktop, fake sidecar, and pixel assertion all executed
- `git diff --check`

Fixes #2418
Fixes #2345
