### PR TITLE
Expose pre-serve video model capabilities

### DIFF
--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -7,6 +7,15 @@ Video generation requires Python 3.11 or newer because the upstream
 `mlx-video-with-audio` runtime does not support Python 3.10. Rapid-MLX's core
 text and audio features continue to support Python 3.10.
 
+## Discover capabilities before serving
+
+`rapid-mlx models --json` lists video aliases separately from other model
+types. Each video entry includes `video_modes` (`text-to-video`,
+`image-to-video`, or both) and `min_memory_gb`, so clients can choose a
+compatible checkpoint before downloading or starting it. After the model is
+serving, `GET /v1/videos/capabilities` remains the source for its live size,
+duration, frame-rate, workload, reference-image, and optional-control limits.
+
 ## Motion and conditioning controls
 
 `POST /v1/videos` accepts optional controls in addition to `seconds`:

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -52,6 +52,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         # download; ``hf_path`` stays a bare repo id everywhere else.
         "subfolder",
         "modality",
+        "video_modes",
         # State-pin (parallel to ``is_hybrid``): serve a vision-config
         # checkpoint through the text-only mlx-lm lane. Translated to the
         # registered ``force_text`` routing kwarg (#393) in

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -40,6 +40,8 @@ def test_available_payload_shape() -> None:
         "mtp_draft_model",
         "mtp_speculative_tokens",
         "modality",
+        "video_modes",
+        "min_memory_gb",
         "is_builtin",
         "is_text_only",
     ):
@@ -50,6 +52,10 @@ def test_available_payload_shape() -> None:
     assert isinstance(entry["is_builtin"], bool)
     assert isinstance(entry["is_text_only"], bool)
     assert entry["size_bytes"] is None or isinstance(entry["size_bytes"], int)
+    assert entry["video_modes"] == []
+    assert entry["min_memory_gb"] is None or isinstance(
+        entry["min_memory_gb"], (int, float)
+    )
 
 
 def test_available_sections_are_split_by_modality() -> None:
@@ -59,6 +65,30 @@ def test_available_sections_are_split_by_modality() -> None:
     assert all(e["modality"] == "video-gen" for e in payload["video"])
     assert all(e["modality"] == "image-gen" for e in payload["image"])
     assert all(e["modality"] == "audio" for e in payload["audio"])
+
+
+def test_video_entries_expose_pre_serve_modes_and_memory_floor() -> None:
+    payload = _available_models_json_payload()
+    expected_modes = {
+        "cogvideox-fun-5b-q4": ["text-to-video"],
+        "cogvideox-fun-5b-q8": ["text-to-video"],
+        "cogvideox-fun-5b-bf16": ["text-to-video"],
+        "wan2.2-ti2v-5b-q8": ["text-to-video", "image-to-video"],
+        "wan2.2-ti2v-5b-bf16": ["text-to-video", "image-to-video"],
+        "wan2.2-i2v-a14b-q8": ["image-to-video"],
+        "wan2.2-t2v-a14b-bf16": ["text-to-video"],
+        "ltx-2.3-mlx-q4": ["text-to-video", "image-to-video"],
+        "ltx-2.5-mlx-q8": ["text-to-video", "image-to-video"],
+    }
+    by_alias = {entry["alias"]: entry for entry in payload["video"]}
+
+    assert set(by_alias) == set(expected_modes)
+    for alias, modes in expected_modes.items():
+        assert by_alias[alias]["video_modes"] == modes
+        assert by_alias[alias]["min_memory_gb"] > 0
+
+    assert all(entry["video_modes"] == [] for entry in payload["text"])
+    assert all(entry["video_modes"] == [] for entry in payload["image"])
 
 
 def test_cached_payload_shape() -> None:

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -343,6 +343,22 @@ def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
             {
                 "hf_path": "org/video",
                 "modality": "video-gen",
+                "video_modes": [],
+            },
+            "must be a non-empty list",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": "text-to-video",
+            },
+            "must be a non-empty list",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
                 "video_modes": ["video-to-video"],
             },
             "entries must be one of",

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -70,6 +70,22 @@ def test_every_alias_has_explicit_profile_fields() -> None:
         assert isinstance(value["supports_spec_decode"], bool)
 
 
+def test_video_aliases_declare_valid_generation_modes() -> None:
+    with open(ALIASES_PATH) as f:
+        raw = json.load(f)
+    allowed = {"text-to-video", "image-to-video"}
+    for alias, value in raw.items():
+        modes = value.get("video_modes")
+        if value.get("modality") == "video-gen":
+            assert isinstance(modes, list) and modes, (
+                f"{alias!r}: video aliases require at least one video mode"
+            )
+            assert set(modes) <= allowed
+            assert len(modes) == len(set(modes))
+        else:
+            assert modes is None, f"{alias!r}: non-video alias declares video modes"
+
+
 def test_no_orphan_aliases() -> None:
     """Every advertised alias must resolve to an explicit profile."""
     aliases = list_aliases()
