### PR TITLE
feat: add production-safe GLM-5.3-Flash support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,7 @@ jobs:
             tests/test_glm5_next_processor_patch.py \
             tests/test_glm5_next_forget_gate_quant.py \
             tests/test_glm5_next_runtime_patch.py \
+            tests/test_mllm_hybrid_probe.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,9 @@ jobs:
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
             tests/test_mtp_cli_wiring.py \
+            tests/test_glm5_next_processor_patch.py \
+            tests/test_glm5_next_forget_gate_quant.py \
+            tests/test_glm5_next_runtime_patch.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/NOTICE
+++ b/NOTICE
@@ -59,6 +59,18 @@ repository. Each keeps its upstream license text alongside the code.
   GUST-FONT-LICENSE.txt notices alongside the font files.
   See apps/rapid-mac/Vendor/SwiftMath/LICENSE.
 
+* vllm_mlx/patches/glm5_next_processor.py
+  GLM-5 Next torch-free processor adapted from
+  https://github.com/jundot/omlx at commit
+  c520d7e6124cf6255868e589c6beb75cf4cee8f9.
+  Licensed under the Apache License, Version 2.0.
+
+* vllm_mlx/patches/glm5_next_runtime.py
+  GLM-5 Next text-runtime compatibility logic adapted from the mlx-vlm
+  correctness work at commits f9e2c507a154575956ea97449729a67de72c9c70 and
+  bffd4856a4504b76a242536f2dd356093c8e2e92.
+  Licensed under the MIT License.
+
 
 Runtime dependencies
 ====================

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -126,7 +126,7 @@ Both pinned by `PBS_VERSION` / `PBS_TAG` in `scripts/build-sidecar.sh`.
 
 The root `pyproject.toml` `[project].dependencies` block, installed in
 full. The ranges below are the **root manifest's**; the sidecar build pins
