### PR TITLE
Persist completed video jobs across server restarts

### DIFF
--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -7,6 +7,29 @@ Video generation requires Python 3.11 or newer because the upstream
 `mlx-video-with-audio` runtime does not support Python 3.10. Rapid-MLX's core
 text and audio features continue to support Python 3.10.
 
+## Keep completed videos across restarts
+
+By default, video jobs and MP4 files use a process-temporary directory and are
+removed when the server exits. For a desktop app or another long-lived client,
+pass an explicit artifact directory when starting the server:
+
+```bash
+rapid-mlx serve ltx-2.3-mlx-q4 \
+  --video-output-dir /path/to/rapid-mlx-video-artifacts
+```
+
+Every completed job is committed atomically beside its MP4. Starting a later
+server with the same directory restores up to the newest 100 completed jobs, so
+they remain available through `GET /v1/videos`, `GET /v1/videos/{id}` and
+`GET /v1/videos/{id}/content`. `DELETE /v1/videos/{id}` removes both the record
+and its MP4. Queued, interrupted, failed, incomplete or malformed records are
+never restored as completed work.
+
+The metadata includes the prompt and generation settings. Choose a
+user-private directory with enough free space; Rapid-MLX creates new job
+directories with owner-only permissions but does not change the permissions of
+an existing parent directory.
+
 ## Motion and conditioning controls
 
 `POST /v1/videos` accepts optional controls in addition to `seconds`:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -52,6 +52,17 @@ def test_ltx23_model_discovery_is_video_shaped() -> None:
     assert info.capabilities == ["video.generation"]
 
 