@@ -315,6 +331,47 @@ def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
         patch.object(ma, "_hf_to_alias", None),
         patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
         pytest.raises(ValueError, match="foo"),
+    ):
+        ma.list_profiles()
+
+
+@pytest.mark.parametrize(
+    "profile,message",
+    [
+        ({"hf_path": "org/video", "modality": "video-gen"}, "requires video_modes"),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": ["video-to-video"],
+            },
+            "entries must be one of",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": ["text-to-video", "text-to-video"],
+            },
+            "must not contain duplicates",
+        ),
+        (
+            {"hf_path": "org/text", "video_modes": ["text-to-video"]},
+            "only valid",
+        ),
+    ],
+)
+def test_invalid_video_modes_fail_at_registry_load(tmp_path, profile, message) -> None:
+    bad = tmp_path / "aliases.json"
+    bad.write_text(json.dumps({"bad-video": profile}))
+
+    import vllm_mlx.model_aliases as ma
+
+    with (
+        patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+        pytest.raises(ValueError, match=message),
     ):
         ma.list_profiles()
 

--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -4,7 +4,67 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
+
+
+@pytest.mark.parametrize(
+    "alias,engine",
+    [
+        (
+            "cogvideox-fun-5b-q4",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "cogvideox-fun-5b-q8",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "cogvideox-fun-5b-bf16",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "wan2.2-ti2v-5b-q8",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="ti2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-ti2v-5b-bf16",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="ti2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-i2v-a14b-q8",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="i2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-t2v-a14b-bf16",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="t2v", max_area=None),
+            ),
+        ),
+        ("ltx-2.3-mlx-q4", SimpleNamespace(video_family="ltx-2.3")),
+        ("ltx-2.5-mlx-q8", SimpleNamespace(video_family="ltx-2.5")),
+    ],
+)
+def test_builtin_pre_serve_modes_match_live_capabilities(alias, engine) -> None:
+    profile = resolve_profile(alias)
+    assert profile is not None
+    engine.model_name = profile.hf_path
+
+    assert list(profile.video_modes or ()) == video._video_capabilities(engine)["modes"]
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1695,6 +1695,7 @@
   "cogvideox-fun-5b-q4": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1707,6 +1708,7 @@
   "cogvideox-fun-5b-q8": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1719,6 +1721,7 @@
   "cogvideox-fun-5b-bf16": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1731,6 +1734,7 @@
   "wan2.2-ti2v-5b-q8": {
     "hf_path": "Anes1032/Wan2.2-TI2V-5B-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1743,6 +1747,7 @@
   "wan2.2-ti2v-5b-bf16": {
     "hf_path": "rickylin20260522/Wan2.2-TI2V-5B-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1755,6 +1760,7 @@
   "wan2.2-i2v-a14b-q8": {
     "hf_path": "Anes1032/Wan2.2-I2V-A14B-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1767,6 +1773,7 @@
   "wan2.2-t2v-a14b-bf16": {
     "hf_path": "rickylin20260522/Wan2.2-T2V-A14B-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1779,6 +1786,7 @@
   "ltx-2.3-mlx-q4": {
     "hf_path": "notapalindrome/ltx23-mlx-av-q4",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1791,6 +1799,7 @@
   "ltx-2.5-mlx-q8": {
     "hf_path": "MrMofer/ltx-2.5-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6275,6 +6275,8 @@ def _available_models_json_payload() -> dict:
             "mtp_draft_model": getattr(p, "mtp_draft_model", None),
             "mtp_speculative_tokens": getattr(p, "mtp_speculative_tokens", None),
             "modality": _modality(p),
+            "video_modes": list(p.video_modes or ()),
+            "min_memory_gb": p.min_memory_gb,
             # Desktop consumes these as a launch-safety contract. Only
             # curated aliases may opt into eager MLLM loading, and an
             # explicit text-only pin always wins over name inference.

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -14,8 +14,14 @@ that entry just gets default capability flags.
 import difflib
 import json
 import os
+from typing import cast
 
-from .model_profile import Modality, ModelProfile
+from .model_profile import (
+    VIDEO_GENERATION_MODES,
+    Modality,
+    ModelProfile,
+    VideoGenerationMode,
+)
 
 # ``Modality`` and the unified ``ModelProfile`` dataclass live in the
 # import-light ``model_profile`` module — the single source of truth for
@@ -156,6 +162,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             # ``hf_path``.
             "subfolder",
             "modality",
+            "video_modes",
             # State-pin (parallel to ``is_hybrid`` / ``is_moe``): serve
             # this checkpoint through the text mlx-lm lane even though its
             # config declares a vision tower. server.load_model translates
@@ -480,6 +487,31 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"{sorted(_VALID_MODALITIES)}, got {raw_modality!r}"
         )
     modality: Modality = raw_modality  # type: ignore[assignment]
+    raw_video_modes = value.get("video_modes")
+    video_modes: tuple[VideoGenerationMode, ...] | None = None
+    if raw_video_modes is not None:
+        if not isinstance(raw_video_modes, list) or not raw_video_modes:
+            raise ValueError(f"alias {alias!r}: video_modes must be a non-empty list")
+        if any(
+            not isinstance(mode, str) or mode not in VIDEO_GENERATION_MODES
+            for mode in raw_video_modes
+        ):
+            raise ValueError(
+                f"alias {alias!r}: video_modes entries must be one of "
+                f"{list(VIDEO_GENERATION_MODES)}, got {raw_video_modes!r}"
+            )
+        if len(raw_video_modes) != len(set(raw_video_modes)):
+            raise ValueError(
+                f"alias {alias!r}: video_modes must not contain duplicates"
+            )
+        video_modes = cast(tuple[VideoGenerationMode, ...], tuple(raw_video_modes))
+    if modality == "video-gen" and video_modes is None:
+        raise ValueError(f"alias {alias!r}: modality='video-gen' requires video_modes")
+    if modality != "video-gen" and video_modes is not None:
+        raise ValueError(
+            f"alias {alias!r}: video_modes is only valid when "
+            f"modality='video-gen', got modality={modality!r}"
+        )
     # ``is_text_only`` — state-pin that serves a vision-config checkpoint
     # through the AR text mlx-lm lane (translated to the ``force_text``
     # routing kwarg in server.load_model). Only meaningful on the ``text``
@@ -576,6 +608,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         hf_path=hf_path,
         subfolder=subfolder,
         modality=modality,
+        video_modes=video_modes,
         is_text_only=is_text_only,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -29,7 +29,7 @@ also avoids an import cycle: ``model_auto_config`` already imports
 """
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, get_args
 
 # NOTE: deliberately NO ``from __future__ import annotations`` here. The
 # out-of-band-routing guard (tests/test_no_out_of_band_routing.py) inspects
@@ -56,6 +56,8 @@ from typing import Literal
 # in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
 # doesn't silently expose LLM-only columns on a non-LLM alias.
 Modality = Literal["text", "text-diffusion", "vision", "image-gen", "video-gen"]
+VideoGenerationMode = Literal["text-to-video", "image-to-video"]
+VIDEO_GENERATION_MODES: tuple[VideoGenerationMode, ...] = get_args(VideoGenerationMode)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -214,6 +216,11 @@ class ModelProfile:
     # → ``runtime/video_lane.py``; ``"vision"`` reserved for an upcoming
     # VLM integration.
     modality: Modality = "text"
+    # Operations this checkpoint can perform before it is downloaded or
+    # served. Live shape/control limits still come from
+    # ``GET /v1/videos/capabilities`` because they may depend on checkpoint
+    # metadata. ``None`` is required for every non-video modality.
+    video_modes: tuple[VideoGenerationMode, ...] | None = None
     # PFlash long-prompt compression eligibility (#287). Default
     # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a
     # brand-new alias never silently enables compression on an


### PR DESCRIPTION
## User impact

Desktop and other clients can now choose a compatible text-to-video or image-to-video checkpoint before downloading and starting it, and can show the catalogued unified-memory floor during that decision.

Closes #2788.

## What changed

- add a closed, validated `video_modes` contract to model profiles
- declare T2V/I2V support for every built-in video alias
- expose `video_modes` and `min_memory_gb` in `rapid-mlx models --json`
- reject missing, unknown, duplicate, or non-video mode declarations at registry load
- pin static catalog modes to the existing live `/v1/videos/capabilities` derivation
- document pre-serve discovery versus live per-model limits

## Scope / non-goals

This is additive catalog metadata only. It does not change model loading, generation behavior or limits, the live capabilities response, video job cancellation/persistence, or Desktop UI.

## Verification

- exact-head GitHub CI passed on Python 3.10, 3.11 and 3.12, Apple Silicon, lint, type-check, engine contracts and changed-lines coverage
- pre-follow-up full local unit suite: 19,715 passed, 116 skipped, 229 deselected, 6 xfailed
- exact-head focused alias/video contract suite: 2,985 passed
- mypy shrink-only budget: 707 grandfathered errors across 143 files; no growth
- independent review loop passed in 2 rounds
- `make lint` and `git diff --check` passed