### PR TITLE
test(ci): validate 0.13.3 pre-cut integration batch

### DIFF
--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -221,10 +221,15 @@ jobs:
 
       - name: Re-verify blockers and immutable Desktop publication
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The same protected step performs the final publication. Use the
+          # PAT throughout so no step boundary can swap credentials between
+          # the blocker cutoff and the atomic tag claim.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           VERSION: ${{ needs.verify-published-desktop.outputs.version }}
           RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
           EXPECTED_OPEN_IDS: ${{ needs.verify-published-desktop.outputs.open_ids }}
+          NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md
+          REASON: ${{ inputs.reason }}
           # Re-evaluate the secret after protected approval. A pre-approval
           # boolean can become stale while the job waits; publishing with the
           # GITHUB_TOKEN fallback would suppress downstream release events.
@@ -245,12 +250,6 @@ jobs:
           git fetch --force origin refs/heads/main:refs/remotes/origin/main
           LIVE_WAIVER_SOURCE="$RUNNER_TEMP/recovery-live-main"
           git worktree add --detach "$LIVE_WAIVER_SOURCE" origin/main
-          python3 scripts/check_release_blockers.py \
-            --version "$VERSION" \
-            --source-sha "$RELEASE_SHA" \
-            --repo "$REPO" \
-            --waivers-dir "$LIVE_WAIVER_SOURCE/docs/development/release-blockers" \
-            --expected-open-ids "$EXPECTED_OPEN_IDS"
           python3 scripts/check_desktop_publish.py \
             --app-tag "rapid-mac-v${VERSION}" \
             --accepted-sha "$RELEASE_SHA" \
@@ -282,13 +281,13 @@ jobs:
             exit 1
           fi
 
-      - name: Recover the engine tag and Release at the Desktop candidate SHA
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.verify-published-desktop.outputs.version }}
-          RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
-          NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md
-          REASON: ${{ inputs.reason }}
-        run: |
-          set -euo pipefail
+          # The live policy cutoff and the atomic tag/Release transaction stay
+          # in one shell step. Everything slow ran above; no unrelated command
+          # may be inserted between this query and publication.
+          python3 scripts/check_release_blockers.py \
+            --version "$VERSION" \
+            --source-sha "$RELEASE_SHA" \
+            --repo "$REPO" \
+            --waivers-dir "$LIVE_WAIVER_SOURCE/docs/development/release-blockers" \
+            --expected-open-ids "$EXPECTED_OPEN_IDS"
           bash scripts/recover_engine_release.sh

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -56,6 +56,10 @@ jobs:
             echo "::error::a non-empty recovery reason is required" >&2
             exit 1
           fi
+          if [[ -z "${REASON//[[:space:]]/}" ]]; then
+            echo "::error::recovery reason must contain non-whitespace text" >&2
+            exit 1
+          fi
           case "$REASON" in
             *$'\r'*|*$'\n'*)
               echo "::error::recovery reason must be a single line" >&2
@@ -234,11 +238,18 @@ jobs:
           fi
           grep -Fx "VERSION=$VERSION" evidence/recovery-identity.txt
           grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt
+
+          # Approval can wait while waiver policy changes on main. Refresh the
+          # policy tree after approval; the immutable Desktop tag remains the
+          # artifact identity, while live main is the policy source of truth.
+          git fetch --force origin refs/heads/main:refs/remotes/origin/main
+          LIVE_WAIVER_SOURCE="$RUNNER_TEMP/recovery-live-main"
+          git worktree add --detach "$LIVE_WAIVER_SOURCE" origin/main
           python3 scripts/check_release_blockers.py \
             --version "$VERSION" \
             --source-sha "$RELEASE_SHA" \
             --repo "$REPO" \
-            --waivers-dir docs/development/release-blockers \
+            --waivers-dir "$LIVE_WAIVER_SOURCE/docs/development/release-blockers" \
             --expected-open-ids "$EXPECTED_OPEN_IDS"
           python3 scripts/check_desktop_publish.py \
             --app-tag "rapid-mac-v${VERSION}" \

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -12,6 +12,10 @@ on:
         description: "Version whose Desktop DMG is already published but engine Release is missing (for example 0.13.0-rc2)."
         required: true
         type: string
+      desktop_run_id:
+        description: "Exact successful rapid-mac-release workflow_dispatch run that published this Desktop tag."
+        required: true
+        type: string
       reason:
         description: "Operator audit note for the recovery."
         required: true
@@ -30,6 +34,7 @@ jobs:
     outputs:
       version: ${{ steps.identity.outputs.version }}
       release_sha: ${{ steps.identity.outputs.release_sha }}
