### PR TITLE
feat(mac): add command palette

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -102,6 +102,7 @@ enum DevSnapshot {
                     .environment(sampling)
                     .environment(appearance)
                     .environment(settingsRouter)
+                    .environment(CommandPaletteRequestCoordinator())
                     .environment(installTracker)
                     // ``FailedReplaceBanner`` (rendered by ContentView when a
                     // Finder Replace silently failed) hands off to Sparkle, so

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -96,6 +96,7 @@ struct RapidApp: App {
     @State private var appearance: AppearanceConfig
     /// Deep-link channel into the Settings window.
     @State private var settingsRouter: SettingsRouter
+    @State private var commandPaletteRequest = CommandPaletteRequestCoordinator()
     /// App-owned owner of the one-time invitation that follows the first
     /// successful product outcome. Feature models only publish typed success.
     @State private var deferredTelemetryConsent: DeferredTelemetryConsentCoordinator
@@ -376,6 +377,7 @@ struct RapidApp: App {
                 .environment(customInstructions)
                 .environment(appearance)
                 .environment(settingsRouter)
+                .environment(commandPaletteRequest)
                 .environment(deferredTelemetryConsent)
                 .environment(githubStarPrompt)
                 .environment(installTracker)
@@ -513,6 +515,14 @@ struct RapidApp: App {
                 // button both drive this same flag.
                 Toggle("Show Server Log", isOn: $showLogs)
                     .keyboardShortcut("l", modifiers: [.command, .shift])
+            }
+            CommandMenu("Go") {
+                Button("Command Palette…") {
+                    NSApp.activate(ignoringOtherApps: true)
+                    commandPaletteRequest.open()
+                    openWindow(id: "main")
+                }
+                .keyboardShortcut("p", modifiers: .command)
             }
         }
 

--- a/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Localizable.xcstrings
@@ -112,6 +112,136 @@
         }
       }
     },