+def test_invalid_video_reference_image_is_rejected(tmp_path: Path) -> None:
+    invalid = tmp_path / "reference.png"
+    invalid.write_bytes(b"not-an-image")
+
+    with pytest.raises(HTTPException) as exc:
+        video._validate_reference_image(invalid)
+
+    assert exc.value.status_code == 400
+    assert "invalid input_reference" in str(exc.value.detail)
+
+
 def test_video_runtime_preflight_fails_before_download(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -559,6 +559,7 @@ async def test_shutdown_does_not_wait_for_blocked_metadata_persistence(
     video.start_video_jobs()
     persistence_started = threading.Event()
     release_persistence = threading.Event()
+    persist_completed_job = video._persist_completed_job
 
     class FakeEngine:
         model_name = "notapalindrome/ltx23-mlx-av-q4"
@@ -569,6 +570,7 @@ async def test_shutdown_does_not_wait_for_blocked_metadata_persistence(
     def block_persist(job) -> None:
         persistence_started.set()
         release_persistence.wait(timeout=5)
+        persist_completed_job(job)
 
     monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
     monkeypatch.setattr(video, "_persist_completed_job", block_persist)
@@ -585,6 +587,21 @@ async def test_shutdown_does_not_wait_for_blocked_metadata_persistence(
         assert await asyncio.to_thread(persistence_started.wait, 1)
         await asyncio.wait_for(video.shutdown_video_jobs(timeout=0), timeout=0.5)
         assert (await video.retrieve_video(created["id"]))["status"] == "completed"
+        video.start_video_jobs()
+        assert created["id"] not in video._jobs
+        oldest_id = "video_" + f"{0:032x}"
+        for index in range(video._MAX_JOBS):
+            restored = _completed_job("video_" + f"{index:032x}", created_at=index)
+            video._jobs[restored.id] = restored
+        release_persistence.set()
+        for _ in range(100):
+            if not video._persistence_threads and created["id"] in video._jobs:
+                break
+            await asyncio.sleep(0.01)
+        assert (await video.retrieve_video(created["id"]))["status"] == "completed"
+        assert (video._jobs_root / created["id"] / "job.json").is_file()
+        assert len(video._jobs) == video._MAX_JOBS
+        assert oldest_id not in video._jobs
     finally:
         release_persistence.set()
         for _ in range(100):

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Durable completed-job contract for the asynchronous Videos API."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx import cli, server
+from vllm_mlx.routes import video
+
+
+@pytest.fixture(autouse=True)
+def _isolated_video_store():
+    configure = video.configure_video_jobs
+    configure(None)
+    video.start_video_jobs()
+    yield
+    configure(None)
+    video.start_video_jobs()
+
+
+async def _wait_for_completion(video_id: str) -> dict:
+    for _ in range(200):
+        current = await video.retrieve_video(video_id)
+        if current["status"] == "completed":
+            return current
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"video job {video_id} did not complete")
+
+
+def _completed_job(job_id: str, *, created_at: int = 1) -> video._VideoJob:
+    return video._VideoJob(
+        id=job_id,
+        model="ltx-2.3-mlx-q4",
+        prompt=f"prompt {created_at}",
+        seconds="1",
+        size="512x512",
+        status="completed",
+        progress=100,
+        created_at=created_at,
+        completed_at=created_at + 1,
+        output_path=str(video._jobs_root / job_id / "output.mp4"),
+        generation_finished=True,
+    )
+
+
+def _write_completed_job(job: video._VideoJob) -> None:
+    job_dir = video._jobs_root / job.id
+    job_dir.mkdir(mode=0o700)
+    (job_dir / "output.mp4").write_bytes(b"generated-mp4")
+    video._persist_completed_job(job)
+
+
+@pytest.mark.asyncio
+async def test_completed_job_survives_store_reconfiguration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = tmp_path / "videos"
+    assert video.configure_video_jobs(store) == store.resolve()
+    video.start_video_jobs()
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="Ocean waves at sunset",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=42,
+        input_reference=None,
+    )
+    completed = await _wait_for_completion(created["id"])
+    assert completed["progress"] == 100
+    job_dir = store / created["id"]
+    assert (job_dir / "job.json").is_file()
+    assert not list(job_dir.glob(".job-*.json.tmp"))
+
+    # Reconfiguration clears process memory and models a fresh server process
+    # selecting the same operator-owned store.
+    await asyncio.sleep(0)
+    video.configure_video_jobs(store)
+    assert created["id"] not in video._jobs
+    video.start_video_jobs()
+
+    restored = await video.retrieve_video(created["id"])
+    assert restored == completed
+    listing = await video.list_videos(limit=20)
+    assert [item["id"] for item in listing["data"]] == [created["id"]]
+    response = await video.retrieve_video_content(created["id"])
+    assert (
+        b"".join([chunk async for chunk in response.body_iterator]) == b"generated-mp4"
+    )
+
+    deleted = await video.delete_video(created["id"])
+    assert deleted["deleted"] is True
+    assert not job_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_default_store_remains_process_temporary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert video._jobs_are_persistent is False
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="Temporary result",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=1,
+        input_reference=None,
+    )
+    await _wait_for_completion(created["id"])
+    assert not (video._jobs_root / created["id"] / "job.json").exists()
+    await video.delete_video(created["id"])
+
+
+def test_restore_ignores_partial_malformed_and_noncompleted_records(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+
+    malformed_id = "video_" + "a" * 32
+    malformed = store / malformed_id
+    malformed.mkdir()
+    (malformed / "output.mp4").write_bytes(b"mp4")
+    (malformed / "job.json").write_text("{not-json", encoding="utf-8")
+
+    partial_id = "video_" + "b" * 32
+    partial = store / partial_id
+    partial.mkdir()
+    partial_job = _completed_job(partial_id)
+    (partial / "job.json").write_text(
+        json.dumps(video._completed_job_record(partial_job)), encoding="utf-8"
+    )
+
+    queued_id = "video_" + "c" * 32
+    queued = store / queued_id
+    queued.mkdir()
+    (queued / "output.mp4").write_bytes(b"mp4")
+    queued_record = video._completed_job_record(_completed_job(queued_id))
+    queued_record.update(status="queued", progress=0, completed_at=None)
+    (queued / "job.json").write_text(json.dumps(queued_record), encoding="utf-8")
+
+    video.start_video_jobs()
+
+    assert video._jobs == {}
+    # Invalid records are ignored, not destructively removed. A future server
+    # version or an operator can still inspect and recover them.
+    assert malformed.exists()
+    assert partial.exists()
+    assert queued.exists()
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        [],
+        {"schema_version": 2},
+        {"schema_version": 1, "object": "not-video"},
+        {
+            "schema_version": 1,
+            "object": "video",
+            "status": "completed",
+            "progress": 100,
+            "error": {"code": "unexpected"},
+        },
+        {
+            "schema_version": 1,
+            "object": "video",
+            "status": "completed",
+            "progress": 100,
+            "error": None,
+            "model": "",
+        },
+    ],
+)
+def test_restore_rejects_invalid_completed_metadata(
+    tmp_path: Path, record: object
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job_id = "video_" + "e" * 32
+    job_dir = video._jobs_root / job_id
+    job_dir.mkdir()
+    (job_dir / "output.mp4").write_bytes(b"mp4")
+    if isinstance(record, dict):
+        record = {"id": job_id, **record}
+    (job_dir / "job.json").write_text(json.dumps(record), encoding="utf-8")
+
+    assert video._load_completed_job(job_dir) is None
+
+
+def test_restore_rejects_unowned_shapes_and_symlinks(tmp_path: Path) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    assert video._load_completed_job(video._jobs_root / "not-a-video-id") is None
+
+    empty_id = "video_" + "f" * 32
+    empty_dir = video._jobs_root / empty_id
+    empty_dir.mkdir()
+    (empty_dir / "output.mp4").write_bytes(b"")
+    (empty_dir / "job.json").write_text("{}", encoding="utf-8")
+    assert video._load_completed_job(empty_dir) is None
+
+    linked_id = "video_" + "1" * 32
+    linked_dir = video._jobs_root / linked_id
+    linked_dir.mkdir()
+    (linked_dir / "output.mp4").write_bytes(b"mp4")
+    external_metadata = tmp_path / "external.json"
+    external_metadata.write_text("{}", encoding="utf-8")
+    (linked_dir / "job.json").symlink_to(external_metadata)
+    assert video._load_completed_job(linked_dir) is None
+
+
+def test_restore_scan_failure_is_nonfatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+
+    def fail_scan(self):
+        raise OSError("offline volume")
+
+    monkeypatch.setattr(Path, "iterdir", fail_scan)
+    assert video._restore_completed_jobs() == []
+
+
+def test_restore_enforces_existing_hundred_job_retention(tmp_path: Path) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    oldest_id = "video_" + f"{0:032x}"
+    for index in range(video._MAX_JOBS + 1):
+        job_id = "video_" + f"{index:032x}"
+        _write_completed_job(_completed_job(job_id, created_at=index))
+
+    video.start_video_jobs()
+
+    assert len(video._jobs) == video._MAX_JOBS
+    assert oldest_id not in video._jobs
+    assert not (store / oldest_id).exists()
+
+
+def test_failed_metadata_replace_leaves_no_partial_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job = _completed_job("video_" + "d" * 32)
+    job_dir = video._jobs_root / job.id
+    job_dir.mkdir()
+    (job_dir / "output.mp4").write_bytes(b"mp4")
+
+    def fail_replace(source, destination) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(video.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="disk full"):
+        video._persist_completed_job(job)
+
+    assert not (job_dir / "job.json").exists()
+    assert not list(job_dir.glob(".job-*.json.tmp"))
+
+
+@pytest.mark.asyncio
+async def test_metadata_failure_keeps_completed_video_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    video.start_video_jobs()
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    def fail_persist(job) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    monkeypatch.setattr(video, "_persist_completed_job", fail_persist)
+    created = await video.create_video(
+        prompt="Keep the completed output",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=2,
+        input_reference=None,
+    )
+
+    assert (await _wait_for_completion(created["id"]))["status"] == "completed"
+    assert "Unable to persist completed video job metadata" in caplog.text
+    response = await video.retrieve_video_content(created["id"])
+    assert (
+        b"".join([chunk async for chunk in response.body_iterator]) == b"generated-mp4"
+    )
+    await video.delete_video(created["id"])
+
+
+def test_video_output_directory_rejects_a_file(tmp_path: Path) -> None:
+    destination = tmp_path / "not-a-directory"
+    destination.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises((FileExistsError, ValueError)):
+        video.configure_video_jobs(destination)
+
+
+def test_video_store_rejects_blank_path_and_live_reconfiguration(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        video.configure_video_jobs("   ")
+
+    marker = threading.current_thread()
+    video._generation_threads.add(marker)
+    try:
+        with pytest.raises(RuntimeError, match="while jobs run"):
+            video.configure_video_jobs(tmp_path / "videos")
+    finally:
+        video._generation_threads.discard(marker)
+
+
+def test_ephemeral_cleanup_visits_every_owned_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    removed: list[Path] = []
+    monkeypatch.setattr(
+        video.shutil,
+        "rmtree",
+        lambda root, *, ignore_errors: removed.append(Path(root)),
+    )
+
+    video._cleanup_jobs()
+
+    assert set(removed) == video._ephemeral_jobs_roots
+
+
+def test_unified_serve_parser_exposes_video_output_directory(tmp_path: Path) -> None:
+    args = cli.build_parser().parse_args(
+        ["serve", "ltx-2.3-mlx-q4", "--video-output-dir", str(tmp_path)]
+    )
+
+    assert args.video_output_dir == str(tmp_path)
+
+
+def test_both_server_entrypoints_configure_the_shared_video_store() -> None:
+    unified_source = inspect.getsource(cli.serve_command)
+    standalone_source = inspect.getsource(server.main)
+
+    assert (
+        'configure_video_jobs(getattr(args, "video_output_dir", None))'
+        in unified_source
+    )
+    assert "_add_video_job_args_to_server_parser(parser)" in standalone_source
+    assert "configure_video_jobs(args.video_output_dir)" in standalone_source
+    assert unified_source.index("configure_video_jobs(") < unified_source.index(
+        "_ensure_model_downloaded("
+    )
+
+
+def test_unified_serve_reports_video_store_configuration_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        video,
+        "configure_video_jobs",
+        lambda output_dir: (_ for _ in ()).throw(OSError("read-only")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.serve_command(SimpleNamespace(video_output_dir="/unwritable"))
+
+    assert exc.value.code == 2
+    assert (
+        "cannot configure video output directory: read-only" in capsys.readouterr().err
+    )
+
+
+def test_standalone_server_reports_video_store_configuration_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        video,
+        "configure_video_jobs",
+        lambda output_dir: (_ for _ in ()).throw(OSError("read-only")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["vllm_mlx.server", "--video-output-dir", "/unwritable"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        server.main()
+
+    assert exc.value.code == 2
+    assert (
+        "cannot configure video output directory: read-only" in capsys.readouterr().err
+    )

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -315,6 +315,91 @@ async def test_metadata_failure_keeps_completed_video_available(
     await video.delete_video(created["id"])
 
 
+@pytest.mark.asyncio
+async def test_shutdown_does_not_wait_for_blocked_metadata_persistence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    video.start_video_jobs()
+    persistence_started = threading.Event()
+    release_persistence = threading.Event()
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    def block_persist(job) -> None:
+        persistence_started.set()
+        release_persistence.wait(timeout=5)
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    monkeypatch.setattr(video, "_persist_completed_job", block_persist)
+    created = await video.create_video(
+        prompt="Finish within shutdown budget",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=3,
+        input_reference=None,
+    )
+
+    try:
+        assert await asyncio.to_thread(persistence_started.wait, 1)
+        await asyncio.wait_for(video.shutdown_video_jobs(timeout=0), timeout=0.5)
+        assert (await video.retrieve_video(created["id"]))["status"] == "completed"
+    finally:
+        release_persistence.set()
+        for _ in range(100):
+            if not video._persistence_threads:
+                break
+            await asyncio.sleep(0.01)
+        assert not video._persistence_threads
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_output_symlink_swapped_after_restore(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    job = _completed_job("video_" + "9" * 32)
+    _write_completed_job(job)
+    video.start_video_jobs()
+
+    external = tmp_path / "private.txt"
+    external.write_bytes(b"server-readable-secret")
+    output = store / job.id / "output.mp4"
+    output.unlink()
+    output.symlink_to(external)
+
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video_content(job.id)
+
+    assert exc.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_nonregular_output_swapped_after_restore(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    job = _completed_job("video_" + "8" * 32)
+    _write_completed_job(job)
+    video.start_video_jobs()
+
+    output = store / job.id / "output.mp4"
+    output.unlink()
+    output.mkdir()
+
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video_content(job.id)
+
+    assert exc.value.status_code == 410
+
+
 def test_video_output_directory_rejects_a_file(tmp_path: Path) -> None:
     destination = tmp_path / "not-a-directory"
     destination.write_text("occupied", encoding="utf-8")

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import stat
 import sys
 import threading
 from pathlib import Path
@@ -268,7 +269,7 @@ def test_failed_metadata_replace_leaves_no_partial_manifest(
     job_dir.mkdir()
     (job_dir / "output.mp4").write_bytes(b"mp4")
 
-    def fail_replace(source, destination) -> None:
+    def fail_replace(source, destination, **kwargs) -> None:
         raise OSError("disk full")
 
     monkeypatch.setattr(video.os, "replace", fail_replace)
@@ -277,6 +278,51 @@ def test_failed_metadata_replace_leaves_no_partial_manifest(
 
     assert not (job_dir / "job.json").exists()
     assert not list(job_dir.glob(".job-*.json.tmp"))
+
+
+def test_persistence_orders_crash_consistency_barriers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    job = _completed_job("video_" + "7" * 32)
+    job_dir = store / job.id
+    job_dir.mkdir()
+    output = job_dir / "output.mp4"
+    output.write_bytes(b"mp4")
+    events: list[str] = []
+    original_fsync = video.os.fsync
+    original_replace = video.os.replace
+
+    def track_fsync(fd: int) -> None:
+        opened = video.os.fstat(fd)
+        if opened.st_ino == output.stat().st_ino:
+            events.append("output")
+        elif stat.S_ISREG(opened.st_mode):
+            events.append("manifest")
+        elif opened.st_ino == job_dir.stat().st_ino:
+            events.append("job-directory")
+        elif opened.st_ino == store.stat().st_ino:
+            events.append("store-directory")
+        original_fsync(fd)
+
+    def track_replace(source, destination, **kwargs) -> None:
+        events.append("replace")
+        original_replace(source, destination, **kwargs)
+
+    monkeypatch.setattr(video.os, "fsync", track_fsync)
+    monkeypatch.setattr(video.os, "replace", track_replace)
+
+    video._persist_completed_job(job)
+
+    assert events == [
+        "output",
+        "manifest",
+        "replace",
+        "job-directory",
+        "store-directory",
+    ]
+    assert (job_dir / "job.json").is_file()
 
 
 @pytest.mark.asyncio
@@ -398,6 +444,145 @@ async def test_download_rejects_nonregular_output_swapped_after_restore(
         await video.retrieve_video_content(job.id)
 
     assert exc.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_job_directory_symlink_swapped_after_restore(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    job = _completed_job("video_" + "6" * 32)
+    _write_completed_job(job)
+    video.start_video_jobs()
+
+    original = store / job.id
+    original.rename(store / f"{job.id}-original")
+    replacement = tmp_path / "replacement"
+    replacement.mkdir()
+    (replacement / "output.mp4").write_bytes(b"server-readable-data")
+    original.symlink_to(replacement, target_is_directory=True)
+
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video_content(job.id)
+
+    assert exc.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_queued_job_with_active_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            started.set()
+            release.wait(timeout=5)
+            output_path.write_bytes(b"generated-mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: BlockingEngine())
+    first = await video.create_video(
+        prompt="Active job",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=4,
+        input_reference=None,
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+    queued = await video.create_video(
+        prompt="Queued job",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=5,
+        input_reference=None,
+    )
+
+    try:
+        await video.shutdown_video_jobs(timeout=0)
+        assert video._jobs[queued["id"]].error == {
+            "code": "video_server_shutdown",
+            "message": "Video generation was cancelled during server shutdown.",
+        }
+        assert video._jobs[queued["id"]].generation_finished is True
+    finally:
+        release.set()
+        for _ in range(200):
+            if not video._generation_threads and not video._cleanup_tasks:
+                break
+            await asyncio.sleep(0.01)
+        assert not video._generation_threads
+        assert first["id"] in video._jobs
+
+
+@pytest.mark.asyncio
+async def test_failed_job_never_enters_generation_gate() -> None:
+    job = video._VideoJob(
+        id="video_" + "5" * 32,
+        model="ltx-2.3-mlx-q4",
+        prompt="Already failed",
+        seconds="1",
+        size="512x512",
+        status="failed",
+        created_at=1,
+    )
+
+    class UnexpectedEngine:
+        video_family = "ltx-2.3"
+
+        def generate(self, **kwargs) -> None:
+            raise AssertionError("failed job reached generation")
+
+    await video._run_job(
+        job,
+        engine=UnexpectedEngine(),
+        width=512,
+        height=512,
+        num_frames=25,
+        fps=24,
+        seed=6,
+        image_path=None,
+        negative_prompt=None,
+        guidance_scale=None,
+        conditioning_strength=None,
+    )
+
+    assert job.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_new_job_evicts_oldest_finished_job_at_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oldest_id = "video_" + f"{0:032x}"
+    for index in range(video._MAX_JOBS):
+        job = _completed_job("video_" + f"{index:032x}", created_at=index)
+        video._jobs[job.id] = job
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="Newest result",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=7,
+        input_reference=None,
+    )
+    await _wait_for_completion(created["id"])
+
+    assert oldest_id not in video._jobs
+    assert created["id"] in video._jobs
 
 
 def test_video_output_directory_rejects_a_file(tmp_path: Path) -> None:

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -509,6 +509,49 @@ async def test_metadata_failure_keeps_completed_video_available(
 
 
 @pytest.mark.asyncio
+async def test_persistence_thread_start_failure_keeps_completed_video(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    video.start_video_jobs()
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    original_start = video.threading.Thread.start
+
+    def fail_persistence_start(thread: threading.Thread) -> None:
+        if thread.name == "rapid-mlx-video-persistence":
+            raise RuntimeError("cannot start thread")
+        original_start(thread)
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    monkeypatch.setattr(video.threading.Thread, "start", fail_persistence_start)
+    created = await video.create_video(
+        prompt="Keep output after thread exhaustion",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=8,
+        input_reference=None,
+    )
+
+    assert (await _wait_for_completion(created["id"]))["status"] == "completed"
+    assert not video._persistence_threads
+    assert "Unable to persist completed video job metadata" in caplog.text
+    response = await video.retrieve_video_content(created["id"])
+    assert (
+        b"".join([chunk async for chunk in response.body_iterator]) == b"generated-mp4"
+    )
+    await asyncio.sleep(0)
+    assert video.configure_video_jobs(store) == store.resolve()
+
+
+@pytest.mark.asyncio
 async def test_shutdown_does_not_wait_for_blocked_metadata_persistence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -311,6 +311,45 @@ async def test_retrieve_missing_video_returns_not_found() -> None:
     assert exc.value.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_download_rejects_noncompleted_video() -> None:
+    job = video._VideoJob(
+        id="video_" + "0" * 32,
+        model="ltx-2.3-mlx-q4",
+        prompt="Not finished",
+        seconds="1",
+        size="512x512",
+        status="in_progress",
+        created_at=1,
+    )
+    video._jobs[job.id] = job
+
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video_content(job.id)
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_download_closes_output_descriptor_when_wrapping_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job = _completed_job("video_" + "d" * 32)
+    _write_completed_job(job)
+    video.start_video_jobs()
+
+    def fail_fdopen(fd: int, mode: str):
+        raise OSError("cannot wrap descriptor")
+
+    monkeypatch.setattr(video.os, "fdopen", fail_fdopen)
+
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video_content(job.id)
+
+    assert exc.value.status_code == 410
+
+
 def test_restore_scan_failure_is_nonfatal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -336,6 +375,36 @@ def test_restore_enforces_existing_hundred_job_retention(tmp_path: Path) -> None
     assert len(video._jobs) == video._MAX_JOBS
     assert oldest_id not in video._jobs
     assert not (store / oldest_id).exists()
+
+
+def test_same_process_restart_rebuilds_registry_from_disk(tmp_path: Path) -> None:
+    store = tmp_path / "videos"
+    video.configure_video_jobs(store)
+    retained = _completed_job("video_" + "a" * 32, created_at=2)
+    removed = _completed_job("video_" + "b" * 32, created_at=1)
+    _write_completed_job(retained)
+    _write_completed_job(removed)
+    video.start_video_jobs()
+    assert set(video._jobs) == {retained.id, removed.id}
+
+    # Model a stopped server whose operator removed one artifact, while stale
+    # failed state remains in this process from the previous lifespan.
+    (store / removed.id / "job.json").unlink()
+    failed = video._VideoJob(
+        id="video_" + "c" * 32,
+        model="ltx-2.3-mlx-q4",
+        prompt="Stale failed job",
+        seconds="1",
+        size="512x512",
+        status="failed",
+        created_at=3,
+        generation_finished=True,
+    )
+    video._jobs[failed.id] = failed
+
+    video.start_video_jobs()
+
+    assert set(video._jobs) == {retained.id}
 
 
 def test_failed_metadata_replace_leaves_no_partial_manifest(

--- a/tests/test_video_job_persistence.py
+++ b/tests/test_video_job_persistence.py
@@ -233,6 +233,84 @@ def test_restore_rejects_unowned_shapes_and_symlinks(tmp_path: Path) -> None:
     assert video._load_completed_job(linked_dir) is None
 
 
+def test_restore_reads_validated_metadata_descriptor_during_path_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job = _completed_job("video_" + "4" * 32)
+    _write_completed_job(job)
+    job_dir = video._jobs_root / job.id
+    metadata = job_dir / "job.json"
+    metadata_inode = metadata.stat().st_ino
+    replacement = tmp_path / "oversized.json"
+    replacement.write_bytes(b"{" + b" " * video._MAX_VIDEO_JOB_METADATA_BYTES + b"}")
+    original_fstat = video.os.fstat
+    swapped = False
+
+    def swap_path_after_validation(fd: int):
+        nonlocal swapped
+        opened = original_fstat(fd)
+        if opened.st_ino == metadata_inode and not swapped:
+            swapped = True
+            metadata.unlink()
+            metadata.symlink_to(replacement)
+        return opened
+
+    monkeypatch.setattr(video.os, "fstat", swap_path_after_validation)
+
+    restored = video._load_completed_job(job_dir)
+
+    assert swapped is True
+    assert restored is not None
+    assert restored.prompt == job.prompt
+
+
+def test_restore_rejects_nonregular_metadata(tmp_path: Path) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job_id = "video_" + "3" * 32
+    job_dir = video._jobs_root / job_id
+    job_dir.mkdir()
+    (job_dir / "output.mp4").write_bytes(b"mp4")
+    (job_dir / "job.json").mkdir()
+
+    assert video._load_completed_job(job_dir) is None
+
+
+def test_restore_bounds_metadata_that_grows_after_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video.configure_video_jobs(tmp_path / "videos")
+    job = _completed_job("video_" + "2" * 32)
+    _write_completed_job(job)
+    job_dir = video._jobs_root / job.id
+    metadata = job_dir / "job.json"
+    metadata_inode = metadata.stat().st_ino
+    original_fstat = video.os.fstat
+    expanded = False
+
+    def expand_after_validation(fd: int):
+        nonlocal expanded
+        opened = original_fstat(fd)
+        if opened.st_ino == metadata_inode and not expanded:
+            expanded = True
+            with metadata.open("ab") as destination:
+                destination.write(b" " * (video._MAX_VIDEO_JOB_METADATA_BYTES + 1))
+        return opened
+
+    monkeypatch.setattr(video.os, "fstat", expand_after_validation)
+
+    assert video._load_completed_job(job_dir) is None
+    assert expanded is True
+
+
+@pytest.mark.asyncio
+async def test_retrieve_missing_video_returns_not_found() -> None:
+    with pytest.raises(video.HTTPException) as exc:
+        await video.retrieve_video("video_" + "1" * 32)
+
+    assert exc.value.status_code == 404
+
+
 def test_restore_scan_failure_is_nonfatal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -48,6 +48,21 @@ def _log_level_choice(value: str) -> str:
     return value.upper()
 
 
+def _add_video_job_args(parser: argparse.ArgumentParser) -> None:
+    """Register the shared video artifact-store option on a serve parser."""
+    parser.add_argument(
+        "--video-output-dir",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Persist completed video jobs and MP4 files under PATH so they "
+            "remain available after a server restart. The default uses a "
+            "process-temporary directory."
+        ),
+    )
+
+
 def _auth_feature_str(argv_api_key: str | None) -> str | None:
     """Banner-side renderer for the ``auth: on`` feature line.
 
@@ -2988,6 +3003,17 @@ def serve_command(args):
         from ._pysample import install as _pysample_install
 
         _pysample_install()
+
+    # Validate the opt-in artifact store before dependency probes or a large
+    # video-model download. The route owns path resolution and writeability so
+    # the unified and standalone server entrypoints cannot drift.
+    from .routes.video import configure_video_jobs
+
+    try:
+        configure_video_jobs(getattr(args, "video_output_dir", None))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: cannot configure video output directory: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
 
     # Parent-PID watchdog (rapid-desktop issue #449): if the supervisor
     # passed its own PID via ``--watchdog-ppid`` or
@@ -10120,6 +10146,7 @@ Examples:
         ),
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    _add_video_job_args(serve_parser)
     # Socket activation — let an external supervisor (launchd, systemd,
     # parent process) bind the listening socket and execve into
     # ``rapid-mlx`` with the pre-bound fd. This closes the bind→auth

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -260,21 +260,74 @@ def _completed_job_record(job: _VideoJob) -> dict:
     }
 
 
-def _persist_completed_job(job: _VideoJob) -> None:
-    """Atomically commit one completed job after its MP4 is durable."""
-    job_dir = _jobs_root / job.id
-    metadata_path = job_dir / _VIDEO_JOB_METADATA
-    temporary_path: Path | None = None
+def _video_directory_open_flags() -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:  # pragma: no cover - POSIX guard
+        raise OSError("secure video directory access is unavailable")
+    return int(os.O_RDONLY | nofollow | directory | getattr(os, "O_CLOEXEC", 0))
+
+
+def _open_video_job_directory(video_id: str) -> tuple[int, int]:
+    """Open the configured root and one owned job directory without links."""
+    root_fd = os.open(_jobs_root, _video_directory_open_flags())
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            prefix=".job-",
-            suffix=".json.tmp",
-            dir=job_dir,
-            delete=False,
-        ) as temporary:
-            temporary_path = Path(temporary.name)
+        job_fd = os.open(
+            video_id,
+            _video_directory_open_flags(),
+            dir_fd=root_fd,
+        )
+    except BaseException:
+        os.close(root_fd)
+        raise
+    return root_fd, job_fd
+
+
+def _open_video_output(job_fd: int) -> int:
+    """Open and validate a non-empty regular MP4 relative to its job dir."""
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:  # pragma: no cover - POSIX guard
+        raise OSError("secure video output access is unavailable")
+    output_fd = os.open(
+        "output.mp4",
+        os.O_RDONLY
+        | nofollow
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NONBLOCK", 0),
+        dir_fd=job_fd,
+    )
+    try:
+        output_stat = os.fstat(output_fd)
+        if not stat.S_ISREG(output_stat.st_mode) or output_stat.st_size <= 0:
+            raise OSError("video output is not a non-empty regular file")
+    except BaseException:
+        os.close(output_fd)
+        raise
+    return output_fd
+
+
+def _persist_completed_job(job: _VideoJob) -> None:
+    """Durably commit one completed MP4 and its atomic manifest."""
+    root_fd, job_fd = _open_video_job_directory(job.id)
+    temporary_name = f".job-{uuid.uuid4().hex}.json.tmp"
+    try:
+        output_fd = _open_video_output(job_fd)
+        try:
+            os.fsync(output_fd)
+        finally:
+            os.close(output_fd)
+
+        temporary_fd = os.open(
+            temporary_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+            dir_fd=job_fd,
+        )
+        with os.fdopen(temporary_fd, "w", encoding="utf-8") as temporary:
             json.dump(
                 _completed_job_record(job),
                 temporary,
@@ -284,10 +337,22 @@ def _persist_completed_job(job: _VideoJob) -> None:
             )
             temporary.flush()
             os.fsync(temporary.fileno())
-        os.replace(temporary_path, metadata_path)
+        os.replace(
+            temporary_name,
+            _VIDEO_JOB_METADATA,
+            src_dir_fd=job_fd,
+            dst_dir_fd=job_fd,
+        )
+        # Persist the output/manifest entries, then the job directory's entry
+        # in the configured root. Only after both barriers may the API expose
+        # the job as completed.
+        os.fsync(job_fd)
+        os.fsync(root_fd)
     finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_name, dir_fd=job_fd)
+        os.close(job_fd)
+        os.close(root_fd)
 
 
 def _load_completed_job(job_dir: Path) -> _VideoJob | None:
@@ -1164,23 +1229,10 @@ async def retrieve_video_content(video_id: str):
     # restored job directory or output file for a symlink between startup
     # validation and download. O_NONBLOCK also prevents a substituted FIFO
     # from stalling the event loop before fstat can reject it.
-    nofollow = getattr(os, "O_NOFOLLOW", None)
-    directory = getattr(os, "O_DIRECTORY", None)
-    if nofollow is None or directory is None:  # pragma: no cover - POSIX guard
-        raise HTTPException(status_code=410, detail="video content has expired")
-    base_flags = os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0)
     root_fd = job_fd = output_fd = None
     try:
-        root_fd = os.open(_jobs_root, base_flags | directory)
-        job_fd = os.open(job.id, base_flags | directory, dir_fd=root_fd)
-        output_fd = os.open(
-            "output.mp4",
-            base_flags | getattr(os, "O_NONBLOCK", 0),
-            dir_fd=job_fd,
-        )
-        output_stat = os.fstat(output_fd)
-        if not stat.S_ISREG(output_stat.st_mode) or output_stat.st_size <= 0:
-            raise OSError("video output is not a non-empty regular file")
+        root_fd, job_fd = _open_video_job_directory(job.id)
+        output_fd = _open_video_output(job_fd)
         source = os.fdopen(output_fd, "rb")
         output_fd = None
     except OSError as exc:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -468,8 +468,12 @@ def start_video_jobs() -> None:
     restored = _restore_completed_jobs() if _jobs_are_persistent else []
     with _jobs_lock:
         _accepting_jobs = True
-        for job in restored:
-            _jobs.setdefault(job.id, job)
+        if _jobs_are_persistent:
+            # A lifespan restart must reflect the validated disk snapshot, not
+            # merge it with stale failed/partial entries or artifacts removed
+            # while the server was stopped.
+            _jobs.clear()
+            _jobs.update((job.id, job) for job in restored)
 
 
 async def shutdown_video_jobs(timeout: float = 30.0) -> None:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -578,7 +578,12 @@ async def _persist_completed_job_in_daemon_thread(job: _VideoJob) -> None:
     )
     with _jobs_lock:
         _persistence_threads.add(thread)
-    thread.start()
+    try:
+        thread.start()
+    except BaseException:
+        with _jobs_lock:
+            _persistence_threads.discard(thread)
+        raise
     try:
         await asyncio.shield(completed)
     except asyncio.CancelledError:
@@ -890,7 +895,7 @@ async def _run_job(
         if _jobs_are_persistent:
             try:
                 await _persist_completed_job_in_daemon_thread(completed_job)
-            except OSError:
+            except (OSError, RuntimeError):
                 # The MP4 is already complete and remains downloadable for this
                 # process. Keep that user result available while making the
                 # durability loss visible to operators.

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import asyncio
 import atexit
 import contextlib
+import json
 import logging
+import os
+import re
 import shutil
 import tempfile
 import threading
@@ -23,6 +26,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..middleware.auth import _verify_api_key_values, verify_api_key
 from ..model_aliases import resolve_profile
+from ._async_utils import run_to_completion
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -32,8 +36,14 @@ _VIDEO_REQUEST_BYTES = _MAX_REFERENCE_BYTES + 1024 * 1024
 _MAX_JOBS = 100
 _MAX_PIXEL_FRAMES = 768 * 512 * 97
 _MAX_REFERENCE_PIXELS = 16_777_216
+_VIDEO_JOB_SCHEMA_VERSION = 1
+_VIDEO_JOB_METADATA = "job.json"
+_MAX_VIDEO_JOB_METADATA_BYTES = 64 * 1024
+_VIDEO_ID_RE = re.compile(r"video_[0-9a-f]{32}\Z")
 _jobs_lock = threading.Lock()
-_jobs_root = Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))
+_ephemeral_jobs_roots = {Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))}
+_jobs_root = next(iter(_ephemeral_jobs_roots))
+_jobs_are_persistent = False
 
 
 @dataclass
@@ -194,17 +204,186 @@ def _generation_gate_for_current_loop() -> asyncio.Lock:
 
 
 def _cleanup_jobs() -> None:
-    shutil.rmtree(_jobs_root, ignore_errors=True)
+    for root in tuple(_ephemeral_jobs_roots):
+        shutil.rmtree(root, ignore_errors=True)
 
 
 atexit.register(_cleanup_jobs)
 
 
+def configure_video_jobs(output_dir: str | Path | None) -> Path:
+    """Select the job store before the server lifecycle starts.
+
+    ``None`` preserves the historical process-temporary behavior. An explicit
+    directory opts into completed-job persistence; the directory is resolved
+    once so a later working-directory change cannot redirect cleanup or writes.
+    """
+    global _jobs_are_persistent, _jobs_root
+
+    persistent = output_dir is not None
+    if persistent:
+        raw_output_dir = str(output_dir).strip()
+        if not raw_output_dir:
+            raise ValueError("video output directory must not be empty")
+        root = Path(raw_output_dir).expanduser().resolve(strict=False)
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # Fail before a large model download when the selected store cannot be
+        # written. NamedTemporaryFile uses 0600 and removes the probe on close.
+        with tempfile.NamedTemporaryFile(prefix=".rapid-mlx-write-", dir=root):
+            pass
+    else:
+        root = Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))
+        _ephemeral_jobs_roots.add(root)
+
+    with _jobs_lock:
+        active_tasks = [task for task in _tasks.values() if not task.done()]
+        active_cleanup = [task for task in _cleanup_tasks if not task.done()]
+        if active_tasks or active_cleanup or _generation_threads:
+            raise RuntimeError("cannot reconfigure the video job store while jobs run")
+        _jobs.clear()
+        _tasks.clear()
+        _jobs_root = root
+        _jobs_are_persistent = persistent
+    return root
+
+
+def _completed_job_record(job: _VideoJob) -> dict:
+    return {
+        "schema_version": _VIDEO_JOB_SCHEMA_VERSION,
+        **job.public(),
+    }
+
+
+def _persist_completed_job(job: _VideoJob) -> None:
+    """Atomically commit one completed job after its MP4 is durable."""
+    job_dir = _jobs_root / job.id
+    metadata_path = job_dir / _VIDEO_JOB_METADATA
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix=".job-",
+            suffix=".json.tmp",
+            dir=job_dir,
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(
+                _completed_job_record(job),
+                temporary,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_path, metadata_path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _load_completed_job(job_dir: Path) -> _VideoJob | None:
+    if (
+        job_dir.is_symlink()
+        or not job_dir.is_dir()
+        or not _VIDEO_ID_RE.fullmatch(job_dir.name)
+    ):
+        return None
+    metadata_path = job_dir / _VIDEO_JOB_METADATA
+    output_path = job_dir / "output.mp4"
+    try:
+        if metadata_path.is_symlink() or output_path.is_symlink():
+            return None
+        metadata_stat = metadata_path.stat()
+        output_stat = output_path.stat()
+        if (
+            not metadata_path.is_file()
+            or metadata_stat.st_size > _MAX_VIDEO_JOB_METADATA_BYTES
+            or not output_path.is_file()
+            or output_stat.st_size <= 0
+        ):
+            return None
+        value = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        logger.warning("Ignoring unreadable video job record: %s", job_dir.name)
+        return None
+
+    if not isinstance(value, dict):
+        return None
+    if value.get("schema_version") != _VIDEO_JOB_SCHEMA_VERSION:
+        return None
+    if value.get("object") != "video" or value.get("id") != job_dir.name:
+        return None
+    if value.get("status") != "completed" or value.get("progress") != 100:
+        return None
+    if value.get("error") is not None:
+        return None
+
+    model = value.get("model")
+    prompt = value.get("prompt")
+    seconds = value.get("seconds")
+    size = value.get("size")
+    created_at = value.get("created_at")
+    completed_at = value.get("completed_at")
+    if (
+        not isinstance(model, str)
+        or not model
+        or len(model) > 2048
+        or not isinstance(prompt, str)
+        or not prompt
+        or len(prompt) > 4096
+        or not isinstance(seconds, str)
+        or not seconds
+        or len(seconds) > 32
+        or not isinstance(size, str)
+        or not size
+        or len(size) > 64
+        or type(created_at) is not int
+        or type(completed_at) is not int
+        or created_at < 0
+        or completed_at < created_at
+    ):
+        return None
+
+    return _VideoJob(
+        id=job_dir.name,
+        model=model,
+        prompt=prompt,
+        seconds=seconds,
+        size=size,
+        status="completed",
+        progress=100,
+        created_at=created_at,
+        completed_at=completed_at,
+        output_path=str(output_path),
+        generation_finished=True,
+    )
+
+
+def _restore_completed_jobs() -> list[_VideoJob]:
+    try:
+        candidates = list(_jobs_root.iterdir())
+    except OSError:
+        logger.exception("Unable to scan the video job store")
+        return []
+
+    restored = [job for path in candidates if (job := _load_completed_job(path))]
+    restored.sort(key=lambda item: (item.created_at, item.id), reverse=True)
+    for expired in restored[_MAX_JOBS:]:
+        shutil.rmtree(_jobs_root / expired.id, ignore_errors=True)
+    return restored[:_MAX_JOBS]
+
+
 def start_video_jobs() -> None:
     """Reset the route lifecycle when an application instance starts."""
     global _accepting_jobs
+    restored = _restore_completed_jobs() if _jobs_are_persistent else []
     with _jobs_lock:
         _accepting_jobs = True
+        for job in restored:
+            _jobs.setdefault(job.id, job)
 
 
 async def shutdown_video_jobs(timeout: float = 30.0) -> None:
@@ -544,12 +723,30 @@ async def _run_job(
         generated = await asyncio.shield(runner)
         if not generated:
             return
+        completed_job = replace(
+            job,
+            status="completed",
+            progress=100,
+            completed_at=int(time.time()),
+            output_path=str(output),
+            generation_finished=True,
+        )
+        if _jobs_are_persistent:
+            try:
+                await run_to_completion(_persist_completed_job, completed_job)
+            except OSError:
+                # The MP4 is already complete and remains downloadable for this
+                # process. Keep that user result available while making the
+                # durability loss visible to operators.
+                logger.exception(
+                    "Unable to persist completed video job metadata for %s", job.id
+                )
         with _jobs_lock:
-            job.status = "completed"
-            job.progress = 100
-            job.completed_at = int(time.time())
-            job.output_path = str(output)
-            job.generation_finished = True
+            job.status = completed_job.status
+            job.progress = completed_job.progress
+            job.completed_at = completed_job.completed_at
+            job.output_path = completed_job.output_path
+            job.generation_finished = completed_job.generation_finished
     except asyncio.CancelledError:
         with _jobs_lock:
             if job.status != "failed":

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import tempfile
 import threading
 import time
@@ -26,7 +27,6 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..middleware.auth import _verify_api_key_values, verify_api_key
 from ..model_aliases import resolve_profile
-from ._async_utils import run_to_completion
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -73,6 +73,7 @@ _jobs: dict[str, _VideoJob] = {}
 _tasks: dict[str, asyncio.Task] = {}
 _cleanup_tasks: set[asyncio.Task] = set()
 _generation_threads: set[threading.Thread] = set()
+_persistence_threads: set[threading.Thread] = set()
 _accepting_jobs = True
 _generation_gates: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
@@ -238,7 +239,12 @@ def configure_video_jobs(output_dir: str | Path | None) -> Path:
     with _jobs_lock:
         active_tasks = [task for task in _tasks.values() if not task.done()]
         active_cleanup = [task for task in _cleanup_tasks if not task.done()]
-        if active_tasks or active_cleanup or _generation_threads:
+        if (
+            active_tasks
+            or active_cleanup
+            or _generation_threads
+            or _persistence_threads
+        ):
             raise RuntimeError("cannot reconfigure the video job store while jobs run")
         _jobs.clear()
         _tasks.clear()
@@ -429,7 +435,9 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
                 for job_id, task in _tasks.items():
                     if task in pending_set:
                         job = _jobs.get(job_id)
-                        if job is not None:
+                        if job is not None and not (
+                            job.generation_finished and job.output_path is not None
+                        ):
                             job.status = "failed"
                             job.error = {
                                 "code": "video_server_shutdown",
@@ -443,6 +451,61 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
             await asyncio.gather(*pending, return_exceptions=True)
     for job_id in cancelled_job_ids:
         await asyncio.to_thread(shutil.rmtree, _jobs_root / job_id, ignore_errors=True)
+
+
+async def _persist_completed_job_in_daemon_thread(job: _VideoJob) -> None:
+    """Persist a manifest without allowing slow storage to block shutdown.
+
+    Unlike generation, manifest persistence is safe to detach after the MP4 is
+    complete: the atomic temporary-file protocol leaves either the previous
+    complete record or no record. A daemon thread lets the server honor its
+    shutdown deadline even when an external volume stalls in ``fsync`` or
+    ``replace``.
+    """
+    loop = asyncio.get_running_loop()
+    completed = loop.create_future()
+
+    def finish(result: BaseException | None) -> None:
+        if completed.done():  # pragma: no cover - defensive duplicate callback
+            return
+        if result is None:
+            completed.set_result(None)
+        else:
+            completed.set_exception(result)
+
+    def target() -> None:
+        result: BaseException | None
+        try:
+            _persist_completed_job(job)
+        except Exception as exc:  # noqa: BLE001
+            result = exc
+        except BaseException:  # pragma: no cover - defensive thread boundary
+            result = RuntimeError("video job metadata worker terminated unexpectedly")
+        else:
+            result = None
+        finally:
+            with _jobs_lock:
+                _persistence_threads.discard(thread)
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(finish, result)
+
+    thread = threading.Thread(
+        target=target, name="rapid-mlx-video-persistence", daemon=True
+    )
+    with _jobs_lock:
+        _persistence_threads.add(thread)
+    thread.start()
+    try:
+        await asyncio.shield(completed)
+    except asyncio.CancelledError:
+        # If the server abandons this best-effort write at its shutdown
+        # deadline, consume a late worker exception without holding shutdown.
+        def consume_outcome(done: asyncio.Future) -> None:
+            if not done.cancelled():
+                done.exception()
+
+        completed.add_done_callback(consume_outcome)
+        raise
 
 
 async def _run_in_generation_thread(function, /, **kwargs) -> None:
@@ -678,6 +741,8 @@ async def _run_job(
     conditioning_strength: float | None,
 ) -> None:
     started = False
+    generation_completed = False
+    completed_job: _VideoJob | None = None
     output = _jobs_root / job.id / "output.mp4"
     generation_gate = _generation_gate_for_current_loop()
     is_cogvideox = getattr(engine, "video_family", "") == "cogvideox-fun"
@@ -731,9 +796,16 @@ async def _run_job(
             output_path=str(output),
             generation_finished=True,
         )
+        with _jobs_lock:
+            # Keep the job in progress until its atomic manifest commit
+            # finishes. That prevents normal retention from evicting its
+            # directory while the persistence thread still owns it.
+            job.output_path = completed_job.output_path
+            job.generation_finished = completed_job.generation_finished
+        generation_completed = True
         if _jobs_are_persistent:
             try:
-                await run_to_completion(_persist_completed_job, completed_job)
+                await _persist_completed_job_in_daemon_thread(completed_job)
             except OSError:
                 # The MP4 is already complete and remains downloadable for this
                 # process. Keep that user result available while making the
@@ -745,9 +817,16 @@ async def _run_job(
             job.status = completed_job.status
             job.progress = completed_job.progress
             job.completed_at = completed_job.completed_at
-            job.output_path = completed_job.output_path
-            job.generation_finished = completed_job.generation_finished
     except asyncio.CancelledError:
+        if generation_completed:
+            # The completed MP4 remains valid. Metadata persistence is atomic
+            # and may finish in its detached daemon thread after shutdown.
+            assert completed_job is not None
+            with _jobs_lock:
+                job.status = completed_job.status
+                job.progress = completed_job.progress
+                job.completed_at = completed_job.completed_at
+            raise
         with _jobs_lock:
             if job.status != "failed":
                 job.status = "failed"
@@ -1080,14 +1159,41 @@ async def retrieve_video_content(video_id: str):
     job = _get_job(video_id)
     if job.status != "completed" or job.output_path is None:
         raise HTTPException(status_code=409, detail="video is not completed")
-    # Open before releasing control. A concurrent delete/eviction may unlink
-    # the path, but the already-open descriptor remains streamable on macOS.
+    # Open relative to no-follow directory descriptors. This prevents a local
+    # process with access to the operator-owned store from swapping either the
+    # restored job directory or output file for a symlink between startup
+    # validation and download. O_NONBLOCK also prevents a substituted FIFO
+    # from stalling the event loop before fstat can reject it.
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:  # pragma: no cover - POSIX guard
+        raise HTTPException(status_code=410, detail="video content has expired")
+    base_flags = os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0)
+    root_fd = job_fd = output_fd = None
     try:
-        source = open(job.output_path, "rb")  # noqa: SIM115
-    except FileNotFoundError as exc:
+        root_fd = os.open(_jobs_root, base_flags | directory)
+        job_fd = os.open(job.id, base_flags | directory, dir_fd=root_fd)
+        output_fd = os.open(
+            "output.mp4",
+            base_flags | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=job_fd,
+        )
+        output_stat = os.fstat(output_fd)
+        if not stat.S_ISREG(output_stat.st_mode) or output_stat.st_size <= 0:
+            raise OSError("video output is not a non-empty regular file")
+        source = os.fdopen(output_fd, "rb")
+        output_fd = None
+    except OSError as exc:
         raise HTTPException(
             status_code=410, detail="video content has expired"
         ) from exc
+    finally:
+        if output_fd is not None:
+            os.close(output_fd)
+        if job_fd is not None:
+            os.close(job_fd)
+        if root_fd is not None:
+            os.close(root_fd)
 
     def chunks():
         try:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -356,30 +356,45 @@ def _persist_completed_job(job: _VideoJob) -> None:
 
 
 def _load_completed_job(job_dir: Path) -> _VideoJob | None:
-    if (
-        job_dir.is_symlink()
-        or not job_dir.is_dir()
-        or not _VIDEO_ID_RE.fullmatch(job_dir.name)
-    ):
+    if not _VIDEO_ID_RE.fullmatch(job_dir.name):
         return None
-    metadata_path = job_dir / _VIDEO_JOB_METADATA
     output_path = job_dir / "output.mp4"
+    root_fd = job_fd = metadata_fd = output_fd = None
     try:
-        if metadata_path.is_symlink() or output_path.is_symlink():
-            return None
-        metadata_stat = metadata_path.stat()
-        output_stat = output_path.stat()
+        root_fd, job_fd = _open_video_job_directory(job_dir.name)
+        metadata_fd = os.open(
+            _VIDEO_JOB_METADATA,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=job_fd,
+        )
+        metadata_stat = os.fstat(metadata_fd)
         if (
-            not metadata_path.is_file()
+            not stat.S_ISREG(metadata_stat.st_mode)
             or metadata_stat.st_size > _MAX_VIDEO_JOB_METADATA_BYTES
-            or not output_path.is_file()
-            or output_stat.st_size <= 0
         ):
             return None
-        value = json.loads(metadata_path.read_text(encoding="utf-8"))
+        with os.fdopen(metadata_fd, "rb") as metadata_source:
+            metadata_fd = None
+            raw_metadata = metadata_source.read(_MAX_VIDEO_JOB_METADATA_BYTES + 1)
+        if len(raw_metadata) > _MAX_VIDEO_JOB_METADATA_BYTES:
+            return None
+        value = json.loads(raw_metadata.decode("utf-8"))
+        output_fd = _open_video_output(job_fd)
     except (OSError, UnicodeError, json.JSONDecodeError):
         logger.warning("Ignoring unreadable video job record: %s", job_dir.name)
         return None
+    finally:
+        if output_fd is not None:
+            os.close(output_fd)
+        if metadata_fd is not None:
+            os.close(metadata_fd)
+        if job_fd is not None:
+            os.close(job_fd)
+        if root_fd is not None:
+            os.close(root_fd)
 
     if not isinstance(value, dict):
         return None

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -548,6 +548,7 @@ async def _persist_completed_job_in_daemon_thread(job: _VideoJob) -> None:
     """
     loop = asyncio.get_running_loop()
     completed = loop.create_future()
+    store_root = _jobs_root
 
     def finish(result: BaseException | None) -> None:
         if completed.done():  # pragma: no cover - defensive duplicate callback
@@ -570,6 +571,27 @@ async def _persist_completed_job_in_daemon_thread(job: _VideoJob) -> None:
         finally:
             with _jobs_lock:
                 _persistence_threads.discard(thread)
+        expired_id: str | None = None
+        if result is None:
+            with _jobs_lock:
+                if (
+                    _jobs_are_persistent
+                    and _jobs_root == store_root
+                    and _accepting_jobs
+                ):
+                    # A new lifespan may have scanned while this detached write
+                    # was still blocked. Register the now-durable result into
+                    # that current registry instead of requiring another
+                    # process restart to discover it.
+                    _jobs[job.id] = replace(job)
+                    if len(_jobs) > _MAX_JOBS:
+                        oldest = min(
+                            _jobs.values(), key=lambda item: (item.created_at, item.id)
+                        )
+                        _jobs.pop(oldest.id, None)
+                        expired_id = oldest.id
+        if expired_id is not None:
+            shutil.rmtree(store_root / expired_id, ignore_errors=True)
         with contextlib.suppress(RuntimeError):
             loop.call_soon_threadsafe(finish, result)
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2997,6 +2997,9 @@ Examples:
         default=8000,
         help="Port to bind to",
     )
+    from .cli import _add_video_job_args as _add_video_job_args_to_server_parser
+
+    _add_video_job_args_to_server_parser(parser)
     parser.add_argument(
         "--log-level",
         type=normalize_log_level,
@@ -3261,6 +3264,13 @@ Examples:
     )
 
     args = parser.parse_args()
+
+    from .routes.video import configure_video_jobs
+
+    try:
+        configure_video_jobs(args.video_output_dir)
+    except (OSError, RuntimeError, ValueError) as exc:
+        parser.error(f"cannot configure video output directory: {exc}")
 
     # PortSweep pre-flight (codex round-1 MAJOR on PR #848): mirror the
     # ``rapid-mlx serve`` CLI's loopback-shadow probe here so the


### PR DESCRIPTION
## User impact

Long-running video results no longer have to disappear when a serving process or model restarts. Desktop and other local clients can opt into a private artifact directory, reconnect to the next server process, and list, download or delete completed videos from the same HTTP API.

Closes #2793.

## What changed

- add `--video-output-dir PATH` to both supported serve entrypoints
- durably commit each completed MP4 and a versioned manifest with atomic, crash-consistent filesystem barriers
- rebuild the in-memory completed-job registry from validated records at each persistent server start
- keep the existing 100-job retention, content download, eviction and DELETE behavior consistent across the manifest and MP4
- use bounded, no-follow descriptor reads for restored manifests and video downloads
- ignore queued, active, failed, partial, malformed, oversized, non-regular and linked records
- preserve the existing process-temporary default when no directory is supplied
- keep shutdown bounded even when artifact storage stalls
- document durability, retention and prompt-privacy behavior

## Scope / non-goals

This does not add Desktop UI, a database or multi-host queue, interrupted-generation resume, in-progress Metal hard cancellation, new generation parameters, or model/runtime behavior changes.

## Verification

- pre-review full direct unit suite: 19,720 passed, 116 skipped, 229 deselected, 6 xfailed
- final-head focused server/CLI/video suite: 336 passed, 3 deselected
- changed executable lines: 226/226 covered (100%)
- mypy shrink-only budget: 707 grandfathered errors across 143 files; no growth
- `make lint` passed
- standalone server help smoke passed
- `git diff --check` passed
- independent Codex review: LGTM in round 6