+      desktop_run_id: ${{ steps.identity.outputs.desktop_run_id }}
       open_ids: ${{ steps.blockers.outputs.open_ids }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -41,6 +46,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
+          DESKTOP_RUN_ID: ${{ inputs.desktop_run_id }}
           REASON: ${{ inputs.reason }}
           HAVE_PAT: ${{ secrets.RELEASE_PAT != '' }}
           REPO: ${{ github.repository }}
@@ -52,6 +58,10 @@ jobs:
             exit 1
           fi
           python3 scripts/release_version.py validate "$VERSION"
+          if ! [[ "$DESKTOP_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::desktop_run_id must be the positive integer ID of the exact Desktop promotion run" >&2
+            exit 1
+          fi
           if [ -z "$REASON" ]; then
             echo "::error::a non-empty recovery reason is required" >&2
             exit 1
@@ -104,6 +114,7 @@ jobs:
           python3 scripts/check_desktop_publish.py \
             --app-tag "$APP_TAG" \
             --accepted-sha "$RELEASE_SHA" \
+            --expected-run-id "$DESKTOP_RUN_ID" \
             --repo "$REPO" \
             --workflow rapid-mac-release.yml \
             --deadline-min 5 \
@@ -113,11 +124,13 @@ jobs:
           {
             echo "version=$VERSION"
             echo "release_sha=$RELEASE_SHA"
+            echo "desktop_run_id=$DESKTOP_RUN_ID"
           } >> "$GITHUB_OUTPUT"
           {
             echo "VERSION=$VERSION"
             echo "APP_TAG=$APP_TAG"
             echo "RELEASE_SHA=$RELEASE_SHA"
+            echo "DESKTOP_RUN_ID=$DESKTOP_RUN_ID"
             echo "REASON=$REASON"
           } > recovery-identity.txt
 
@@ -164,6 +177,7 @@ jobs:
         env:
           VERSION: ${{ steps.identity.outputs.version }}
           RELEASE_SHA: ${{ steps.identity.outputs.release_sha }}
+          DESKTOP_RUN_ID: ${{ steps.identity.outputs.desktop_run_id }}
           OPEN_IDS: ${{ steps.blockers.outputs.open_ids }}
         run: |
           set -euo pipefail
@@ -172,6 +186,7 @@ jobs:
             echo ""
             echo "Version: $VERSION"
             echo "Immutable Desktop candidate SHA: $RELEASE_SHA"
+            echo "Exact Desktop promotion run: $DESKTOP_RUN_ID"
             echo "Open release-blocker set: ${OPEN_IDS:-none}"
             echo ""
             cat recovery-evidence/desktop-publication-evidence.txt
@@ -227,6 +242,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           VERSION: ${{ needs.verify-published-desktop.outputs.version }}
           RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
+          DESKTOP_RUN_ID: ${{ needs.verify-published-desktop.outputs.desktop_run_id }}
           EXPECTED_OPEN_IDS: ${{ needs.verify-published-desktop.outputs.open_ids }}
           NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md
           REASON: ${{ inputs.reason }}
@@ -243,6 +259,7 @@ jobs:
           fi
           grep -Fx "VERSION=$VERSION" evidence/recovery-identity.txt
           grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt
+          grep -Fx "DESKTOP_RUN_ID=$DESKTOP_RUN_ID" evidence/recovery-identity.txt
 
           # Approval can wait while waiver policy changes on main. Refresh the
           # policy tree after approval; the immutable Desktop tag remains the
@@ -253,6 +270,7 @@ jobs:
           python3 scripts/check_desktop_publish.py \
             --app-tag "rapid-mac-v${VERSION}" \
             --accepted-sha "$RELEASE_SHA" \
+            --expected-run-id "$DESKTOP_RUN_ID" \
             --repo "$REPO" \
             --workflow rapid-mac-release.yml \
             --deadline-min 5 \

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -1,0 +1,252 @@
+name: Post-DMG engine release recovery
+
+# Recovery-only transaction for the narrow state where the immutable Desktop
+# tag and canonical DMG published successfully, but the engine tag/Release did
+# not. The Desktop tag is the source-of-truth candidate identity: this workflow
+# never moves it and never substitutes the current main head for that SHA.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version whose Desktop DMG is already published but engine Release is missing (for example 0.13.0-rc2)."
+        required: true
+        type: string
+      reason:
+        description: "Operator audit note for the recovery."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify-published-desktop:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+      release_sha: ${{ steps.identity.outputs.release_sha }}
+      open_ids: ${{ steps.blockers.outputs.open_ids }}
+      have_pat: ${{ steps.identity.outputs.have_pat }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve immutable Desktop release identity
+        id: identity
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          REASON: ${{ inputs.reason }}
+          HAVE_PAT: ${{ secrets.RELEASE_PAT != '' }}
+          REPO: ${{ github.repository }}
+          EVENT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_REF" != "refs/heads/main" ]; then
+            echo "::error::post-DMG recovery must be dispatched from main (got $EVENT_REF)" >&2
+            exit 1
+          fi
+          python3 scripts/release_version.py validate "$VERSION"
+          if [ -z "$REASON" ]; then
+            echo "::error::a non-empty recovery reason is required" >&2
+            exit 1
+          fi
+          if [ "$HAVE_PAT" != "true" ]; then
+            echo "::error::RELEASE_PAT is required so the published engine Release triggers downstream workflows" >&2
+            exit 1
+          fi
+
+          APP_TAG="rapid-mac-v${VERSION}"
+          git fetch --force origin "refs/tags/${APP_TAG}:refs/tags/${APP_TAG}"
+          RELEASE_SHA="$(git rev-parse --verify "refs/tags/${APP_TAG}^{commit}")"
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "::error::Desktop candidate $RELEASE_SHA is not an ancestor of current main; refusing cross-history recovery" >&2
+            exit 1
+          fi
+
+          git show "${RELEASE_SHA}:pyproject.toml" > "$RUNNER_TEMP/recovery-pyproject.toml"
+          RECOVERED_VERSION="$(python3 - "$RUNNER_TEMP/recovery-pyproject.toml" <<'PY'
+          import pathlib, sys, tomllib
+          print(tomllib.loads(pathlib.Path(sys.argv[1]).read_text())["project"]["version"])
+          PY
+          )"
+          if [ "$RECOVERED_VERSION" != "$VERSION" ]; then
+            echo "::error::Desktop tag $APP_TAG identifies version $RECOVERED_VERSION, not requested $VERSION" >&2
+            exit 1
+          fi
+
+          ENGINE_TAG="v${VERSION}"
+          if git rev-parse --verify --quiet "refs/tags/${ENGINE_TAG}^{commit}" > /dev/null; then
+            ENGINE_SHA="$(git rev-parse --verify "refs/tags/${ENGINE_TAG}^{commit}")"
+            if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]; then
+              echo "::error::existing engine tag $ENGINE_TAG points to $ENGINE_SHA, not Desktop candidate $RELEASE_SHA" >&2
+              exit 1
+            fi
+          fi
+
+          # The exact tagged workflow + immutable manifest + canonical Release
+          # asset are the evidence that the Desktop side already shipped.
+          python3 scripts/check_desktop_publish.py \
+            --app-tag "$APP_TAG" \
+            --accepted-sha "$RELEASE_SHA" \
+            --repo "$REPO" \
+            --workflow rapid-mac-release.yml \
+            --deadline-min 5 \
+            --sleep-sec 5 \
+            | tee desktop-publication-evidence.txt
+
+          {
+            echo "version=$VERSION"
+            echo "release_sha=$RELEASE_SHA"
+            echo "have_pat=$HAVE_PAT"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "VERSION=$VERSION"
+            echo "APP_TAG=$APP_TAG"
+            echo "RELEASE_SHA=$RELEASE_SHA"
+            echo "REASON=$REASON"
+          } > recovery-identity.txt
+
+      - name: Release-blocker evidence for recovered candidate
+        id: blockers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          SHA: ${{ steps.identity.outputs.release_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check_release_blockers.py \
+            --version "$VERSION" \
+            --source-sha "$SHA" \
+            --repo "$REPO" \
+            --waivers-dir docs/development/release-blockers \
+            | tee release-blocker-evidence.txt
+          OPEN_IDS="$(grep '^OPEN_IDS=' release-blocker-evidence.txt | cut -d= -f2-)"
+          echo "open_ids=$OPEN_IDS" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes from the immutable candidate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.release_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p recovery-evidence
+          RECOVERY_SOURCE="$RUNNER_TEMP/recovery-source"
+          git worktree add --detach "$RECOVERY_SOURCE" "$RELEASE_SHA"
+          (
+            cd "$RECOVERY_SOURCE"
+            RELEASE_SHA="$RELEASE_SHA" \
+              GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+              GH_TOKEN="$GH_TOKEN" \
+              bash scripts/build_release_notes.sh
+          ) > recovery-evidence/release-notes.md
+          mv recovery-identity.txt desktop-publication-evidence.txt \
+            release-blocker-evidence.txt recovery-evidence/
+
+      - name: Print pre-approval recovery evidence
+        env:
+          VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.release_sha }}
+          OPEN_IDS: ${{ steps.blockers.outputs.open_ids }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Post-DMG engine recovery evidence"
+            echo ""
+            echo "Version: $VERSION"
+            echo "Immutable Desktop candidate SHA: $RELEASE_SHA"
+            echo "Open release-blocker set: ${OPEN_IDS:-none}"
+            echo ""
+            cat recovery-evidence/desktop-publication-evidence.txt
+            echo ""
+            echo "Approval authorizes only the engine tag/Release at this exact SHA."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable recovery evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: post-dmg-engine-recovery-evidence
+          path: recovery-evidence/
+          if-no-files-found: error
+
+  recover-engine-release:
+    needs: verify-published-desktop
+    runs-on: ubuntu-latest
+    environment: rapid-mac-tag
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Download immutable recovery evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: post-dmg-engine-recovery-evidence
+          path: evidence
+
+      - name: Verify live rapid-mac-tag environment protection
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ENV_NAME="rapid-mac-tag"
+          gh api "repos/${REPO}/environments/${ENV_NAME}" > "$RUNNER_TEMP/re-env.json"
+          gh api "repos/${REPO}/environments/${ENV_NAME}/deployment-branch-policies" > "$RUNNER_TEMP/re-policy.json"
+          python3 scripts/check_release_environment.py \
+            --environment-json "$RUNNER_TEMP/re-env.json" \
+            --policy-json "$RUNNER_TEMP/re-policy.json" \
+            --expected-env-name "$ENV_NAME"
+
+      - name: Re-verify blockers and immutable Desktop publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.verify-published-desktop.outputs.version }}
+          RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
+          EXPECTED_OPEN_IDS: ${{ needs.verify-published-desktop.outputs.open_ids }}
+          HAVE_PAT: ${{ needs.verify-published-desktop.outputs.have_pat }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$HAVE_PAT" != "true" ]; then
+            echo "::error::RELEASE_PAT disappeared after pre-approval evidence" >&2
+            exit 1
+          fi
+          grep -Fx "VERSION=$VERSION" evidence/recovery-identity.txt
+          grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt
+          python3 scripts/check_release_blockers.py \
+            --version "$VERSION" \
+            --source-sha "$RELEASE_SHA" \
+            --repo "$REPO" \
+            --waivers-dir docs/development/release-blockers \
+            --expected-open-ids "$EXPECTED_OPEN_IDS"
+          python3 scripts/check_desktop_publish.py \
+            --app-tag "rapid-mac-v${VERSION}" \
+            --accepted-sha "$RELEASE_SHA" \
+            --repo "$REPO" \
+            --workflow rapid-mac-release.yml \
+            --deadline-min 5 \
+            --sleep-sec 5
+
+      - name: Recover the engine tag and Release at the Desktop candidate SHA
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.verify-published-desktop.outputs.version }}
+          RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
+          NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md
+        run: |
+          set -euo pipefail
+          bash scripts/create_release.sh

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -242,6 +242,29 @@ jobs:
             --deadline-min 5 \
             --sleep-sec 5
 
+          # Approval can wait indefinitely. Re-read the engine tag namespace
+          # after every other live check and immediately before publication;
+          # absence is the expected recovery state, a same-SHA tag is an
+          # idempotent retry, and any other SHA fails closed.
+          ENGINE_TAG="v${VERSION}"
+          set +e
+          git ls-remote --exit-code --refs origin "refs/tags/${ENGINE_TAG}" \
+            > "$RUNNER_TEMP/recovery-engine-tag.txt"
+          TAG_QUERY_RC=$?
+          set -e
+          if [ "$TAG_QUERY_RC" -eq 0 ]; then
+            git fetch --force origin \
+              "refs/tags/${ENGINE_TAG}:refs/tags/${ENGINE_TAG}"
+            ENGINE_SHA="$(git rev-parse --verify "refs/tags/${ENGINE_TAG}^{commit}")"
+            if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]; then
+              echo "::error::engine tag $ENGINE_TAG appeared during approval at $ENGINE_SHA, not approved SHA $RELEASE_SHA" >&2
+              exit 1
+            fi
+          elif [ "$TAG_QUERY_RC" -ne 2 ]; then
+            echo "::error::cannot re-read engine tag $ENGINE_TAG after approval" >&2
+            exit 1
+          fi
+
       - name: Recover the engine tag and Release at the Desktop candidate SHA
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -56,6 +56,12 @@ jobs:
             echo "::error::a non-empty recovery reason is required" >&2
             exit 1
           fi
