### PR TITLE
feat(mac): persistent memory extraction from completed conversations

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -252,8 +252,26 @@ jobs:
       #
       # The real fix is to stop blocking threads inside async tests; until
       # then, do not drop this flag.
+      #
+      # #2488: wrapped by scripts/desktop-test-timeout.sh so a hung suite
+      # (per-suite .timeLimit(.minutes(2)) on the hang-prone suites) or a hung
+      # whole run (per-run deadline + /usr/bin/sample + ps + vm_stat artifact)
+      # fails fast with a readable reason instead of burning the job timeout.
       - name: swift test
-        run: swift test --no-parallel
+        run: ./scripts/desktop-test-timeout.sh
+
+      # #2488: upload the hang-sample artifact (stack + system state) so the
+      # cause of a hung/failed desktop-test run is inspectable from the CI log
+      # without re-running. `if-no-files-found: ignore` keeps healthy runs from
+      # failing on an empty artifact dir.
+      - name: Upload Desktop test hang sample
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: desktop-test-hang-sample-${{ github.sha }}
+          path: apps/rapid-mac/build/desktop-hang-artifacts
+          if-no-files-found: ignore
+          retention-days: 1
 
       # Kept alongside `swift test` rather than folded into it: this script
       # runs without the test target, so it stays usable while bisecting a

--- a/apps/rapid-mac/Package.swift
+++ b/apps/rapid-mac/Package.swift
@@ -96,6 +96,32 @@ let package = Package(
             name: "SwiftMathVendorTests",
             dependencies: ["SwiftMath"],
             path: "Vendor/SwiftMath/Tests"
+        ),
+        // #2488: the Desktop test-suite hang watchdog.
+        //
+        // ``RapidDesktopTestWatchdog`` is a small library holding the pure,
+        // seam-injectable hang-watchdog logic (deadline math, artifact path,
+        // sample invocation) that the CI wrapper
+        // (``scripts/desktop-test-timeout.sh``) uses to convert a hung
+        // `swift test` run into a fast, readable failure with a sampled stack
+        // artifact. Its decision logic is unit-tested in
+        // ``RapidDesktopTestWatchdogTests`` with fake clock / process / sample
+        // seams. It deliberately does NOT ship in the `.app` (the ``Rapid``
+        // executable target does not depend on it) — it is a CI/test-runner
+        // concern only.
+        .target(
+            name: "RapidDesktopTestWatchdog",
+            path: "Sources/RapidDesktopTestWatchdog"
+        ),
+        .executableTarget(
+            name: "RapidDesktopTestWatchdogRun",
+            dependencies: ["RapidDesktopTestWatchdog"],
+            path: "Sources/RapidDesktopTestWatchdogRun"
+        ),
+        .testTarget(
+            name: "RapidDesktopTestWatchdogTests",
+            dependencies: ["RapidDesktopTestWatchdog"],
+            path: "Tests/RapidDesktopTestWatchdogTests"
         )
         // NOTE (2026-08-05): the RapidTests target is BACK in the manifest,
         // above. It had been excluded on the reasoning that the strip

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -204,9 +204,17 @@ final class ChatViewModel {
             // A turn just ended (stream finished, failed, or was stopped) —
             // snapshot the final exchange into history + disk. Covers every
             // completion path without hooking each one.
-            if oldValue && !isStreaming { persistActive() }
+            if oldValue && !isStreaming {
+                persistActive()
+                scheduleMemoryExtraction()
+            }
         }
     }
+
+    /// The model alias used for the most recent turn, captured at
+    /// ``beginAssistantTurn`` so the background memory extractor can
+    /// address the same engine after the stream finishes.
+    private var lastTurnAlias: String?
     /// Most recent transport / parse error. Cleared on the next ``send``.
     /// Shown as a banner above the compose bar so the user knows what
     /// went wrong without scraping the log tail.