+    "Type a command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入命令"
+          }
+        }
+      }
+    },
+    "No commands match" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的命令"
+          }
+        }
+      }
+    },
+    "Open Images" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开图像"
+          }
+        }
+      }
+    },
+    "Open Audio" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开音频"
+          }
+        }
+      }
+    },
+    "Open Launch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开启动"
+          }
+        }
+      }
+    },
+    "Open Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开设置"
+          }
+        }
+      }
+    },
+    "Open Model Management" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开模型管理"
+          }
+        }
+      }
+    },
+    "Open Connectors" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开连接器"
+          }
+        }
+      }
+    },
+    "Show or hide server logs" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示或隐藏服务器日志"
+          }
+        }
+      }
+    },
+    "Export diagnostics…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出诊断…"
+          }
+        }
+      }
+    },
+    "Check for updates" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新"
+          }
+        }
+      }
+    },
+    "Command Palette…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令面板…"
+          }
+        }
+      }
+    },
+    "Go" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往"
+          }
+        }
+      }
+    },
     "RECENTS" : {
       "localizations" : {
         "zh-Hans" : {

--- a/apps/rapid-mac/Sources/Rapid/UI/CommandPaletteView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommandPaletteView.swift
@@ -1,0 +1,296 @@
+import Observation
+import SwiftUI
+
+/// A compact keyboard entry point for primary navigation and existing app
+/// actions. The first version deliberately uses a fixed command registry so
+/// every action follows the same lifecycle as its menu or toolbar equivalent.
+struct CommandPaletteView: View {
+    let onRun: (CommandPalette.Command) -> Void
+    let onDismiss: () -> Void
+
+    @State private var query = ""
+    @State private var selectedCommandID: CommandPalette.Command.ID?
+    @State private var hoveredCommandID: CommandPalette.Command.ID?
+    @FocusState private var queryFieldFocused: Bool
+
+    private var results: [CommandPalette.Command] {
+        CommandPalette.filter(CommandPalette.Command.allCases, matching: query)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchHeader
+            Divider()
+                .overlay(RapidTheme.hairlineStrong)
+            commandList
+        }
+        .background {
+            RapidTheme.surfaceOverlay
+                .accessibilityElement()
+                .accessibilityIdentifier("CommandPalette.Panel")
+        }
+        .clipShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.22), radius: 28, x: 0, y: 12)
+        .onExitCommand(perform: onDismiss)
+        .onMoveCommand(perform: moveSelection)
+        .onChange(of: query) { _, _ in
+            selectedCommandID = results.first?.id
+        }
+        .task {
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            selectedCommandID = results.first?.id
+            queryFieldFocused = true
+        }
+    }
+
+    private var searchHeader: some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            Image(systemName: "command")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            TextField("Type a command", text: $query)
+                .textFieldStyle(.plain)
+                .font(RapidFont.body)
+                .focused($queryFieldFocused)
+                .onSubmit { runSelectedCommand() }
+                .accessibilityIdentifier("CommandPalette.Field")
+
+            SheetCloseButton(action: onDismiss)
+                .accessibilityIdentifier("CommandPalette.Close")
+        }
+        .padding(.horizontal, RapidTheme.Space.lg)
+        .frame(height: 56)
+    }
+
+    private var commandList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 1) {
+                    ForEach(results) { command in
+                        commandRow(command)
+                            .id(command.id)
+                    }
+                    if results.isEmpty {
+                        emptyState
+                    }
+                }
+                .padding(RapidTheme.Space.md)
+            }
+            .scrollIndicators(.never)
+            .onChange(of: selectedCommandID) { _, id in
+                guard let id else { return }
+                proxy.scrollTo(id, anchor: .center)
+            }
+        }
+    }
+
+    private func commandRow(_ command: CommandPalette.Command) -> some View {
+        let hovering = hoveredCommandID == command.id
+        let selected = selectedCommandID == command.id
+        return Button {
+            onRun(command)
+        } label: {
+            HStack(spacing: RapidTheme.Space.md) {
+                Image(systemName: command.systemImage)
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: RapidTheme.Layout.iconSlot)
+                Text(command.title)
+                    .font(selected ? RapidFont.bodyEmphasis : RapidFont.body)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, RapidTheme.Space.md)
+            .frame(height: 40)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(selected ? RapidTheme.selectionFill : (hovering ? RapidTheme.hoverFill : .clear))
+            )
+            .overlay(alignment: .leading) {
+                if selected {
+                    Capsule(style: .continuous)
+                        .fill(RapidTheme.selectionBar)
+                        .frame(
+                            width: RapidTheme.Layout.selectionBarWidth,
+                            height: RapidTheme.Layout.selectionBarHeight
+                        )
+                }
+            }
+            .contentShape(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(Color.primary)
+        .onHover {
+            hoveredCommandID = $0 ? command.id : nil
+        }
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityIdentifier("CommandPalette.Command.\(command.rawValue)")
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: RapidTheme.Space.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(.secondary)
+            Text("No commands match")
+                .font(RapidFont.body)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, RapidTheme.Space.xxl)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("CommandPalette.Empty")
+    }
+
+    private func runSelectedCommand() {
+        guard let id = selectedCommandID ?? results.first?.id,
+              let command = results.first(where: { $0.id == id }) else { return }
+        onRun(command)
+    }
+
+    private func moveSelection(_ direction: MoveCommandDirection) {
+        guard direction == .up || direction == .down, !results.isEmpty else { return }
+        let currentIndex = selectedCommandID.flatMap { id in
+            results.firstIndex(where: { $0.id == id })
+        }
+        let nextIndex: Int
+        switch direction {
+        case .up:
+            nextIndex = max(0, (currentIndex ?? 1) - 1)
+        case .down:
+            nextIndex = min(results.count - 1, (currentIndex ?? -1) + 1)
+        default:
+            return
+        }
+        selectedCommandID = results[nextIndex].id
+    }
+}
+
+enum CommandPalette {
+    enum Command: String, CaseIterable, Identifiable {
+        case newChat
+        case searchChats
+        case images
+        case audio
+        case launch
+        case settings
+        case modelManagement
+        case connectors
+        case serverLogs
+        case exportDiagnostics
+        case checkUpdates
+
+        var id: String { rawValue }
+
+        var title: LocalizedStringKey {
+            switch self {
+            case .newChat: return "New chat"
+            case .searchChats: return "Search chats"
+            case .images: return "Open Images"
+            case .audio: return "Open Audio"
+            case .launch: return "Open Launch"
+            case .settings: return "Open Settings"
+            case .modelManagement: return "Open Model Management"
+            case .connectors: return "Open Connectors"
+            case .serverLogs: return "Show or hide server logs"
+            case .exportDiagnostics: return "Export diagnostics…"
+            case .checkUpdates: return "Check for updates"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .newChat: return "square.and.pencil"
+            case .searchChats: return "magnifyingglass"
+            case .images: return "photo"
+            case .audio: return "waveform"
+            case .launch: return "paperplane"
+            case .settings: return "gearshape"
+            case .modelManagement: return "externaldrive.fill"
+            case .connectors: return "powerplug.fill"
+            case .serverLogs: return "terminal"
+            case .exportDiagnostics: return "stethoscope"
+            case .checkUpdates: return "arrow.triangle.2.circlepath"
+            }
+        }
+
+        var keywords: String {
+            switch self {
+            case .newChat: return "create conversation message chat new"
+            case .searchChats: return "find conversation history search chat"
+            case .images: return "image generation gallery photo"
+            case .audio: return "speech transcription voice audio"
+            case .launch: return "connect agents tools launch"
+            case .settings: return "preferences configuration settings"
+            case .modelManagement: return "models download cache storage"
+            case .connectors: return "mcp tools integrations connectors"
+            case .serverLogs: return "diagnostics output terminal logs"
+            case .exportDiagnostics: return "support report troubleshoot diagnostics"
+            case .checkUpdates: return "upgrade version software update"
+            }
+        }
+
+        var searchTitle: String {
+            switch self {
+            case .newChat: return String(localized: String.LocalizationValue("New chat"))
+            case .searchChats: return String(localized: String.LocalizationValue("Search chats"))
+            case .images: return String(localized: String.LocalizationValue("Open Images"))
+            case .audio: return String(localized: String.LocalizationValue("Open Audio"))
+            case .launch: return String(localized: String.LocalizationValue("Open Launch"))
+            case .settings: return String(localized: String.LocalizationValue("Open Settings"))
+            case .modelManagement: return String(localized: String.LocalizationValue("Open Model Management"))
+            case .connectors: return String(localized: String.LocalizationValue("Open Connectors"))
+            case .serverLogs: return String(localized: String.LocalizationValue("Show or hide server logs"))
+            case .exportDiagnostics: return String(localized: String.LocalizationValue("Export diagnostics…"))
+            case .checkUpdates: return String(localized: String.LocalizationValue("Check for updates"))
+            }
+        }
+    }
+
+    static func filter(
+        _ commands: [Command],
+        matching query: String
+    ) -> [Command] {
+        let terms = normalizedTerms(query)
+        guard !terms.isEmpty else { return commands }
+
+        return commands.filter { command in
+            let haystack = normalizedTerms("\(command.searchTitle) \(command.keywords)")
+                .joined(separator: " ")
+            return terms.allSatisfy { haystack.contains($0) }
+        }
+    }
+
+    private static func normalizedTerms(_ value: String) -> [String] {
+        value.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: .current
+        )
+        .split(whereSeparator: \.isWhitespace)
+        .map(String.init)
+    }
+}
+
+@MainActor
+@Observable
+final class CommandPaletteRequestCoordinator {
+    private(set) var requestID: UInt = 0
+    private(set) var lastConsumedRequestID: UInt = 0
+
+    func open() {
+        requestID &+= 1
+    }
+
+    func consume(_ requestID: UInt) -> Bool {
+        guard requestID > lastConsumedRequestID else { return false }
+        lastConsumedRequestID = requestID
+        return true
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -82,6 +82,8 @@ struct ContentView: View {
     @Environment(MCPToolApprovalStore.self) private var mcpApproval
     @Environment(DeferredTelemetryConsentCoordinator.self) private var deferredTelemetryConsent
     @Environment(GitHubStarPromptCoordinator.self) private var githubStarPrompt
+    @Environment(SparkleUpdateController.self) private var sparkleUpdater
+    @Environment(CommandPaletteRequestCoordinator.self) private var commandPaletteRequest
     @Environment(\.openWindow) private var openWindow
 
     @State private var alias: String = ""
@@ -101,6 +103,7 @@ struct ContentView: View {
     // restoration data. With a single main window the persistence scope is
     // the same in practice.
     @AppStorage(ContentView.showLogsKey) private var showLogs: Bool = false
+    @State private var showCommandPalette = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
     /// Explicit recovery route from the no-model empty state into the
@@ -178,7 +181,15 @@ struct ContentView: View {
         .overlay {
             if showConversationSearch {
                 conversationSearchOverlay
+            } else if showCommandPalette {
+                commandPaletteOverlay
             }
+        }
+        .onChange(of: commandPaletteRequest.requestID) { _, requestID in
+            showCommandPaletteFromRequest(requestID)
+        }
+        .onAppear {
+            showCommandPaletteFromRequest(commandPaletteRequest.requestID)
         }
         .onChange(of: server.state) { _, newState in
             // A chat-model replacement can keep the process or respawn it.
@@ -465,7 +476,7 @@ struct ContentView: View {
                     section = .chat
                 },
                 onSearchChats: {
-                    showConversationSearch = true
+                    openConversationSearch()
                 },
                 onSelectConversation: { id in
                     chat.selectConversation(id)
@@ -569,7 +580,88 @@ struct ContentView: View {
                 || server.pendingModelSwitch != nil
                 || browseApproval.pendingRequest != nil
                 || mcpApproval.pendingRequest != nil
+                || showCommandPalette
         )
+    }
+
+    private var commandPaletteOverlay: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.black.opacity(0.28)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { showCommandPalette = false }
+                    .accessibilityHidden(true)
+
+                CommandPaletteView(
+                    onRun: runCommandPaletteAction,
+                    onDismiss: { showCommandPalette = false }
+                )
+                .frame(
+                    width: min(620, max(480, proxy.size.width - 64)),
+                    height: min(460, max(340, proxy.size.height - 80))
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .accessibilityIdentifier("ContentView.CommandPalette")
+    }
+
+    private func runCommandPaletteAction(_ command: CommandPalette.Command) {
+        showCommandPalette = false
+        switch command {
+        case .newChat:
+            chat.newConversation()
+            section = .chat
+        case .searchChats:
+            openConversationSearch()
+        case .images:
+            section = .images
+        case .audio:
+            section = .audio
+        case .launch:
+            section = .launch
+        case .settings:
+            openWindow(id: "settings")
+        case .modelManagement:
+            settingsRouter.route(to: .modelManagement) {
+                openWindow(id: "settings")
+            }
+        case .connectors:
+            settingsRouter.route(to: .connectors) {
+                openWindow(id: "settings")
+            }
+        case .serverLogs:
+            showLogs.toggle()
+        case .exportDiagnostics:
+            DiagnosticsBundle.exportViaSavePanel(server: server)
+        case .checkUpdates:
+            if sparkleUpdater.isEnabled {
+                if sparkleUpdater.canCheckForUpdates {
+                    sparkleUpdater.checkForUpdates()
+                } else {
+                    settingsRouter.route(to: .app) {
+                        openWindow(id: "settings")
+                    }
+                }
+            } else {
+                Task { _ = await updater.check() }
+                settingsRouter.route(to: .app) {
+                    openWindow(id: "settings")
+                }
+            }
+        }
+    }
+
+    private func openConversationSearch() {
+        showCommandPalette = false
+        showConversationSearch = true
+    }
+
+    private func showCommandPaletteFromRequest(_ requestID: UInt) {
+        guard commandPaletteRequest.consume(requestID) else { return }
+        showConversationSearch = false
+        showCommandPalette = true
     }
 
     private var conversationSearchOverlay: some View {

--- a/apps/rapid-mac/Tests/RapidTests/CommandPaletteTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommandPaletteTests.swift
@@ -1,0 +1,68 @@
+import Testing
+@testable import Rapid
+
+@Suite("Command palette")
+struct CommandPaletteTests {
+    @Test("Filtering accepts all terms across titles and keywords")
+    func filteringRequiresEveryTerm() {
+        let titleResults = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "chat new"
+        )
+        let imageTitleResults = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "open images"
+        )
+        let updateTitleResults = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "check for updates"
+        )
+        let punctuationResults = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "export diagnostics"
+        )
+
+        #expect(titleResults == [.newChat])
+        #expect(imageTitleResults == [.images])
+        #expect(updateTitleResults == [.checkUpdates])
+        #expect(punctuationResults == [.exportDiagnostics])
+    }
+
+    @Test("Filtering is case-insensitive and ignores diacritics")
+    func filteringNormalizesQuery() {
+        let results = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "CHÂT NEW"
+        )
+
+        #expect(results == [.newChat])
+    }
+
+    @Test("A request is consumed once and survives window recreation only until shown")
+    @MainActor
+    func requestConsumptionIsAppScoped() {
+        let coordinator = CommandPaletteRequestCoordinator()
+
+        coordinator.open()
+        #expect(coordinator.consume(coordinator.requestID))
+        #expect(!coordinator.consume(coordinator.requestID))
+
+        coordinator.open()
+        let requestID = coordinator.requestID
+        #expect(coordinator.consume(requestID))
+        #expect(!coordinator.consume(requestID))
+    }
+
+    @Test("The fixed registry keeps IDs unique and includes primary actions")
+    func registryIsStableAndActionable() {
+        let commands = CommandPalette.Command.allCases
+
+        #expect(Set(commands.map(\.id)).count == commands.count)
+        #expect(commands.contains(.newChat))
+        #expect(commands.contains(.searchChats))
+        #expect(commands.contains(.settings))
+        #expect(commands.contains(.modelManagement))
+        #expect(commands.contains(.serverLogs))
+        #expect(commands.contains(.exportDiagnostics))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -532,6 +532,12 @@ struct CoreWorkspaceVisualFoundationTests {
             "Sources/Rapid/UI/ReadinessBanner.swift": [
                 "Readiness.Action",
             ],
+            "Sources/Rapid/UI/CommandPaletteView.swift": [
+                "CommandPalette.Panel",
+                "CommandPalette.Field",
+                "CommandPalette.Close",
+                "CommandPalette.Empty",
+            ],
         ]
         for (path, identifiers) in expectations {
             let source = try strippedSource(path)
@@ -746,6 +752,36 @@ struct CoreWorkspaceVisualFoundationTests {
         #expect(
             app.contains(#"@AppStorage(ContentView.showLogsKey)"#),
             "The menu command and the in-window controls must read one flag; a scene-scoped value is unreachable from .commands."
+        )
+    }
+
+    @Test("Command palette has a keyboard menu path")
+    func commandPaletteHasAMenuCommand() throws {
+        let app = try strippedSource("Sources/Rapid/RapidApp.swift")
+        let content = try strippedSource("Sources/Rapid/UI/ContentView.swift")
+        #expect(
+            app.contains(#"keyboardShortcut("p",modifiers:.command)"#),
+            "Command palette must stay reachable from the keyboard, not only from hover controls."
+        )
+        #expect(
+            app.contains("commandPaletteRequest.open()"),
+            "The menu command must stage a monotonic request for the main window."
+        )
+        #expect(
+            content.contains(#"@StateprivatevarshowCommandPalette=false"#),
+            "Palette visibility is a window session state, not a persisted preference."
+        )
+        #expect(
+            content.contains("privatefuncopenConversationSearch(){showCommandPalette=falseshowConversationSearch=true}"),
+            "Chat search must clear palette state so the two overlays cannot queue."
+        )
+        #expect(
+            app.contains("NSApp.activate(ignoringOtherApps:true)"),
+            "The menu path must activate the app before showing the window-scoped palette."
+        )
+        #expect(
+            content.contains(".onChange(of:commandPaletteRequest.requestID)"),
+            "A recreated main window must consume a menu palette request on appear."
         )
     }
 }


### PR DESCRIPTION
## Summary
- Adds a focused `⌘P` command palette for primary navigation and existing app actions.
- Uses a fixed command registry with localized title/keyword filtering, keyboard selection, and the same selected-row treatment as the existing rail.
- Adds tests for filtering, command stability, request consumption, accessibility identifiers, and the keyboard menu path.

## Validation
- [x] `swift test --filter CommandPalette|CoreWorkspaceVisualFoundation`
- [x] `SKIP_SIDECAR=1 bash apps/rapid-mac/scripts/build.sh`
- [x] `pr_validate` full unit suite: 19856 passed, MERGE-SAFE
- [x] Focused Codex review: no findings

## Review contract
- User-visible goal: users can discover and reach common navigation/actions without hunting through separate surfaces.
- Allowed scope: command palette overlay, fixed registry, request coordinator, `⌘P` menu path, localization, snapshot environment, and focused tests.
- Non-goals: arbitrary command execution, new backend behavior, telemetry, release changes, or other UI redesigns.