+          case "$REASON" in
+            *$'\r'*|*$'\n'*)
+              echo "::error::recovery reason must be a single line" >&2
+              exit 1
+              ;;
+          esac
           if [ "$HAVE_PAT" != "true" ]; then
             echo "::error::RELEASE_PAT is required so the published engine Release triggers downstream workflows" >&2
             exit 1
@@ -268,9 +274,10 @@ jobs:
       - name: Recover the engine tag and Release at the Desktop candidate SHA
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          TAG: v${{ needs.verify-published-desktop.outputs.version }}
+          VERSION: ${{ needs.verify-published-desktop.outputs.version }}
           RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
           NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md
+          REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
-          bash scripts/create_release.sh
+          bash scripts/recover_engine_release.sh

--- a/.github/workflows/post-dmg-engine-recovery.yml
+++ b/.github/workflows/post-dmg-engine-recovery.yml
@@ -31,7 +31,6 @@ jobs:
       version: ${{ steps.identity.outputs.version }}
       release_sha: ${{ steps.identity.outputs.release_sha }}
       open_ids: ${{ steps.blockers.outputs.open_ids }}
-      have_pat: ${{ steps.identity.outputs.have_pat }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -104,7 +103,6 @@ jobs:
           {
             echo "version=$VERSION"
             echo "release_sha=$RELEASE_SHA"
-            echo "have_pat=$HAVE_PAT"
           } >> "$GITHUB_OUTPUT"
           {
             echo "VERSION=$VERSION"
@@ -217,11 +215,14 @@ jobs:
           VERSION: ${{ needs.verify-published-desktop.outputs.version }}
           RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}
           EXPECTED_OPEN_IDS: ${{ needs.verify-published-desktop.outputs.open_ids }}
-          HAVE_PAT: ${{ needs.verify-published-desktop.outputs.have_pat }}
+          # Re-evaluate the secret after protected approval. A pre-approval
+          # boolean can become stale while the job waits; publishing with the
+          # GITHUB_TOKEN fallback would suppress downstream release events.
+          LIVE_HAVE_PAT: ${{ secrets.RELEASE_PAT != '' }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "$HAVE_PAT" != "true" ]; then
+          if [ "$LIVE_HAVE_PAT" != "true" ]; then
             echo "::error::RELEASE_PAT disappeared after pre-approval evidence" >&2
             exit 1
           fi

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -278,6 +279,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RapidUITestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D3511FF388A5B23AA16F8D1 /* ChatAttachmentJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentJourneyTests.swift; sourceTree = "<group>"; };
 		7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RapidUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		956DE8BFE793F597BFBB4385 /* RapidUITests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RapidUITests.entitlements; sourceTree = "<group>"; };
 		981AB696C88019DDE1FC4C44 /* RapidUITestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RapidUITestHarness.swift; sourceTree = "<group>"; };
 		C125516144CFDFB692F0EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB04F3C22EF0AAABD315027F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -55,6 +56,7 @@
 		E6A84D31EDC64D755BA80792 = {
 			isa = PBXGroup;
 			children = (
+				956DE8BFE793F597BFBB4385 /* RapidUITests.entitlements */,
 				1B5A8BB0E7AD6E27D95CB510 /* Host */,
 				F27E5155342C1F7C1AFFB341 /* Tests */,
 				0227B5A18E76E11410CE7982 /* Products */,

--- a/apps/rapid-mac/Tests/RapidUITests/project.yml
+++ b/apps/rapid-mac/Tests/RapidUITests/project.yml
@@ -7,6 +7,8 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     CODE_SIGN_STYLE: Automatic
+fileGroups:
+  - RapidUITests.entitlements
 targets:
   RapidUITestHost:
     type: application
@@ -34,6 +36,7 @@ targets:
       - target: RapidUITestHost
     settings:
       base:
+        CODE_SIGN_ENTITLEMENTS: RapidUITests.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.rapidmlx.rapid-uitests
         GENERATE_INFOPLIST_FILE: YES
         TEST_TARGET_NAME: RapidUITestHost

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -11,6 +11,20 @@ Run it with full Xcode after building the app:
 ./scripts/run-xcui-tests.sh
 ```
 
+The runner needs no Apple signing identity: the script requests Xcode's local
+ad-hoc identity, verifies each run in its own DerivedData directory, and prints
+the host's Automation Mode state before launch. Do not replace that with
+`CODE_SIGNING_ALLOWED=NO`; Xcode copies and modifies its runner bundle, and an
+unsigned copy has an invalid resource seal that Gatekeeper can kill before any
+test starts.
+
+If Xcode reports `Timed out while enabling automation mode` even though
+`automationmodetool` prints `ENABLED`, treat it as a stale per-user
+`testmanagerd` service, not as a product-test failure. Stop other UI tests,
+terminate that service once (`pkill -9 -x testmanagerd`), and rerun with a new
+result-bundle path. Launchd starts a fresh service on demand. A second identical
+failure is a host blocker and must not be retried again.
+
 The target is additive; do not remove an AX journey until its semantic and
 structural assertions have equivalent native coverage.
 

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -33,4 +33,8 @@ xcodebuild test \
     -destination 'platform=macOS' \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
-    CODE_SIGNING_ALLOWED=NO
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGNING_ALLOWED=YES \
+    CODE_SIGNING_REQUIRED=YES \
+    CODE_SIGN_IDENTITY=- \
+    DEVELOPMENT_TEAM=

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -18,6 +18,9 @@ xcodebuild -version >/dev/null 2>&1 || {
     echo "error: generated Xcode project missing: $PROJECT" >&2
     exit 1
 }
+if [[ -x /usr/bin/automationmodetool ]]; then
+    /usr/bin/automationmodetool
+fi
 
 # XCUIApplication(bundleIdentifier:) resolves through LaunchServices.
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
@@ -34,7 +37,7 @@ xcodebuild test \
     -destination 'platform=macOS' \
     -derivedDataPath "$DERIVED_DATA" \
     -resultBundlePath "$RESULT_BUNDLE" \
-    "${test_selection[@]}" \
+    ${test_selection[@]+"${test_selection[@]}"} \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
 APP="$ROOT/build/Rapid-MLX Desktop.app"
 RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
+DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:-${RESULT_BUNDLE%.xcresult}-DerivedData}"
 ONLY_TESTING="${RAPID_XCUI_ONLY_TESTING:-}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
@@ -31,6 +32,7 @@ xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \
     -destination 'platform=macOS' \
+    -derivedDataPath "$DERIVED_DATA" \
     -resultBundlePath "$RESULT_BUNDLE" \
     "${test_selection[@]}" \
     CODE_SIGN_STYLE=Manual \

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -7,6 +7,15 @@ Video generation requires Python 3.11 or newer because the upstream
 `mlx-video-with-audio` runtime does not support Python 3.10. Rapid-MLX's core
 text and audio features continue to support Python 3.10.
 
+## Discover capabilities before serving
+
+`rapid-mlx models --json` lists video aliases separately from other model
+types. Each video entry includes `video_modes` (`text-to-video`,
+`image-to-video`, or both) and `min_memory_gb`, so clients can choose a
+compatible checkpoint before downloading or starting it. After the model is
+serving, `GET /v1/videos/capabilities` remains the source for its live size,
+duration, frame-rate, workload, reference-image, and optional-control limits.
+
 ## Motion and conditioning controls
 
 `POST /v1/videos` accepts optional controls in addition to `seconds`:

--- a/scripts/recover_engine_release.sh
+++ b/scripts/recover_engine_release.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 : "${NOTES_FILE:?recover_engine_release.sh: NOTES_FILE is required}"
 : "${REASON:?recover_engine_release.sh: REASON is required}"
 
+if [[ -z "${REASON//[[:space:]]/}" ]]; then
+  echo "recover_engine_release.sh: REASON must contain non-whitespace text" >&2
+  exit 2
+fi
 case "$REASON" in
   *$'\r'*|*$'\n'*)
     echo "recover_engine_release.sh: REASON must be a single line" >&2

--- a/scripts/recover_engine_release.sh
+++ b/scripts/recover_engine_release.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Publish the engine half of a verified post-DMG recovery transaction.
+#
+# Live blocker, environment, Desktop artifact and tag checks belong to the
+# protected workflow job. This unit owns the final workflow-to-create_release
+# wiring so it can be executed offline with a create_release.sh double.
+
+set -euo pipefail
+
+: "${VERSION:?recover_engine_release.sh: VERSION is required}"
+: "${RELEASE_SHA:?recover_engine_release.sh: RELEASE_SHA is required}"
+: "${NOTES_FILE:?recover_engine_release.sh: NOTES_FILE is required}"
+: "${REASON:?recover_engine_release.sh: REASON is required}"
+
+case "$REASON" in
+  *$'\r'*|*$'\n'*)
+    echo "recover_engine_release.sh: REASON must be a single line" >&2
+    exit 2
+    ;;
+esac
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+export TAG="v${VERSION}"
+export RELEASE_SHA NOTES_FILE
+
+bash "$SCRIPT_DIR/create_release.sh"

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -19,6 +19,8 @@ RECOVER=$(sed -n '/^  recover-engine-release:/,$p' "$WORKFLOW")
 contains "$ALL" "workflow_dispatch:" "recovery is explicit, never automatic"
 lacks "$ALL" "push:" "recovery cannot run from an ordinary main push"
 contains "$VERIFY" 'EVENT_REF: ${{ github.ref }}' "preflight binds dispatch to main"
+contains "$VERIFY" 'DESKTOP_RUN_ID: ${{ inputs.desktop_run_id }}' "operator supplies the exact Desktop promotion run"
+contains "$VERIFY" 'desktop_run_id must be the positive integer ID' "Desktop promotion run ID is validated before evidence"
 contains "$VERIFY" 'refs/tags/${APP_TAG}^{commit}' "Desktop tag is the recovery identity SSOT"
 contains "$VERIFY" 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' "candidate must belong to main history"
 contains "$VERIFY" 'git show "${RELEASE_SHA}:pyproject.toml"' "version is read from the recovered candidate"
@@ -26,6 +28,12 @@ contains "$VERIFY" 'recovery reason must be a single line' "multiline recovery r
 contains "$VERIFY" 'recovery reason must contain non-whitespace text' "blank recovery reasons fail before evidence"
 contains "$VERIFY" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "a mismatched existing engine tag fails before approval"
 contains "$VERIFY" 'scripts/check_desktop_publish.py' "exact Desktop publication is verified before approval"
+if [ "$(grep -cF -- '--expected-run-id "$DESKTOP_RUN_ID"' "$WORKFLOW")" -eq 2 ]; then
+  ok "both Desktop publication checks bind the exact promotion run"
+else
+  bad "both Desktop publication checks bind the exact promotion run"
+fi
+contains "$VERIFY" 'echo "desktop_run_id=$DESKTOP_RUN_ID"' "exact Desktop promotion run crosses the job boundary"
 contains "$VERIFY" 'scripts/check_release_blockers.py' "release blockers are checked before approval"
 contains "$VERIFY" 'scripts/build_release_notes.sh' "notes are generated for the immutable candidate"
 contains "$VERIFY" 'git worktree add --detach "$RECOVERY_SOURCE" "$RELEASE_SHA"' "curated notes are read from the immutable candidate tree"
@@ -44,6 +52,7 @@ contains "$RECOVER" "LIVE_HAVE_PAT: \${{ secrets.RELEASE_PAT != '' }}" "PAT pres
 lacks "$RECOVER" 'needs.verify-published-desktop.outputs.have_pat' "protected job never trusts a stale pre-approval PAT output"
 contains "$RECOVER" 'scripts/check_desktop_publish.py' "Desktop publication is re-verified after approval"
 contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved SHA"
+contains "$RECOVER" 'grep -Fx "DESKTOP_RUN_ID=$DESKTOP_RUN_ID" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved Desktop run"
 contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"
 contains "$RECOVER" 'git fetch --force origin refs/heads/main:refs/remotes/origin/main' "waiver policy is refreshed after approval"
 contains "$RECOVER" '--waivers-dir "$LIVE_WAIVER_SOURCE/docs/development/release-blockers"' "blocker recheck consumes live waiver policy"
@@ -70,6 +79,7 @@ chmod +x "$TMP/reverify.sh"
 printf '%s\n' \
   'VERSION=0.13.0' \
   'RELEASE_SHA=0000000000000000000000000000000000000001' \
+  'DESKTOP_RUN_ID=123456789' \
   > "$TMP/evidence/recovery-identity.txt"
 
 cat > "$TMP/bin/python3" <<'SH'
@@ -82,7 +92,12 @@ case "$1" in
     fi
     exit "${BLOCKERS_RC:-0}"
     ;;
-  *check_desktop_publish.py) exit "${DESKTOP_RC:-0}" ;;
+  *check_desktop_publish.py)
+    if ! printf ' %s ' "$*" | grep -Fq -- " --expected-run-id $DESKTOP_RUN_ID "; then
+      exit 64
+    fi
+    exit "${DESKTOP_RC:-0}"
+    ;;
 esac
 exit 0
 SH
@@ -119,6 +134,7 @@ run_transaction() {
       LIVE_HAVE_PAT="${LIVE_HAVE_PAT:-true}" \
       VERSION=0.13.0 \
       RELEASE_SHA=0000000000000000000000000000000000000001 \
+      DESKTOP_RUN_ID=123456789 \
       EXPECTED_OPEN_IDS= \
       REPO=raullenchai/Rapid-MLX \
       LIVE_WAIVER_DIR="$TMP/recovery-live-main/docs/development/release-blockers" \

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -23,6 +23,7 @@ contains "$VERIFY" 'refs/tags/${APP_TAG}^{commit}' "Desktop tag is the recovery 
 contains "$VERIFY" 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' "candidate must belong to main history"
 contains "$VERIFY" 'git show "${RELEASE_SHA}:pyproject.toml"' "version is read from the recovered candidate"
 contains "$VERIFY" 'recovery reason must be a single line' "multiline recovery reasons fail before evidence"
+contains "$VERIFY" 'recovery reason must contain non-whitespace text' "blank recovery reasons fail before evidence"
 contains "$VERIFY" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "a mismatched existing engine tag fails before approval"
 contains "$VERIFY" 'scripts/check_desktop_publish.py' "exact Desktop publication is verified before approval"
 contains "$VERIFY" 'scripts/check_release_blockers.py' "release blockers are checked before approval"
@@ -44,6 +45,8 @@ lacks "$RECOVER" 'needs.verify-published-desktop.outputs.have_pat' "protected jo
 contains "$RECOVER" 'scripts/check_desktop_publish.py' "Desktop publication is re-verified after approval"
 contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved SHA"
 contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"
+contains "$RECOVER" 'git fetch --force origin refs/heads/main:refs/remotes/origin/main' "waiver policy is refreshed after approval"
+contains "$RECOVER" '--waivers-dir "$LIVE_WAIVER_SOURCE/docs/development/release-blockers"' "blocker recheck consumes live waiver policy"
 contains "$RECOVER" 'git ls-remote --exit-code --refs origin "refs/tags/${ENGINE_TAG}"' "engine tag is re-read after approval"
 contains "$RECOVER" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "post-approval engine tag mismatch fails closed"
 contains "$RECOVER" 'bash scripts/recover_engine_release.sh' "testable recovery publication unit is executed"
@@ -72,7 +75,12 @@ cat > "$TMP/bin/python3" <<'SH'
 #!/usr/bin/env bash
 echo "python3 $*" >> "$CALLS"
 case "$1" in
-  *check_release_blockers.py) exit "${BLOCKERS_RC:-0}" ;;
+  *check_release_blockers.py)
+    if printf '%s\n' "$*" | grep -Fq -- "$LIVE_WAIVER_DIR"; then
+      exit "${WAIVER_DRIFT_RC:-${BLOCKERS_RC:-0}}"
+    fi
+    exit "${BLOCKERS_RC:-0}"
+    ;;
   *check_desktop_publish.py) exit "${DESKTOP_RC:-0}" ;;
 esac
 exit 0
@@ -83,6 +91,10 @@ echo "git $*" >> "$CALLS"
 case "$1" in
   ls-remote) exit "${TAG_QUERY_RC:-2}" ;;
   fetch) exit "${TAG_FETCH_RC:-0}" ;;
+  worktree)
+    mkdir -p "$4/docs/development/release-blockers"
+    exit 0
+    ;;
   rev-parse) printf '%s\n' "${ENGINE_SHA:-0000000000000000000000000000000000000001}" ;;
 esac
 exit 0
@@ -101,7 +113,9 @@ run_transaction() {
       RELEASE_SHA=0000000000000000000000000000000000000001 \
       EXPECTED_OPEN_IDS= \
       REPO=raullenchai/Rapid-MLX \
+      LIVE_WAIVER_DIR="$TMP/recovery-live-main/docs/development/release-blockers" \
       BLOCKERS_RC="${BLOCKERS_RC:-0}" \
+      WAIVER_DRIFT_RC="${WAIVER_DRIFT_RC:-${BLOCKERS_RC:-0}}" \
       DESKTOP_RC="${DESKTOP_RC:-0}" \
       TAG_QUERY_RC="${TAG_QUERY_RC:-2}" \
       ENGINE_SHA="${ENGINE_SHA:-0000000000000000000000000000000000000001}" \
@@ -114,6 +128,8 @@ run_transaction() {
 
 BLOCKERS_RC=1 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction || true
 [ ! -e "$TMP/published" ] && ok "live blocker failure makes publication unreachable" || bad "blocker failure reached publication"
+BLOCKERS_RC=0 WAIVER_DRIFT_RC=1 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction || true
+[ ! -e "$TMP/published" ] && ok "live waiver drift with unchanged issue IDs makes publication unreachable" || bad "waiver drift reached publication"
 LIVE_HAVE_PAT=false BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction || true
 [ ! -e "$TMP/published" ] && ok "post-approval PAT loss makes publication unreachable" || bad "PAT loss reached publication"
 BLOCKERS_RC=0 DESKTOP_RC=1 TAG_QUERY_RC=2 run_transaction || true
@@ -171,6 +187,11 @@ if run_publication $'forged reason\rSECOND_RECORD'; then
   bad "multiline CR reason reached create_release"
 else
   [ ! -e "$TMP/publication/call" ] && ok "CR reason is rejected before create_release" || bad "CR reason reached create_release"
+fi
+if run_publication $' \t  '; then
+  bad "whitespace-only reason reached create_release"
+else
+  [ ! -e "$TMP/publication/call" ] && ok "whitespace-only reason is rejected before create_release" || bad "whitespace-only reason reached create_release"
 fi
 
 echo "passed: $PASS failed: $FAIL"

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -43,9 +43,84 @@ lacks "$RECOVER" 'needs.verify-published-desktop.outputs.have_pat' "protected jo
 contains "$RECOVER" 'scripts/check_desktop_publish.py' "Desktop publication is re-verified after approval"
 contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved SHA"
 contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"
+contains "$RECOVER" 'git ls-remote --exit-code --refs origin "refs/tags/${ENGINE_TAG}"' "engine tag is re-read after approval"
+contains "$RECOVER" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "post-approval engine tag mismatch fails closed"
 contains "$RECOVER" 'bash scripts/create_release.sh' "existing idempotent engine release helper is reused"
 lacks "$ALL" 'tag_desktop_app.sh' "recovery never creates or moves the Desktop tag"
 lacks "$ALL" 'rapid-mac-release.yml --ref' "recovery never dispatches another DMG build"
+
+# Execute the actual post-approval run block with controlled command doubles.
+# A textual ordering assertion alone cannot prove that `set -e` propagates each
+# live-check failure before the following publication step becomes reachable.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin" "$TMP/evidence"
+sed -n '/- name: Re-verify blockers and immutable Desktop publication/,/- name: Recover the engine tag and Release at the Desktop candidate SHA/p' "$WORKFLOW" \
+  | sed '1,/run: |/d; $d; s/^          //' > "$TMP/reverify.sh"
+chmod +x "$TMP/reverify.sh"
+printf '%s\n' \
+  'VERSION=0.13.0' \
+  'RELEASE_SHA=0000000000000000000000000000000000000001' \
+  > "$TMP/evidence/recovery-identity.txt"
+
+cat > "$TMP/bin/python3" <<'SH'
+#!/usr/bin/env bash
+echo "python3 $*" >> "$CALLS"
+case "$1" in
+  *check_release_blockers.py) exit "${BLOCKERS_RC:-0}" ;;
+  *check_desktop_publish.py) exit "${DESKTOP_RC:-0}" ;;
+esac
+exit 0
+SH
+cat > "$TMP/bin/git" <<'SH'
+#!/usr/bin/env bash
+echo "git $*" >> "$CALLS"
+case "$1" in
+  ls-remote) exit "${TAG_QUERY_RC:-2}" ;;
+  fetch) exit "${TAG_FETCH_RC:-0}" ;;
+  rev-parse) printf '%s\n' "${ENGINE_SHA:-0000000000000000000000000000000000000001}" ;;
+esac
+exit 0
+SH
+chmod +x "$TMP/bin/python3" "$TMP/bin/git"
+
+run_transaction() {
+  : > "$TMP/calls"
+  rm -f "$TMP/published"
+  if (cd "$TMP" && env \
+      PATH="$TMP/bin:/usr/bin:/bin" \
+      CALLS="$TMP/calls" \
+      RUNNER_TEMP="$TMP" \
+      LIVE_HAVE_PAT="${LIVE_HAVE_PAT:-true}" \
+      VERSION=0.13.0 \
+      RELEASE_SHA=0000000000000000000000000000000000000001 \
+      EXPECTED_OPEN_IDS= \
+      REPO=raullenchai/Rapid-MLX \
+      BLOCKERS_RC="${BLOCKERS_RC:-0}" \
+      DESKTOP_RC="${DESKTOP_RC:-0}" \
+      TAG_QUERY_RC="${TAG_QUERY_RC:-2}" \
+      ENGINE_SHA="${ENGINE_SHA:-0000000000000000000000000000000000000001}" \
+      bash "$TMP/reverify.sh"); then
+    touch "$TMP/published"
+    return 0
+  fi
+  return 1
+}
+
+BLOCKERS_RC=1 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction || true
+[ ! -e "$TMP/published" ] && ok "live blocker failure makes publication unreachable" || bad "blocker failure reached publication"
+LIVE_HAVE_PAT=false BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction || true
+[ ! -e "$TMP/published" ] && ok "post-approval PAT loss makes publication unreachable" || bad "PAT loss reached publication"
+BLOCKERS_RC=0 DESKTOP_RC=1 TAG_QUERY_RC=2 run_transaction || true
+[ ! -e "$TMP/published" ] && ok "Desktop evidence failure makes publication unreachable" || bad "Desktop failure reached publication"
+BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=1 run_transaction || true
+[ ! -e "$TMP/published" ] && ok "engine-tag API failure makes publication unreachable" || bad "tag query failure reached publication"
+BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=0 ENGINE_SHA=ffffffffffffffffffffffffffffffffffffffff run_transaction || true
+[ ! -e "$TMP/published" ] && ok "post-approval engine-tag mismatch makes publication unreachable" || bad "tag mismatch reached publication"
+BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=0 ENGINE_SHA=0000000000000000000000000000000000000001 run_transaction
+[ -e "$TMP/published" ] && ok "same-SHA engine tag permits idempotent recovery" || bad "same-SHA tag blocked recovery"
+BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction
+[ -e "$TMP/published" ] && ok "absent engine tag permits recovery publication" || bad "valid recovery did not reach publication"
 
 echo "passed: $PASS failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -38,6 +38,8 @@ else
   bad "protected approval/recheck/publication ordering"
 fi
 contains "$RECOVER" 'scripts/check_release_environment.py' "live environment protection is re-read after approval"
+contains "$RECOVER" "LIVE_HAVE_PAT: \${{ secrets.RELEASE_PAT != '' }}" "PAT presence is re-evaluated inside the protected job"
+lacks "$RECOVER" 'needs.verify-published-desktop.outputs.have_pat' "protected job never trusts a stale pre-approval PAT output"
 contains "$RECOVER" 'scripts/check_desktop_publish.py' "Desktop publication is re-verified after approval"
 contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved SHA"
 contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -33,8 +33,8 @@ contains "$VERIFY" 'path: recovery-evidence/' "evidence upload has one stable ar
 
 ENV_LINE=$(grep -n 'environment: rapid-mac-tag' "$WORKFLOW" | cut -d: -f1)
 RECHECK_LINE=$(grep -n 'Re-verify blockers and immutable Desktop publication' "$WORKFLOW" | cut -d: -f1)
-CREATE_LINE=$(grep -n 'Recover the engine tag and Release at the Desktop candidate SHA' "$WORKFLOW" | cut -d: -f1)
-if [ "$ENV_LINE" -lt "$RECHECK_LINE" ] && [ "$RECHECK_LINE" -lt "$CREATE_LINE" ]; then
+PUBLISH_LINE=$(grep -n 'bash scripts/recover_engine_release.sh' "$WORKFLOW" | cut -d: -f1)
+if [ "$ENV_LINE" -lt "$RECHECK_LINE" ] && [ "$RECHECK_LINE" -lt "$PUBLISH_LINE" ]; then
   ok "protected approval precedes live rechecks and engine publication"
 else
   bad "protected approval/recheck/publication ordering"
@@ -54,6 +54,7 @@ contains "$RECOVER" 'VERSION: ${{ needs.verify-published-desktop.outputs.version
 contains "$RECOVER" 'RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}' "publication receives the verified SHA"
 contains "$RECOVER" 'NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md' "publication receives immutable notes"
 contains "$RECOVER" 'REASON: ${{ inputs.reason }}' "publication receives the operator reason"
+contains "$RECOVER" 'GH_TOKEN: ${{ secrets.RELEASE_PAT }}' "publication step uses the required PAT directly"
 lacks "$ALL" 'tag_desktop_app.sh' "recovery never creates or moves the Desktop tag"
 lacks "$ALL" 'rapid-mac-release.yml --ref' "recovery never dispatches another DMG build"
 
@@ -63,8 +64,8 @@ lacks "$ALL" 'rapid-mac-release.yml --ref' "recovery never dispatches another DM
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/bin" "$TMP/evidence"
-sed -n '/- name: Re-verify blockers and immutable Desktop publication/,/- name: Recover the engine tag and Release at the Desktop candidate SHA/p' "$WORKFLOW" \
-  | sed '1,/run: |/d; $d; s/^          //' > "$TMP/reverify.sh"
+sed -n '/- name: Re-verify blockers and immutable Desktop publication/,$p' "$WORKFLOW" \
+  | sed '1,/run: |/d; s/^          //' > "$TMP/reverify.sh"
 chmod +x "$TMP/reverify.sh"
 printf '%s\n' \
   'VERSION=0.13.0' \
@@ -100,6 +101,13 @@ esac
 exit 0
 SH
 chmod +x "$TMP/bin/python3" "$TMP/bin/git"
+mkdir -p "$TMP/scripts"
+cat > "$TMP/scripts/recover_engine_release.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+touch "$PUBLICATION_MARKER"
+SH
+chmod +x "$TMP/scripts/recover_engine_release.sh"
 
 run_transaction() {
   : > "$TMP/calls"
@@ -119,8 +127,8 @@ run_transaction() {
       DESKTOP_RC="${DESKTOP_RC:-0}" \
       TAG_QUERY_RC="${TAG_QUERY_RC:-2}" \
       ENGINE_SHA="${ENGINE_SHA:-0000000000000000000000000000000000000001}" \
+      PUBLICATION_MARKER="$TMP/published" \
       bash "$TMP/reverify.sh"); then
-    touch "$TMP/published"
     return 0
   fi
   return 1
@@ -142,6 +150,14 @@ BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=0 ENGINE_SHA=000000000000000000000000000
 [ -e "$TMP/published" ] && ok "same-SHA engine tag permits idempotent recovery" || bad "same-SHA tag blocked recovery"
 BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction
 [ -e "$TMP/published" ] && ok "absent engine tag permits recovery publication" || bad "valid recovery did not reach publication"
+
+BLOCKER_LINE=$(grep -n 'python3 scripts/check_release_blockers.py' "$TMP/reverify.sh" | tail -1 | cut -d: -f1)
+PUBLICATION_LINE=$(grep -n 'bash scripts/recover_engine_release.sh' "$TMP/reverify.sh" | cut -d: -f1)
+if [ "$((BLOCKER_LINE + 6))" -eq "$PUBLICATION_LINE" ]; then
+  ok "live blocker cutoff immediately precedes the publication unit"
+else
+  bad "commands intervene between live blocker cutoff and publication"
+fi
 
 # Execute the real publication unit with a create_release.sh double. This
 # proves the final workflow step constructs TAG from the verified version and

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -22,6 +22,7 @@ contains "$VERIFY" 'EVENT_REF: ${{ github.ref }}' "preflight binds dispatch to m
 contains "$VERIFY" 'refs/tags/${APP_TAG}^{commit}' "Desktop tag is the recovery identity SSOT"
 contains "$VERIFY" 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' "candidate must belong to main history"
 contains "$VERIFY" 'git show "${RELEASE_SHA}:pyproject.toml"' "version is read from the recovered candidate"
+contains "$VERIFY" 'recovery reason must be a single line' "multiline recovery reasons fail before evidence"
 contains "$VERIFY" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "a mismatched existing engine tag fails before approval"
 contains "$VERIFY" 'scripts/check_desktop_publish.py' "exact Desktop publication is verified before approval"
 contains "$VERIFY" 'scripts/check_release_blockers.py' "release blockers are checked before approval"
@@ -45,7 +46,11 @@ contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-ident
 contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"
 contains "$RECOVER" 'git ls-remote --exit-code --refs origin "refs/tags/${ENGINE_TAG}"' "engine tag is re-read after approval"
 contains "$RECOVER" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "post-approval engine tag mismatch fails closed"
-contains "$RECOVER" 'bash scripts/create_release.sh' "existing idempotent engine release helper is reused"
+contains "$RECOVER" 'bash scripts/recover_engine_release.sh' "testable recovery publication unit is executed"
+contains "$RECOVER" 'VERSION: ${{ needs.verify-published-desktop.outputs.version }}' "publication receives the verified version"
+contains "$RECOVER" 'RELEASE_SHA: ${{ needs.verify-published-desktop.outputs.release_sha }}' "publication receives the verified SHA"
+contains "$RECOVER" 'NOTES_FILE: ${{ github.workspace }}/evidence/release-notes.md' "publication receives immutable notes"
+contains "$RECOVER" 'REASON: ${{ inputs.reason }}' "publication receives the operator reason"
 lacks "$ALL" 'tag_desktop_app.sh' "recovery never creates or moves the Desktop tag"
 lacks "$ALL" 'rapid-mac-release.yml --ref' "recovery never dispatches another DMG build"
 
@@ -121,6 +126,52 @@ BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=0 ENGINE_SHA=000000000000000000000000000
 [ -e "$TMP/published" ] && ok "same-SHA engine tag permits idempotent recovery" || bad "same-SHA tag blocked recovery"
 BLOCKERS_RC=0 DESKTOP_RC=0 TAG_QUERY_RC=2 run_transaction
 [ -e "$TMP/published" ] && ok "absent engine tag permits recovery publication" || bad "valid recovery did not reach publication"
+
+# Execute the real publication unit with a create_release.sh double. This
+# proves the final workflow step constructs TAG from the verified version and
+# preserves the exact RELEASE_SHA / NOTES_FILE values passed by the workflow.
+mkdir -p "$TMP/publication/scripts"
+cp "$REPO_ROOT/scripts/recover_engine_release.sh" "$TMP/publication/scripts/"
+cat > "$TMP/publication/scripts/create_release.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'TAG=%s\n' "$TAG"
+  printf 'RELEASE_SHA=%s\n' "$RELEASE_SHA"
+  printf 'NOTES_FILE=%s\n' "$NOTES_FILE"
+  printf 'REASON=%s\n' "$REASON"
+} > "$PUBLICATION_CALL"
+SH
+chmod +x "$TMP/publication/scripts/create_release.sh"
+printf 'release notes\n' > "$TMP/publication/notes.md"
+
+run_publication() {
+  rm -f "$TMP/publication/call"
+  env \
+    VERSION=0.13.0 \
+    RELEASE_SHA=0000000000000000000000000000000000000001 \
+    NOTES_FILE="$TMP/publication/notes.md" \
+    REASON="$1" \
+    PUBLICATION_CALL="$TMP/publication/call" \
+    bash "$TMP/publication/scripts/recover_engine_release.sh"
+}
+
+run_publication 'recover missing engine half'
+contains "$(cat "$TMP/publication/call")" 'TAG=v0.13.0' "publication constructs the exact engine tag"
+contains "$(cat "$TMP/publication/call")" 'RELEASE_SHA=0000000000000000000000000000000000000001' "publication preserves the approved SHA"
+contains "$(cat "$TMP/publication/call")" "NOTES_FILE=$TMP/publication/notes.md" "publication preserves the immutable notes path"
+contains "$(cat "$TMP/publication/call")" 'REASON=recover missing engine half' "publication preserves the audited reason"
+
+if run_publication $'forged reason\nSECOND_RECORD'; then
+  bad "multiline LF reason reached create_release"
+else
+  [ ! -e "$TMP/publication/call" ] && ok "LF reason is rejected before create_release" || bad "LF reason reached create_release"
+fi
+if run_publication $'forged reason\rSECOND_RECORD'; then
+  bad "multiline CR reason reached create_release"
+else
+  [ ! -e "$TMP/publication/call" ] && ok "CR reason is rejected before create_release" || bad "CR reason reached create_release"
+fi
 
 echo "passed: $PASS failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/release/test_post_dmg_engine_recovery.sh
+++ b/tests/release/test_post_dmg_engine_recovery.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+WORKFLOW="$REPO_ROOT/.github/workflows/post-dmg-engine-recovery.yml"
+PASS=0
+FAIL=0
+
+ok() { PASS=$((PASS + 1)); printf '  PASS %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL %s\n' "$1"; }
+contains() { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3"; fi; }
+lacks() { if grep -qF -- "$2" <<<"$1"; then bad "$3"; else ok "$3"; fi; }
+
+ALL=$(cat "$WORKFLOW")
+VERIFY=$(sed -n '/^  verify-published-desktop:/,/^  recover-engine-release:/p' "$WORKFLOW")
+RECOVER=$(sed -n '/^  recover-engine-release:/,$p' "$WORKFLOW")
+
+contains "$ALL" "workflow_dispatch:" "recovery is explicit, never automatic"
+lacks "$ALL" "push:" "recovery cannot run from an ordinary main push"
+contains "$VERIFY" 'EVENT_REF: ${{ github.ref }}' "preflight binds dispatch to main"
+contains "$VERIFY" 'refs/tags/${APP_TAG}^{commit}' "Desktop tag is the recovery identity SSOT"
+contains "$VERIFY" 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' "candidate must belong to main history"
+contains "$VERIFY" 'git show "${RELEASE_SHA}:pyproject.toml"' "version is read from the recovered candidate"
+contains "$VERIFY" 'if [ "$ENGINE_SHA" != "$RELEASE_SHA" ]' "a mismatched existing engine tag fails before approval"
+contains "$VERIFY" 'scripts/check_desktop_publish.py' "exact Desktop publication is verified before approval"
+contains "$VERIFY" 'scripts/check_release_blockers.py' "release blockers are checked before approval"
+contains "$VERIFY" 'scripts/build_release_notes.sh' "notes are generated for the immutable candidate"
+contains "$VERIFY" 'git worktree add --detach "$RECOVERY_SOURCE" "$RELEASE_SHA"' "curated notes are read from the immutable candidate tree"
+contains "$VERIFY" 'path: recovery-evidence/' "evidence upload has one stable artifact root"
+
+ENV_LINE=$(grep -n 'environment: rapid-mac-tag' "$WORKFLOW" | cut -d: -f1)
+RECHECK_LINE=$(grep -n 'Re-verify blockers and immutable Desktop publication' "$WORKFLOW" | cut -d: -f1)
+CREATE_LINE=$(grep -n 'Recover the engine tag and Release at the Desktop candidate SHA' "$WORKFLOW" | cut -d: -f1)
+if [ "$ENV_LINE" -lt "$RECHECK_LINE" ] && [ "$RECHECK_LINE" -lt "$CREATE_LINE" ]; then
+  ok "protected approval precedes live rechecks and engine publication"
+else
+  bad "protected approval/recheck/publication ordering"
+fi
+contains "$RECOVER" 'scripts/check_release_environment.py' "live environment protection is re-read after approval"
+contains "$RECOVER" 'scripts/check_desktop_publish.py' "Desktop publication is re-verified after approval"
+contains "$RECOVER" 'grep -Fx "RELEASE_SHA=$RELEASE_SHA" evidence/recovery-identity.txt' "downloaded evidence is bound to the approved SHA"
+contains "$RECOVER" '--expected-open-ids "$EXPECTED_OPEN_IDS"' "blocker set drift fails closed"
+contains "$RECOVER" 'bash scripts/create_release.sh' "existing idempotent engine release helper is reused"
+lacks "$ALL" 'tag_desktop_app.sh' "recovery never creates or moves the Desktop tag"
+lacks "$ALL" 'rapid-mac-release.yml --ref' "recovery never dispatches another DMG build"
+
+echo "passed: $PASS failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -52,6 +52,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         # download; ``hf_path`` stays a bare repo id everywhere else.
         "subfolder",
         "modality",
+        "video_modes",
         # State-pin (parallel to ``is_hybrid``): serve a vision-config
         # checkpoint through the text-only mlx-lm lane. Translated to the
         # registered ``force_text`` routing kwarg (#393) in

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -40,6 +40,8 @@ def test_available_payload_shape() -> None:
         "mtp_draft_model",
         "mtp_speculative_tokens",
         "modality",
+        "video_modes",
+        "min_memory_gb",
         "is_builtin",
         "is_text_only",
     ):
@@ -50,6 +52,10 @@ def test_available_payload_shape() -> None:
     assert isinstance(entry["is_builtin"], bool)
     assert isinstance(entry["is_text_only"], bool)
     assert entry["size_bytes"] is None or isinstance(entry["size_bytes"], int)
+    assert entry["video_modes"] == []
+    assert entry["min_memory_gb"] is None or isinstance(
+        entry["min_memory_gb"], (int, float)
+    )
 
 
 def test_available_sections_are_split_by_modality() -> None:
@@ -59,6 +65,30 @@ def test_available_sections_are_split_by_modality() -> None:
     assert all(e["modality"] == "video-gen" for e in payload["video"])
     assert all(e["modality"] == "image-gen" for e in payload["image"])
     assert all(e["modality"] == "audio" for e in payload["audio"])
+
+
+def test_video_entries_expose_pre_serve_modes_and_memory_floor() -> None:
+    payload = _available_models_json_payload()
+    expected_modes = {
+        "cogvideox-fun-5b-q4": ["text-to-video"],
+        "cogvideox-fun-5b-q8": ["text-to-video"],
+        "cogvideox-fun-5b-bf16": ["text-to-video"],
+        "wan2.2-ti2v-5b-q8": ["text-to-video", "image-to-video"],
+        "wan2.2-ti2v-5b-bf16": ["text-to-video", "image-to-video"],
+        "wan2.2-i2v-a14b-q8": ["image-to-video"],
+        "wan2.2-t2v-a14b-bf16": ["text-to-video"],
+        "ltx-2.3-mlx-q4": ["text-to-video", "image-to-video"],
+        "ltx-2.5-mlx-q8": ["text-to-video", "image-to-video"],
+    }
+    by_alias = {entry["alias"]: entry for entry in payload["video"]}
+
+    assert set(by_alias) == set(expected_modes)
+    for alias, modes in expected_modes.items():
+        assert by_alias[alias]["video_modes"] == modes
+        assert by_alias[alias]["min_memory_gb"] > 0
+
+    assert all(entry["video_modes"] == [] for entry in payload["text"])
+    assert all(entry["video_modes"] == [] for entry in payload["image"])
 
 
 def test_cached_payload_shape() -> None:

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -343,6 +343,22 @@ def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
             {
                 "hf_path": "org/video",
                 "modality": "video-gen",
+                "video_modes": [],
+            },
+            "must be a non-empty list",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": "text-to-video",
+            },
+            "must be a non-empty list",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
                 "video_modes": ["video-to-video"],
             },
             "entries must be one of",

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -70,6 +70,22 @@ def test_every_alias_has_explicit_profile_fields() -> None:
         assert isinstance(value["supports_spec_decode"], bool)
 
 
+def test_video_aliases_declare_valid_generation_modes() -> None:
+    with open(ALIASES_PATH) as f:
+        raw = json.load(f)
+    allowed = {"text-to-video", "image-to-video"}
+    for alias, value in raw.items():
+        modes = value.get("video_modes")
+        if value.get("modality") == "video-gen":
+            assert isinstance(modes, list) and modes, (
+                f"{alias!r}: video aliases require at least one video mode"
+            )
+            assert set(modes) <= allowed
+            assert len(modes) == len(set(modes))
+        else:
+            assert modes is None, f"{alias!r}: non-video alias declares video modes"
+
+
 def test_no_orphan_aliases() -> None:
     """Every advertised alias must resolve to an explicit profile."""
     aliases = list_aliases()
@@ -315,6 +331,47 @@ def test_invalid_value_raises_with_alias_name(tmp_path) -> None:
         patch.object(ma, "_hf_to_alias", None),
         patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
         pytest.raises(ValueError, match="foo"),
+    ):
+        ma.list_profiles()
+
+
+@pytest.mark.parametrize(
+    "profile,message",
+    [
+        ({"hf_path": "org/video", "modality": "video-gen"}, "requires video_modes"),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": ["video-to-video"],
+            },
+            "entries must be one of",
+        ),
+        (
+            {
+                "hf_path": "org/video",
+                "modality": "video-gen",
+                "video_modes": ["text-to-video", "text-to-video"],
+            },
+            "must not contain duplicates",
+        ),
+        (
+            {"hf_path": "org/text", "video_modes": ["text-to-video"]},
+            "only valid",
+        ),
+    ],
+)
+def test_invalid_video_modes_fail_at_registry_load(tmp_path, profile, message) -> None:
+    bad = tmp_path / "aliases.json"
+    bad.write_text(json.dumps({"bad-video": profile}))
+
+    import vllm_mlx.model_aliases as ma
+
+    with (
+        patch.object(ma, "_aliases", None),
+        patch.object(ma, "_hf_to_alias", None),
+        patch("vllm_mlx.model_aliases.os.path.join", return_value=str(bad)),
+        pytest.raises(ValueError, match=message),
     ):
         ma.list_profiles()
 

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert 'DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:' in runner
+    assert "${RESULT_BUNDLE%.xcresult}-DerivedData" in runner
+    assert '-derivedDataPath "$DERIVED_DATA"' in runner
     assert "CODE_SIGN_STYLE=Manual" in runner
     assert "CODE_SIGNING_ALLOWED=YES" in runner
     assert "CODE_SIGNING_REQUIRED=YES" in runner

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -1,3 +1,4 @@
+import plistlib
 from pathlib import Path
 
 import yaml
@@ -154,6 +155,17 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert "isExecutableFile" in source
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
+
+
+def test_xcui_runner_can_reserve_its_loopback_listener():
+    project = (
+        MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
+    ).read_text()
+    entitlements_path = MAC / "Tests/RapidUITests/RapidUITests.entitlements"
+    entitlements = plistlib.loads(entitlements_path.read_bytes())
+
+    assert project.count("CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;") == 2
+    assert entitlements == {"com.apple.security.network.server": True}
 
 
 def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -83,6 +83,11 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert "CODE_SIGN_STYLE=Manual" in runner
+    assert "CODE_SIGNING_ALLOWED=YES" in runner
+    assert "CODE_SIGNING_REQUIRED=YES" in runner
+    assert "CODE_SIGN_IDENTITY=-" in runner
+    assert "CODE_SIGNING_ALLOWED=NO" not in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -160,12 +160,22 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
 
 
 def test_xcui_runner_can_reserve_its_loopback_listener():
+    project_source = yaml.safe_load(
+        (MAC / "Tests/RapidUITests/project.yml").read_text()
+    )
     project = (
         MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
     ).read_text()
     entitlements_path = MAC / "Tests/RapidUITests/RapidUITests.entitlements"
     entitlements = plistlib.loads(entitlements_path.read_bytes())
 
+    assert "RapidUITests.entitlements" in project_source["fileGroups"]
+    assert (
+        project_source["targets"]["RapidUITests"]["settings"]["base"][
+            "CODE_SIGN_ENTITLEMENTS"
+        ]
+        == "RapidUITests.entitlements"
+    )
     assert project.count("CODE_SIGN_ENTITLEMENTS = RapidUITests.entitlements;") == 2
     assert entitlements == {"com.apple.security.network.server": True}
 

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -84,6 +84,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert "xcodebuild -version" in runner
+    assert "/usr/bin/automationmodetool" in runner
     assert 'DERIVED_DATA="${RAPID_XCUI_DERIVED_DATA:' in runner
     assert "${RESULT_BUNDLE%.xcresult}-DerivedData" in runner
     assert '-derivedDataPath "$DERIVED_DATA"' in runner
@@ -92,6 +93,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "CODE_SIGNING_REQUIRED=YES" in runner
     assert "CODE_SIGN_IDENTITY=-" in runner
     assert "CODE_SIGNING_ALLOWED=NO" not in runner
+    assert '${test_selection[@]+"${test_selection[@]}"}' in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1

--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -4,7 +4,67 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
+
+
+@pytest.mark.parametrize(
+    "alias,engine",
+    [
+        (
+            "cogvideox-fun-5b-q4",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "cogvideox-fun-5b-q8",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "cogvideox-fun-5b-bf16",
+            SimpleNamespace(video_family="cogvideox-fun"),
+        ),
+        (
+            "wan2.2-ti2v-5b-q8",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="ti2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-ti2v-5b-bf16",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="ti2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-i2v-a14b-q8",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="i2v", max_area=None),
+            ),
+        ),
+        (
+            "wan2.2-t2v-a14b-bf16",
+            SimpleNamespace(
+                video_family="wan",
+                native_fps=24,
+                _wan_engine=SimpleNamespace(model_type="t2v", max_area=None),
+            ),
+        ),
+        ("ltx-2.3-mlx-q4", SimpleNamespace(video_family="ltx-2.3")),
+        ("ltx-2.5-mlx-q8", SimpleNamespace(video_family="ltx-2.5")),
+    ],
+)
+def test_builtin_pre_serve_modes_match_live_capabilities(alias, engine) -> None:
+    profile = resolve_profile(alias)
+    assert profile is not None
+    engine.model_name = profile.hf_path
+
+    assert list(profile.video_modes or ()) == video._video_capabilities(engine)["modes"]
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1695,6 +1695,7 @@
   "cogvideox-fun-5b-q4": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1707,6 +1708,7 @@
   "cogvideox-fun-5b-q8": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1719,6 +1721,7 @@
   "cogvideox-fun-5b-bf16": {
     "hf_path": "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1731,6 +1734,7 @@
   "wan2.2-ti2v-5b-q8": {
     "hf_path": "Anes1032/Wan2.2-TI2V-5B-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1743,6 +1747,7 @@
   "wan2.2-ti2v-5b-bf16": {
     "hf_path": "rickylin20260522/Wan2.2-TI2V-5B-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1755,6 +1760,7 @@
   "wan2.2-i2v-a14b-q8": {
     "hf_path": "Anes1032/Wan2.2-I2V-A14B-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1767,6 +1773,7 @@
   "wan2.2-t2v-a14b-bf16": {
     "hf_path": "rickylin20260522/Wan2.2-T2V-A14B-mlx",
     "modality": "video-gen",
+    "video_modes": ["text-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1779,6 +1786,7 @@
   "ltx-2.3-mlx-q4": {
     "hf_path": "notapalindrome/ltx23-mlx-av-q4",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -1791,6 +1799,7 @@
   "ltx-2.5-mlx-q8": {
     "hf_path": "MrMofer/ltx-2.5-mlx-q8",
     "modality": "video-gen",
+    "video_modes": ["text-to-video", "image-to-video"],
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6275,6 +6275,8 @@ def _available_models_json_payload() -> dict:
             "mtp_draft_model": getattr(p, "mtp_draft_model", None),
             "mtp_speculative_tokens": getattr(p, "mtp_speculative_tokens", None),
             "modality": _modality(p),
+            "video_modes": list(p.video_modes or ()),
+            "min_memory_gb": p.min_memory_gb,
             # Desktop consumes these as a launch-safety contract. Only
             # curated aliases may opt into eager MLLM loading, and an
             # explicit text-only pin always wins over name inference.

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -14,8 +14,14 @@ that entry just gets default capability flags.
 import difflib
 import json
 import os
+from typing import cast
 
-from .model_profile import Modality, ModelProfile
+from .model_profile import (
+    VIDEO_GENERATION_MODES,
+    Modality,
+    ModelProfile,
+    VideoGenerationMode,
+)
 
 # ``Modality`` and the unified ``ModelProfile`` dataclass live in the
 # import-light ``model_profile`` module — the single source of truth for
@@ -156,6 +162,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             # ``hf_path``.
             "subfolder",
             "modality",
+            "video_modes",
             # State-pin (parallel to ``is_hybrid`` / ``is_moe``): serve
             # this checkpoint through the text mlx-lm lane even though its
             # config declares a vision tower. server.load_model translates
@@ -480,6 +487,31 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"{sorted(_VALID_MODALITIES)}, got {raw_modality!r}"
         )
     modality: Modality = raw_modality  # type: ignore[assignment]
+    raw_video_modes = value.get("video_modes")
+    video_modes: tuple[VideoGenerationMode, ...] | None = None
+    if raw_video_modes is not None:
+        if not isinstance(raw_video_modes, list) or not raw_video_modes:
+            raise ValueError(f"alias {alias!r}: video_modes must be a non-empty list")
+        if any(
+            not isinstance(mode, str) or mode not in VIDEO_GENERATION_MODES
+            for mode in raw_video_modes
+        ):
+            raise ValueError(
+                f"alias {alias!r}: video_modes entries must be one of "
+                f"{list(VIDEO_GENERATION_MODES)}, got {raw_video_modes!r}"
+            )
+        if len(raw_video_modes) != len(set(raw_video_modes)):
+            raise ValueError(
+                f"alias {alias!r}: video_modes must not contain duplicates"
+            )
+        video_modes = cast(tuple[VideoGenerationMode, ...], tuple(raw_video_modes))
+    if modality == "video-gen" and video_modes is None:
+        raise ValueError(f"alias {alias!r}: modality='video-gen' requires video_modes")
+    if modality != "video-gen" and video_modes is not None:
+        raise ValueError(
+            f"alias {alias!r}: video_modes is only valid when "
+            f"modality='video-gen', got modality={modality!r}"
+        )
     # ``is_text_only`` — state-pin that serves a vision-config checkpoint
     # through the AR text mlx-lm lane (translated to the ``force_text``
     # routing kwarg in server.load_model). Only meaningful on the ``text``
@@ -576,6 +608,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         hf_path=hf_path,
         subfolder=subfolder,
         modality=modality,
+        video_modes=video_modes,
         is_text_only=is_text_only,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -29,7 +29,7 @@ also avoids an import cycle: ``model_auto_config`` already imports
 """
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, get_args
 
 # NOTE: deliberately NO ``from __future__ import annotations`` here. The
 # out-of-band-routing guard (tests/test_no_out_of_band_routing.py) inspects
@@ -56,6 +56,8 @@ from typing import Literal
 # in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
 # doesn't silently expose LLM-only columns on a non-LLM alias.
 Modality = Literal["text", "text-diffusion", "vision", "image-gen", "video-gen"]
+VideoGenerationMode = Literal["text-to-video", "image-to-video"]
+VIDEO_GENERATION_MODES: tuple[VideoGenerationMode, ...] = get_args(VideoGenerationMode)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -214,6 +216,11 @@ class ModelProfile:
     # → ``runtime/video_lane.py``; ``"vision"`` reserved for an upcoming
     # VLM integration.
     modality: Modality = "text"
+    # Operations this checkpoint can perform before it is downloaded or
+    # served. Live shape/control limits still come from
+    # ``GET /v1/videos/capabilities`` because they may depend on checkpoint
+    # metadata. ``None`` is required for every non-video modality.
+    video_modes: tuple[VideoGenerationMode, ...] | None = None
     # PFlash long-prompt compression eligibility (#287). Default
     # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a
     # brand-new alias never silently enables compression on an


### PR DESCRIPTION
## Why

Mergify accepted the release-bound PRs but stopped before creating a speculative check PR. This validation-only branch reproduces the intended batch so the combined tree receives one shared Full CI/macOS gate before the original PRs are merged.

## Exact inputs

Applied to `main@7da40670f349f9faa4b690b48be5110953496610` in queue order:

- #2332 at `10e268d45aa26326410cf531cedaa21af9f130a0`
- #2791 at `168e824c5a962b97494d54041d95df4127f897e9`
- #2787 at `210b6564101267ddc381862ad5cfcd1ecb26ed19`

## Scope

Shared integration evidence only. This PR must remain draft and must not merge. After its exact-head Full CI/macOS gate passes, the three original PRs will be admin squash-merged in the same order under explicit human authorization.

## Non-goals

- No additional product or CI implementation changes.
- No release, version bump, tag, or publication.
- No bypass of combined-state validation.

## Test plan

- [x] Combined all three exact heads without conflicts.
- [x] Post-DMG recovery executable contract: 54/54.
- [x] Focused Python contracts across aliases, model profiles, video capabilities, CLI output, and XCUITest target: 2990/2990.
- [x] Bash syntax and `git diff --check`.
- [ ] Exact-head GitHub Full CI/macOS integration gate.