### PR TITLE
feat(mtp): add routing qualification and bounded telemetry

### DIFF
--- a/tests/test_batched_self_mtp_contract.py
+++ b/tests/test_batched_self_mtp_contract.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-free contracts for the future continuous self-MTP coordinator."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.batched import (
+    BatchedMTPBookkeeper,
+    BatchedMTPCapabilities,
+    BatchedMTPConfig,
+    BatchedMTPRoute,
+    BatchedMTPTransactionError,
+    LaneAdmission,
+    SamplingContract,
+    assess_lane,
+    plan_admission,
+)
+
+
+def _capabilities(**overrides) -> BatchedMTPCapabilities:
+    values = dict(
+        target_batch_forward=True,
+        mtp_batch_forward=True,
+        ragged_target_rollback=True,
+        ragged_mtp_rollback=True,
+        atomic_cache_commit=True,
+        per_lane_rng=True,
+        transformed_distribution_verify=True,
+        dynamic_membership=True,
+    )
+    values.update(overrides)
+    return BatchedMTPCapabilities(**values)
+
+
+def _config(**overrides) -> BatchedMTPConfig:
+    values = dict(enabled=True, hard_reserve_bytes=100, max_draft_tokens=2)
+    values.update(overrides)
+    return BatchedMTPConfig(**values)
+
+
+def test_feature_is_default_off_and_capabilities_fail_closed():
+    lane = LaneAdmission("a")
+    gate = assess_lane(
+        lane,
+        config=BatchedMTPConfig(),
+        capabilities=BatchedMTPCapabilities(),
+    )
+
+    assert not gate.eligible
+    assert "batched self-MTP is disabled" in gate.reasons
+    assert "missing capability: target_batch_forward" in gate.reasons
+
+
+def test_truthy_non_boolean_capability_does_not_open_gate():
+    caps = replace(_capabilities(), target_batch_forward="yes")
+    gate = assess_lane(LaneAdmission("a"), config=_config(), capabilities=caps)
+    assert gate.reasons == ("missing capability: target_batch_forward",)
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "target_batch_forward",
+        "mtp_batch_forward",
+        "ragged_target_rollback",
+        "ragged_mtp_rollback",
+        "atomic_cache_commit",
+    ],
+)
+def test_each_core_capability_is_mandatory(missing):
+    gate = assess_lane(
+        LaneAdmission("a"),
+        config=_config(),
+        capabilities=replace(_capabilities(), **{missing: False}),
+    )
+    assert not gate.eligible
+    assert gate.reasons == (f"missing capability: {missing}",)
+
+
+def test_sampled_lanes_require_rng_and_transformed_verifier():
+    lane = LaneAdmission("sampled", sampling=SamplingContract(greedy=False))
+    gate = assess_lane(
+        lane,
+        config=_config(),
+        capabilities=_capabilities(
+            per_lane_rng=False, transformed_distribution_verify=False
+        ),
+    )
+    assert gate.reasons == (
+        "missing capability: per_lane_rng",
+        "missing capability: transformed_distribution_verify",
+    )
+
+
+def test_xtc_and_logits_processors_fail_closed():
+    xtc = LaneAdmission("xtc", sampling=SamplingContract(greedy=False, uses_xtc=True))
+    processors = LaneAdmission(
+        "processors", sampling=SamplingContract(has_logits_processors=True)
+    )
+    caps = _capabilities(xtc_exact_verify=False)
+
+    assert assess_lane(xtc, config=_config(), capabilities=caps).reasons == (
+        "XTC verification is not exact",
+    )
+    assert assess_lane(processors, config=_config(), capabilities=caps).reasons == (
+        "logits processors are not supported",
+    )
+
+
+def test_dynamic_membership_requires_explicit_capability():
+    gate = assess_lane(
+        LaneAdmission("a"),
+        config=_config(allow_dynamic_membership=True),
+        capabilities=_capabilities(dynamic_membership=False),
+    )
+    assert gate.reasons == ("missing capability: dynamic_membership",)
+
+
+def test_admission_lowers_depth_to_admit_more_lanes():
+    lanes = [
+        LaneAdmission(str(index), base_bytes=10, bytes_per_draft_token=20)
+        for index in range(4)
+    ]
+    # usable=140: K=2 fits 2 lanes (50 each), K=1 fits 4 lanes (30 each).
+    decision = plan_admission(
+        lanes,
+        config=_config(),
+        capabilities=_capabilities(),
+        free_bytes=240,
+    )
+
+    assert decision.route is BatchedMTPRoute.BATCHED_MTP
+    assert decision.batched_lane_ids == ("0", "1", "2", "3")
+    assert decision.draft_tokens == 1
+    assert decision.estimated_bytes == 120
+
+
+def test_admission_keeps_ineligible_lanes_plain_and_overflow_queued():
+    lanes = [
+        LaneAdmission("plain", cache_ready=False),
+        LaneAdmission("a", base_bytes=60),
+        LaneAdmission("b", base_bytes=60),
+        LaneAdmission("c", base_bytes=60),
+    ]
+    decision = plan_admission(
+        lanes,
+        config=_config(max_lanes=3),
+        capabilities=_capabilities(),
+        free_bytes=230,
+    )
+
+    assert decision.batched_lane_ids == ("a", "b")
+    assert decision.plain_lane_ids == ("plain",)
+    assert decision.queued_lane_ids == ("c",)
+
+
+def test_lanes_over_configured_limit_are_explicitly_queued():
+    lanes = [LaneAdmission(str(index)) for index in range(5)]
+    decision = plan_admission(
+        lanes,
+        config=_config(max_lanes=3),
+        capabilities=_capabilities(),
+        free_bytes=1000,
+    )
+
+    assert decision.batched_lane_ids == ("0", "1", "2")
+    assert decision.queued_lane_ids == ("3", "4")
+
+
+def test_memory_reserve_queues_an_otherwise_eligible_batch():
+    lanes = [LaneAdmission("a", base_bytes=1), LaneAdmission("b", base_bytes=1)]
+    decision = plan_admission(
+        lanes,
+        config=_config(),
+        capabilities=_capabilities(),
+        free_bytes=100,
+    )
+
+    assert decision.route is BatchedMTPRoute.QUEUE
+    assert decision.queued_lane_ids == ("a", "b")
+    assert decision.draft_tokens == 0
+
+
+def test_single_eligible_lane_uses_plain_decode_instead_of_waiting():
+    decision = plan_admission(
+        [LaneAdmission("a")],
+        config=_config(),
+        capabilities=_capabilities(),
+        free_bytes=1000,
+    )
+    assert decision.route is BatchedMTPRoute.PLAIN_DECODE
+    assert decision.plain_lane_ids == ("a",)
+
+
+def test_proposal_ticket_binds_epoch_order_and_verify_shape():
+    ledger = BatchedMTPBookkeeper(("a", "b", "c"))
+    ticket = ledger.begin_proposal(draft_tokens=2)
+
+    assert ticket.membership_epoch == 1
+    assert ticket.lane_ids == ("a", "b", "c")
+    assert ticket.verify_rows == 9
+
+    receipt = ledger.commit(
+        ticket,
+        emitted_counts={"c": 3, "a": 1, "b": 2},
+        terminal_lane_ids=("c",),
+    )
+    assert receipt.emitted_counts == (("a", 1), ("b", 2), ("c", 3))
+    assert receipt.total_emitted == 6
+    assert ledger.committed_tokens("b") == 2
+    # Commit reports terminal lanes; the coordinator detaches them only after
+    # it has committed the corresponding model/cache transaction.
+    assert ledger.lane_ids == ("a", "b", "c")
+
+
+def test_membership_cannot_change_during_proposal_and_abort_unlocks_it():
+    ledger = BatchedMTPBookkeeper(("a", "b"))
+    ticket = ledger.begin_proposal(draft_tokens=1)
+
+    with pytest.raises(BatchedMTPTransactionError, match="membership cannot change"):
+        ledger.attach(("c",))
+    with pytest.raises(BatchedMTPTransactionError, match="membership cannot change"):
+        ledger.detach(("a",))
+
+    ledger.abort(ticket)
+    assert ledger.attach(("c",)) == 2
+    assert ledger.lane_ids == ("a", "b", "c")
+
+
+def test_stale_or_double_commit_is_rejected():
+    ledger = BatchedMTPBookkeeper(("a", "b"))
+    first = ledger.begin_proposal(draft_tokens=1)
+    ledger.abort(first)
+    second = ledger.begin_proposal(draft_tokens=1)
+
+    with pytest.raises(BatchedMTPTransactionError, match="stale or foreign"):
+        ledger.commit(first, emitted_counts={"a": 1, "b": 1})
+
+    ledger.commit(second, emitted_counts={"a": 1, "b": 2})
+    with pytest.raises(BatchedMTPTransactionError, match="no proposal"):
+        ledger.commit(second, emitted_counts={"a": 1, "b": 2})
+
+
+@pytest.mark.parametrize(
+    "counts",
+    [
+        {"a": 1},
+        {"a": 0, "b": 1},
+        {"a": 3, "b": 1},
+        {"a": True, "b": 1},
+    ],
+)
+def test_commit_rejects_incomplete_or_impossible_counts(counts):
+    ledger = BatchedMTPBookkeeper(("a", "b"))
+    ticket = ledger.begin_proposal(draft_tokens=1)
+    with pytest.raises(BatchedMTPTransactionError):
+        ledger.commit(ticket, emitted_counts=counts)
+    assert ledger.outstanding == ticket
+
+
+def test_detach_advances_epoch_and_preserves_remaining_order():
+    ledger = BatchedMTPBookkeeper(("a", "b", "c"))
+    assert ledger.detach(("b",)) == 2
+    assert ledger.lane_ids == ("a", "c")
+
+
+def test_inputs_are_validated_without_model_or_array_dependencies():
+    with pytest.raises(ValueError, match="unique"):
+        plan_admission(
+            [LaneAdmission("a"), LaneAdmission("a")],
+            config=_config(),
+            capabilities=_capabilities(),
+            free_bytes=1000,
+        )
+    with pytest.raises(ValueError, match="positive integer"):
+        BatchedMTPBookkeeper(("a",)).begin_proposal(draft_tokens=True)
+    with pytest.raises(ValueError, match="positive integer"):
+        BatchedMTPBookkeeper(("a",)).begin_proposal(draft_tokens="2")
+    with pytest.raises(ValueError, match="policy flags"):
+        BatchedMTPConfig(enabled=1)
+    with pytest.raises(ValueError, match="free_bytes must be an integer"):
+        plan_admission(
+            [LaneAdmission("a"), LaneAdmission("b")],
+            config=_config(),
+            capabilities=_capabilities(),
+            free_bytes=True,
+        )

--- a/tests/test_continuous_mtp_generation_batch.py
+++ b/tests/test_continuous_mtp_generation_batch.py
@@ -1,0 +1,295 @@
+"""Pure-Python contract tests for the continuous MTP generation wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MTP_DIR = Path(__file__).parents[1] / "vllm_mlx" / "spec_decode" / "mtp"
+PACKAGE = "_continuous_mtp_generation_batch_probe"
+package = types.ModuleType(PACKAGE)
+package.__path__ = [str(MTP_DIR)]
+sys.modules[PACKAGE] = package
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE}.{name}", MTP_DIR / f"{name}.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+engine = _load("continuous_engine")
+generation = _load("continuous_batch")
+
+
+class _Compute:
+    def __init__(self):
+        self.calls = []
+        self.queued_outputs = []
+
+    def prepare(self, spec, forwards):
+        del forwards
+        self.calls.append(("prepare", spec.uid))
+        token = 100 + spec.uid
+        return engine.PreparedLaneData(
+            cur=token,
+            seed_hidden=f"hidden-{spec.uid}",
+            token_prefix=(spec.uid,),
+            caches=engine.SelfMTPCachePair(
+                target=f"target-cache-{spec.uid}",
+                draft=f"draft-cache-{spec.uid}",
+            ),
+            first_token=engine.MTPToken(token, f"lp-{token}", False),
+        )
+
+    def propose(self, lanes, caches, forwards):
+        del caches, forwards
+        self.calls.append(("propose", tuple(lane.uid for lane in lanes)))
+        rows = self.queued_outputs.pop(0)
+        accepted = tuple(
+            sum(1 for token in row[:-1] if token.from_draft) for row in rows
+        )
+        return engine.CycleComputation(
+            lane_uids=tuple(lane.uid for lane in lanes),
+            draft_depths=accepted,
+            accepted_lengths=accepted,
+            target_drops=tuple(0 for _ in lanes),
+            draft_drops=accepted,
+            outputs=tuple(tuple(row) for row in rows),
+            payload=f"cycle-{len(self.calls)}",
+        )
+
+    def commit(self, lanes, computation, *, emitted_counts, terminal):
+        self.calls.append(("commit", emitted_counts, terminal))
+        for lane, outputs, count in zip(lanes, computation.outputs, emitted_counts):
+            if count:
+                lane.cur = outputs[count - 1].token
+
+    def detach_lane(self, lane, caches):
+        self.calls.append(("detach", lane.uid, caches.target, caches.draft))
+
+
+class _Caches:
+    def __init__(self):
+        self.calls = []
+
+    def attach(self, current, joining):
+        assert current is None
+        self.calls.append(("attach", tuple(joining)))
+        return engine.SelfMTPCachePair(
+            target=[pair.target for pair in joining],
+            draft=[pair.draft for pair in joining],
+        )
+
+    def rollback(self, caches, *, target_drops, draft_drops, verify_width):
+        del caches
+        self.calls.append(
+            ("rollback", tuple(target_drops), tuple(draft_drops), verify_width)
+        )
+
+    def detach(self, caches, indices, keep_indices):
+        self.calls.append(("detach", tuple(indices), tuple(keep_indices)))
+        detached = [
+            engine.SelfMTPCachePair(
+                target=caches.target[index], draft=caches.draft[index]
+            )
+            for index in indices
+        ]
+        remaining = engine.SelfMTPCachePair(
+            target=[caches.target[index] for index in keep_indices],
+            draft=[caches.draft[index] for index in keep_indices],
+        )
+        return remaining, detached
+
+
+def _runtime(*, flash_dynamic=False):
+    compute = _Compute()
+    caches = _Caches()
+    capabilities = engine.ContinuousSelfMTPCapabilities(
+        target_return_hidden=True,
+        mtp_return_hidden=True,
+        confirmed_target_forward=True,
+        ragged_rollback=True,
+        atomic_cache_commit=True,
+        dynamic_membership=flash_dynamic,
+        flash_dynamic_membership_attested=flash_dynamic,
+    )
+    runtime = engine.ContinuousSelfMTPRuntime(
+        config=engine.ContinuousSelfMTPConfig(
+            enabled=True,
+            allow_dynamic_membership=flash_dynamic,
+            architecture="qwen4_flash_next" if flash_dynamic else "qwen3_5",
+        ),
+        capabilities=capabilities,
+        forwards=engine.RapidForwardSeams(
+            lambda *args, **kwargs: None,
+            lambda *args, **kwargs: None,
+        ),
+        compute=compute,
+        caches=caches,
+    )
+    return runtime, compute, caches
+
+
+def _spec(uid, *, max_tokens=8):
+    return engine.SelfMTPLaneSpec(
+        uid=uid,
+        prompt=(uid,),
+        max_tokens=max_tokens,
+        num_draft=2,
+    )
+
+
+def _draft(token):
+    return engine.MTPToken(token, f"lp-{token}", True)
+
+
+def _target(token):
+    return engine.MTPToken(token, f"lp-{token}", False)
+
+
+def test_initial_tokens_are_emitted_once_and_terminal_detaches_whole_cohort():
+    runtime, compute, caches = _runtime()
+    batch = generation.ContinuousMTPGenerationBatch.create(
+        [_spec(1, max_tokens=1), _spec(2)], runtime
+    )
+
+    burst = batch.next_burst()
+
+    assert burst.initial is True
+    assert burst.emitted_counts == (1, 1)
+    assert [emission.token_ids for emission in burst.emissions] == [(101,), (102,)]
+    assert burst.emissions[0].finish_reason == "length"
+    assert burst.emissions[1].finish_reason is None
+    assert [package.uid for package in burst.terminal_detaches] == [1]
+    assert [package.uid for package in burst.resumable_detaches] == [2]
+    assert burst.resumable_detaches[0].token_ids == (102,)
+    assert batch.closed is True
+    assert not any(call[0] == "propose" for call in compute.calls)
+    assert caches.calls[-1] == ("detach", (0, 1), ())
+
+
+def test_one_proposal_burst_commits_exact_stop_prefix_then_extracts_caches():
+    runtime, compute, _caches = _runtime()
+    compute.queued_outputs.append([(_draft(111), _target(112)), (_target(212),)])
+    batch = generation.ContinuousMTPGenerationBatch.create(
+        [_spec(1), _spec(2)], runtime, stop_tokens={1: {111}}
+    )
+    batch.next_burst()  # prepared first-token cohort
+
+    burst = batch.next_burst()
+
+    assert burst.initial is False
+    assert burst.emitted_counts == (1, 1)
+    assert [emission.token_ids for emission in burst.emissions] == [(111,), (212,)]
+    assert ("commit", (1, 1), (True, False)) in compute.calls
+    terminal = burst.terminal_detaches[0]
+    assert terminal.uid == 1
+    assert terminal.finish_reason == "stop"
+    assert terminal.token_ids == (101, 111)
+    assert terminal.target_cache == "target-cache-1"
+    assert terminal.draft_cache == "draft-cache-1"
+    companion = burst.resumable_detaches[0]
+    assert companion.uid == 2
+    assert companion.token_ids == (102, 212)
+    assert companion.terminal is False
+
+
+def test_max_token_boundary_marks_the_full_final_proposal_as_length():
+    runtime, compute, _caches = _runtime()
+    compute.queued_outputs.append([(_draft(111), _target(112)), (_target(212),)])
+    batch = generation.ContinuousMTPGenerationBatch.create(
+        [_spec(1, max_tokens=3), _spec(2)], runtime
+    )
+    batch.next_burst()
+
+    burst = batch.next_burst()
+
+    assert burst.emitted_counts == (2, 1)
+    assert burst.emissions[0].token_ids == (111, 112)
+    assert burst.emissions[0].finish_reason == "length"
+    assert ("commit", (2, 1), (True, False)) in compute.calls
+    assert burst.terminal_detaches[0].token_ids == (101, 111, 112)
+
+
+def test_one_proposal_per_call_and_manual_detach_is_idempotent():
+    runtime, compute, _caches = _runtime()
+    compute.queued_outputs.extend(
+        [
+            [(_target(111),), (_target(211),)],
+            [(_target(112),), (_target(212),)],
+        ]
+    )
+    batch = generation.ContinuousMTPGenerationBatch.create(
+        [_spec(1), _spec(2)], runtime
+    )
+
+    initial = batch.next_burst()
+    first = batch.next_burst()
+    second = batch.next_burst()
+
+    assert initial.initial is True
+    assert first.initial is second.initial is False
+    assert sum(call[0] == "propose" for call in compute.calls) == 2
+    assert [state.emitted_tokens for state in batch.lane_states] == [3, 3]
+    detached = batch.detach_all()
+    assert [package.token_ids for package in detached] == [
+        (101, 111, 112),
+        (102, 211, 212),
+    ]
+    assert all(not package.terminal for package in detached)
+    assert batch.detach_all() is detached
+    with pytest.raises(
+        generation.ContinuousMTPGenerationBatchError, match="already detached"
+    ):
+        batch.next_burst()
+
+
+def test_failed_commit_does_not_publish_delivery_ledger():
+    runtime, compute, _caches = _runtime()
+    compute.queued_outputs.append([(_draft(111), _target(112))])
+    batch = generation.ContinuousMTPGenerationBatch.create([_spec(1)], runtime)
+    batch.next_burst()
+
+    def fail_commit(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("commit failed")
+
+    compute.commit = fail_commit
+    with pytest.raises(RuntimeError, match="commit failed"):
+        batch.next_burst()
+
+    assert batch.lane_states[0].emitted_tokens == 1
+    assert batch.closed is False
+
+
+def test_flash_incremental_join_stays_impossible_despite_core_attestation():
+    runtime, _compute, _caches = _runtime(flash_dynamic=True)
+    batch = generation.ContinuousMTPGenerationBatch.create([_spec(1)], runtime)
+
+    with pytest.raises(
+        engine.ContinuousSelfMTPUnsupportedError,
+        match="fixed-cohort.*including Flash",
+    ):
+        batch.attach_lanes([])
+
+
+def test_stop_token_configuration_fails_closed_on_unknown_lane_or_bad_token():
+    runtime, _compute, _caches = _runtime()
+    with pytest.raises(ValueError, match="unknown lane uid"):
+        generation.ContinuousMTPGenerationBatch.create(
+            [_spec(1)], runtime, stop_tokens={2: {200}}
+        )
+    with pytest.raises(ValueError, match="must be integers"):
+        generation.ContinuousMTPGenerationBatch.create(
+            [_spec(1)], runtime, stop_tokens={1: {True}}
+        )

--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -1,0 +1,279 @@
+"""Model-free and AST tests for PR 9 continuous-MTP routing."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from vllm_mlx.spec_decode.config import (
+    SpeculativeConfigError,
+    parse_speculative_config,
+)
+from vllm_mlx.spec_decode.mtp.batched import SamplingContract
+from vllm_mlx.spec_decode.mtp.continuous_routing import (
+    ContinuousMTPAPCHit,
+    ContinuousMTPIntegrationRoute,
+    ContinuousMTPRequestMetadata,
+    plan_router_install,
+)
+from vllm_mlx.spec_decode.mtp.prepared_state import (
+    PreparedStateIdentity,
+    prepare_mtp_state,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _descriptor(family="qwen3_5"):
+    return MappingProxyType(
+        {
+            "protocol_version": 1,
+            "model_family": family,
+            "batch_forward": "mtp_batch_forward",
+            "recursive_draft_depth": 2,
+            "fixed_membership": True,
+            "dynamic_join": family == "qwen3_5",
+            "quantized_cache": False,
+            "windowed_cache": False,
+            "xtc": False,
+        }
+    )
+
+
+class _Model:
+    batched_mtp_capability = _descriptor()
+    mtp = object()
+
+    def __call__(self, *args, **kwargs):
+        return args, kwargs
+
+    def mtp_batch_forward(self, *args, **kwargs):
+        return args, kwargs
+
+    def mtp_forward(self, *args, **kwargs):
+        return args, kwargs
+
+    def make_mtp_cache(self):
+        return object()
+
+
+def _request(lane, uid, **changes):
+    values = {
+        "lane_id": lane,
+        "uid": uid,
+        "prompt_tokens": (10 + uid, 20 + uid),
+        "max_tokens": 16,
+    }
+    values.update(changes)
+    return ContinuousMTPRequestMetadata(**values)
+
+
+def _router(**changes):
+    values = {"enabled": True, "hard_reserve_bytes": 0}
+    values.update(changes)
+    decision = plan_router_install(_Model(), **values)
+    assert decision.admitted is True
+    assert decision.router is not None
+    return decision.router
+
+
+def _identity():
+    return PreparedStateIdentity.from_config(
+        model_id="Qwen/Qwen3.8-Flash-Next",
+        model_revision="revision-a",
+        speculative_config={"method": "mtp", "continuous_batching": True},
+        target_cache_layout="qwen4-batch-kv:bf16",
+        mtp_cache_layout="qwen4-mtp-batch-kv:bf16",
+        seed_hidden_layout="bf16[1,1,2048]",
+    )
+
+
+def _apc_hit(prefix, *, identity=None):
+    expected = _identity()
+    state = prepare_mtp_state(
+        identity=identity or expected,
+        prefix_tokens=prefix,
+        target_cache="target-cache",
+        target_cache_tokens=len(prefix),
+        mtp_cache="mtp-cache",
+        mtp_cache_pairs=len(prefix) - 1,
+        seed_hidden="seed-hidden",
+        captured_at=10.0,
+    )
+    return ContinuousMTPAPCHit(
+        state=state,
+        expected_identity=expected,
+        target_cache_tokens=len(prefix),
+        mtp_cache_pairs=len(prefix) - 1,
+        now=11.0,
+        max_age_seconds=60.0,
+    )
+
+
+def test_speculative_config_continuous_batching_is_explicit_and_mtp_only():
+    default = parse_speculative_config('{"method":"mtp"}')
+    enabled = parse_speculative_config('{"method":"mtp","continuous_batching":true}')
+    assert default is not None and default.continuous_batching is False
+    assert enabled is not None and enabled.continuous_batching is True
+
+    with pytest.raises(SpeculativeConfigError, match="must be a boolean"):
+        parse_speculative_config('{"method":"mtp","continuous_batching":1}')
+    with pytest.raises(SpeculativeConfigError, match="unsupported speculative-config"):
+        parse_speculative_config('{"method":"suffix","continuous_batching":true}')
+
+
+def test_install_plan_is_default_off_and_fails_closed_without_mutation():
+    model = _Model()
+    before = dict(vars(model))
+
+    disabled = plan_router_install(model, enabled=False, hard_reserve_bytes=0)
+    quantized = plan_router_install(
+        model,
+        enabled=True,
+        cache_quantized=True,
+        hard_reserve_bytes=0,
+    )
+
+    assert disabled.admitted is False
+    assert disabled.fallback is ContinuousMTPIntegrationRoute.LEGACY_MTP
+    assert "disabled" in " ".join(disabled.reasons)
+    assert quantized.admitted is False
+    assert "quantized cache" in " ".join(quantized.reasons)
+    assert vars(model) == before
+
+
+def test_supported_requests_build_an_immutable_fixed_cohort_plan():
+    router = _router()
+
+    decision = router.plan([_request("a", 1), _request("b", 2)], free_bytes=1)
+
+    assert decision.route is ContinuousMTPIntegrationRoute.CONTINUOUS_PLANNED
+    assert decision.live_token_delivery is False
+    assert [lane.lane_id for lane in decision.cohort] == ["a", "b"]
+    assert [lane.spec.uid for lane in decision.cohort] == [1, 2]
+    assert [lane.spec.num_draft for lane in decision.cohort] == [2, 2]
+    assert all(lane.prepared_state is None for lane in decision.cohort)
+
+
+def test_exact_apc_sidecar_is_validated_and_carried_as_a_resume_plan():
+    router = _router()
+    prefix = tuple(range(64))
+    hit = _apc_hit(prefix)
+    requests = [
+        _request(
+            "a",
+            1,
+            prompt_tokens=prefix + (999,),
+            apc_hit=hit,
+        ),
+        _request("b", 2),
+    ]
+
+    decision = router.plan(requests, free_bytes=1)
+
+    assert decision.route is ContinuousMTPIntegrationRoute.CONTINUOUS_PLANNED
+    restored = decision.cohort[0]
+    assert restored.resume_at == 64
+    assert restored.spec.prompt == (999,)
+    assert restored.spec.prompt_cache == "target-cache"
+    assert restored.spec.mtp_cache == "mtp-cache"
+    assert restored.prepared_state is hit.state
+    assert decision.live_token_delivery is False
+
+
+def test_bad_apc_sidecar_routes_plain_while_other_lanes_form_cohort():
+    router = _router()
+    prefix = tuple(range(64))
+    foreign = PreparedStateIdentity.from_config(
+        model_id="other/model",
+        model_revision="revision-a",
+        speculative_config={"method": "mtp", "continuous_batching": True},
+        target_cache_layout="qwen4-batch-kv:bf16",
+        mtp_cache_layout="qwen4-mtp-batch-kv:bf16",
+        seed_hidden_layout="bf16[1,1,2048]",
+    )
+    requests = [
+        _request(
+            "bad-apc",
+            1,
+            prompt_tokens=prefix + (999,),
+            apc_hit=_apc_hit(prefix, identity=foreign),
+        ),
+        _request("a", 2),
+        _request("b", 3),
+    ]
+
+    decision = router.plan(requests, free_bytes=1)
+
+    assert decision.route is ContinuousMTPIntegrationRoute.CONTINUOUS_PLANNED
+    assert [lane.lane_id for lane in decision.cohort] == ["a", "b"]
+    assert decision.plain_lane_ids == ("bad-apc",)
+    assert "model_mismatch" in " ".join(decision.reasons)
+
+
+def test_unsupported_sampling_falls_back_to_legacy_without_a_cohort():
+    router = _router()
+    transformed = SamplingContract(greedy=False)
+    requests = [
+        _request("a", 1, sampling=transformed, temperature=0.8),
+        _request("b", 2, sampling=transformed, temperature=0.8),
+    ]
+
+    decision = router.plan(requests, free_bytes=1)
+
+    assert decision.route is ContinuousMTPIntegrationRoute.LEGACY_MTP
+    assert decision.cohort == ()
+    assert decision.legacy_lane_ids == ("a", "b")
+    assert "transformed_distribution_verify" in " ".join(decision.reasons)
+
+
+def test_scheduler_wiring_is_planning_only_and_refusal_precedes_mutation():
+    tree = ast.parse((ROOT / "vllm_mlx" / "scheduler.py").read_text(encoding="utf-8"))
+    installer = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_install_continuous_mtp_router"
+    )
+    assignments = [
+        node
+        for node in ast.walk(installer)
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+    ]
+    assert not any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute) and target.attr == "_step"
+            for target in node.targets
+        )
+        for node in assignments
+    )
+    source = ast.get_source_segment(
+        (ROOT / "vllm_mlx" / "scheduler.py").read_text(encoding="utf-8"),
+        installer,
+    )
+    assert source is not None
+    assert "if not decision.admitted" in source
+    assert source.index("if not decision.admitted") < source.index(
+        "batch_gen._continuous_mtp_router"
+    )
+    assert "live token delivery " in source
+    assert "is not wired in PR 9" in source
+
+
+def test_cli_and_scheduler_config_carry_the_default_off_opt_in_by_ast():
+    cli_source = (ROOT / "vllm_mlx" / "cli.py").read_text(encoding="utf-8")
+    scheduler_source = (ROOT / "vllm_mlx" / "scheduler.py").read_text(encoding="utf-8")
+    assert "args.mtp_continuous_batching = config.continuous_batching" in cli_source
+    assert (
+        'mtp_continuous_batching=getattr(args, "mtp_continuous_batching", False)'
+        in cli_source
+    )
+    assert "mtp_continuous_batching: bool = False" in scheduler_source
+    assert (
+        'if self.mtp_continuous_batching and self.spec_decode != "mtp"'
+        in scheduler_source
+    )

--- a/tests/test_continuous_mtp_telemetry.py
+++ b/tests/test_continuous_mtp_telemetry.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.continuous_telemetry import (
+    BOUNDED_METRIC_DIMENSIONS,
+    AbortReason,
+    AdmissionOutcome,
+    AdmissionReason,
+    CohortQualification,
+    CommitKind,
+    ContinuousMTPCounters,
+    DigestClassification,
+    EvidenceKind,
+    FinishReason,
+    LaneQualification,
+    QualificationIdentity,
+    TransactionOutcome,
+    TransactionTicket,
+    evaluate_cohort_qualification,
+    evaluate_qualification_suite,
+)
+
+
+def _identity(**changes) -> QualificationIdentity:
+    values = {
+        "candidate_sha": "a" * 40,
+        "model_id": "Qwen/Qwen3.8-Flash-Next",
+        "model_revision": "f5d08274",
+        "config_fingerprint": "b" * 64,
+        "prompt_manifest_sha256": "c" * 64,
+        "environment_fingerprint": "d" * 64,
+    }
+    values.update(changes)
+    return QualificationIdentity(**values)
+
+
+def _clean_record(
+    cohort_size: int = 4,
+    *,
+    identity: QualificationIdentity | None = None,
+    evidence_kind: EvidenceKind = EvidenceKind.SYNTHETIC,
+    raw_artifact_sha256: str | None = None,
+) -> CohortQualification:
+    counters = ContinuousMTPCounters()
+    counters.record_admission(
+        AdmissionOutcome.BATCHED,
+        AdmissionReason.ELIGIBLE,
+        lanes=cohort_size,
+        draft_depth=2,
+    )
+    ticket = counters.begin_transaction(
+        lanes=cohort_size,
+        proposed_draft_tokens=cohort_size * 2,
+    )
+    counters.commit_transaction(
+        ticket,
+        accepted_draft_tokens=cohort_size,
+        committed_tokens=cohort_size * 2,
+    )
+    counters.record_cleanup(lanes=cohort_size)
+    lanes = tuple(
+        LaneQualification(
+            lane_index=index,
+            output_tokens=2,
+            proposed_draft_tokens=2,
+            accepted_draft_tokens=1,
+            elapsed_seconds=1.0 + index / 10,
+            digest=DigestClassification.EXACT,
+            finish_reason=FinishReason.STOP,
+        )
+        for index in range(cohort_size)
+    )
+    return CohortQualification(
+        identity=identity or _identity(),
+        evidence_kind=evidence_kind,
+        cohort_size=cohort_size,
+        draft_depth=2,
+        aggregate_elapsed_seconds=1.0,
+        active_memory_bytes=100,
+        peak_memory_bytes=120,
+        cache_equal=True,
+        lanes=lanes,
+        telemetry=counters.snapshot(),
+        raw_artifact_sha256=raw_artifact_sha256,
+    )
+
+
+def test_metric_dimensions_are_fixed_enums_without_identity_labels() -> None:
+    assert set(BOUNDED_METRIC_DIMENSIONS) == {
+        "admission_outcome",
+        "admission_reason",
+        "transaction_outcome",
+        "commit_kind",
+        "abort_reason",
+    }
+    flattened = {
+        value for dimension in BOUNDED_METRIC_DIMENSIONS.values() for value in dimension
+    }
+    assert "request_id" not in flattened
+    assert "model_id" not in flattened
+    with pytest.raises(TypeError):
+        BOUNDED_METRIC_DIMENSIONS["request_id"] = ("uid-1",)
+
+
+def test_zero_snapshot_exports_every_bounded_counter() -> None:
+    payload = ContinuousMTPCounters().snapshot().to_dict()
+
+    assert payload["admissions"] == {value.value: 0 for value in AdmissionOutcome}
+    assert payload["transactions"] == {value.value: 0 for value in TransactionOutcome}
+    assert payload["totals"]["open_transaction"] is False
+
+
+def test_admission_counts_batch_fallback_queue_and_refusal() -> None:
+    counters = ContinuousMTPCounters()
+    counters.record_admission(
+        AdmissionOutcome.BATCHED,
+        AdmissionReason.DEPTH_REDUCED,
+        lanes=4,
+        draft_depth=1,
+    )
+    counters.record_admission(
+        AdmissionOutcome.PLAIN,
+        AdmissionReason.SAMPLING,
+        lanes=1,
+        draft_depth=0,
+    )
+    counters.record_admission(
+        AdmissionOutcome.QUEUED,
+        AdmissionReason.MEMORY,
+        lanes=2,
+        draft_depth=0,
+    )
+    counters.record_admission(
+        AdmissionOutcome.REFUSED,
+        AdmissionReason.CAPABILITY,
+        lanes=1,
+        draft_depth=0,
+    )
+
+    payload = counters.snapshot().to_dict()
+    assert payload["admissions"] == {
+        "batched": 1,
+        "plain": 1,
+        "queued": 1,
+        "refused": 1,
+    }
+    assert payload["totals"]["admitted_lanes"] == 4
+
+
+@pytest.mark.parametrize(
+    "outcome,reason,draft_depth",
+    [
+        ("batched", AdmissionReason.ELIGIBLE, 2),
+        (AdmissionOutcome.BATCHED, AdmissionReason.MEMORY, 2),
+        (AdmissionOutcome.PLAIN, AdmissionReason.ELIGIBLE, 0),
+        (AdmissionOutcome.QUEUED, AdmissionReason.MEMORY, 1),
+    ],
+)
+def test_admission_rejects_unbounded_or_incoherent_labels(
+    outcome, reason, draft_depth
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        ContinuousMTPCounters().record_admission(
+            outcome,
+            reason,
+            lanes=1,
+            draft_depth=draft_depth,
+        )
+
+
+def test_proposal_commit_and_cleanup_reconcile() -> None:
+    counters = ContinuousMTPCounters()
+    ticket = counters.begin_transaction(lanes=4, proposed_draft_tokens=8)
+    assert counters.snapshot().open_transaction is True
+
+    counters.commit_transaction(
+        ticket,
+        accepted_draft_tokens=5,
+        committed_tokens=9,
+        terminal_lanes=1,
+        kind=CommitKind.TERMINAL_PARTIAL,
+    )
+    counters.record_cleanup(lanes=1)
+
+    snapshot = counters.snapshot()
+    assert dict(snapshot.transactions) == {
+        "proposed": 1,
+        "committed": 1,
+        "aborted": 0,
+        "failed": 0,
+    }
+    assert dict(snapshot.commits) == {"full": 0, "terminal_partial": 1}
+    assert snapshot.proposed_draft_tokens == 8
+    assert snapshot.accepted_draft_tokens == 5
+    assert snapshot.committed_tokens == 9
+    assert snapshot.terminal_lanes == 1
+    assert snapshot.cleaned_lanes == 1
+    assert snapshot.open_transaction is False
+
+
+def test_abort_is_single_use_and_does_not_publish_commit_totals() -> None:
+    counters = ContinuousMTPCounters()
+    ticket = counters.begin_transaction(lanes=2, proposed_draft_tokens=4)
+
+    counters.abort_transaction(ticket, reason=AbortReason.DISCONNECTED)
+
+    snapshot = counters.snapshot()
+    assert dict(snapshot.transactions)["aborted"] == 1
+    assert dict(snapshot.aborts)["disconnected"] == 1
+    assert snapshot.committed_tokens == 0
+    with pytest.raises(RuntimeError, match="stale"):
+        counters.abort_transaction(ticket, reason=AbortReason.CALLER)
+
+
+def test_failed_transaction_is_distinct_from_benign_abort() -> None:
+    counters = ContinuousMTPCounters()
+    ticket = counters.begin_transaction(lanes=1, proposed_draft_tokens=2)
+
+    counters.abort_transaction(
+        ticket,
+        reason=AbortReason.COMPUTE_ERROR,
+        failed=True,
+    )
+
+    snapshot = counters.snapshot()
+    assert dict(snapshot.transactions)["failed"] == 1
+    assert dict(snapshot.transactions)["aborted"] == 0
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"accepted_draft_tokens": 9},
+        {"accepted_draft_tokens": 5, "committed_tokens": 4},
+        {"terminal_lanes": 5},
+        {"kind": CommitKind.TERMINAL_PARTIAL, "terminal_lanes": 0},
+    ],
+)
+def test_invalid_commit_does_not_close_transaction(changes) -> None:
+    counters = ContinuousMTPCounters()
+    ticket = counters.begin_transaction(lanes=4, proposed_draft_tokens=8)
+    kwargs = {
+        "accepted_draft_tokens": 4,
+        "committed_tokens": 8,
+        "terminal_lanes": 0,
+        "kind": CommitKind.FULL,
+    }
+    kwargs.update(changes)
+
+    with pytest.raises(ValueError):
+        counters.commit_transaction(ticket, **kwargs)
+
+    assert counters.snapshot().open_transaction is True
+    counters.abort_transaction(ticket, reason=AbortReason.INVARIANT, failed=True)
+
+
+def test_foreign_ticket_cannot_mutate_counters() -> None:
+    counters = ContinuousMTPCounters()
+    ticket = counters.begin_transaction(lanes=1, proposed_draft_tokens=2)
+    foreign = TransactionTicket(ticket.sequence + 1, 1, 2)
+
+    with pytest.raises(RuntimeError, match="foreign"):
+        counters.commit_transaction(
+            foreign,
+            accepted_draft_tokens=1,
+            committed_tokens=2,
+        )
+
+    counters.abort_transaction(ticket, reason=AbortReason.CALLER)
+
+
+def test_clean_synthetic_record_reconciles_but_cannot_qualify_performance() -> None:
+    record = _clean_record()
+
+    result = evaluate_cohort_qualification(record)
+
+    assert result.structurally_valid is True
+    assert result.errors == ()
+    assert result.performance_qualified is False
+    assert record.aggregate_tokens == 8
+    assert record.aggregate_tokens_per_second == 8.0
+
+
+@pytest.mark.parametrize(
+    "record_change,error",
+    [
+        ({"cache_equal": False}, "cache equality"),
+        ({"peak_memory_bytes": 99}, "memory totals"),
+        ({"lanes": ()}, "lane indices"),
+    ],
+)
+def test_qualification_refuses_failed_structural_gates(record_change, error) -> None:
+    record = replace(_clean_record(), **record_change)
+
+    result = evaluate_cohort_qualification(record)
+
+    assert result.structurally_valid is False
+    assert any(error in message for message in result.errors)
+    assert result.performance_qualified is False
+
+
+def test_qualification_reconciles_lane_and_counter_totals() -> None:
+    record = _clean_record()
+    bad_lane = replace(record.lanes[0], output_tokens=3)
+    record = replace(record, lanes=(bad_lane,) + record.lanes[1:])
+
+    result = evaluate_cohort_qualification(record)
+
+    assert result.structurally_valid is False
+    assert "committed token totals do not reconcile" in result.errors
+
+
+def test_divergent_or_unrun_digest_refuses_structural_record() -> None:
+    record = _clean_record()
+    for classification in (
+        DigestClassification.DIVERGENT,
+        DigestClassification.NOT_RUN,
+    ):
+        lane = replace(record.lanes[0], digest=classification)
+        changed = replace(record, lanes=(lane,) + record.lanes[1:])
+        result = evaluate_cohort_qualification(changed)
+        assert "digest classification gate failed" in result.errors
+
+
+def test_hardware_label_without_artifact_digest_cannot_qualify() -> None:
+    record = _clean_record(evidence_kind=EvidenceKind.APPLE_SILICON_HARDWARE)
+
+    result = evaluate_cohort_qualification(record)
+
+    assert result.structurally_valid is True
+    assert result.performance_qualified is False
+
+
+def test_suite_requires_identity_matched_n1_n2_n4() -> None:
+    identity = _identity()
+    records = tuple(_clean_record(size, identity=identity) for size in (1, 2, 4))
+
+    result = evaluate_qualification_suite(records)
+
+    assert result.structurally_complete is True
+    assert result.performance_qualified is False
+    assert result.errors == ()
+
+    wrong_identity = _identity(model_revision="different")
+    mismatched = records[:2] + (_clean_record(4, identity=wrong_identity),)
+    mismatch_result = evaluate_qualification_suite(mismatched)
+    assert mismatch_result.structurally_complete is False
+    assert "suite identities differ" in mismatch_result.errors
+
+
+def test_suite_refuses_missing_cohort() -> None:
+    records = (_clean_record(1), _clean_record(4))
+
+    result = evaluate_qualification_suite(records)
+
+    assert result.structurally_complete is False
+    assert "suite must contain exactly N=1,2,4" in result.errors
+
+
+@pytest.mark.parametrize(
+    "changes,field",
+    [
+        ({"candidate_sha": "a" * 39}, "candidate_sha"),
+        ({"candidate_sha": "A" * 40}, "candidate_sha"),
+        ({"model_id": ""}, "model_id"),
+        ({"config_fingerprint": "x" * 64}, "config_fingerprint"),
+    ],
+)
+def test_qualification_identity_requires_exact_immutable_fingerprints(
+    changes, field
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _identity(**changes)

--- a/tests/test_continuous_mtp_telemetry.py
+++ b/tests/test_continuous_mtp_telemetry.py
@@ -70,7 +70,9 @@ def _clean_record(
             proposed_draft_tokens=2,
             accepted_draft_tokens=1,
             elapsed_seconds=1.0 + index / 10,
-            digest=DigestClassification.EXACT,
+            batched_b1_digest=DigestClassification.EXACT,
+            batch_shape_digest=DigestClassification.EXACT,
+            legacy_single_lane_digest=DigestClassification.EXACT,
             finish_reason=FinishReason.STOP,
         )
         for index in range(cohort_size)
@@ -315,16 +317,81 @@ def test_qualification_reconciles_lane_and_counter_totals() -> None:
     assert "committed token totals do not reconcile" in result.errors
 
 
-def test_divergent_or_unrun_digest_refuses_structural_record() -> None:
+def test_batched_b1_digest_must_be_exact_without_shape_tolerance() -> None:
     record = _clean_record()
     for classification in (
+        DigestClassification.DISTRIBUTIONAL,
         DigestClassification.DIVERGENT,
         DigestClassification.NOT_RUN,
     ):
-        lane = replace(record.lanes[0], digest=classification)
+        lane = replace(record.lanes[0], batched_b1_digest=classification)
         changed = replace(record, lanes=(lane,) + record.lanes[1:])
         result = evaluate_cohort_qualification(changed)
-        assert "digest classification gate failed" in result.errors
+        assert "batched-B1 exact digest gate failed" in result.errors
+
+
+def test_b1_cohort_cannot_claim_a_distributional_batch_shape_band() -> None:
+    record = _clean_record(cohort_size=1)
+    lane = replace(
+        record.lanes[0],
+        batch_shape_digest=DigestClassification.DISTRIBUTIONAL,
+    )
+
+    result = evaluate_cohort_qualification(replace(record, lanes=(lane,)))
+
+    assert result.structurally_valid is False
+    assert "batched-B1 cannot use a batch-shape tolerance" in result.errors
+
+
+def test_bn_may_use_own_b1_distributional_band_but_not_diverge() -> None:
+    record = _clean_record(cohort_size=4)
+    lane = replace(
+        record.lanes[0],
+        batch_shape_digest=DigestClassification.DISTRIBUTIONAL,
+    )
+    banded = replace(record, lanes=(lane,) + record.lanes[1:])
+
+    assert evaluate_cohort_qualification(banded).structurally_valid is True
+
+    divergent = replace(
+        lane,
+        batch_shape_digest=DigestClassification.DIVERGENT,
+    )
+    result = evaluate_cohort_qualification(
+        replace(record, lanes=(divergent,) + record.lanes[1:])
+    )
+    assert result.structurally_valid is False
+    assert "B>1 batch-shape digest gate failed" in result.errors
+
+
+@pytest.mark.parametrize(
+    "classification",
+    [DigestClassification.DIVERGENT, DigestClassification.NOT_RUN],
+)
+def test_legacy_single_lane_comparison_is_informative_only(classification) -> None:
+    record = _clean_record(cohort_size=4)
+    lane = replace(record.lanes[0], legacy_single_lane_digest=classification)
+
+    result = evaluate_cohort_qualification(
+        replace(record, lanes=(lane,) + record.lanes[1:])
+    )
+
+    assert result.structurally_valid is True
+
+
+def test_distributional_band_never_substitutes_for_cache_equality() -> None:
+    record = _clean_record(cohort_size=4)
+    lanes = tuple(
+        replace(lane, batch_shape_digest=DigestClassification.DISTRIBUTIONAL)
+        for lane in record.lanes
+    )
+
+    result = evaluate_cohort_qualification(
+        replace(record, lanes=lanes, cache_equal=False)
+    )
+
+    assert result.structurally_valid is False
+    assert "cache equality gate failed" in result.errors
 
 
 def test_hardware_label_without_artifact_digest_cannot_qualify() -> None:

--- a/tests/test_continuous_self_mtp_engine.py
+++ b/tests/test_continuous_self_mtp_engine.py
@@ -1,0 +1,342 @@
+"""Mock-only tests for the fixed-membership continuous self-MTP engine."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "vllm_mlx"
+    / "spec_decode"
+    / "mtp"
+    / "continuous_engine.py"
+)
+SPEC = importlib.util.spec_from_file_location("continuous_engine_probe", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+engine = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = engine
+SPEC.loader.exec_module(engine)
+
+
+def _capabilities(**overrides):
+    values = {
+        "target_return_hidden": True,
+        "mtp_return_hidden": True,
+        "confirmed_target_forward": True,
+        "ragged_rollback": True,
+        "atomic_cache_commit": True,
+    }
+    values.update(overrides)
+    return engine.ContinuousSelfMTPCapabilities(**values)
+
+
+class _Compute:
+    def __init__(self):
+        self.calls = []
+
+    def prepare(self, spec, forwards):
+        target = forwards.target(spec.prompt, f"target-{spec.uid}", n_confirmed=0)
+        draft = forwards.draft(target[1], spec.prompt, f"draft-{spec.uid}")
+        self.calls.append(("prepare", spec.uid, target, draft))
+        token = 100 + spec.uid
+        return engine.PreparedLaneData(
+            cur=token,
+            seed_hidden=f"hidden-{spec.uid}",
+            token_prefix=(spec.uid,),
+            caches=engine.SelfMTPCachePair(
+                target=[f"target-{spec.uid}"], draft=[f"draft-{spec.uid}"]
+            ),
+            first_token=engine.MTPToken(token, f"lp-{token}", False),
+            backend_state={"uid": spec.uid},
+        )
+
+    def propose(self, lanes, caches, forwards):
+        del caches, forwards
+        self.calls.append(("propose", tuple(lane.uid for lane in lanes)))
+        outputs = []
+        accepted = []
+        for row, lane in enumerate(lanes):
+            n_accept = 1 if row == 0 else 0
+            accepted.append(n_accept)
+            row_outputs = [engine.MTPToken(lane.cur + 1, f"lp-draft-{lane.uid}", True)][
+                :n_accept
+            ]
+            row_outputs.append(
+                engine.MTPToken(lane.cur + 10, f"lp-target-{lane.uid}", False)
+            )
+            outputs.append(tuple(row_outputs))
+        depths = tuple(2 for _ in lanes)
+        accepted_tuple = tuple(accepted)
+        return engine.CycleComputation(
+            lane_uids=tuple(lane.uid for lane in lanes),
+            draft_depths=depths,
+            accepted_lengths=accepted_tuple,
+            target_drops=tuple(2 - count for count in accepted_tuple),
+            draft_drops=depths,
+            outputs=tuple(outputs),
+            payload="opaque-cycle",
+        )
+
+    def commit(self, lanes, computation, *, emitted_counts, terminal):
+        self.calls.append(("commit", computation.payload, emitted_counts, terminal))
+        for lane, outputs in zip(lanes, computation.outputs):
+            if outputs:
+                lane.cur = outputs[-1].token
+
+    def detach_lane(self, lane, caches):
+        self.calls.append(("detach", lane.uid, caches.target, caches.draft))
+
+
+class _Caches:
+    def __init__(self):
+        self.calls = []
+
+    def attach(self, current, joining):
+        self.calls.append(("attach", current, tuple(joining)))
+        target = [] if current is None else list(current.target)
+        draft = [] if current is None else list(current.draft)
+        for item in joining:
+            target.extend(item.target)
+            draft.extend(item.draft)
+        return engine.SelfMTPCachePair(target, draft)
+
+    def rollback(self, caches, *, target_drops, draft_drops, verify_width):
+        self.calls.append(
+            (
+                "rollback",
+                tuple(target_drops),
+                tuple(draft_drops),
+                verify_width,
+            )
+        )
+
+    def detach(self, caches, indices, keep_indices):
+        self.calls.append(("detach", tuple(indices), tuple(keep_indices)))
+        detached = [
+            engine.SelfMTPCachePair([caches.target[index]], [caches.draft[index]])
+            for index in indices
+        ]
+        remaining = engine.SelfMTPCachePair(
+            [caches.target[index] for index in keep_indices],
+            [caches.draft[index] for index in keep_indices],
+        )
+        return remaining, detached
+
+
+def _runtime(*, config=None, capabilities=None):
+    calls = []
+
+    def target(inputs, **kwargs):
+        calls.append(("target", inputs, kwargs))
+        return "target-logits", f"target-hidden-{inputs}"
+
+    def draft(hidden, token_ids, cache, **kwargs):
+        calls.append(("draft", hidden, token_ids, cache, kwargs))
+        return "draft-logits", "draft-hidden"
+
+    compute = _Compute()
+    caches = _Caches()
+    runtime = engine.ContinuousSelfMTPRuntime(
+        config=config or engine.ContinuousSelfMTPConfig(enabled=True),
+        capabilities=capabilities or _capabilities(),
+        forwards=engine.RapidForwardSeams(target, draft),
+        compute=compute,
+        caches=caches,
+    )
+    return runtime, compute, caches, calls
+
+
+def _prepare(runtime, uid, **spec_kwargs):
+    spec = engine.SelfMTPLaneSpec(
+        uid=uid,
+        prompt=(uid, uid + 1),
+        max_tokens=20,
+        num_draft=2,
+        **spec_kwargs,
+    )
+    return engine.prepare_self_mtp_lane(spec, runtime)
+
+
+def test_rapid_forward_seams_use_return_hidden_and_n_confirmed():
+    runtime, _compute, _caches, calls = _runtime()
+    detached, first = _prepare(runtime, 1)
+
+    assert first.token == detached.lane.cur == 101
+    assert calls[0] == (
+        "target",
+        (1, 2),
+        {
+            "cache": "target-1",
+            "return_hidden": True,
+            "n_confirmed": 0,
+        },
+    )
+    assert calls[1][-1] == {"return_hidden": True}
+
+
+def test_fixed_membership_prepare_attach_propose_commit_detach_lifecycle():
+    runtime, compute, caches, _calls = _runtime()
+    lane1, first1 = _prepare(runtime, 1)
+    lane2, first2 = _prepare(runtime, 2)
+    assert (first1.token, first2.token) == (101, 102)
+
+    batch = engine.attach_self_mtp_lanes(None, [lane1, lane2])
+    assert [lane.uid for lane in batch.lanes] == [1, 2]
+    assert batch.membership_epoch == 1
+
+    proposal = engine.propose_batched_self_mtp(batch)
+    assert proposal.lane_uids == (1, 2)
+    assert proposal.accepted_lengths == (1, 0)
+    assert caches.calls[-1] == ("rollback", (1, 2), (2, 2), 3)
+    with pytest.raises(engine.ContinuousSelfMTPError, match="proposal is open"):
+        engine.detach_self_mtp_lanes(batch, [0, 1])
+
+    engine.commit_batched_self_mtp(
+        batch,
+        proposal,
+        emitted_counts=[2, 1],
+        terminal=[False, False],
+    )
+    assert [lane.ntoks for lane in batch.lanes] == [3, 2]
+    assert compute.calls[-1] == (
+        "commit",
+        "opaque-cycle",
+        (2, 1),
+        (False, False),
+    )
+
+    previous_epoch = batch.membership_epoch
+    batch, detached = engine.detach_self_mtp_lanes(batch, [0, 1])
+    assert batch.lanes == []
+    assert batch.membership_epoch == previous_epoch + 1
+    assert [item.lane.uid for item in detached] == [1, 2]
+
+
+def test_default_off_refuses_before_compute():
+    runtime, compute, _caches, _calls = _runtime(
+        config=engine.ContinuousSelfMTPConfig()
+    )
+    with pytest.raises(engine.ContinuousSelfMTPUnsupportedError, match="disabled"):
+        _prepare(runtime, 1)
+    assert compute.calls == []
+
+
+def test_xtc_is_unconditionally_fail_closed():
+    runtime, compute, _caches, _calls = _runtime(
+        capabilities=_capabilities(
+            transformed_sampling=True,
+            logits_processors_exact=True,
+            dynamic_membership=True,
+            flash_dynamic_membership_attested=True,
+        )
+    )
+    sampling = engine.SelfMTPSampling(temperature=0.8, uses_xtc=True)
+    with pytest.raises(engine.ContinuousSelfMTPUnsupportedError, match="XTC"):
+        _prepare(runtime, 1, sampling=sampling)
+    assert compute.calls == []
+
+
+def test_fixed_membership_refuses_incremental_attach_and_partial_detach():
+    runtime, _compute, _caches, _calls = _runtime()
+    lane1, _ = _prepare(runtime, 1)
+    lane2, _ = _prepare(runtime, 2)
+    batch = engine.attach_self_mtp_lanes(None, [lane1, lane2])
+    lane3, _ = _prepare(runtime, 3)
+
+    with pytest.raises(
+        engine.ContinuousSelfMTPUnsupportedError, match="fixed-membership"
+    ):
+        engine.attach_self_mtp_lanes(batch, [lane3])
+    with pytest.raises(
+        engine.ContinuousSelfMTPUnsupportedError, match="fixed-membership"
+    ):
+        engine.detach_self_mtp_lanes(batch, [1])
+
+
+def test_flash_dynamic_membership_requires_specific_attestation():
+    config = engine.ContinuousSelfMTPConfig(
+        enabled=True,
+        allow_dynamic_membership=True,
+        architecture="qwen4-flash-next",
+    )
+    runtime, _compute, _caches, _calls = _runtime(
+        config=config,
+        capabilities=_capabilities(dynamic_membership=True),
+    )
+    lane1, _ = _prepare(runtime, 1)
+    batch = engine.attach_self_mtp_lanes(None, [lane1])
+    lane2, _ = _prepare(runtime, 2)
+    with pytest.raises(engine.ContinuousSelfMTPUnsupportedError, match="Flash dynamic"):
+        engine.attach_self_mtp_lanes(batch, [lane2])
+
+
+def test_attested_flash_runtime_can_use_explicit_dynamic_seam():
+    config = engine.ContinuousSelfMTPConfig(
+        enabled=True,
+        allow_dynamic_membership=True,
+        architecture="qwen4-flash-next",
+    )
+    runtime, _compute, _caches, _calls = _runtime(
+        config=config,
+        capabilities=_capabilities(
+            dynamic_membership=True,
+            flash_dynamic_membership_attested=True,
+        ),
+    )
+    lane1, _ = _prepare(runtime, 1)
+    lane2, _ = _prepare(runtime, 2)
+    batch = engine.attach_self_mtp_lanes(None, [lane1])
+    batch = engine.attach_self_mtp_lanes(batch, [lane2])
+    assert [lane.uid for lane in batch.lanes] == [1, 2]
+    batch, detached = engine.detach_self_mtp_lanes(batch, [1])
+    assert [lane.uid for lane in batch.lanes] == [1]
+    assert detached[0].lane.uid == 2
+
+
+def test_commit_rejects_partial_nonterminal_delivery_without_closing_cycle():
+    runtime, _compute, _caches, _calls = _runtime()
+    lane1, _ = _prepare(runtime, 1)
+    lane2, _ = _prepare(runtime, 2)
+    batch = engine.attach_self_mtp_lanes(None, [lane1, lane2])
+    proposal = engine.propose_batched_self_mtp(batch)
+
+    with pytest.raises(ValueError, match="nonterminal lane"):
+        engine.commit_batched_self_mtp(
+            batch,
+            proposal,
+            emitted_counts=[1, 1],
+            terminal=[False, False],
+        )
+    assert batch.proposal_open is True
+    assert [lane.ntoks for lane in batch.lanes] == [1, 1]
+
+
+@pytest.mark.parametrize(
+    ("emitted", "terminal", "message"),
+    [
+        ([True, 1], [False, False], "emitted_counts values"),
+        ([1.0, 1], [False, False], "emitted_counts values"),
+        ([2, 1], [0, False], "terminal values"),
+        ([2, 1], ["yes", False], "terminal values"),
+    ],
+)
+def test_commit_rejects_coercible_vector_values(emitted, terminal, message):
+    runtime, _compute, _caches, _calls = _runtime()
+    lane1, _ = _prepare(runtime, 1)
+    lane2, _ = _prepare(runtime, 2)
+    batch = engine.attach_self_mtp_lanes(None, [lane1, lane2])
+    proposal = engine.propose_batched_self_mtp(batch)
+
+    with pytest.raises(ValueError, match=message):
+        engine.commit_batched_self_mtp(
+            batch,
+            proposal,
+            emitted_counts=emitted,
+            terminal=terminal,
+        )
+    assert batch.proposal_open is True
+    assert [lane.ntoks for lane in batch.lanes] == [1, 1]

--- a/tests/test_continuous_self_mtp_mlx_backend.py
+++ b/tests/test_continuous_self_mtp_mlx_backend.py
@@ -1,0 +1,357 @@
+"""CPU/mock contracts for the Rapid continuous self-MTP data plane."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vllm_mlx.spec_decode.mtp.continuous_engine import (
+    ContinuousSelfMTPCapabilities,
+    ContinuousSelfMTPConfig,
+    ContinuousSelfMTPRuntime,
+    RapidForwardSeams,
+    SelfMTPCachePair,
+    SelfMTPLaneSpec,
+    SelfMTPSampling,
+    attach_self_mtp_lanes,
+    commit_batched_self_mtp,
+    detach_self_mtp_lanes,
+    prepare_self_mtp_lane,
+    propose_batched_self_mtp,
+)
+from vllm_mlx.spec_decode.mtp.continuous_engine import (
+    ContinuousSelfMTPUnsupportedError as ContinuousSelfMTPUnsupported,
+)
+from vllm_mlx.spec_decode.mtp.mlx_backend import (
+    RapidMLXSelfMTPBackend,
+    RapidRaggedCacheAdapter,
+)
+
+
+class _NumpyOps:
+    @staticmethod
+    def uint32(value):
+        return np.asarray(value, dtype=np.uint32)
+
+    @staticmethod
+    def concatenate(values, *, axis):
+        return np.concatenate(list(values), axis=axis)
+
+    @staticmethod
+    def pad(value, widths):
+        return np.pad(value, widths)
+
+    @staticmethod
+    def expand_dims(value, axis):
+        return np.expand_dims(value, axis)
+
+    @staticmethod
+    def logprobs(logits):
+        logits = np.asarray(logits, dtype=np.float64)
+        shifted = logits - np.max(logits, axis=-1, keepdims=True)
+        return shifted - np.log(np.exp(shifted).sum(axis=-1, keepdims=True))
+
+    @staticmethod
+    def argmax_int(logprobs):
+        return int(np.argmax(logprobs, axis=-1))
+
+
+class _LayerCache:
+    def __init__(self, label, rows=None):
+        self.label = label
+        self.rows = list([label] if rows is None else rows)
+        self.events = []
+
+    @classmethod
+    def merge(cls, caches):
+        merged = cls("merged", [])
+        for cache in caches:
+            merged.rows.extend(cache.rows)
+        return merged
+
+    def extend(self, other):
+        self.events.append(("extend", tuple(other.rows)))
+        self.rows.extend(other.rows)
+
+    def prepare(self, *, lengths, right_padding):
+        self.events.append(("prepare", tuple(lengths), tuple(right_padding)))
+
+    def finalize(self):
+        self.events.append(("finalize",))
+
+    def extract(self, index):
+        self.events.append(("extract", index))
+        return type(self)(f"{self.label}:{index}", [self.rows[index]])
+
+    def filter(self, indices):
+        self.events.append(("filter", tuple(indices)))
+        self.rows = [self.rows[index] for index in indices]
+
+
+class _FakeForwards:
+    def __init__(self):
+        self.calls = []
+
+    @staticmethod
+    def _logits(tokens, chosen):
+        batch, width = tokens.shape
+        logits = np.full((batch, width, 32), -20.0)
+        for row in range(batch):
+            for position in range(width):
+                logits[row, position, chosen(row, position)] = 20.0
+        return logits
+
+    def target(self, inputs, *, cache, return_hidden, n_confirmed):
+        tokens = np.asarray(inputs)
+        self.calls.append(("target", tokens.copy(), cache, return_hidden, n_confirmed))
+        hidden = np.repeat(tokens[..., None].astype(float), 4, axis=-1)
+        if tokens.shape[1] == 3:
+            # Row 0 accepts d1 then rejects d2; row 1 accepts both.
+            selected = (
+                [int(tokens[0, 1]), 19, 20]
+                if tokens.shape[0] == 1
+                else [
+                    [int(tokens[0, 1]), 19, 20],
+                    [int(tokens[1, 1]), int(tokens[1, 2]), 10],
+                ]
+            )
+            if tokens.shape[0] == 1:
+                logits = self._logits(tokens, lambda _r, p: selected[p])
+            else:
+                logits = self._logits(tokens, lambda r, p: selected[r][p])
+        else:
+            logits = self._logits(tokens, lambda r, p: (int(tokens[r, p]) + 1) % 32)
+        return logits, hidden
+
+    def draft(self, hidden, token_ids, cache, *, return_hidden):
+        tokens = np.asarray(token_ids)
+        self.calls.append(
+            ("draft", np.asarray(hidden).copy(), tokens.copy(), cache, return_hidden)
+        )
+        logits = self._logits(tokens, lambda r, p: (int(tokens[r, p]) + 1) % 32)
+        post = np.repeat(tokens[..., None].astype(float) + 0.5, 4, axis=-1)
+        return logits, post
+
+
+def _runtime():
+    forward = _FakeForwards()
+    backend = RapidMLXSelfMTPBackend(
+        target_cache_factory=lambda: [_LayerCache("target")],
+        draft_cache_factory=lambda: [_LayerCache("draft")],
+        array_ops=_NumpyOps(),
+        prefill_step_size=8,
+    )
+    cache_events = []
+
+    def preflight(group, drops, **kwargs):
+        cache_events.append(("preflight", tuple(drops), kwargs))
+
+    def trim(group, drops, **kwargs):
+        cache_events.append(("trim", tuple(drops), kwargs))
+
+    cache_adapter = RapidRaggedCacheAdapter(preflight=preflight, trim=trim)
+    runtime = ContinuousSelfMTPRuntime(
+        config=ContinuousSelfMTPConfig(enabled=True),
+        capabilities=ContinuousSelfMTPCapabilities(
+            target_return_hidden=True,
+            mtp_return_hidden=True,
+            confirmed_target_forward=True,
+            ragged_rollback=True,
+            atomic_cache_commit=True,
+        ),
+        forwards=RapidForwardSeams(forward.target, forward.draft),
+        compute=backend,
+        caches=cache_adapter,
+    )
+    return runtime, forward, cache_events
+
+
+def _prepare(runtime, uid, prompt):
+    return prepare_self_mtp_lane(
+        SelfMTPLaneSpec(
+            uid=uid,
+            prompt=prompt,
+            max_tokens=12,
+            num_draft=2,
+        ),
+        runtime,
+    )
+
+
+def test_k2_recursive_draft_target_verify_and_delivery_commit():
+    runtime, forward, cache_events = _runtime()
+    detached0, first0 = _prepare(runtime, 0, [1, 2])
+    detached1, first1 = _prepare(runtime, 1, [5, 6])
+    assert (first0.token, first1.token) == (3, 7)
+    batch = attach_self_mtp_lanes(None, [detached0, detached1])
+
+    proposal = propose_batched_self_mtp(batch)
+    assert proposal.draft_depths == (2, 2)
+    assert proposal.accepted_lengths == (1, 2)
+    assert [[token.token for token in row] for row in proposal.outputs] == [
+        [4, 19],
+        [8, 9, 10],
+    ]
+    verify = [call for call in forward.calls if call[0] == "target"][-1]
+    assert verify[1].tolist() == [[3, 4, 5], [7, 8, 9]]
+    assert verify[-1] == 2  # Rapid n_confirmed ABI for a K=2 verify.
+    assert ("trim", (1, 0), {"verify_size": 3, "validate": False}) in cache_events
+    assert ("trim", (2, 2), {"verify_size": 3, "validate": False}) in cache_events
+
+    commit_batched_self_mtp(
+        batch,
+        proposal,
+        emitted_counts=[2, 3],
+        terminal=[False, False],
+    )
+    assert [lane.cur for lane in batch.lanes] == [19, 10]
+    assert [lane.pending_tokens for lane in batch.lanes] == [[3, 4], [7, 8, 9]]
+    assert [lane.ntoks for lane in batch.lanes] == [3, 4]
+
+
+def test_next_cycle_flushes_persistent_pending_pairs_before_new_drafts():
+    runtime, forward, _events = _runtime()
+    lane0, _ = _prepare(runtime, 0, [1, 2])
+    lane1, _ = _prepare(runtime, 1, [5, 6])
+    batch = attach_self_mtp_lanes(None, [lane0, lane1])
+    first = propose_batched_self_mtp(batch)
+    commit_batched_self_mtp(
+        batch, first, emitted_counts=[2, 3], terminal=[False, False]
+    )
+
+    draft_calls_before = len([call for call in forward.calls if call[0] == "draft"])
+    propose_batched_self_mtp(batch)
+    draft_calls = [call for call in forward.calls if call[0] == "draft"]
+    first_cycle_call = draft_calls[draft_calls_before]
+    # Pending [old cur + accepted drafts] plus current bonus are flushed in one
+    # recursive first-head job; rows are padded to the longest valid length.
+    assert first_cycle_call[2].shape == (2, 4)
+    assert first_cycle_call[2][0].tolist() == [3, 4, 19, 0]
+    assert first_cycle_call[2][1].tolist() == [7, 8, 9, 10]
+
+
+def test_terminal_delivery_prefix_updates_cur_seed_and_detach_flushes_debt():
+    runtime, forward, _events = _runtime()
+    lane0, _ = _prepare(runtime, 0, [1, 2])
+    lane1, _ = _prepare(runtime, 1, [5, 6])
+    batch = attach_self_mtp_lanes(None, [lane0, lane1])
+    proposal = propose_batched_self_mtp(batch)
+    commit_batched_self_mtp(
+        batch,
+        proposal,
+        emitted_counts=[1, 2],
+        terminal=[True, True],
+    )
+    assert [lane.cur for lane in batch.lanes] == [4, 9]
+    assert [lane.pending_tokens for lane in batch.lanes] == [[3], [7, 8]]
+
+    draft_count = len([call for call in forward.calls if call[0] == "draft"])
+    batch, detached = detach_self_mtp_lanes(batch, [0, 1])
+    assert batch.lanes == []
+    assert [item.lane.uid for item in detached] == [0, 1]
+    flushes = [call for call in forward.calls if call[0] == "draft"][draft_count:]
+    assert [call[2].tolist() for call in flushes] == [[[3]], [[7, 8]]]
+    assert all(item.lane.pending_tokens == [] for item in detached)
+
+
+def test_transformed_sampling_fails_closed_without_residual_hooks():
+    runtime, _forward, _events = _runtime()
+    runtime = ContinuousSelfMTPRuntime(
+        config=runtime.config,
+        capabilities=ContinuousSelfMTPCapabilities(
+            target_return_hidden=True,
+            mtp_return_hidden=True,
+            confirmed_target_forward=True,
+            ragged_rollback=True,
+            atomic_cache_commit=True,
+            transformed_sampling=True,
+        ),
+        forwards=runtime.forwards,
+        compute=runtime.compute,
+        caches=runtime.caches,
+    )
+    with pytest.raises(ContinuousSelfMTPUnsupported, match="residual hooks"):
+        prepare_self_mtp_lane(
+            SelfMTPLaneSpec(
+                uid=0,
+                prompt=[1, 2],
+                max_tokens=8,
+                num_draft=2,
+                sampling=SelfMTPSampling(temperature=0.8),
+            ),
+            runtime,
+        )
+
+
+def test_cache_adapter_merge_extend_extract_filter_and_atomic_preflight():
+    events = []
+    adapter = RapidRaggedCacheAdapter(
+        preflight=lambda group, drops, **kwargs: events.append(
+            ("preflight", tuple(drops), kwargs)
+        ),
+        trim=lambda group, drops, **kwargs: events.append(
+            ("trim", tuple(drops), kwargs)
+        ),
+    )
+    one = SelfMTPCachePair([_LayerCache("t1")], [_LayerCache("d1")])
+    two = SelfMTPCachePair([_LayerCache("t2")], [_LayerCache("d2")])
+    merged = adapter.attach(None, [one, two])
+    assert merged.target[0].rows == ["t1", "t2"]
+    assert merged.draft[0].rows == ["d1", "d2"]
+
+    adapter.rollback(
+        merged,
+        target_drops=[1, 0],
+        draft_drops=[2, 2],
+        verify_width=3,
+    )
+    assert [event[0] for event in events] == [
+        "preflight",
+        "preflight",
+        "trim",
+        "trim",
+    ]
+    remaining, detached = adapter.detach(merged, [1], [0])
+    assert remaining.target[0].rows == ["t1"]
+    assert detached[0].target[0].rows == ["t2"]
+
+    third = SelfMTPCachePair([_LayerCache("t3")], [_LayerCache("d3")])
+    adapter.attach(remaining, [third])
+    assert remaining.target[0].rows == ["t1", "t3"]
+
+
+@pytest.mark.parametrize("name", ["QuantizedKVCache", "SinkWindowKVCache"])
+def test_cache_adapter_rejects_quantized_and_windowed_classes(name):
+    unsupported = type(name, (_LayerCache,), {})
+    pair = SelfMTPCachePair([unsupported("target")], [_LayerCache("draft")])
+    adapter = RapidRaggedCacheAdapter(
+        preflight=lambda *a, **k: None, trim=lambda *a, **k: None
+    )
+    with pytest.raises(ContinuousSelfMTPUnsupported, match="unsupported"):
+        adapter.attach(None, [pair])
+
+
+def test_backend_has_no_eager_mlx_import_and_uses_only_rapid_forward_seams():
+    source = (
+        Path(__file__).parents[1]
+        / "vllm_mlx"
+        / "spec_decode"
+        / "mtp"
+        / "mlx_backend.py"
+    ).read_text()
+    tree = ast.parse(source)
+    eager_mlx = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        and (
+            any(alias.name.startswith("mlx") for alias in getattr(node, "names", []))
+            or getattr(node, "module", "") == "mlx.core"
+        )
+    ]
+    assert eager_mlx == []
+    assert "forwards.target(" in source
+    assert "forwards.draft(" in source

--- a/tests/test_continuous_self_mtp_mlx_backend.py
+++ b/tests/test_continuous_self_mtp_mlx_backend.py
@@ -30,6 +30,8 @@ from vllm_mlx.spec_decode.mtp.mlx_backend import (
     RapidRaggedCacheAdapter,
 )
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 class _NumpyOps:
     @staticmethod
@@ -91,6 +93,56 @@ class _LayerCache:
         self.rows = [self.rows[index] for index in indices]
 
 
+class _SharedQSAFake(_LayerCache):
+    def __init__(self, label, rows=None):
+        super().__init__(label, rows)
+        self._mtp_share_topk = False
+        self._mtp_shared_topk = None
+
+    def begin_self_mtp_cycle(self):
+        assert self._mtp_share_topk is False
+        assert self._mtp_shared_topk is None
+        self._mtp_share_topk = True
+        self.events.append(("share_begin",))
+
+    def end_self_mtp_cycle(self):
+        self.events.append(("share_end", self._mtp_shared_topk))
+        self._mtp_share_topk = False
+        self._mtp_shared_topk = None
+
+    def prepare_self_mtp_step(self, *, lengths, right_padding):
+        assert self._mtp_share_topk is True
+        mode = "capture" if self._mtp_shared_topk is None else "reuse"
+        self.events.append(
+            ("share_prepare", mode, tuple(lengths), tuple(right_padding))
+        )
+        if self._mtp_shared_topk is None:
+            self._mtp_shared_topk = tuple(
+                f"row-{index}" for index in range(len(lengths))
+            )
+
+    def finalize_self_mtp_step(self):
+        assert self._mtp_share_topk is True
+        assert self._mtp_shared_topk is not None
+        self.events.append(("share_finalize", self._mtp_shared_topk))
+
+
+class _CacheListFake:
+    """Production-shaped composite: one ordinary KV plus one QSA sidecar."""
+
+    def __init__(self, *caches):
+        self.caches = list(caches)
+
+    @classmethod
+    def merge(cls, cache_lists):
+        return cls(
+            *(
+                type(rows[0]).merge(list(rows))
+                for rows in zip(*(cache_list.caches for cache_list in cache_lists))
+            )
+        )
+
+
 class _FakeForwards:
     def __init__(self):
         self.calls = []
@@ -136,12 +188,13 @@ class _FakeForwards:
         return logits, post
 
 
-def _runtime():
+def _runtime(*, share_qsa_indices=False, draft_cache_factory=None):
     forward = _FakeForwards()
     backend = RapidMLXSelfMTPBackend(
         target_cache_factory=lambda: [_LayerCache("target")],
-        draft_cache_factory=lambda: [_LayerCache("draft")],
+        draft_cache_factory=draft_cache_factory or (lambda: [_LayerCache("draft")]),
         array_ops=_NumpyOps(),
+        share_qsa_indices=share_qsa_indices,
         prefill_step_size=8,
     )
     cache_events = []
@@ -231,6 +284,45 @@ def test_next_cycle_flushes_persistent_pending_pairs_before_new_drafts():
     assert first_cycle_call[2].shape == (2, 4)
     assert first_cycle_call[2][0].tolist() == [3, 4, 19, 0]
     assert first_cycle_call[2][1].tolist() == [7, 8, 9, 10]
+
+
+def test_recursive_drafts_preserve_qsa_selection_then_disarm_cycle():
+    runtime, _forward, _events = _runtime(
+        share_qsa_indices=True,
+        draft_cache_factory=lambda: [
+            _CacheListFake(_LayerCache("kv"), _SharedQSAFake("qsa"))
+        ],
+    )
+    lane0, _ = _prepare(runtime, 0, [1, 2])
+    lane1, _ = _prepare(runtime, 1, [5, 6])
+    batch = attach_self_mtp_lanes(None, [lane0, lane1])
+    merged_cache_list = batch.caches.draft[0]
+    merged_kv, merged_qsa = merged_cache_list.caches
+
+    propose_batched_self_mtp(batch)
+
+    share_events = [
+        event for event in merged_qsa.events if event[0].startswith("share_")
+    ]
+    assert [event[0] for event in share_events] == [
+        "share_begin",
+        "share_prepare",
+        "share_finalize",
+        "share_prepare",
+        "share_finalize",
+        "share_end",
+    ]
+    assert share_events[1][1] == "capture"
+    assert share_events[3][1] == "reuse"
+    assert share_events[-1][1] == ("row-0", "row-1")
+    assert merged_qsa._mtp_share_topk is False
+    assert merged_qsa._mtp_shared_topk is None
+    assert [event[0] for event in merged_kv.events] == [
+        "prepare",
+        "finalize",
+        "prepare",
+        "finalize",
+    ]
 
 
 def test_terminal_delivery_prefix_updates_cur_seed_and_detach_flushes_debt():
@@ -355,3 +447,16 @@ def test_backend_has_no_eager_mlx_import_and_uses_only_rapid_forward_seams():
     assert eager_mlx == []
     assert "forwards.target(" in source
     assert "forwards.draft(" in source
+
+
+def test_qwen4_qsa_source_has_cycle_local_capture_reuse_and_cleanup():
+    cache_source = (ROOT / "vllm_mlx/models/qwen4_exp_cache.py").read_text()
+    model_source = (ROOT / "vllm_mlx/models/qwen4_exp.py").read_text()
+
+    assert "def begin_self_mtp_cycle" in cache_source
+    assert "def prepare_self_mtp_step" in cache_source
+    assert "def finalize_self_mtp_step" in cache_source
+    assert "def end_self_mtp_cycle" in cache_source
+    assert "capture_shared = cache._mtp_share_topk" in model_source
+    assert "cache._mtp_shared_topk = mx.stack(shared_rows)" in model_source
+    assert "shared_topk[batch_index : batch_index + 1]" in model_source

--- a/tests/test_continuous_self_mtp_residual_sampling.py
+++ b/tests/test_continuous_self_mtp_residual_sampling.py
@@ -1,0 +1,353 @@
+"""NumPy-only gates for transformed continuous self-MTP verification."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vllm_mlx.spec_decode.mtp.continuous_engine import (
+    ContinuousSelfMTPUnsupportedError,
+    SelfMTPLane,
+    SelfMTPSampling,
+)
+from vllm_mlx.spec_decode.mtp.mlx_backend import RapidMLXSelfMTPBackend
+from vllm_mlx.spec_decode.mtp.residual_sampling import (
+    TransformedResidualSamplingHooks,
+    TransformedSamplingProfile,
+)
+
+
+class _NumpyResidualOps:
+    def __init__(self, seed=0):
+        self.rng = np.random.default_rng(seed)
+        self.transform_calls = 0
+
+    @staticmethod
+    def _logsumexp_native(values):
+        values = np.asarray(values)
+        maximum = np.max(values, axis=-1, keepdims=True)
+        exponentials = np.exp(values - maximum).astype(values.dtype)
+        total = np.sum(exponentials, axis=-1, keepdims=True, dtype=values.dtype)
+        return (maximum + np.log(total).astype(values.dtype)).astype(values.dtype)
+
+    def native_logprobs(self, logits):
+        self.transform_calls += 1
+        logits = np.asarray(logits)
+        return (logits - self._logsumexp_native(logits)).astype(logits.dtype)
+
+    @staticmethod
+    def top_p(logprobs, value):
+        values = np.asarray(logprobs)
+        indices = np.argsort(values, axis=-1)
+        probabilities = np.exp(values)
+        sorted_probabilities = np.take_along_axis(probabilities, indices, axis=-1)
+        cumulative = np.cumsum(sorted_probabilities, axis=-1)
+        inverse = np.argsort(indices, axis=-1)
+        cumulative = np.take_along_axis(cumulative, inverse, axis=-1)
+        return np.where(cumulative > 1 - value, values, -np.inf)
+
+    @staticmethod
+    def min_p(logprobs, value, min_tokens):
+        values = np.asarray(logprobs)
+        remove = values < np.max(values, axis=-1, keepdims=True) + np.log(value)
+        if min_tokens > 1:
+            indices = np.argpartition(values, -min_tokens, axis=-1)[..., -min_tokens:]
+            np.put_along_axis(remove, indices, False, axis=-1)
+        return np.where(remove, -np.inf, values)
+
+    @staticmethod
+    def top_k(logprobs, value):
+        values = np.asarray(logprobs)
+        vocab = values.shape[-1]
+        if not 0 < value < vocab:
+            raise ValueError(f"top_k must be in (0, {vocab}); got {value}")
+        indices = np.argpartition(-values, value - 1, axis=-1)[..., value:]
+        result = values.copy()
+        np.put_along_axis(result, indices, -np.inf, axis=-1)
+        return result
+
+    @staticmethod
+    def scaled_float32_logprobs(logprobs, temperature):
+        values = (np.asarray(logprobs) * (1 / temperature)).astype(np.float32)
+        maximum = np.max(values, axis=-1, keepdims=True)
+        total = np.sum(np.exp(values - maximum), axis=-1, keepdims=True)
+        return values - (maximum + np.log(total))
+
+    def categorical(self, logprobs):
+        probabilities = np.exp(np.asarray(logprobs, dtype=np.float64))
+        probabilities /= probabilities.sum()
+        return int(self.rng.choice(len(probabilities), p=probabilities))
+
+    @staticmethod
+    def gather_rows(logprobs, tokens):
+        values = np.asarray(logprobs)
+        return values[np.arange(len(tokens)), np.asarray(tokens)]
+
+    @staticmethod
+    def stack(values):
+        return np.stack(values)
+
+    @staticmethod
+    def exp(value):
+        return np.exp(value)
+
+    @staticmethod
+    def minimum_scalar(value, scalar):
+        return np.minimum(value, scalar)
+
+    @staticmethod
+    def maximum_scalar(value, scalar):
+        return np.maximum(value, scalar)
+
+    @staticmethod
+    def subtract(left, right):
+        return left - right
+
+    @staticmethod
+    def sum_float(value):
+        return float(np.sum(value))
+
+    @staticmethod
+    def normalize_probabilities_to_logprobs(probabilities):
+        probabilities = np.asarray(probabilities)
+        with np.errstate(divide="ignore"):
+            return np.log(probabilities / probabilities.sum())
+
+    def uniforms(self, count):
+        return self.rng.uniform(size=count).tolist()
+
+    @staticmethod
+    def tolist(value):
+        return np.asarray(value).tolist()
+
+
+class _CombinedOps(_NumpyResidualOps):
+    @staticmethod
+    def uint32(value):
+        return np.asarray(value, dtype=np.uint32)
+
+    @staticmethod
+    def concatenate(values, *, axis):
+        return np.concatenate(list(values), axis=axis)
+
+    @staticmethod
+    def pad(value, widths):
+        return np.pad(value, widths)
+
+    @staticmethod
+    def expand_dims(value, axis):
+        return np.expand_dims(value, axis)
+
+    @staticmethod
+    def logprobs(logits):
+        values = np.asarray(logits, dtype=np.float64)
+        maximum = np.max(values, axis=-1, keepdims=True)
+        return (
+            values
+            - maximum
+            - np.log(np.exp(values - maximum).sum(axis=-1, keepdims=True))
+        )
+
+    @staticmethod
+    def argmax_int(logprobs):
+        return int(np.argmax(logprobs))
+
+
+def _hook(profile, *, seed=0, ops=None):
+    return TransformedResidualSamplingHooks(
+        TransformedSamplingProfile(**profile),
+        array_ops=ops or _NumpyResidualOps(seed),
+    )
+
+
+PROFILES = [
+    dict(temperature=1.0, top_p=0.95, top_k=20, min_p=0.0),
+    dict(temperature=0.7, top_p=0.8, top_k=20, min_p=0.0),
+    dict(temperature=0.9, top_p=0.6, top_k=0, min_p=0.0),
+    dict(temperature=1.3, top_p=1.0, top_k=5, min_p=0.0),
+    dict(temperature=0.8, top_p=1.0, top_k=0, min_p=0.05),
+    dict(temperature=0.7, top_p=0.85, top_k=12, min_p=0.02),
+]
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_transformed_profiles_are_normalized_and_respect_filter_support(profile):
+    logits = np.random.default_rng(17).normal(size=32).astype(np.float32) * 2
+    hooks = _hook(profile)
+    transformed = hooks.logprobs(logits, profile["temperature"])
+    probabilities = np.exp(transformed)
+    assert probabilities.sum() == pytest.approx(1.0, abs=1e-6)
+
+    # Independent filter-chain reference in Rapid order.
+    reference_ops = _NumpyResidualOps()
+    reference = reference_ops.native_logprobs(logits)
+    if 0 < profile["top_p"] < 1:
+        reference = reference_ops.top_p(reference, profile["top_p"])
+    if profile["min_p"]:
+        reference = reference_ops.min_p(reference, profile["min_p"], 1)
+    if profile["top_k"]:
+        reference = reference_ops.top_k(reference, profile["top_k"])
+    assert set(np.flatnonzero(np.isfinite(transformed))) == set(
+        np.flatnonzero(np.isfinite(reference))
+    )
+
+
+def test_temperature_only_and_top_p_zero_match_direct_softmax():
+    logits = np.array([3.0, 2.0, 0.0, -1.0], dtype=np.float32)
+    profile = dict(temperature=0.7, top_p=0.0)
+    transformed = _hook(profile).logprobs(logits, 0.7)
+    scaled = logits.astype(np.float32) / 0.7
+    expected = scaled - np.log(np.exp(scaled).sum())
+    assert transformed == pytest.approx(expected, abs=1e-6)
+
+
+def test_top_k_and_min_p_boundary_semantics():
+    logits = np.array([1.0, 0.5, 0.5, 0.5, 0.0, -1.0])
+    top_k = _hook(dict(temperature=0.8, top_k=2)).logprobs(logits, 0.8)
+    assert np.isfinite(top_k).sum() == 2
+    assert np.isfinite(top_k[0])
+
+    min_p_logits = np.array([0.0, np.log(0.1), np.log(0.05), -6.0])
+    min_p = _hook(dict(temperature=1.0, min_p=0.1)).logprobs(min_p_logits, 1.0)
+    # Strict '<' keeps a token exactly at max probability * min_p.
+    assert np.isfinite(min_p[1])
+    assert not np.isfinite(min_p[3])
+
+
+def test_disjoint_support_forces_rejection_and_target_residual():
+    target_logits = np.array([3.0, 2.5, 2.0, -1.0, -1.5, -2.0])
+    draft_logits = np.array([-1.0, -1.5, -2.0, 3.0, 2.5, 2.0])
+    hooks = _hook(dict(temperature=0.8, top_k=3), seed=9)
+    target = hooks.logprobs(target_logits, 0.8)
+    draft = hooks.logprobs(draft_logits, 0.8)
+    target_rows = np.stack([target, target, target])
+    for _ in range(100):
+        drafts = [hooks.sample(draft, 0.8), hooks.sample(draft, 0.8)]
+        accepted, bonus = hooks.verify(target_rows, [draft, draft], drafts, 0.8)
+        assert accepted == 0
+        assert bonus in {0, 1, 2}
+
+
+def test_residual_verifier_preserves_transformed_target_marginal():
+    target_logits = np.array([2.8, 2.2, 1.7, 0.2, -0.5, -1.0])
+    draft_logits = np.array([-0.5, -1.0, 1.7, 2.8, 2.2, 0.2])
+    hooks = _hook(dict(temperature=0.8, top_k=3), seed=1234)
+    target = hooks.logprobs(target_logits, 0.8)
+    draft = hooks.logprobs(draft_logits, 0.8)
+    rows = np.stack([target, target])
+    counts = Counter()
+    trials = 12000
+    for _ in range(trials):
+        proposed = hooks.sample(draft, 0.8)
+        accepted, correction = hooks.verify(rows, [draft], [proposed], 0.8)
+        counts[proposed if accepted else correction] += 1
+    empirical = np.array([counts[i] / trials for i in range(len(target))])
+    tv = 0.5 * np.abs(empirical - np.exp(target)).sum()
+    assert tv < 0.025
+
+
+def test_zero_residual_falls_back_to_target_distribution():
+    hooks = _hook(dict(temperature=0.8, top_k=3), seed=44)
+    target = hooks.logprobs(np.array([3.0, 2.0, 1.0, -4.0]), 0.8)
+    rows = np.stack([target, target])
+    for _ in range(50):
+        proposed = hooks.sample(target, 0.8)
+        accepted, bonus = hooks.verify(rows, [target], [proposed], 0.8)
+        assert accepted == 1
+        assert bonus in {0, 1, 2}
+
+
+def test_xtc_and_profile_mismatch_fail_closed():
+    with pytest.raises(ContinuousSelfMTPUnsupportedError, match="XTC"):
+        TransformedSamplingProfile(temperature=0.8, xtc_probability=0.1)
+    hooks = _hook(dict(temperature=0.8))
+    with pytest.raises(ContinuousSelfMTPUnsupportedError, match="temperature"):
+        hooks.validate_sampling(SelfMTPSampling(temperature=0.7))
+    with pytest.raises(ContinuousSelfMTPUnsupportedError, match="XTC"):
+        hooks.validate_sampling(SelfMTPSampling(temperature=0.8, uses_xtc=True))
+
+
+def test_backend_consumes_hooks_without_changing_greedy_path():
+    ops = _CombinedOps(seed=5)
+    hooks = _hook(dict(temperature=0.8, top_k=3), ops=ops)
+    backend = RapidMLXSelfMTPBackend(
+        array_ops=ops,
+        residual_sampling=hooks,
+    )
+    logits = np.array([3.0, 2.0, 1.0, -2.0])
+    transformed_lane = SelfMTPLane(
+        uid=1,
+        cur=4,
+        seed_hidden=None,
+        token_prefix=np.array([1, 2]),
+        ntoks=1,
+        max_tokens=8,
+        num_draft=2,
+        sampling=SelfMTPSampling(temperature=0.8),
+    )
+    token, transformed = backend._distribution(
+        transformed_lane, transformed_lane.token_prefix, logits
+    )
+    assert token in {0, 1, 2}
+    assert np.isfinite(transformed).sum() == 3
+    transformed_calls = ops.transform_calls
+
+    greedy_lane = SelfMTPLane(
+        uid=2,
+        cur=4,
+        seed_hidden=None,
+        token_prefix=np.array([1, 2]),
+        ntoks=1,
+        max_tokens=8,
+        num_draft=2,
+        sampling=SelfMTPSampling(temperature=0.0),
+    )
+    greedy_token, greedy = backend._distribution(
+        greedy_lane, greedy_lane.token_prefix, logits
+    )
+    assert greedy_token == 0
+    assert ops.transform_calls == transformed_calls  # residual hook was bypassed
+    assert np.isfinite(greedy).all()
+
+
+def test_backend_rejects_processors_without_exact_processor_hook():
+    ops = _CombinedOps(seed=1)
+    hooks = _hook(dict(temperature=0.8), ops=ops)
+    backend = RapidMLXSelfMTPBackend(array_ops=ops, residual_sampling=hooks)
+    lane = SelfMTPLane(
+        uid=1,
+        cur=4,
+        seed_hidden=None,
+        token_prefix=np.array([1, 2]),
+        ntoks=1,
+        max_tokens=8,
+        num_draft=2,
+        sampling=SelfMTPSampling(
+            temperature=0.8,
+            has_logits_processors=True,
+        ),
+    )
+    with pytest.raises(ContinuousSelfMTPUnsupportedError, match="processors"):
+        backend._distribution(lane, lane.token_prefix, np.array([1.0, 0.0]))
+
+
+def test_sampling_module_has_no_eager_mlx_import():
+    source = (
+        Path(__file__).parents[1]
+        / "vllm_mlx"
+        / "spec_decode"
+        / "mtp"
+        / "residual_sampling.py"
+    ).read_text()
+    tree = ast.parse(source)
+    eager = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        and getattr(node, "module", "") == "mlx.core"
+    ]
+    assert eager == []

--- a/tests/test_mtp_batch_handoff_exact.py
+++ b/tests/test_mtp_batch_handoff_exact.py
@@ -1,0 +1,214 @@
+"""Pure-Python contracts for the vendored MTP batch handoff.
+
+The production function is AST-extracted so these tests never import MLX or
+construct a model.  Fake arrays exercise only the scheduler state machine.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import types
+from collections import deque
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCHEDULER = Path(__file__).parents[1] / "vllm_mlx" / "scheduler.py"
+
+
+class _Scalar:
+    def __init__(self, value):
+        self.value = value
+
+    def item(self):
+        return self.value
+
+
+class _Array:
+    def __init__(self, values):
+        self.values = list(values)
+        self.dtype = "uint32"
+
+    def __getitem__(self, index):
+        return _Scalar(self.values[index])
+
+    def astype(self, _dtype):
+        return self
+
+
+class _MX:
+    uint32 = "uint32"
+
+    @staticmethod
+    def array(values, dtype=None):
+        del dtype
+        return _Array(values)
+
+
+class _Logger:
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: None
+
+
+def _extract_function(name: str, *, class_name: str | None = None):
+    tree = ast.parse(SCHEDULER.read_text())
+    body = tree.body
+    if class_name is not None:
+        cls = next(
+            n for n in body if isinstance(n, ast.ClassDef) and n.name == class_name
+        )
+        body = cls.body
+    fn = next(n for n in body if isinstance(n, ast.FunctionDef) and n.name == name)
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias("annotations")], level=0
+            ),
+            fn,
+        ],
+        type_ignores=[],
+    )
+    namespace = {
+        "__name__": "vllm_mlx.scheduler_test_probe",
+        "__package__": "vllm_mlx",
+        "logger": _Logger(),
+        "mx": _MX,
+    }
+    exec(compile(ast.fix_missing_locations(module), str(SCHEDULER), "exec"), namespace)
+    return namespace[name]
+
+
+def _install_with_yields(yields):
+    controller = types.ModuleType("vllm_mlx.spec_decode.mtp.draft_k_controller_v2")
+    controller.derive_controller_key = lambda model: "test-model"
+    generator = types.ModuleType("vllm_mlx.spec_decode.mtp.generator")
+
+    def mtp_generate_step(**_kwargs):
+        yield from yields
+
+    generator.mtp_generate_step = mtp_generate_step
+    modules = {
+        "vllm_mlx.spec_decode": types.ModuleType("vllm_mlx.spec_decode"),
+        "vllm_mlx.spec_decode.mtp": types.ModuleType("vllm_mlx.spec_decode.mtp"),
+        controller.__name__: controller,
+        generator.__name__: generator,
+    }
+    modules["vllm_mlx.spec_decode"].__path__ = []
+    modules["vllm_mlx.spec_decode.mtp"].__path__ = []
+
+    gb = types.SimpleNamespace(
+        uids=[7],
+        _next_tokens=_Array([500]),
+        _next_logprobs=["lp500"],
+        tokens=[[]],
+        max_tokens=[32],
+        prompt_cache=[],
+        logits_processors=None,
+    )
+
+    def baseline_step():
+        current = list(gb._next_tokens.values)
+        logprobs = list(gb._next_logprobs)
+        for row, token in enumerate(current):
+            gb.tokens[row].append(token)
+        gb._next_tokens = _Array([token + 100 for token in current])
+        gb._next_logprobs = [f"lp{token + 100}" for token in current]
+        return current, logprobs
+
+    gb._step = baseline_step
+    batch_gen = types.SimpleNamespace(
+        _generation_batch=gb,
+        stop_tokens=set(),
+    )
+    model = types.SimpleNamespace(
+        mtp_forward=object(),
+        make_mtp_cache=object(),
+        mtp=object(),
+        mtp_max_speculative_tokens=1,
+    )
+    request = types.SimpleNamespace(
+        sampling_params=types.SimpleNamespace(temperature=0.0)
+    )
+    install = _extract_function("_install_mtp_vendored")
+    with patch.dict(sys.modules, modules):
+        assert install(
+            batch_gen,
+            model,
+            requests={"req": request},
+            uid_to_request_id={7: "req"},
+            max_k=1,
+        )
+    return batch_gen, gb
+
+
+def test_b1_to_b2_emits_prepared_token_once_without_stale_placeholder():
+    batch_gen, gb = _install_with_yields([(600, "lp600", False)])
+
+    assert gb._step()[0] == [500]
+    assert gb.tokens[0] == [500]
+
+    assert batch_gen._mtp_vendored_prepare_batch_expansion() is True
+    assert gb._next_tokens.values == [600]
+    assert gb.tokens[0] == [500]  # prepared, not prematurely published
+
+    # Model BatchGenerator.extend concatenating the newly admitted row.
+    gb.uids = [7, 8]
+    gb.tokens.append([])
+    gb._next_tokens = _Array([600, 800])
+    gb._next_logprobs = ["lp600", "lp800"]
+
+    assert gb._step()[0] == [600, 800]
+    assert gb.tokens == [[500, 600], [800]]
+    assert batch_gen._mtp_vendored_stats["ft_mid_stream_handoff"] == 1
+
+
+def test_accepted_draft_drains_before_exact_batch_expansion():
+    batch_gen, gb = _install_with_yields([(601, "lp601", True), (602, "lp602", False)])
+
+    assert gb._step()[0] == [500]
+    assert batch_gen._mtp_vendored_prepare_batch_expansion() is False
+    assert gb._step()[0] == [601]
+    assert gb.tokens[0] == [500, 601]
+
+    assert batch_gen._mtp_vendored_prepare_batch_expansion() is True
+    gb.uids = [7, 8]
+    gb.tokens.append([])
+    gb._next_tokens = _Array([602, 800])
+    gb._next_logprobs = ["lp602", "lp800"]
+    assert gb._step()[0] == [602, 800]
+    assert gb.tokens[0] == [500, 601, 602]
+
+
+def test_unprepared_batch_growth_fails_closed_before_baseline_step():
+    _batch_gen, gb = _install_with_yields([(600, "lp600", False)])
+    assert gb._step()[0] == [500]
+    gb.uids = [7, 8]
+    gb.tokens.append([])
+    gb._next_tokens = _Array([500, 800])
+    gb._next_logprobs = ["lp500", "lp800"]
+
+    with pytest.raises(RuntimeError, match="before exact MTP handoff"):
+        gb._step()
+    assert gb.tokens == [[500], []]
+
+
+def test_scheduler_defers_waiting_request_until_mtp_hook_is_ready():
+    schedule_waiting = _extract_function("_schedule_waiting", class_name="Scheduler")
+    request = types.SimpleNamespace(sampling_params=object())
+    hook_calls = []
+    batch_gen = types.SimpleNamespace(
+        _mtp_vendored_prepare_batch_expansion=lambda: hook_calls.append(True) or False
+    )
+    scheduler = types.SimpleNamespace(
+        waiting=deque([request]),
+        running={"active": object()},
+        config=types.SimpleNamespace(max_num_seqs=2),
+        batch_generator=batch_gen,
+        _ensure_batch_generator=lambda _params: True,
+    )
+
+    assert schedule_waiting(scheduler) == []
+    assert list(scheduler.waiting) == [request]
+    assert hook_calls == [True]

--- a/tests/test_mtp_batched_family_capability.py
+++ b/tests/test_mtp_batched_family_capability.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure mocked/AST checks for model-family continuous-MTP capability seams."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp import qwen3_5_inject, qwen4_exp_inject
+
+ROOT = Path(__file__).resolve().parents[1]
+FAMILY_MODULES = (qwen4_exp_inject, qwen3_5_inject)
+
+
+@pytest.mark.parametrize(
+    "module,family,dynamic_join",
+    [
+        (qwen4_exp_inject, "qwen4_exp", False),
+        (qwen3_5_inject, "qwen3_5", True),
+    ],
+)
+def test_capability_descriptor_is_explicit_immutable_and_conservative(
+    module, family, dynamic_join
+):
+    capability = module.BATCHED_MTP_CAPABILITY
+    assert dict(capability) == {
+        "protocol_version": 1,
+        "model_family": family,
+        "batch_forward": "mtp_batch_forward",
+        "recursive_draft_depth": 2,
+        "fixed_membership": True,
+        "dynamic_join": dynamic_join,
+        "quantized_cache": False,
+        "windowed_cache": False,
+        "xtc": False,
+    }
+    with pytest.raises(TypeError):
+        capability["dynamic_join"] = not dynamic_join
+
+
+@pytest.mark.parametrize("module", FAMILY_MODULES)
+def test_batch_forward_delegates_to_existing_recursive_hidden_path(module):
+    calls = []
+
+    class FakeInjectedModel:
+        def mtp_forward(self, hidden, tokens, cache, *, return_hidden=False):
+            calls.append((hidden, tokens, cache, return_hidden))
+            return "logits", "next-hidden"
+
+    result = module._mtp_batch_forward(FakeInjectedModel(), "hidden", "tokens", "cache")
+    assert result == ("logits", "next-hidden")
+    assert calls == [("hidden", "tokens", "cache", True)]
+
+
+@pytest.mark.parametrize(
+    "relative_path,injected_class",
+    [
+        ("vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py", "_Qwen4ExpWithMTP"),
+        ("vllm_mlx/spec_decode/mtp/qwen3_5_inject.py", "_Qwen3_5WithMTP"),
+    ],
+)
+def test_injected_class_exposes_descriptor_seam_and_separate_recursive_depth(
+    relative_path, injected_class
+):
+    tree = ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+    cls = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == injected_class
+    )
+    assignments = {
+        target.id: node.value
+        for node in cls.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+    assert isinstance(assignments["batched_mtp_capability"], ast.Name)
+    assert assignments["batched_mtp_capability"].id == "BATCHED_MTP_CAPABILITY"
+    assert isinstance(assignments["mtp_batch_forward"], ast.Name)
+    assert assignments["mtp_batch_forward"].id == "_mtp_batch_forward"
+    depth = assignments["mtp_recursive_draft_depth"]
+    assert isinstance(depth, ast.Constant) and depth.value == 2
+    # The new recursive batch depth is deliberately not implemented by
+    # changing the legacy single-request cap on the injected class.
+    assert "mtp_max_speculative_tokens" not in assignments
+
+
+def test_flash_and_qwen35_join_claims_remain_intentionally_asymmetric():
+    assert qwen4_exp_inject.BATCHED_MTP_CAPABILITY["dynamic_join"] is False
+    assert qwen3_5_inject.BATCHED_MTP_CAPABILITY["dynamic_join"] is True

--- a/tests/test_mtp_batched_family_capability.py
+++ b/tests/test_mtp_batched_family_capability.py
@@ -30,6 +30,7 @@ def test_capability_descriptor_is_explicit_immutable_and_conservative(
         "model_family": family,
         "batch_forward": "mtp_batch_forward",
         "recursive_draft_depth": 2,
+        "share_qsa_indices": family == "qwen4_exp",
         "fixed_membership": True,
         "dynamic_join": dynamic_join,
         "quantized_cache": False,
@@ -92,3 +93,8 @@ def test_injected_class_exposes_descriptor_seam_and_separate_recursive_depth(
 def test_flash_and_qwen35_join_claims_remain_intentionally_asymmetric():
     assert qwen4_exp_inject.BATCHED_MTP_CAPABILITY["dynamic_join"] is False
     assert qwen3_5_inject.BATCHED_MTP_CAPABILITY["dynamic_join"] is True
+
+
+def test_qsa_selection_sharing_is_attested_only_for_qwen4():
+    assert qwen4_exp_inject.BATCHED_MTP_CAPABILITY["share_qsa_indices"] is True
+    assert qwen3_5_inject.BATCHED_MTP_CAPABILITY["share_qsa_indices"] is False

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1724,13 +1724,19 @@ def test_install_mtp_vendored_fails_closed_on_batch_size_growth(monkeypatch):
     gb._step()
     assert fake_gen_calls["closed"] == 0
 
-    # Production admission keeps MTP at B=1. Simulate a broken admission
-    # boundary and prove the wrapper terminates before _orig_step can consume
-    # the last-emitted placeholder as a new model input.
+    # Stage the exact not-yet-emitted target token before transitioning to
+    # B=2. The scheduler calls this barrier before BatchGenerator.extend;
+    # accepted drafts would return False and keep the incoming lane queued.
+    prepare = batch_gen._mtp_vendored_prepare_batch_expansion
+    assert prepare() is True
+    staged = int(gb._next_tokens[0].item())
+
+    # Model BatchGenerator.extend retaining uid=7 and appending uid=8.
     orig_step_before = gb.orig_step_calls
-    gb.uids = [1, 2]
-    with pytest.raises(RuntimeError, match="admission invariant violated"):
-        gb._step()
+    gb.uids = [7, 8]
+    gb._next_tokens = mx.array([staged, 800], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0]), mx.array([0.0])]
+    result = gb._step()
 
     assert gb.orig_step_calls == orig_step_before
     stats = batch_gen._mtp_vendored_stats

--- a/tests/test_mtp_prepared_state.py
+++ b/tests/test_mtp_prepared_state.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.prepared_state import (
+    PreparedMTPState,
+    PreparedStateIdentity,
+    RestoreReason,
+    evaluate_restore,
+    fingerprint_config,
+    prepare_mtp_state,
+)
+
+
+def _identity(**changes) -> PreparedStateIdentity:
+    values = {
+        "model_id": "Qwen/Qwen3.8-Flash-Next",
+        "model_revision": "f5d08274",
+        "speculative_config_fingerprint": fingerprint_config(
+            {"method": "mtp", "num_speculative_tokens": 3}
+        ),
+        "target_cache_layout": "qwen4:12qsa+36arrays:bf16",
+        "mtp_cache_layout": "qwen4-mtp:1qsa:bf16",
+        "seed_hidden_layout": "bf16[1,1,2048]",
+        "adapter_id": None,
+        "tokenizer_fingerprint": "tokenizer-sha256",
+    }
+    values.update(changes)
+    return PreparedStateIdentity(**values)
+
+
+def _state(
+    *,
+    covered: int = 128,
+    identity: PreparedStateIdentity | None = None,
+    captured_at: float = 100.0,
+) -> tuple[PreparedMTPState, tuple[int, ...]]:
+    prefix = tuple(range(covered))
+    return (
+        prepare_mtp_state(
+            identity=identity or _identity(),
+            prefix_tokens=prefix,
+            target_cache=object(),
+            target_cache_tokens=covered,
+            mtp_cache=object(),
+            mtp_cache_pairs=covered - 1,
+            seed_hidden=object(),
+            captured_at=captured_at,
+        ),
+        prefix,
+    )
+
+
+def _evaluate(
+    state: PreparedMTPState,
+    prefix: tuple[int, ...],
+    **changes,
+):
+    values = {
+        "expected_identity": _identity(),
+        "request_tokens": prefix + (999,),
+        "target_cache_tokens": len(prefix),
+        "mtp_cache_pairs": len(prefix) - 1,
+        "now": 110.0,
+        "max_age_seconds": 60.0,
+        "min_useful_prefix_tokens": 64,
+    }
+    values.update(changes)
+    return evaluate_restore(state, **values)
+
+
+def test_exact_joint_boundary_is_restore_eligible() -> None:
+    state, prefix = _state()
+
+    decision = _evaluate(state, prefix)
+
+    assert decision.eligible is True
+    assert decision.reason is RestoreReason.ELIGIBLE
+    assert decision.covered_tokens == 128
+    assert decision.resume_at == 128
+    assert decision.bypass_hit is False
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"target_cache_tokens": 127}, "exact covered prefix length"),
+        ({"mtp_cache_pairs": 126}, "target_cache_tokens - 1"),
+        ({"seed_hidden": None}, "seed_hidden"),
+        ({"target_cache": None}, "target_cache"),
+        ({"mtp_cache": None}, "mtp_cache"),
+    ],
+)
+def test_capture_rejects_incomplete_or_unaligned_state(changes, message) -> None:
+    kwargs = {
+        "identity": _identity(),
+        "prefix_tokens": tuple(range(128)),
+        "target_cache": object(),
+        "target_cache_tokens": 128,
+        "mtp_cache": object(),
+        "mtp_cache_pairs": 127,
+        "seed_hidden": object(),
+        "captured_at": 100.0,
+    }
+    kwargs.update(changes)
+
+    with pytest.raises(ValueError, match=message):
+        prepare_mtp_state(**kwargs)
+
+
+def test_valid_trivial_hit_fails_open_to_normal_mtp() -> None:
+    state, prefix = _state(covered=8)
+
+    decision = _evaluate(state, prefix)
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.TRIVIAL_HIT
+    assert decision.bypass_hit is True
+    assert decision.resume_at is None
+
+
+@pytest.mark.parametrize(
+    "expected_identity",
+    [
+        _identity(model_id="other/model"),
+        _identity(model_revision="different-revision"),
+        _identity(adapter_id="adapter-a"),
+        _identity(tokenizer_fingerprint="different-tokenizer"),
+    ],
+)
+def test_model_identity_mismatch_refuses_restore(expected_identity) -> None:
+    state, prefix = _state()
+
+    decision = _evaluate(
+        state,
+        prefix,
+        expected_identity=expected_identity,
+    )
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.MODEL_MISMATCH
+    assert decision.bypass_hit is False
+
+
+@pytest.mark.parametrize(
+    "expected_identity",
+    [
+        _identity(
+            speculative_config_fingerprint=fingerprint_config(
+                {"method": "mtp", "num_speculative_tokens": 2}
+            )
+        ),
+        _identity(target_cache_layout="different-target-layout"),
+        _identity(mtp_cache_layout="different-mtp-layout"),
+        _identity(seed_hidden_layout="bf16[1,1,4096]"),
+    ],
+)
+def test_config_or_layout_mismatch_refuses_restore(expected_identity) -> None:
+    state, prefix = _state()
+
+    decision = _evaluate(
+        state,
+        prefix,
+        expected_identity=expected_identity,
+    )
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.CONFIG_MISMATCH
+
+
+def test_stale_state_refuses_restore() -> None:
+    state, prefix = _state(captured_at=100.0)
+
+    decision = _evaluate(
+        state,
+        prefix,
+        now=161.0,
+        max_age_seconds=60.0,
+    )
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.STALE
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"target_cache_tokens": 127},
+        {"mtp_cache_pairs": 126},
+        {"request_tokens": tuple(range(127)) + (777, 999)},
+        {"request_tokens": tuple(range(128))},
+    ],
+)
+def test_live_or_token_boundary_mismatch_refuses_restore(changes) -> None:
+    state, prefix = _state()
+
+    decision = _evaluate(state, prefix, **changes)
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.BOUNDARY_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "metadata_change",
+    [
+        {"mtp_covered_pairs": 3},
+        {"schema_version": 999},
+        {"captured_at": "not-a-timestamp"},
+        {"boundary_fingerprint": "z" * 64},
+    ],
+)
+def test_corrupt_persisted_metadata_refuses_without_raising(
+    metadata_change,
+) -> None:
+    state, prefix = _state()
+    corrupt = PreparedMTPState(
+        metadata=replace(state.metadata, **metadata_change),
+        target_cache=state.target_cache,
+        mtp_cache=state.mtp_cache,
+        seed_hidden=state.seed_hidden,
+    )
+
+    decision = _evaluate(corrupt, prefix)
+
+    assert decision.eligible is False
+    assert decision.reason is RestoreReason.MALFORMED
+
+
+def test_config_fingerprint_is_order_independent_and_value_sensitive() -> None:
+    left = fingerprint_config({"method": "mtp", "k": 3})
+    reordered = fingerprint_config({"k": 3, "method": "mtp"})
+    changed = fingerprint_config({"method": "mtp", "k": 2})
+
+    assert left == reordered
+    assert left != changed

--- a/tests/test_mtp_ragged_cache.py
+++ b/tests/test_mtp_ragged_cache.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure/mock coverage for the mlx-lm 0.31.x ragged rollback adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.ragged_cache import (
+    RaggedCacheUnsupportedError,
+    install_ragged_cache_rollback,
+    preflight_ragged_cache,
+    trim_ragged_cache,
+)
+
+
+class Rows:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.shape = (len(self.rows), 1)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return Rows(self.rows[item])
+        return self.rows[item]
+
+    def __eq__(self, other):
+        return isinstance(other, Rows) and self.rows == other.rows
+
+
+class Vector:
+    def __init__(self, values):
+        self.values = list(values)
+
+    def tolist(self):
+        return list(self.values)
+
+    def __sub__(self, other):
+        values = (
+            other.values if isinstance(other, Vector) else [other] * len(self.values)
+        )
+        return Vector([left - right for left, right in zip(self.values, values)])
+
+    def __add__(self, other):
+        values = (
+            other.values if isinstance(other, Vector) else [other] * len(self.values)
+        )
+        return Vector([left + right for left, right in zip(self.values, values)])
+
+
+class FakeOps:
+    def __init__(self):
+        self.rolls = []
+
+    @staticmethod
+    def vector(values):
+        return Vector(values)
+
+    @staticmethod
+    def tolist(value):
+        return value.tolist()
+
+    @staticmethod
+    def concat(rows):
+        result = []
+        for row in rows:
+            result.extend(row.rows)
+        return Rows(result)
+
+    def roll_rows(self, value, shifts, *, axis, stop):
+        self.rolls.append((value, shifts.tolist(), axis, stop))
+        return ("rolled", value, tuple(shifts.tolist()), axis, stop)
+
+
+class FakeArraysCache:
+    rollback_state = None
+
+    def __init__(self, cache):
+        self.cache = cache
+        self.rollback_state = None
+
+    @property
+    def batch_size(self):
+        return self.cache[0].shape[0]
+
+    def trim(self, count):
+        return count
+
+
+class FakeBatchKVCache:
+    def __init__(self):
+        self.keys = "keys"
+        self.values = "values"
+        self.offset = Vector([8, 6])
+        self.left_padding = Vector([0, 2])
+        self._idx = 8
+        self._right_padding = None
+
+    def trim(self, count):
+        self._idx -= count
+        self.offset = self.offset - count
+        return count
+
+    def _invalidate_attention_groups(self):
+        self.invalidations = getattr(self, "invalidations", 0) + 1
+
+
+class FakeQwen4StateCache(FakeArraysCache):
+    def __init__(self, cache):
+        super().__init__(cache)
+        self._rollback_slots = None
+
+    def restore_rollback(self, n_to_drop, verify_size):
+        self.scalar_restore = (n_to_drop, verify_size)
+
+
+class FakeQSAIndexCache(FakeArraysCache):
+    def __init__(self):
+        super().__init__([Rows(["raw-a", "raw-b"])])
+        self._offsets = [9, 8]
+        self._compressed_counts = [2, 2]
+        self.compress_ratio = 4
+        self._right_padding = None
+        self.lengths = None
+
+    @staticmethod
+    def _can_trim_row(offset, count):
+        if count < 0 or count > offset:
+            return False
+        if count == 0:
+            return True
+        remainder = offset % 4
+        available = remainder if remainder else min(4, offset)
+        return count <= available
+
+    def trim(self, count):
+        if not all(self._can_trim_row(offset, count) for offset in self._offsets):
+            return 0
+        self._offsets = [offset - count for offset in self._offsets]
+        return count
+
+
+def _install(ops=None, **kwargs):
+    arrays = kwargs.pop("arrays", type("TestArraysCache", (FakeArraysCache,), {}))
+    batch_kv = kwargs.pop("batch_kv", type("TestBatchKVCache", (FakeBatchKVCache,), {}))
+    module = kwargs.pop(
+        "module", SimpleNamespace(ArraysCache=arrays, BatchKVCache=batch_kv)
+    )
+    return install_ragged_cache_rollback(
+        mlx_lm_version=kwargs.pop("version", "0.31.3"),
+        cache_module=module,
+        qwen4_state_cls=kwargs.pop("qwen", None),
+        qsa_cls=kwargs.pop("qsa", None),
+        array_ops=ops or FakeOps(),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("version", ["0.31.2", "0.32.0", "main"])
+def test_installer_is_strictly_version_gated(version):
+    with pytest.raises(RaggedCacheUnsupportedError):
+        _install(version=version)
+
+
+def test_install_is_idempotent_and_preserves_scalar_methods():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    class Qwen(FakeQwen4StateCache, Arrays):
+        pass
+
+    module = SimpleNamespace(ArraysCache=Arrays, BatchKVCache=Batch)
+    ops = FakeOps()
+    scalar_kv = Batch.trim
+    scalar_qwen = Qwen.restore_rollback
+    first = _install(ops, module=module, qwen=Qwen)
+    second = _install(ops, module=module, qwen=Qwen)
+
+    assert first.patched
+    assert not second.patched
+    assert second.already_present
+    assert Batch.trim is scalar_kv
+    assert Qwen.restore_rollback is scalar_qwen
+
+
+def test_installer_refuses_to_replace_an_unknown_existing_method():
+    class ConflictingArrays(FakeArraysCache):
+        def trim_ragged(self, values, **kwargs):
+            return values
+
+    with pytest.raises(RaggedCacheUnsupportedError, match="refusing to replace"):
+        _install(arrays=ConflictingArrays, qwen=None, qsa=None)
+
+
+def test_installer_rejects_qwen_cache_from_a_different_runtime():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class ForeignQwen:
+        pass
+
+    with pytest.raises(RaggedCacheUnsupportedError, match="not an ArraysCache"):
+        _install(arrays=Arrays, qwen=ForeignQwen, qsa=None)
+
+
+def test_batch_kv_splits_uniform_cursor_move_from_residual_row_roll():
+    ops = FakeOps()
+
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(ops, arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+    cache = Batch()
+    assert cache.trim_ragged([1, 3], verify_size=3) == [1, 3]
+
+    assert cache._idx == 7
+    assert cache.offset.tolist() == [7, 3]
+    assert cache.left_padding.tolist() == [0, 4]
+    assert len(ops.rolls) == 2
+    assert ops.rolls[0][1:] == ([0, 2], 2, 7)
+    assert cache.invalidations == 1
+
+
+def test_unknown_batch_kv_subclass_cannot_silently_inherit_adapter():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+
+    class UndeclaredLedgerCache(Batch):
+        pass
+
+    with pytest.raises(RaggedCacheUnsupportedError, match="without declaring"):
+        UndeclaredLedgerCache().preflight_ragged_trim([1, 2], verify_size=2)
+
+
+def test_declared_batch_kv_auxiliary_ledger_rolls_with_kv():
+    ops = FakeOps()
+
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(ops, arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+
+    class DeclaredLedgerCache(Batch):
+        _RAGGED_TRIM_AUX_ARRAYS = (("ledger", 1),)
+
+        def __init__(self):
+            super().__init__()
+            self.ledger = type("Ledger", (), {"shape": (2, 8)})()
+
+    cache = DeclaredLedgerCache()
+    cache.trim_ragged([1, 2], verify_size=2)
+    assert ops.rolls[-1][0] is not None
+    assert ops.rolls[-1][2:] == (1, 7)
+
+
+def test_batch_kv_preflight_rejects_pending_padding_and_overtrim():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+    cache = Batch()
+    cache._right_padding = Vector([0, 1])
+    with pytest.raises(RaggedCacheUnsupportedError, match="finalize"):
+        cache.preflight_ragged_trim([1, 1], verify_size=2)
+    cache._right_padding = None
+    with pytest.raises(ValueError, match="before token zero"):
+        cache.preflight_ragged_trim([1, 7], verify_size=7)
+
+
+def test_arrays_cache_selects_each_rows_exact_verify_boundary():
+    class Arrays(FakeArraysCache):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, qwen=None, qsa=None)
+    cache = Arrays([Rows(["a-live", "b-live"]), Rows(["A-live", "B-live"])])
+    cache.rollback_state = [
+        [Rows(["a-keep1", "b-keep1"]), Rows(["A-keep1", "B-keep1"])],
+        [Rows(["a-keep2", "b-keep2"]), Rows(["A-keep2", "B-keep2"])],
+    ]
+
+    assert cache.trim_ragged([2, 0], verify_size=3) == [2, 0]
+    assert cache.cache == [
+        Rows(["a-keep1", "b-live"]),
+        Rows(["A-keep1", "B-live"]),
+    ]
+    assert cache.rollback_state is None
+
+
+def test_qwen4_refuses_partially_staged_atomic_state():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Qwen(FakeQwen4StateCache, Arrays):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, qwen=Qwen, qsa=None)
+    cache = Qwen([Rows(["a", "b"])])
+    cache.rollback_state = [[Rows(["a0", "b0"])]]
+    cache._rollback_slots = {0: [Rows(["staged-a", "staged-b"])]}
+    with pytest.raises(RaggedCacheUnsupportedError, match="partially staged"):
+        cache.preflight_ragged_trim([1, 1], verify_size=2)
+
+
+def test_qsa_rewinds_logical_rows_only_within_retained_raw_group():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class QSA(FakeQSAIndexCache, Arrays):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, qwen=None, qsa=QSA)
+    cache = QSA()
+    assert cache.trim_ragged([1, 3], verify_size=4) == [1, 3]
+    assert cache._offsets == [8, 5]
+    assert cache._compressed_counts == [2, 1]
+
+    cache._offsets = [9, 8]
+    with pytest.raises(RaggedCacheUnsupportedError, match="raw-ring history"):
+        cache.preflight_ragged_trim([2, 1], verify_size=3)
+
+
+@pytest.mark.parametrize(
+    "cache_type, message",
+    [("BatchQuantizedKVCache", "quantized"), ("BatchRotatingKVCache", "windowed")],
+)
+def test_public_preflight_fails_loud_for_unsupported_cache_families(
+    cache_type, message
+):
+    cache = type(cache_type, (), {})()
+    with pytest.raises(RaggedCacheUnsupportedError, match=message):
+        preflight_ragged_cache(cache, [1, 1], verify_size=2)
+
+
+def test_cache_tree_preflights_every_member_before_mutating_anything():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+    first = Batch()
+    unsupported = type("QuantizedKVCache", (), {})()
+    tree = SimpleNamespace(caches=(first, unsupported))
+
+    with pytest.raises(RaggedCacheUnsupportedError, match="quantized"):
+        trim_ragged_cache(tree, [1, 1], verify_size=2)
+    assert first._idx == 8
+    assert first.offset.tolist() == [8, 6]
+
+
+def test_supported_cache_tree_applies_after_successful_preflight():
+    class Arrays(FakeArraysCache):
+        pass
+
+    class Batch(FakeBatchKVCache):
+        pass
+
+    _install(FakeOps(), arrays=Arrays, batch_kv=Batch, qwen=None, qsa=None)
+    first, second = Batch(), Batch()
+    tree = SimpleNamespace(caches=(first, second))
+    assert trim_ragged_cache(tree, [1, 1], verify_size=2) == [1, 1]
+    assert first._idx == second._idx == 7

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2143,6 +2143,7 @@ def _normalize_speculative_config_or_exit(args):
             "mtp_sidecar": None,
             "mtp_max_k": 1,
             "mtp_disable_auto_k": False,
+            "mtp_continuous_batching": False,
             "suffix_decoding": False,
         }
         for name, value in defaults.items():
@@ -2418,6 +2419,7 @@ def _normalize_speculative_config_or_exit(args):
         args.dspark_num_speculative_tokens = config.num_speculative_tokens or 5
     elif config.method == "mtp":
         args.spec_decode = "mtp"
+        args.mtp_continuous_batching = config.continuous_batching
         if legacy_enable_mtp_requested:
             args.enable_mtp = True
             if config.num_speculative_tokens is not None:
@@ -4207,6 +4209,10 @@ def serve_command(args):
         # 0.9.13 PR-B: EV depth controller knobs.
         mtp_max_k=getattr(args, "mtp_max_k", 3),
         mtp_disable_auto_k=getattr(args, "mtp_disable_auto_k", False),
+        # Default-off planning seam for persistent fixed-cohort self-MTP.
+        # Live token delivery remains on the vendored legacy path until the
+        # scheduler coordinator lands.
+        mtp_continuous_batching=getattr(args, "mtp_continuous_batching", False),
         # SuffixDecoding
         enable_suffix_decoding=args.suffix_decoding,
         suffix_max_draft=args.suffix_max_draft,
@@ -10478,7 +10484,9 @@ Examples:
             '\'{"method":"dflash"}\', DDTree with '
             '\'{"method":"ddtree"}\', and MTP with '
             '\'{"method":"mtp","num_speculative_tokens":3,'
-            '"disable_auto_k":false}\'. SuffixDecoding is an explicit, '
+            '"disable_auto_k":false,"continuous_batching":false}\'. '
+            "Continuous self-MTP is planning-only and default-off. "
+            "SuffixDecoding is an explicit, "
             "workload-specific flag for high prompt/output-overlap traffic "
             "and is available with "
             '\'{"method":"suffix","num_speculative_tokens":8}\'.'

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -743,13 +743,27 @@ class QSAIndexer(nn.Module):
             if cache.left_padding is None
             else [int(value) for value in cache.left_padding.tolist()]
         )
+        shared_topk = cache._mtp_shared_topk
+        if shared_topk is not None and (
+            shared_topk.ndim != 2
+            or shared_topk.shape[0] != batch
+            or shared_topk.shape[1] != self.block_topk
+        ):
+            raise RuntimeError("QSA shared self-MTP selection shape changed")
+        capture_shared = cache._mtp_share_topk and shared_topk is None
+        shared_rows = []
         compact_indices = []
         compact_valid = []
         for batch_index in range(batch):
             input_start, valid_length = valid_spans[batch_index]
             available_blocks = cache._compressed_counts[batch_index]
             selected_blocks = None
-            if available_blocks > self.block_topk:
+            if shared_topk is not None:
+                selected_blocks = mx.broadcast_to(
+                    shared_topk[batch_index : batch_index + 1],
+                    (length, self.block_topk),
+                )
+            elif available_blocks > self.block_topk:
                 keys = cache.keys_for_blocks(batch_index, available_blocks)
                 # Preserve the reference's single batched matmul and FP32
                 # reduction. Per-token matmuls choose a different Metal
@@ -785,6 +799,13 @@ class QSAIndexer(nn.Module):
                     mx.arange(self.block_topk, dtype=mx.int32)[None, :],
                     (length, self.block_topk),
                 )
+            if capture_shared:
+                if valid_length:
+                    shared_rows.append(
+                        mx.contiguous(selected_blocks[input_start + valid_length - 1])
+                    )
+                else:
+                    shared_rows.append(mx.zeros((self.block_topk,), dtype=mx.int32))
 
             dense_blocks = mx.broadcast_to(
                 mx.arange(self.block_topk, dtype=mx.int32)[None, :],
@@ -824,6 +845,9 @@ class QSAIndexer(nn.Module):
             )
             compact_indices.append(indices)
             compact_valid.append(valid)
+
+        if capture_shared:
+            cache._mtp_shared_topk = mx.stack(shared_rows)
 
         selection = _QSASelection(
             token_indices=mx.stack(compact_indices),

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -115,6 +115,8 @@ class QSAIndexCache(ArraysCache):
         self._valid_until: list[int] | None = None
         self._right_padding: list[int] | None = None
         self._pending_left_padding = [int(item) for item in (left_padding or [0])]
+        self._mtp_share_topk = False
+        self._mtp_shared_topk = None
 
     def _ensure_batch(self, batch: int):
         """Adopt mlx-lm's fresh-batch size before state is committed."""
@@ -157,7 +159,20 @@ class QSAIndexCache(ArraysCache):
             raise AttributeError("batched QSA cache has per-row compressed counts")
         return self._compressed_counts[0]
 
-    def prepare(self, lengths=None, right_padding=None, **_kwargs):
+    def begin_self_mtp_cycle(self):
+        """Arm one recursive draft cycle without crossing membership boundaries."""
+        if self._mtp_share_topk or self._mtp_shared_topk is not None:
+            raise RuntimeError("QSA self-MTP selection cycle is already armed")
+        self._mtp_share_topk = True
+
+    def end_self_mtp_cycle(self):
+        """Disarm the cycle-local selection at every transaction boundary."""
+        self._mtp_share_topk = False
+        self._mtp_shared_topk = None
+
+    def _prepare(self, lengths=None, right_padding=None, *, keep_shared=False):
+        if not keep_shared:
+            self.end_self_mtp_cycle()
         batch = (
             int(self.left_padding.size)
             if self.left_padding is not None
@@ -172,7 +187,13 @@ class QSAIndexCache(ArraysCache):
             None if right_padding is None else [int(item) for item in right_padding]
         )
 
-    def finalize(self):
+    def prepare(self, lengths=None, right_padding=None, **_kwargs):
+        self._prepare(lengths, right_padding)
+
+    def prepare_self_mtp_step(self, lengths=None, right_padding=None, **_kwargs):
+        self._prepare(lengths, right_padding, keep_shared=True)
+
+    def _finalize(self, *, keep_shared=False):
         if self._right_padding is not None and self.left_padding is not None:
             self.left_padding += mx.array(self._right_padding, dtype=mx.int32)
         self._valid_until = None
@@ -180,6 +201,14 @@ class QSAIndexCache(ArraysCache):
         self.lengths = None
         # QSA state contains only logical tokens, so unlike the main KV cache
         # it needs no physical roll after a right-padded prefill.
+        if not keep_shared:
+            self.end_self_mtp_cycle()
+
+    def finalize(self):
+        self._finalize()
+
+    def finalize_self_mtp_step(self):
+        self._finalize(keep_shared=True)
 
     def valid_lengths(self, input_length: int) -> list[int]:
         return [count for _, count in self.valid_spans(input_length)]
@@ -356,6 +385,7 @@ class QSAIndexCache(ArraysCache):
 
     @meta_state.setter
     def meta_state(self, value):
+        self.end_self_mtp_cycle()
         decoded = json.loads(value)
         self.compress_ratio = int(decoded["compress_ratio"])
         self._offsets = [int(item) for item in decoded["offsets"]]
@@ -405,6 +435,7 @@ class QSAIndexCache(ArraysCache):
         # recently completed group at a boundary. Rewind only within that
         # recoverable window; the next update overwrites discarded rows and
         # deterministically recomputes a removed compressed block.
+        self.end_self_mtp_cycle()
         if not all(self._can_trim_row(offset, n) for offset in self._offsets):
             return 0
         self._offsets = [offset - n for offset in self._offsets]
@@ -424,6 +455,7 @@ class QSAIndexCache(ArraysCache):
         return sum(item.nbytes for item in self.cache if item is not None)
 
     def filter(self, batch_indices):
+        self.end_self_mtp_cycle()
         indices = (
             batch_indices.tolist()
             if isinstance(batch_indices, mx.array)
@@ -444,6 +476,7 @@ class QSAIndexCache(ArraysCache):
         # retained shorter row's padding into zero.
 
     def extend(self, other):
+        self.end_self_mtp_cycle()
         rows = [self.extract(index) for index in range(len(self._offsets))]
         rows.extend(other.extract(index) for index in range(len(other._offsets)))
         merged = self.merge(rows)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -521,7 +521,15 @@ class SchedulerConfig:
     # can retain the safe MLLM default without taking control from operators.
     vision_prefill_token_budget: int | None = None
 
+    # Default-off PR 9 planning seam. This does not replace GenerationBatch
+    # token delivery; the vendored single-request MTP path remains live.
+    mtp_continuous_batching: bool = False
+
     def __post_init__(self) -> None:
+        if not isinstance(self.mtp_continuous_batching, bool):
+            raise ValueError("mtp_continuous_batching must be a boolean")
+        if self.mtp_continuous_batching and self.spec_decode != "mtp":
+            raise ValueError("mtp_continuous_batching requires spec_decode='mtp'")
         if (
             self.vision_prefill_token_budget is not None
             and self.vision_prefill_token_budget <= 0
@@ -735,6 +743,48 @@ def _mtp_controller_key(model_name: str | None, sidecar: str | None) -> str | No
     if not sidecar:
         return f"{len(model_name)}:{model_name}"
     return f"{len(model_name)}:{model_name}+mtp:{sidecar}"
+
+
+def _install_continuous_mtp_router(
+    batch_gen: "BatchGenerator",
+    model: Any,
+    config: SchedulerConfig,
+) -> bool:
+    """Attach the PR 9 planning seam after static admission succeeds.
+
+    The router is metadata-only. It does not replace ``GenerationBatch._step``
+    and therefore cannot claim live continuous-MTP token delivery. A refusal
+    returns before mutating ``batch_gen``; the caller retains legacy MTP/plain
+    behavior.
+    """
+    from .spec_decode.mtp.continuous_routing import plan_router_install
+
+    cache_quantized = bool(
+        getattr(config, "kv_cache_quantization", False)
+        or getattr(config, "kv_cache_turboquant", False)
+        or getattr(config, "kv_cache_dtype", "bf16") != "bf16"
+    )
+    decision = plan_router_install(
+        model,
+        enabled=getattr(config, "mtp_continuous_batching", False),
+        cache_quantized=cache_quantized,
+        cache_windowed=bool(getattr(config, "use_paged_cache", False)),
+        max_lanes=max(2, int(getattr(config, "max_num_seqs", 4))),
+    )
+    if not decision.admitted or decision.router is None:
+        logger.warning(
+            "[MTP-continuous] planning router refused; retaining %s: %s",
+            decision.fallback.value,
+            "; ".join(decision.reasons),
+        )
+        return False
+    batch_gen._continuous_mtp_router = decision.router
+    logger.warning(
+        "[MTP-continuous] fixed-cohort planner installed; live token delivery "
+        "is not wired in PR 9, so the vendored legacy MTP/plain data plane "
+        "remains authoritative."
+    )
+    return True
 
 
 def _install_mtp_vendored(
@@ -3965,6 +4015,11 @@ class Scheduler:
                     mtp_model_type,
                 )
             else:
+                if getattr(self.config, "mtp_continuous_batching", False):
+                    _install_continuous_mtp_router(bg, self.model, self.config)
+                # The continuous-router commit installs only its planner. The
+                # vendored generator remains the live data plane until the
+                # later scheduler commit wires continuous token delivery.
                 mtp_installed = _install_mtp_vendored(
                     bg,
                     model=self.model,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -926,6 +926,16 @@ def _install_mtp_vendored(
             reason,
         )
 
+    def _stage_handoff_input(tok_int: int, lp_arr: Any) -> None:
+        """Publish an un-emitted, cache-safe target token for plain decode.
+
+        Baseline ``GenerationBatch._step`` returns its current
+        ``_next_tokens`` while forwarding it.  It must therefore receive a
+        not-yet-emitted token, never MTP's last-emitted shape placeholder.
+        """
+        gb._next_tokens = mx.array([int(tok_int)], dtype=mx.uint32)
+        gb._next_logprobs = [lp_arr]
+
     def _cleanup_uid(uid: int) -> None:
         # Codex round-G BLOCKING #1: DO NOT clear _disabled_uids here.
         # This helper runs on every fallthrough branch (B>1, non-greedy,
@@ -969,6 +979,45 @@ def _install_mtp_vendored(
         _initial_skip_logged.difference_update(
             key for key in _initial_skip_logged if key[0] == uid
         )
+
+    def _prepare_batch_expansion() -> bool:
+        """Prepare an exact B=1 -> B>1 handoff before scheduler admission."""
+        active_uids = [uid for uid in gb.uids if uid in _state]
+        if not active_uids:
+            return True
+        if len(active_uids) != 1 or len(gb.uids) != 1:
+            return False
+
+        uid = active_uids[0]
+        state = _state[uid]
+        if state.get("handoff_ready"):
+            return True
+        queue = state["queue"]
+        if queue:
+            # Accepted drafts are request-visible work and must drain at B=1.
+            return False
+
+        try:
+            tok_int, lp_arr, from_draft = next(state["gen"])
+        except Exception as e:  # noqa: BLE001
+            _stats["gen_raised"] += 1
+            req_id = uid_to_request_id.get(uid) if uid_to_request_id else None
+            _disabled_uids[uid] = req_id
+            _cleanup_uid(uid)
+            raise RuntimeError(
+                f"[MTP-vendored] uid={uid} could not prepare a state-exact "
+                "B=1 -> B>1 handoff"
+            ) from e
+
+        queue.append((int(tok_int), lp_arr, bool(from_draft)))
+        if from_draft:
+            return False
+
+        # Non-draft yields are not yet emitted and target cache is behind them:
+        # exactly the input/return invariant baseline _step requires.
+        state["handoff_ready"] = True
+        _stage_handoff_input(int(tok_int), lp_arr)
+        return True
 
     def _sampling_options_for_uid(uid: int) -> tuple[dict[str, Any] | None, str]:
         """Resolve the request-local MTP sampling contract, fail closed.
@@ -1181,17 +1230,50 @@ def _install_mtp_vendored(
         if not gb.uids or len(gb.uids) != 1:
             _stats["fallthrough_steps"] += 1
             _stats["ft_batch_size"] += 1
+            # Scheduler admission must stage a cache-safe, not-yet-emitted
+            # token before extending an active MTP batch.  Fail closed if a
+            # caller bypasses that barrier: the placeholder is the last
+            # emitted token and baseline _step would return it again.
             if _state:
                 terminal_uids = list(_state)
-                _stats["invariant_violations"] += 1
+                unprepared = [
+                    stale_uid
+                    for stale_uid in terminal_uids
+                    if not _state[stale_uid].get("handoff_ready")
+                ]
+                if unprepared:
+                    raise RuntimeError(
+                        "[MTP-vendored] batch expanded before exact MTP "
+                        "handoff preparation; refusing stale _next_tokens for "
+                        f"uid(s)={unprepared}"
+                    )
+
                 for stale_uid in terminal_uids:
+                    state = _state[stale_uid]
+                    queue = state["queue"]
+                    if not queue or queue[0][2]:
+                        raise RuntimeError(
+                            "[MTP-vendored] prepared handoff lost its "
+                            f"cache-safe token for uid={stale_uid}"
+                        )
+                    row = list(gb.uids).index(stale_uid)
+                    staged_tok = int(gb._next_tokens[row].item())
+                    if staged_tok != queue[0][0]:
+                        raise RuntimeError(
+                            "[MTP-vendored] BatchGenerator.extend replaced "
+                            f"the prepared token for uid={stale_uid}: "
+                            f"expected={queue[0][0]} actual={staged_tok}"
+                        )
+
+                _stats["ft_mid_stream_handoff"] += len(terminal_uids)
+                for stale_uid in terminal_uids:
+                    logger.info(
+                        "[MTP-vendored] uid=%s completed state-exact handoff "
+                        "as batch grew to size %d",
+                        stale_uid,
+                        len(gb.uids),
+                    )
                     _record_terminal_disable(stale_uid)
-                raise RuntimeError(
-                    "[MTP-vendored] single-request admission invariant violated: "
-                    f"batch grew to {len(gb.uids)} after MTP emitted for "
-                    f"uids={terminal_uids}. Failing closed because plain-decode "
-                    "handoff would corrupt the output stream."
-                )
             return _orig_step()
 
         uid = gb.uids[0]
@@ -1458,6 +1540,7 @@ def _install_mtp_vendored(
                 "primed": True,
                 "request_id": _first_call_req_id,
                 "sampling_fingerprint": sampling_options["fingerprint"],
+                "handoff_ready": False,
             }
             _stats["vendored_steps"] += 1
             # Codex round-I BLOCKING #2 / round-J BLOCKING #2+#3:
@@ -1481,8 +1564,8 @@ def _install_mtp_vendored(
         if not queue:
             gen = state["gen"]
             try:
-                tok_int, lp_arr, _from_draft = next(gen)
-                queue.append((int(tok_int), lp_arr))
+                tok_int, lp_arr, from_draft = next(gen)
+                queue.append((int(tok_int), lp_arr, bool(from_draft)))
             except StopIteration:
                 _stats["gen_exhausted"] += 1
                 # Codex round-G BLOCKING #2: preserve the terminal
@@ -1568,7 +1651,10 @@ def _install_mtp_vendored(
                     "output stream. Original exception logged above."
                 ) from e
 
-        tok_int, lp_arr = queue.pop(0)
+        tok_int, lp_arr, _from_draft = queue.pop(0)
+        # Admission may have prepared a safe token but then failed before
+        # extending the batch.  Publishing it here keeps the B=1 stream exact.
+        state["handoff_ready"] = False
         gb.tokens[0].append(tok_int)
         _stats["vendored_steps"] += 1
         # Codex round-I BLOCKING #2 / round-J BLOCKING #2+#3:
@@ -1650,6 +1736,7 @@ def _install_mtp_vendored(
     gb._mtp_vendored_state = _state
     gb._mtp_vendored_disabled_uids = _disabled_uids
     gb._mtp_vendored_terminal_uids = _terminal_uids
+    batch_gen._mtp_vendored_prepare_batch_expansion = _prepare_batch_expansion
 
     logger.info(
         "[MTP-vendored] installed on GenerationBatch._step "
@@ -6900,6 +6987,22 @@ class Scheduler:
 
             if self.batch_generator is None:
                 # Put back and try again later
+                self.waiting.appendleft(request)
+                break
+
+            # Before continuous batching extends a live B=1 MTP stream, stage
+            # a not-yet-emitted target token at the exact baseline cache
+            # boundary. Accepted drafts return False and drain at B=1 first.
+            prepare_mtp_expansion = getattr(
+                self.batch_generator,
+                "_mtp_vendored_prepare_batch_expansion",
+                None,
+            )
+            if (
+                self.running
+                and callable(prepare_mtp_expansion)
+                and not prepare_mtp_expansion()
+            ):
                 self.waiting.appendleft(request)
                 break
 

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -29,6 +29,7 @@ class SpeculativeConfig:
     num_speculative_tokens: int | None = None
     tree_budget: int | None = None
     disable_auto_k: bool | None = None
+    continuous_batching: bool = False
     max_suffix_len: int | None = None
     min_confidence: float | None = None
     min_draft_len: int | None = None
@@ -45,7 +46,14 @@ _METHOD_KEYS = {
     "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
     "dflash": frozenset({"model"}),
     "dspark": frozenset({"num_speculative_tokens"}),
-    "mtp": frozenset({"model", "num_speculative_tokens", "disable_auto_k"}),
+    "mtp": frozenset(
+        {
+            "model",
+            "num_speculative_tokens",
+            "disable_auto_k",
+            "continuous_batching",
+        }
+    ),
     "suffix": frozenset(
         {
             "num_speculative_tokens",
@@ -150,6 +158,10 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
         ),
         tree_budget=_positive_int(payload.get("tree_budget"), "tree_budget"),
         disable_auto_k=_optional_bool(payload.get("disable_auto_k"), "disable_auto_k"),
+        continuous_batching=(
+            _optional_bool(payload.get("continuous_batching"), "continuous_batching")
+            or False
+        ),
         max_suffix_len=_positive_int(payload.get("max_suffix_len"), "max_suffix_len"),
         min_confidence=_confidence(payload.get("min_confidence"), "min_confidence"),
         min_draft_len=_positive_int(payload.get("min_draft_len"), "min_draft_len"),

--- a/vllm_mlx/spec_decode/mtp/batched.py
+++ b/vllm_mlx/spec_decode/mtp/batched.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python contracts for continuous batched self-MTP.
+
+This module deliberately does not import MLX or the model-specific MTP
+implementations.  It owns the control-plane invariants that a later MLX
+coordinator must satisfy before it may run a batched propose/verify pass:
+
+* the feature is explicit-opt-in and every required capability is fail-closed;
+* lane admission respects a hard memory reserve and degrades draft depth;
+* a proposal is bound to an ordered membership epoch; and
+* membership cannot change until that proposal is committed or aborted.
+
+It does not execute model work, mutate caches, or sample tokens.  Those remain
+the responsibility of the future coordinator, which should use
+:class:`BatchedMTPBookkeeper` as its transaction ledger.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+
+class BatchedMTPRoute(str, enum.Enum):
+    """Control-plane route chosen for a lane set."""
+
+    BATCHED_MTP = "batched_mtp"
+    PLAIN_DECODE = "plain_decode"
+    QUEUE = "queue"
+
+
+@dataclass(frozen=True)
+class BatchedMTPCapabilities:
+    """Observed runtime capabilities; every field defaults to refusal.
+
+    These are runtime facts, not architecture-name promises.  An injector or
+    coordinator must explicitly attest each capability after installing the
+    corresponding model/cache surface.
+    """
+
+    target_batch_forward: bool = False
+    mtp_batch_forward: bool = False
+    ragged_target_rollback: bool = False
+    ragged_mtp_rollback: bool = False
+    atomic_cache_commit: bool = False
+    per_lane_rng: bool = False
+    transformed_distribution_verify: bool = False
+    dynamic_membership: bool = False
+    xtc_exact_verify: bool = False
+
+    def missing_core(self) -> tuple[str, ...]:
+        required = (
+            "target_batch_forward",
+            "mtp_batch_forward",
+            "ragged_target_rollback",
+            "ragged_mtp_rollback",
+            "atomic_cache_commit",
+        )
+        return tuple(name for name in required if getattr(self, name) is not True)
+
+
+@dataclass(frozen=True)
+class BatchedMTPConfig:
+    """Default-off policy for the future continuous-batching coordinator."""
+
+    enabled: bool = False
+    max_lanes: int = 4
+    max_draft_tokens: int = 2
+    min_batch_lanes: int = 2
+    hard_reserve_bytes: int = 8 * 1024**3
+    allow_dynamic_membership: bool = False
+    queue_on_memory_pressure: bool = True
+
+    def __post_init__(self) -> None:
+        boolean_fields = (
+            "enabled",
+            "allow_dynamic_membership",
+            "queue_on_memory_pressure",
+        )
+        if any(not isinstance(getattr(self, name), bool) for name in boolean_fields):
+            raise ValueError("batched MTP policy flags must be booleans")
+        if isinstance(self.max_lanes, bool) or not isinstance(self.max_lanes, int):
+            raise ValueError("max_lanes must be a positive integer")
+        if self.max_lanes < 1:
+            raise ValueError("max_lanes must be positive")
+        if isinstance(self.max_draft_tokens, bool) or not isinstance(
+            self.max_draft_tokens, int
+        ):
+            raise ValueError("max_draft_tokens must be a positive integer")
+        if self.max_draft_tokens < 1:
+            raise ValueError("max_draft_tokens must be positive")
+        if isinstance(self.min_batch_lanes, bool) or not isinstance(
+            self.min_batch_lanes, int
+        ):
+            raise ValueError("min_batch_lanes must be an integer")
+        if self.min_batch_lanes < 2:
+            raise ValueError("min_batch_lanes must be at least 2")
+        if self.min_batch_lanes > self.max_lanes:
+            raise ValueError("min_batch_lanes cannot exceed max_lanes")
+        if self.hard_reserve_bytes < 0:
+            raise ValueError("hard_reserve_bytes cannot be negative")
+
+
+@dataclass(frozen=True)
+class SamplingContract:
+    """Sampling features that must remain exact through verification."""
+
+    greedy: bool = True
+    has_logits_processors: bool = False
+    uses_xtc: bool = False
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, bool)
+            for value in (self.greedy, self.has_logits_processors, self.uses_xtc)
+        ):
+            raise ValueError("sampling contract flags must be booleans")
+
+
+@dataclass(frozen=True)
+class LaneAdmission:
+    """Scheduler-neutral description of one candidate request lane."""
+
+    lane_id: str
+    base_bytes: int = 0
+    bytes_per_draft_token: int = 0
+    sampling: SamplingContract = SamplingContract()
+    cache_ready: bool = True
+    terminal: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lane_id, str) or not self.lane_id:
+            raise ValueError("lane_id must be a non-empty string")
+        estimates = (self.base_bytes, self.bytes_per_draft_token)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) for value in estimates
+        ):
+            raise ValueError("lane memory estimates must be integers")
+        if self.base_bytes < 0 or self.bytes_per_draft_token < 0:
+            raise ValueError("lane memory estimates cannot be negative")
+        if not isinstance(self.cache_ready, bool) or not isinstance(
+            self.terminal, bool
+        ):
+            raise ValueError("lane lifecycle flags must be booleans")
+
+    def estimated_bytes(self, draft_tokens: int) -> int:
+        return self.base_bytes + self.bytes_per_draft_token * draft_tokens
+
+
+@dataclass(frozen=True)
+class LaneGate:
+    """Fail-closed eligibility verdict for one lane."""
+
+    eligible: bool
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """A deterministic routing plan; it performs no scheduler mutation."""
+
+    route: BatchedMTPRoute
+    batched_lane_ids: tuple[str, ...] = ()
+    plain_lane_ids: tuple[str, ...] = ()
+    queued_lane_ids: tuple[str, ...] = ()
+    draft_tokens: int = 0
+    estimated_bytes: int = 0
+    reasons: tuple[str, ...] = ()
+
+
+def assess_lane(
+    lane: LaneAdmission,
+    *,
+    config: BatchedMTPConfig,
+    capabilities: BatchedMTPCapabilities,
+) -> LaneGate:
+    """Return an explicit, fail-closed eligibility verdict for ``lane``."""
+
+    reasons: list[str] = []
+    if config.enabled is not True:
+        reasons.append("batched self-MTP is disabled")
+    reasons.extend(
+        f"missing capability: {name}" for name in capabilities.missing_core()
+    )
+    if (
+        config.allow_dynamic_membership is True
+        and capabilities.dynamic_membership is not True
+    ):
+        reasons.append("missing capability: dynamic_membership")
+    if lane.cache_ready is not True:
+        reasons.append("lane cache is not ready")
+    if lane.terminal is True:
+        reasons.append("lane is terminal")
+    if lane.sampling.has_logits_processors is True:
+        reasons.append("logits processors are not supported")
+    if lane.sampling.greedy is not True:
+        if capabilities.per_lane_rng is not True:
+            reasons.append("missing capability: per_lane_rng")
+        if capabilities.transformed_distribution_verify is not True:
+            reasons.append("missing capability: transformed_distribution_verify")
+    if lane.sampling.uses_xtc is True and capabilities.xtc_exact_verify is not True:
+        reasons.append("XTC verification is not exact")
+    return LaneGate(not reasons, tuple(reasons))
+
+
+def plan_admission(
+    lanes: Iterable[LaneAdmission],
+    *,
+    config: BatchedMTPConfig,
+    capabilities: BatchedMTPCapabilities,
+    free_bytes: int,
+) -> AdmissionDecision:
+    """Choose a lane set and draft depth without allocating memory.
+
+    The input order is scheduler priority.  The planner maximizes admitted
+    lane count first, then draft depth.  Consequently it lowers K when doing
+    so admits more concurrent requests.  Ineligible lanes always use plain
+    decode; eligible lanes that cannot fit the hard reserve are queued when
+    ``queue_on_memory_pressure`` is true.
+    """
+
+    if isinstance(free_bytes, bool) or not isinstance(free_bytes, int):
+        raise ValueError("free_bytes must be an integer")
+    if free_bytes < 0:
+        raise ValueError("free_bytes cannot be negative")
+    lane_list = tuple(lanes)
+    ids = [lane.lane_id for lane in lane_list]
+    if len(ids) != len(set(ids)):
+        raise ValueError("lane_id values must be unique")
+    if not lane_list:
+        return AdmissionDecision(
+            BatchedMTPRoute.PLAIN_DECODE, reasons=("no candidate lanes",)
+        )
+
+    eligible: list[LaneAdmission] = []
+    plain: list[str] = []
+    refusal_reasons: list[str] = []
+    for lane in lane_list:
+        gate = assess_lane(lane, config=config, capabilities=capabilities)
+        if gate.eligible:
+            eligible.append(lane)
+        else:
+            plain.append(lane.lane_id)
+            refusal_reasons.extend(
+                f"{lane.lane_id}: {reason}" for reason in gate.reasons
+            )
+
+    candidates = eligible[: config.max_lanes]
+    over_limit = tuple(lane.lane_id for lane in eligible[config.max_lanes :])
+    if len(candidates) < config.min_batch_lanes:
+        plain.extend(lane.lane_id for lane in candidates)
+        plain.extend(over_limit)
+        return AdmissionDecision(
+            BatchedMTPRoute.PLAIN_DECODE,
+            plain_lane_ids=tuple(plain),
+            reasons=tuple(refusal_reasons or ("fewer than minimum eligible lanes",)),
+        )
+
+    usable = max(0, free_bytes - config.hard_reserve_bytes)
+    best: tuple[int, int, int] | None = None
+    # Score by lane count first, then K.  Each depth considers the longest
+    # scheduler-priority prefix that fits the reserve.
+    for depth in range(config.max_draft_tokens, 0, -1):
+        used = 0
+        count = 0
+        for lane in candidates:
+            cost = lane.estimated_bytes(depth)
+            if used + cost > usable:
+                break
+            used += cost
+            count += 1
+        candidate = (count, depth, used)
+        if best is None or candidate[:2] > best[:2]:
+            best = candidate
+
+    assert best is not None
+    count, depth, used = best
+    if count >= config.min_batch_lanes:
+        admitted = tuple(lane.lane_id for lane in candidates[:count])
+        overflow = tuple(lane.lane_id for lane in candidates[count:]) + over_limit
+        if config.queue_on_memory_pressure:
+            queued = overflow
+        else:
+            plain.extend(overflow)
+            queued = ()
+        return AdmissionDecision(
+            BatchedMTPRoute.BATCHED_MTP,
+            batched_lane_ids=admitted,
+            plain_lane_ids=tuple(plain),
+            queued_lane_ids=queued,
+            draft_tokens=depth,
+            estimated_bytes=used,
+            reasons=tuple(refusal_reasons),
+        )
+
+    pressured = tuple(lane.lane_id for lane in candidates) + over_limit
+    if config.queue_on_memory_pressure:
+        return AdmissionDecision(
+            BatchedMTPRoute.QUEUE,
+            plain_lane_ids=tuple(plain),
+            queued_lane_ids=pressured,
+            reasons=tuple(refusal_reasons + ["hard memory reserve prevents a batch"]),
+        )
+    plain.extend(pressured)
+    return AdmissionDecision(
+        BatchedMTPRoute.PLAIN_DECODE,
+        plain_lane_ids=tuple(plain),
+        reasons=tuple(refusal_reasons + ["hard memory reserve prevents a batch"]),
+    )
+
+
+class BatchedMTPTransactionError(RuntimeError):
+    """A propose/commit or membership-epoch invariant was violated."""
+
+
+@dataclass(frozen=True)
+class ProposalTicket:
+    """Opaque proof that a proposal belongs to one ordered membership epoch."""
+
+    transaction_id: int
+    membership_epoch: int
+    lane_ids: tuple[str, ...]
+    draft_tokens: int
+    verify_rows: int
+
+
+@dataclass(frozen=True)
+class CommitReceipt:
+    transaction_id: int
+    membership_epoch: int
+    emitted_counts: tuple[tuple[str, int], ...]
+    terminal_lane_ids: tuple[str, ...]
+    total_emitted: int
+
+
+class BatchedMTPBookkeeper:
+    """Pure-Python membership and propose-to-commit transaction ledger."""
+
+    def __init__(self, lane_ids: Iterable[str] = ()) -> None:
+        self._lane_ids: list[str] = []
+        self._membership_epoch = 0
+        self._next_transaction_id = 1
+        self._outstanding: ProposalTicket | None = None
+        self._committed_tokens: dict[str, int] = {}
+        initial = tuple(lane_ids)
+        if initial:
+            self.attach(initial)
+
+    @property
+    def lane_ids(self) -> tuple[str, ...]:
+        return tuple(self._lane_ids)
+
+    @property
+    def membership_epoch(self) -> int:
+        return self._membership_epoch
+
+    @property
+    def outstanding(self) -> ProposalTicket | None:
+        return self._outstanding
+
+    def committed_tokens(self, lane_id: str) -> int:
+        try:
+            return self._committed_tokens[lane_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown lane_id: {lane_id}") from exc
+
+    def _require_membership_boundary(self) -> None:
+        if self._outstanding is not None:
+            raise BatchedMTPTransactionError(
+                "membership cannot change while a proposal is outstanding"
+            )
+
+    @staticmethod
+    def _validate_ids(lane_ids: Iterable[str]) -> tuple[str, ...]:
+        ids = tuple(lane_ids)
+        if any(not isinstance(lane_id, str) or not lane_id for lane_id in ids):
+            raise ValueError("lane_id values must be non-empty strings")
+        if len(ids) != len(set(ids)):
+            raise ValueError("lane_id values must be unique")
+        return ids
+
+    def attach(self, lane_ids: Iterable[str]) -> int:
+        """Attach lanes at a transaction boundary and return the new epoch."""
+
+        self._require_membership_boundary()
+        ids = self._validate_ids(lane_ids)
+        duplicates = set(ids).intersection(self._lane_ids)
+        if duplicates:
+            raise BatchedMTPTransactionError(
+                f"lane already attached: {', '.join(sorted(duplicates))}"
+            )
+        if ids:
+            self._lane_ids.extend(ids)
+            self._committed_tokens.update((lane_id, 0) for lane_id in ids)
+            self._membership_epoch += 1
+        return self._membership_epoch
+
+    def detach(self, lane_ids: Iterable[str]) -> int:
+        """Detach lanes at a transaction boundary and return the new epoch."""
+
+        self._require_membership_boundary()
+        ids = self._validate_ids(lane_ids)
+        unknown = set(ids).difference(self._lane_ids)
+        if unknown:
+            raise BatchedMTPTransactionError(
+                f"lane not attached: {', '.join(sorted(unknown))}"
+            )
+        if ids:
+            removed = set(ids)
+            self._lane_ids = [
+                lane_id for lane_id in self._lane_ids if lane_id not in removed
+            ]
+            for lane_id in ids:
+                del self._committed_tokens[lane_id]
+            self._membership_epoch += 1
+        return self._membership_epoch
+
+    def begin_proposal(self, *, draft_tokens: int) -> ProposalTicket:
+        """Open one proposal for the current ordered membership."""
+
+        if self._outstanding is not None:
+            raise BatchedMTPTransactionError("a proposal is already outstanding")
+        if not self._lane_ids:
+            raise BatchedMTPTransactionError("cannot propose with no attached lanes")
+        if (
+            isinstance(draft_tokens, bool)
+            or not isinstance(draft_tokens, int)
+            or draft_tokens < 1
+        ):
+            raise ValueError("draft_tokens must be a positive integer")
+        ticket = ProposalTicket(
+            transaction_id=self._next_transaction_id,
+            membership_epoch=self._membership_epoch,
+            lane_ids=tuple(self._lane_ids),
+            draft_tokens=draft_tokens,
+            verify_rows=(draft_tokens + 1) * len(self._lane_ids),
+        )
+        self._next_transaction_id += 1
+        self._outstanding = ticket
+        return ticket
+
+    def _require_ticket(self, ticket: ProposalTicket) -> None:
+        if self._outstanding is None:
+            raise BatchedMTPTransactionError("no proposal is outstanding")
+        if ticket != self._outstanding:
+            raise BatchedMTPTransactionError("stale or foreign proposal ticket")
+        if ticket.membership_epoch != self._membership_epoch:
+            raise BatchedMTPTransactionError("proposal membership epoch is stale")
+        if ticket.lane_ids != tuple(self._lane_ids):
+            raise BatchedMTPTransactionError("proposal lane order is stale")
+
+    def commit(
+        self,
+        ticket: ProposalTicket,
+        *,
+        emitted_counts: Mapping[str, int],
+        terminal_lane_ids: Iterable[str] = (),
+    ) -> CommitReceipt:
+        """Commit per-lane accepted counts, without changing membership."""
+
+        self._require_ticket(ticket)
+        if set(emitted_counts) != set(ticket.lane_ids):
+            raise BatchedMTPTransactionError(
+                "emitted_counts must contain every proposal lane exactly once"
+            )
+        ordered: list[tuple[str, int]] = []
+        maximum = ticket.draft_tokens + 1
+        for lane_id in ticket.lane_ids:
+            count = emitted_counts[lane_id]
+            if isinstance(count, bool) or not isinstance(count, int):
+                raise BatchedMTPTransactionError("emitted counts must be integers")
+            if count < 1 or count > maximum:
+                raise BatchedMTPTransactionError(
+                    f"emitted count for {lane_id} must be between 1 and {maximum}"
+                )
+            ordered.append((lane_id, count))
+
+        terminal = self._validate_ids(terminal_lane_ids)
+        unknown_terminal = set(terminal).difference(ticket.lane_ids)
+        if unknown_terminal:
+            raise BatchedMTPTransactionError(
+                "terminal lanes must belong to the committed proposal"
+            )
+
+        for lane_id, count in ordered:
+            self._committed_tokens[lane_id] += count
+        self._outstanding = None
+        return CommitReceipt(
+            transaction_id=ticket.transaction_id,
+            membership_epoch=ticket.membership_epoch,
+            emitted_counts=tuple(ordered),
+            terminal_lane_ids=terminal,
+            total_emitted=sum(count for _, count in ordered),
+        )
+
+    def abort(self, ticket: ProposalTicket) -> None:
+        """Discard bookkeeping for an uncommitted proposal."""
+
+        self._require_ticket(ticket)
+        self._outstanding = None
+
+
+__all__ = [
+    "AdmissionDecision",
+    "BatchedMTPBookkeeper",
+    "BatchedMTPCapabilities",
+    "BatchedMTPConfig",
+    "BatchedMTPRoute",
+    "BatchedMTPTransactionError",
+    "CommitReceipt",
+    "LaneAdmission",
+    "LaneGate",
+    "ProposalTicket",
+    "SamplingContract",
+    "assess_lane",
+    "plan_admission",
+]

--- a/vllm_mlx/spec_decode/mtp/continuous_batch.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_batch.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler-neutral generation wrapper for continuous self-MTP.
+
+The transaction engine in :mod:`continuous_engine` deliberately knows
+nothing about request delivery.  This module adds that missing, pure-Python
+boundary: it delivers the prepared first token, limits one proposal to each
+lane's remaining token budget and stop-token set, and commits exactly the
+prefix that the caller receives.
+
+This milestone is intentionally fixed-cohort.  A lane reaching a terminal
+condition tears down the *whole* cohort after the open proposal is committed.
+Terminal lanes are marked for finalization; companion lanes are returned as
+resumable detach packages.  A later scheduler integration may form a new
+cohort from those companions, but it must not turn that turnover into an
+incremental join.  In particular, the wrapper never enables Flash dynamic
+membership, even if a lower-level runtime is accidentally over-attested.
+
+No MLX type is imported here.  Model execution, cache merge/rollback/extract,
+and the target/MTP forward calls remain injected through ``continuous_engine``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from .continuous_engine import (
+    BatchedSelfMTPState,
+    ContinuousSelfMTPError,
+    ContinuousSelfMTPRuntime,
+    ContinuousSelfMTPUnsupportedError,
+    DetachedSelfMTPLane,
+    MTPToken,
+    SelfMTPLaneSpec,
+    attach_self_mtp_lanes,
+    commit_batched_self_mtp,
+    detach_self_mtp_lanes,
+    prepare_self_mtp_lane,
+    propose_batched_self_mtp,
+)
+
+
+class ContinuousMTPGenerationBatchError(ContinuousSelfMTPError):
+    """A delivery or lifecycle invariant failed in the generation wrapper."""
+
+
+@dataclass(frozen=True)
+class ContinuousMTPLaneState:
+    """Immutable scheduler-facing snapshot of one lane's delivery state."""
+
+    uid: int
+    emitted_tokens: int
+    max_tokens: int
+    remaining_tokens: int
+    stop_tokens: frozenset[int]
+    terminal: bool
+    finish_reason: str | None
+
+
+@dataclass(frozen=True)
+class ContinuousMTPLaneEmission:
+    """The exact token prefix delivered for one lane in one burst."""
+
+    uid: int
+    tokens: tuple[MTPToken, ...]
+    terminal: bool = False
+    finish_reason: str | None = None
+
+    @property
+    def token_ids(self) -> tuple[int, ...]:
+        return tuple(token.token for token in self.tokens)
+
+    @property
+    def logprobs(self) -> tuple[Any, ...]:
+        return tuple(token.logprobs for token in self.tokens)
+
+
+@dataclass(frozen=True)
+class ContinuousMTPDetachPackage:
+    """A detached lane plus its exact delivered-token ledger.
+
+    ``terminal`` distinguishes a request the scheduler should finalize from a
+    companion that was detached only because fixed-cohort turnover was
+    required.  Companion packages retain their canonical lane and cache pair
+    and are therefore resumable by a later integration.
+    """
+
+    detached: DetachedSelfMTPLane
+    tokens: tuple[MTPToken, ...]
+    terminal: bool
+    finish_reason: str | None
+
+    @property
+    def uid(self) -> int:
+        return self.detached.lane.uid
+
+    @property
+    def lane(self):
+        return self.detached.lane
+
+    @property
+    def caches(self):
+        return self.detached.caches
+
+    @property
+    def target_cache(self):
+        return self.detached.caches.target
+
+    @property
+    def draft_cache(self):
+        return self.detached.caches.draft
+
+    @property
+    def token_ids(self) -> tuple[int, ...]:
+        return tuple(token.token for token in self.tokens)
+
+    @property
+    def logprobs(self) -> tuple[Any, ...]:
+        return tuple(token.logprobs for token in self.tokens)
+
+
+@dataclass(frozen=True)
+class ContinuousMTPGenerationBurst:
+    """One delivery event: initial tokens or one proposal transaction."""
+
+    emissions: tuple[ContinuousMTPLaneEmission, ...]
+    emitted_counts: tuple[int, ...]
+    initial: bool
+    detached: tuple[ContinuousMTPDetachPackage, ...] = ()
+
+    @property
+    def cohort_detached(self) -> bool:
+        return bool(self.detached)
+
+    @property
+    def terminal_detaches(self) -> tuple[ContinuousMTPDetachPackage, ...]:
+        return tuple(package for package in self.detached if package.terminal)
+
+    @property
+    def resumable_detaches(self) -> tuple[ContinuousMTPDetachPackage, ...]:
+        return tuple(package for package in self.detached if not package.terminal)
+
+
+@dataclass
+class _LaneDeliveryState:
+    uid: int
+    max_tokens: int
+    stop_tokens: frozenset[int]
+    tokens: list[MTPToken] = field(default_factory=list)
+    finish_reason: str | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return self.finish_reason is not None
+
+
+class ContinuousMTPGenerationBatch:
+    """Own one fixed cohort from preparation through full-cohort extraction."""
+
+    def __init__(
+        self,
+        *,
+        batch: BatchedSelfMTPState,
+        first_tokens: Sequence[MTPToken],
+        stop_tokens: Mapping[int, frozenset[int]],
+    ) -> None:
+        if len(first_tokens) != len(batch.lanes):
+            raise ValueError("first_tokens must have one entry per lane")
+        self._batch = batch
+        self._first_tokens = tuple(first_tokens)
+        self._initial_pending = True
+        self._closed = False
+        self._detached: tuple[ContinuousMTPDetachPackage, ...] = ()
+        self._states = {
+            lane.uid: _LaneDeliveryState(
+                uid=lane.uid,
+                max_tokens=lane.max_tokens,
+                stop_tokens=stop_tokens[lane.uid],
+            )
+            for lane in batch.lanes
+        }
+
+    @classmethod
+    def create(
+        cls,
+        specs: Sequence[SelfMTPLaneSpec],
+        runtime: ContinuousSelfMTPRuntime,
+        *,
+        stop_tokens: Mapping[int, Iterable[int]] | None = None,
+    ) -> ContinuousMTPGenerationBatch:
+        """Prepare and attach one initial cohort.
+
+        ``stop_tokens`` is keyed by lane uid.  Unknown keys are rejected so a
+        scheduler typo cannot silently disable a request's stop condition.
+        """
+        specs = tuple(specs)
+        if not specs:
+            raise ValueError("cannot create an empty continuous MTP cohort")
+        uids = tuple(spec.uid for spec in specs)
+        if len(uids) != len(set(uids)):
+            raise ValueError("continuous MTP lane uid values must be unique")
+        normalized_stops = _normalize_stop_tokens(uids, stop_tokens)
+
+        prepared: list[DetachedSelfMTPLane] = []
+        first_tokens: list[MTPToken] = []
+        for spec in specs:
+            detached, first = prepare_self_mtp_lane(spec, runtime)
+            prepared.append(detached)
+            first_tokens.append(first)
+        batch = attach_self_mtp_lanes(None, prepared, runtime=runtime)
+        return cls(
+            batch=batch,
+            first_tokens=first_tokens,
+            stop_tokens=normalized_stops,
+        )
+
+    @property
+    def lane_uids(self) -> tuple[int, ...]:
+        return tuple(self._states)
+
+    @property
+    def initial_pending(self) -> bool:
+        return self._initial_pending
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def lane_states(self) -> tuple[ContinuousMTPLaneState, ...]:
+        snapshots = []
+        for state in self._states.values():
+            emitted = len(state.tokens)
+            snapshots.append(
+                ContinuousMTPLaneState(
+                    uid=state.uid,
+                    emitted_tokens=emitted,
+                    max_tokens=state.max_tokens,
+                    remaining_tokens=max(state.max_tokens - emitted, 0),
+                    stop_tokens=state.stop_tokens,
+                    terminal=state.terminal,
+                    finish_reason=state.finish_reason,
+                )
+            )
+        return tuple(snapshots)
+
+    def attach_lanes(self, joining: Sequence[DetachedSelfMTPLane]) -> None:
+        """Refuse incremental joins at the wrapper's fixed-cohort boundary.
+
+        This is unconditional, including for a Flash runtime whose lower-level
+        dynamic flags were set.  ``joining`` is accepted only to make the
+        scheduler integration seam explicit; its contents are never touched.
+        """
+        del joining
+        raise ContinuousSelfMTPUnsupportedError(
+            "ContinuousMTPGenerationBatch is fixed-cohort; incremental join "
+            "is unsupported (including Flash)"
+        )
+
+    def next_burst(self) -> ContinuousMTPGenerationBurst:
+        """Deliver initial tokens or run, bound, and commit one proposal."""
+        self._require_open()
+        if self._initial_pending:
+            return self._deliver_initial()
+
+        proposal = propose_batched_self_mtp(self._batch)
+        planned: list[tuple[int, tuple[MTPToken, ...], str | None]] = []
+        emitted_counts: list[int] = []
+        terminal: list[bool] = []
+        for uid, outputs in zip(proposal.lane_uids, proposal.outputs):
+            state = self._states[uid]
+            delivered, finish_reason = _bounded_prefix(state, outputs)
+            planned.append((uid, delivered, finish_reason))
+            emitted_counts.append(len(delivered))
+            terminal.append(finish_reason is not None)
+
+        commit_batched_self_mtp(
+            self._batch,
+            proposal,
+            emitted_counts=emitted_counts,
+            terminal=terminal,
+        )
+        emissions: list[ContinuousMTPLaneEmission] = []
+        for uid, delivered, finish_reason in planned:
+            state = self._states[uid]
+            state.tokens.extend(delivered)
+            state.finish_reason = finish_reason
+            emissions.append(
+                ContinuousMTPLaneEmission(
+                    uid=uid,
+                    tokens=delivered,
+                    terminal=state.terminal,
+                    finish_reason=state.finish_reason,
+                )
+            )
+        detached = self._detach_cohort() if any(terminal) else ()
+        return ContinuousMTPGenerationBurst(
+            emissions=tuple(emissions),
+            emitted_counts=tuple(emitted_counts),
+            initial=False,
+            detached=detached,
+        )
+
+    def detach_all(self) -> tuple[ContinuousMTPDetachPackage, ...]:
+        """Extract every lane/cache pair without inventing finish reasons.
+
+        This is idempotent after a successful teardown.  It is suitable for
+        cancellation, shutdown, or scheduler turnover.  If the prepared first
+        tokens have not yet been delivered, their token ledger is intentionally
+        empty even though the detached canonical lane retains its ``cur``.
+        """
+        if self._closed:
+            return self._detached
+        return self._detach_cohort()
+
+    def _deliver_initial(self) -> ContinuousMTPGenerationBurst:
+        emissions: list[ContinuousMTPLaneEmission] = []
+        terminal: list[bool] = []
+        for uid, token in zip(self.lane_uids, self._first_tokens):
+            state = self._states[uid]
+            state.tokens.append(token)
+            if token.token in state.stop_tokens:
+                state.finish_reason = "stop"
+            elif len(state.tokens) >= state.max_tokens:
+                state.finish_reason = "length"
+            emissions.append(
+                ContinuousMTPLaneEmission(
+                    uid=uid,
+                    tokens=(token,),
+                    terminal=state.terminal,
+                    finish_reason=state.finish_reason,
+                )
+            )
+            terminal.append(state.terminal)
+        self._initial_pending = False
+        detached = self._detach_cohort() if any(terminal) else ()
+        return ContinuousMTPGenerationBurst(
+            emissions=tuple(emissions),
+            emitted_counts=tuple(1 for _ in emissions),
+            initial=True,
+            detached=detached,
+        )
+
+    def _detach_cohort(self) -> tuple[ContinuousMTPDetachPackage, ...]:
+        if self._closed:
+            return self._detached
+        indices = tuple(range(len(self._batch.lanes)))
+        self._batch, detached = detach_self_mtp_lanes(self._batch, indices)
+        packages = []
+        for item in detached:
+            state = self._states[item.lane.uid]
+            packages.append(
+                ContinuousMTPDetachPackage(
+                    detached=item,
+                    tokens=tuple(state.tokens),
+                    terminal=state.terminal,
+                    finish_reason=state.finish_reason,
+                )
+            )
+        self._detached = tuple(packages)
+        self._closed = True
+        return self._detached
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ContinuousMTPGenerationBatchError(
+                "continuous MTP generation cohort is already detached"
+            )
+
+
+def _normalize_stop_tokens(
+    uids: Sequence[int],
+    stop_tokens: Mapping[int, Iterable[int]] | None,
+) -> dict[int, frozenset[int]]:
+    raw = {} if stop_tokens is None else dict(stop_tokens)
+    unknown = set(raw).difference(uids)
+    if unknown:
+        raise ValueError(
+            f"stop_tokens contains unknown lane uid values: {sorted(unknown)}"
+        )
+    normalized: dict[int, frozenset[int]] = {}
+    for uid in uids:
+        values = frozenset(raw.get(uid, ()))
+        if any(
+            isinstance(token, bool) or not isinstance(token, int) for token in values
+        ):
+            raise ValueError("stop token ids must be integers")
+        normalized[uid] = values
+    return normalized
+
+
+def _bounded_prefix(
+    state: _LaneDeliveryState,
+    outputs: Sequence[MTPToken],
+) -> tuple[tuple[MTPToken, ...], str | None]:
+    remaining = state.max_tokens - len(state.tokens)
+    if remaining <= 0:
+        raise ContinuousMTPGenerationBatchError(
+            f"lane {state.uid} was proposed after exhausting max_tokens"
+        )
+    bounded = tuple(outputs[:remaining])
+    for index, token in enumerate(bounded):
+        if token.token in state.stop_tokens:
+            return bounded[: index + 1], "stop"
+    if len(bounded) < len(outputs) or len(bounded) == remaining:
+        return bounded, "length"
+    return bounded, None
+
+
+__all__ = [
+    "ContinuousMTPDetachPackage",
+    "ContinuousMTPGenerationBatch",
+    "ContinuousMTPGenerationBatchError",
+    "ContinuousMTPGenerationBurst",
+    "ContinuousMTPLaneEmission",
+    "ContinuousMTPLaneState",
+]

--- a/vllm_mlx/spec_decode/mtp/continuous_engine.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_engine.py
@@ -1,0 +1,641 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-membership continuous self-MTP transaction core.
+
+This is a scheduler-neutral port of the persistent batched self-MTP lifecycle
+introduced by immutable source commit ``92576ced``.  It deliberately imports no
+MLX modules and makes no model or cache-layout assumptions.  Model execution and
+ragged cache operations cross explicit injected protocols, allowing Rapid's
+``return_hidden=True`` / ``n_confirmed=...`` ABI and its version-gated ragged
+adapter to evolve independently.
+
+The first milestone is fixed membership: an initial group may attach, transact,
+and detach as a whole.  Incremental attach or partial detach is refused unless
+both policy and runtime capabilities attest dynamic membership.  Flash-family
+models require an additional architecture-specific attestation.  The feature is
+default-off and XTC is unconditionally refused until an exact verifier exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+class ContinuousSelfMTPError(RuntimeError):
+    """Base error for a fail-closed engine invariant."""
+
+
+class ContinuousSelfMTPUnsupportedError(ContinuousSelfMTPError):
+    """The requested policy lacks an explicitly attested runtime capability."""
+
+
+@dataclass(frozen=True)
+class ContinuousSelfMTPConfig:
+    enabled: bool = False
+    allow_dynamic_membership: bool = False
+    architecture: str = "unknown"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.enabled, bool) or not isinstance(
+            self.allow_dynamic_membership, bool
+        ):
+            raise ValueError("continuous self-MTP policy flags must be booleans")
+        if not isinstance(self.architecture, str) or not self.architecture:
+            raise ValueError("architecture must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class ContinuousSelfMTPCapabilities:
+    """Runtime facts.  Every field defaults to refusal."""
+
+    target_return_hidden: bool = False
+    mtp_return_hidden: bool = False
+    confirmed_target_forward: bool = False
+    ragged_rollback: bool = False
+    atomic_cache_commit: bool = False
+    transformed_sampling: bool = False
+    logits_processors_exact: bool = False
+    dynamic_membership: bool = False
+    flash_dynamic_membership_attested: bool = False
+
+    def missing_fixed_core(self) -> tuple[str, ...]:
+        required = (
+            "target_return_hidden",
+            "mtp_return_hidden",
+            "confirmed_target_forward",
+            "ragged_rollback",
+            "atomic_cache_commit",
+        )
+        return tuple(name for name in required if getattr(self, name) is not True)
+
+
+@dataclass(frozen=True)
+class RapidForwardSeams:
+    """Adapters for Rapid's current target and MTP call signatures.
+
+    ``target`` always requests hidden states and explicitly supplies
+    ``n_confirmed``. ``draft`` requests the post-MTP hidden state.  Backends use
+    these helpers instead of assuming mlx-lm-unified's ``mtp_step`` API.
+    """
+
+    model_forward: Callable[..., Any]
+    mtp_forward: Callable[..., Any]
+
+    def __post_init__(self) -> None:
+        if not callable(self.model_forward) or not callable(self.mtp_forward):
+            raise TypeError("Rapid forward seams must be callable")
+
+    def target(
+        self,
+        inputs: Any,
+        cache: Any,
+        *,
+        n_confirmed: int = 0,
+    ) -> Any:
+        if isinstance(n_confirmed, bool) or not isinstance(n_confirmed, int):
+            raise ValueError("n_confirmed must be an integer")
+        if n_confirmed < 0:
+            raise ValueError("n_confirmed cannot be negative")
+        return self.model_forward(
+            inputs,
+            cache=cache,
+            return_hidden=True,
+            n_confirmed=n_confirmed,
+        )
+
+    def draft(self, hidden: Any, token_ids: Any, cache: Any) -> Any:
+        return self.mtp_forward(
+            hidden,
+            token_ids,
+            cache,
+            return_hidden=True,
+        )
+
+
+@dataclass(frozen=True)
+class SelfMTPSampling:
+    temperature: float = 0.0
+    has_logits_processors: bool = False
+    uses_xtc: bool = False
+
+    def __post_init__(self) -> None:
+        if isinstance(self.temperature, bool) or not isinstance(
+            self.temperature, (int, float)
+        ):
+            raise ValueError("temperature must be numeric")
+        if self.temperature < 0:
+            raise ValueError("temperature cannot be negative")
+        if not isinstance(self.has_logits_processors, bool) or not isinstance(
+            self.uses_xtc, bool
+        ):
+            raise ValueError("sampling feature flags must be booleans")
+
+
+@dataclass(frozen=True)
+class SelfMTPLaneSpec:
+    uid: int
+    prompt: Any
+    max_tokens: int
+    num_draft: int = 1
+    sampling: SelfMTPSampling = SelfMTPSampling()
+    prompt_cache: Any = None
+    mtp_cache: Any = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.uid, bool) or not isinstance(self.uid, int):
+            raise ValueError("uid must be an integer")
+        for name in ("max_tokens", "num_draft"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class MTPToken:
+    token: int
+    logprobs: Any
+    from_draft: bool
+
+    def __post_init__(self) -> None:
+        if isinstance(self.token, bool) or not isinstance(self.token, int):
+            raise ValueError("token must be an integer")
+        if not isinstance(self.from_draft, bool):
+            raise ValueError("from_draft must be a boolean")
+
+
+@dataclass
+class SelfMTPCachePair:
+    target: Any
+    draft: Any
+
+
+@dataclass
+class SelfMTPLane:
+    uid: int
+    cur: int
+    seed_hidden: Any
+    token_prefix: Any
+    ntoks: int
+    max_tokens: int
+    num_draft: int
+    sampling: SelfMTPSampling
+    pending_hidden: Any = None
+    pending_tokens: list[int] = field(default_factory=list)
+    backend_state: Any = None
+
+
+@dataclass
+class DetachedSelfMTPLane:
+    lane: SelfMTPLane
+    caches: SelfMTPCachePair
+    _runtime: ContinuousSelfMTPRuntime = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class PreparedLaneData:
+    """Data-plane result returned by ``SelfMTPComputeBackend.prepare``."""
+
+    cur: int
+    seed_hidden: Any
+    token_prefix: Any
+    caches: SelfMTPCachePair
+    first_token: MTPToken
+    backend_state: Any = None
+
+
+@dataclass(frozen=True)
+class CycleComputation:
+    """Uncommitted result returned by ``SelfMTPComputeBackend.propose``."""
+
+    lane_uids: tuple[int, ...]
+    draft_depths: tuple[int, ...]
+    accepted_lengths: tuple[int, ...]
+    target_drops: tuple[int, ...]
+    draft_drops: tuple[int, ...]
+    outputs: tuple[tuple[MTPToken, ...], ...]
+    payload: Any = None
+
+
+@dataclass(frozen=True)
+class SelfMTPCycleResult:
+    membership_epoch: int
+    lane_uids: tuple[int, ...]
+    draft_depths: tuple[int, ...]
+    accepted_lengths: tuple[int, ...]
+    target_drops: tuple[int, ...]
+    draft_drops: tuple[int, ...]
+    outputs: tuple[tuple[MTPToken, ...], ...]
+    _computation: CycleComputation = field(repr=False, compare=False)
+
+
+class SelfMTPComputeBackend(Protocol):
+    """Model-specific compute seam; implementations may import MLX."""
+
+    def prepare(
+        self, spec: SelfMTPLaneSpec, forwards: RapidForwardSeams
+    ) -> PreparedLaneData: ...
+
+    def propose(
+        self,
+        lanes: Sequence[SelfMTPLane],
+        caches: SelfMTPCachePair,
+        forwards: RapidForwardSeams,
+    ) -> CycleComputation: ...
+
+    def commit(
+        self,
+        lanes: Sequence[SelfMTPLane],
+        computation: CycleComputation,
+        *,
+        emitted_counts: tuple[int, ...],
+        terminal: tuple[bool, ...],
+    ) -> None: ...
+
+    def detach_lane(self, lane: SelfMTPLane, caches: SelfMTPCachePair) -> None: ...
+
+
+class SelfMTPCacheAdapter(Protocol):
+    """Injected merge/rollback/extract seam for Rapid's ragged adapter."""
+
+    def attach(
+        self,
+        current: SelfMTPCachePair | None,
+        joining: Sequence[SelfMTPCachePair],
+    ) -> SelfMTPCachePair: ...
+
+    def rollback(
+        self,
+        caches: SelfMTPCachePair,
+        *,
+        target_drops: Sequence[int],
+        draft_drops: Sequence[int],
+        verify_width: int,
+    ) -> None: ...
+
+    def detach(
+        self,
+        caches: SelfMTPCachePair,
+        indices: Sequence[int],
+        keep_indices: Sequence[int],
+    ) -> tuple[SelfMTPCachePair, list[SelfMTPCachePair]]: ...
+
+
+@dataclass(frozen=True)
+class ContinuousSelfMTPRuntime:
+    config: ContinuousSelfMTPConfig
+    capabilities: ContinuousSelfMTPCapabilities
+    forwards: RapidForwardSeams
+    compute: SelfMTPComputeBackend
+    caches: SelfMTPCacheAdapter
+
+
+@dataclass
+class BatchedSelfMTPState:
+    lanes: list[SelfMTPLane]
+    caches: SelfMTPCachePair
+    membership_epoch: int
+    _runtime: ContinuousSelfMTPRuntime = field(repr=False, compare=False)
+    proposal_open: bool = False
+    _open_proposal: SelfMTPCycleResult | None = field(
+        default=None, repr=False, compare=False
+    )
+
+
+def _require_fixed_core(runtime: ContinuousSelfMTPRuntime) -> None:
+    if runtime.config.enabled is not True:
+        raise ContinuousSelfMTPUnsupportedError("continuous self-MTP is disabled")
+    missing = runtime.capabilities.missing_fixed_core()
+    if missing:
+        raise ContinuousSelfMTPUnsupportedError(
+            "missing fixed-membership capability: " + ", ".join(missing)
+        )
+
+
+def _require_dynamic(runtime: ContinuousSelfMTPRuntime) -> None:
+    if runtime.config.allow_dynamic_membership is not True:
+        raise ContinuousSelfMTPUnsupportedError(
+            "dynamic membership is disabled; fixed-membership milestone only"
+        )
+    if runtime.capabilities.dynamic_membership is not True:
+        raise ContinuousSelfMTPUnsupportedError(
+            "dynamic membership lacks runtime capability attestation"
+        )
+    if (
+        "flash" in runtime.config.architecture.lower()
+        and runtime.capabilities.flash_dynamic_membership_attested is not True
+    ):
+        raise ContinuousSelfMTPUnsupportedError(
+            "Flash dynamic membership lacks capability attestation"
+        )
+
+
+def _require_sampling(
+    sampling: SelfMTPSampling, capabilities: ContinuousSelfMTPCapabilities
+) -> None:
+    if sampling.uses_xtc:
+        raise ContinuousSelfMTPUnsupportedError(
+            "XTC is not supported by the exact continuous self-MTP verifier"
+        )
+    if sampling.temperature > 0 and capabilities.transformed_sampling is not True:
+        raise ContinuousSelfMTPUnsupportedError(
+            "transformed sampling lacks exact-verification attestation"
+        )
+    if (
+        sampling.has_logits_processors
+        and capabilities.logits_processors_exact is not True
+    ):
+        raise ContinuousSelfMTPUnsupportedError(
+            "logits processors lack exact-verification attestation"
+        )
+
+
+def prepare_self_mtp_lane(
+    spec: SelfMTPLaneSpec,
+    runtime: ContinuousSelfMTPRuntime,
+) -> tuple[DetachedSelfMTPLane, MTPToken]:
+    """Prepare one canonical lane without changing batch membership."""
+    _require_fixed_core(runtime)
+    _require_sampling(spec.sampling, runtime.capabilities)
+    prepared = runtime.compute.prepare(spec, runtime.forwards)
+    if not isinstance(prepared, PreparedLaneData):
+        raise TypeError("compute.prepare must return PreparedLaneData")
+    if prepared.first_token.from_draft:
+        raise ContinuousSelfMTPError("the prepared first token cannot be a draft")
+    if prepared.first_token.token != prepared.cur:
+        raise ContinuousSelfMTPError("prepared first token and lane cur disagree")
+
+    lane = SelfMTPLane(
+        uid=spec.uid,
+        cur=prepared.cur,
+        seed_hidden=prepared.seed_hidden,
+        token_prefix=prepared.token_prefix,
+        ntoks=1,
+        max_tokens=spec.max_tokens,
+        num_draft=spec.num_draft,
+        sampling=spec.sampling,
+        backend_state=prepared.backend_state,
+    )
+    return (
+        DetachedSelfMTPLane(lane, prepared.caches, runtime),
+        prepared.first_token,
+    )
+
+
+def attach_self_mtp_lanes(
+    batch: BatchedSelfMTPState | None,
+    joining: Sequence[DetachedSelfMTPLane],
+    *,
+    runtime: ContinuousSelfMTPRuntime | None = None,
+) -> BatchedSelfMTPState:
+    """Attach initial lanes; later membership changes require attestation."""
+    joining = list(joining)
+    if batch is not None and batch.proposal_open:
+        raise ContinuousSelfMTPError("cannot attach while a proposal is open")
+    if batch is None:
+        if not joining:
+            raise ValueError("cannot create an empty self-MTP batch")
+        active_runtime = runtime or joining[0]._runtime
+    else:
+        active_runtime = batch._runtime
+        if not joining:
+            return batch
+        _require_dynamic(active_runtime)
+    _require_fixed_core(active_runtime)
+    if any(item._runtime is not active_runtime for item in joining):
+        raise ContinuousSelfMTPError("all lanes must share one runtime")
+
+    existing = [] if batch is None else batch.lanes
+    uids = [lane.uid for lane in existing] + [item.lane.uid for item in joining]
+    if len(uids) != len(set(uids)):
+        raise ValueError("self-MTP lane uid values must be unique")
+    depths = {lane.num_draft for lane in existing}
+    depths.update(item.lane.num_draft for item in joining)
+    if len(depths) != 1:
+        raise ValueError("adaptive per-lane draft depth is excluded")
+
+    merged = active_runtime.caches.attach(
+        None if batch is None else batch.caches,
+        [item.caches for item in joining],
+    )
+    if batch is None:
+        return BatchedSelfMTPState(
+            lanes=[item.lane for item in joining],
+            caches=merged,
+            membership_epoch=1,
+            _runtime=active_runtime,
+        )
+    batch.caches = merged
+    batch.lanes.extend(item.lane for item in joining)
+    batch.membership_epoch += 1
+    return batch
+
+
+def _validate_computation(
+    batch: BatchedSelfMTPState, computation: CycleComputation
+) -> None:
+    n = len(batch.lanes)
+    expected_uids = tuple(lane.uid for lane in batch.lanes)
+    if computation.lane_uids != expected_uids:
+        raise ContinuousSelfMTPError("compute backend changed lane order")
+    vectors = (
+        computation.draft_depths,
+        computation.accepted_lengths,
+        computation.target_drops,
+        computation.draft_drops,
+        computation.outputs,
+    )
+    if any(len(vector) != n for vector in vectors):
+        raise ContinuousSelfMTPError("proposal vectors must match lane count")
+    for row, (lane, depth, accepted, target_drop, draft_drop, outputs) in enumerate(
+        zip(batch.lanes, *vectors)
+    ):
+        if any(
+            isinstance(value, bool) or not isinstance(value, int)
+            for value in (depth, accepted, target_drop, draft_drop)
+        ):
+            raise ContinuousSelfMTPError(f"proposal row {row} has non-integer counts")
+        if depth < 0 or accepted < 0 or accepted > depth:
+            raise ContinuousSelfMTPError(f"proposal row {row} has invalid acceptance")
+        maximum_depth = min(
+            lane.num_draft,
+            max(lane.max_tokens - lane.ntoks - 1, 0),
+        )
+        if depth > maximum_depth:
+            raise ContinuousSelfMTPError(
+                f"proposal row {row} exceeds its remaining draft budget"
+            )
+        if target_drop != depth - accepted or draft_drop != depth:
+            raise ContinuousSelfMTPError(f"proposal row {row} rollback is inconsistent")
+        if len(outputs) != accepted + 1:
+            raise ContinuousSelfMTPError(
+                f"proposal row {row} must contain accepted drafts plus one target token"
+            )
+        if any(not isinstance(token, MTPToken) for token in outputs):
+            raise ContinuousSelfMTPError(f"proposal row {row} has an invalid token")
+        if any(not token.from_draft for token in outputs[:-1]):
+            raise ContinuousSelfMTPError(
+                f"proposal row {row} accepted output is not marked as a draft"
+            )
+        if outputs[-1].from_draft:
+            raise ContinuousSelfMTPError(
+                f"proposal row {row} final target token is marked as a draft"
+            )
+
+
+def propose_batched_self_mtp(batch: BatchedSelfMTPState) -> SelfMTPCycleResult:
+    """Open one fixed-membership batched draft/verify transaction."""
+    _require_fixed_core(batch._runtime)
+    if batch.proposal_open:
+        raise ContinuousSelfMTPError("a self-MTP proposal is already open")
+    if not batch.lanes:
+        raise ValueError("cannot propose on an empty self-MTP batch")
+    computation = batch._runtime.compute.propose(
+        batch.lanes, batch.caches, batch._runtime.forwards
+    )
+    if not isinstance(computation, CycleComputation):
+        raise TypeError("compute.propose must return CycleComputation")
+    _validate_computation(batch, computation)
+    verify_width = max(depth + 1 for depth in computation.draft_depths)
+    batch._runtime.caches.rollback(
+        batch.caches,
+        target_drops=computation.target_drops,
+        draft_drops=computation.draft_drops,
+        verify_width=verify_width,
+    )
+    proposal = SelfMTPCycleResult(
+        membership_epoch=batch.membership_epoch,
+        lane_uids=computation.lane_uids,
+        draft_depths=computation.draft_depths,
+        accepted_lengths=computation.accepted_lengths,
+        target_drops=computation.target_drops,
+        draft_drops=computation.draft_drops,
+        outputs=computation.outputs,
+        _computation=computation,
+    )
+    batch.proposal_open = True
+    batch._open_proposal = proposal
+    return proposal
+
+
+def commit_batched_self_mtp(
+    batch: BatchedSelfMTPState,
+    proposal: SelfMTPCycleResult,
+    *,
+    emitted_counts: Sequence[int],
+    terminal: Sequence[bool],
+) -> None:
+    """Commit exactly the delivered prefix of the open proposal."""
+    if not batch.proposal_open or batch._open_proposal is not proposal:
+        raise ContinuousSelfMTPError("commit requires the currently open proposal")
+    if proposal.membership_epoch != batch.membership_epoch:
+        raise ContinuousSelfMTPError("membership changed during an open proposal")
+    if proposal.lane_uids != tuple(lane.uid for lane in batch.lanes):
+        raise ContinuousSelfMTPError("lane order changed during an open proposal")
+    n = len(batch.lanes)
+    if len(emitted_counts) != n or len(terminal) != n:
+        raise ValueError("commit vectors must have one entry per lane")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in emitted_counts
+    ):
+        raise ValueError("emitted_counts values must be integers")
+    if any(not isinstance(value, bool) for value in terminal):
+        raise ValueError("terminal values must be booleans")
+    emitted = tuple(emitted_counts)
+    terminal_flags = tuple(terminal)
+    delivery_drops: list[int] = []
+    for row, (count, is_terminal, outputs, accepted) in enumerate(
+        zip(emitted, terminal_flags, proposal.outputs, proposal.accepted_lengths)
+    ):
+        if count < 0 or count > len(outputs):
+            raise ValueError(f"lane {row} emitted_count {count} is out of range")
+        if not is_terminal and count != len(outputs):
+            raise ValueError("a nonterminal lane must consume its entire proposal")
+        if is_terminal and count < len(outputs) and count > accepted:
+            raise ValueError("a terminal prefix cannot split the target bonus token")
+        delivery_drops.append(
+            accepted - count + 1 if is_terminal and count <= accepted else 0
+        )
+
+    if any(delivery_drops):
+        batch._runtime.caches.rollback(
+            batch.caches,
+            target_drops=delivery_drops,
+            draft_drops=[0] * n,
+            verify_width=max(depth + 1 for depth in proposal.draft_depths),
+        )
+    batch._runtime.compute.commit(
+        batch.lanes,
+        proposal._computation,
+        emitted_counts=emitted,
+        terminal=terminal_flags,
+    )
+    for lane, count in zip(batch.lanes, emitted):
+        lane.ntoks += count
+    batch.proposal_open = False
+    batch._open_proposal = None
+
+
+def detach_self_mtp_lanes(
+    batch: BatchedSelfMTPState,
+    indices: Sequence[int],
+) -> tuple[BatchedSelfMTPState, list[DetachedSelfMTPLane]]:
+    """Detach all lanes at teardown; partial detach requires dynamic support."""
+    if batch.proposal_open:
+        raise ContinuousSelfMTPError("cannot detach while a proposal is open")
+    requested = [int(index) for index in indices]
+    if len(requested) != len(set(requested)):
+        raise ValueError("detach indices must be unique")
+    if any(index < 0 or index >= len(batch.lanes) for index in requested):
+        raise IndexError("detach index is outside the self-MTP batch")
+    if not requested:
+        return batch, []
+    if len(requested) != len(batch.lanes):
+        _require_dynamic(batch._runtime)
+
+    leaving = set(requested)
+    keep = [index for index in range(len(batch.lanes)) if index not in leaving]
+    remaining_caches, detached_caches = batch._runtime.caches.detach(
+        batch.caches, requested, keep
+    )
+    if len(detached_caches) != len(requested):
+        raise ContinuousSelfMTPError("cache adapter returned wrong detached row count")
+    detached: list[DetachedSelfMTPLane] = []
+    for index, caches in zip(requested, detached_caches):
+        lane = batch.lanes[index]
+        batch._runtime.compute.detach_lane(lane, caches)
+        lane.pending_hidden = None
+        lane.pending_tokens = []
+        detached.append(DetachedSelfMTPLane(lane, caches, batch._runtime))
+    batch.lanes = [batch.lanes[index] for index in keep]
+    batch.caches = remaining_caches
+    batch.membership_epoch += 1
+    return batch, detached
+
+
+__all__ = [
+    "BatchedSelfMTPState",
+    "ContinuousSelfMTPConfig",
+    "ContinuousSelfMTPCapabilities",
+    "ContinuousSelfMTPError",
+    "ContinuousSelfMTPRuntime",
+    "ContinuousSelfMTPUnsupportedError",
+    "CycleComputation",
+    "DetachedSelfMTPLane",
+    "MTPToken",
+    "PreparedLaneData",
+    "RapidForwardSeams",
+    "SelfMTPCacheAdapter",
+    "SelfMTPCachePair",
+    "SelfMTPComputeBackend",
+    "SelfMTPCycleResult",
+    "SelfMTPLane",
+    "SelfMTPLaneSpec",
+    "SelfMTPSampling",
+    "attach_self_mtp_lanes",
+    "commit_batched_self_mtp",
+    "detach_self_mtp_lanes",
+    "prepare_self_mtp_lane",
+    "propose_batched_self_mtp",
+]

--- a/vllm_mlx/spec_decode/mtp/continuous_routing.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_routing.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure integration planner for default-off continuous self-MTP.
+
+This module is the scheduler boundary, not a live token coordinator.  It turns
+immutable request metadata into a fixed-cohort plan, validates joint APC/MTP
+prepared-state sidecars, and chooses continuous, legacy-MTP, queue, or plain
+decode without touching scheduler queues, caches, or generation batches.
+
+The scheduler may attach an admitted router for later use, but PR 9 deliberately
+leaves its existing vendored MTP ``_step`` implementation as the live data
+plane.  ``live_token_delivery`` therefore remains unconditionally false.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from .batched import (
+    AdmissionDecision,
+    BatchedMTPCapabilities,
+    BatchedMTPConfig,
+    BatchedMTPRoute,
+    LaneAdmission,
+    SamplingContract,
+    plan_admission,
+)
+from .continuous_engine import SelfMTPLaneSpec, SelfMTPSampling
+from .prepared_state import (
+    PreparedMTPState,
+    PreparedStateIdentity,
+    RestoreEligibility,
+    evaluate_restore,
+)
+
+
+class ContinuousMTPIntegrationRoute(str, enum.Enum):
+    CONTINUOUS_PLANNED = "continuous_planned"
+    LEGACY_MTP = "legacy_mtp"
+    PLAIN_DECODE = "plain_decode"
+    QUEUE = "queue"
+
+
+@dataclass(frozen=True)
+class ContinuousMTPAPCHit:
+    """Opaque joint target/MTP/hidden sidecar plus its live cache counts."""
+
+    state: PreparedMTPState
+    expected_identity: PreparedStateIdentity
+    target_cache_tokens: int
+    mtp_cache_pairs: int
+    now: float | None = None
+    max_age_seconds: float | None = None
+    min_useful_prefix_tokens: int = 64
+
+
+@dataclass(frozen=True)
+class ContinuousMTPRequestMetadata:
+    """Scheduler-owned facts copied into the non-mutating planner."""
+
+    lane_id: str
+    uid: int
+    prompt_tokens: tuple[int, ...]
+    max_tokens: int
+    stop_tokens: frozenset[int] = frozenset()
+    sampling: SamplingContract = SamplingContract()
+    temperature: float = 0.0
+    base_bytes: int = 0
+    bytes_per_draft_token: int = 0
+    cache_ready: bool = True
+    cache_quantized: bool = False
+    cache_windowed: bool = False
+    terminal: bool = False
+    apc_hit: ContinuousMTPAPCHit | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.uid, int) or isinstance(self.uid, bool):
+            raise ValueError("uid must be an integer")
+        if not self.prompt_tokens or any(
+            not isinstance(token, int) or isinstance(token, bool) or token < 0
+            for token in self.prompt_tokens
+        ):
+            raise ValueError("prompt_tokens must contain non-negative integers")
+        if not isinstance(self.max_tokens, int) or isinstance(self.max_tokens, bool):
+            raise ValueError("max_tokens must be an integer")
+        if self.max_tokens < 1:
+            raise ValueError("max_tokens must be positive")
+        if any(
+            not isinstance(token, int) or isinstance(token, bool)
+            for token in self.stop_tokens
+        ):
+            raise ValueError("stop_tokens must contain integers")
+        if self.sampling.greedy and self.temperature != 0:
+            raise ValueError("greedy sampling requires temperature=0")
+        if not self.sampling.greedy and self.temperature <= 0:
+            raise ValueError("non-greedy sampling requires temperature>0")
+
+
+@dataclass(frozen=True)
+class ContinuousMTPRuntimeFacts:
+    """Static install facts; no architecture or cache support is inferred."""
+
+    model_family: str
+    capability_descriptor: Mapping[str, Any]
+    capabilities: BatchedMTPCapabilities
+    legacy_mtp_available: bool
+    cache_quantized: bool = False
+    cache_windowed: bool = False
+
+    def __post_init__(self) -> None:
+        descriptor = MappingProxyType(dict(self.capability_descriptor))
+        object.__setattr__(self, "capability_descriptor", descriptor)
+
+
+@dataclass(frozen=True)
+class PlannedContinuousMTPLane:
+    lane_id: str
+    spec: SelfMTPLaneSpec
+    stop_tokens: frozenset[int]
+    prepared_state: PreparedMTPState | None = None
+    resume_at: int | None = None
+
+
+@dataclass(frozen=True)
+class ContinuousMTPRoutingDecision:
+    route: ContinuousMTPIntegrationRoute
+    cohort: tuple[PlannedContinuousMTPLane, ...] = ()
+    legacy_lane_ids: tuple[str, ...] = ()
+    plain_lane_ids: tuple[str, ...] = ()
+    queued_lane_ids: tuple[str, ...] = ()
+    reasons: tuple[str, ...] = ()
+    admission: AdmissionDecision | None = None
+    live_token_delivery: bool = False
+
+
+@dataclass(frozen=True)
+class ContinuousMTPRouterInstallDecision:
+    admitted: bool
+    router: ContinuousMTPIntegrationRouter | None
+    fallback: ContinuousMTPIntegrationRoute
+    reasons: tuple[str, ...] = ()
+    live_token_delivery: bool = False
+
+
+class ContinuousMTPIntegrationRouter:
+    """Immutable, repeatable planner for one loaded model/runtime."""
+
+    def __init__(
+        self,
+        *,
+        config: BatchedMTPConfig,
+        runtime: ContinuousMTPRuntimeFacts,
+    ) -> None:
+        self.config = config
+        self.runtime = runtime
+        self._static_refusals = _runtime_refusals(config, runtime)
+
+    @property
+    def static_refusals(self) -> tuple[str, ...]:
+        return self._static_refusals
+
+    def plan(
+        self,
+        requests: Sequence[ContinuousMTPRequestMetadata],
+        *,
+        free_bytes: int,
+    ) -> ContinuousMTPRoutingDecision:
+        requests = tuple(requests)
+        lane_ids = tuple(request.lane_id for request in requests)
+        if len(lane_ids) != len(set(lane_ids)):
+            raise ValueError("lane_id values must be unique")
+        uids = tuple(request.uid for request in requests)
+        if len(uids) != len(set(uids)):
+            raise ValueError("uid values must be unique")
+        if self._static_refusals:
+            return _fallback_decision(
+                lane_ids,
+                legacy=self.runtime.legacy_mtp_available,
+                reasons=self._static_refusals,
+            )
+
+        by_id = {request.lane_id: request for request in requests}
+        restore: dict[str, RestoreEligibility] = {}
+        apc_plain: list[str] = []
+        apc_reasons: list[str] = []
+        candidates: list[LaneAdmission] = []
+        for request in requests:
+            if request.cache_quantized or request.cache_windowed:
+                apc_plain.append(request.lane_id)
+                apc_reasons.append(
+                    f"{request.lane_id}: quantized/windowed cache is unsupported"
+                )
+                continue
+            if request.apc_hit is not None:
+                eligibility = _evaluate_apc(request)
+                restore[request.lane_id] = eligibility
+                if not eligibility.eligible and not eligibility.bypass_hit:
+                    apc_plain.append(request.lane_id)
+                    apc_reasons.append(
+                        f"{request.lane_id}: APC prepared state refused "
+                        f"({eligibility.reason.value})"
+                    )
+                    continue
+            candidates.append(
+                LaneAdmission(
+                    lane_id=request.lane_id,
+                    base_bytes=request.base_bytes,
+                    bytes_per_draft_token=request.bytes_per_draft_token,
+                    sampling=request.sampling,
+                    cache_ready=request.cache_ready,
+                    terminal=request.terminal,
+                )
+            )
+
+        admission = plan_admission(
+            candidates,
+            config=self.config,
+            capabilities=self.runtime.capabilities,
+            free_bytes=free_bytes,
+        )
+        reasons = tuple(apc_reasons) + admission.reasons
+        if admission.route is not BatchedMTPRoute.BATCHED_MTP:
+            fallback_ids = tuple(
+                lane_id for lane_id in lane_ids if lane_id not in apc_plain
+            )
+            if admission.route is BatchedMTPRoute.QUEUE and not fallback_ids:
+                route = ContinuousMTPIntegrationRoute.QUEUE
+            elif self.runtime.legacy_mtp_available and fallback_ids:
+                route = ContinuousMTPIntegrationRoute.LEGACY_MTP
+            else:
+                route = ContinuousMTPIntegrationRoute.PLAIN_DECODE
+            return ContinuousMTPRoutingDecision(
+                route=route,
+                legacy_lane_ids=(
+                    fallback_ids
+                    if route is ContinuousMTPIntegrationRoute.LEGACY_MTP
+                    else ()
+                ),
+                plain_lane_ids=tuple(apc_plain)
+                + (
+                    fallback_ids
+                    if route is ContinuousMTPIntegrationRoute.PLAIN_DECODE
+                    else ()
+                ),
+                queued_lane_ids=admission.queued_lane_ids,
+                reasons=reasons,
+                admission=admission,
+            )
+
+        cohort = tuple(
+            _planned_lane(by_id[lane_id], admission.draft_tokens, restore.get(lane_id))
+            for lane_id in admission.batched_lane_ids
+        )
+        fallthrough = tuple(
+            lane_id
+            for lane_id in lane_ids
+            if lane_id not in admission.batched_lane_ids and lane_id not in apc_plain
+        )
+        return ContinuousMTPRoutingDecision(
+            route=ContinuousMTPIntegrationRoute.CONTINUOUS_PLANNED,
+            cohort=cohort,
+            legacy_lane_ids=(fallthrough if self.runtime.legacy_mtp_available else ()),
+            plain_lane_ids=tuple(apc_plain)
+            + (() if self.runtime.legacy_mtp_available else fallthrough),
+            queued_lane_ids=admission.queued_lane_ids,
+            reasons=reasons,
+            admission=admission,
+        )
+
+
+def plan_router_install(
+    model: Any,
+    *,
+    enabled: bool,
+    cache_quantized: bool = False,
+    cache_windowed: bool = False,
+    max_lanes: int = 4,
+    hard_reserve_bytes: int = 8 * 1024**3,
+) -> ContinuousMTPRouterInstallDecision:
+    """Feature-detect a model and return an install plan without mutation."""
+    candidate = getattr(model, "language_model", model)
+    descriptor = getattr(candidate, "batched_mtp_capability", None)
+    descriptor_map = descriptor if isinstance(descriptor, Mapping) else {}
+    family = descriptor_map.get("model_family", "unknown")
+    batch_forward_name = descriptor_map.get("batch_forward")
+    batch_forward = (
+        getattr(candidate, batch_forward_name, None)
+        if isinstance(batch_forward_name, str)
+        else None
+    )
+    legacy = (
+        all(
+            callable(getattr(candidate, name, None))
+            for name in ("mtp_forward", "make_mtp_cache")
+        )
+        and getattr(candidate, "mtp", None) is not None
+    )
+    descriptor_core = (
+        descriptor_map.get("protocol_version") == 1
+        and descriptor_map.get("fixed_membership") is True
+        and descriptor_map.get("recursive_draft_depth") == 2
+        and callable(batch_forward)
+    )
+    capabilities = BatchedMTPCapabilities(
+        target_batch_forward=descriptor_core and callable(candidate),
+        mtp_batch_forward=descriptor_core,
+        ragged_target_rollback=descriptor_core
+        and not cache_quantized
+        and not cache_windowed,
+        ragged_mtp_rollback=descriptor_core
+        and not cache_quantized
+        and not cache_windowed,
+        atomic_cache_commit=descriptor_core
+        and not cache_quantized
+        and not cache_windowed,
+    )
+    runtime = ContinuousMTPRuntimeFacts(
+        model_family=str(family),
+        capability_descriptor=descriptor_map,
+        capabilities=capabilities,
+        legacy_mtp_available=legacy,
+        cache_quantized=cache_quantized,
+        cache_windowed=cache_windowed,
+    )
+    router = ContinuousMTPIntegrationRouter(
+        config=BatchedMTPConfig(
+            enabled=enabled,
+            max_lanes=max_lanes,
+            hard_reserve_bytes=hard_reserve_bytes,
+            allow_dynamic_membership=False,
+        ),
+        runtime=runtime,
+    )
+    if router.static_refusals:
+        return ContinuousMTPRouterInstallDecision(
+            admitted=False,
+            router=None,
+            fallback=(
+                ContinuousMTPIntegrationRoute.LEGACY_MTP
+                if legacy
+                else ContinuousMTPIntegrationRoute.PLAIN_DECODE
+            ),
+            reasons=router.static_refusals,
+        )
+    return ContinuousMTPRouterInstallDecision(
+        admitted=True,
+        router=router,
+        fallback=ContinuousMTPIntegrationRoute.LEGACY_MTP,
+    )
+
+
+def _runtime_refusals(
+    config: BatchedMTPConfig,
+    runtime: ContinuousMTPRuntimeFacts,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if config.enabled is not True:
+        reasons.append("continuous self-MTP is disabled")
+    if runtime.model_family not in {"qwen4_exp", "qwen3_5"}:
+        reasons.append(f"unsupported model family: {runtime.model_family}")
+    descriptor = runtime.capability_descriptor
+    required_descriptor = {
+        "protocol_version": 1,
+        "recursive_draft_depth": 2,
+        "fixed_membership": True,
+        "quantized_cache": False,
+        "windowed_cache": False,
+        "xtc": False,
+    }
+    for name, expected in required_descriptor.items():
+        if descriptor.get(name) != expected:
+            reasons.append(f"capability descriptor mismatch: {name}")
+    if runtime.cache_quantized:
+        reasons.append("quantized cache is unsupported")
+    if runtime.cache_windowed:
+        reasons.append("windowed cache is unsupported")
+    reasons.extend(
+        f"missing capability: {name}" for name in runtime.capabilities.missing_core()
+    )
+    return tuple(reasons)
+
+
+def _evaluate_apc(request: ContinuousMTPRequestMetadata) -> RestoreEligibility:
+    hit = request.apc_hit
+    assert hit is not None
+    return evaluate_restore(
+        hit.state,
+        expected_identity=hit.expected_identity,
+        request_tokens=request.prompt_tokens,
+        target_cache_tokens=hit.target_cache_tokens,
+        mtp_cache_pairs=hit.mtp_cache_pairs,
+        now=hit.now,
+        max_age_seconds=hit.max_age_seconds,
+        min_useful_prefix_tokens=hit.min_useful_prefix_tokens,
+    )
+
+
+def _planned_lane(
+    request: ContinuousMTPRequestMetadata,
+    draft_tokens: int,
+    restore: RestoreEligibility | None,
+) -> PlannedContinuousMTPLane:
+    prepared = None
+    resume_at = None
+    prompt = request.prompt_tokens
+    target_cache = None
+    mtp_cache = None
+    if restore is not None and restore.eligible:
+        assert request.apc_hit is not None and restore.resume_at is not None
+        prepared = request.apc_hit.state
+        resume_at = restore.resume_at
+        prompt = request.prompt_tokens[resume_at:]
+        target_cache = prepared.target_cache
+        mtp_cache = prepared.mtp_cache
+    return PlannedContinuousMTPLane(
+        lane_id=request.lane_id,
+        spec=SelfMTPLaneSpec(
+            uid=request.uid,
+            prompt=prompt,
+            max_tokens=request.max_tokens,
+            num_draft=draft_tokens,
+            sampling=SelfMTPSampling(
+                temperature=request.temperature,
+                has_logits_processors=request.sampling.has_logits_processors,
+                uses_xtc=request.sampling.uses_xtc,
+            ),
+            prompt_cache=target_cache,
+            mtp_cache=mtp_cache,
+        ),
+        stop_tokens=request.stop_tokens,
+        prepared_state=prepared,
+        resume_at=resume_at,
+    )
+
+
+def _fallback_decision(
+    lane_ids: tuple[str, ...],
+    *,
+    legacy: bool,
+    reasons: tuple[str, ...],
+) -> ContinuousMTPRoutingDecision:
+    route = (
+        ContinuousMTPIntegrationRoute.LEGACY_MTP
+        if legacy
+        else ContinuousMTPIntegrationRoute.PLAIN_DECODE
+    )
+    return ContinuousMTPRoutingDecision(
+        route=route,
+        legacy_lane_ids=lane_ids if legacy else (),
+        plain_lane_ids=() if legacy else lane_ids,
+        reasons=reasons,
+    )
+
+
+__all__ = [
+    "ContinuousMTPAPCHit",
+    "ContinuousMTPIntegrationRoute",
+    "ContinuousMTPIntegrationRouter",
+    "ContinuousMTPRequestMetadata",
+    "ContinuousMTPRouterInstallDecision",
+    "ContinuousMTPRoutingDecision",
+    "ContinuousMTPRuntimeFacts",
+    "PlannedContinuousMTPLane",
+    "plan_router_install",
+]

--- a/vllm_mlx/spec_decode/mtp/continuous_telemetry.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_telemetry.py
@@ -317,7 +317,9 @@ class LaneQualification:
     proposed_draft_tokens: int
     accepted_draft_tokens: int
     elapsed_seconds: float
-    digest: DigestClassification
+    batched_b1_digest: DigestClassification
+    batch_shape_digest: DigestClassification
+    legacy_single_lane_digest: DigestClassification
     finish_reason: FinishReason
 
     def __post_init__(self) -> None:
@@ -332,7 +334,21 @@ class LaneQualification:
         if accepted > proposed:
             raise ValueError("lane accepted drafts cannot exceed proposals")
         _positive_float(self.elapsed_seconds, "elapsed_seconds")
-        _require_enum(self.digest, DigestClassification, "digest")
+        _require_enum(
+            self.batched_b1_digest,
+            DigestClassification,
+            "batched_b1_digest",
+        )
+        _require_enum(
+            self.batch_shape_digest,
+            DigestClassification,
+            "batch_shape_digest",
+        )
+        _require_enum(
+            self.legacy_single_lane_digest,
+            DigestClassification,
+            "legacy_single_lane_digest",
+        )
         _require_enum(self.finish_reason, FinishReason, "finish_reason")
 
 
@@ -429,10 +445,21 @@ def evaluate_cohort_qualification(
     if not record.cache_equal:
         errors.append("cache equality gate failed")
     if any(
-        lane.digest in (DigestClassification.DIVERGENT, DigestClassification.NOT_RUN)
+        lane.batched_b1_digest is not DigestClassification.EXACT
         for lane in record.lanes
     ):
-        errors.append("digest classification gate failed")
+        errors.append("batched-B1 exact digest gate failed")
+    if any(
+        lane.batch_shape_digest
+        in (DigestClassification.DIVERGENT, DigestClassification.NOT_RUN)
+        for lane in record.lanes
+    ):
+        errors.append("B>1 batch-shape digest gate failed")
+    if record.cohort_size == 1 and any(
+        lane.batch_shape_digest is not DigestClassification.EXACT
+        for lane in record.lanes
+    ):
+        errors.append("batched-B1 cannot use a batch-shape tolerance")
 
     structurally_valid = not errors
     hardware_evidence = (

--- a/vllm_mlx/spec_decode/mtp/continuous_telemetry.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_telemetry.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded telemetry and offline qualification for continuous self-MTP.
+
+This module is deliberately pure Python and is not imported by any production
+path.  It defines the fixed-cardinality counters a later integration may wire
+around the continuous transaction core, plus an artifact-oriented qualification
+record.  Metric dimensions accept enums only: request IDs, model IDs, arbitrary
+exception text, and other unbounded labels cannot enter a snapshot.
+
+Synthetic/model-free evidence can prove schema and reconciliation behavior but
+can never set ``performance_qualified``.  That property additionally requires a
+hardware evidence declaration and a raw-artifact digest bound to an exact
+candidate/model identity.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+
+class AdmissionOutcome(str, Enum):
+    BATCHED = "batched"
+    PLAIN = "plain"
+    QUEUED = "queued"
+    REFUSED = "refused"
+
+
+class AdmissionReason(str, Enum):
+    ELIGIBLE = "eligible"
+    DEPTH_REDUCED = "depth_reduced"
+    FEATURE_DISABLED = "feature_disabled"
+    CAPABILITY = "capability"
+    SAMPLING = "sampling"
+    CACHE_TOPOLOGY = "cache_topology"
+    MEMORY = "memory"
+    LANE_LIMIT = "lane_limit"
+    MEMBERSHIP = "membership"
+    APC_STATE = "apc_state"
+    INTERNAL = "internal"
+
+
+class TransactionOutcome(str, Enum):
+    PROPOSED = "proposed"
+    COMMITTED = "committed"
+    ABORTED = "aborted"
+    FAILED = "failed"
+
+
+class CommitKind(str, Enum):
+    FULL = "full"
+    TERMINAL_PARTIAL = "terminal_partial"
+
+
+class AbortReason(str, Enum):
+    CALLER = "caller"
+    CANCELLED = "cancelled"
+    DISCONNECTED = "disconnected"
+    COMPUTE_ERROR = "compute_error"
+    INVARIANT = "invariant"
+
+
+class EvidenceKind(str, Enum):
+    SYNTHETIC = "synthetic"
+    APPLE_SILICON_HARDWARE = "apple_silicon_hardware"
+
+
+class DigestClassification(str, Enum):
+    EXACT = "exact"
+    DISTRIBUTIONAL = "distributional"
+    DIVERGENT = "divergent"
+    NOT_RUN = "not_run"
+
+
+class FinishReason(str, Enum):
+    STOP = "stop"
+    LENGTH = "length"
+    CANCELLED = "cancelled"
+    DISCONNECTED = "disconnected"
+
+
+@dataclass(frozen=True)
+class TransactionTicket:
+    """One non-exported proposal identity; never used as a metric label."""
+
+    sequence: int
+    lanes: int
+    proposed_draft_tokens: int
+
+
+@dataclass(frozen=True)
+class ContinuousMTPSnapshot:
+    """Immutable fixed-cardinality telemetry snapshot."""
+
+    admissions: tuple[tuple[str, int], ...]
+    admission_reasons: tuple[tuple[str, int], ...]
+    transactions: tuple[tuple[str, int], ...]
+    commits: tuple[tuple[str, int], ...]
+    aborts: tuple[tuple[str, int], ...]
+    admitted_lanes: int
+    proposed_draft_tokens: int
+    accepted_draft_tokens: int
+    committed_tokens: int
+    terminal_lanes: int
+    cleaned_lanes: int
+    open_transaction: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-ready data with a statically bounded key space."""
+
+        return {
+            "admissions": dict(self.admissions),
+            "admission_reasons": dict(self.admission_reasons),
+            "transactions": dict(self.transactions),
+            "commits": dict(self.commits),
+            "aborts": dict(self.aborts),
+            "totals": {
+                "admitted_lanes": self.admitted_lanes,
+                "proposed_draft_tokens": self.proposed_draft_tokens,
+                "accepted_draft_tokens": self.accepted_draft_tokens,
+                "committed_tokens": self.committed_tokens,
+                "terminal_lanes": self.terminal_lanes,
+                "cleaned_lanes": self.cleaned_lanes,
+                "open_transaction": self.open_transaction,
+            },
+        }
+
+
+class ContinuousMTPCounters:
+    """Thread-safe, bounded counters around one transaction stream."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._admissions = {value: 0 for value in AdmissionOutcome}
+        self._admission_reasons = {value: 0 for value in AdmissionReason}
+        self._transactions = {value: 0 for value in TransactionOutcome}
+        self._commits = {value: 0 for value in CommitKind}
+        self._aborts = {value: 0 for value in AbortReason}
+        self._admitted_lanes = 0
+        self._proposed_draft_tokens = 0
+        self._accepted_draft_tokens = 0
+        self._committed_tokens = 0
+        self._terminal_lanes = 0
+        self._cleaned_lanes = 0
+        self._next_sequence = 1
+        self._open: TransactionTicket | None = None
+
+    def record_admission(
+        self,
+        outcome: AdmissionOutcome,
+        reason: AdmissionReason,
+        *,
+        lanes: int,
+        draft_depth: int,
+    ) -> None:
+        """Record one bounded admission/fallback decision."""
+
+        _require_enum(outcome, AdmissionOutcome, "outcome")
+        _require_enum(reason, AdmissionReason, "reason")
+        lanes = _positive_int(lanes, "lanes")
+        draft_depth = _non_negative_int(draft_depth, "draft_depth")
+        if outcome is AdmissionOutcome.BATCHED:
+            if reason not in (
+                AdmissionReason.ELIGIBLE,
+                AdmissionReason.DEPTH_REDUCED,
+            ):
+                raise ValueError("batched admission requires an eligible reason")
+            if draft_depth < 1:
+                raise ValueError("batched admission requires positive draft_depth")
+        else:
+            if reason in (
+                AdmissionReason.ELIGIBLE,
+                AdmissionReason.DEPTH_REDUCED,
+            ):
+                raise ValueError("fallback/refusal requires a refusal reason")
+            if draft_depth != 0:
+                raise ValueError("non-batched admission must report draft_depth=0")
+        with self._lock:
+            self._admissions[outcome] += 1
+            self._admission_reasons[reason] += 1
+            if outcome is AdmissionOutcome.BATCHED:
+                self._admitted_lanes += lanes
+
+    def begin_transaction(
+        self,
+        *,
+        lanes: int,
+        proposed_draft_tokens: int,
+    ) -> TransactionTicket:
+        """Open one proposal and return its single-use ticket."""
+
+        lanes = _positive_int(lanes, "lanes")
+        proposed = _positive_int(proposed_draft_tokens, "proposed_draft_tokens")
+        with self._lock:
+            if self._open is not None:
+                raise RuntimeError("a telemetry transaction is already open")
+            ticket = TransactionTicket(self._next_sequence, lanes, proposed)
+            self._next_sequence += 1
+            self._open = ticket
+            self._transactions[TransactionOutcome.PROPOSED] += 1
+            self._proposed_draft_tokens += proposed
+            return ticket
+
+    def commit_transaction(
+        self,
+        ticket: TransactionTicket,
+        *,
+        accepted_draft_tokens: int,
+        committed_tokens: int,
+        terminal_lanes: int = 0,
+        kind: CommitKind = CommitKind.FULL,
+    ) -> None:
+        """Close a proposal after validating aggregate delivery counts."""
+
+        _require_enum(kind, CommitKind, "kind")
+        accepted = _non_negative_int(accepted_draft_tokens, "accepted_draft_tokens")
+        committed = _non_negative_int(committed_tokens, "committed_tokens")
+        terminal = _non_negative_int(terminal_lanes, "terminal_lanes")
+        with self._lock:
+            self._require_ticket(ticket)
+            if accepted > ticket.proposed_draft_tokens:
+                raise ValueError("accepted drafts cannot exceed proposed drafts")
+            if accepted > committed:
+                raise ValueError("accepted drafts cannot exceed committed tokens")
+            if terminal > ticket.lanes:
+                raise ValueError("terminal_lanes cannot exceed transaction lanes")
+            if kind is CommitKind.TERMINAL_PARTIAL and terminal == 0:
+                raise ValueError("terminal partial commit requires a terminal lane")
+            self._transactions[TransactionOutcome.COMMITTED] += 1
+            self._commits[kind] += 1
+            self._accepted_draft_tokens += accepted
+            self._committed_tokens += committed
+            self._terminal_lanes += terminal
+            self._open = None
+
+    def abort_transaction(
+        self,
+        ticket: TransactionTicket,
+        *,
+        reason: AbortReason,
+        failed: bool = False,
+    ) -> None:
+        """Close a proposal without publishing commit totals."""
+
+        _require_enum(reason, AbortReason, "reason")
+        if not isinstance(failed, bool):
+            raise ValueError("failed must be a boolean")
+        with self._lock:
+            self._require_ticket(ticket)
+            outcome = (
+                TransactionOutcome.FAILED if failed else TransactionOutcome.ABORTED
+            )
+            self._transactions[outcome] += 1
+            self._aborts[reason] += 1
+            self._open = None
+
+    def record_cleanup(self, *, lanes: int) -> None:
+        lanes = _positive_int(lanes, "lanes")
+        with self._lock:
+            self._cleaned_lanes += lanes
+
+    def snapshot(self) -> ContinuousMTPSnapshot:
+        with self._lock:
+            return ContinuousMTPSnapshot(
+                admissions=_enum_counts(self._admissions),
+                admission_reasons=_enum_counts(self._admission_reasons),
+                transactions=_enum_counts(self._transactions),
+                commits=_enum_counts(self._commits),
+                aborts=_enum_counts(self._aborts),
+                admitted_lanes=self._admitted_lanes,
+                proposed_draft_tokens=self._proposed_draft_tokens,
+                accepted_draft_tokens=self._accepted_draft_tokens,
+                committed_tokens=self._committed_tokens,
+                terminal_lanes=self._terminal_lanes,
+                cleaned_lanes=self._cleaned_lanes,
+                open_transaction=self._open is not None,
+            )
+
+    def _require_ticket(self, ticket: TransactionTicket) -> None:
+        if not isinstance(ticket, TransactionTicket) or ticket != self._open:
+            raise RuntimeError("stale, foreign, or already closed transaction")
+
+
+@dataclass(frozen=True)
+class QualificationIdentity:
+    """Exact offline identity for one candidate/model/config battery."""
+
+    candidate_sha: str
+    model_id: str
+    model_revision: str
+    config_fingerprint: str
+    prompt_manifest_sha256: str
+    environment_fingerprint: str
+
+    def __post_init__(self) -> None:
+        _require_hex(self.candidate_sha, 40, "candidate_sha")
+        for name in ("model_id", "model_revision"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        for name in (
+            "config_fingerprint",
+            "prompt_manifest_sha256",
+            "environment_fingerprint",
+        ):
+            _require_hex(getattr(self, name), 64, name)
+
+
+@dataclass(frozen=True)
+class LaneQualification:
+    lane_index: int
+    output_tokens: int
+    proposed_draft_tokens: int
+    accepted_draft_tokens: int
+    elapsed_seconds: float
+    digest: DigestClassification
+    finish_reason: FinishReason
+
+    def __post_init__(self) -> None:
+        _non_negative_int(self.lane_index, "lane_index")
+        _non_negative_int(self.output_tokens, "output_tokens")
+        proposed = _non_negative_int(
+            self.proposed_draft_tokens, "proposed_draft_tokens"
+        )
+        accepted = _non_negative_int(
+            self.accepted_draft_tokens, "accepted_draft_tokens"
+        )
+        if accepted > proposed:
+            raise ValueError("lane accepted drafts cannot exceed proposals")
+        _positive_float(self.elapsed_seconds, "elapsed_seconds")
+        _require_enum(self.digest, DigestClassification, "digest")
+        _require_enum(self.finish_reason, FinishReason, "finish_reason")
+
+
+@dataclass(frozen=True)
+class CohortQualification:
+    """One N-lane result plus the counters produced during that run."""
+
+    identity: QualificationIdentity
+    evidence_kind: EvidenceKind
+    cohort_size: int
+    draft_depth: int
+    aggregate_elapsed_seconds: float
+    active_memory_bytes: int
+    peak_memory_bytes: int
+    cache_equal: bool
+    lanes: tuple[LaneQualification, ...]
+    telemetry: ContinuousMTPSnapshot
+    raw_artifact_sha256: str | None = None
+
+    @property
+    def aggregate_tokens(self) -> int:
+        return sum(lane.output_tokens for lane in self.lanes)
+
+    @property
+    def aggregate_tokens_per_second(self) -> float:
+        return self.aggregate_tokens / self.aggregate_elapsed_seconds
+
+
+@dataclass(frozen=True)
+class QualificationResult:
+    structurally_valid: bool
+    performance_qualified: bool
+    errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class QualificationSuiteResult:
+    structurally_complete: bool
+    performance_qualified: bool
+    errors: tuple[str, ...]
+
+
+def evaluate_cohort_qualification(
+    record: CohortQualification,
+) -> QualificationResult:
+    """Reconcile one offline record without executing a model."""
+
+    errors: list[str] = []
+    if not isinstance(record, CohortQualification):
+        return QualificationResult(False, False, ("record type",))
+    if record.cohort_size not in (1, 2, 4):
+        errors.append("cohort_size must be one of 1, 2, 4")
+    if record.draft_depth < 1:
+        errors.append("draft_depth must be positive")
+    if not math.isfinite(record.aggregate_elapsed_seconds) or (
+        record.aggregate_elapsed_seconds <= 0
+    ):
+        errors.append("aggregate elapsed time must be positive")
+    if record.active_memory_bytes < 0 or (
+        record.peak_memory_bytes < record.active_memory_bytes
+    ):
+        errors.append("memory totals are inconsistent")
+    if not isinstance(record.cache_equal, bool):
+        errors.append("cache_equal must be boolean")
+    expected_indices = tuple(range(record.cohort_size))
+    observed_indices = tuple(sorted(lane.lane_index for lane in record.lanes))
+    if observed_indices != expected_indices:
+        errors.append("lane indices must cover the cohort exactly once")
+
+    proposed = sum(lane.proposed_draft_tokens for lane in record.lanes)
+    accepted = sum(lane.accepted_draft_tokens for lane in record.lanes)
+    committed = sum(lane.output_tokens for lane in record.lanes)
+    snapshot = record.telemetry
+    if snapshot.proposed_draft_tokens != proposed:
+        errors.append("proposed draft totals do not reconcile")
+    if snapshot.accepted_draft_tokens != accepted:
+        errors.append("accepted draft totals do not reconcile")
+    if snapshot.committed_tokens != committed:
+        errors.append("committed token totals do not reconcile")
+    transaction_counts = dict(snapshot.transactions)
+    if transaction_counts.get(TransactionOutcome.PROPOSED.value) != 1:
+        errors.append("qualification run must contain one proposal")
+    if transaction_counts.get(TransactionOutcome.COMMITTED.value) != 1:
+        errors.append("qualification run must contain one commit")
+    if transaction_counts.get(TransactionOutcome.ABORTED.value) != 0 or (
+        transaction_counts.get(TransactionOutcome.FAILED.value) != 0
+    ):
+        errors.append("qualification run contains an abort or failure")
+    admissions = dict(snapshot.admissions)
+    if admissions.get(AdmissionOutcome.BATCHED.value) != 1:
+        errors.append("qualification run must contain one batched admission")
+    if snapshot.open_transaction:
+        errors.append("qualification run has an open transaction")
+    if not record.cache_equal:
+        errors.append("cache equality gate failed")
+    if any(
+        lane.digest in (DigestClassification.DIVERGENT, DigestClassification.NOT_RUN)
+        for lane in record.lanes
+    ):
+        errors.append("digest classification gate failed")
+
+    structurally_valid = not errors
+    hardware_evidence = (
+        record.evidence_kind is EvidenceKind.APPLE_SILICON_HARDWARE
+        and isinstance(record.raw_artifact_sha256, str)
+        and _is_hex(record.raw_artifact_sha256, 64)
+    )
+    return QualificationResult(
+        structurally_valid=structurally_valid,
+        performance_qualified=structurally_valid and hardware_evidence,
+        errors=tuple(errors),
+    )
+
+
+def evaluate_qualification_suite(
+    records: tuple[CohortQualification, ...],
+) -> QualificationSuiteResult:
+    """Require one identity-matched N=1/2/4 battery."""
+
+    errors: list[str] = []
+    if not records:
+        return QualificationSuiteResult(False, False, ("suite is empty",))
+    sizes = tuple(sorted(record.cohort_size for record in records))
+    if sizes != (1, 2, 4):
+        errors.append("suite must contain exactly N=1,2,4")
+    identity = records[0].identity
+    if any(record.identity != identity for record in records[1:]):
+        errors.append("suite identities differ")
+    results = tuple(evaluate_cohort_qualification(record) for record in records)
+    for index, result in enumerate(results):
+        if not result.structurally_valid:
+            errors.append(f"cohort[{index}] is structurally invalid")
+    structurally_complete = not errors
+    return QualificationSuiteResult(
+        structurally_complete=structurally_complete,
+        performance_qualified=(
+            structurally_complete
+            and all(result.performance_qualified for result in results)
+        ),
+        errors=tuple(errors),
+    )
+
+
+def _enum_counts(values: dict[Enum, int]) -> tuple[tuple[str, int], ...]:
+    return tuple((key.value, values[key]) for key in type(next(iter(values))))
+
+
+def _require_enum(value: Any, expected: type[Enum], name: str) -> None:
+    if not isinstance(value, expected):
+        raise TypeError(f"{name} must be {expected.__name__}")
+
+
+def _non_negative_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _positive_int(value: Any, name: str) -> int:
+    value = _non_negative_int(value, name)
+    if value == 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _positive_float(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a positive finite number")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return numeric
+
+
+def _is_hex(value: Any, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _require_hex(value: Any, length: int, name: str) -> None:
+    if not _is_hex(value, length):
+        raise ValueError(f"{name} must be {length} lowercase hex characters")
+
+
+BOUNDED_METRIC_DIMENSIONS = MappingProxyType(
+    {
+        "admission_outcome": tuple(value.value for value in AdmissionOutcome),
+        "admission_reason": tuple(value.value for value in AdmissionReason),
+        "transaction_outcome": tuple(value.value for value in TransactionOutcome),
+        "commit_kind": tuple(value.value for value in CommitKind),
+        "abort_reason": tuple(value.value for value in AbortReason),
+    }
+)
+
+
+__all__ = [
+    "BOUNDED_METRIC_DIMENSIONS",
+    "AbortReason",
+    "AdmissionOutcome",
+    "AdmissionReason",
+    "CohortQualification",
+    "CommitKind",
+    "ContinuousMTPCounters",
+    "ContinuousMTPSnapshot",
+    "DigestClassification",
+    "EvidenceKind",
+    "FinishReason",
+    "LaneQualification",
+    "QualificationIdentity",
+    "QualificationResult",
+    "QualificationSuiteResult",
+    "TransactionOutcome",
+    "TransactionTicket",
+    "evaluate_cohort_qualification",
+    "evaluate_qualification_suite",
+]

--- a/vllm_mlx/spec_decode/mtp/mlx_backend.py
+++ b/vllm_mlx/spec_decode/mtp/mlx_backend.py
@@ -300,6 +300,9 @@ class RapidMLXSelfMTPBackend:
             raise ContinuousSelfMTPUnsupported(
                 "transformed sampling requires exact residual hooks"
             )
+        validate_sampling = getattr(hooks, "validate_sampling", None)
+        if callable(validate_sampling):
+            validate_sampling(lane.sampling)
         logprobs = hooks.logprobs(logits, lane.sampling.temperature)
         return hooks.sample(logprobs, lane.sampling.temperature), logprobs
 
@@ -329,6 +332,12 @@ class RapidMLXSelfMTPBackend:
             raise ContinuousSelfMTPUnsupported(
                 "transformed sampling requires exact residual hooks"
             )
+        if self.residual_sampling is not None:
+            validate_sampling = getattr(
+                self.residual_sampling, "validate_sampling", None
+            )
+            if callable(validate_sampling):
+                validate_sampling(spec.sampling)
         if spec.sampling.has_logits_processors and self.logits_processor is None:
             raise ContinuousSelfMTPUnsupported(
                 "logits processors require an exact injected hook"

--- a/vllm_mlx/spec_decode/mtp/mlx_backend.py
+++ b/vllm_mlx/spec_decode/mtp/mlx_backend.py
@@ -119,46 +119,115 @@ def _validate_pair(pair: SelfMTPCachePair) -> tuple[list[Any], list[Any]]:
     return target, draft
 
 
+def _cache_children(cache: Any) -> tuple[Any, ...]:
+    children = getattr(cache, "caches", None)
+    if isinstance(children, (list, tuple)):
+        return tuple(children)
+    return ()
+
+
+def _prepare_cache(cache: Any, lengths: Sequence[int], right_padding) -> None:
+    prepare = getattr(cache, "prepare_self_mtp_step", None)
+    if callable(prepare):
+        prepare(lengths=list(lengths), right_padding=right_padding)
+        return
+    children = _cache_children(cache)
+    if children:
+        prepared = []
+        try:
+            for child in children:
+                _prepare_cache(child, lengths, right_padding)
+                prepared.append(child)
+        except Exception:
+            for child in reversed(prepared):
+                _finalize_cache(child)
+            raise
+        return
+    prepare = getattr(cache, "prepare", None)
+    if not callable(prepare):
+        raise ContinuousSelfMTPUnsupported(
+            f"cache {type(cache).__name__} has no prepare surface"
+        )
+    prepare(lengths=list(lengths), right_padding=right_padding)
+
+
 def _prepare_group(group: Sequence[Any], lengths: Sequence[int]) -> None:
     width = max(lengths)
     right_padding = [width - length for length in lengths]
     prepared: list[Any] = []
     try:
         for cache in group:
-            prepare = getattr(cache, "prepare_self_mtp_step", None)
-            if not callable(prepare):
-                prepare = getattr(cache, "prepare", None)
-            if not callable(prepare):
-                raise ContinuousSelfMTPUnsupported(
-                    f"cache {type(cache).__name__} has no prepare surface"
-                )
-            prepare(lengths=list(lengths), right_padding=right_padding)
+            _prepare_cache(cache, lengths, right_padding)
             prepared.append(cache)
     except Exception:
         for cache in reversed(prepared):
-            finalize = getattr(cache, "finalize_self_mtp_step", None)
-            if not callable(finalize):
-                finalize = getattr(cache, "finalize", None)
-            if callable(finalize):
-                finalize()
+            _finalize_cache(cache)
         raise
+
+
+def _finalize_cache(cache: Any) -> None:
+    finalize = getattr(cache, "finalize_self_mtp_step", None)
+    if callable(finalize):
+        finalize()
+        return
+    children = _cache_children(cache)
+    if children:
+        first_error: BaseException | None = None
+        for child in children:
+            try:
+                _finalize_cache(child)
+            except BaseException as exc:  # noqa: BLE001 - finalize every child
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+        return
+    finalize = getattr(cache, "finalize", None)
+    if not callable(finalize):
+        raise ContinuousSelfMTPUnsupported(
+            f"cache {type(cache).__name__} has no finalize surface"
+        )
+    finalize()
 
 
 def _finalize_group(group: Sequence[Any]) -> None:
     first_error: BaseException | None = None
     for cache in group:
-        finalize = getattr(cache, "finalize_self_mtp_step", None)
-        if not callable(finalize):
-            finalize = getattr(cache, "finalize", None)
-        if not callable(finalize):
+        try:
+            _finalize_cache(cache)
+        except BaseException as exc:  # noqa: BLE001 - finalize every layer
             if first_error is None:
-                first_error = ContinuousSelfMTPUnsupported(
-                    f"cache {type(cache).__name__} has no finalize surface"
-                )
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+
+
+def _begin_qsa_share_cycle(group: Sequence[Any]) -> tuple[Any, ...]:
+    armed = []
+    try:
+        pending = list(group)
+        while pending:
+            cache = pending.pop(0)
+            begin = getattr(cache, "begin_self_mtp_cycle", None)
+            if callable(begin):
+                begin()
+                armed.append(cache)
+            pending[0:0] = list(_cache_children(cache))
+    except Exception:
+        _end_qsa_share_cycle(armed)
+        raise
+    return tuple(armed)
+
+
+def _end_qsa_share_cycle(group: Sequence[Any]) -> None:
+    first_error: BaseException | None = None
+    for cache in reversed(group):
+        end = getattr(cache, "end_self_mtp_cycle", None)
+        if not callable(end):
             continue
         try:
-            finalize()
-        except BaseException as exc:  # noqa: BLE001 - finalize every layer
+            end()
+        except BaseException as exc:  # noqa: BLE001 - disarm every cache
             if first_error is None:
                 first_error = exc
     if first_error is not None:
@@ -180,6 +249,7 @@ class RapidMLXSelfMTPBackend:
         array_ops: ArrayOps | None = None,
         residual_sampling: ResidualSamplingHooks | None = None,
         logits_processor: Callable[[SelfMTPLane, Any, Any], Any] | None = None,
+        share_qsa_indices: bool = False,
         prefill_step_size: int = 512,
         draft_depth: int = 2,
     ) -> None:
@@ -187,11 +257,14 @@ class RapidMLXSelfMTPBackend:
             raise ValueError("prefill_step_size must be positive")
         if draft_depth != 2:
             raise ValueError("the first Rapid continuous self-MTP backend is K=2")
+        if not isinstance(share_qsa_indices, bool):
+            raise ValueError("share_qsa_indices must be boolean")
         self.target_cache_factory = target_cache_factory
         self.draft_cache_factory = draft_cache_factory
         self.ops = array_ops or _MLXArrayOps()
         self.residual_sampling = residual_sampling
         self.logits_processor = logits_processor
+        self.share_qsa_indices = share_qsa_indices
         self.prefill_step_size = int(prefill_step_size)
         self.draft_depth = draft_depth
 
@@ -389,60 +462,71 @@ class RapidMLXSelfMTPBackend:
                 self.ops.pad(tokens, [(0, 0), (0, first_width - max(valid, 1))])
             )
 
-        _prepare_group(draft_cache, first_lengths)
-        try:
-            first_logits, first_hidden = self._forward_pair(
-                forwards.draft(
-                    self.ops.concatenate(hidden_rows, axis=0),
-                    self.ops.concatenate(token_rows, axis=0),
-                    draft_cache,
-                ),
-                "MTP forward",
-            )
-        finally:
-            _finalize_group(draft_cache)
-        for row, (lane, depth, valid) in enumerate(zip(lanes, depths, first_lengths)):
-            if depth == 0:
-                continue
-            position = valid - 1
-            token, logprobs = self._distribution(
-                lane,
-                self._prefix(lane, [lane.cur]),
-                first_logits[row, position],
-            )
-            drafts[row].append(token)
-            draft_logprobs[row].append(logprobs)
-            draft_hidden[row] = first_hidden[row : row + 1, position : position + 1]
-            lane.pending_hidden = None
-            lane.pending_tokens = []
-
         second_lengths = [1 if depth > 1 else 0 for depth in depths]
-        if any(second_lengths):
-            hidden_batch = self.ops.concatenate(draft_hidden, axis=0)
-            token_batch = self.ops.uint32(
-                [
-                    [drafts[row][-1] if active else 0]
-                    for row, active in enumerate(second_lengths)
-                ]
-            )
-            _prepare_group(draft_cache, second_lengths)
+        shared_qsa = (
+            _begin_qsa_share_cycle(draft_cache)
+            if self.share_qsa_indices and any(second_lengths)
+            else ()
+        )
+        try:
+            _prepare_group(draft_cache, first_lengths)
             try:
-                second_logits, _ = self._forward_pair(
-                    forwards.draft(hidden_batch, token_batch, draft_cache),
+                first_logits, first_hidden = self._forward_pair(
+                    forwards.draft(
+                        self.ops.concatenate(hidden_rows, axis=0),
+                        self.ops.concatenate(token_rows, axis=0),
+                        draft_cache,
+                    ),
                     "MTP forward",
                 )
             finally:
                 _finalize_group(draft_cache)
-            for row, (lane, active) in enumerate(zip(lanes, second_lengths)):
-                if not active:
+
+            for row, (lane, depth, valid) in enumerate(
+                zip(lanes, depths, first_lengths)
+            ):
+                if depth == 0:
                     continue
+                position = valid - 1
                 token, logprobs = self._distribution(
                     lane,
-                    self._prefix(lane, [lane.cur] + drafts[row]),
-                    second_logits[row, -1],
+                    self._prefix(lane, [lane.cur]),
+                    first_logits[row, position],
                 )
                 drafts[row].append(token)
                 draft_logprobs[row].append(logprobs)
+                draft_hidden[row] = first_hidden[row : row + 1, position : position + 1]
+                lane.pending_hidden = None
+                lane.pending_tokens = []
+
+            if any(second_lengths):
+                hidden_batch = self.ops.concatenate(draft_hidden, axis=0)
+                token_batch = self.ops.uint32(
+                    [
+                        [drafts[row][-1] if active else 0]
+                        for row, active in enumerate(second_lengths)
+                    ]
+                )
+                _prepare_group(draft_cache, second_lengths)
+                try:
+                    second_logits, _ = self._forward_pair(
+                        forwards.draft(hidden_batch, token_batch, draft_cache),
+                        "MTP forward",
+                    )
+                finally:
+                    _finalize_group(draft_cache)
+                for row, (lane, active) in enumerate(zip(lanes, second_lengths)):
+                    if not active:
+                        continue
+                    token, logprobs = self._distribution(
+                        lane,
+                        self._prefix(lane, [lane.cur] + drafts[row]),
+                        second_logits[row, -1],
+                    )
+                    drafts[row].append(token)
+                    draft_logprobs[row].append(logprobs)
+        finally:
+            _end_qsa_share_cycle(shared_qsa)
 
         verify_width = max(depth + 1 for depth in depths)
         verify_rows = [

--- a/vllm_mlx/spec_decode/mtp/mlx_backend.py
+++ b/vllm_mlx/spec_decode/mtp/mlx_backend.py
@@ -1,0 +1,752 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rapid MLX data plane for fixed-membership continuous self-MTP.
+
+The module is import-safe without MLX.  Production defaults lazily construct an
+MLX array adapter, while tests may inject a NumPy-like or fully mocked surface.
+No scheduler or model class knowledge lives here: target and MTP forwards use
+``RapidForwardSeams`` and cache topology uses ``RapidRaggedCacheAdapter``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .continuous_engine import (
+    ContinuousSelfMTPUnsupportedError as ContinuousSelfMTPUnsupported,
+)
+from .continuous_engine import (
+    CycleComputation,
+    MTPToken,
+    PreparedLaneData,
+    RapidForwardSeams,
+    SelfMTPCachePair,
+    SelfMTPLane,
+    SelfMTPLaneSpec,
+)
+
+
+class ArrayOps(Protocol):
+    def uint32(self, value: Any) -> Any: ...
+
+    def concatenate(self, values: Sequence[Any], *, axis: int) -> Any: ...
+
+    def pad(self, value: Any, widths: Sequence[tuple[int, int]]) -> Any: ...
+
+    def expand_dims(self, value: Any, axis: int) -> Any: ...
+
+    def logprobs(self, logits: Any) -> Any: ...
+
+    def argmax_int(self, logprobs: Any) -> int: ...
+
+
+class ResidualSamplingHooks(Protocol):
+    """Exact transformed-distribution hooks supplied by a later PR."""
+
+    def logprobs(self, logits: Any, temperature: float) -> Any: ...
+
+    def sample(self, logprobs: Any, temperature: float) -> int: ...
+
+    def verify(
+        self,
+        target_logprobs: Any,
+        draft_logprobs: Sequence[Any],
+        draft_tokens: Sequence[int],
+        temperature: float,
+    ) -> tuple[int, int]: ...
+
+
+class _MLXArrayOps:
+    """Lazy production adapter; construction is the first MLX import."""
+
+    def __init__(self) -> None:
+        import mlx.core as mx
+
+        self.mx = mx
+
+    def uint32(self, value: Any) -> Any:
+        return self.mx.array(value, dtype=self.mx.uint32)
+
+    def concatenate(self, values: Sequence[Any], *, axis: int) -> Any:
+        return self.mx.concatenate(list(values), axis=axis)
+
+    def pad(self, value: Any, widths: Sequence[tuple[int, int]]) -> Any:
+        return self.mx.pad(value, list(widths))
+
+    def expand_dims(self, value: Any, axis: int) -> Any:
+        return self.mx.expand_dims(value, axis)
+
+    def logprobs(self, logits: Any) -> Any:
+        return logits - self.mx.logsumexp(logits, axis=-1, keepdims=True)
+
+    def argmax_int(self, logprobs: Any) -> int:
+        return int(self.mx.argmax(logprobs, axis=-1).item())
+
+
+@dataclass(frozen=True)
+class _CyclePayload:
+    old_curs: tuple[int, ...]
+    old_seed_hidden: tuple[Any, ...]
+    drafts: tuple[tuple[int, ...], ...]
+    verify_hidden: tuple[Any, ...]
+    bonuses: tuple[int, ...]
+
+
+def _as_group(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise ValueError(f"{name} cache must be a non-empty layer sequence")
+    return list(value)
+
+
+def _reject_cache(cache: Any) -> None:
+    name = type(cache).__name__.lower()
+    if "quantized" in name:
+        raise ContinuousSelfMTPUnsupported(
+            f"quantized cache {type(cache).__name__} is unsupported"
+        )
+    if any(marker in name for marker in ("window", "rotating", "sink")):
+        raise ContinuousSelfMTPUnsupported(
+            f"windowed cache {type(cache).__name__} is unsupported"
+        )
+
+
+def _validate_pair(pair: SelfMTPCachePair) -> tuple[list[Any], list[Any]]:
+    target = _as_group(pair.target, "target")
+    draft = _as_group(pair.draft, "draft")
+    for cache in target + draft:
+        _reject_cache(cache)
+    return target, draft
+
+
+def _prepare_group(group: Sequence[Any], lengths: Sequence[int]) -> None:
+    width = max(lengths)
+    right_padding = [width - length for length in lengths]
+    prepared: list[Any] = []
+    try:
+        for cache in group:
+            prepare = getattr(cache, "prepare_self_mtp_step", None)
+            if not callable(prepare):
+                prepare = getattr(cache, "prepare", None)
+            if not callable(prepare):
+                raise ContinuousSelfMTPUnsupported(
+                    f"cache {type(cache).__name__} has no prepare surface"
+                )
+            prepare(lengths=list(lengths), right_padding=right_padding)
+            prepared.append(cache)
+    except Exception:
+        for cache in reversed(prepared):
+            finalize = getattr(cache, "finalize_self_mtp_step", None)
+            if not callable(finalize):
+                finalize = getattr(cache, "finalize", None)
+            if callable(finalize):
+                finalize()
+        raise
+
+
+def _finalize_group(group: Sequence[Any]) -> None:
+    first_error: BaseException | None = None
+    for cache in group:
+        finalize = getattr(cache, "finalize_self_mtp_step", None)
+        if not callable(finalize):
+            finalize = getattr(cache, "finalize", None)
+        if not callable(finalize):
+            if first_error is None:
+                first_error = ContinuousSelfMTPUnsupported(
+                    f"cache {type(cache).__name__} has no finalize surface"
+                )
+            continue
+        try:
+            finalize()
+        except BaseException as exc:  # noqa: BLE001 - finalize every layer
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+
+
+class RapidMLXSelfMTPBackend:
+    """K=2 persistent batched self-MTP compute backend.
+
+    Greedy verification is built in.  Temperature sampling and logits
+    processors are rejected unless exact hooks are supplied explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        target_cache_factory: Callable[[], Any] | None = None,
+        draft_cache_factory: Callable[[], Any] | None = None,
+        array_ops: ArrayOps | None = None,
+        residual_sampling: ResidualSamplingHooks | None = None,
+        logits_processor: Callable[[SelfMTPLane, Any, Any], Any] | None = None,
+        prefill_step_size: int = 512,
+        draft_depth: int = 2,
+    ) -> None:
+        if prefill_step_size < 1:
+            raise ValueError("prefill_step_size must be positive")
+        if draft_depth != 2:
+            raise ValueError("the first Rapid continuous self-MTP backend is K=2")
+        self.target_cache_factory = target_cache_factory
+        self.draft_cache_factory = draft_cache_factory
+        self.ops = array_ops or _MLXArrayOps()
+        self.residual_sampling = residual_sampling
+        self.logits_processor = logits_processor
+        self.prefill_step_size = int(prefill_step_size)
+        self.draft_depth = draft_depth
+
+    def _cache(self, existing: Any, factory: Callable[[], Any] | None, name: str):
+        value = existing
+        if value is None:
+            if factory is None:
+                raise ContinuousSelfMTPUnsupported(
+                    f"{name} cache requires an explicit factory"
+                )
+            value = factory()
+        group = _as_group(value, name)
+        for cache in group:
+            _reject_cache(cache)
+        return group
+
+    def _apply_processor(self, lane: SelfMTPLane, prefix: Any, logits: Any) -> Any:
+        if not lane.sampling.has_logits_processors:
+            return logits
+        if self.logits_processor is None:
+            raise ContinuousSelfMTPUnsupported(
+                "logits processors require an exact injected hook"
+            )
+        return self.logits_processor(lane, prefix, logits)
+
+    def _distribution(self, lane: SelfMTPLane, prefix: Any, logits: Any):
+        logits = self._apply_processor(lane, prefix, logits)
+        if lane.sampling.temperature == 0:
+            logprobs = self.ops.logprobs(logits)
+            return self.ops.argmax_int(logprobs), logprobs
+        hooks = self.residual_sampling
+        if hooks is None:
+            raise ContinuousSelfMTPUnsupported(
+                "transformed sampling requires exact residual hooks"
+            )
+        logprobs = hooks.logprobs(logits, lane.sampling.temperature)
+        return hooks.sample(logprobs, lane.sampling.temperature), logprobs
+
+    def _prefix(self, lane: SelfMTPLane, extra: Sequence[int]) -> Any:
+        if not extra:
+            return lane.token_prefix
+        return self.ops.concatenate(
+            [lane.token_prefix, self.ops.uint32(list(extra))], axis=0
+        )
+
+    @staticmethod
+    def _forward_pair(value: Any, who: str) -> tuple[Any, Any]:
+        if not isinstance(value, tuple) or len(value) != 2:
+            raise ContinuousSelfMTPUnsupported(
+                f"{who} must return (logits, hidden) with return_hidden=True"
+            )
+        return value
+
+    def prepare(
+        self, spec: SelfMTPLaneSpec, forwards: RapidForwardSeams
+    ) -> PreparedLaneData:
+        if spec.num_draft != self.draft_depth:
+            raise ContinuousSelfMTPUnsupported("Rapid continuous self-MTP requires K=2")
+        if spec.sampling.uses_xtc:
+            raise ContinuousSelfMTPUnsupported("XTC has no exact verifier")
+        if spec.sampling.temperature > 0 and self.residual_sampling is None:
+            raise ContinuousSelfMTPUnsupported(
+                "transformed sampling requires exact residual hooks"
+            )
+        if spec.sampling.has_logits_processors and self.logits_processor is None:
+            raise ContinuousSelfMTPUnsupported(
+                "logits processors require an exact injected hook"
+            )
+
+        target = self._cache(spec.prompt_cache, self.target_cache_factory, "target")
+        draft = self._cache(spec.mtp_cache, self.draft_cache_factory, "draft")
+        prompt = self.ops.uint32(spec.prompt)
+        if len(prompt.shape) != 1 or int(prompt.shape[0]) < 1:
+            raise ValueError("prompt must be a non-empty rank-1 token array")
+
+        y = prompt
+        previous_hidden = None
+        while int(y.shape[0]) > 1:
+            n = min(self.prefill_step_size, int(y.shape[0]) - 1)
+            _, hidden = self._forward_pair(
+                forwards.target(self.ops.expand_dims(y[:n], 0), target, n_confirmed=0),
+                "target forward",
+            )
+            if previous_hidden is None:
+                pair_hidden = hidden[:, :-1]
+                pair_tokens = y[1:n]
+            else:
+                pair_hidden = self.ops.concatenate(
+                    [previous_hidden, hidden[:, :-1]], axis=1
+                )
+                pair_tokens = y[:n]
+            if int(pair_tokens.shape[0]) > 0:
+                self._forward_pair(
+                    forwards.draft(
+                        pair_hidden,
+                        self.ops.expand_dims(pair_tokens, 0),
+                        draft,
+                    ),
+                    "MTP forward",
+                )
+            previous_hidden = hidden[:, -1:]
+            y = y[n:]
+
+        if previous_hidden is not None:
+            self._forward_pair(
+                forwards.draft(
+                    previous_hidden,
+                    self.ops.expand_dims(y, 0),
+                    draft,
+                ),
+                "MTP forward",
+            )
+        logits, hidden = self._forward_pair(
+            forwards.target(self.ops.expand_dims(y, 0), target, n_confirmed=0),
+            "target forward",
+        )
+        final_logits = logits[0, -1]
+        temporary_lane = SelfMTPLane(
+            uid=spec.uid,
+            cur=0,
+            seed_hidden=hidden[:, -1:],
+            token_prefix=prompt,
+            ntoks=0,
+            max_tokens=spec.max_tokens,
+            num_draft=spec.num_draft,
+            sampling=spec.sampling,
+        )
+        token, logprobs = self._distribution(temporary_lane, prompt, final_logits)
+        first = MTPToken(token, logprobs, False)
+        return PreparedLaneData(
+            cur=token,
+            seed_hidden=hidden[:, -1:],
+            token_prefix=prompt,
+            caches=SelfMTPCachePair(target=target, draft=draft),
+            first_token=first,
+            backend_state={"forwards": forwards},
+        )
+
+    def propose(
+        self,
+        lanes: Sequence[SelfMTPLane],
+        caches: SelfMTPCachePair,
+        forwards: RapidForwardSeams,
+    ) -> CycleComputation:
+        target, draft_cache = _validate_pair(caches)
+        if not lanes:
+            raise ValueError("cannot propose an empty batch")
+        depths = tuple(
+            min(
+                self.draft_depth,
+                lane.num_draft,
+                max(lane.max_tokens - lane.ntoks - 1, 0),
+            )
+            for lane in lanes
+        )
+        if max(depths) == 0:
+            raise ContinuousSelfMTPUnsupported(
+                "all lanes are terminal; no K=2 proposal can be formed"
+            )
+
+        drafts: list[list[int]] = [[] for _ in lanes]
+        draft_logprobs: list[list[Any]] = [[] for _ in lanes]
+        draft_hidden = [lane.seed_hidden for lane in lanes]
+
+        first_lengths = [
+            len(lane.pending_tokens) + 1 if depth > 0 else 0
+            for lane, depth in zip(lanes, depths)
+        ]
+        first_width = max(first_lengths)
+        hidden_rows = []
+        token_rows = []
+        for lane, valid in zip(lanes, first_lengths):
+            if valid:
+                hidden = lane.seed_hidden
+                if lane.pending_hidden is not None:
+                    if len(lane.pending_tokens) == 0:
+                        raise RuntimeError("pending hidden has no pending tokens")
+                    hidden = self.ops.concatenate(
+                        [lane.pending_hidden, lane.seed_hidden], axis=1
+                    )
+                elif lane.pending_tokens:
+                    raise RuntimeError("pending tokens have no pending hidden")
+                tokens = self.ops.uint32([lane.pending_tokens + [lane.cur]])
+            else:
+                # This row is padded and ignored by cache lengths.
+                hidden = lane.seed_hidden
+                tokens = self.ops.uint32([[0]])
+            hidden_rows.append(
+                self.ops.pad(
+                    hidden,
+                    [(0, 0), (0, first_width - max(valid, 1)), (0, 0)],
+                )
+            )
+            token_rows.append(
+                self.ops.pad(tokens, [(0, 0), (0, first_width - max(valid, 1))])
+            )
+
+        _prepare_group(draft_cache, first_lengths)
+        try:
+            first_logits, first_hidden = self._forward_pair(
+                forwards.draft(
+                    self.ops.concatenate(hidden_rows, axis=0),
+                    self.ops.concatenate(token_rows, axis=0),
+                    draft_cache,
+                ),
+                "MTP forward",
+            )
+        finally:
+            _finalize_group(draft_cache)
+        for row, (lane, depth, valid) in enumerate(zip(lanes, depths, first_lengths)):
+            if depth == 0:
+                continue
+            position = valid - 1
+            token, logprobs = self._distribution(
+                lane,
+                self._prefix(lane, [lane.cur]),
+                first_logits[row, position],
+            )
+            drafts[row].append(token)
+            draft_logprobs[row].append(logprobs)
+            draft_hidden[row] = first_hidden[row : row + 1, position : position + 1]
+            lane.pending_hidden = None
+            lane.pending_tokens = []
+
+        second_lengths = [1 if depth > 1 else 0 for depth in depths]
+        if any(second_lengths):
+            hidden_batch = self.ops.concatenate(draft_hidden, axis=0)
+            token_batch = self.ops.uint32(
+                [
+                    [drafts[row][-1] if active else 0]
+                    for row, active in enumerate(second_lengths)
+                ]
+            )
+            _prepare_group(draft_cache, second_lengths)
+            try:
+                second_logits, _ = self._forward_pair(
+                    forwards.draft(hidden_batch, token_batch, draft_cache),
+                    "MTP forward",
+                )
+            finally:
+                _finalize_group(draft_cache)
+            for row, (lane, active) in enumerate(zip(lanes, second_lengths)):
+                if not active:
+                    continue
+                token, logprobs = self._distribution(
+                    lane,
+                    self._prefix(lane, [lane.cur] + drafts[row]),
+                    second_logits[row, -1],
+                )
+                drafts[row].append(token)
+                draft_logprobs[row].append(logprobs)
+
+        verify_width = max(depth + 1 for depth in depths)
+        verify_rows = [
+            [lane.cur] + row + [0] * (verify_width - len(row) - 1)
+            for lane, row in zip(lanes, drafts)
+        ]
+        verify_ids = self.ops.uint32(verify_rows)
+        verify_lengths = [depth + 1 for depth in depths]
+        _prepare_group(target, verify_lengths)
+        try:
+            target_logits, target_hidden = self._forward_pair(
+                forwards.target(
+                    verify_ids,
+                    target,
+                    n_confirmed=max(depths),
+                ),
+                "target forward",
+            )
+        finally:
+            _finalize_group(target)
+
+        accepted: list[int] = []
+        bonuses: list[int] = []
+        output_rows: list[tuple[MTPToken, ...]] = []
+        hidden_rows = []
+        for row, (lane, depth) in enumerate(zip(lanes, depths)):
+            valid = depth + 1
+            target_lps = []
+            target_tokens = []
+            for position in range(valid):
+                prefix = self._prefix(lane, [lane.cur] + drafts[row][:position])
+                logits = self._apply_processor(
+                    lane, prefix, target_logits[row, position]
+                )
+                if lane.sampling.temperature == 0:
+                    logprobs = self.ops.logprobs(logits)
+                    token = self.ops.argmax_int(logprobs)
+                else:
+                    hooks = self.residual_sampling
+                    if hooks is None:
+                        raise ContinuousSelfMTPUnsupported(
+                            "transformed sampling requires exact residual hooks"
+                        )
+                    logprobs = hooks.logprobs(logits, lane.sampling.temperature)
+                    token = -1
+                target_lps.append(logprobs)
+                target_tokens.append(token)
+
+            if lane.sampling.temperature == 0:
+                n_accept = 0
+                while (
+                    n_accept < depth
+                    and target_tokens[n_accept] == drafts[row][n_accept]
+                ):
+                    n_accept += 1
+                bonus = target_tokens[n_accept]
+            else:
+                hooks = self.residual_sampling
+                assert hooks is not None
+                stacked_target = self.ops.concatenate(
+                    [self.ops.expand_dims(value, 0) for value in target_lps], axis=0
+                )
+                n_accept, bonus = hooks.verify(
+                    stacked_target,
+                    draft_logprobs[row],
+                    drafts[row],
+                    lane.sampling.temperature,
+                )
+                if n_accept < 0 or n_accept > depth:
+                    raise RuntimeError("residual verifier returned invalid acceptance")
+            accepted.append(n_accept)
+            bonuses.append(int(bonus))
+            output_rows.append(
+                tuple(
+                    [
+                        MTPToken(drafts[row][position], target_lps[position], True)
+                        for position in range(n_accept)
+                    ]
+                    + [MTPToken(int(bonus), target_lps[n_accept], False)]
+                )
+            )
+            hidden_rows.append(target_hidden[row : row + 1, :valid])
+
+        accepted_tuple = tuple(accepted)
+        return CycleComputation(
+            lane_uids=tuple(lane.uid for lane in lanes),
+            draft_depths=depths,
+            accepted_lengths=accepted_tuple,
+            target_drops=tuple(
+                depth - count for depth, count in zip(depths, accepted_tuple)
+            ),
+            draft_drops=depths,
+            outputs=tuple(output_rows),
+            payload=_CyclePayload(
+                old_curs=tuple(lane.cur for lane in lanes),
+                old_seed_hidden=tuple(lane.seed_hidden for lane in lanes),
+                drafts=tuple(tuple(row) for row in drafts),
+                verify_hidden=tuple(hidden_rows),
+                bonuses=tuple(bonuses),
+            ),
+        )
+
+    def commit(
+        self,
+        lanes: Sequence[SelfMTPLane],
+        computation: CycleComputation,
+        *,
+        emitted_counts: tuple[int, ...],
+        terminal: tuple[bool, ...],
+    ) -> None:
+        payload = computation.payload
+        if not isinstance(payload, _CyclePayload):
+            raise TypeError("Rapid backend received a foreign cycle payload")
+        for row, lane in enumerate(lanes):
+            accepted = computation.accepted_lengths[row]
+            count = emitted_counts[row]
+            old_cur = payload.old_curs[row]
+            old_seed = payload.old_seed_hidden[row]
+            drafts = list(payload.drafts[row])
+            hidden = payload.verify_hidden[row]
+
+            if terminal[row] and count <= accepted:
+                if count > 0:
+                    pending_hidden = old_seed
+                    if count > 1:
+                        pending_hidden = self.ops.concatenate(
+                            [old_seed, hidden[:, : count - 1]], axis=1
+                        )
+                    pending_tokens = [old_cur] + drafts[: count - 1]
+                    lane.pending_hidden = pending_hidden
+                    lane.pending_tokens = pending_tokens
+                    lane.seed_hidden = hidden[:, count - 1 : count]
+                    lane.cur = computation.outputs[row][count - 1].token
+                    lane.token_prefix = self.ops.concatenate(
+                        [lane.token_prefix, self.ops.uint32(pending_tokens)], axis=0
+                    )
+                continue
+
+            new_hidden = self.ops.concatenate([old_seed, hidden[:, :accepted]], axis=1)
+            new_tokens = [old_cur] + drafts[:accepted]
+            if lane.pending_tokens:
+                if lane.pending_hidden is None:
+                    raise RuntimeError("pending tokens have no pending hidden")
+                new_hidden = self.ops.concatenate(
+                    [lane.pending_hidden, new_hidden], axis=1
+                )
+                new_tokens = lane.pending_tokens + new_tokens
+            lane.pending_hidden = new_hidden
+            lane.pending_tokens = new_tokens
+            lane.seed_hidden = hidden[:, accepted : accepted + 1]
+            lane.cur = payload.bonuses[row]
+            lane.token_prefix = self.ops.concatenate(
+                [
+                    lane.token_prefix,
+                    self.ops.uint32([old_cur] + drafts[:accepted]),
+                ],
+                axis=0,
+            )
+
+    def detach_lane(self, lane: SelfMTPLane, caches: SelfMTPCachePair) -> None:
+        """Flush owed hidden/token pairs into the detached draft cache."""
+        if not lane.pending_tokens:
+            return
+        if lane.pending_hidden is None:
+            raise RuntimeError("pending tokens have no pending hidden")
+        _target, draft = _validate_pair(caches)
+        state = lane.backend_state
+        forwards = state.get("forwards") if isinstance(state, dict) else None
+        if not isinstance(forwards, RapidForwardSeams):
+            raise ContinuousSelfMTPUnsupported(
+                "detached pending-pair flush has no Rapid forward seam"
+            )
+        self._forward_pair(
+            forwards.draft(
+                lane.pending_hidden,
+                self.ops.uint32([lane.pending_tokens]),
+                draft,
+            ),
+            "MTP forward",
+        )
+
+
+class RapidRaggedCacheAdapter:
+    """Merge/extend/rollback/extract adapter for mlx-lm 0.31.x caches."""
+
+    def __init__(
+        self,
+        *,
+        preflight: Callable[..., Any] | None = None,
+        trim: Callable[..., Any] | None = None,
+    ) -> None:
+        if preflight is None or trim is None:
+            from .ragged_cache import preflight_ragged_cache, trim_ragged_cache
+
+            preflight = preflight or preflight_ragged_cache
+            trim = trim or trim_ragged_cache
+        self._preflight = preflight
+        self._trim = trim
+
+    @staticmethod
+    def _merge(groups: Sequence[Sequence[Any]], name: str) -> list[Any]:
+        if not groups:
+            raise ValueError(f"cannot merge an empty {name} cache group")
+        width = len(groups[0])
+        if width == 0 or any(len(group) != width for group in groups):
+            raise ValueError(f"{name} cache groups must have equal non-zero width")
+        merged = []
+        for rows in zip(*groups):
+            for cache in rows:
+                _reject_cache(cache)
+            merge = getattr(type(rows[0]), "merge", None)
+            if not callable(merge):
+                raise ContinuousSelfMTPUnsupported(
+                    f"cache {type(rows[0]).__name__} has no merge surface"
+                )
+            if any(type(cache) is not type(rows[0]) for cache in rows):
+                raise ContinuousSelfMTPUnsupported(
+                    f"mixed {name} cache classes cannot be merged"
+                )
+            merged.append(merge(list(rows)))
+        return merged
+
+    def attach(
+        self,
+        current: SelfMTPCachePair | None,
+        joining: Sequence[SelfMTPCachePair],
+    ) -> SelfMTPCachePair:
+        if not joining:
+            if current is None:
+                raise ValueError("cannot attach no cache rows")
+            return current
+        pairs = [_validate_pair(pair) for pair in joining]
+        incoming = SelfMTPCachePair(
+            target=self._merge([pair[0] for pair in pairs], "target"),
+            draft=self._merge([pair[1] for pair in pairs], "draft"),
+        )
+        if current is None or not current.target:
+            return incoming
+        target, draft = _validate_pair(current)
+        incoming_target, incoming_draft = _validate_pair(incoming)
+        if len(target) != len(incoming_target) or len(draft) != len(incoming_draft):
+            raise ValueError("cache layer widths differ during extend")
+        # Preflight the entire reflective surface before any layer mutates.
+        if any(
+            not callable(getattr(cache, "extend", None)) for cache in target + draft
+        ):
+            raise ContinuousSelfMTPUnsupported("cache has no extend surface")
+        for cache, other in zip(target, incoming_target):
+            cache.extend(other)
+        for cache, other in zip(draft, incoming_draft):
+            cache.extend(other)
+        return current
+
+    def rollback(
+        self,
+        caches: SelfMTPCachePair,
+        *,
+        target_drops: Sequence[int],
+        draft_drops: Sequence[int],
+        verify_width: int,
+    ) -> None:
+        target, draft = _validate_pair(caches)
+        # Cross-group preflight gives atomic failure before either cache moves.
+        self._preflight(target, target_drops, verify_size=verify_width, validate=True)
+        if any(draft_drops):
+            self._preflight(draft, draft_drops, verify_size=verify_width, validate=True)
+        self._trim(target, target_drops, verify_size=verify_width, validate=False)
+        if any(draft_drops):
+            self._trim(draft, draft_drops, verify_size=verify_width, validate=False)
+
+    def detach(
+        self,
+        caches: SelfMTPCachePair,
+        indices: Sequence[int],
+        keep_indices: Sequence[int],
+    ) -> tuple[SelfMTPCachePair, list[SelfMTPCachePair]]:
+        target, draft = _validate_pair(caches)
+        all_caches = target + draft
+        if any(not callable(getattr(cache, "extract", None)) for cache in all_caches):
+            raise ContinuousSelfMTPUnsupported("cache has no extract surface")
+        if keep_indices and any(
+            not callable(getattr(cache, "filter", None)) for cache in all_caches
+        ):
+            raise ContinuousSelfMTPUnsupported("cache has no filter surface")
+
+        detached = [
+            SelfMTPCachePair(
+                target=[cache.extract(index) for cache in target],
+                draft=[cache.extract(index) for cache in draft],
+            )
+            for index in indices
+        ]
+        if keep_indices:
+            for cache in all_caches:
+                cache.filter(list(keep_indices))
+            remaining = caches
+        else:
+            remaining = SelfMTPCachePair(target=[], draft=[])
+        return remaining, detached
+
+
+__all__ = [
+    "ArrayOps",
+    "RapidMLXSelfMTPBackend",
+    "RapidRaggedCacheAdapter",
+    "ResidualSamplingHooks",
+]

--- a/vllm_mlx/spec_decode/mtp/prepared_state.py
+++ b/vllm_mlx/spec_decode/mtp/prepared_state.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python contract for composing prefix-cache hits with persistent MTP.
+
+Automatic prefix caching owns target-cache storage.  Persistent self-MTP owns
+an additional draft cache and the trunk hidden state that seeds the first pair
+after a restored prefix.  Those three objects are reusable only when they were
+captured together at one exact token boundary::
+
+    target tokens == covered tokens
+    MTP pairs     == covered tokens - 1
+    seed hidden   == hidden state of the final covered token
+
+This module deliberately does not import MLX or modify the prefix cache.  It is
+the validation/policy seam an eventual APC integration can call before it
+mutates either cache.  Producer mistakes raise at capture time; persisted or
+lookup-time mismatches return a refusal so serving can fall back safely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+PREPARED_STATE_SCHEMA_VERSION = 1
+DEFAULT_MIN_USEFUL_PREFIX_TOKENS = 64
+
+
+class RestoreReason(str, Enum):
+    """Stable result codes for prepared-state admission."""
+
+    ELIGIBLE = "eligible"
+    TRIVIAL_HIT = "trivial_hit"
+    STALE = "stale"
+    MODEL_MISMATCH = "model_mismatch"
+    CONFIG_MISMATCH = "config_mismatch"
+    BOUNDARY_MISMATCH = "boundary_mismatch"
+    MALFORMED = "malformed"
+
+
+@dataclass(frozen=True)
+class PreparedStateIdentity:
+    """Identity of the exact runtime contract that produced a sidecar.
+
+    ``model_id`` alone is not sufficient: an alias can be repointed, an
+    adapter can change the target distribution, or a speculative configuration
+    can change the draft-cache meaning.  Cache and seed-hidden layout strings
+    are caller-provided stable fingerprints (for example, topology + dtype +
+    hidden width), keeping this module independent of MLX objects.
+    """
+
+    model_id: str
+    model_revision: str
+    speculative_config_fingerprint: str
+    target_cache_layout: str
+    mtp_cache_layout: str
+    seed_hidden_layout: str
+    adapter_id: str | None = None
+    tokenizer_fingerprint: str | None = None
+
+    def __post_init__(self) -> None:
+        required = {
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "speculative_config_fingerprint": (self.speculative_config_fingerprint),
+            "target_cache_layout": self.target_cache_layout,
+            "mtp_cache_layout": self.mtp_cache_layout,
+            "seed_hidden_layout": self.seed_hidden_layout,
+        }
+        for name, value in required.items():
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        for name, value in (
+            ("adapter_id", self.adapter_id),
+            ("tokenizer_fingerprint", self.tokenizer_fingerprint),
+        ):
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ValueError(f"{name} must be None or a non-empty string")
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        model_id: str,
+        model_revision: str,
+        speculative_config: Mapping[str, Any],
+        target_cache_layout: str,
+        mtp_cache_layout: str,
+        seed_hidden_layout: str,
+        adapter_id: str | None = None,
+        tokenizer_fingerprint: str | None = None,
+    ) -> PreparedStateIdentity:
+        """Build an identity with a canonical speculative-config digest."""
+
+        return cls(
+            model_id=model_id,
+            model_revision=model_revision,
+            speculative_config_fingerprint=fingerprint_config(speculative_config),
+            target_cache_layout=target_cache_layout,
+            mtp_cache_layout=mtp_cache_layout,
+            seed_hidden_layout=seed_hidden_layout,
+            adapter_id=adapter_id,
+            tokenizer_fingerprint=tokenizer_fingerprint,
+        )
+
+
+@dataclass(frozen=True)
+class PreparedStateMetadata:
+    """Serializable metadata paired with the three opaque runtime objects."""
+
+    identity: PreparedStateIdentity
+    covered_tokens: int
+    mtp_covered_pairs: int
+    boundary_fingerprint: str
+    captured_at: float
+    schema_version: int = PREPARED_STATE_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class PreparedMTPState:
+    """Target cache, draft cache, and seed hidden captured as one unit."""
+
+    metadata: PreparedStateMetadata
+    target_cache: Any
+    mtp_cache: Any
+    seed_hidden: Any
+
+
+@dataclass(frozen=True)
+class RestoreEligibility:
+    """Non-throwing lookup decision for a prepared state.
+
+    ``bypass_hit`` is true for a valid but too-small prefix.  That is the
+    trivial-hit fail-open rule: the caller should ignore the APC hit and start
+    the normal MTP path instead of letting a few cached template tokens disable
+    speculation.  Other refusals leave fallback selection to the caller.
+    """
+
+    eligible: bool
+    reason: RestoreReason
+    covered_tokens: int = 0
+    resume_at: int | None = None
+    bypass_hit: bool = False
+
+
+def fingerprint_config(config: Mapping[str, Any]) -> str:
+    """Return a deterministic SHA-256 fingerprint for JSON config data."""
+
+    if not isinstance(config, Mapping):
+        raise TypeError("config must be a mapping")
+    try:
+        encoded = json.dumps(
+            dict(config),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("config must contain canonical JSON values") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def fingerprint_tokens(tokens: Sequence[int]) -> str:
+    """Fingerprint an ordered token boundary without retaining prompt text."""
+
+    digest = hashlib.sha256()
+    for token in tokens:
+        if isinstance(token, bool) or not isinstance(token, int) or token < 0:
+            raise ValueError("tokens must contain non-negative integers")
+        if token >= 1 << 64:
+            raise ValueError("token ids must fit in an unsigned 64-bit integer")
+        digest.update(token.to_bytes(8, byteorder="big", signed=False))
+    return digest.hexdigest()
+
+
+def prepare_mtp_state(
+    *,
+    identity: PreparedStateIdentity,
+    prefix_tokens: Sequence[int],
+    target_cache: Any,
+    target_cache_tokens: int,
+    mtp_cache: Any,
+    mtp_cache_pairs: int,
+    seed_hidden: Any,
+    captured_at: float | None = None,
+) -> PreparedMTPState:
+    """Validate and capture one exact target/MTP/hidden boundary.
+
+    This strict producer-side function raises for a programmer error.  Lookup
+    uses :func:`evaluate_restore`, which converts corrupted, stale, or mismatched
+    state into a refusal instead of raising on the serving path.
+    """
+
+    prefix = tuple(prefix_tokens)
+    covered = _validated_count(target_cache_tokens, "target_cache_tokens")
+    mtp_pairs = _validated_count(mtp_cache_pairs, "mtp_cache_pairs")
+    if not prefix or covered == 0:
+        raise ValueError("prepared MTP state requires a non-empty prefix")
+    if covered != len(prefix):
+        raise ValueError(
+            "target_cache_tokens must equal the exact covered prefix length"
+        )
+    if mtp_pairs != covered - 1:
+        raise ValueError("mtp_cache_pairs must equal target_cache_tokens - 1")
+    if target_cache is None:
+        raise ValueError("target_cache must be present")
+    if mtp_cache is None:
+        raise ValueError("mtp_cache must be present")
+    if seed_hidden is None:
+        raise ValueError("seed_hidden must cover the final prefix token")
+    timestamp = time.time() if captured_at is None else float(captured_at)
+    if not math.isfinite(timestamp) or timestamp < 0:
+        raise ValueError("captured_at must be a finite non-negative timestamp")
+
+    metadata = PreparedStateMetadata(
+        identity=identity,
+        covered_tokens=covered,
+        mtp_covered_pairs=mtp_pairs,
+        boundary_fingerprint=fingerprint_tokens(prefix),
+        captured_at=timestamp,
+    )
+    return PreparedMTPState(metadata, target_cache, mtp_cache, seed_hidden)
+
+
+def evaluate_restore(
+    state: PreparedMTPState,
+    *,
+    expected_identity: PreparedStateIdentity,
+    request_tokens: Sequence[int],
+    target_cache_tokens: int,
+    mtp_cache_pairs: int,
+    now: float | None = None,
+    max_age_seconds: float | None = None,
+    min_useful_prefix_tokens: int = DEFAULT_MIN_USEFUL_PREFIX_TOKENS,
+) -> RestoreEligibility:
+    """Return whether ``state`` may be restored for ``request_tokens``.
+
+    Validation order intentionally reports identity and staleness before the
+    performance-only trivial-hit rule.  A malformed or foreign state is never
+    disguised as a benign small hit.
+    """
+
+    if (
+        isinstance(min_useful_prefix_tokens, bool)
+        or not isinstance(min_useful_prefix_tokens, int)
+        or min_useful_prefix_tokens < 1
+    ):
+        raise ValueError("min_useful_prefix_tokens must be a positive integer")
+    if max_age_seconds is not None:
+        max_age_seconds = float(max_age_seconds)
+        if not math.isfinite(max_age_seconds) or max_age_seconds < 0:
+            raise ValueError("max_age_seconds must be finite and non-negative")
+
+    metadata = getattr(state, "metadata", None)
+    if not _metadata_is_well_formed(metadata):
+        return _refusal(RestoreReason.MALFORMED)
+    covered = metadata.covered_tokens
+    if not isinstance(expected_identity, PreparedStateIdentity):
+        return _refusal(RestoreReason.MALFORMED, covered)
+
+    identity_reason = _identity_mismatch(metadata.identity, expected_identity)
+    if identity_reason is not None:
+        return _refusal(identity_reason, covered)
+
+    try:
+        current_time = time.time() if now is None else float(now)
+    except (TypeError, ValueError):
+        return _refusal(RestoreReason.MALFORMED, covered)
+    if not math.isfinite(current_time) or current_time < metadata.captured_at:
+        return _refusal(RestoreReason.STALE, covered)
+    if (
+        max_age_seconds is not None
+        and current_time - metadata.captured_at > max_age_seconds
+    ):
+        return _refusal(RestoreReason.STALE, covered)
+
+    try:
+        live_target = _validated_count(target_cache_tokens, "target_cache_tokens")
+        live_mtp = _validated_count(mtp_cache_pairs, "mtp_cache_pairs")
+        request = tuple(request_tokens)
+        boundary_matches = (
+            len(request) > covered
+            and fingerprint_tokens(request[:covered]) == metadata.boundary_fingerprint
+        )
+    except (TypeError, ValueError):
+        return _refusal(RestoreReason.MALFORMED, covered)
+
+    exact_boundary = (
+        getattr(state, "target_cache", None) is not None
+        and getattr(state, "mtp_cache", None) is not None
+        and getattr(state, "seed_hidden", None) is not None
+        and metadata.mtp_covered_pairs == covered - 1
+        and live_target == covered
+        and live_mtp == covered - 1
+        and boundary_matches
+    )
+    if not exact_boundary:
+        return _refusal(RestoreReason.BOUNDARY_MISMATCH, covered)
+
+    if covered < min_useful_prefix_tokens:
+        return RestoreEligibility(
+            eligible=False,
+            reason=RestoreReason.TRIVIAL_HIT,
+            covered_tokens=covered,
+            bypass_hit=True,
+        )
+
+    return RestoreEligibility(
+        eligible=True,
+        reason=RestoreReason.ELIGIBLE,
+        covered_tokens=covered,
+        resume_at=covered,
+    )
+
+
+def _validated_count(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _metadata_is_well_formed(metadata: Any) -> bool:
+    if not isinstance(metadata, PreparedStateMetadata):
+        return False
+    if metadata.schema_version != PREPARED_STATE_SCHEMA_VERSION:
+        return False
+    try:
+        covered = _validated_count(metadata.covered_tokens, "covered_tokens")
+        pairs = _validated_count(metadata.mtp_covered_pairs, "mtp_covered_pairs")
+    except ValueError:
+        return False
+    try:
+        valid_timestamp = (
+            math.isfinite(metadata.captured_at) and metadata.captured_at >= 0
+        )
+        valid_fingerprint = (
+            isinstance(metadata.boundary_fingerprint, str)
+            and len(metadata.boundary_fingerprint) == 64
+            and all(
+                character in "0123456789abcdef"
+                for character in metadata.boundary_fingerprint
+            )
+        )
+    except TypeError:
+        return False
+    return (
+        covered > 0
+        and pairs == covered - 1
+        and valid_fingerprint
+        and valid_timestamp
+        and isinstance(metadata.identity, PreparedStateIdentity)
+    )
+
+
+def _identity_mismatch(
+    actual: PreparedStateIdentity,
+    expected: PreparedStateIdentity,
+) -> RestoreReason | None:
+    model_actual = (
+        actual.model_id,
+        actual.model_revision,
+        actual.adapter_id,
+        actual.tokenizer_fingerprint,
+    )
+    model_expected = (
+        expected.model_id,
+        expected.model_revision,
+        expected.adapter_id,
+        expected.tokenizer_fingerprint,
+    )
+    if model_actual != model_expected:
+        return RestoreReason.MODEL_MISMATCH
+    config_actual = (
+        actual.speculative_config_fingerprint,
+        actual.target_cache_layout,
+        actual.mtp_cache_layout,
+        actual.seed_hidden_layout,
+    )
+    config_expected = (
+        expected.speculative_config_fingerprint,
+        expected.target_cache_layout,
+        expected.mtp_cache_layout,
+        expected.seed_hidden_layout,
+    )
+    if config_actual != config_expected:
+        return RestoreReason.CONFIG_MISMATCH
+    return None
+
+
+def _refusal(
+    reason: RestoreReason,
+    covered_tokens: int = 0,
+) -> RestoreEligibility:
+    return RestoreEligibility(False, reason, covered_tokens=max(0, covered_tokens))
+
+
+__all__ = [
+    "DEFAULT_MIN_USEFUL_PREFIX_TOKENS",
+    "PREPARED_STATE_SCHEMA_VERSION",
+    "PreparedMTPState",
+    "PreparedStateIdentity",
+    "PreparedStateMetadata",
+    "RestoreEligibility",
+    "RestoreReason",
+    "evaluate_restore",
+    "fingerprint_config",
+    "fingerprint_tokens",
+    "prepare_mtp_state",
+]

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -62,6 +62,7 @@ BATCHED_MTP_CAPABILITY = MappingProxyType(
         "model_family": "qwen3_5",
         "batch_forward": "mtp_batch_forward",
         "recursive_draft_depth": 2,
+        "share_qsa_indices": False,
         "fixed_membership": True,
         "dynamic_join": True,
         "quantized_cache": False,

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -50,9 +50,36 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+BATCHED_MTP_CAPABILITY = MappingProxyType(
+    {
+        "protocol_version": 1,
+        "model_family": "qwen3_5",
+        "batch_forward": "mtp_batch_forward",
+        "recursive_draft_depth": 2,
+        "fixed_membership": True,
+        "dynamic_join": True,
+        "quantized_cache": False,
+        "windowed_cache": False,
+        "xtc": False,
+    }
+)
+
+
+def _mtp_batch_forward(self, hidden_states, next_token_ids, mtp_cache):
+    """Batch seam: recursive drafting always needs the returned hidden state."""
+
+    return self.mtp_forward(
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden=True,
+    )
 
 
 def _resolve_inner_text_model(model: Any) -> Any:
@@ -889,6 +916,9 @@ def inject_mtp_support(
         # backends whose MTP cache-history synchronization has been audited.
         # This injector covers the Qwen 3.5/3.6/3.8 family.
         mtp_prompt_lookup_supported = True
+        batched_mtp_capability = BATCHED_MTP_CAPABILITY
+        mtp_recursive_draft_depth = 2
+        mtp_batch_forward = _mtp_batch_forward
 
         def __call__(  # type: ignore[override]
             self,
@@ -1013,6 +1043,9 @@ def inject_mtp_support(
     # regardless of which supported shape reaches the generator.
     if model is not inner:
         model.mtp_prompt_lookup_supported = True
+        model.mtp_batch_forward = inner.mtp_batch_forward
+    model.batched_mtp_capability = BATCHED_MTP_CAPABILITY
+    model.mtp_recursive_draft_depth = 2
     logger.info(
         "[mtp.inject] Patched %s with MTP surfaces "
         "(return_hidden, n_confirmed, mtp_forward, make_mtp_cache).",
@@ -1048,6 +1081,15 @@ def validate_mtp_support(model: Any) -> bool:
         return False
     if not callable(getattr(inner, "mtp_forward", None)):
         logger.warning("[mtp.validate] model.mtp_forward is missing.")
+        return False
+    if not callable(getattr(inner, "mtp_batch_forward", None)):
+        logger.warning("[mtp.validate] model.mtp_batch_forward is missing.")
+        return False
+    if getattr(inner, "batched_mtp_capability", None) is not BATCHED_MTP_CAPABILITY:
+        logger.warning("[mtp.validate] batched MTP capability descriptor is missing.")
+        return False
+    if getattr(inner, "mtp_recursive_draft_depth", None) != 2:
+        logger.warning("[mtp.validate] recursive batch draft depth is missing.")
         return False
     if not callable(getattr(inner, "make_mtp_cache", None)):
         logger.warning("[mtp.validate] model.make_mtp_cache is missing.")

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -25,6 +25,7 @@ BATCHED_MTP_CAPABILITY = MappingProxyType(
         "model_family": "qwen4_exp",
         "batch_forward": "mtp_batch_forward",
         "recursive_draft_depth": 2,
+        "share_qsa_indices": True,
         "fixed_membership": True,
         "dynamic_join": False,
         "quantized_cache": False,

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -13,9 +13,36 @@ import inspect
 import json
 import logging
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+BATCHED_MTP_CAPABILITY = MappingProxyType(
+    {
+        "protocol_version": 1,
+        "model_family": "qwen4_exp",
+        "batch_forward": "mtp_batch_forward",
+        "recursive_draft_depth": 2,
+        "fixed_membership": True,
+        "dynamic_join": False,
+        "quantized_cache": False,
+        "windowed_cache": False,
+        "xtc": False,
+    }
+)
+
+
+def _mtp_batch_forward(self, hidden_states, next_token_ids, mtp_cache):
+    """Batch seam: recursive drafting always needs the returned hidden state."""
+
+    return self.mtp_forward(
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden=True,
+    )
 
 
 def _resolve_inner(model: Any) -> Any | None:
@@ -203,6 +230,9 @@ def inject_qwen4_exp_mtp_support(
 
         class _Qwen4ExpWithMTP(original_class):  # type: ignore[valid-type, misc]
             mtp_prompt_lookup_supported = False
+            batched_mtp_capability = BATCHED_MTP_CAPABILITY
+            mtp_recursive_draft_depth = 2
+            mtp_batch_forward = _mtp_batch_forward
 
             def mtp_forward(
                 self,
@@ -229,11 +259,15 @@ def inject_qwen4_exp_mtp_support(
                 ratio = self.mtp.layers[0].self_attn.indexer.compress_ratio
                 return [CacheList(KVCache(), QSAIndexCache(ratio))]
 
+        mx.eval(mtp.parameters())
         inner.mtp = mtp
         inner.mtp_max_speculative_tokens = 1
-        model.mtp_max_speculative_tokens = 1
         inner.__class__ = _Qwen4ExpWithMTP
-        mx.eval(mtp.parameters())
+        model.mtp_max_speculative_tokens = 1
+        model.batched_mtp_capability = BATCHED_MTP_CAPABILITY
+        model.mtp_recursive_draft_depth = 2
+        if model is not inner:
+            model.mtp_batch_forward = inner.mtp_batch_forward
         return True
     except Exception:
         logger.exception("[mtp.qwen4] native MTP attachment failed")
@@ -250,7 +284,10 @@ def validate_qwen4_exp_mtp_support(model: Any) -> bool:
         return False
     return (
         callable(getattr(inner, "mtp_forward", None))
+        and callable(getattr(inner, "mtp_batch_forward", None))
         and callable(getattr(inner, "make_mtp_cache", None))
+        and getattr(inner, "batched_mtp_capability", None) is BATCHED_MTP_CAPABILITY
+        and getattr(inner, "mtp_recursive_draft_depth", None) == 2
         and "return_hidden" in signature.parameters
         and "n_confirmed" in signature.parameters
     )

--- a/vllm_mlx/spec_decode/mtp/ragged_cache.py
+++ b/vllm_mlx/spec_decode/mtp/ragged_cache.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Version-gated ragged rollback adapter for mlx-lm 0.31.x caches.
+
+mlx-lm 0.31.3 has scalar cache rollback but no per-row rewind contract.  A
+continuous self-MTP verify batch needs exactly that contract because lanes may
+accept different numbers of draft tokens.  This module vendors the narrow
+control/cache adapter while Rapid remains pinned to ``mlx-lm>=0.31.3,<0.32``.
+
+Installation is explicit and idempotent.  Existing scalar ``trim`` and
+``restore_rollback`` methods are never replaced.  Unknown, quantized, and
+rotating/windowed caches fail loudly instead of receiving a uniform rewind.
+The module imports no MLX surface until :func:`install_ragged_cache_rollback`
+is called, which keeps its contract testable with pure Python fakes.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+class RaggedCacheUnsupportedError(RuntimeError):
+    """A cache cannot prove exact per-row rollback under this adapter."""
+
+
+@dataclass(frozen=True)
+class RaggedCacheInstallReport:
+    version: str
+    patched: tuple[str, ...]
+    already_present: tuple[str, ...]
+
+
+_INSTALL_LOCK = threading.Lock()
+_ADAPTER_MARKER = "__rapid_ragged_cache_adapter__"
+_UNSET = object()
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise RaggedCacheUnsupportedError(f"cannot parse mlx-lm version {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def _validate_version(version: str) -> None:
+    parsed = _version_tuple(version)
+    if parsed < (0, 31, 3) or parsed >= (0, 32, 0):
+        raise RaggedCacheUnsupportedError(
+            f"ragged rollback adapter supports mlx-lm>=0.31.3,<0.32; found {version}"
+        )
+
+
+def _drop_vector(values: Any, batch: int, who: str) -> list[int]:
+    if isinstance(values, (bool, int)):
+        raise TypeError(f"{who} requires one rollback count per row")
+    if hasattr(values, "tolist"):
+        values = values.tolist()
+    try:
+        raw = list(values)
+    except TypeError as exc:
+        raise TypeError(f"{who} requires an iterable of row counts") from exc
+    if len(raw) != batch:
+        raise ValueError(f"{who} got {len(raw)} counts for {batch} rows")
+    drops: list[int] = []
+    for value in raw:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{who} requires non-negative integer counts")
+        if value < 0:
+            raise ValueError(f"{who} received a negative rollback count")
+        drops.append(value)
+    return drops
+
+
+class _DefaultArrayOps:
+    def __init__(self, cache_module: Any) -> None:
+        self.mx = cache_module.mx
+        self._dynamic_roll = cache_module.dynamic_roll
+
+    def vector(self, values: list[int]):
+        return self.mx.array(values)
+
+    @staticmethod
+    def tolist(value: Any) -> list[int]:
+        return [int(item) for item in value.tolist()]
+
+    def concat(self, rows: list[Any]):
+        return self.mx.concatenate(rows, axis=0)
+
+    def roll_rows(self, value: Any, shifts: Any, *, axis: int, stop: int):
+        if value is None or stop <= 0:
+            return value
+        window = (slice(None),) * axis + (slice(0, stop),)
+        shaped = shifts.reshape((-1,) + (1,) * (axis - 1))
+        value[window] = self._dynamic_roll(value[window], shaped, axis)
+        return value
+
+
+def _snapshot_rows(
+    cache: Any,
+    drops: list[int],
+    verify_size: int,
+    ops: Any,
+) -> list[Any]:
+    snapshots = getattr(cache, "rollback_state", None)
+    if snapshots is None:
+        raise RaggedCacheUnsupportedError("recurrent cache has no rollback snapshots")
+    batch = int(cache.batch_size)
+    if isinstance(snapshots, list):
+        if not snapshots:
+            raise RaggedCacheUnsupportedError(
+                "recurrent rollback snapshot list is empty"
+            )
+        boundaries = snapshots
+        slot_count = len(boundaries[0])
+        if any(len(boundary) != slot_count for boundary in boundaries):
+            raise RaggedCacheUnsupportedError("recurrent rollback slot counts diverge")
+    else:
+        boundaries = [snapshots]
+        slot_count = len(snapshots)
+
+    selected: list[list[Any]] = [[] for _ in range(slot_count)]
+    for row, drop in enumerate(drops):
+        if drop == 0:
+            source = cache.cache
+        elif isinstance(snapshots, list):
+            keep = verify_size - drop
+            if keep < 1 or keep > len(boundaries):
+                raise RaggedCacheUnsupportedError(
+                    f"row {row} needs verify boundary {keep}, but only "
+                    f"{len(boundaries)} snapshots exist"
+                )
+            source = boundaries[keep - 1]
+        else:
+            if drop != 1:
+                raise RaggedCacheUnsupportedError(
+                    "legacy recurrent snapshot can only rewind one token"
+                )
+            source = boundaries[0]
+        for slot, value in enumerate(source):
+            if value is None:
+                raise RaggedCacheUnsupportedError(
+                    f"recurrent rollback slot {slot} is None for row {row}"
+                )
+            if not hasattr(value, "shape") or int(value.shape[0]) != batch:
+                raise RaggedCacheUnsupportedError(
+                    f"recurrent rollback slot {slot} does not cover {batch} rows"
+                )
+            selected[slot].append(value[row : row + 1])
+    return [ops.concat(rows) for rows in selected]
+
+
+def _arrays_preflight(self, n, *, verify_size: int, validate: bool = True):
+    del validate
+    if isinstance(verify_size, bool) or not isinstance(verify_size, int):
+        raise ValueError("verify_size must be a positive integer")
+    if verify_size < 1:
+        raise ValueError("verify_size must be a positive integer")
+    drops = _drop_vector(n, int(self.batch_size), "ArraysCache.trim_ragged")
+    _snapshot_rows(self, drops, verify_size, self._rapid_ragged_ops)
+    return drops
+
+
+def _arrays_trim(self, n, *, verify_size: int, validate: bool = True):
+    drops = self.preflight_ragged_trim(n, verify_size=verify_size, validate=validate)
+    if max(drops, default=0) == 0:
+        self.rollback_state = None
+        return drops
+    self.cache = _snapshot_rows(self, drops, verify_size, self._rapid_ragged_ops)
+    self.rollback_state = None
+    return drops
+
+
+def _batch_kv_preflight(self, n, *, verify_size=None, validate: bool = True):
+    del verify_size
+    base = self._rapid_ragged_batch_kv_base
+    if type(self) is base:
+        aux_spec = ()
+        aux_hook = None
+    else:
+        aux_spec = None
+        aux_hook = None
+        for cls in type(self).__mro__:
+            if cls is base:
+                break
+            if "_trim_ragged_aux" in cls.__dict__:
+                aux_hook = cls.__dict__["_trim_ragged_aux"]
+                break
+            if "_RAGGED_TRIM_AUX_ARRAYS" in cls.__dict__:
+                aux_spec = cls.__dict__["_RAGGED_TRIM_AUX_ARRAYS"]
+                break
+        if aux_spec is None and aux_hook is None:
+            raise RaggedCacheUnsupportedError(
+                f"{type(self).__name__} extends BatchKVCache without declaring "
+                "_RAGGED_TRIM_AUX_ARRAYS or _trim_ragged_aux"
+            )
+    batch = len(self._rapid_ragged_ops.tolist(self.offset))
+    drops = _drop_vector(n, batch, "BatchKVCache.trim_ragged")
+    if getattr(self, "_right_padding", None) is not None:
+        raise RaggedCacheUnsupportedError(
+            "BatchKVCache requires finalize() before ragged rollback"
+        )
+    if max(drops, default=0) > int(self._idx):
+        raise ValueError("ragged rollback exceeds the shared KV cursor")
+    if validate:
+        offsets = self._rapid_ragged_ops.tolist(self.offset)
+        if any(offset - drop < 0 for offset, drop in zip(offsets, drops)):
+            raise ValueError("ragged rollback would move a KV row before token zero")
+    uniform = min(drops, default=0)
+    residual = [drop - uniform for drop in drops]
+    if max(residual, default=0) and aux_spec is not None:
+        stop = int(self._idx) - uniform
+        for name, axis in aux_spec:
+            ledger = getattr(self, name, None)
+            if ledger is not None and int(ledger.shape[axis]) < stop:
+                raise RaggedCacheUnsupportedError(
+                    f"{type(self).__name__}.{name} does not reach KV cursor {stop}"
+                )
+    return drops, uniform, residual, aux_spec, aux_hook
+
+
+def _batch_kv_trim(self, n, *, verify_size=None, validate: bool = True):
+    drops, uniform, residual, aux_spec, aux_hook = self.preflight_ragged_trim(
+        n, verify_size=verify_size, validate=validate
+    )
+    invalidate = getattr(self, "_invalidate_attention_groups", None)
+    if callable(invalidate):
+        invalidate()
+    if uniform:
+        self._idx -= uniform
+        self.offset = self.offset - uniform
+    if max(residual, default=0):
+        shifts = self._rapid_ragged_ops.vector(residual)
+        self.keys = self._rapid_ragged_ops.roll_rows(
+            self.keys, shifts, axis=2, stop=self._idx
+        )
+        self.values = self._rapid_ragged_ops.roll_rows(
+            self.values, shifts, axis=2, stop=self._idx
+        )
+        if aux_hook is not None:
+            aux_hook(
+                self,
+                shifts,
+                stop=self._idx,
+                array_ops=self._rapid_ragged_ops,
+            )
+        else:
+            for name, axis in aux_spec:
+                ledger = getattr(self, name, None)
+                if ledger is not None:
+                    setattr(
+                        self,
+                        name,
+                        self._rapid_ragged_ops.roll_rows(
+                            ledger, shifts, axis=axis, stop=self._idx
+                        ),
+                    )
+        self.left_padding = self.left_padding + shifts
+        self.offset = self.offset - shifts
+    return drops
+
+
+def _qsa_preflight(self, n, *, verify_size=None, validate: bool = True):
+    del verify_size, validate
+    drops = _drop_vector(n, len(self._offsets), "QSAIndexCache.trim_ragged")
+    if (
+        getattr(self, "_right_padding", None) is not None
+        or getattr(self, "lengths", None) is not None
+    ):
+        raise RaggedCacheUnsupportedError(
+            "QSAIndexCache requires finalize() before ragged rollback"
+        )
+    refused = [
+        row
+        for row, (offset, drop) in enumerate(zip(self._offsets, drops))
+        if not self._can_trim_row(offset, drop)
+    ]
+    if refused:
+        raise RaggedCacheUnsupportedError(
+            f"QSA raw-ring history cannot rewind rows {refused} by the requested counts"
+        )
+    return drops
+
+
+def _qsa_trim(self, n, *, verify_size=None, validate: bool = True):
+    drops = self.preflight_ragged_trim(n, verify_size=verify_size, validate=validate)
+    self._offsets = [offset - drop for offset, drop in zip(self._offsets, drops)]
+    self._compressed_counts = [
+        offset // self.compress_ratio for offset in self._offsets
+    ]
+    return drops
+
+
+def _qwen4_preflight(self, n, *, verify_size: int, validate: bool = True):
+    if getattr(self, "_rollback_slots", None):
+        raise RaggedCacheUnsupportedError(
+            "Qwen4 state cache has partially staged PLE/GDN rollback slots"
+        )
+    return _arrays_preflight(self, n, verify_size=verify_size, validate=validate)
+
+
+def _mark(function):
+    setattr(function, _ADAPTER_MARKER, True)
+    return function
+
+
+for _function in (
+    _arrays_preflight,
+    _arrays_trim,
+    _batch_kv_preflight,
+    _batch_kv_trim,
+    _qsa_preflight,
+    _qsa_trim,
+    _qwen4_preflight,
+):
+    _mark(_function)
+
+
+def _patch_specs(cache_module, qwen4_state_cls, qsa_cls, ops):
+    arrays = cache_module.ArraysCache
+    batch_kv = cache_module.BatchKVCache
+    specs = [
+        (arrays, "preflight_ragged_trim", _arrays_preflight),
+        (arrays, "trim_ragged", _arrays_trim),
+        (batch_kv, "preflight_ragged_trim", _batch_kv_preflight),
+        (batch_kv, "trim_ragged", _batch_kv_trim),
+    ]
+    if qwen4_state_cls is not None:
+        specs.append((qwen4_state_cls, "preflight_ragged_trim", _qwen4_preflight))
+    if qsa_cls is not None:
+        specs.extend(
+            [
+                (qsa_cls, "preflight_ragged_trim", _qsa_preflight),
+                (qsa_cls, "trim_ragged", _qsa_trim),
+            ]
+        )
+    classes = {arrays, batch_kv, qwen4_state_cls, qsa_cls} - {None}
+    return specs, classes
+
+
+def install_ragged_cache_rollback(
+    *,
+    mlx_lm_version: str | None = None,
+    cache_module: Any = None,
+    qwen4_state_cls: Any = _UNSET,
+    qsa_cls: Any = _UNSET,
+    array_ops: Any = None,
+) -> RaggedCacheInstallReport:
+    """Install exact per-row rollback on the supported 0.31.x cache classes."""
+
+    version = mlx_lm_version or importlib.metadata.version("mlx-lm")
+    _validate_version(version)
+    if cache_module is None:
+        from mlx_lm.models import cache as cache_module
+    if qwen4_state_cls is _UNSET or qsa_cls is _UNSET:
+        from vllm_mlx.models.qwen4_exp_cache import (
+            QSAIndexCache,
+            Qwen4ExpStateCache,
+        )
+
+        if qwen4_state_cls is _UNSET:
+            qwen4_state_cls = Qwen4ExpStateCache
+        if qsa_cls is _UNSET:
+            qsa_cls = QSAIndexCache
+    arrays_cls = getattr(cache_module, "ArraysCache", None)
+    batch_kv_cls = getattr(cache_module, "BatchKVCache", None)
+    if not isinstance(arrays_cls, type) or not isinstance(batch_kv_cls, type):
+        raise RaggedCacheUnsupportedError(
+            "mlx-lm cache module lacks ArraysCache or BatchKVCache"
+        )
+    for label, cls in (
+        ("Qwen4ExpStateCache", qwen4_state_cls),
+        ("QSAIndexCache", qsa_cls),
+    ):
+        if cls is not None and (
+            not isinstance(cls, type) or not issubclass(cls, arrays_cls)
+        ):
+            raise RaggedCacheUnsupportedError(
+                f"{label} is not an ArraysCache subclass from this mlx-lm runtime"
+            )
+    ops = array_ops or _DefaultArrayOps(cache_module)
+    specs, classes = _patch_specs(cache_module, qwen4_state_cls, qsa_cls, ops)
+
+    patched: list[str] = []
+    already: list[str] = []
+    with _INSTALL_LOCK:
+        # Preflight every method before mutating any class.
+        for cls, name, _ in specs:
+            existing = cls.__dict__.get(name)
+            if existing is not None and not getattr(existing, _ADAPTER_MARKER, False):
+                raise RaggedCacheUnsupportedError(
+                    f"refusing to replace existing {cls.__name__}.{name}"
+                )
+        for cls in classes:
+            existing_ops = cls.__dict__.get("_rapid_ragged_ops")
+            if existing_ops is not None and existing_ops is not ops:
+                raise RaggedCacheUnsupportedError(
+                    f"{cls.__name__} already uses a different ragged array adapter"
+                )
+        for cls in classes:
+            if "_rapid_ragged_ops" not in cls.__dict__:
+                cls._rapid_ragged_ops = ops
+        arrays = cache_module.ArraysCache
+        batch_kv = cache_module.BatchKVCache
+        if "_rapid_ragged_batch_kv_base" not in batch_kv.__dict__:
+            batch_kv._rapid_ragged_batch_kv_base = batch_kv
+        if "rollback_state" not in arrays.__dict__:
+            arrays.rollback_state = None
+        for cls, name, function in specs:
+            label = f"{cls.__name__}.{name}"
+            if name in cls.__dict__:
+                already.append(label)
+            else:
+                setattr(cls, name, function)
+                patched.append(label)
+    return RaggedCacheInstallReport(version, tuple(patched), tuple(already))
+
+
+def _cache_children(cache: Any) -> tuple[Any, ...]:
+    children = getattr(cache, "caches", None)
+    if children is not None:
+        return tuple(children)
+    if isinstance(cache, (list, tuple)):
+        return tuple(cache)
+    return ()
+
+
+def _reject_unsupported_shape(cache: Any) -> None:
+    name = type(cache).__name__.lower()
+    if "quantized" in name:
+        raise RaggedCacheUnsupportedError(
+            f"quantized cache {type(cache).__name__} has no supported ragged contract"
+        )
+    if "rotating" in name or "window" in name:
+        raise RaggedCacheUnsupportedError(
+            f"windowed cache {type(cache).__name__} has no supported ragged contract"
+        )
+
+
+def preflight_ragged_cache(
+    cache: Any,
+    drops: Iterable[int],
+    *,
+    verify_size: int,
+    validate: bool = True,
+) -> list[int]:
+    """Preflight a cache tree without mutating any member."""
+
+    values = list(drops)
+    children = _cache_children(cache)
+    if children:
+        for child in children:
+            preflight_ragged_cache(
+                child, values, verify_size=verify_size, validate=validate
+            )
+        return values
+    _reject_unsupported_shape(cache)
+    preflight = getattr(cache, "preflight_ragged_trim", None)
+    if not callable(preflight):
+        raise RaggedCacheUnsupportedError(
+            f"cache {type(cache).__name__} has no ragged rollback adapter"
+        )
+    result = preflight(values, verify_size=verify_size, validate=validate)
+    return result[0] if isinstance(result, tuple) and len(result) == 5 else result
+
+
+def trim_ragged_cache(
+    cache: Any,
+    drops: Iterable[int],
+    *,
+    verify_size: int,
+    validate: bool = True,
+) -> list[int]:
+    """Atomically preflight a cache tree, then apply the per-row rewind."""
+
+    values = list(drops)
+    preflight_ragged_cache(cache, values, verify_size=verify_size, validate=validate)
+
+    def apply(node: Any) -> None:
+        children = _cache_children(node)
+        if children:
+            for child in children:
+                apply(child)
+            return
+        node.trim_ragged(values, verify_size=verify_size, validate=False)
+
+    apply(cache)
+    return values
+
+
+__all__ = [
+    "RaggedCacheInstallReport",
+    "RaggedCacheUnsupportedError",
+    "install_ragged_cache_rollback",
+    "preflight_ragged_cache",
+    "trim_ragged_cache",
+]

--- a/vllm_mlx/spec_decode/mtp/residual_sampling.py
+++ b/vllm_mlx/spec_decode/mtp/residual_sampling.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact transformed-distribution hooks for continuous self-MTP.
+
+Adapted from immutable source commit ``5d51d766``.  Module import is MLX-free;
+constructing the default ops adapter performs the lazy ``mlx.core`` import.
+The transform mirrors Rapid/mlx-lm sampler order exactly: native-dtype
+normalization, top-p, min-p, top-k, temperature scaling, then float32
+renormalization.  XTC is intentionally unsupported because its stochastic mask
+is not shared between target and draft distributions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .continuous_engine import ContinuousSelfMTPUnsupportedError, SelfMTPSampling
+
+
+class ResidualArrayOps(Protocol):
+    def native_logprobs(self, logits: Any) -> Any: ...
+
+    def top_p(self, logprobs: Any, value: float) -> Any: ...
+
+    def min_p(self, logprobs: Any, value: float, min_tokens: int) -> Any: ...
+
+    def top_k(self, logprobs: Any, value: int) -> Any: ...
+
+    def scaled_float32_logprobs(self, logprobs: Any, temperature: float) -> Any: ...
+
+    def categorical(self, logprobs: Any) -> int: ...
+
+    def gather_rows(self, logprobs: Any, tokens: list[int]) -> Any: ...
+
+    def stack(self, values: list[Any]) -> Any: ...
+
+    def exp(self, value: Any) -> Any: ...
+
+    def minimum_scalar(self, value: Any, scalar: float) -> Any: ...
+
+    def maximum_scalar(self, value: Any, scalar: float) -> Any: ...
+
+    def subtract(self, left: Any, right: Any) -> Any: ...
+
+    def sum_float(self, value: Any) -> float: ...
+
+    def normalize_probabilities_to_logprobs(self, probabilities: Any) -> Any: ...
+
+    def uniforms(self, count: int) -> list[float]: ...
+
+    def tolist(self, value: Any) -> list[float]: ...
+
+
+class _MLXResidualOps:
+    """Lazy production ops matching mlx-lm ``sample_utils`` semantics."""
+
+    def __init__(self) -> None:
+        import mlx.core as mx
+
+        self.mx = mx
+
+    def native_logprobs(self, logits: Any) -> Any:
+        return logits - self.mx.logsumexp(logits, axis=-1, keepdims=True)
+
+    def top_p(self, logprobs: Any, value: float) -> Any:
+        probs = self.mx.exp(logprobs)
+        indices = self.mx.argsort(logprobs, axis=-1)
+        sorted_probs = self.mx.take_along_axis(probs, indices, axis=-1)
+        cumulative = self.mx.cumsum(sorted_probs, axis=-1)
+        inverse = self.mx.put_along_axis(
+            self.mx.zeros_like(indices),
+            indices,
+            self.mx.arange(indices.shape[-1], dtype=indices.dtype),
+            axis=-1,
+        )
+        cumulative = self.mx.take_along_axis(cumulative, inverse, axis=-1)
+        return self.mx.where(cumulative > 1 - value, logprobs, -self.mx.inf)
+
+    def min_p(self, logprobs: Any, value: float, min_tokens: int) -> Any:
+        import math
+
+        threshold = self.mx.max(logprobs, axis=-1, keepdims=True) + math.log(value)
+        remove = logprobs < threshold
+        if min_tokens > 1:
+            indices = self.mx.argpartition(logprobs, kth=-min_tokens, axis=-1)[
+                ..., -min_tokens:
+            ]
+            remove = self.mx.put_along_axis(remove, indices, False, axis=-1)
+        return self.mx.where(remove, -self.mx.inf, logprobs)
+
+    def top_k(self, logprobs: Any, value: int) -> Any:
+        vocab = int(logprobs.shape[-1])
+        if not 0 < value < vocab:
+            raise ValueError(f"top_k must be in (0, {vocab}); got {value}")
+        indices = self.mx.argpartition(-logprobs, kth=value - 1, axis=-1)[..., value:]
+        return self.mx.put_along_axis(
+            logprobs,
+            indices,
+            self.mx.array(-self.mx.inf, logprobs.dtype),
+            axis=-1,
+        )
+
+    def scaled_float32_logprobs(self, logprobs: Any, temperature: float) -> Any:
+        scaled = (logprobs * (1 / temperature)).astype(self.mx.float32)
+        return scaled - self.mx.logsumexp(scaled, axis=-1, keepdims=True)
+
+    def categorical(self, logprobs: Any) -> int:
+        return int(self.mx.random.categorical(logprobs).item())
+
+    def gather_rows(self, logprobs: Any, tokens: list[int]) -> Any:
+        token_array = self.mx.array(tokens)[:, None]
+        return self.mx.take_along_axis(logprobs, token_array, axis=-1)[:, 0]
+
+    def stack(self, values: list[Any]) -> Any:
+        return self.mx.stack(values)
+
+    def exp(self, value: Any) -> Any:
+        return self.mx.exp(value)
+
+    def minimum_scalar(self, value: Any, scalar: float) -> Any:
+        return self.mx.minimum(value, scalar)
+
+    def maximum_scalar(self, value: Any, scalar: float) -> Any:
+        return self.mx.maximum(value, scalar)
+
+    @staticmethod
+    def subtract(left: Any, right: Any) -> Any:
+        return left - right
+
+    def sum_float(self, value: Any) -> float:
+        total = self.mx.sum(value)
+        self.mx.eval(total)
+        return float(total.item())
+
+    def normalize_probabilities_to_logprobs(self, probabilities: Any) -> Any:
+        total = self.mx.sum(probabilities)
+        return self.mx.log(probabilities / total)
+
+    def uniforms(self, count: int) -> list[float]:
+        values = self.mx.random.uniform(shape=(count,))
+        self.mx.eval(values)
+        return [float(value) for value in values.tolist()]
+
+    @staticmethod
+    def tolist(value: Any) -> list[float]:
+        return [float(item) for item in value.tolist()]
+
+
+@dataclass(frozen=True)
+class TransformedSamplingProfile:
+    temperature: float
+    top_p: float = 1.0
+    top_k: int = 0
+    min_p: float = 0.0
+    min_tokens_to_keep: int = 1
+    xtc_probability: float = 0.0
+
+    def __post_init__(self) -> None:
+        if isinstance(self.temperature, bool) or not isinstance(
+            self.temperature, (int, float)
+        ):
+            raise ValueError("temperature must be numeric")
+        if self.temperature <= 0:
+            raise ValueError("transformed sampling requires temperature > 0")
+        if not 0 <= self.top_p <= 1:
+            raise ValueError("top_p must be in [0, 1]")
+        if isinstance(self.top_k, bool) or not isinstance(self.top_k, int):
+            raise ValueError("top_k must be an integer")
+        if self.top_k < 0:
+            raise ValueError("top_k cannot be negative")
+        if not 0 <= self.min_p <= 1:
+            raise ValueError("min_p must be in [0, 1]")
+        if (
+            isinstance(self.min_tokens_to_keep, bool)
+            or not isinstance(self.min_tokens_to_keep, int)
+            or self.min_tokens_to_keep < 1
+        ):
+            raise ValueError("min_tokens_to_keep must be a positive integer")
+        if not 0 <= self.xtc_probability <= 1:
+            raise ValueError("xtc_probability must be in [0, 1]")
+        if self.xtc_probability > 0:
+            raise ContinuousSelfMTPUnsupportedError(
+                "XTC has no exact shared-mask residual verifier"
+            )
+
+
+class TransformedResidualSamplingHooks:
+    """Shared draft/target transform and exact residual verifier."""
+
+    def __init__(
+        self,
+        profile: TransformedSamplingProfile,
+        *,
+        array_ops: ResidualArrayOps | None = None,
+    ) -> None:
+        self.profile = profile
+        self.ops = array_ops or _MLXResidualOps()
+
+    def validate_sampling(self, sampling: SelfMTPSampling) -> None:
+        if sampling.uses_xtc:
+            raise ContinuousSelfMTPUnsupportedError(
+                "XTC has no exact shared-mask residual verifier"
+            )
+        if sampling.temperature != self.profile.temperature:
+            raise ContinuousSelfMTPUnsupportedError(
+                "lane temperature does not match transformed hook profile"
+            )
+
+    def logprobs(self, logits: Any, temperature: float) -> Any:
+        if temperature != self.profile.temperature:
+            raise ContinuousSelfMTPUnsupportedError(
+                "runtime temperature does not match transformed hook profile"
+            )
+        values = self.ops.native_logprobs(logits)
+        profile = self.profile
+        # Exact Rapid/mlx-lm make_sampler order.
+        if 0 < profile.top_p < 1:
+            values = self.ops.top_p(values, profile.top_p)
+        if profile.min_p != 0:
+            values = self.ops.min_p(values, profile.min_p, profile.min_tokens_to_keep)
+        if profile.top_k > 0:
+            values = self.ops.top_k(values, profile.top_k)
+        return self.ops.scaled_float32_logprobs(values, temperature)
+
+    def sample(self, logprobs: Any, temperature: float) -> int:
+        if temperature != self.profile.temperature:
+            raise ContinuousSelfMTPUnsupportedError(
+                "runtime temperature does not match transformed hook profile"
+            )
+        return self.ops.categorical(logprobs)
+
+    def _residual_sample(self, target: Any, draft: Any) -> int:
+        residual = self.ops.maximum_scalar(
+            self.ops.subtract(self.ops.exp(target), self.ops.exp(draft)), 0.0
+        )
+        if self.ops.sum_float(residual) <= 0:
+            return self.ops.categorical(target)
+        return self.ops.categorical(
+            self.ops.normalize_probabilities_to_logprobs(residual)
+        )
+
+    def verify(
+        self,
+        target_logprobs: Any,
+        draft_logprobs: list[Any],
+        draft_tokens: list[int],
+        temperature: float,
+    ) -> tuple[int, int]:
+        if temperature != self.profile.temperature:
+            raise ContinuousSelfMTPUnsupportedError(
+                "runtime temperature does not match transformed hook profile"
+            )
+        k = len(draft_tokens)
+        if len(draft_logprobs) != k:
+            raise ValueError("draft logprob/token lengths disagree")
+        if int(target_logprobs.shape[0]) != k + 1:
+            raise ValueError("target verification requires K draft rows plus bonus")
+        if k == 0:
+            return 0, self.ops.categorical(target_logprobs[0])
+
+        target_at = self.ops.gather_rows(target_logprobs[:k], draft_tokens)
+        draft_at = self.ops.gather_rows(
+            self.ops.stack(list(draft_logprobs)), draft_tokens
+        )
+        ratios = self.ops.exp(
+            self.ops.minimum_scalar(self.ops.subtract(target_at, draft_at), 0.0)
+        )
+        ratio_values = self.ops.tolist(ratios)
+        uniforms = self.ops.uniforms(k)
+        accepted = 0
+        while (
+            accepted < k
+            and ratio_values[accepted] > 0
+            and uniforms[accepted] <= ratio_values[accepted]
+        ):
+            accepted += 1
+        if accepted < k:
+            bonus = self._residual_sample(
+                target_logprobs[accepted], draft_logprobs[accepted]
+            )
+        else:
+            bonus = self.ops.categorical(target_logprobs[accepted])
+        return accepted, bonus
+
+
+__all__ = [
+    "ResidualArrayOps",
+    "TransformedResidualSamplingHooks",
+    "TransformedSamplingProfile",
+]


### PR DESCRIPTION
## Why

A speculative backend is not reviewable or safe unless route decisions, fallback reasons, acceptance, and exactness qualification are observable and cannot be confused across batch geometry.

This is PR **3/13** in the reviewed Qwen4 optimization series and is stacked on #2798. The head is cumulative; review the incremental range listed below. Merge in order.

## Scope

Aligns exact handoff regressions, adds the continuous routing/APC plan, bounded qualification telemetry, and separates the single-lane digest oracle from the batched-B1 engine oracle. The incremental review range is `c60f6705..48e45915`.

## Non-goals

No live scheduler turnover, no automatic model policy, and no claim that telemetry alone proves performance.

## Acceptance

Every candidate decision has bounded route/fallback counters; digest qualification uses the same B1 geometry as the engine; unsupported paths remain explicit.

## Verification

- Exact final cumulative Rapid head: `6fe89b07` (61 reviewed commits over `7da40670`).
- Focused Rapid integration battery: **358 passed**.
- Paired native Qwen4 battery: **178 passed, 1 skipped**, plus **69 subtests passed**.
- Real Flash-Next receipt: all 49 fused-auto blocks reached; M=1 tile4 dispatched; unsupported verify widths used stock fallback; clean shutdown.
- Matched one-real-user Rapid-current ladder: Flash decode **1.81–2.19x** through 8K and PLD **1.47x** at 32K; dense 27B seeded self-MTP **1.72–1.88x** from 1K through 64K with exact hashes.
- Changed Python files passed `ruff check` and `ruff format --check` on the verified stack.
- Pierre Lamy reviewed the complete series and explicitly signed off on upstream submission on 2026-08-31.

## Behaviour delta

No serving default change.

## AI assistance disclosure

Claude and Codex assisted with implementation, tests, review, and documentation in the files and commits listed under Scope. Pierre Lamy directed the work, reviewed the complete 61-commit series, verified the recorded test and benchmark evidence, and explicitly approved this upstream submission. The exact final stack was exercised by the focused tests and real-model gates listed above.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated or scaffolded sections, the assistance and verification are identified above.

## Checklist

- [x] Focused tests and changed-file lint/format pass on the exact final stack.
- [x] Critical route changes have reached-path or fail-closed evidence as described above.
- [x] README/docs are updated where applicable.
- [x] No intentional breaking API change.
- [x] Human review and upstream sign-off completed by Pierre Lamy.