@@ -246,6 +254,12 @@ final class ChatViewModel {
     /// Global custom instructions shared with Settings.
     let customInstructions: CustomInstructionsConfig
 
+    /// Persistent memory entries. Injected into the system prompt and
+    /// updated by the background extractor after each completed turn.
+    /// Optional so unit tests can construct a viewmodel without a real
+    /// memory store; production wires this from ``RapidApp.init``.
+    let memoryStore: MemoryStore?
+
     /// v0.5.1: live handle on the embedded server so the chat loop can
     /// resolve `request.model` against the alias currently being served
     /// instead of trusting the picker bar's state. Mirrors the global
@@ -265,6 +279,7 @@ final class ChatViewModel {
         toolDefaults: UserDefaults = .standard,
         sampling: SamplingConfig? = nil,
         customInstructions: CustomInstructionsConfig? = nil,
+        memoryStore: MemoryStore? = nil,
         server: ServerManager? = nil,
         persistsConversations: Bool = true,
         conversationStoreURL: URL? = nil,
@@ -275,6 +290,7 @@ final class ChatViewModel {
         self.toolDefaults = toolDefaults
         self.sampling = sampling
         self.customInstructions = customInstructions ?? CustomInstructionsConfig()
+        self.memoryStore = memoryStore
         self.server = server
         self.persistsConversations = persistsConversations
         self.conversationStoreURL = conversationStoreURL
@@ -792,6 +808,56 @@ final class ChatViewModel {
         return true
     }
 
+    /// Fires a detached background task to review the completed exchange
+    /// and upsert any durable facts into ``memoryStore``. Called from the
+    /// ``isStreaming`` didSet when a turn ends; never blocks the UI or
+    /// competes with an active stream because it runs on a separate task.
+    private func scheduleMemoryExtraction() {
+        guard let memoryStore, memoryStore.isEnabled else { return }
+        guard let alias = lastTurnAlias else { return }
+        guard messages.count >= 2 else { return }
+        let conversationID = activeConversationID
+        let turnMessages: [(role: String, content: String)] = messages
+            .filter { $0.role == .user || $0.role == .assistant }
+            .map { (role: $0.role.rawValue, content: $0.content) }
+        let baseURL = client.baseURL
+
+        Task { [weak self] in
+            // The network call hops off MainActor via URLSession's async
+            // implementation; we only return to the main actor for the
+            // store mutation below.
+            guard !Task.isCancelled else { return }
+            let extractor = MemoryExtractor(
+                baseURL: baseURL,
+                bearerToken: nil
+            )
+            do {
+                let operations = try await extractor.extract(
+                    model: alias,
+                    messages: turnMessages
+                )
+                for operation in operations {
+                    switch operation {
+                    case .add(let content):
+                        memoryStore.upsert(content: content, conversationID: conversationID)
+                    case .remove(let content):
+                        let matching = memoryStore.entries.first {
+                            $0.content.localizedCaseInsensitiveContains(content)
+                                || content.localizedCaseInsensitiveContains($0.content)
+                        }
+                        if let match = matching {
+                            memoryStore.remove(id: match.id)
+                        }
+                    }
+                }
+            } catch {
+                // Memory extraction is best-effort; a failure here is
+                // invisible to the user and logged only if diagnostics
+                // capture it. The next completed turn gets another chance.
+            }
+        }
+    }
+
     /// Append the user message, open a placeholder assistant row, and
     /// kick off the streaming task. The text field clears immediately on
     /// the caller's side.
@@ -849,6 +915,7 @@ final class ChatViewModel {
         lastError = nil
         lastFailureKind = nil
         lastFailureAlias = nil
+        lastTurnAlias = alias
         isStreaming = true
 
         let epoch = conversationEpoch
@@ -857,6 +924,7 @@ final class ChatViewModel {
         // multi-round tool exchange.
         let globalInstruction = customInstructions.global
         let chatInstruction = conversationInstructions
+        let memoryContext = memoryStore?.formattedForPrompt()
         inflight = Task { [weak self] in
             guard let self else { return }
 
@@ -922,7 +990,8 @@ final class ChatViewModel {
                 epoch: epoch,
                 supportsImageInput: supportsImageInput,
                 globalInstruction: globalInstruction,
-                conversationInstruction: chatInstruction
+                conversationInstruction: chatInstruction,
+                memoryContext: memoryContext
             )
         }
     }
@@ -1850,7 +1919,8 @@ final class ChatViewModel {
         epoch: Int,
         supportsImageInput: Bool,
         globalInstruction: String = "",
-        conversationInstruction: String = ""
+        conversationInstruction: String = "",
+        memoryContext: String? = nil
     ) async {
         var currentPlaceholder = initialPlaceholder
         defer {
@@ -1924,6 +1994,7 @@ final class ChatViewModel {
                 to: history,
                 ambientPreamble: ambientPreamble,
                 dateContext: ChatViewModel.currentDateTimeContext(),
+                memoryContext: memoryContext,
                 global: globalInstruction,
                 conversation: conversationInstruction
             )
@@ -2333,6 +2404,7 @@ final class ChatViewModel {
         to messages: [ChatMessage],
         ambientPreamble: String?,
         dateContext: String? = nil,
+        memoryContext: String? = nil,
         global: String,
         conversation: String
     ) -> [ChatMessage] {
@@ -2344,6 +2416,9 @@ final class ChatViewModel {
         // rides below it because it is valid regardless of tool presence.
         var parts = [ambientPreamble, dateContext, existing]
             .compactMap { $0.flatMap(normalizedInstruction) }
+        if let memoryContext, let memory = normalizedInstruction(memoryContext) {
+            parts.append(memory)
+        }
         if let global = normalizedInstruction(global) {
             parts.append("""
             [GLOBAL USER INSTRUCTIONS]
@@ -2372,6 +2447,7 @@ final class ChatViewModel {
     /// automatic context cannot drift from what Rapid sends.
     nonisolated static func effectiveSystemPrompt(
         dateContext: String? = nil,
+        memoryContext: String? = nil,
         global: String,
         conversation: String
     ) -> String {
@@ -2379,6 +2455,7 @@ final class ChatViewModel {
             to: [],
             ambientPreamble: nil,
             dateContext: dateContext ?? currentDateTimeContext(),
+            memoryContext: memoryContext,
             global: global,
             conversation: conversation
         ).first?.content ?? ""

--- a/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Extracts durable user memories from a completed conversation turn by
+/// asking the active model to review the recent messages and return a
+/// structured JSON list of operations.
+///
+/// The review call is a single non-streaming POST to the same
+/// ``v1/chat/completions`` endpoint the chat already uses. It runs in a
+/// background task after ``isStreaming`` transitions to ``false``, so it
+/// never blocks the UI or competes with an active stream.
+struct MemoryExtractor {
+    /// Maximum characters per message included in the review prompt.
+    /// Open WebUI truncates at 1600 chars (1000 head + 400 tail); we
+    /// use a similar bound so a long paste or code block doesn't blow
+    /// the small model's context window.
+    static let maximumMessageCharacters = 1_200
+    /// Maximum number of recent messages included in the review prompt.
+    static let maximumReviewedMessages = 16
+    /// Upper bound on the non-streaming review request. Memory extraction
+    /// is a short single-turn completion; 60 s is generous for a 4B model
+    /// on a ~2K-token prompt.
+    static let requestTimeout: TimeInterval = 60
+
+    /// Errors surfaced to the caller for logging; never shown to the user
+    /// as a banner because memory extraction is a background best-effort.
+    enum ExtractError: Error, LocalizedError {
+        case serverNotReady
+        case httpStatus(Int)
+        case emptyResponse
+        case parseFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .serverNotReady: return "Memory extraction skipped: server not ready"
+            case .httpStatus(let code): return "Memory extraction HTTP \(code)"
+            case .emptyResponse: return "Memory extraction returned an empty response"
+            case .parseFailed: return "Memory extraction could not parse model output"
+            }
+        }
+    }
+
+    /// A structured operation the review model returned.
+    enum Operation: Equatable, Sendable {
+        case add(String)
+        case remove(String)
+    }
+
+    let baseURL: URL
+    let bearerToken: String?
+
+    init(baseURL: URL, bearerToken: String? = nil) {
+        self.baseURL = baseURL
+        self.bearerToken = bearerToken
+    }
+
+    /// Runs the review and returns the parsed operations. The caller
+    /// decides how to apply them (typically via ``MemoryStore.upsert``).
+    func extract(
+        model: String,
+        messages: [(role: String, content: String)]
+    ) async throws -> [Operation] {
+        let transcript = Self.buildTranscript(from: messages)
+        guard !transcript.isEmpty else { return [] }
+
+        let prompt = Self.reviewPrompt(transcript: transcript)
+        let response = try await Self.sendCompletion(
+            baseURL: baseURL,
+            bearerToken: bearerToken,
+            model: model,
+            prompt: prompt
+        )
+        return Self.parseOperations(from: response)
+    }
+
+    // MARK: - Prompt Construction
+
+    /// Formats recent messages into a compact transcript for the review
+    /// prompt. Tool messages and system rows are excluded — they are not
+    /// user-authored content and would dilute the reviewer's signal.
+    static func buildTranscript(
+        from messages: [(role: String, content: String)]
+    ) -> String {
+        let relevant = messages
+            .filter { $0.role == "user" || $0.role == "assistant" }
+            .suffix(maximumReviewedMessages)
+        guard !relevant.isEmpty else { return "" }
+
+        return relevant.map { message in
+            let content = message.content.count > maximumMessageCharacters
+                ? String(message.content.prefix(maximumMessageCharacters)) + "…"
+                : message.content
+            return "\(message.role): \(content)"
+        }.joined(separator: "\n")
+    }
+
+    /// The system-level prompt sent to the reviewer model. Mirrors Open
+    /// WebUI's approach: strict JSON schema, conservative rules about
+    /// what to remember, and an explicit "return empty" path.
+    static func reviewPrompt(transcript: String) -> String {
+        """
+        Review the following conversation and decide whether any durable user preference or fact should be remembered for future conversations.
+
+        Rules:
+        - Save only enduring details: preferences, recurring tasks, environment quirks, long-term context.
+        - Do NOT save one-off questions, temporary states, secrets, or transient task steps.
+        - Do NOT save anything the user did not explicitly say or confirm.
+        - Return ONLY a JSON array. Each element is either:
+          {"action": "add", "content": "..."} or {"action": "remove", "content": "..."}
+        - "add" saves a new fact. "remove" removes a previously saved fact that is now wrong.
+        - Return [] if nothing should change.
+
+        Conversation:
+        \(transcript)
+        """
+    }
+
+    // MARK: - HTTP
+
+    /// Non-streaming POST to the chat-completions endpoint. Reuses the
+    /// same URL shape and auth pattern as ``ChatStreamClient`` but
+    /// avoids SSE parsing because the memory review doesn't need
+    /// progressive output.
+    static func sendCompletion(
+        baseURL: URL,
+        bearerToken: String?,
+        model: String,
+        prompt: String
+    ) async throws -> String {
+        let url = ChatStreamClient.chatCompletionsURL(base: baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = requestTimeout
+
+        if let bearerToken, !bearerToken.isEmpty {
+            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": "You are a memory reviewer. Return only valid JSON."
+                ],
+                ["role": "user", "content": prompt]
+            ],
+            "stream": false,
+            "max_tokens": 512,
+            "temperature": 0.1
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ExtractError.serverNotReady
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw ExtractError.httpStatus(httpResponse.statusCode)
+        }
+
+        struct CompletionResponse: Decodable {
+            struct Choice: Decodable {
+                struct Message: Decodable {
+                    let content: String?
+                }
+                let message: Message
+            }
+            let choices: [Choice]
+        }
+
+        guard let decoded = try? JSONDecoder().decode(CompletionResponse.self, from: data),
+              let content = decoded.choices.first?.message.content,
+              !content.isEmpty
+        else {
+            throw ExtractError.emptyResponse
+        }
+        return content
+    }
+
+    // MARK: - Parsing
+
+    /// Extracts operations from the model's JSON output. Tolerates
+    /// leading/trailing prose (some models wrap JSON in markdown code
+    /// fences) by scanning for the first `[` and last `]`.
+    static func parseOperations(from content: String) -> [Operation] {
+        guard let start = content.firstIndex(of: "["),
+              let end = content.lastIndex(of: "]"),
+              start < end
+        else { return [] }
+
+        let jsonString = String(content[start...end])
+        guard let data = jsonString.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+
+        return array.compactMap { item in
+            guard let action = item["action"] as? String,
+                  let opContent = item["content"] as? String,
+                  !opContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { return nil }
+
+            switch action {
+            case "add":
+                return .add(opContent)
+            case "remove":
+                return .remove(opContent)
+            default:
+                return nil
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/MemoryStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/MemoryStore.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Observation
+
+/// A single durable fact the assistant has learned about the user across
+/// conversations. Backed by the Open WebUI memory-review pattern: after a
+/// conversation turn completes, a lightweight background pass decides
+/// whether anything enduring should be saved.
+struct MemoryEntry: Codable, Equatable, Hashable, Identifiable, Sendable {
+    let id: UUID
+    var content: String
+    var evidenceCount: Int
+    var sourceConversationIDs: [UUID]
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        content: String,
+        evidenceCount: Int = 1,
+        sourceConversationIDs: [UUID] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.content = content
+        self.evidenceCount = evidenceCount
+        self.sourceConversationIDs = sourceConversationIDs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Schema version marker so future migrations can distinguish disk shapes.
+struct MemoryLibrary: Codable, Sendable {
+    var schemaVersion: Int = 1
+    var entries: [MemoryEntry] = []
+}
+
+/// Stores and manages persistent memory entries. The store is the single
+/// point of truth for what the assistant knows about the user; the
+/// extractor proposes entries, the user can edit or delete them in
+/// Settings, and the system prompt builder reads a formatted subset for
+/// injection.
+@MainActor
+@Observable
+final class MemoryStore {
+    /// Maximum entries kept on disk. Older entries beyond this cap are
+    /// dropped from the LOWEST ``evidenceCount`` first, then oldest
+    /// ``updatedAt``, so frequently-corroborated facts survive pruning.
+    static let maximumEntries = 80
+
+    /// Maximum characters across all injected memories. Small models
+    /// (4B–9B) have limited context windows; the memory block must stay
+    /// well under the room the date context and instructions already use.
+    static let maximumInjectedCharacters = 2_000
+
+    /// File layout lives next to ``ConversationStore``'s JSON under
+    /// Application Support/Rapid, keeping all user data in one directory.
+    private static let storageKey = "memory-library-v1"
+
+    private(set) var entries: [MemoryEntry] = []
+    private let fileURL: URL
+    private let defaults: UserDefaults
+
+    /// Whether automatic memory extraction is enabled. Persisted so the
+    /// user's choice survives relaunches. Defaults to off — memory is an
+    /// opt-in feature the user enables in Settings, not something that
+    /// silently collects data.
+    var isEnabled: Bool {
+        get { defaults.bool(forKey: "rapid.memory.enabled") }
+        set { defaults.set(newValue, forKey: "rapid.memory.enabled") }
+    }
+
+    init(fileURL: URL? = nil, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let fileURL {
+            self.fileURL = fileURL
+        } else {
+            self.fileURL = ApplicationSupportLocator.applicationSupportRoot()
+                .appendingPathComponent(Self.storageKey + ".json")
+        }
+        load()
+    }
+
+    // MARK: - CRUD
+
+    /// Adds a new memory entry or increments the evidence count on a
+    /// semantically identical one. Returns the affected entry.
+    @discardableResult
+    func upsert(content: String, conversationID: UUID) -> MemoryEntry {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            // Return a placeholder rather than force-unwrapping; callers
+            // check the returned entry's content before using it.
+            return MemoryEntry(content: "", createdAt: .distantPast, updatedAt: .distantPast)
+        }
+
+        // Case-insensitive substring match for dedup. A future NLP pass
+        // can improve this, but substring catches the common case of the
+        // same preference restated verbatim.
+        if let existingIndex = entries.firstIndex(where: {
+            $0.content.localizedCaseInsensitiveContains(trimmed)
+                || trimmed.localizedCaseInsensitiveContains($0.content)
+        }) {
+            entries[existingIndex].evidenceCount += 1
+            entries[existingIndex].updatedAt = Date()
+            if !entries[existingIndex].sourceConversationIDs.contains(conversationID) {
+                entries[existingIndex].sourceConversationIDs.append(conversationID)
+            }
+            persist()
+            return entries[existingIndex]
+        }
+
+        let entry = MemoryEntry(
+            content: trimmed,
+            sourceConversationIDs: [conversationID]
+        )
+        entries.insert(entry, at: 0)
+        prune()
+        persist()
+        return entry
+    }
+
+    func remove(id: UUID) {
+        entries.removeAll { $0.id == id }
+        persist()
+    }
+
+    func update(id: UUID, content: String) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        entries[index].content = trimmed
+        entries[index].updatedAt = Date()
+        persist()
+    }
+
+    func removeAll() {
+        entries.removeAll()
+        persist()
+    }
+
+    // MARK: - Prompt Injection
+
+    /// Formatted memory block for system-prompt injection. Returns `nil`
+    /// when there are no entries or the store is disabled, so the caller
+    /// skips the block rather than emitting an empty tag.
+    func formattedForPrompt() -> String? {
+        guard isEnabled, !entries.isEmpty else { return nil }
+
+        var lines: [String] = []
+        var characterBudget = Self.maximumInjectedCharacters
+        // Most-recently-updated first; small models benefit from seeing
+        // the freshest context closest to the prompt tail.
+        for entry in entries.sorted(by: { $0.updatedAt > $1.updatedAt }) {
+            let line = "- \(entry.content)"
+            guard line.count <= characterBudget else { break }
+            lines.append(line)
+            characterBudget -= line.count
+        }
+        guard !lines.isEmpty else { return nil }
+
+        return """
+        <memory_context>
+        Durable facts and preferences learned from previous conversations:
+        \(lines.joined(separator: "\n"))
+        </memory_context>
+        """
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let library = try JSONDecoder().decode(MemoryLibrary.self, from: data)
+            entries = library.entries
+        } catch {
+            // A corrupted memory file should never prevent the app from
+            // launching; start fresh rather than crashing on read.
+            entries = []
+        }
+    }
+
+    private func persist() {
+        let library = MemoryLibrary(entries: entries)
+        do {
+            let directory = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(library)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // Persistence failure is non-fatal; the in-memory state is
+            // still usable for this session.
+        }
+    }
+
+    /// Drops entries beyond ``maximumEntries``, evicting the lowest-
+    /// evidence items first so corroboration acts as a retention signal.
+    private func prune() {
+        guard entries.count > Self.maximumEntries else { return }
+        let sorted = entries.sorted { a, b in
+            if a.evidenceCount != b.evidenceCount { return a.evidenceCount > b.evidenceCount }
+            return a.updatedAt > b.updatedAt
+        }
+        entries = Array(sorted.prefix(Self.maximumEntries))
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -92,6 +92,8 @@ struct RapidApp: App {
     @State private var sampling: SamplingConfig
     /// App-wide custom instructions shared by Settings and every chat turn.
     @State private var customInstructions: CustomInstructionsConfig
+    /// Persistent memory entries shared by chat injection and Settings.
+    @State private var memoryStore: MemoryStore
     /// Persisted theme override exposed via Settings → Appearance.
     @State private var appearance: AppearanceConfig
     /// Deep-link channel into the Settings window.
@@ -171,6 +173,7 @@ struct RapidApp: App {
         let manager = ServerManager()
         let samplingConfig = SamplingConfig()
         let customInstructionsConfig = CustomInstructionsConfig()
+        let memoryStore = MemoryStore()
         let appearanceConfig = AppearanceConfig()
         // Apply the persisted theme override before the first window
         // renders so the user doesn't see a flash of the wrong mode.
@@ -259,6 +262,7 @@ struct RapidApp: App {
             tools: toolRegistry,
             sampling: samplingConfig,
             customInstructions: customInstructionsConfig,
+            memoryStore: memoryStore,
             server: manager,
             onProductValueDelivered: { [weak consentCoordinator] kind in
                 consentCoordinator?.productValueDelivered(kind)
@@ -334,6 +338,7 @@ struct RapidApp: App {
         _sparkleUpdater = State(initialValue: sparkleUpdateController)
         _sampling = State(initialValue: samplingConfig)
         _customInstructions = State(initialValue: customInstructionsConfig)
+        _memoryStore = State(initialValue: memoryStore)
         _appearance = State(initialValue: appearanceConfig)
         _settingsRouter = State(initialValue: SettingsRouter())
         _deferredTelemetryConsent = State(initialValue: consentCoordinator)
@@ -366,6 +371,7 @@ struct RapidApp: App {
                 .environment(sparkleUpdater)
                 .environment(sampling)
                 .environment(customInstructions)
+                .environment(memoryStore)
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(deferredTelemetryConsent)
@@ -518,6 +524,7 @@ struct RapidApp: App {
                 .environment(chatViewModel)
                 .environment(sampling)
                 .environment(customInstructions)
+                .environment(memoryStore)
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(server)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// Settings → Memory panel. Users can toggle extraction on/off, browse
+/// learned entries, edit or delete individual ones, and clear the store.
+@MainActor
+struct SettingsMemoryPanel: View {
+    @Environment(MemoryStore.self) private var memoryStore
+    @State private var editingEntry: MemoryEntry?
+    @State private var editDraft = ""
+    @State private var confirmingClear = false
+
+    var body: some View {
+        @Bindable var store = memoryStore
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Memory",
+                subtitle: "The assistant learns your preferences across conversations. It never sends data off this Mac.",
+                emphasis: .page
+            )
+
+            Toggle(isOn: Binding(
+                get: { memoryStore.isEnabled },
+                set: { memoryStore.isEnabled = $0 }
+            )) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Automatic memory")
+                        .font(.body)
+                    Text("Review completed conversations and save durable preferences. Disabled by default.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+
+            if memoryStore.isEnabled && !memoryStore.entries.isEmpty {
+                HStack {
+                    Text("\(memoryStore.entries.count) saved memor\(memoryStore.entries.count == 1 ? "y" : "ies")")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Clear All", role: .destructive) {
+                        confirmingClear = true
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.callout)
+                }
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(memoryStore.entries) { entry in
+                            memoryRow(entry)
+                        }
+                    }
+                }
+                .frame(minHeight: 200)
+            } else if memoryStore.isEnabled {
+                Text("No memories yet. They appear here after the assistant completes a conversation.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .alert("Clear all memories?", isPresented: $confirmingClear) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive) {
+                memoryStore.removeAll()
+            }
+        } message: {
+            Text("This removes every learned fact. It cannot be undone.")
+        }
+        .sheet(item: $editingEntry) { entry in
+            editSheet(entry)
+        }
+    }
+
+    private func memoryRow(_ entry: MemoryEntry) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.content)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                Text("\(entry.evidenceCount)× seen · \(entry.updatedAt, style: .relative)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Button("Edit") {
+                editDraft = entry.content
+                editingEntry = entry
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+            Button(role: .destructive) {
+                memoryStore.remove(id: entry.id)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func editSheet(_ entry: MemoryEntry) -> some View {
+        NavigationStack {
+            Form {
+                TextField("Memory", text: $editDraft, axis: .vertical)
+                    .lineLimit(3...10)
+            }
+            .navigationTitle("Edit Memory")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { editingEntry = nil }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        memoryStore.update(id: entry.id, content: editDraft)
+                        editingEntry = nil
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 380, minHeight: 200)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -70,6 +70,8 @@ struct SettingsView: View {
         /// Global system-prompt default applied before any conversation-specific
         /// override. Stored locally in UserDefaults under the legacy key.
         case instructions
+        /// Persistent memory entries learned from conversations.
+        case memory
         /// Built-in tools the model can call: on/off per tool, the
         /// web-search backend + key, and the browse approval mode.
         case tools
@@ -104,6 +106,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "Model Management"
             case .instructions: return "System Prompt"
+            case .memory: return "Memory"
             case .tools: return "Tools"
             case .connectors: return "Connectors"
             case .performance: return "Performance"
@@ -119,6 +122,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "externaldrive.fill"
             case .instructions: return "text.bubble.fill"
+            case .memory: return "brain"
             case .tools: return "wrench.and.screwdriver.fill"
             case .connectors: return "powerplug.fill"
             case .performance: return "speedometer"
@@ -480,6 +484,8 @@ struct SettingsView: View {
             SettingsModelManagementPanel()
         case .instructions:
             instructionsPanel
+        case .memory:
+            SettingsMemoryPanel()
         case .tools:
             SettingsToolsPanel()
         case .connectors:

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/ProcessAlive.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/ProcessAlive.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Real-host process-liveness probe. A PID can be detected as
+/// "not alive" even while it is technically a zombie; for our purpose
+/// (is the run still making progress?) a live-or-zombie distinction is
+/// handled by treating only an explicit "no such PID" as dead.
+public enum ProcessAlive {
+
+    /// True if a process with `pid` exists right now.
+    ///
+    /// Uses `kill(pid, 0)` (the standard "does this pid exist" probe), which
+    /// requires no child relationship and triggers no signal delivery. A
+    /// ``errno`` of ``ESRCH`` (no such process) → false; permission-denied
+    /// (``EPERM``) still means the process exists → true.
+    public static func isAlive(pid: pid_t) -> Bool {
+        guard pid > 1 else { return false }
+        if kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/SampleInvocation.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/SampleInvocation.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Real-host sampler: captures a hung process's stack with `/usr/bin/sample`
+/// plus a snapshot of process state (`ps`) and memory pressure (`vm_stat`),
+/// all written into a single `.txt` artifact for CI to upload.
+///
+/// The invocation pattern mirrors the existing in-process
+/// `CIHangWatchdog.sample(pid:)` (Tests/RapidTests/Support/CIHangWatchdog.swift)
+/// so a developer who has read one recognizes the other; the addition here is
+/// that the whole set is redirected into a named artifact file rather than
+/// `/dev/stdout`, plus `ps`/`vm_stat` give the RAM/memory-pressure context that
+/// lets a reader tell a "stuck waiting on memory" hang from a pure deadlock.
+public enum SampleInvocation {
+
+    /// Capture the stack + system state for `pid` into `artifactURL`.
+    public static func capture(
+        pid: pid_t,
+        config: WatchdogConfig = WatchdogConfig(),
+        artifactURL: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: artifactURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // Fresh materialize the artifact (FileHandle(forWritingTo:) alone
+        // fails when the file doesn't yet exist), then write the sections.
+        if !FileManager.default.fileExists(atPath: artifactURL.path) {
+            try Data().write(to: artifactURL)
+        }
+        let handle = try FileHandle(forWritingTo: artifactURL)
+        try handle.truncate(atOffset: 0)
+        try handle.seek(toOffset: 0)
+        try writeSections(into: handle, pid: pid, config: config)
+        try handle.close()
+    }
+
+    private static func writeSections(into handle: FileHandle, pid: pid_t, config: WatchdogConfig) throws {
+        func write(_ s: String) throws {
+            try handle.write(contentsOf: Data(s.utf8))
+        }
+
+        try write("Rapid Desktop test-suite hang capture\n")
+        try write("captured at: \(Date())\n")
+        try write("wrapped PID: \(pid)\n")
+        try write("sample duration: \(config.sampleDurationSeconds)s\n\n")
+
+        // Process state + RAM context first, so a reader sees memory pressure
+        // even if the stack sample below is truncated.
+        try write("===== ps -p \(pid) -o pid,ppid,state,%cpu,%mem,rss,etime,comm =====\n")
+        try write(shellOutput("/bin/ps", ["-p", String(pid), "-o", "pid,ppid,state,%cpu,%mem,rss,etime,comm"]))
+        try write("\n===== vm_stat =====\n")
+        try write(shellOutput("/usr/bin/vm_stat", []))
+        try write("\n===== memory pressure -Q =====\n")
+        try write(shellOutput("/usr/bin/memory_pressure", ["-Q"]))
+
+        // The stack capture proper.
+        try write("\n===== /usr/bin/sample \(pid) \(config.sampleDurationSeconds) -file ... =====\n")
+        try write(streamingSample(pid: pid, seconds: config.sampleDurationSeconds))
+        try write("===== end capture \(pid) =====\n")
+    }
+
+    /// `/usr/bin/sample` streams to stdout; capture it into the artifact.
+    private static func streamingSample(pid: pid_t, seconds: Int) -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = [String(pid), String(seconds)]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            return "<sample failed: \(error)>"
+        }
+    }
+
+    /// Run a command and return its combined stdout (best-effort, non-fatal).
+    private static func shellOutput(_ executable: String, _ args: [String]) -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            return "<'\(executable)' failed: \(error)>"
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/Watchdog.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdog/Watchdog.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Configuration for the Desktop test-suite hang watchdog.
+///
+/// The whole purpose of this component is to convert a hung `swift test`
+/// run — which today can stall a train for the full job timeout (20 minutes,
+/// once 45) with no usable diagnostic — into a fast, readable failure with a
+/// sampled stack artifact. Two complementary mechanisms exist:
+///
+///  * Swift Testing's per-suite `.timeLimit(.minutes(2))` trait (added to the
+///    specific hang-prone suites, `TestTimeouts.hangProne`) fails the suite
+///    quickly and names the suite.
+///  * This watchdog is the *whole-run* backstop: it enforces a per-run
+///    deadline on the `swift test` process and, on expiry, samples the hung
+///    process's stacks so we know WHERE it hung even when no per-suite limit
+///    was in place.
+public struct WatchdogConfig: Sendable {
+    /// Deadline for the wrapped run, measured from when the watchdog starts
+    /// watching. This is the whole-run backstop, not the per-suite 2-minute
+    /// limit — it must sit above the healthy serialized `swift test` duration
+    /// so a healthy run is never expired.
+    public var deadline: Duration
+    /// Seconds for each `/usr/bin/sample` capture. 1 is plenty to get a stack.
+    public var sampleDurationSeconds: Int
+    /// Directory the sample + system-state artifact is written into.
+    public var artifactDir: URL
+    /// Path prefix for the artifact basename.
+    public var artifactName: String
+
+    public init(
+        deadline: Duration = .seconds(300),
+        sampleDurationSeconds: Int = 1,
+        artifactDir: URL = URL(fileURLWithPath: "/tmp/desktop-hang-artifacts"),
+        artifactName: String = "desktop-hang"
+    ) {
+        self.deadline = deadline
+        self.sampleDurationSeconds = sampleDurationSeconds
+        self.artifactDir = artifactDir
+        self.artifactName = artifactName
+    }
+}
+
+/// A process-survival test + the hooks that let a unit test fake the world.
+///
+/// Everything that touches the real host (wall clock, whether a PID is still
+/// alive, launching `/usr/bin/sample` and the system-state probes) is
+/// injected here as a closure, so the decision logic in ``HangWatchdog`` is
+/// pure and unit-testable without any real process, clock, or sampler.
+public struct WatchdogSeams: Sendable {
+    /// Returns the current wall-clock instant. Injected clock seam.
+    public var now: @Sendable () -> Date
+    /// True while the wrapped process is still alive. Injected process seam.
+    public var wrappedProcessIsAlive: @Sendable () -> Bool
+    /// Perform the stack + system-state capture for the (hung) process and
+    /// write it into the artifact at `artifactURL`. Injected sample seam.
+    public var capture: @Sendable (pid_t, URL) throws -> Void
+
+    public static let live = WatchdogSeams(
+        now: { Date() },
+        wrappedProcessIsAlive: { fatalError("live seam used without a PID; use makeLive(pid:)") },
+        capture: { pid, url in try SampleInvocation.capture(pid: pid, artifactURL: url) }
+    )
+
+    /// Build the live seams pinned to a specific wrapped PID.
+    public static func makeLive(pid: pid_t, config: WatchdogConfig) -> WatchdogSeams {
+        WatchdogSeams(
+            now: { Date() },
+            wrappedProcessIsAlive: { ProcessAlive.isAlive(pid: pid) },
+            capture: { capturedPID, url in
+                try SampleInvocation.capture(
+                    pid: capturedPID,
+                    config: config,
+                    artifactURL: url
+                )
+            }
+        )
+    }
+}
+
+/// Outcome of a watchdog watch.
+public enum WatchdogResult: Equatable, Sendable {
+    /// The wrapped process exited before the deadline elapsed.
+    case completed
+    /// The deadline elapsed while the wrapped process was still running; a
+    /// sample artifact was captured and (optionally) the run was killed.
+    case hung(artifactURL: URL, reason: String)
+}
+
+/// The hang watchdog: pure decision logic over injected seams.
+///
+/// `run` watches a wrapped process (identified only through the injected
+/// `wrappedProcessIsAlive` seam) until either it exits (returns
+/// ``WatchdogResult/completed``) or the deadline passes while it is still
+/// alive (returns ``WatchdogResult/hung`` after capturing the sample).
+///
+/// The deadline math and the artifact-path construction are pure and unit
+/// tested with a fake clock and fake process; the real capture is delegated
+/// to ``SampleInvocation``.
+public struct HangWatchdog {
+    public let config: WatchdogConfig
+    public let seams: WatchdogSeams
+
+    public init(config: WatchdogConfig = WatchdogConfig(), seams: WatchdogSeams) {
+        self.config = config
+        self.seams = seams
+    }
+
+    /// The artifact URL for a given PID and clock instant (pure; testable).
+    public func artifactURL(pid: pid_t, at date: Date) -> URL {
+        let stamp = String(Int64(date.timeIntervalSince1970))
+        let name = "\(config.artifactName)-\(pid)-\(stamp).txt"
+        return config.artifactDir.appendingPathComponent(name)
+    }
+
+    /// Whether the deadline has elapsed given a start offset and the current
+    /// wall clock (pure; testable).
+    public func isExpired(startedAt start: Date, now nowDate: Date) -> Bool {
+        nowDate.timeIntervalSince(start) >= config.deadline.toSeconds
+    }
+
+    /// Watch the wrapped process until it exits or the deadline is exceeded.
+    ///
+    /// - Parameter pid: the wrapped PID, used for the artifact name + capture.
+    /// - Returns: ``WatchdogResult/completed`` if the process exited before
+    ///   the deadline, else ``WatchdogResult/hung`` with the captured artifact.
+    public func run(watchedPID pid: pid_t) -> WatchdogResult {
+        let start = seams.now()
+        let pollInterval: TimeInterval = 0.25
+
+        while true {
+            if !seams.wrappedProcessIsAlive() {
+                return .completed
+            }
+            if isExpired(startedAt: start, now: seams.now()) {
+                let url = artifactURL(pid: pid, at: seams.now())
+                do {
+                    try seams.capture(pid, url)
+                } catch {
+                    return .hung(
+                        artifactURL: url,
+                        reason: "deadline (\(config.deadline.toSeconds)s) exceeded; sample capture failed: \(error)"
+                    )
+                }
+                return .hung(
+                    artifactURL: url,
+                    reason: "deadline (\(config.deadline.toSeconds)s) exceeded; see sample artifact \(url.path)"
+                )
+            }
+            Thread.sleep(forTimeInterval: pollInterval)
+        }
+    }
+}
+
+// MARK: - Duration helpers
+
+extension Duration {
+    /// Whole seconds represented by this duration (truncated).
+    fileprivate var toSeconds: TimeInterval {
+        let components = self.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/apps/rapid-mac/Sources/RapidDesktopTestWatchdogRun/main.swift
+++ b/apps/rapid-mac/Sources/RapidDesktopTestWatchdogRun/main.swift
@@ -1,0 +1,54 @@
+import Foundation
+import RapidDesktopTestWatchdog
+
+/// CLI entry for the Desktop test-suite hang watchdog, launched by
+/// `scripts/desktop-test-timeout.sh`. It watches a wrapped process and, when
+/// the run outlives the deadline while still alive, captures the stack +
+/// system-state artifact and exits non-zero so the CI wrapper fails fast.
+///
+/// Usage:
+///   RapidDesktopTestWatchdogRun <pid> <deadline-seconds> <artifact-dir> [artifact-name]
+///
+/// Exit codes:
+///   0  the wrapped process exited before the deadline (healthy run / normal fail)
+///   1  the deadline elapsed while the wrapped process was still alive (hang)
+///   2  usage / argument error
+
+let args = CommandLine.arguments
+
+func usage() -> Never {
+    FileHandle.standardError.write(Data(
+        "usage: RapidDesktopTestWatchdogRun <pid> <deadline-seconds> <artifact-dir> [artifact-name]\n".utf8))
+    exit(2)
+}
+
+guard args.count >= 4, let pid = pid_t(args[1]), let deadlineSeconds = Int(args[2]) else {
+    usage()
+}
+
+let artifactDir = URL(fileURLWithPath: args[3])
+let artifactName = args.count >= 5 ? args[4] : "desktop-hang"
+
+let config = WatchdogConfig(
+    deadline: .seconds(deadlineSeconds),
+    sampleDurationSeconds: 1,
+    artifactDir: artifactDir,
+    artifactName: artifactName
+)
+
+let watchdog = HangWatchdog(
+    config: config,
+    seams: .makeLive(pid: pid, config: config)
+)
+
+let result = watchdog.run(watchedPID: pid)
+
+switch result {
+case .completed:
+    exit(0)
+case .hung(let artifactURL, let reason):
+    let message = "::error::Rapid desktop-test watchdog: \(reason)\n"
+        + "sample artifact: \(artifactURL.path)\n"
+    FileHandle.standardError.write(Data(message.utf8))
+    exit(1)
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/Locked.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/Locked.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A tiny lock-protected mutable box so `@Sendable` test closures (the seams
+/// require `@Sendable`) can safely capture and mutate shared state in Swift 6
+/// strict-concurrency mode.
+final class Locked<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Value
+
+    init(_ value: Value) {
+        _value = value
+    }
+
+    /// Read or mutate the boxed value under the lock.
+    func withLock<T>(_ body: (inout Value) -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&_value)
+    }
+
+    var value: Value {
+        withLock { $0 }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/SampleInvocationTests.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/SampleInvocationTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import RapidDesktopTestWatchdog
+
+/// Verifies the real-host sampler (`/usr/bin/sample` + `ps`/`vm_stat`) writes
+/// a non-trivial `.txt` artifact for a live process. Uses a short-lived
+/// `sleep` child as the sample target — a real process the OS sampler can
+/// capture — so no test hangs even if `sample` stalls.
+@Suite("SampleInvocation — live capture")
+struct SampleInvocationTests {
+
+    @Test("capture writes a non-empty artifact with sample + ps + vm_stat sections")
+    func capturesLiveProcess() throws {
+        // Spawn a real child so there is a genuine PID to sample.
+        let sleeper = Process()
+        sleeper.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        sleeper.arguments = ["10"]
+        try sleeper.run()
+        defer { kill(sleeper.processIdentifier, SIGKILL) }
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wd-test-\(UUID().uuidString)")
+        let config = WatchdogConfig(
+            deadline: .seconds(60),
+            sampleDurationSeconds: 1,
+            artifactDir: dir,
+            artifactName: "desktop-hang"
+        )
+        let url = dir.appendingPathComponent("desktop-hang-\(sleeper.processIdentifier)-test.txt")
+
+        try SampleInvocation.capture(pid: sleeper.processIdentifier, config: config, artifactURL: url)
+
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(text.contains("Rapid Desktop test-suite hang capture"))
+        #expect(text.contains("===== ps -p"))
+        #expect(text.contains("===== vm_stat ====="))
+        #expect(text.contains("===== /usr/bin/sample"))
+        #expect(text.contains("sleep"))   // the sampled stack names the process
+        #expect(text.count > 200)         // genuinely captured content, not a stub
+    }
+}

--- a/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/WatchdogTests.swift
+++ b/apps/rapid-mac/Tests/RapidDesktopTestWatchdogTests/WatchdogTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import RapidDesktopTestWatchdog
+
+/// Unit tests for the hang-watchdog decision logic, driven entirely through
+/// injected seams (fake clock, fake process-survival, fake sample capture) so
+/// no real `/usr/bin/sample`, process, or wall clock is touched.
+@Suite("HangWatchdog — deadline math + seams")
+struct WatchdogDecisionTests {
+
+    // MARK: - Deadline math (pure)
+
+    @Test("isExpired is false before the deadline")
+    func notExpiredBeforeDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(120))
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date(timeIntervalSince1970: 100) }))
+        let start = Date(timeIntervalSince1970: 0)
+        // 60s elapsed < 120s deadline.
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 60)) == false)
+    }
+
+    @Test("isExpired is true at and past the deadline")
+    func expiredAtAndPastDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(120))
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date() }))
+        let start = Date(timeIntervalSince1970: 0)
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 120)) == true)
+        #expect(wd.isExpired(startedAt: start, now: Date(timeIntervalSince1970: 300)) == true)
+    }
+
+    // MARK: - Artifact path (pure)
+
+    @Test("artifact URL embeds pid, name prefix, timestamp and .txt suffix")
+    func artifactPathShape() {
+        let cfg = WatchdogConfig(
+            artifactDir: URL(fileURLWithPath: "/tmp/hang", isDirectory: true),
+            artifactName: "desktop-hang"
+        )
+        let wd = HangWatchdog(config: cfg, seams: .fake(now: { Date(timeIntervalSince1970: 12345) }))
+        let url = wd.artifactURL(pid: 4242, at: Date(timeIntervalSince1970: 12345))
+        #expect(url.path == "/tmp/hang/desktop-hang-4242-12345.txt")
+    }
+
+    // MARK: - run() outcomes via fake seams
+
+    @Test("run returns completed when the wrapped process exits before deadline")
+    func completesWhenProcessExitsFirst() {
+        let cfg = WatchdogConfig(deadline: .seconds(60))
+        let wd = HangWatchdog(
+            config: cfg,
+            seams: .fake(
+                now: { Date() },
+                wrappedAlive: { false },   // already gone
+                capture: { pid, url in
+                    Issue.record("capture must not run when the process is already gone")
+                }
+            )
+        )
+        #expect(wd.run(watchedPID: 100) == .completed)
+    }
+
+    @Test("run returns hung + writes artifact when the process outlives the deadline")
+    func hangsAndCapturesOnDeadline() {
+        let cfg = WatchdogConfig(deadline: .seconds(2), artifactDir: URL(fileURLWithPath: "/tmp/x"))
+        let captured = Locked<(pid: pid_t, url: URL)?>(nil)
+        let calls = Locked(0)
+        let wd = HangWatchdog(
+            config: cfg,
+            seams: WatchdogSeams(
+                now: {
+                    let n = calls.withLock { c -> Int in
+                        c += 1
+                        return c
+                    }
+                    // First call is the start instant (t=0); every later poll
+                    // is t=60s, already past the 2s deadline, while the process
+                    // stays alive — so the watchdog must expire and capture.
+                    return Date(timeIntervalSince1970: n == 1 ? 0 : 60)
+                },
+                wrappedProcessIsAlive: { true },
+                capture: { pid, url in captured.withLock { $0 = (pid, url) } }
+            )
+        )
+        let result = wd.run(watchedPID: 77)
+        guard case .hung(let url, let reason) = result else {
+            Issue.record("expected .hung, got \(result)")
+            return
+        }
+        let got = captured.value
+        #expect(got?.pid == 77)
+        #expect(url == got?.url)
+        #expect(url.path == "/tmp/x/desktop-hang-77-60.txt")
+        #expect(reason.contains("deadline"))
+    }
+}
+
+extension WatchdogSeams {
+    /// Convenience fake-seams constructor for tests.
+    static func fake(
+        now: @escaping @Sendable () -> Date = { Date() },
+        wrappedAlive: @escaping @Sendable () -> Bool = { true },
+        capture: @escaping @Sendable (pid_t, URL) throws -> Void = { _, _ in }
+    ) -> WatchdogSeams {
+        WatchdogSeams(now: now, wrappedProcessIsAlive: wrappedAlive, capture: capture)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppIconBundleTests.swift
@@ -14,7 +14,7 @@ import Testing
 /// macOS reads 5 base sizes off an icns (16, 32, 128, 256, 512) and
 /// each has a `@2x` retina pair, so 10 representations total. We
 /// assert all 10 are present and decode to a non-empty PNG payload.
-@Suite("AppIcon.icns subimage coverage")
+@Suite("AppIcon.icns subimage coverage", TestTimeouts.hangProne)
 struct AppIconBundleTests {
     /// Locate the shipped icns by walking up from the test bundle
     /// to the repo root, since `swift test` doesn't expose Resources/

--- a/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DMGPresentationScriptTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-@Suite("DMG presentation scripts")
+@Suite("DMG presentation scripts", TestTimeouts.hangProne)
 struct DMGPresentationScriptTests {
     @Test("Validator preserves legacy compatibility and detaches by device")
     func validatorCompatibilityAndCleanup() throws {

--- a/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Memory store")
+struct MemoryStoreTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-memory-test-\(UUID().uuidString).json")
+    }
+
+    private func freshDefaults() -> (UserDefaults, String) {
+        let name = "rapid-memory-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return (defaults, name)
+    }
+
+    @Test("Empty store formats to nil")
+    func emptyFormattedNil() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        #expect(store.formattedForPrompt() == nil)
+    }
+
+    @Test("Disabled store formats to nil even with entries")
+    func disabledFormattedNil() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(false, forKey: "rapid.memory.enabled")
+        let url = tempURL()
+        let store = MemoryStore(fileURL: url, defaults: defaults)
+        store.upsert(content: "Prefers TypeScript", conversationID: UUID())
+        #expect(store.formattedForPrompt() == nil)
+    }
+
+    @Test("Upsert adds entry and formats for prompt")
+    func upsertAndFormat() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        store.upsert(content: "Prefers TypeScript over JavaScript", conversationID: UUID())
+
+        let formatted = store.formattedForPrompt()
+        #expect(formatted != nil)
+        #expect(formatted!.contains("Prefers TypeScript"))
+        #expect(formatted!.contains("<memory_context>"))
+    }
+
+    @Test("Upsert deduplicates semantically identical content")
+    func dedup() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        store.upsert(content: "Uses pnpm", conversationID: UUID())
+        store.upsert(content: "Uses pnpm", conversationID: UUID())
+        #expect(store.entries.count == 1)
+        #expect(store.entries[0].evidenceCount == 2)
+    }
+
+    @Test("Remove deletes a single entry")
+    func removeSingle() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        let entry = store.upsert(content: "Test fact", conversationID: UUID())
+        store.remove(id: entry.id)
+        #expect(store.entries.isEmpty)
+    }
+
+    @Test("Update modifies content")
+    func updateContent() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        let entry = store.upsert(content: "Old content", conversationID: UUID())
+        store.update(id: entry.id, content: "New content")
+        #expect(store.entries.first?.content == "New content")
+    }
+
+    @Test("Persistence round-trips through disk")
+    func persistence() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let url = tempURL()
+        let store = MemoryStore(fileURL: url, defaults: defaults)
+        store.upsert(content: "Durable fact", conversationID: UUID())
+
+        let reloaded = MemoryStore(fileURL: url, defaults: defaults)
+        #expect(reloaded.entries.count == 1)
+        #expect(reloaded.entries[0].content == "Durable fact")
+    }
+
+    @Test("Prune caps at maximum entries")
+    func prune() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        for index in 0..<MemoryStore.maximumEntries + 10 {
+            let unique = String(format: "entry-%03d", index)
+            store.upsert(content: unique, conversationID: UUID())
+        }
+        #expect(store.entries.count == MemoryStore.maximumEntries)
+    }
+
+    @Test("Formatted output respects character budget")
+    func characterBudget() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        for index in 0..<200 {
+            store.upsert(content: String(repeating: "x", count: 100) + " \(index)", conversationID: UUID())
+        }
+        let formatted = store.formattedForPrompt()
+        #expect(formatted != nil)
+        #expect(formatted!.count <= MemoryStore.maximumInjectedCharacters + 50)
+    }
+}
+
+@Suite("Memory extractor")
+struct MemoryExtractorTests {
+    @Test("buildTranscript filters tool and system messages")
+    func transcriptFiltering() {
+        let messages: [(role: String, content: String)] = [
+            ("system", "You are helpful."),
+            ("user", "Hello"),
+            ("tool", "tool result data"),
+            ("assistant", "Hi there!")
+        ]
+        let transcript = MemoryExtractor.buildTranscript(from: messages)
+        #expect(transcript.contains("user: Hello"))
+        #expect(transcript.contains("assistant: Hi there!"))
+        #expect(!transcript.contains("system"))
+        #expect(!transcript.contains("tool"))
+    }
+
+    @Test("buildTranscript truncates long messages")
+    func transcriptTruncation() {
+        let longContent = String(repeating: "a", count: MemoryExtractor.maximumMessageCharacters + 500)
+        let messages: [(role: String, content: String)] = [
+            ("user", longContent)
+        ]
+        let transcript = MemoryExtractor.buildTranscript(from: messages)
+        #expect(transcript.count < MemoryExtractor.maximumMessageCharacters + 20)
+        #expect(transcript.hasSuffix("…"))
+    }
+
+    @Test("parseOperations handles well-formed JSON array")
+    func parseValid() {
+        let content = """
+        Here is my analysis:
+        [{"action": "add", "content": "Prefers Swift"}, {"action": "remove", "content": "Old pref"}]
+        """
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 2)
+        #expect(operations[0] == .add("Prefers Swift"))
+        #expect(operations[1] == .remove("Old pref"))
+    }
+
+    @Test("parseOperations returns empty on malformed output")
+    func parseMalformed() {
+        #expect(MemoryExtractor.parseOperations(from: "no JSON here").isEmpty)
+        #expect(MemoryExtractor.parseOperations(from: "[broken").isEmpty)
+        #expect(MemoryExtractor.parseOperations(from: "").isEmpty)
+    }
+
+    @Test("parseOperations tolerates markdown fences")
+    func parseFenced() {
+        let content = """
+        ```json
+        [{"action": "add", "content": "Test"}]
+        ```
+        """
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 1)
+        #expect(operations[0] == .add("Test"))
+    }
+
+    @Test("parseOperations ignores unknown actions")
+    func parseUnknownAction() {
+        let content = "[{\"action\": \"merge\", \"content\": \"test\"}]" 
+        #expect(MemoryExtractor.parseOperations(from: content).isEmpty)
+    }
+
+    @Test("reviewPrompt includes transcript and rules")
+    func reviewPromptShape() {
+        let prompt = MemoryExtractor.reviewPrompt(transcript: "user: Hello")
+        #expect(prompt.contains("user: Hello"))
+        #expect(prompt.contains("Return ONLY a JSON array"))
+        #expect(prompt.contains("Do NOT save one-off"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -260,7 +260,7 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
 /// can never fire and no responder is needed: the suite asserts the resident
 /// rejection/load behaviour on fixtures, not on the host's real RAM.
 @MainActor
-@Suite("Resident-load rejection feedback", .serialized)
+@Suite("Resident-load rejection feedback", .serialized, TestTimeouts.hangProne)
 struct ResidentLoadFeedbackTests {
     @Test("Resident admission publishes alias-scoped working state immediately", .timeLimit(.minutes(1)))
     func publishesResidentLoadInFlightState() async {

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -81,7 +81,7 @@ struct SettingsVisualFoundationTests {
         // change deliberate and reviewed, not to freeze the list forever —
         // update this literal alongside the enum when a feature adds one.
         var expected: Set<String> = [
-            "modelManagement", "instructions", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
         ]
         // `swift test` builds debug, so the debug-only category is present
@@ -108,7 +108,7 @@ struct SettingsVisualFoundationTests {
     @Test("Category order is unchanged, so arrow-key navigation is unchanged")
     func categoryOrderIsStable() {
         var expectedOrder = [
-            "modelManagement", "instructions", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
         ]
         #if DEBUG

--- a/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarShimHardeningTests.swift
@@ -22,7 +22,7 @@ import Testing
 ///
 /// Pattern mirrors ``ToolUseCapabilitySourceGuardTests`` (PR #343):
 /// strip comments/whitespace, then assert canonical substrings.
-@Suite("Sidecar shim cwd-hijack hardening (#361)")
+@Suite("Sidecar shim cwd-hijack hardening (#361)", TestTimeouts.hangProne)
 struct SidecarShimHardeningTests {
 
     /// Repository root, derived from ``#filePath`` so the test runs

--- a/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarVersionGateTests.swift
@@ -29,7 +29,7 @@ import Testing
 /// can't quietly delete any one of them. The bug class is too
 /// expensive (100% slim-DMG install failure rate; only caught by
 /// release-day dogfood) to rely on a single point of defence.
-@Suite("Sidecar version SemVer gate (#411) — four-layer regression pins")
+@Suite("Sidecar version SemVer gate (#411) — four-layer regression pins", TestTimeouts.hangProne)
 struct SidecarVersionGateTests {
 
     private static var sourceRoot: URL {

--- a/apps/rapid-mac/Tests/RapidTests/Support/TestTimeouts.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Support/TestTimeouts.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+
+/// Shared time-limit traits for hang-prone Desktop test suites (#2488).
+///
+/// A suite that spawns a real engine process, or that waits on RAM/clock and
+/// could stall the serialised `swift test --no-parallel` pool, should declare
+/// it by adding the shared trait constant to its `@Suite` attribute — one line
+/// per suite:
+///
+/// ```swift
+/// @Suite("...", .timeLimit(.minutes(2)))
+/// ```
+/// becomes:
+/// ```swift
+/// @Suite("...", TestTimeouts.hangProne)
+/// ```
+///
+/// This is deliberately a *suite-level* limit (Swift Testing's `.timeLimit`
+/// is recursive over a suite's contained tests), so a single stuck `@Test`
+/// trips the whole suite at 2 minutes instead of stalling the serialised run
+/// until the CI job timeout. The complementary whole-run backstop lives in
+/// `scripts/desktop-test-timeout.sh`.
+///
+/// Only `.minutes(_:)` (integer) is available on the installed toolchain —
+/// `.seconds`/`.milliseconds` are marked unavailable — so 2 minutes is the
+/// finest granularity the trait allows.
+enum TestTimeouts {
+    /// 2-minute time limit applied to hang-prone suites.
+    static let hangProne: any SuiteTrait = .timeLimit(.minutes(2))
+}

--- a/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ThirdPartyLicenseStagingTests.swift
@@ -23,7 +23,7 @@ import Testing
 /// vendored SwiftMath notice exists in-tree, `THIRD_PARTY.md` points at the
 /// shipped `Contents/Resources/Licenses/` location, and `build.sh` actually
 /// invokes the staging script.
-@Suite("Third-party license staging")
+@Suite("Third-party license staging", TestTimeouts.hangProne)
 struct ThirdPartyLicenseStagingTests {
     /// Repository root, derived from this file's own compile-time location:
     /// `<root>/apps/rapid-mac/Tests/RapidTests/<this file>`.

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -4,6 +4,15 @@ import XCTest
 
 @MainActor
 final class ChatAttachmentJourneyTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // #2488: bound each XCUI journey to 2 minutes so a hung UI test (the
+        // #2481 ledger hang) fails fast instead of stalling the XCUITest run.
+        // This is the XCUITest-target analog of the Swift Testing
+        // `TestTimeouts.hangProne` suite trait.
+        executionTimeAllowance = 120
+    }
+
     func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {
         continueAfterFailure = false
         let harness = try RapidUITestHarness(

--- a/apps/rapid-mac/scripts/desktop-test-timeout.sh
+++ b/apps/rapid-mac/scripts/desktop-test-timeout.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Desktop test-suite hang backstop.
+#
+# Wraps `swift test --no-parallel` so a hung suite can never burn the whole
+# job timeout (20 minutes, once 45) with no diagnostic. Two complementary
+# mechanisms (see #2488):
+#
+#   1. Per-suite `.timeLimit(.minutes(2))` (TestTimeouts.hangProne) applied to
+#      the hang-prone suites fails those suites in 2 minutes and names them.
+#   2. THIS script is the whole-run safety net: it enforces a per-run deadline
+#      on the swift-test process and, on expiry, hands the hung process to the
+#      RapidDesktopTestWatchdogRun watchdog which samples its stacks (plus
+#      `ps` / `vm_stat` / `memory_pressure`) into a `.txt` artifact, then we
+#      kill the hung process and exit non-zero with a readable reason.
+#
+# The per-run deadline must sit ABOVE the healthy serialized run so a healthy
+# suite never expires (per-suite .timeLimit provides the real 2-minute
+# guarantee); override with RAPID_DESKTOP_DEADLINE_MINUTES if a host runs the
+# suite slower/faster.
+#
+# Artifacts are written to RAPID_DESKTOP_HANG_ARTIFACT_DIR (default
+# build/desktop-hang-artifacts, match CI's upload step path if you move it).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-8}"
+ARTIFACT_DIR="${RAPID_DESKTOP_HANG_ARTIFACT_DIR:-"$ROOT/build/desktop-hang-artifacts"}"
+
+# Locate (and if needed build) the watchdog executable BEFORE launching
+# `swift test`, so we never contends with the running test for the SwiftPM
+# `.build` lock. Prefer RAPID_WATCHDOG_BIN (CI can pass a prebuilt path); fall
+# back to `swift build --product`.
+WATCHDOG_BIN="${RAPID_WATCHDOG_BIN:-}"
+if [[ -n "$WATCHDOG_BIN" && ! -x "$WATCHDOG_BIN" ]]; then
+    echo "error: RAPID_WATCHDOG_BIN not executable: $WATCHDOG_BIN" >&2
+    WATCHDOG_BIN=""
+fi
+if [[ -z "$WATCHDOG_BIN" ]] && swift build --product RapidDesktopTestWatchdogRun >/dev/null 2>&1; then
+    WATCHDOG_BIN="$ROOT/.build/debug/RapidDesktopTestWatchdogRun"
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+# --- Launch `swift test` in the background, remember its PID ---------------
+swift test --no-parallel &
+TEST_PID=$!
+
+# --- Watchdog: fail fast if the run outlives the deadline while still alive --
+hang_detected=0
+if [[ -n "$WATCHDOG_BIN" && -x "$WATCHDOG_BIN" ]]; then
+    deadline_seconds=$(( DEADLINE_MINUTES * 60 ))
+    if "$WATCHDOG_BIN" "$TEST_PID" "$deadline_seconds" "$ARTIFACT_DIR" \
+        > "$ARTIFACT_DIR/watchdog.stdout" 2> "$ARTIFACT_DIR/watchdog.stderr"; then
+        # Watchdog exited 0 => the wrapped process exited before the deadline.
+        :
+    else
+        hang_detected=1
+    fi
+else
+    # No watchdog binary: fall back to a plain `wait` (no fast-fail guarantee,
+    # but the job's own timeout-minutes still bounds the burn).
+    echo "warning: RapidDesktopTestWatchdogRun not built; running without hang backstop" >&2
+fi
+
+# --- Reap the test process; on hang, kill it so nothing is orphaned ---------
+if [[ $hang_detected -eq 1 ]]; then
+    echo "::error::Desktop test suite exceeded ${DEADLINE_MINUTES} min hard deadline; killing hung process $TEST_PID" >&2
+    kill -9 "$TEST_PID" 2>/dev/null || true
+    # Also kill any swift-testing/xctest children that outlived the kill.
+    pkill -9 -P "$TEST_PID" 2>/dev/null || true
+    # Surface the artifact path the watchdog wrote.
+    if [[ -d "$ARTIFACT_DIR" ]]; then
+        echo "hang sample artifact(s) under: $ARTIFACT_DIR" >&2
+        ls -1 "$ARTIFACT_DIR" >&2 || true
+    fi
+    wait "$TEST_PID" 2>/dev/null || true
+    exit 124   # matches timeout(1)'s kill exit code convention
+fi
+
+# Normal path: propagate the test process's own exit code.
+set +e
+wait "$TEST_PID"
+TEST_EXIT=$?
+set -e
+# Avoid stale hang artifacts confusing the upload step on a healthy run.
+if [[ -d "$ARTIFACT_DIR" && -n "${ARTIFACT_DIR}" && "${ARTIFACT_DIR}" != "/" ]]; then
+    # Keep the dir (CI `if-no-files-found: ignore` needs a stable path) but
+    # clear it so an empty upload shows no false hang.
+    rm -rf -- "${ARTIFACT_DIR:?}"/* 2>/dev/null || true
+fi
+exit "$TEST_EXIT"

--- a/apps/rapid-mac/scripts/desktop-test-timeout.sh
+++ b/apps/rapid-mac/scripts/desktop-test-timeout.sh
@@ -16,7 +16,10 @@
 # The per-run deadline must sit ABOVE the healthy serialized run so a healthy
 # suite never expires (per-suite .timeLimit provides the real 2-minute
 # guarantee); override with RAPID_DESKTOP_DEADLINE_MINUTES if a host runs the
-# suite slower/faster.
+# suite slower/faster. Default 15 min: generously above any healthy serialized
+# run while still 5 min below the job's 20-min timeout AND producing a sample
+# artifact (which a plain job timeout never does). The suite-level .timeLimit
+# is what actually delivers the 2-minute fail-fast for the hang-prone suites.
 #
 # Artifacts are written to RAPID_DESKTOP_HANG_ARTIFACT_DIR (default
 # build/desktop-hang-artifacts, match CI's upload step path if you move it).
@@ -25,7 +28,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-8}"
+DEADLINE_MINUTES="${RAPID_DESKTOP_DEADLINE_MINUTES:-15}"
 ARTIFACT_DIR="${RAPID_DESKTOP_HANG_ARTIFACT_DIR:-"$ROOT/build/desktop-hang-artifacts"}"
 
 # Locate (and if needed build) the watchdog executable BEFORE launching

--- a/scripts/train_gates_parser.py
+++ b/scripts/train_gates_parser.py
@@ -261,16 +261,27 @@ def parse_diff_cover_invocation() -> dict[str, Any]:
 
 
 def parse_swift_test_invocation() -> dict[str, Any]:
-    """Parse the Desktop ``swift test`` invocation from rapid-mac-ci.yml."""
+    """Parse the Desktop ``swift test`` invocation from rapid-mac-ci.yml.
+
+    Since #2488 the hosted Desktop gate wraps ``swift test --no-parallel`` in
+    ``scripts/desktop-test-timeout.sh`` (per-run hang deadline + sample
+    artifact). The authoritative invocation is now that wrapper; the legacy
+    bare ``swift test --no-parallel`` remains accepted so an unpinned checkout
+    (or a pre-#2488 branch) doesn't drift-fail. ``train_gates.sh`` Gate 5 runs
+    the real ``swift test --no-parallel`` itself; this parser's value only
+    feeds the deterministic gates-hash.
+    """
+    desktop_wrapper = "./scripts/desktop-test-timeout.sh"
     parsed = yaml.safe_load(MAC_CI_WORKFLOW.read_text())
     for job in parsed["jobs"].values():
         for step in job.get("steps", []):
             if isinstance(step, dict) and step.get("name") == "swift test":
                 run = step["run"].strip()
-                if run != "swift test --no-parallel":
+                if run not in (desktop_wrapper, "swift test --no-parallel"):
                     raise _drift(
                         f"Desktop swift test drifted: expected "
-                        f"'swift test --no-parallel', found {run!r}"
+                        f"{desktop_wrapper!r} or 'swift test --no-parallel', "
+                        f"found {run!r}"
                     )
                 return {"cmd": run}
     raise _drift("could not find the Desktop 'swift test' step")

--- a/tests/test_train_gates_matches_ci.py
+++ b/tests/test_train_gates_matches_ci.py
@@ -342,9 +342,19 @@ def test_train_gates_refuses_base_equal_to_head() -> None:
 # Desktop swift test (Gate 5)
 # ---------------------------------------------------------------------------
 def test_swift_test_invocation_matches_workflow() -> None:
+    # Since #2488 the hosted Desktop gate wraps `swift test --no-parallel` in
+    # ``scripts/desktop-test-timeout.sh``. The parser must reflect THAT as the
+    # authoritative desktop-test invocation (it feeds the gates-hash).
     parsed = parse_swift_test_invocation()
-    assert parsed == {"cmd": "swift test --no-parallel"}
-    assert "swift test --no-parallel" in MAC_CI
+    assert parsed in (
+        {"cmd": "swift test --no-parallel"},
+        {"cmd": "./scripts/desktop-test-timeout.sh"},
+    )
+    hosted = MAC_CI
+    assert (
+        "swift test --no-parallel" in hosted
+        or "./scripts/desktop-test-timeout.sh" in hosted
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an opt-in persistent memory system following the Open WebUI background-review pattern. After each conversation turn completes, a lightweight reviewer call asks the active local model whether any durable user preference should be saved. Extracted facts persist as a JSON file, inject into the system prompt on the next conversation, and remain user-editable in Settings → Memory.

## Changes

- **MemoryStore** (`MemoryStore.swift`): JSON-persisted entry list with case-insensitive dedup, evidence counting, character-budget pruning (80 entries max, ~2K chars injected), and `<memory_context>` prompt formatting
- **MemoryExtractor** (`MemoryExtractor.swift`): non-streaming reviewer call to the same `v1/chat/completions` endpoint the chat uses, with JSON operation parsing that tolerates markdown fences and prose wrapping
- **SettingsMemoryPanel** (`SettingsMemoryPanel.swift`): enable/disable toggle (off by default), per-entry view/edit/delete, clear-all with confirmation
- **ChatViewModel**: memory context injected into system prompt via `addingInstructionLayers`, background extraction triggered on `isStreaming → false` transition
- **SettingsView**: new "Memory" category (brain icon)

## Design decisions

- Disabled by default — memory is opt-in, not something that silently collects data
- No data leaves the Mac — extraction uses the local model, storage is a local JSON file
- Background extraction uses a regular `Task` (inherits MainActor) so store mutations stay on the main actor; the network call hops off via `URLSession.data`'s async implementation
- Evidence-count-based pruning: frequently corroborated facts survive the 80-entry cap longer than one-off observations
- Character budget (2K) keeps the memory block well under the context window on 4B models

## Testing

- 16 new unit tests in `MemoryStoreTests.swift` covering store CRUD, dedup, persistence round-trip, prune, character budget, transcript filtering, operation parsing, and review prompt shape
- Full suite: **2986 tests, 0 failures**