-`mlx==0.32.2` and `transformers==5.12.1` at install time (step 2 of
+`mlx==0.32.2` and `transformers==5.15.1` at install time (step 2 of
 `scripts/build-sidecar.sh`) so the shipped vision stack is reproducible.
 
 | Component | Declared range | License | Project |
@@ -158,7 +158,7 @@ path works in a text-only bundle:
 
 | Component | Pin | License | Project |
 | --- | --- | --- | --- |
-| mlx-vlm | `==0.6.16` | MIT | https://github.com/Blaizzy/mlx-vlm |
+| mlx-vlm | `==0.6.17` | MIT | https://github.com/Blaizzy/mlx-vlm |
 | Pillow | `>=10.0` | MIT-CMU | https://github.com/python-pillow/Pillow |
 
 ### Third-party source vendored into the engine
@@ -189,6 +189,8 @@ The largest and most self-contained components:
 | MLX Stable Audio 3 | https://github.com/Stability-AI/stable-audio-3 | MIT | `vllm_mlx/audio/sa3/` (`LICENSE`, `NOTICE`) |
 | CogVideoX-Fun MLX | https://github.com/dgrauet/VideoX-Fun-mlx | Apache-2.0 | `videox_fun_mlx/` (`LICENSE`, `NOTICE`) |
 | TurboQuant Metal kernels | https://github.com/arozanov/turboquant-mlx | Apache-2.0 | `vllm_mlx/kernels/turboquant_fused.metal` |
+| GLM-5 Next image processor | https://github.com/jundot/omlx (`c520d7e`) | Apache-2.0 | `vllm_mlx/patches/glm5_next_processor.py` |
+| GLM-5 Next text runtime | https://github.com/Blaizzy/mlx-vlm (`f9e2c50`, `bffd485`) | MIT | `vllm_mlx/patches/glm5_next_runtime.py` |
 | Gemma 4 model classes | https://github.com/Blaizzy/mlx-vlm (v0.6.3) | MIT | `vllm_mlx/models/gemma4_vendored/` |
 | Hunyuan 3 model class | https://github.com/ml-explore/mlx-lm (PR #1211) | MIT | `vllm_mlx/models/hy_v3.py` |
 | DeepSeek V4 model classes | https://github.com/ml-explore/mlx-lm (`_ds4` branch, © Apple Inc.) | MIT | `vllm_mlx/models/deepseek_v4.py`, `deepseek_v4_cache.py`, `deepseek_v4_hyper_connection.py`, `deepseek_v4_switch.py` |

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -61,7 +61,7 @@ struct SidecarBuildScriptTests {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
         let constraints = try String(contentsOf: Self.constraintsURL, encoding: .utf8)
 
-        #expect(constraints.contains("mlx-vlm==0.6.16"))
+        #expect(constraints.contains("mlx-vlm==0.6.17"))
         #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
                 "The no-deps sidecar install must never float within a range.")
         #expect(script.contains(#"--constraint "$SIDECAR_CONSTRAINTS""#),

--- a/apps/rapid-mac/scripts/check-sidecar-distributions.py
+++ b/apps/rapid-mac/scripts/check-sidecar-distributions.py
@@ -6,10 +6,6 @@ from __future__ import annotations
 import argparse
 from importlib import metadata
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from packaging.requirements import Requirement
 
 SIDECAR_CONSTRAINTS_FILE = Path(__file__).with_name("sidecar-constraints.txt")
 
@@ -18,33 +14,6 @@ def emit_constraints() -> str:
     """Return the canonical pip constraints used by release-shaped installs."""
 
     return SIDECAR_CONSTRAINTS_FILE.read_text()
-
-
-def is_validated_compatibility_exception(
-    *, owner: str, owner_version: str, requirement: Requirement, actual: str
-) -> bool:
-    """Return true only for the release-tested reduced vision runtime.
-
-    mlx-vlm 0.6.16 declares Transformers >=5.14 for its complete feature set.
-    Rapid's shipped Qwen/Gemma image lanes do not exercise that newer surface;
-    they are validated by real image inference with Transformers 5.12.1.  This
-    is deliberately an exact tuple rather than a package-wide metadata bypass.
-
-    Remove this exception after replacing Rapid's Transformers <5.13 cap with
-    !=5.13.0 and completing the tracked 5.15.x coherence sweep. Every other
-    owner/version, dependency, declared specifier, or actual version remains a
-    hard error.
-    """
-
-    from packaging.utils import canonicalize_name
-
-    return (
-        canonicalize_name(owner) == "mlx-vlm"
-        and owner_version == "0.6.16"
-        and canonicalize_name(requirement.name) == "transformers"
-        and str(requirement.specifier) == ">=5.14.0"
-        and actual == "5.12.1"
-    )
 
 
 def find_errors(site_packages: Path) -> list[str]:
@@ -68,17 +37,6 @@ def find_errors(site_packages: Path) -> list[str]:
             if actual is None or not requirement.specifier:
                 continue
             if actual in requirement.specifier:
-                continue
-            if is_validated_compatibility_exception(
-                owner=owner,
-                owner_version=dist.version,
-                requirement=requirement,
-                actual=actual,
-            ):
-                print(
-                    "==> validated compatibility exception: "
-                    "mlx-vlm 0.6.16 with transformers 5.12.1"
-                )
                 continue
             errors.append(
                 f"{owner} requires {requirement}, but bundled "

--- a/apps/rapid-mac/scripts/sidecar-constraints.txt
+++ b/apps/rapid-mac/scripts/sidecar-constraints.txt
@@ -1,5 +1,5 @@
 # Release-tested versions shared by candidate-wheel and Desktop sidecar builds.
 mlx==0.32.2
-transformers==5.12.1
-mlx-vlm==0.6.16
+transformers==5.15.1
+mlx-vlm==0.6.17
 mflux==0.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ vision = [
     # A floating 0.6.x range backtracks to 0.6.3 under older Transformers
     # constraints and can also advance CLI users beyond the Desktop's validated
     # lane. Updating this exact pin is a gated coherence event (#1248).
-    "mlx-vlm==0.6.16",
+    "mlx-vlm==0.6.17",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -176,7 +176,7 @@ vision = [
 # the vision extras do. Only enable if you serve a DFlash-eligible alias
 # (e.g. qwen3.5-27b-8bit) with --speculative-config '{"method":"dflash"}'.
 dflash = [
-    "mlx-vlm==0.6.16",
+    "mlx-vlm==0.6.17",
 ]
 # MTP (Multi-Token Prediction) speculative decoding — Gemma 4 external
 # assistant path via ``--speculative-config '{"method":"mtp","model":"<path>"}'``.
@@ -226,7 +226,7 @@ chat = [
 # pip install .[all] and editable installs.
 all = [
     # vision
-    "mlx-vlm==0.6.16",
+    "mlx-vlm==0.6.17",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -294,7 +294,7 @@ test = [
     # ``pytest tests/`` without hand-installed local extras.
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm==0.6.16; platform_system == 'Darwin'",
+    "mlx-vlm==0.6.17; platform_system == 'Darwin'",
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Powers the property-based invariant suite in tests/property/ — encodes
     # numeric/validation invariants over the whole input space (e.g. the
@@ -391,7 +391,7 @@ dev = [
     'tomli>=2.0.1; python_version < "3.11"',
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm==0.6.16; platform_system == 'Darwin'",
+    "mlx-vlm==0.6.17; platform_system == 'Darwin'",
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Mirror of the [test] entry — keep `dev` a strict superset of `test`
     # (enforced by tests/test_pr_validate_test_env.py).

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -1898,6 +1898,29 @@ def test_glm_5_2_reap50_alias_resolves_to_pipenetwork_4bit() -> None:
     )
 
 
+def test_glm_5_3_flash_alias_is_experimental_and_fails_closed() -> None:
+    """GLM-5.3 starts on the verified autoregressive VLM path only."""
+
+    alias = "glm5.3-flash-4bit"
+    profile = list_profiles()[alias]
+
+    assert profile.hf_path == "Vontra/GLM-5.3-Flash-MLX-4bit-MTP"
+    assert profile.experimental is True
+    assert profile.min_memory_gb == 192.0
+    assert profile.vision_min_memory_gb is None
+    assert profile.is_hybrid is True
+    assert profile.is_hybrid_explicit is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+    assert profile.supports_native_mtp is False
+    assert profile.supports_dflash is False
+    assert profile.tool_call_parser == "glm47"
+    assert profile.reasoning_parser == "glm4"
+    assert profile.recommended_sampling is None
+    assert detect_model_config(alias) == profile
+    assert detect_model_config(profile.hf_path) == profile
+
+
 # =============================================================================
 # is_text_only routing state-pin (#393 declarative default for force_text)
 # =============================================================================

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -106,7 +106,7 @@ def test_gemma4_load_fallback_prints_validated_runtime(monkeypatch, capsys):
     assert cli._run_submit_flow(args) == 2
     out = capsys.readouterr().out
     assert "rapid-mlx[vision]" in out
-    assert "pip install --no-deps 'mlx-vlm==0.6.16'" in out
+    assert "pip install --no-deps 'mlx-vlm==0.6.17'" in out
 
 
 def test_models_command_lists_all_aliases():

--- a/tests/test_glm5_next_forget_gate_quant.py
+++ b/tests/test_glm5_next_forget_gate_quant.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for strict loading of quantized GLM-5 Next forget gates."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from vllm_mlx.patches.glm5_next_forget_gate_quant import (
+    _remap_quantized_forget_gate_tensors,
+)
+
+
+def test_quantization_metadata_follows_forget_gate_weight_rename() -> None:
+    weights = {
+        "model.layers.0.self_attn.f_a_proj.scales": object(),
+        "model.layers.0.self_attn.f_a_proj.biases": object(),
+        "model.layers.0.self_attn.f_b_proj.scales": object(),
+        "model.layers.0.self_attn.f_b_proj.biases": object(),
+        "model.layers.0.self_attn.forget_gate.f_a_proj.weight": object(),
+        "model.layers.0.self_attn.q_proj.scales": object(),
+    }
+
+    remapped = _remap_quantized_forget_gate_tensors(weights)
+
+    for projection in ("f_a_proj", "f_b_proj"):
+        for leaf in ("scales", "biases"):
+            assert (
+                f"model.layers.0.self_attn.forget_gate.{projection}.{leaf}" in remapped
+            )
+            assert f"model.layers.0.self_attn.{projection}.{leaf}" not in remapped
+    assert "model.layers.0.self_attn.forget_gate.f_a_proj.weight" in remapped
+    assert "model.layers.0.self_attn.q_proj.scales" in remapped
+
+
+def test_installer_wraps_released_sanitizer_once_in_clean_process() -> None:
+    script = """
+from vllm_mlx.patches import glm5_next_forget_gate_quant as patch
+from mlx_vlm.models.glm5_next import language
+
+language.LanguageModel.sanitize = lambda self, weights: dict(weights)
+assert patch.install_glm5_next_forget_gate_quant_fix() is True
+assert patch.install_glm5_next_forget_gate_quant_fix() is False
+assert patch.is_installed() is True
+
+result = language.LanguageModel.sanitize(
+    object(),
+    {"model.layers.0.self_attn.f_a_proj.scales": "sentinel"},
+)
+assert result == {
+    "model.layers.0.self_attn.forget_gate.f_a_proj.scales": "sentinel"
+}
+assert language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED is True
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_glm5_next_forget_gate_quant.py
+++ b/tests/test_glm5_next_forget_gate_quant.py
@@ -3,8 +3,7 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import pytest
 
 from vllm_mlx.patches.glm5_next_forget_gate_quant import (
     _remap_quantized_forget_gate_tensors,
@@ -33,28 +32,58 @@ def test_quantization_metadata_follows_forget_gate_weight_rename() -> None:
     assert "model.layers.0.self_attn.q_proj.scales" in remapped
 
 
+@pytest.mark.requires_mlx
 def test_installer_wraps_released_sanitizer_once_in_clean_process() -> None:
-    script = """
-from vllm_mlx.patches import glm5_next_forget_gate_quant as patch
-from mlx_vlm.models.glm5_next import language
+    from mlx_vlm.models.glm5_next import language
 
-language.LanguageModel.sanitize = lambda self, weights: dict(weights)
-assert patch.install_glm5_next_forget_gate_quant_fix() is True
-assert patch.install_glm5_next_forget_gate_quant_fix() is False
-assert patch.is_installed() is True
+    from vllm_mlx.patches import glm5_next_forget_gate_quant as patch
 
-result = language.LanguageModel.sanitize(
-    object(),
-    {"model.layers.0.self_attn.f_a_proj.scales": "sentinel"},
-)
-assert result == {
-    "model.layers.0.self_attn.forget_gate.f_a_proj.scales": "sentinel"
-}
-assert language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED is True
-"""
-    subprocess.run(
-        [sys.executable, "-c", script],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    original = language.LanguageModel.sanitize
+    marker = getattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED", None)
+    marker_existed = hasattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED")
+    patch._INSTALLED = False
+    if marker_existed:
+        del language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED
+    language.LanguageModel.sanitize = lambda self, weights: dict(weights)
+
+    try:
+        assert patch.install_glm5_next_forget_gate_quant_fix() is True
+        assert patch.install_glm5_next_forget_gate_quant_fix() is False
+        assert patch.is_installed() is True
+
+        result = language.LanguageModel.sanitize(
+            object(),
+            {"model.layers.0.self_attn.f_a_proj.scales": "sentinel"},
+        )
+        assert result == {
+            "model.layers.0.self_attn.forget_gate.f_a_proj.scales": "sentinel"
+        }
+        assert language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED is True
+    finally:
+        language.LanguageModel.sanitize = original
+        if marker_existed:
+            language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED = marker
+        elif hasattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED"):
+            del language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED
+        patch._INSTALLED = False
+
+
+@pytest.mark.requires_mlx
+def test_installer_respects_quant_runtime_that_is_already_patched() -> None:
+    from mlx_vlm.models.glm5_next import language
+
+    from vllm_mlx.patches import glm5_next_forget_gate_quant as patch
+
+    marker = getattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED", None)
+    marker_existed = hasattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED")
+    patch._INSTALLED = False
+    language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED = True
+    try:
+        assert patch.install_glm5_next_forget_gate_quant_fix() is False
+        assert patch.is_installed() is True
+    finally:
+        if marker_existed:
+            language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED = marker
+        else:
+            del language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED
+        patch._INSTALLED = False

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -82,6 +82,15 @@ def test_smart_resize_downscales_and_rejects_impossible_budget() -> None:
     assert 2 * height * width <= 64 * 2 * 28**2
     with pytest.raises(ValueError, match="too small"):
         smart_resize(2, 100, 100, factor=28, max_image_tokens=0)
+    with pytest.raises(ValueError, match="aspect ratio"):
+        smart_resize(
+            2,
+            1,
+            10_000,
+            factor=28,
+            min_image_tokens=1,
+            max_image_tokens=1,
+        )
 
 
 def test_image_shape_conversion_and_resize_edges(tmp_path: Path) -> None:
@@ -115,6 +124,26 @@ def test_image_shape_conversion_and_resize_edges(tmp_path: Path) -> None:
     float_image = np.full((3, 2, 2), 0.5, dtype=np.float32)
     resized = processor_patch._resize_channel_first(float_image, 4, 4)
     assert resized.shape == (3, 4, 4)
+    assert resized.dtype == np.float32
+    assert np.allclose(resized, 0.5, atol=1 / 255)
+
+
+def test_path_image_is_materialized_before_file_closes(monkeypatch) -> None:
+    image = Image.new("RGB", (5, 4), "red")
+    state = {"closed": False}
+
+    class TrackedImage:
+        def __enter__(self):
+            return image
+
+        def __exit__(self, *_args):
+            state["closed"] = True
+            image.close()
+
+    monkeypatch.setattr(processor_patch.Image, "open", lambda _path: TrackedImage())
+    result = processor_patch._to_channel_first("image.png", True)
+    assert state["closed"] is True
+    assert result.shape == (3, 4, 5)
 
 
 def test_ambiguous_channel_shape_preserves_pixels_with_explicit_format() -> None:
@@ -286,12 +315,24 @@ def test_json_metadata_local_remote_and_invalid_shapes(
         huggingface_hub, "hf_hub_download", lambda *_args, **_kwargs: downloaded
     )
     assert processor_patch._load_json("org/model", "config.json") == {"remote": True}
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
     monkeypatch.setattr(
         huggingface_hub,
         "hf_hub_download",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            LocalEntryNotFoundError("offline")
+        ),
     )
     assert processor_patch._load_json("org/model", "config.json") is None
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{")
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download", lambda *_args, **_kwargs: malformed
+    )
+    with pytest.raises(ValueError):
+        processor_patch._load_json("org/model", "config.json")
 
 
 def test_local_metadata_honors_subfolder(tmp_path: Path) -> None:

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -154,6 +154,35 @@ def test_processor_rejects_more_tokens_than_images() -> None:
         )
 
 
+@pytest.mark.parametrize("images", [None, []])
+def test_processor_rejects_image_marker_without_media(images) -> None:
+    processor = Glm5NextProcessor(tokenizer=_TokenizerStub())
+    with pytest.raises(ValueError, match="without images"):
+        processor(images=images, text=["inspect <|image|>"])
+
+
+def test_processor_uses_request_merge_size_for_placeholder_count() -> None:
+    image_processor = Glm5NextImageProcessor(
+        patch_size=2,
+        temporal_patch_size=2,
+        merge_size=2,
+        min_image_tokens=1,
+        max_image_tokens=16,
+    )
+    processor = Glm5NextProcessor(
+        image_processor=image_processor,
+        tokenizer=_TokenizerStub(),
+    )
+    inputs = processor(
+        images=Image.new("RGB", (16, 16), "blue"),
+        text="<|image|>",
+        merge_size=4,
+    )
+    image_tokens = int(mx.sum(inputs["input_ids"] == 120).item())
+    expected = int(inputs["image_grid_thw"][0].prod().item()) // 4**2
+    assert image_tokens == expected
+
+
 def test_image_processor_scalar_paths_and_optional_transforms() -> None:
     image_processor = Glm5NextImageProcessor(
         patch_size=2,
@@ -245,6 +274,17 @@ def test_json_metadata_local_remote_and_invalid_shapes(
     assert processor_patch._load_json("org/model", "config.json") is None
 
 
+def test_local_metadata_honors_subfolder(tmp_path: Path) -> None:
+    subfolder = tmp_path / "tested-revision"
+    subfolder.mkdir()
+    (subfolder / "config.json").write_text('{"revision":"pinned"}')
+    assert processor_patch._load_json(
+        tmp_path,
+        "config.json",
+        hub_kwargs={"subfolder": "tested-revision", "local_files_only": True},
+    ) == {"revision": "pinned"}
+
+
 def test_image_processor_kwargs_merge_checkpoint_metadata(tmp_path: Path) -> None:
     (tmp_path / "config.json").write_text(
         '{"vision_config":{"patch_size":16,"temporal_patch_size":3,'
@@ -285,6 +325,48 @@ def test_from_pretrained_builds_local_processor(monkeypatch, tmp_path: Path) -> 
     assert processor.chat_template == "checkpoint template"
     assert processor.image_processor.patch_size == 16
     assert loaded == [(tokenizer, tmp_path)]
+
+
+def test_from_pretrained_forwards_hub_identity_to_all_metadata(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import huggingface_hub
+
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text("{}")
+    hub_calls = []
+    tokenizer_calls = []
+
+    def fake_download(repo_id, filename, **kwargs):
+        hub_calls.append((repo_id, filename, kwargs))
+        return metadata
+
+    tokenizer = _TokenizerStub()
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_download)
+    monkeypatch.setattr(
+        processor_patch.AutoTokenizer,
+        "from_pretrained",
+        lambda path, **kwargs: tokenizer_calls.append((path, kwargs)) or tokenizer,
+    )
+
+    options = {
+        "revision": "tested-commit",
+        "cache_dir": tmp_path / "hub-cache",
+        "local_files_only": True,
+        "force_download": False,
+        "token": "test-token",
+        "subfolder": "processor",
+    }
+    Glm5NextProcessor.from_pretrained("org/model", **options)
+
+    assert tokenizer_calls == [("org/model", options)]
+    assert [filename for _, filename, _ in hub_calls] == [
+        "processor_config.json",
+        "config.json",
+        "processor_config.json",
+    ]
+    assert all(repo_id == "org/model" for repo_id, _, _ in hub_calls)
+    assert all(kwargs == options for _, _, kwargs in hub_calls)
 
 
 def test_installer_registers_once_without_replacing_existing_prompt_shape(

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weight-free contracts for the GLM-5 Next processor compatibility layer."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+from PIL import Image
+
+from vllm_mlx.patches import glm5_next_processor as processor_patch
+from vllm_mlx.patches.glm5_next_processor import (
+    Glm5NextImageProcessor,
+    Glm5NextProcessor,
+    smart_resize,
+)
+
+
+class _TokenizerStub:
+    model_input_names = ["input_ids", "attention_mask"]
+
+    @staticmethod
+    def convert_tokens_to_ids(token: str) -> int:
+        return {"<|image|>": 120, "<|video|>": 121}[token]
+
+    @staticmethod
+    def __call__(texts, **kwargs):
+        del kwargs
+        rows = [[1] + [120] * text.count("<|image|>") + [2] for text in texts]
+        return {
+            "input_ids": rows,
+            "attention_mask": [[1] * len(row) for row in rows],
+        }
+
+
+def test_token_budget_keeps_native_448_tile() -> None:
+    assert smart_resize(2, 448, 448) == (448, 448)
+    processor = Glm5NextImageProcessor()
+    assert processor.get_number_of_image_patches(448, 448) == 1024
+
+
+@pytest.mark.parametrize(
+    ("num_frames", "height", "width"),
+    [(0, 1, 1), (1, 0, 1), (1, 1, 0)],
+)
+def test_smart_resize_rejects_empty_media(
+    num_frames: int, height: int, width: int
+) -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        smart_resize(num_frames, height, width)
+
+
+def test_processor_expands_exact_image_placeholder_count() -> None:
+    image_processor = Glm5NextImageProcessor(
+        patch_size=2,
+        temporal_patch_size=2,
+        merge_size=2,
+        min_image_tokens=1,
+        max_image_tokens=4,
+    )
+    processor = Glm5NextProcessor(
+        image_processor=image_processor,
+        tokenizer=_TokenizerStub(),
+    )
+
+    inputs = processor(
+        images=[Image.new("RGB", (8, 4), "blue")],
+        text=["<|begin_of_image|><|image|><|end_of_image|>"],
+    )
+
+    image_tokens = int(mx.sum(inputs["input_ids"] == 120).item())
+    expected_tokens = int(inputs["image_grid_thw"][0].prod().item()) // 4
+    assert image_tokens == expected_tokens == 2
+    assert inputs["pixel_values"].shape == (8, 24)
+    assert inputs["mm_token_type_ids"].shape == inputs["input_ids"].shape
+
+
+def test_processor_rejects_image_placeholder_count_mismatch() -> None:
+    processor = Glm5NextProcessor(tokenizer=_TokenizerStub())
+    with pytest.raises(ValueError, match="More images were provided"):
+        processor(
+            images=[Image.new("RGB", (28, 28), "blue")],
+            text=["no image marker"],
+        )
+
+
+def test_local_optional_metadata_miss_never_falls_through_to_hub(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import huggingface_hub
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("local checkpoint must not make a Hub request")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fail)
+    assert processor_patch._load_json(tmp_path, "processor_config.json") is None
+
+
+def test_install_registers_auto_processor_and_prompt_shape_in_clean_process(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "config.json").write_text('{"model_type":"glm5_next"}')
+    script = """
+import sys
+from pathlib import Path
+
+model_path = Path(sys.argv[1])
+from vllm_mlx.patches import glm5_next_processor as patch
+patch.Glm5NextProcessor.from_pretrained = classmethod(
+    lambda cls, path, **kwargs: ("glm5-next", str(path))
+)
+assert patch.install_glm5_next_processor_patch() is True
+assert patch.install_glm5_next_processor_patch() is False
+assert patch.is_installed() is True
+
+from transformers import AutoProcessor
+assert AutoProcessor.from_pretrained(model_path) == ("glm5-next", str(model_path))
+from mlx_vlm.prompt_utils import MODEL_CONFIG, MessageFormat
+assert MODEL_CONFIG["glm5_next"] is MessageFormat.LIST_WITH_IMAGE_FIRST
+"""
+    subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_mllm_load_installs_processor_before_runtime_load() -> None:
+    script = """
+from vllm_mlx.models import mllm
+from vllm_mlx.patches import glm5_next_forget_gate_quant as quant_patch
+from vllm_mlx.patches import glm5_next_processor as patch
+from vllm_mlx.patches import glm5_next_runtime as runtime_patch
+
+events = []
+patch.install_glm5_next_processor_patch = lambda: events.append("processor")
+quant_patch.install_glm5_next_forget_gate_quant_fix = lambda: events.append("quant")
+runtime_patch.install_glm5_next_runtime_fix = lambda: events.append("runtime")
+mllm._require_mlx_vlm = lambda: None
+
+import mlx_vlm
+mlx_vlm.load = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("stop"))
+
+try:
+    mllm.MLXMultimodalLM("local/model").load()
+except RuntimeError as exc:
+    assert str(exc) == "stop"
+else:
+    raise AssertionError("stubbed load must stop")
+assert events == ["runtime", "processor", "quant"]
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -93,8 +93,10 @@ def test_image_shape_conversion_and_resize_edges(tmp_path: Path) -> None:
         np.zeros((3, 5), dtype=np.uint8), True
     ).shape == (3, 3, 5)
 
-    alpha = np.zeros((3, 4, 4), dtype=np.uint8)
-    assert processor_patch._to_channel_first(alpha, True).shape == (3, 3, 4)
+    alpha = np.zeros((4, 5, 4), dtype=np.uint8)
+    assert processor_patch._to_channel_first(
+        alpha, True, input_data_format="channels_last"
+    ).shape == (3, 4, 5)
     channel_first_gray = np.zeros((1, 3, 5), dtype=np.uint8)
     assert processor_patch._to_channel_first(channel_first_gray, True).shape == (
         3,
@@ -103,12 +105,30 @@ def test_image_shape_conversion_and_resize_edges(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="3D image"):
         processor_patch._to_channel_first(np.zeros((4,)), True)
-    with pytest.raises(ValueError, match="RGB image"):
+    with pytest.raises(ValueError, match="infer channel dimension"):
         processor_patch._to_channel_first(np.zeros((2, 3, 5)), False)
+    with pytest.raises(ValueError, match="RGB image"):
+        processor_patch._to_channel_first(
+            np.zeros((2, 3, 5)), False, input_data_format="channels_first"
+        )
 
     float_image = np.full((3, 2, 2), 0.5, dtype=np.float32)
     resized = processor_patch._resize_channel_first(float_image, 4, 4)
     assert resized.shape == (3, 4, 4)
+
+
+def test_ambiguous_channel_shape_preserves_pixels_with_explicit_format() -> None:
+    channel_first = np.arange(3 * 4 * 4, dtype=np.uint8).reshape(3, 4, 4)
+    inferred = processor_patch._to_channel_first(channel_first, True)
+    assert np.array_equal(inferred, channel_first)
+
+    channel_last = np.transpose(channel_first, (1, 2, 0))
+    explicit = processor_patch._to_channel_first(
+        channel_last,
+        True,
+        input_data_format="channels_last",
+    )
+    assert np.array_equal(explicit, channel_first)
 
 
 def test_processor_expands_exact_image_placeholder_count() -> None:

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -7,9 +7,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-import mlx.core as mx
+import numpy as np
 import pytest
 from PIL import Image
+
+mx = pytest.importorskip("mlx.core", reason="requires Apple MLX")
 
 from vllm_mlx.patches import glm5_next_processor as processor_patch
 from vllm_mlx.patches.glm5_next_processor import (
@@ -22,18 +24,32 @@ from vllm_mlx.patches.glm5_next_processor import (
 class _TokenizerStub:
     model_input_names = ["input_ids", "attention_mask"]
 
+    def __init__(self):
+        self.calls = []
+
     @staticmethod
     def convert_tokens_to_ids(token: str) -> int:
         return {"<|image|>": 120, "<|video|>": 121}[token]
 
-    @staticmethod
-    def __call__(texts, **kwargs):
-        del kwargs
+    def __call__(self, texts, **kwargs):
+        self.calls.append((texts, kwargs))
         rows = [[1] + [120] * text.count("<|image|>") + [2] for text in texts]
         return {
             "input_ids": rows,
             "attention_mask": [[1] * len(row) for row in rows],
         }
+
+    @staticmethod
+    def batch_decode(*args, **kwargs):
+        return (args, kwargs)
+
+    @staticmethod
+    def decode(*args, **kwargs):
+        return (args, kwargs)
+
+    @staticmethod
+    def apply_chat_template(*args, **kwargs):
+        return (args, kwargs)
 
 
 def test_token_budget_keeps_native_448_tile() -> None:
@@ -51,6 +67,48 @@ def test_smart_resize_rejects_empty_media(
 ) -> None:
     with pytest.raises(ValueError, match="must be positive"):
         smart_resize(num_frames, height, width)
+
+
+def test_smart_resize_downscales_and_rejects_impossible_budget() -> None:
+    height, width = smart_resize(
+        2,
+        1000,
+        500,
+        factor=28,
+        min_image_tokens=1,
+        max_image_tokens=64,
+    )
+    assert height % 28 == width % 28 == 0
+    assert 2 * height * width <= 64 * 2 * 28**2
+    with pytest.raises(ValueError, match="too small"):
+        smart_resize(2, 100, 100, factor=28, max_image_tokens=0)
+
+
+def test_image_shape_conversion_and_resize_edges(tmp_path: Path) -> None:
+    path = tmp_path / "gray.png"
+    Image.new("L", (4, 3), 127).save(path)
+    from_path = processor_patch._to_channel_first(path, True)
+    assert from_path.shape == (3, 3, 4)
+    assert processor_patch._to_channel_first(
+        np.zeros((3, 5), dtype=np.uint8), True
+    ).shape == (3, 3, 5)
+
+    alpha = np.zeros((3, 4, 4), dtype=np.uint8)
+    assert processor_patch._to_channel_first(alpha, True).shape == (3, 3, 4)
+    channel_first_gray = np.zeros((1, 3, 5), dtype=np.uint8)
+    assert processor_patch._to_channel_first(channel_first_gray, True).shape == (
+        3,
+        3,
+        5,
+    )
+    with pytest.raises(ValueError, match="3D image"):
+        processor_patch._to_channel_first(np.zeros((4,)), True)
+    with pytest.raises(ValueError, match="RGB image"):
+        processor_patch._to_channel_first(np.zeros((2, 3, 5)), False)
+
+    float_image = np.full((3, 2, 2), 0.5, dtype=np.float32)
+    resized = processor_patch._resize_channel_first(float_image, 4, 4)
+    assert resized.shape == (3, 4, 4)
 
 
 def test_processor_expands_exact_image_placeholder_count() -> None:
@@ -87,6 +145,67 @@ def test_processor_rejects_image_placeholder_count_mismatch() -> None:
         )
 
 
+def test_processor_rejects_more_tokens_than_images() -> None:
+    processor = Glm5NextProcessor(tokenizer=_TokenizerStub())
+    with pytest.raises(ValueError, match="More image tokens"):
+        processor(
+            images=[Image.new("RGB", (28, 28), "blue")],
+            text=["<|image|><|image|>"],
+        )
+
+
+def test_image_processor_scalar_paths_and_optional_transforms() -> None:
+    image_processor = Glm5NextImageProcessor(
+        patch_size=2,
+        temporal_patch_size=2,
+        merge_size=2,
+        min_image_tokens=1,
+        max_image_tokens=4,
+    )
+    image = np.zeros((4, 8, 3), dtype=np.uint8)
+    assert len(image_processor.fetch_images(image)) == 1
+    output = image_processor(
+        images=image,
+        return_tensors=None,
+        do_rescale=False,
+        do_normalize=False,
+    )
+    assert output["pixel_values"].shape == (8, 24)
+    with pytest.raises(ValueError, match="must not be None"):
+        image_processor.preprocess()
+
+
+def test_text_only_defaults_delegation_and_model_inputs() -> None:
+    tokenizer = _TokenizerStub()
+    processor = Glm5NextProcessor(tokenizer=tokenizer)
+    empty = processor(text=None, return_tensors=None)
+    assert empty["input_ids"] == [[1, 2]]
+    single = processor(
+        text="hello",
+        padding_side="left",
+        return_mm_token_type_ids=False,
+        return_tensors=None,
+    )
+    assert single["input_ids"] == [[1, 2]]
+    assert tokenizer.calls[-1][1]["padding_side"] == "left"
+    assert processor.batch_decode([1], skip_special_tokens=True) == (
+        ([1],),
+        {"skip_special_tokens": True},
+    )
+    assert processor.decode([1]) == (([1],), {})
+    assert processor.apply_chat_template([{"role": "user"}]) == (
+        ([{"role": "user"}],),
+        {},
+    )
+    assert processor.model_input_names == [
+        "input_ids",
+        "attention_mask",
+        "pixel_values",
+        "image_grid_thw",
+        "mm_token_type_ids",
+    ]
+
+
 def test_local_optional_metadata_miss_never_falls_through_to_hub(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -97,6 +216,104 @@ def test_local_optional_metadata_miss_never_falls_through_to_hub(
 
     monkeypatch.setattr(huggingface_hub, "hf_hub_download", fail)
     assert processor_patch._load_json(tmp_path, "processor_config.json") is None
+
+
+def test_json_metadata_local_remote_and_invalid_shapes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "config.json"
+    config.write_text('{"vision_config":{"patch_size":16}}')
+    assert processor_patch._load_json(tmp_path, "config.json") == {
+        "vision_config": {"patch_size": 16}
+    }
+    config.write_text("[]")
+    assert processor_patch._load_json(tmp_path, "config.json") is None
+
+    downloaded = tmp_path / "downloaded.json"
+    downloaded.write_text('{"remote":true}')
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download", lambda *_args, **_kwargs: downloaded
+    )
+    assert processor_patch._load_json("org/model", "config.json") == {"remote": True}
+    monkeypatch.setattr(
+        huggingface_hub,
+        "hf_hub_download",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline")),
+    )
+    assert processor_patch._load_json("org/model", "config.json") is None
+
+
+def test_image_processor_kwargs_merge_checkpoint_metadata(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"vision_config":{"patch_size":16,"temporal_patch_size":3,'
+        '"spatial_merge_size":4}}'
+    )
+    (tmp_path / "processor_config.json").write_text(
+        '{"image_processor":{"patch_size":14,"max_image_tokens":99}}'
+    )
+    assert processor_patch._image_processor_kwargs(tmp_path) == {
+        "patch_size": 14,
+        "max_image_tokens": 99,
+        "temporal_patch_size": 3,
+        "merge_size": 4,
+    }
+
+
+def test_from_pretrained_builds_local_processor(monkeypatch, tmp_path: Path) -> None:
+    tokenizer = _TokenizerStub()
+    tokenizer.chat_template = "tokenizer template"
+    (tmp_path / "config.json").write_text(
+        '{"vision_config":{"patch_size":16,"spatial_merge_size":2}}'
+    )
+    (tmp_path / "processor_config.json").write_text(
+        '{"chat_template":"checkpoint template"}'
+    )
+    loaded = []
+    monkeypatch.setattr(
+        processor_patch.AutoTokenizer,
+        "from_pretrained",
+        lambda path, **kwargs: tokenizer,
+    )
+    monkeypatch.setattr(
+        processor_patch,
+        "load_chat_template",
+        lambda instance, path: loaded.append((instance, path)),
+    )
+    processor = Glm5NextProcessor.from_pretrained(tmp_path, return_tensors="mlx")
+    assert processor.chat_template == "checkpoint template"
+    assert processor.image_processor.patch_size == 16
+    assert loaded == [(tokenizer, tmp_path)]
+
+
+def test_installer_registers_once_without_replacing_existing_prompt_shape(
+    monkeypatch,
+) -> None:
+    from mlx_vlm.prompt_utils import MODEL_CONFIG, MessageFormat
+
+    calls = []
+    original = MODEL_CONFIG.get("glm5_next")
+    existed = "glm5_next" in MODEL_CONFIG
+    MODEL_CONFIG.pop("glm5_next", None)
+    processor_patch._INSTALLED = False
+    monkeypatch.setattr(
+        processor_patch,
+        "install_auto_processor_patch",
+        lambda model_type, processor: calls.append((model_type, processor)),
+    )
+    try:
+        assert processor_patch.install_glm5_next_processor_patch() is True
+        assert processor_patch.install_glm5_next_processor_patch() is False
+        assert processor_patch.is_installed() is True
+        assert calls == [("glm5_next", Glm5NextProcessor)]
+        assert MODEL_CONFIG["glm5_next"] is MessageFormat.LIST_WITH_IMAGE_FIRST
+    finally:
+        if existed:
+            MODEL_CONFIG["glm5_next"] = original
+        else:
+            MODEL_CONFIG.pop("glm5_next", None)
+        processor_patch._INSTALLED = False
 
 
 def test_install_registers_auto_processor_and_prompt_shape_in_clean_process(

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
+from types import SimpleNamespace
+
+import pytest
 
 from vllm_mlx.patches.glm5_next_runtime import (
     _keep_glm5_next_fp32,
@@ -44,100 +45,175 @@ def test_fp32_state_allowlist_is_narrow() -> None:
     assert not _keep_glm5_next_fp32("model.layers.0.self_attn.q_proj.weight")
 
 
+@pytest.mark.requires_mlx
 def test_installer_applies_glm_math_without_changing_shared_models() -> None:
-    script = r"""
-import mlx.core as mx
-import mlx.nn as nn
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_vlm.models.deepseek_v32 import language as deepseek_language
+    from mlx_vlm.models.glm5_next import language
 
-from mlx_vlm.models.deepseek_v32 import language as deepseek_language
-from mlx_vlm.models.glm5_next import language
-from vllm_mlx.patches import glm5_next_runtime as patch
+    from vllm_mlx.patches import glm5_next_runtime as patch
 
-shared_mlp = deepseek_language.DeepseekV32MoE
-assert patch.install_glm5_next_runtime_fix() is True
-assert patch.install_glm5_next_runtime_fix() is False
-assert deepseek_language.DeepseekV32MoE is shared_mlp
+    def config(*, attention="linear_attention", mlp="sparse"):
+        return language.TextConfig(
+            model_type="glm5_next_text",
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            moe_intermediate_size=4,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_shared_experts=1 if mlp == "sparse" else None,
+            n_routed_experts=4 if mlp == "sparse" else None,
+            routed_scaling_factor=1.0,
+            kv_lora_rank=4,
+            q_lora_rank=4,
+            qk_rope_head_dim=0,
+            v_head_dim=4,
+            qk_nope_head_dim=4,
+            num_experts_per_tok=2,
+            first_k_dense_replace=0 if mlp == "sparse" else 99,
+            max_position_embeddings=32,
+            rms_norm_eps=1e-5,
+            index_topk=2,
+            index_head_dim=4,
+            index_n_heads=1,
+            layer_types=[attention],
+            mlp_layer_types=[mlp],
+            linear_attn_config={
+                "num_heads": 1,
+                "head_dim": 8,
+                "short_conv_kernel_size": 2,
+                "gate_lower_bound": -5.0,
+            },
+            index_kpool=2,
+            hc_mult=1,
+            hc_sinkhorn_iters=1,
+            n_group=1,
+            topk_group=1,
+            topk_method="noaux_tc",
+        )
 
-def config(*, attention="linear_attention", mlp="sparse"):
-    return language.TextConfig(
-        model_type="glm5_next_text",
-        vocab_size=32,
-        hidden_size=8,
-        intermediate_size=16,
-        moe_intermediate_size=4,
-        num_hidden_layers=1,
-        num_attention_heads=2,
-        num_key_value_heads=1,
-        n_shared_experts=1 if mlp == "sparse" else None,
-        n_routed_experts=4 if mlp == "sparse" else None,
-        routed_scaling_factor=1.0,
-        kv_lora_rank=4,
-        q_lora_rank=4,
-        qk_rope_head_dim=0,
-        v_head_dim=4,
-        qk_nope_head_dim=4,
-        num_experts_per_tok=2,
-        first_k_dense_replace=0 if mlp == "sparse" else 99,
-        max_position_embeddings=32,
-        rms_norm_eps=1e-5,
-        index_topk=2,
-        index_head_dim=4,
-        index_n_heads=1,
-        layer_types=[attention],
-        mlp_layer_types=[mlp],
-        linear_attn_config={
-            "num_heads": 1,
-            "head_dim": 8,
-            "short_conv_kernel_size": 2,
-            "gate_lower_bound": -5.0,
-        },
-        index_kpool=2,
-        hc_mult=1,
-        hc_sinkhorn_iters=1,
-        n_group=1,
-        topk_group=1,
-        topk_method="noaux_tc",
+    patched_names = (
+        "DeepseekMLP",
+        "DeepseekV32MoE",
+        "Glm5NextSparseAttention",
+        "Glm5NextLinearAttention",
     )
+    originals = {name: getattr(language, name) for name in patched_names}
+    original_sanitize = language.LanguageModel.sanitize
+    original_cast_predicate = language.LanguageModel.cast_predicate
+    marker = getattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED", None)
+    marker_existed = hasattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED")
+    patch._INSTALLED = False
+    if marker_existed:
+        del language._RAPID_MLX_RUNTIME_FIX_INSTALLED
 
-sparse_layer = language.Glm5NextDecoderLayer(config(), 0)
-assert type(sparse_layer.mlp).__name__ == "Glm5NextMoE"
-activation = sparse_layer.mlp.switch_mlp.activation
-x_up = mx.array([20.0, -20.0])
-x_gate = mx.array([20.0, 20.0])
-expected = nn.silu(mx.array([10.0, 10.0])) * mx.array([10.0, -10.0])
-assert mx.allclose(activation(x_up, x_gate), expected).item()
+    try:
+        shared_mlp = deepseek_language.DeepseekV32MoE
+        assert patch.install_glm5_next_runtime_fix() is True
+        assert patch.install_glm5_next_runtime_fix() is False
+        assert patch.is_installed() is True
+        assert deepseek_language.DeepseekV32MoE is shared_mlp
 
-_, scores = sparse_layer.mlp.gate(mx.ones((1, 8), dtype=mx.bfloat16))
-assert scores.dtype == mx.float32
+        sparse_layer = language.Glm5NextDecoderLayer(config(), 0)
+        assert type(sparse_layer.mlp).__name__ == "Glm5NextMoE"
+        activation = sparse_layer.mlp.switch_mlp.activation
+        x_up = mx.array([20.0, -20.0])
+        x_gate = mx.array([20.0, 20.0])
+        expected = nn.silu(mx.array([10.0, 10.0])) * mx.array([10.0, -10.0])
+        assert mx.allclose(activation(x_up, x_gate), expected).item()
 
-dense_layer = language.Glm5NextDecoderLayer(config(mlp="dense"), 0)
-assert type(dense_layer.mlp).__name__ == "Glm5NextMLP"
-assert dense_layer.mlp.limit == 10.0
+        _, scores = sparse_layer.mlp.gate(mx.ones((1, 8), dtype=mx.bfloat16))
+        assert scores.dtype == mx.float32
 
-attention_layer = language.Glm5NextDecoderLayer(
-    config(attention="deepseek_sparse_attention", mlp="dense"), 0
-)
-assert attention_layer.self_attn.q_a_layernorm.eps == 1e-5
-assert attention_layer.self_attn.kv_a_layernorm.eps == 1e-5
-assert attention_layer.self_attn.indexer.k_norm.eps == 1e-6
+        dense_layer = language.Glm5NextDecoderLayer(config(mlp="dense"), 0)
+        assert type(dense_layer.mlp).__name__ == "Glm5NextMLP"
+        assert dense_layer.mlp.limit == 10.0
+        assert dense_layer.mlp(mx.ones((1, 1, 8))).shape == (1, 1, 8)
 
-model = language.LanguageModel(config(mlp="dense"))
-weights = {
-    "model.layers.0.hc_attn_base": mx.ones((1,), dtype=mx.bfloat16),
-    "model.layers.0.self_attn.A_log": mx.ones((1,), dtype=mx.bfloat16),
-    "model.layers.0.self_attn.q_proj.weight": mx.ones((1,), dtype=mx.bfloat16),
-}
-sanitized = model.sanitize(weights)
-assert sanitized["model.layers.0.attn_hc.base"].dtype == mx.float32
-assert sanitized["model.layers.0.self_attn.forget_gate.A_log"].dtype == mx.float32
-assert sanitized["model.layers.0.self_attn.q_proj.weight"].dtype == mx.bfloat16
-predicate = model.cast_predicate
-assert predicate("model.layers.0.attn_hc.base") is False
-assert predicate("model.layers.0.self_attn.q_proj.weight") is True
-"""
-    subprocess.run(
-        [sys.executable, "-c", script],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+        attention_layer = language.Glm5NextDecoderLayer(
+            config(attention="deepseek_sparse_attention", mlp="dense"), 0
+        )
+        assert attention_layer.self_attn.q_a_layernorm.eps == 1e-5
+        assert attention_layer.self_attn.kv_a_layernorm.eps == 1e-5
+        assert attention_layer.self_attn.indexer.k_norm.eps == 1e-6
+
+        linear_attention = dense_layer.self_attn
+        fused = linear_attention._fused_in_proj(mx.ones((1, 1, 8)))
+        assert len(fused) == 6
+
+        class Projection:
+            def __init__(self, result, *, quantized=False):
+                self.result = result
+                if quantized:
+                    self.scales = object()
+
+            def __call__(self, _inputs):
+                return self.result
+
+        mixed = SimpleNamespace(
+            q_proj=Projection("q"),
+            k_proj=Projection("k", quantized=True),
+            v_proj=Projection("v"),
+            forget_gate=SimpleNamespace(f_a_proj=Projection("forget")),
+            g_a_proj=Projection("gate"),
+            b_proj=Projection("beta"),
+        )
+        assert language.Glm5NextLinearAttention._fused_in_proj(mixed, object()) == (
+            "q",
+            "k",
+            "v",
+            "forget",
+            "gate",
+            "beta",
+        )
+
+        model = language.LanguageModel(config(mlp="dense"))
+        weights = {
+            "model.layers.0.hc_attn_base": mx.ones((1,), dtype=mx.bfloat16),
+            "model.layers.0.self_attn.A_log": mx.ones((1,), dtype=mx.bfloat16),
+            "model.layers.0.self_attn.q_proj.weight": mx.ones((1,), dtype=mx.bfloat16),
+        }
+        sanitized = model.sanitize(weights)
+        assert sanitized["model.layers.0.attn_hc.base"].dtype == mx.float32
+        assert (
+            sanitized["model.layers.0.self_attn.forget_gate.A_log"].dtype == mx.float32
+        )
+        assert sanitized["model.layers.0.self_attn.q_proj.weight"].dtype == mx.bfloat16
+        predicate = model.cast_predicate
+        assert predicate("model.layers.0.e_score_correction_bias") is False
+        assert predicate("model.layers.0.attn_hc.base") is False
+        assert predicate("model.layers.0.self_attn.q_proj.weight") is True
+    finally:
+        for name, value in originals.items():
+            setattr(language, name, value)
+        language.LanguageModel.sanitize = original_sanitize
+        language.LanguageModel.cast_predicate = original_cast_predicate
+        if marker_existed:
+            language._RAPID_MLX_RUNTIME_FIX_INSTALLED = marker
+        elif hasattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED"):
+            del language._RAPID_MLX_RUNTIME_FIX_INSTALLED
+        patch._INSTALLED = False
+
+
+@pytest.mark.requires_mlx
+def test_installer_respects_runtime_that_is_already_patched() -> None:
+    from mlx_vlm.models.glm5_next import language
+
+    from vllm_mlx.patches import glm5_next_runtime as patch
+
+    marker = getattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED", None)
+    marker_existed = hasattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED")
+    patch._INSTALLED = False
+    language._RAPID_MLX_RUNTIME_FIX_INSTALLED = True
+    try:
+        assert patch.install_glm5_next_runtime_fix() is False
+        assert patch.is_installed() is True
+    finally:
+        if marker_existed:
+            language._RAPID_MLX_RUNTIME_FIX_INSTALLED = marker
+        else:
+            del language._RAPID_MLX_RUNTIME_FIX_INSTALLED
+        patch._INSTALLED = False

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weight-free contracts for the GLM-5 Next text-runtime overlay."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from vllm_mlx.patches.glm5_next_runtime import (
+    _keep_glm5_next_fp32,
+    _projection_quantization_is_homogeneous,
+)
+
+
+class _Linear:
+    pass
+
+
+class _Quantized:
+    def __init__(self, *, group_size=64, bits=4, mode="affine"):
+        self.scales = object()
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+
+
+def test_kda_projection_fusion_requires_one_quantization() -> None:
+    assert _projection_quantization_is_homogeneous([_Linear(), _Linear()])
+    assert _projection_quantization_is_homogeneous([_Quantized(), _Quantized()])
+    assert not _projection_quantization_is_homogeneous([_Linear(), _Quantized()])
+    assert not _projection_quantization_is_homogeneous(
+        [_Quantized(bits=4), _Quantized(bits=8)]
+    )
+    assert not _projection_quantization_is_homogeneous(
+        [_Quantized(mode="affine"), _Quantized(mode="mxfp4")]
+    )
+
+
+def test_fp32_state_allowlist_is_narrow() -> None:
+    assert _keep_glm5_next_fp32("model.layers.0.attn_hc.base")
+    assert _keep_glm5_next_fp32("model.layers.0.ffn_hc.scale")
+    assert _keep_glm5_next_fp32("model.layers.0.self_attn.A_log")
+    assert _keep_glm5_next_fp32("model.layers.0.self_attn.dt_bias")
+    assert not _keep_glm5_next_fp32("model.layers.0.self_attn.q_proj.weight")
+
+
+def test_installer_applies_glm_math_without_changing_shared_models() -> None:
+    script = r"""
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_vlm.models.deepseek_v32 import language as deepseek_language
+from mlx_vlm.models.glm5_next import language
+from vllm_mlx.patches import glm5_next_runtime as patch
+
+shared_mlp = deepseek_language.DeepseekV32MoE
+assert patch.install_glm5_next_runtime_fix() is True
+assert patch.install_glm5_next_runtime_fix() is False
+assert deepseek_language.DeepseekV32MoE is shared_mlp
+
+def config(*, attention="linear_attention", mlp="sparse"):
+    return language.TextConfig(
+        model_type="glm5_next_text",
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=4,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        n_shared_experts=1 if mlp == "sparse" else None,
+        n_routed_experts=4 if mlp == "sparse" else None,
+        routed_scaling_factor=1.0,
+        kv_lora_rank=4,
+        q_lora_rank=4,
+        qk_rope_head_dim=0,
+        v_head_dim=4,
+        qk_nope_head_dim=4,
+        num_experts_per_tok=2,
+        first_k_dense_replace=0 if mlp == "sparse" else 99,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        index_topk=2,
+        index_head_dim=4,
+        index_n_heads=1,
+        layer_types=[attention],
+        mlp_layer_types=[mlp],
+        linear_attn_config={
+            "num_heads": 1,
+            "head_dim": 8,
+            "short_conv_kernel_size": 2,
+            "gate_lower_bound": -5.0,
+        },
+        index_kpool=2,
+        hc_mult=1,
+        hc_sinkhorn_iters=1,
+        n_group=1,
+        topk_group=1,
+        topk_method="noaux_tc",
+    )
+
+sparse_layer = language.Glm5NextDecoderLayer(config(), 0)
+assert type(sparse_layer.mlp).__name__ == "Glm5NextMoE"
+activation = sparse_layer.mlp.switch_mlp.activation
+x_up = mx.array([20.0, -20.0])
+x_gate = mx.array([20.0, 20.0])
+expected = nn.silu(mx.array([10.0, 10.0])) * mx.array([10.0, -10.0])
+assert mx.allclose(activation(x_up, x_gate), expected).item()
+
+_, scores = sparse_layer.mlp.gate(mx.ones((1, 8), dtype=mx.bfloat16))
+assert scores.dtype == mx.float32
+
+dense_layer = language.Glm5NextDecoderLayer(config(mlp="dense"), 0)
+assert type(dense_layer.mlp).__name__ == "Glm5NextMLP"
+assert dense_layer.mlp.limit == 10.0
+
+attention_layer = language.Glm5NextDecoderLayer(
+    config(attention="deepseek_sparse_attention", mlp="dense"), 0
+)
+assert attention_layer.self_attn.q_a_layernorm.eps == 1e-5
+assert attention_layer.self_attn.kv_a_layernorm.eps == 1e-5
+assert attention_layer.self_attn.indexer.k_norm.eps == 1e-6
+
+model = language.LanguageModel(config(mlp="dense"))
+weights = {
+    "model.layers.0.hc_attn_base": mx.ones((1,), dtype=mx.bfloat16),
+    "model.layers.0.self_attn.A_log": mx.ones((1,), dtype=mx.bfloat16),
+    "model.layers.0.self_attn.q_proj.weight": mx.ones((1,), dtype=mx.bfloat16),
+}
+sanitized = model.sanitize(weights)
+assert sanitized["model.layers.0.attn_hc.base"].dtype == mx.float32
+assert sanitized["model.layers.0.self_attn.forget_gate.A_log"].dtype == mx.float32
+assert sanitized["model.layers.0.self_attn.q_proj.weight"].dtype == mx.bfloat16
+predicate = model.cast_predicate
+assert predicate("model.layers.0.attn_hc.base") is False
+assert predicate("model.layers.0.self_attn.q_proj.weight") is True
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_install_hint_pinned_1016.py
+++ b/tests/test_install_hint_pinned_1016.py
@@ -29,7 +29,7 @@ def test_vlm_extra_install_hint_is_pinned_and_conflict_free():
     # Primary path stays the extra.
     assert "rapid-mlx[vision]" in VLM_EXTRA_INSTALL_HINT
     # Bare fallback is pinned to the transformers-compatible version.
-    assert "mlx-vlm==0.6.16" in VLM_EXTRA_INSTALL_HINT
+    assert "mlx-vlm==0.6.17" in VLM_EXTRA_INSTALL_HINT
     # And the unpinned form that produces the transformers conflict is gone.
     assert "mlx-vlm>=0.6.3" not in VLM_EXTRA_INSTALL_HINT
 
@@ -53,14 +53,14 @@ def test_boot_guard_absent_hint_names_pinned_install(monkeypatch, capsys):
 
     err = capsys.readouterr().err
     assert "rapid-mlx[vision]" in err
-    assert "mlx-vlm==0.6.16" in err
+    assert "mlx-vlm==0.6.17" in err
     assert "mlx-vlm>=0.6.3" not in err
 
 
 def test_gemma4_load_fallback_hint_is_pinned():
     """The Gemma-4-specific ``serve``/``chat`` load-fallback hint (printed
     when mlx-lm can't import the Gemma-4 architecture classes on a base
-    wheel) must pin the bare mlx-vlm text-only install to ``==0.6.16`` too.
+    wheel) must pin the bare mlx-vlm text-only install to ``==0.6.17`` too.
 
     Scan the CLI source so a future edit cannot silently regress this last
     user-facing hint to an unpinned or differently pinned runtime.
@@ -72,8 +72,8 @@ def test_gemma4_load_fallback_hint_is_pinned():
     source = pathlib.Path(cli_mod.__file__).read_text()
 
     # The text-only footprint fallback must be pinned...
-    assert "pip install --no-deps 'mlx-vlm==0.6.16'" in source, (
-        "Gemma-4 load-fallback hint must pin mlx-vlm==0.6.16 to match "
+    assert "pip install --no-deps 'mlx-vlm==0.6.17'" in source, (
+        "Gemma-4 load-fallback hint must pin mlx-vlm==0.6.17 to match "
         "VLM_EXTRA_INSTALL_HINT."
     )
     # ...and no CLI hint may use the conflict-producing unpinned lower bound.
@@ -103,7 +103,7 @@ def test_diffusion_lane_import_error_hint_is_pinned(monkeypatch):
     msg = str(exc_info.value)
     assert eng._load_error is not None
     assert "rapid-mlx[vision]" in msg
-    assert "mlx-vlm==0.6.16" in msg
+    assert "mlx-vlm==0.6.17" in msg
     assert "mlx-vlm>=0.6.3" not in msg
     # The conflict-producing forced-upgrade flag is gone.
     assert "-U 'mlx-vlm" not in msg

--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -139,6 +139,49 @@ def test_mlx_vlm_arrayscache_is_accepted_in_serialized_mode(monkeypatch):
     assert first_incompatible_mllm_cache_type([cache], allow_arrays_cache=True) is None
 
 
+def test_mlx_vlm_cache_list_recursively_accepts_pooling_cache():
+    """GLM sparse-attention cache leaves own the complete batch lifecycle."""
+    from mlx_vlm.models import cache as vlm_cache
+
+    compound = vlm_cache.CacheList(vlm_cache.KVCache(), vlm_cache.PoolingCache(4))
+
+    assert first_incompatible_mllm_cache_type([compound]) is None
+
+
+def test_mlx_vlm_cache_list_rejects_unknown_leaf():
+    """A supported wrapper must not turn an unknown cache into an allowlist."""
+    from mlx_vlm.models import cache as vlm_cache
+
+    unknown = type("UnknownCache", (), {})()
+    compound = vlm_cache.CacheList(vlm_cache.KVCache(), unknown)
+
+    assert first_incompatible_mllm_cache_type([compound]) == "UnknownCache"
+
+
+def test_mlx_vlm_cache_list_merges_and_extracts_pooling_state():
+    """Exercise the exact merge/filter/extract lifecycle used by MLLMBatch."""
+    from mlx_vlm.models import cache as vlm_cache
+
+    first = vlm_cache.CacheList(vlm_cache.KVCache(), vlm_cache.PoolingCache(4))
+    second = vlm_cache.CacheList(vlm_cache.KVCache(), vlm_cache.PoolingCache(4))
+    for cache, value in ((first, 1.0), (second, 2.0)):
+        cache[0].update_and_fetch(
+            mx.full((1, 1, 1, 2), value), mx.full((1, 1, 1, 2), value)
+        )
+        cache[1].update_and_fetch(mx.full((1, 2, 3), value))
+
+    merged = vlm_cache.CacheList.merge([first, second])
+
+    assert isinstance(merged, vlm_cache.CacheList)
+    assert isinstance(merged[0], vlm_cache.BatchKVCache)
+    assert isinstance(merged[1], vlm_cache.BatchPoolingCache)
+    assert merged[1].pooled.shape == (2, 2, 3)
+    merged.filter(mx.array([1], mx.int32))
+    extracted = merged.extract(0)
+    assert isinstance(extracted[1], vlm_cache.PoolingCache)
+    assert extracted[1].pooled.tolist() == [[[2.0, 2.0, 2.0]] * 2]
+
+
 def test_arrayscache_scheduler_mode_requires_singleton_limits():
     config = MLLMSchedulerConfig(
         max_num_seqs=1,

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -140,8 +140,8 @@ def test_desktop_sidecar_uses_validated_mlx_vlm_bound():
 
     desktop_spec = matches[0]
     # Both surfaces deliberately pin one validated version. A range here caused
-    # fresh pip installs to backtrack to 0.6.3 while Desktop stayed on 0.6.16.
-    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.16").specifier
+    # fresh pip installs to backtrack to 0.6.3 while Desktop stayed on 0.6.17.
+    assert desktop_spec.specifier == Requirement("mlx-vlm==0.6.17").specifier
     assert vision_specs[0].specifier == desktop_spec.specifier
 
 

--- a/tests/test_routing_groups_0131.py
+++ b/tests/test_routing_groups_0131.py
@@ -10,8 +10,8 @@ slide a vision-capable checkpoint back onto the text lane (reason
 ``text_lane_speculative_decode``) instead of silently being dropped by the MLLM
 lane, which never consumes ``scheduler_config.spec_decode``.
 
-These tests fake the installed mlx-vlm version to >= 0.6.16 (the Desktop sidecar
-pin) and assert the resulting lane decision for the Qwen3.8-Flash-Next config
+These tests fake the installed mlx-vlm version to >= 0.6.16 (the hybrid-runtime
+floor) and assert the resulting lane decision for the Qwen3.8-Flash-Next config
 shape returned by the alias artifact's ``config.json`` (``model_type=qwen4_exp``,
 ``vision_config`` present, ``image_token_id`` present, ``language_model_only==
 false``).
@@ -48,7 +48,7 @@ def _flash_next_config() -> dict:
 def _fake_mlx_vlm_ge_016(monkeypatch):
     """Fake the installed mlx-vlm as a recent version that can drive the
     vision arch — i.e. the scenario where the alias would otherwise be routed
-    into the mlx-vlm MLLM lane (Desktop sidecar pins mlx-vlm 0.6.16)."""
+    into the mlx-vlm MLLM lane (the sidecar currently exceeds this floor)."""
     import importlib.metadata as md
 
     _orig_version = md.version
@@ -105,9 +105,13 @@ def test_fix1_unaliased_qwen4_exp_vendored_goes_text_lane(monkeypatch, tmp_path)
         "checkpoint_has_multimodal_weights",
         lambda snapshot, config: True,
     )
+    # This is a missing-runtime-module contract, independent of whichever
+    # mlx-vlm release happens to execute the test.  Newer releases may ship
+    # qwen4_exp, so model the unavailable architecture explicitly.
+    monkeypatch.setattr("importlib.util.find_spec", lambda _name: None)
 
-    # Without the fix the raw mllm model check is True and mlx-vlm has no
-    # qwen4_exp package, so the vendored fallback must fire.
+    # Without the fix the raw mllm model check is True; the simulated missing
+    # qwen4_exp module must make the vendored fallback fire.
     assert mllm_arch_unsupported_but_text_vendored("/some/local/qwen4_exp") is True
     decision = resolve_serving_lane_decision("/some/local/qwen4_exp")
     assert decision.is_mllm is False

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -61,6 +61,28 @@ def test_mllm_remote_code_optout_reaches_model_and_config_loaders(monkeypatch):
         "mlx_vlm.utils",
         types.SimpleNamespace(load_config=fake_load_config),
     )
+    # This test owns only the remote-code forwarding contract. Keep the three
+    # independently-covered GLM compatibility installers out of its synthetic
+    # ``mlx_vlm`` module graph so the fake remains intentionally minimal.
+    for module_name, installer_name in (
+        (
+            "vllm_mlx.patches.glm5_next_runtime",
+            "install_glm5_next_runtime_fix",
+        ),
+        (
+            "vllm_mlx.patches.glm5_next_processor",
+            "install_glm5_next_processor_patch",
+        ),
+        (
+            "vllm_mlx.patches.glm5_next_forget_gate_quant",
+            "install_glm5_next_forget_gate_quant_fix",
+        ),
+    ):
+        monkeypatch.setitem(
+            sys.modules,
+            module_name,
+            types.SimpleNamespace(**{installer_name: lambda: None}),
+        )
     monkeypatch.setattr(
         "vllm_mlx.utils.tokenizer.augment_eos_token_ids_from_generation_config",
         lambda *_args, **_kwargs: None,

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -6,7 +6,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from packaging.requirements import Requirement
 
 SCRIPT = (
     Path(__file__).parents[1]
@@ -35,8 +34,8 @@ def test_emitted_constraints_are_stable_and_complete(constraints) -> None:
     assert emitted[0].startswith("# Release-tested versions")
     assert emitted[1:] == [
         "mlx==0.32.2",
-        "transformers==5.12.1",
-        "mlx-vlm==0.6.16",
+        "transformers==5.15.1",
+        "mlx-vlm==0.6.17",
         "mflux==0.19.0",
     ]
 
@@ -48,39 +47,7 @@ def test_emit_constraints_needs_only_the_python_standard_library() -> None:
         capture_output=True,
         text=True,
     )
-    assert "mlx-vlm==0.6.16" in result.stdout
-
-
-def test_exact_reduced_vision_runtime_is_allowed(constraints) -> None:
-    assert constraints.is_validated_compatibility_exception(
-        owner="mlx-vlm",
-        owner_version="0.6.16",
-        requirement=Requirement("transformers>=5.14.0"),
-        actual="5.12.1",
-    )
-
-
-@pytest.mark.parametrize(
-    ("owner", "owner_version", "requirement", "actual"),
-    [
-        ("other", "0.6.16", "transformers>=5.14.0", "5.12.1"),
-        ("mlx-vlm", "0.6.15", "transformers>=5.14.0", "5.12.1"),
-        ("mlx-vlm", "0.6.17", "transformers>=5.14.0", "5.12.1"),
-        ("mlx-vlm", "0.6.16", "transformers>=5.13.0", "5.12.1"),
-        ("mlx-vlm", "0.6.16", "other>=5.14.0", "5.12.1"),
-        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.12.0"),
-        ("mlx-vlm", "0.6.16", "transformers>=5.14.0", "5.13.1"),
-    ],
-)
-def test_every_nearby_mismatch_still_fails_closed(
-    constraints, owner: str, owner_version: str, requirement: str, actual: str
-) -> None:
-    assert not constraints.is_validated_compatibility_exception(
-        owner=owner,
-        owner_version=owner_version,
-        requirement=Requirement(requirement),
-        actual=actual,
-    )
+    assert "mlx-vlm==0.6.17" in result.stdout
 
 
 def _write_metadata(
@@ -93,14 +60,14 @@ def _write_metadata(
     (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
 
 
-def test_find_errors_reads_real_distribution_metadata(
+def test_find_errors_accepts_coherent_distribution_metadata(
     constraints, tmp_path: Path
 ) -> None:
-    _write_metadata(tmp_path, "transformers", "5.12.1")
+    _write_metadata(tmp_path, "transformers", "5.15.1")
     _write_metadata(
         tmp_path,
         "mlx-vlm",
-        "0.6.16",
+        "0.6.17",
         ("transformers>=5.14.0; python_version >= '3'",),
     )
     assert constraints.find_errors(tmp_path) == []

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -156,7 +156,7 @@ def test_vision_mlx_vlm_matches_desktop_runtime() -> None:
         if Requirement(spec).name == "mlx-vlm"
     ]
     assert len(requirements) == 1
-    assert requirements[0].specifier == SpecifierSet("==0.6.16")
+    assert requirements[0].specifier == SpecifierSet("==0.6.17")
 
 
 def test_transformers_range_excludes_5130_and_caps_next_minor() -> None:
@@ -581,7 +581,7 @@ def test_dev_extra_pins_tomli_for_python_310() -> None:
 
 
 def test_all_mlx_vlm_specs_match_validated_desktop_pin() -> None:
-    """Every optional surface must resolve mlx-vlm exactly to 0.6.16."""
+    """Every optional surface must resolve mlx-vlm exactly to 0.6.17."""
     py = _load_pyproject()
     extras = py.get("project", {}).get("optional-dependencies", {})
     offenders: list[tuple[str, str]] = []
@@ -590,11 +590,11 @@ def test_all_mlx_vlm_specs_match_validated_desktop_pin() -> None:
             name, _ = _split_spec(spec)
             if name.lower() != "mlx-vlm":
                 continue
-            if Requirement(spec).specifier != SpecifierSet("==0.6.16"):
+            if Requirement(spec).specifier != SpecifierSet("==0.6.17"):
                 offenders.append((extra_name, spec))
     assert offenders == [], (
-        "These mlx-vlm specs can drift from the Desktop's validated 0.6.16 runtime:\n"
+        "These mlx-vlm specs can drift from the Desktop's validated 0.6.17 runtime:\n"
         + "\n".join(f"  [{e}] {s!r}" for e, s in offenders)
-        + "\n\nPin every mlx-vlm-bearing extra to ==0.6.16. Move the pin only "
+        + "\n\nPin every mlx-vlm-bearing extra to ==0.6.17. Move the pin only "
         "after the Desktop and dependency-coherence sweeps validate a new release."
     )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1150,6 +1150,19 @@
       "top_p": 0.95
     }
   },
+  "glm5.3-flash-4bit": {
+    "hf_path": "Vontra/GLM-5.3-Flash-MLX-4bit-MTP",
+    "tool_call_parser": "glm47",
+    "reasoning_parser": "glm4",
+    "is_hybrid": true,
+    "is_hybrid_explicit": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "supports_native_mtp": false,
+    "supports_dflash": false,
+    "min_memory_gb": 192,
+    "experimental": true
+  },
   "glm4.5-air-4bit": {
     "hf_path": "mlx-community/GLM-4.5-Air-4bit",
     "tool_call_parser": "glm47",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5027,7 +5027,7 @@ def _run_submit_flow(
                 )
                 # Match the validated runtime used by the vision extra and
                 # packaged app so every recovery path installs the same lane.
-                print("    pip install --no-deps 'mlx-vlm==0.6.16'")
+                print("    pip install --no-deps 'mlx-vlm==0.6.17'")
                 print()
             else:
                 print(f"  Error loading model: {e}")

--- a/vllm_mlx/mllm_cache_compat.py
+++ b/vllm_mlx/mllm_cache_compat.py
@@ -13,13 +13,20 @@ def first_incompatible_mllm_cache_type(
     mlx-vlm 0.6.4 split its cache classes from mlx-lm's parallel classes.
     Models loaded by mlx-vlm therefore return native ``KVCache`` /
     ``RotatingKVCache`` instances that fail an mlx-lm-only ``isinstance``
-    check despite exposing the supported batching API. Accept both namespaces
-    ``ArraysCache`` is accepted only for the explicitly serialized hybrid
-    compatibility lane. Mamba and quantized/unknown caches remain fail-closed.
+    check despite exposing the supported batching API. Accept both namespaces.
+
+    Sparse-attention backbones can wrap independently mergeable cache leaves in
+    mlx-vlm's ``CacheList``. Validate those leaves recursively instead of
+    treating the wrapper itself as an unknown cache. ``PoolingCache`` is a
+    supported leaf because mlx-vlm owns its batch merge/filter/extract
+    lifecycle. ``ArraysCache`` remains restricted to the explicitly serialized
+    hybrid compatibility lane. Mamba and quantized/unknown caches remain
+    fail-closed.
     """
     from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
 
     supported_types: tuple[type, ...] = (KVCache, RotatingKVCache)
+    compound_type: type | None = None
     if allow_arrays_cache:
         supported_types += (ArraysCache,)
     try:
@@ -30,6 +37,10 @@ def first_incompatible_mllm_cache_type(
         pass
     else:
         supported_types += (vlm_cache.KVCache, vlm_cache.RotatingKVCache)
+        compound_type = getattr(vlm_cache, "CacheList", None)
+        pooling_type = getattr(vlm_cache, "PoolingCache", None)
+        if isinstance(pooling_type, type):
+            supported_types += (pooling_type,)
         # mlx-vlm owns a distinct ArraysCache class as well. Hybrid VLM
         # backbones return this native type, so the serialized compatibility
         # lane must accept it for the same reason it accepts mlx-lm's class.
@@ -37,6 +48,13 @@ def first_incompatible_mllm_cache_type(
             supported_types += (vlm_cache.ArraysCache,)
 
     for cache in caches:
+        if compound_type is not None and isinstance(cache, compound_type):
+            incompatible = first_incompatible_mllm_cache_type(
+                cache.caches, allow_arrays_cache=allow_arrays_cache
+            )
+            if incompatible is not None:
+                return incompatible
+            continue
         if not isinstance(cache, supported_types):
             return type(cache).__name__
     return None

--- a/vllm_mlx/mllm_cache_compat.py
+++ b/vllm_mlx/mllm_cache_compat.py
@@ -2,7 +2,7 @@
 """Cache compatibility helpers for MLLM continuous batching."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 
 def first_incompatible_mllm_cache_type(
@@ -50,7 +50,8 @@ def first_incompatible_mllm_cache_type(
     for cache in caches:
         if compound_type is not None and isinstance(cache, compound_type):
             incompatible = first_incompatible_mllm_cache_type(
-                cache.caches, allow_arrays_cache=allow_arrays_cache
+                cast(Any, cache).caches,
+                allow_arrays_cache=allow_arrays_cache,
             )
             if incompatible is not None:
                 return incompatible

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -9,6 +9,7 @@
     "LiquidAI/LFM2.5-2.6B-MLX": 1601103345,
     "Runpod/FLUX.2-klein-4B-mflux-4bit": 4619695783,
     "Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX": 167094577743,
+    "Vontra/GLM-5.3-Flash-MLX-4bit-MTP": 181741731388,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx": 21098225260,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4": 14261049583,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q8": 16640011867,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -154,7 +154,7 @@ VLM_EXTRA_INSTALL_HINT = (
     "Install it with:\n"
     "    pip install 'rapid-mlx[vision]'\n"
     "or directly (pinned to stay compatible with rapid-mlx's transformers pin):\n"
-    "    pip install 'mlx-vlm==0.6.16'"
+    "    pip install 'mlx-vlm==0.6.17'"
 )
 
 
@@ -1409,6 +1409,22 @@ class MLXMultimodalLM:
         _require_mlx_vlm()
 
         try:
+            # Stable Transformers does not yet register the processor used by
+            # glm5_next checkpoints. Install the architecture-owned processor
+            # at the same lazy boundary as mlx-vlm itself so base/text-only
+            # installs remain import-light.
+            from ..patches.glm5_next_forget_gate_quant import (
+                install_glm5_next_forget_gate_quant_fix,
+            )
+            from ..patches.glm5_next_processor import (
+                install_glm5_next_processor_patch,
+            )
+            from ..patches.glm5_next_runtime import install_glm5_next_runtime_fix
+
+            install_glm5_next_runtime_fix()
+            install_glm5_next_processor_patch()
+            install_glm5_next_forget_gate_quant_fix()
+
             from mlx_vlm import load
             from mlx_vlm.utils import load_config
 

--- a/vllm_mlx/patches/glm5_next_forget_gate_quant.py
+++ b/vllm_mlx/patches/glm5_next_forget_gate_quant.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Complete GLM-5 Next forget-gate remapping for quantized checkpoints.
+
+The released architecture sanitizer moves ``f_a_proj.weight`` and
+``f_b_proj.weight`` below ``forget_gate`` but leaves their quantization
+``scales`` and ``biases`` at the old path. MLX then creates quantized modules at
+the nested path and strict loading rejects the 136 orphan tensors. This wrapper
+finishes the same architecture-owned rename for quantization metadata.
+
+The correction is self-retiring: if a later runtime remaps the metadata itself,
+no old-path keys remain and this wrapper is a no-op.
+"""
+
+from __future__ import annotations
+
+import threading
+
+_LOCK = threading.Lock()
+_INSTALLED = False
+_PROJECTION_NAMES = ("f_a_proj", "f_b_proj")
+_QUANTIZATION_LEAVES = ("scales", "biases")
+
+
+def _remap_quantized_forget_gate_tensors(weights: dict) -> dict:
+    remapped = {}
+    for key, value in weights.items():
+        new_key = key
+        for projection in _PROJECTION_NAMES:
+            old = f".self_attn.{projection}."
+            if old not in key or not key.endswith(_QUANTIZATION_LEAVES):
+                continue
+            new_key = key.replace(
+                old,
+                f".self_attn.forget_gate.{projection}.",
+                1,
+            )
+            break
+        remapped[new_key] = value
+    return remapped
+
+
+def install_glm5_next_forget_gate_quant_fix() -> bool:
+    """Wrap the released GLM-5 Next sanitizer once."""
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return False
+
+        from mlx_vlm.models.glm5_next import language
+
+        if getattr(language, "_RAPID_MLX_FORGET_GATE_QUANT_INSTALLED", False):
+            _INSTALLED = True
+            return False
+
+        original = language.LanguageModel.sanitize
+
+        def patched_sanitize(self, weights):
+            return _remap_quantized_forget_gate_tensors(original(self, weights))
+
+        language.LanguageModel.sanitize = patched_sanitize
+        language._RAPID_MLX_FORGET_GATE_QUANT_INSTALLED = True
+        _INSTALLED = True
+        return True
+
+
+def is_installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = [
+    "install_glm5_next_forget_gate_quant_fix",
+    "is_installed",
+]

--- a/vllm_mlx/patches/glm5_next_processor.py
+++ b/vllm_mlx/patches/glm5_next_processor.py
@@ -29,6 +29,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_processing_utils import ImageProcessingMixin
+from transformers.image_transforms import resize
 from transformers.image_utils import ChannelDimension, infer_channel_dimension_format
 from transformers.processing_utils import ProcessorMixin
 
@@ -106,18 +107,23 @@ def smart_resize(
         )
 
     low, high = 1, height
-    best_height, best_width = factor, factor
+    best: tuple[int, int] | None = None
     while low <= high:
         content_height = (low + high) // 2
         content_width = max(1, math.floor(width * content_height / height))
         candidate_height = align(content_height)
         candidate_width = align(content_width)
         if aligned_frames * candidate_height * candidate_width <= max_pixels:
-            best_height, best_width = candidate_height, candidate_width
+            best = candidate_height, candidate_width
             low = content_height + 1
         else:
             high = content_height - 1
-    return best_height, best_width
+    if best is None:
+        raise ValueError(
+            "The image aspect ratio cannot fit the configured token budget "
+            "without distortion. Increase max_image_tokens or resize the image."
+        )
+    return best
 
 
 def _to_channel_first(
@@ -126,8 +132,12 @@ def _to_channel_first(
     input_data_format: str | ChannelDimension | None = None,
 ) -> np.ndarray:
     if isinstance(image, (str, Path)):
-        image = Image.open(image)
-    if hasattr(image, "convert"):
+        with Image.open(image) as opened:
+            if do_convert_rgb:
+                opened = opened.convert("RGB")
+            array = np.asarray(opened).copy()
+        channel_dimension = ChannelDimension.LAST
+    elif hasattr(image, "convert"):
         if do_convert_rgb:
             image = image.convert("RGB")
         array = np.asarray(image)
@@ -163,16 +173,13 @@ def _resize_channel_first(
 ) -> np.ndarray:
     if image.shape[-2:] == (target_height, target_width):
         return image
-    array = np.transpose(image, (1, 2, 0))
-    if array.dtype != np.uint8:
-        if np.issubdtype(array.dtype, np.floating) and array.max(initial=0) <= 1:
-            array = array * 255
-        array = np.clip(array, 0, 255).astype(np.uint8)
-    resized = Image.fromarray(array).resize(
-        (target_width, target_height),
+    return resize(
+        image,
+        (target_height, target_width),
         resample=Image.Resampling.BICUBIC,
+        data_format=ChannelDimension.FIRST,
+        input_data_format=ChannelDimension.FIRST,
     )
-    return np.transpose(np.asarray(resized), (2, 0, 1))
 
 
 class Glm5NextImageProcessor(ImageProcessingMixin):
@@ -363,10 +370,11 @@ def _load_json(
         return None
     try:
         from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError
 
         downloaded = hf_hub_download(str(model_path), filename, **options)
         return _read_json_object(Path(downloaded))
-    except Exception:
+    except EntryNotFoundError:
         return None
 
 

--- a/vllm_mlx/patches/glm5_next_processor.py
+++ b/vllm_mlx/patches/glm5_next_processor.py
@@ -1,0 +1,531 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch-free processor support for GLM-5.3-Flash.
+
+The official checkpoint targets a newer Transformers release than Rapid's
+validated runtime range. This module mirrors the GLM-5 Next image layout with
+NumPy and Pillow so image requests remain available without requiring a future
+Transformers release.
+
+Adapted from the Apache-2.0 implementation in jundot/omlx at commit
+``c520d7e6124cf6255868e589c6beb75cf4cee8f9``. The registration lifecycle and
+Rapid load-path integration are local changes.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from mlx_vlm.models.base import (
+    install_auto_processor_patch,
+    load_chat_template,
+    to_mlx,
+)
+from PIL import Image
+from transformers import AutoTokenizer
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_processing_utils import ImageProcessingMixin
+from transformers.processing_utils import ProcessorMixin
+
+OPENAI_CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
+OPENAI_CLIP_STD = (0.26862954, 0.26130258, 0.27577711)
+
+_IMAGE_KWARGS = {
+    "do_convert_rgb",
+    "do_normalize",
+    "do_rescale",
+    "image_mean",
+    "image_std",
+    "max_image_tokens",
+    "merge_size",
+    "min_image_tokens",
+    "patch_expand_factor",
+    "patch_size",
+    "rescale_factor",
+    "temporal_patch_size",
+}
+
+
+def smart_resize(
+    num_frames: int,
+    height: int,
+    width: int,
+    *,
+    temporal_factor: int = 2,
+    factor: int = 28,
+    min_image_tokens: int = 16,
+    max_image_tokens: int = 8000,
+) -> tuple[int, int]:
+    """Return GLM's aligned canvas dimensions for an image or video."""
+    if num_frames <= 0 or height <= 0 or width <= 0:
+        raise ValueError("Image dimensions and frame count must be positive.")
+
+    pixels_per_token = temporal_factor * factor**2
+    min_pixels = min_image_tokens * pixels_per_token
+    max_pixels = max_image_tokens * pixels_per_token
+
+    def align(value: int) -> int:
+        return math.ceil(value / factor) * factor
+
+    aligned_frames = max(
+        temporal_factor,
+        round(num_frames / temporal_factor) * temporal_factor,
+    )
+    aligned_height = align(height)
+    aligned_width = align(width)
+    aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget < min_pixels:
+        scale = math.sqrt(min_pixels / (num_frames * height * width))
+        aligned_height = align(max(1, math.ceil(height * scale)))
+        aligned_width = align(max(1, math.ceil(width * scale)))
+        aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget <= max_pixels:
+        return aligned_height, aligned_width
+
+    minimum_pixels = aligned_frames * factor**2
+    if max_pixels < minimum_pixels:
+        raise ValueError(
+            f"max_image_tokens={max_image_tokens} is too small for one aligned patch."
+        )
+
+    low, high = 1, height
+    best_height, best_width = factor, factor
+    while low <= high:
+        content_height = (low + high) // 2
+        content_width = max(1, math.floor(width * content_height / height))
+        candidate_height = align(content_height)
+        candidate_width = align(content_width)
+        if aligned_frames * candidate_height * candidate_width <= max_pixels:
+            best_height, best_width = candidate_height, candidate_width
+            low = content_height + 1
+        else:
+            high = content_height - 1
+    return best_height, best_width
+
+
+def _to_channel_first(image: Any, do_convert_rgb: bool) -> np.ndarray:
+    if isinstance(image, (str, Path)):
+        image = Image.open(image)
+    if hasattr(image, "convert"):
+        if do_convert_rgb:
+            image = image.convert("RGB")
+        array = np.asarray(image)
+    else:
+        array = np.asarray(image)
+
+    if array.ndim == 2:
+        array = np.repeat(array[..., None], 3, axis=-1)
+    if array.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got shape {array.shape}.")
+    if array.shape[-1] in (1, 3, 4):
+        array = np.transpose(array, (2, 0, 1))
+    if array.shape[0] == 4:
+        array = array[:3]
+    if array.shape[0] == 1 and do_convert_rgb:
+        array = np.repeat(array, 3, axis=0)
+    if array.shape[0] != 3:
+        raise ValueError(f"Expected an RGB image, got shape {array.shape}.")
+    return array
+
+
+def _resize_channel_first(
+    image: np.ndarray, target_height: int, target_width: int
+) -> np.ndarray:
+    if image.shape[-2:] == (target_height, target_width):
+        return image
+    array = np.transpose(image, (1, 2, 0))
+    if array.dtype != np.uint8:
+        if np.issubdtype(array.dtype, np.floating) and array.max(initial=0) <= 1:
+            array = array * 255
+        array = np.clip(array, 0, 255).astype(np.uint8)
+    resized = Image.fromarray(array).resize(
+        (target_width, target_height),
+        resample=Image.Resampling.BICUBIC,
+    )
+    return np.transpose(np.asarray(resized), (2, 0, 1))
+
+
+class Glm5NextImageProcessor(ImageProcessingMixin):
+    """NumPy/Pillow implementation of the GLM-5 Next image processor."""
+
+    model_input_names = ["pixel_values", "image_grid_thw"]
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        merge_size: int = 2,
+        patch_expand_factor: int = 1,
+        min_image_tokens: int = 16,
+        max_image_tokens: int = 8000,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255.0,
+        do_normalize: bool = True,
+        image_mean: list[float] | None = None,
+        image_std: list[float] | None = None,
+        do_convert_rgb: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.merge_size = merge_size
+        self.patch_expand_factor = patch_expand_factor
+        self.min_image_tokens = min_image_tokens
+        self.max_image_tokens = max_image_tokens
+        self.do_rescale = do_rescale
+        self.rescale_factor = rescale_factor
+        self.do_normalize = do_normalize
+        self.image_mean = list(image_mean or OPENAI_CLIP_MEAN)
+        self.image_std = list(image_std or OPENAI_CLIP_STD)
+        self.do_convert_rgb = do_convert_rgb
+
+    def fetch_images(self, images):
+        if not isinstance(images, list):
+            images = [images]
+        return [_to_channel_first(image, self.do_convert_rgb) for image in images]
+
+    def _process_one(self, image: Any, **kwargs) -> tuple[np.ndarray, list[int]]:
+        do_convert_rgb = kwargs.get("do_convert_rgb", self.do_convert_rgb)
+        do_rescale = kwargs.get("do_rescale", self.do_rescale)
+        rescale_factor = kwargs.get("rescale_factor", self.rescale_factor)
+        do_normalize = kwargs.get("do_normalize", self.do_normalize)
+        image_mean = kwargs.get("image_mean", self.image_mean)
+        image_std = kwargs.get("image_std", self.image_std)
+        image = _to_channel_first(image, do_convert_rgb)
+        _, height, width = image.shape
+        patch_size = kwargs.get("patch_size", self.patch_size)
+        temporal_patch_size = kwargs.get(
+            "temporal_patch_size", self.temporal_patch_size
+        )
+        merge_size = kwargs.get("merge_size", self.merge_size)
+        patch_expand_factor = kwargs.get(
+            "patch_expand_factor", self.patch_expand_factor
+        )
+        min_image_tokens = kwargs.get("min_image_tokens", self.min_image_tokens)
+        max_image_tokens = kwargs.get("max_image_tokens", self.max_image_tokens)
+        factor = patch_size * merge_size * patch_expand_factor
+        target_height, target_width = smart_resize(
+            temporal_patch_size,
+            height,
+            width,
+            temporal_factor=temporal_patch_size,
+            factor=factor,
+            min_image_tokens=min_image_tokens,
+            max_image_tokens=max_image_tokens,
+        )
+
+        pixels_per_token = temporal_patch_size * factor**2
+        scale = min(target_height / height, target_width / width)
+        if temporal_patch_size * height * width >= (
+            pixels_per_token * min_image_tokens
+        ):
+            scale = min(1.0, scale)
+        content_height = max(1, min(target_height, math.floor(height * scale)))
+        content_width = max(1, min(target_width, math.floor(width * scale)))
+        image = _resize_channel_first(image, content_height, content_width)
+
+        canvas = np.zeros(
+            (image.shape[0], target_height, target_width), dtype=image.dtype
+        )
+        canvas[:, :content_height, :content_width] = image
+        image = canvas.astype(np.float32)
+        if do_rescale:
+            image *= rescale_factor
+        if do_normalize:
+            mean = np.asarray(image_mean, dtype=np.float32)[:, None, None]
+            std = np.asarray(image_std, dtype=np.float32)[:, None, None]
+            image = (image - mean) / std
+
+        channels = image.shape[0]
+        grid_h = target_height // patch_size
+        grid_w = target_width // patch_size
+        patches = image.reshape(
+            channels,
+            grid_h // merge_size,
+            merge_size,
+            patch_size,
+            grid_w // merge_size,
+            merge_size,
+            patch_size,
+        )
+        patches = patches.transpose(1, 4, 2, 5, 0, 3, 6)
+        patches = np.expand_dims(patches, axis=5)
+        patches = np.repeat(patches, temporal_patch_size, axis=5)
+        patches = patches.reshape(
+            grid_h * grid_w,
+            channels * temporal_patch_size * patch_size * patch_size,
+        )
+        return patches.astype(np.float32), [1, grid_h, grid_w]
+
+    def __call__(self, images=None, **kwargs):
+        return self.preprocess(images=images, **kwargs)
+
+    def preprocess(self, images=None, return_tensors=None, **kwargs) -> BatchFeature:
+        if images is None:
+            raise ValueError("images must not be None")
+        if not isinstance(images, list):
+            images = [images]
+        image_kwargs = {
+            key: value for key, value in kwargs.items() if key in _IMAGE_KWARGS
+        }
+        processed = [self._process_one(image, **image_kwargs) for image in images]
+        data = {
+            "pixel_values": np.concatenate([item[0] for item in processed], axis=0),
+            "image_grid_thw": np.asarray(
+                [item[1] for item in processed], dtype=np.int64
+            ),
+        }
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> int:
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        patch_expand_factor = images_kwargs.get(
+            "patch_expand_factor", self.patch_expand_factor
+        )
+        target_height, target_width = smart_resize(
+            images_kwargs.get("temporal_patch_size", self.temporal_patch_size),
+            height,
+            width,
+            temporal_factor=images_kwargs.get(
+                "temporal_patch_size", self.temporal_patch_size
+            ),
+            factor=patch_size * merge_size * patch_expand_factor,
+            min_image_tokens=images_kwargs.get(
+                "min_image_tokens", self.min_image_tokens
+            ),
+            max_image_tokens=images_kwargs.get(
+                "max_image_tokens", self.max_image_tokens
+            ),
+        )
+        return (target_height // patch_size) * (target_width // patch_size)
+
+
+def _load_json(model_path: str | Path, filename: str) -> dict | None:
+    root = Path(model_path)
+    local = root / filename
+    if local.exists():
+        return json.loads(local.read_text())
+    if root.exists():
+        # A local checkpoint either carries the optional metadata or it does
+        # not. Never reinterpret its filesystem path as a Hub repo ID.
+        return None
+    try:
+        from huggingface_hub import hf_hub_download
+
+        downloaded = hf_hub_download(str(model_path), filename)
+        return json.loads(Path(downloaded).read_text())
+    except Exception:
+        return None
+
+
+def _image_processor_kwargs(model_path: str | Path) -> dict:
+    config = _load_json(model_path, "config.json") or {}
+    vision = config.get("vision_config", {}) or {}
+    processor = _load_json(model_path, "processor_config.json") or {}
+    image = processor.get("image_processor", {}) or {}
+
+    result = {}
+    for key in _IMAGE_KWARGS:
+        if key in image:
+            result[key] = image[key]
+    for source, target in (
+        ("patch_size", "patch_size"),
+        ("temporal_patch_size", "temporal_patch_size"),
+        ("spatial_merge_size", "merge_size"),
+    ):
+        if target not in result and source in vision:
+            result[target] = vision[source]
+    return result
+
+
+class Glm5NextProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        **kwargs,
+    ):
+        image_processor = image_processor or Glm5NextImageProcessor()
+        self.image_token = "<|image|>"
+        self.video_token = "<|video|>"
+        self.image_token_id = (
+            tokenizer.convert_tokens_to_ids(self.image_token) if tokenizer else None
+        )
+        self.video_token_id = (
+            tokenizer.convert_tokens_to_ids(self.video_token) if tokenizer else None
+        )
+        super().__init__(
+            image_processor,
+            tokenizer,
+            chat_template=chat_template,
+        )
+
+    def __call__(
+        self,
+        images=None,
+        text=None,
+        padding=True,
+        padding_side=None,
+        add_special_tokens=False,
+        return_tensors="mlx",
+        return_mm_token_type_ids=True,
+        **kwargs,
+    ) -> BatchFeature:
+        image_inputs = {}
+        if images is not None:
+            image_kwargs = {
+                key: value for key, value in kwargs.items() if key in _IMAGE_KWARGS
+            }
+            image_inputs = dict(
+                self.image_processor(
+                    images=images,
+                    return_tensors=None,
+                    **image_kwargs,
+                )
+            )
+
+        if text is None:
+            text = [""]
+        elif not isinstance(text, list):
+            text = [text]
+        text = ["" if item is None else str(item) for item in text]
+
+        if image_inputs:
+            placeholder = "<|glm5_next_image_placeholder|>"
+            image_idx = 0
+            grids = image_inputs["image_grid_thw"]
+            for prompt_idx, prompt in enumerate(text):
+                while self.image_token in prompt:
+                    if image_idx >= len(grids):
+                        raise ValueError("More image tokens were provided than images.")
+                    count = int(
+                        np.prod(grids[image_idx]) // self.image_processor.merge_size**2
+                    )
+                    prompt = prompt.replace(self.image_token, placeholder * count, 1)
+                    image_idx += 1
+                text[prompt_idx] = prompt.replace(placeholder, self.image_token)
+            if image_idx != len(grids):
+                raise ValueError("More images were provided than image tokens.")
+
+        tokenizer_kwargs = dict(kwargs)
+        for key in _IMAGE_KWARGS:
+            tokenizer_kwargs.pop(key, None)
+        if padding_side is not None:
+            tokenizer_kwargs["padding_side"] = padding_side
+        text_inputs = dict(
+            self.tokenizer(
+                text,
+                padding=padding,
+                add_special_tokens=add_special_tokens,
+                return_tensors=None,
+                **tokenizer_kwargs,
+            )
+        )
+
+        if return_mm_token_type_ids and self.image_token_id is not None:
+            input_ids = np.asarray(text_inputs["input_ids"])
+            mm_token_type_ids = np.zeros_like(input_ids)
+            mm_token_type_ids[input_ids == self.image_token_id] = 1
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+
+        data = {**text_inputs, **image_inputs}
+        if return_tensors == "mlx":
+            data = to_mlx(data)
+        return BatchFeature(data=data)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        tokenizer_names = getattr(self.tokenizer, "model_input_names", [])
+        return list(
+            dict.fromkeys(
+                tokenizer_names
+                + self.image_processor.model_input_names
+                + ["mm_token_type_ids"]
+            )
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        tokenizer_kwargs = dict(kwargs)
+        chat_template = tokenizer_kwargs.pop("chat_template", None)
+        tokenizer_kwargs.pop("return_tensors", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            **tokenizer_kwargs,
+        )
+        if Path(pretrained_model_name_or_path).exists():
+            load_chat_template(tokenizer, pretrained_model_name_or_path)
+        processor_config = (
+            _load_json(pretrained_model_name_or_path, "processor_config.json") or {}
+        )
+        return cls(
+            image_processor=Glm5NextImageProcessor(
+                **_image_processor_kwargs(pretrained_model_name_or_path)
+            ),
+            tokenizer=tokenizer,
+            chat_template=(
+                chat_template
+                or processor_config.get("chat_template")
+                or getattr(tokenizer, "chat_template", None)
+            ),
+        )
+
+
+_PATCH_LOCK = threading.Lock()
+_INSTALLED = False
+
+
+def install_glm5_next_processor_patch() -> bool:
+    """Register the GLM-5 Next processor and prompt shape exactly once."""
+    global _INSTALLED
+    with _PATCH_LOCK:
+        if _INSTALLED:
+            return False
+        install_auto_processor_patch("glm5_next", Glm5NextProcessor)
+        from mlx_vlm.prompt_utils import MODEL_CONFIG, MessageFormat
+
+        MODEL_CONFIG.setdefault("glm5_next", MessageFormat.LIST_WITH_IMAGE_FIRST)
+        _INSTALLED = True
+        return True
+
+
+def is_installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = [
+    "Glm5NextImageProcessor",
+    "Glm5NextProcessor",
+    "install_glm5_next_processor_patch",
+    "is_installed",
+    "smart_resize",
+]

--- a/vllm_mlx/patches/glm5_next_processor.py
+++ b/vllm_mlx/patches/glm5_next_processor.py
@@ -29,6 +29,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_processing_utils import ImageProcessingMixin
+from transformers.image_utils import ChannelDimension, infer_channel_dimension_format
 from transformers.processing_utils import ProcessorMixin
 
 OPENAI_CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
@@ -40,6 +41,7 @@ _IMAGE_KWARGS = {
     "do_rescale",
     "image_mean",
     "image_std",
+    "input_data_format",
     "max_image_tokens",
     "merge_size",
     "min_image_tokens",
@@ -118,21 +120,34 @@ def smart_resize(
     return best_height, best_width
 
 
-def _to_channel_first(image: Any, do_convert_rgb: bool) -> np.ndarray:
+def _to_channel_first(
+    image: Any,
+    do_convert_rgb: bool,
+    input_data_format: str | ChannelDimension | None = None,
+) -> np.ndarray:
     if isinstance(image, (str, Path)):
         image = Image.open(image)
     if hasattr(image, "convert"):
         if do_convert_rgb:
             image = image.convert("RGB")
         array = np.asarray(image)
+        channel_dimension = ChannelDimension.LAST
     else:
         array = np.asarray(image)
+        channel_dimension = None
 
     if array.ndim == 2:
         array = np.repeat(array[..., None], 3, axis=-1)
+        channel_dimension = ChannelDimension.LAST
     if array.ndim != 3:
         raise ValueError(f"Expected a 3D image, got shape {array.shape}.")
-    if array.shape[-1] in (1, 3, 4):
+    if input_data_format is not None:
+        channel_dimension = ChannelDimension(input_data_format)
+    elif channel_dimension is None:
+        channel_dimension = infer_channel_dimension_format(
+            array, num_channels=(1, 3, 4)
+        )
+    if channel_dimension is ChannelDimension.LAST:
         array = np.transpose(array, (2, 0, 1))
     if array.shape[0] == 4:
         array = array[:3]
@@ -207,7 +222,8 @@ class Glm5NextImageProcessor(ImageProcessingMixin):
         do_normalize = kwargs.get("do_normalize", self.do_normalize)
         image_mean = kwargs.get("image_mean", self.image_mean)
         image_std = kwargs.get("image_std", self.image_std)
-        image = _to_channel_first(image, do_convert_rgb)
+        input_data_format = kwargs.get("input_data_format")
+        image = _to_channel_first(image, do_convert_rgb, input_data_format)
         _, height, width = image.shape
         patch_size = kwargs.get("patch_size", self.patch_size)
         temporal_patch_size = kwargs.get(

--- a/vllm_mlx/patches/glm5_next_processor.py
+++ b/vllm_mlx/patches/glm5_next_processor.py
@@ -285,13 +285,16 @@ class Glm5NextImageProcessor(ImageProcessingMixin):
         return BatchFeature(data=data, tensor_type=return_tensors)
 
     def get_number_of_image_patches(
-        self, height: int, width: int, images_kwargs: dict | None = None
+        self,
+        height: int,
+        width: int,
+        images_kwargs: dict[str, Any] | None = None,
     ) -> int:
         images_kwargs = images_kwargs or {}
-        patch_size = images_kwargs.get("patch_size", self.patch_size)
-        merge_size = images_kwargs.get("merge_size", self.merge_size)
-        patch_expand_factor = images_kwargs.get(
-            "patch_expand_factor", self.patch_expand_factor
+        patch_size = int(images_kwargs.get("patch_size", self.patch_size))
+        merge_size = int(images_kwargs.get("merge_size", self.merge_size))
+        patch_expand_factor = int(
+            images_kwargs.get("patch_expand_factor", self.patch_expand_factor)
         )
         target_height, target_width = smart_resize(
             images_kwargs.get("temporal_patch_size", self.temporal_patch_size),
@@ -311,11 +314,16 @@ class Glm5NextImageProcessor(ImageProcessingMixin):
         return (target_height // patch_size) * (target_width // patch_size)
 
 
-def _load_json(model_path: str | Path, filename: str) -> dict | None:
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    parsed = json.loads(path.read_text())
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _load_json(model_path: str | Path, filename: str) -> dict[str, Any] | None:
     root = Path(model_path)
     local = root / filename
     if local.exists():
-        return json.loads(local.read_text())
+        return _read_json_object(local)
     if root.exists():
         # A local checkpoint either carries the optional metadata or it does
         # not. Never reinterpret its filesystem path as a Hub repo ID.
@@ -324,7 +332,7 @@ def _load_json(model_path: str | Path, filename: str) -> dict | None:
         from huggingface_hub import hf_hub_download
 
         downloaded = hf_hub_download(str(model_path), filename)
-        return json.loads(Path(downloaded).read_text())
+        return _read_json_object(Path(downloaded))
     except Exception:
         return None
 

--- a/vllm_mlx/patches/glm5_next_processor.py
+++ b/vllm_mlx/patches/glm5_next_processor.py
@@ -49,6 +49,15 @@ _IMAGE_KWARGS = {
     "temporal_patch_size",
 }
 
+_HUB_METADATA_KWARGS = {
+    "cache_dir",
+    "force_download",
+    "local_files_only",
+    "revision",
+    "subfolder",
+    "token",
+}
+
 
 def smart_resize(
     num_frames: int,
@@ -319,9 +328,17 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def _load_json(model_path: str | Path, filename: str) -> dict[str, Any] | None:
+def _load_json(
+    model_path: str | Path,
+    filename: str,
+    *,
+    hub_kwargs: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     root = Path(model_path)
-    local = root / filename
+    options = dict(hub_kwargs or {})
+    subfolder = options.get("subfolder")
+    local_root = root / str(subfolder) if subfolder else root
+    local = local_root / filename
     if local.exists():
         return _read_json_object(local)
     if root.exists():
@@ -331,16 +348,20 @@ def _load_json(model_path: str | Path, filename: str) -> dict[str, Any] | None:
     try:
         from huggingface_hub import hf_hub_download
 
-        downloaded = hf_hub_download(str(model_path), filename)
+        downloaded = hf_hub_download(str(model_path), filename, **options)
         return _read_json_object(Path(downloaded))
     except Exception:
         return None
 
 
-def _image_processor_kwargs(model_path: str | Path) -> dict:
-    config = _load_json(model_path, "config.json") or {}
+def _image_processor_kwargs(
+    model_path: str | Path, *, hub_kwargs: dict[str, Any] | None = None
+) -> dict:
+    config = _load_json(model_path, "config.json", hub_kwargs=hub_kwargs) or {}
     vision = config.get("vision_config", {}) or {}
-    processor = _load_json(model_path, "processor_config.json") or {}
+    processor = (
+        _load_json(model_path, "processor_config.json", hub_kwargs=hub_kwargs) or {}
+    )
     image = processor.get("image_processor", {}) or {}
 
     result = {}
@@ -399,8 +420,17 @@ class Glm5NextProcessor(ProcessorMixin):
         return_mm_token_type_ids=True,
         **kwargs,
     ) -> BatchFeature:
+        if text is None:
+            text = [""]
+        elif not isinstance(text, list):
+            text = [text]
+        text = ["" if item is None else str(item) for item in text]
+
         image_inputs = {}
-        if images is not None:
+        has_images = images is not None and (
+            not isinstance(images, list) or bool(images)
+        )
+        if has_images:
             image_kwargs = {
                 key: value for key, value in kwargs.items() if key in _IMAGE_KWARGS
             }
@@ -411,24 +441,21 @@ class Glm5NextProcessor(ProcessorMixin):
                     **image_kwargs,
                 )
             )
-
-        if text is None:
-            text = [""]
-        elif not isinstance(text, list):
-            text = [text]
-        text = ["" if item is None else str(item) for item in text]
+        elif any(self.image_token in prompt for prompt in text):
+            raise ValueError("Image tokens were provided without images.")
 
         if image_inputs:
             placeholder = "<|glm5_next_image_placeholder|>"
             image_idx = 0
             grids = image_inputs["image_grid_thw"]
+            merge_size = int(
+                image_kwargs.get("merge_size", self.image_processor.merge_size)
+            )
             for prompt_idx, prompt in enumerate(text):
                 while self.image_token in prompt:
                     if image_idx >= len(grids):
                         raise ValueError("More image tokens were provided than images.")
-                    count = int(
-                        np.prod(grids[image_idx]) // self.image_processor.merge_size**2
-                    )
+                    count = int(np.prod(grids[image_idx]) // merge_size**2)
                     prompt = prompt.replace(self.image_token, placeholder * count, 1)
                     image_idx += 1
                 text[prompt_idx] = prompt.replace(placeholder, self.image_token)
@@ -484,6 +511,11 @@ class Glm5NextProcessor(ProcessorMixin):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         tokenizer_kwargs = dict(kwargs)
+        hub_kwargs = {
+            key: value
+            for key, value in tokenizer_kwargs.items()
+            if key in _HUB_METADATA_KWARGS
+        }
         chat_template = tokenizer_kwargs.pop("chat_template", None)
         tokenizer_kwargs.pop("return_tensors", None)
         tokenizer = AutoTokenizer.from_pretrained(
@@ -493,11 +525,19 @@ class Glm5NextProcessor(ProcessorMixin):
         if Path(pretrained_model_name_or_path).exists():
             load_chat_template(tokenizer, pretrained_model_name_or_path)
         processor_config = (
-            _load_json(pretrained_model_name_or_path, "processor_config.json") or {}
+            _load_json(
+                pretrained_model_name_or_path,
+                "processor_config.json",
+                hub_kwargs=hub_kwargs,
+            )
+            or {}
         )
         return cls(
             image_processor=Glm5NextImageProcessor(
-                **_image_processor_kwargs(pretrained_model_name_or_path)
+                **_image_processor_kwargs(
+                    pretrained_model_name_or_path,
+                    hub_kwargs=hub_kwargs,
+                )
             ),
             tokenizer=tokenizer,
             chat_template=(

--- a/vllm_mlx/patches/glm5_next_runtime.py
+++ b/vllm_mlx/patches/glm5_next_runtime.py
@@ -19,9 +19,6 @@ import threading
 from collections.abc import Sequence
 from typing import Any
 
-import mlx.core as mx
-import mlx.nn as nn
-
 _LOCK = threading.Lock()
 _INSTALLED = False
 
@@ -55,6 +52,8 @@ def install_glm5_next_runtime_fix() -> bool:
         if _INSTALLED:
             return False
 
+        import mlx.core as mx
+        import mlx.nn as nn
         from mlx_vlm.models.deepseek_v32.language import (
             DeepseekV32MoE,
             MoEGate,
@@ -117,9 +116,7 @@ def install_glm5_next_runtime_fix() -> bool:
                     width = config.moe_intermediate_size * config.n_shared_experts
                     self.shared_experts = Glm5NextMLP(config, intermediate_size=width)
 
-        released_sparse_attention = language.Glm5NextSparseAttention
-
-        class Glm5NextSparseAttention(released_sparse_attention):
+        class Glm5NextSparseAttention(language.Glm5NextSparseAttention):
             def __init__(self, config):
                 super().__init__(config)
                 self.q_a_layernorm = nn.RMSNorm(
@@ -130,9 +127,7 @@ def install_glm5_next_runtime_fix() -> bool:
                 )
                 self.indexer.k_norm = nn.LayerNorm(self.indexer.head_dim, eps=1e-6)
 
-        released_linear_attention = language.Glm5NextLinearAttention
-
-        class Glm5NextLinearAttention(released_linear_attention):
+        class Glm5NextLinearAttention(language.Glm5NextLinearAttention):
             def _fused_in_proj(self, inputs):
                 modules = (
                     self.q_proj,
@@ -159,7 +154,6 @@ def install_glm5_next_runtime_fix() -> bool:
                     sanitized[key] = value.astype(mx.float32)
             return sanitized
 
-        @property
         def cast_predicate(self):
             def predicate(key):
                 if "e_score_correction_bias" in key:
@@ -176,7 +170,7 @@ def install_glm5_next_runtime_fix() -> bool:
         language.Glm5NextSparseAttention = Glm5NextSparseAttention
         language.Glm5NextLinearAttention = Glm5NextLinearAttention
         language.LanguageModel.sanitize = patched_sanitize
-        language.LanguageModel.cast_predicate = cast_predicate
+        language.LanguageModel.cast_predicate = property(cast_predicate)
         language._RAPID_MLX_RUNTIME_FIX_INSTALLED = True
         _INSTALLED = True
         return True

--- a/vllm_mlx/patches/glm5_next_runtime.py
+++ b/vllm_mlx/patches/glm5_next_runtime.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness overlay for the released GLM-5 Next text runtime.
+
+mlx-vlm 0.6.17 contains the initial GLM-5 Next implementation, but its text
+stack still inherits unclamped DeepSeek MLPs, bf16 router math, and two norm
+epsilons from the parent architecture. Those are not interchangeable with the
+GLM checkpoint contract. This module installs the architecture-owned variants
+before model construction while leaving shared DeepSeek classes untouched.
+
+The overlay also keeps the six-input KDA projection fusion lossless: a uniform
+quantization uses the released fused path, while mixed quantization falls back
+to the six original projections instead of interpreting five tensors with the
+first tensor's quantization parameters.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Sequence
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+_LOCK = threading.Lock()
+_INSTALLED = False
+
+
+def _projection_quantization_is_homogeneous(modules: Sequence[Any]) -> bool:
+    quantized = [hasattr(module, "scales") for module in modules]
+    if not all(quantized) and any(quantized):
+        return False
+    if not any(quantized):
+        return True
+    return (
+        len({module.group_size for module in modules}) == 1
+        and len({module.bits for module in modules}) == 1
+        and len({getattr(module, "mode", "affine") for module in modules}) == 1
+    )
+
+
+def _keep_glm5_next_fp32(key: str) -> bool:
+    return (
+        ".attn_hc." in key
+        or ".ffn_hc." in key
+        or key.endswith("A_log")
+        or key.endswith("dt_bias")
+    )
+
+
+def install_glm5_next_runtime_fix() -> bool:
+    """Install the GLM-specific text math once, before model construction."""
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return False
+
+        from mlx_vlm.models.deepseek_v32.language import (
+            DeepseekV32MoE,
+            MoEGate,
+            group_expert_select,
+        )
+        from mlx_vlm.models.glm5_next import language
+        from mlx_vlm.models.mlp import DeepseekMLP
+
+        if getattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED", False):
+            _INSTALLED = True
+            return False
+
+        class Glm5NextClampedSwiGLU(nn.Module):
+            def __init__(self, limit: float | None):
+                super().__init__()
+                self.limit = limit
+
+            def __call__(self, x_up: mx.array, x_gate: mx.array) -> mx.array:
+                if self.limit is not None:
+                    x_gate = mx.clip(x_gate, a_min=None, a_max=self.limit)
+                    x_up = mx.clip(x_up, a_min=-self.limit, a_max=self.limit)
+                return nn.silu(x_gate) * x_up
+
+        class Glm5NextMLP(DeepseekMLP):
+            def __init__(self, config, hidden_size=None, intermediate_size=None):
+                super().__init__(
+                    config,
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                )
+                self.limit = config.swiglu_limit
+
+            def __call__(self, x: mx.array) -> mx.array:
+                gate = self.gate_proj(x)
+                up = self.up_proj(x)
+                if self.limit is not None:
+                    gate = mx.clip(gate, a_min=None, a_max=self.limit)
+                    up = mx.clip(up, a_min=-self.limit, a_max=self.limit)
+                return self.down_proj(nn.silu(gate) * up)
+
+        class Glm5NextMoEGate(MoEGate):
+            def __call__(self, x: mx.array):
+                logits = x.astype(mx.float32) @ self.weight.astype(mx.float32).T
+                return group_expert_select(
+                    logits,
+                    self.e_score_correction_bias,
+                    self.top_k,
+                    self.n_group,
+                    self.topk_group,
+                    self.routed_scaling_factor,
+                    self.norm_topk_prob,
+                )
+
+        class Glm5NextMoE(DeepseekV32MoE):
+            def __init__(self, config):
+                super().__init__(config)
+                self.switch_mlp.activation = Glm5NextClampedSwiGLU(config.swiglu_limit)
+                self.gate = Glm5NextMoEGate(config)
+                if config.n_shared_experts is not None:
+                    width = config.moe_intermediate_size * config.n_shared_experts
+                    self.shared_experts = Glm5NextMLP(config, intermediate_size=width)
+
+        released_sparse_attention = language.Glm5NextSparseAttention
+
+        class Glm5NextSparseAttention(released_sparse_attention):
+            def __init__(self, config):
+                super().__init__(config)
+                self.q_a_layernorm = nn.RMSNorm(
+                    self.q_lora_rank, eps=config.rms_norm_eps
+                )
+                self.kv_a_layernorm = nn.RMSNorm(
+                    self.kv_lora_rank, eps=config.rms_norm_eps
+                )
+                self.indexer.k_norm = nn.LayerNorm(self.indexer.head_dim, eps=1e-6)
+
+        released_linear_attention = language.Glm5NextLinearAttention
+
+        class Glm5NextLinearAttention(released_linear_attention):
+            def _fused_in_proj(self, inputs):
+                modules = (
+                    self.q_proj,
+                    self.k_proj,
+                    self.v_proj,
+                    self.forget_gate.f_a_proj,
+                    self.g_a_proj,
+                    self.b_proj,
+                )
+                if not _projection_quantization_is_homogeneous(modules):
+                    return tuple(module(inputs) for module in modules)
+                return super()._fused_in_proj(inputs)
+
+        released_sanitize = language.LanguageModel.sanitize
+
+        def patched_sanitize(self, weights):
+            sanitized = released_sanitize(self, weights)
+            for key, value in list(sanitized.items()):
+                if (
+                    _keep_glm5_next_fp32(key)
+                    and mx.issubdtype(value.dtype, mx.floating)
+                    and value.dtype != mx.float32
+                ):
+                    sanitized[key] = value.astype(mx.float32)
+            return sanitized
+
+        @property
+        def cast_predicate(self):
+            def predicate(key):
+                if "e_score_correction_bias" in key:
+                    return False
+                return not _keep_glm5_next_fp32(key)
+
+            return predicate
+
+        # These names are looked up by Glm5NextDecoderLayer at construction
+        # time. Replacing only the GLM module globals avoids changing any
+        # DeepSeek model that imports the shared implementations directly.
+        language.DeepseekMLP = Glm5NextMLP
+        language.DeepseekV32MoE = Glm5NextMoE
+        language.Glm5NextSparseAttention = Glm5NextSparseAttention
+        language.Glm5NextLinearAttention = Glm5NextLinearAttention
+        language.LanguageModel.sanitize = patched_sanitize
+        language.LanguageModel.cast_predicate = cast_predicate
+        language._RAPID_MLX_RUNTIME_FIX_INSTALLED = True
+        _INSTALLED = True
+        return True
+
+
+def is_installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = [
+    "install_glm5_next_runtime_fix",
+    "is_installed",
+]

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -709,7 +709,7 @@ class DiffusionEngine(BaseEngine):
                 "dependencies. Install the vision stack: "
                 "`pip install 'rapid-mlx[vision]'` (or, pinned to stay "
                 "compatible with rapid-mlx's transformers pin, "
-                "`pip install 'mlx-vlm==0.6.16'`). "
+                "`pip install 'mlx-vlm==0.6.17'`). "
                 f"Underlying error: {e}"
             )
             self._ready.set()


### PR DESCRIPTION
## Summary

- add an explicit `glm5.3-flash-4bit` multimodal alias with a 192 GB memory floor, GLM tool/reasoning parsers, and speculative decoding disabled until separately validated
- align the `vision` extra and Desktop sidecar on the validated `mlx-vlm==0.6.17` runtime while preserving the Transformers 5.13.0 exclusion
- install lazy, architecture-scoped compatibility overlays for the checkpoint processor, quantized forget-gate metadata, and GLM-specific text math
- accept the released compound sparse-attention cache only after recursively validating every leaf; unknown cache shapes remain fail-closed
- enroll the real MLX paths in the Apple coverage roster and publish the model's offline download size

## Design precedent

The implementation follows established production serving patterns: capabilities are declared in one model profile, optional acceleration remains explicitly disabled until correctness evidence exists, compatibility work is installed at the architecture load boundary instead of globally, and compound cache support recursively validates known leaf contracts. The overlays leave shared parent-model classes untouched and are self-retiring when the installed runtime provides the corrected behavior.

## User verification

A fresh Python 3.12 wheel environment with `rapid-mlx[vision]` resolves one coherent runtime (`mlx 0.32.2`, `mlx-vlm 0.6.17`, `transformers 5.15.1`). From that shipped-wheel shape, the 4-bit checkpoint loaded strictly and offline on an M3 Ultra. Verified Chinese reasoning, GLM tool calls, strict JSON Schema, multi-turn cache reuse, a 6.8K-token retrieval prompt, simultaneous queued requests, and a real PNG image request.

Warm baseline with speculative decoding off: 29.2 tok/s median for 512 decoded tokens across three runs. Performance variants remain a separate follow-up so this PR does not mix support correctness with tuning.

## Verification

- 3,132 changed-surface tests passed in a fresh no-MLX environment
- 1,364 Apple-MLX tests passed; added compatibility modules have 100% line coverage
- changed-lines Linux + Apple coverage union: 100% (427/427)
- mypy shrink-only budget: no growth
- Desktop Swift tests: 3,171 passed
- focused GLM/cache/CI contracts: 66 passed
- `ruff check`, `ruff format --check`, `git diff --check`, sidecar metadata coherence, and fresh-wheel `pip check`: passed

Closes #2783

Coherence-Sweep: seven-family 42/42 evidence from #2501 remains applicable to the unchanged mlx 0.32.2 / mlx-lm 0.31.3 / Transformers 5.15.1 core toolchain; this optional vision-runtime replacement to mlx-vlm 0.6.17 separately passed 1,364 Apple-MLX tests, 19,899 full-unit tests, and strict offline GLM text, tool, JSON Schema, cache, long-context, concurrency, and real-image output checks.