### PR TITLE
fix(ci): settle transcript before fresh-install baseline

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -890,6 +890,29 @@ wait_identifier() {
     die "timed out waiting for AX identifier $identifier"
 }
 
+settle_transcript_at_bottom() {
+    local destination="$1" press_result="$2"
+    see_main "$destination"
+    if ! jq -e '.data.ui_elements[]?
+                | select(.identifier == "Transcript.JumpToBottom")' \
+        "$destination" >/dev/null; then
+        return
+    fi
+
+    press "$destination" Transcript.JumpToBottom "$press_result" \
+        || die "transcript was not at its tail and Jump to latest was not pressable"
+    for _ in {1..60}; do
+        see_main "$destination"
+        if ! jq -e '.data.ui_elements[]?
+                    | select(.identifier == "Transcript.JumpToBottom")' \
+            "$destination" >/dev/null; then
+            return
+        fi
+        sleep 0.1
+    done
+    die "Jump to latest did not settle the transcript at its tail"
+}
+
 wait_identifier_enabled() {
     local identifier="$1" destination="$2" attempts="${3:-80}"
     for ((i=0; i<attempts; i++)); do
@@ -1807,6 +1830,10 @@ flow_fresh_install() {
     start_model
     send_prompt "Say hello in one short sentence." "post-value-consent"
     wait_identifier TelemetryConsent.PostValueBanner "$OUT/post-value-consent-visible.json"
+    # Streaming completion and scroll anchoring settle independently. Capture
+    # the structural baseline only after the transcript reaches its stable tail.
+    settle_transcript_at_bottom "$OUT/post-value-consent-visible.json" \
+        "$OUT/post-value-consent-jump-press.json"
     assert_tree_text "$OUT/post-value-consent-visible.json" "Hello"
     [[ "$(jq '[.data.ui_elements[]? | select(.identifier == "TelemetryConsent.PostValueBanner")] | length' \
         "$OUT/post-value-consent-visible.json")" == 1 ]] \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -899,18 +899,44 @@ settle_transcript_at_bottom() {
         return
     fi
 
+    local before_value
+    before_value="$(jq -r '[.data.ui_elements[]?
+        | select(.role == "AXScrollBar" and (.value | type) == "number")
+        | .value] | max // empty' "$destination")"
+    [[ -n "$before_value" ]] \
+        || die "transcript exposes no measurable scroll position before Jump to latest"
     press "$destination" Transcript.JumpToBottom "$press_result" \
         || die "transcript was not at its tail and Jump to latest was not pressable"
+    local previous_value="" stable_samples=0
     for _ in {1..60}; do
         see_main "$destination"
-        if ! jq -e '.data.ui_elements[]?
-                    | select(.identifier == "Transcript.JumpToBottom")' \
-            "$destination" >/dev/null; then
-            return
+        local current_value
+        current_value="$(jq -r '[.data.ui_elements[]?
+            | select(.role == "AXScrollBar" and (.value | type) == "number")
+            | .value] | max // empty' "$destination")"
+        if [[ -n "$current_value" ]] \
+            && ! jq -e '.data.ui_elements[]?
+                        | select(.identifier == "Transcript.JumpToBottom")' \
+                "$destination" >/dev/null \
+            && awk -v before="$before_value" -v current="$current_value" \
+                'BEGIN { exit !(current >= 0.99 || current > before + 0.02) }'; then
+            if [[ -n "$previous_value" ]] \
+                && awk -v previous="$previous_value" -v current="$current_value" \
+                    'BEGIN { delta = current - previous; if (delta < 0) delta = -delta; exit !(delta <= 0.001) }'; then
+                stable_samples=$((stable_samples + 1))
+            else
+                stable_samples=1
+            fi
+            if (( stable_samples >= 2 )); then
+                return
+            fi
+        else
+            stable_samples=0
         fi
+        previous_value="$current_value"
         sleep 0.1
     done
-    die "Jump to latest did not settle the transcript at its tail"
+    die "Jump to latest did not physically settle the transcript at its tail"
 }
 
 wait_identifier_enabled() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -939,8 +939,8 @@ settle_transcript_at_bottom() {
             && ! jq -e '.data.ui_elements[]?
                         | select(.identifier == "Transcript.JumpToBottom")' \
                 "$destination" >/dev/null \
-            && awk -v before="$before_value" -v current="$current_value" \
-                'BEGIN { exit !(current >= 0.99 || current > before + 0.02) }'; then
+            && awk -v current="$current_value" \
+                'BEGIN { exit !(current >= 0.99) }'; then
             if [[ -n "$previous_value" ]] \
                 && awk -v previous="$previous_value" -v current="$current_value" \
                     'BEGIN { delta = current - previous; if (delta < 0) delta = -delta; exit !(delta <= 0.001) }'; then

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -924,25 +924,48 @@ settle_transcript_at_bottom() {
         press "$destination" Transcript.JumpToBottom "$press_result" \
             || die "transcript was not at its tail and Jump to latest was not pressable"
     fi
-    local previous_value="" stable_samples=0
+    local previous_tail_key="" stable_samples=0
     for _ in {1..60}; do
         see_main "$destination"
-        local current_value
+        local current_value tail_marker_visible tail_key=""
         current_value="$(jq -r --argjson scroll_x "$scroll_x" '
             [.data.ui_elements[]?
              | select(.role == "AXScrollBar"
                       and (.value | type) == "number"
                       and ((.bounds.x - $scroll_x) | fabs) < 1)
              | .value] | first // empty' "$destination")"
+        # AppKit may remove an overlay scrollbar once a short transcript fits
+        # entirely inside its viewport. In that state, the last assistant
+        # action row being fully visible is stronger physical evidence than a
+        # scrollbar value that no longer exists.
+        tail_marker_visible="$(jq -r '
+            ([.data.ui_elements[]?
+              | select(.role == "AXScrollArea"
+                       and .bounds.x > 200
+                       and .bounds.width > 300
+                       and .bounds.height > 100)]
+             | sort_by(.bounds.width) | last) as $transcript
+            | if $transcript == null then false else
+                ([.data.ui_elements[]?
+                  | select((.identifier // "")
+                           | startswith("ChatView.Message.Retry."))
+                  | select(.bounds.y >= $transcript.bounds.y
+                           and (.bounds.y + .bounds.height)
+                               <= ($transcript.bounds.y + $transcript.bounds.height))]
+                 | length) > 0
+              end' "$destination")"
         if [[ -n "$current_value" ]] \
-            && ! jq -e '.data.ui_elements[]?
-                        | select(.identifier == "Transcript.JumpToBottom")' \
-                "$destination" >/dev/null \
             && awk -v current="$current_value" \
                 'BEGIN { exit !(current >= 0.99) }'; then
-            if [[ -n "$previous_value" ]] \
-                && awk -v previous="$previous_value" -v current="$current_value" \
-                    'BEGIN { delta = current - previous; if (delta < 0) delta = -delta; exit !(delta <= 0.001) }'; then
+            tail_key="$current_value"
+        elif [[ -z "$current_value" && "$tail_marker_visible" == "true" ]]; then
+            tail_key="assistant-tail-visible"
+        fi
+        if [[ -n "$tail_key" ]] \
+            && ! jq -e '.data.ui_elements[]?
+                        | select(.identifier == "Transcript.JumpToBottom")' \
+                "$destination" >/dev/null; then
+            if [[ "$previous_tail_key" == "$tail_key" ]]; then
                 stable_samples=$((stable_samples + 1))
             else
                 stable_samples=1
@@ -953,7 +976,7 @@ settle_transcript_at_bottom() {
         else
             stable_samples=0
         fi
-        previous_value="$current_value"
+        previous_tail_key="$tail_key"
         sleep 0.1
     done
     die "Jump to latest did not physically settle the transcript at its tail"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -899,10 +899,28 @@ settle_transcript_at_bottom() {
         return
     fi
 
-    local before_value
-    before_value="$(jq -r '[.data.ui_elements[]?
-        | select(.role == "AXScrollBar" and (.value | type) == "number")
-        | .value] | max // empty' "$destination")"
+    # The window can expose both sidebar and transcript scrollbars. Correlate
+    # the transcript bar with its overlay button: it is the first vertical bar
+    # to the button's right. Keep that x-coordinate after the button hides.
+    local scroll_x before_value
+    scroll_x="$(jq -r '
+        ([.data.ui_elements[]?
+          | select(.identifier == "Transcript.JumpToBottom")
+          | .bounds.x] | first) as $jump_x
+        | [.data.ui_elements[]?
+           | select(.role == "AXScrollBar"
+                    and (.value | type) == "number"
+                    and .bounds.height > .bounds.width
+                    and .bounds.x > $jump_x)]
+        | sort_by(.bounds.x) | .[0].bounds.x // empty' "$destination")"
+    [[ -n "$scroll_x" ]] \
+        || die "could not identify the transcript scrollbar beside Jump to latest"
+    before_value="$(jq -r --argjson scroll_x "$scroll_x" '
+        [.data.ui_elements[]?
+         | select(.role == "AXScrollBar"
+                  and (.value | type) == "number"
+                  and ((.bounds.x - $scroll_x) | fabs) < 1)
+         | .value] | first // empty' "$destination")"
     [[ -n "$before_value" ]] \
         || die "transcript exposes no measurable scroll position before Jump to latest"
     press "$destination" Transcript.JumpToBottom "$press_result" \
@@ -911,9 +929,12 @@ settle_transcript_at_bottom() {
     for _ in {1..60}; do
         see_main "$destination"
         local current_value
-        current_value="$(jq -r '[.data.ui_elements[]?
-            | select(.role == "AXScrollBar" and (.value | type) == "number")
-            | .value] | max // empty' "$destination")"
+        current_value="$(jq -r --argjson scroll_x "$scroll_x" '
+            [.data.ui_elements[]?
+             | select(.role == "AXScrollBar"
+                      and (.value | type) == "number"
+                      and ((.bounds.x - $scroll_x) | fabs) < 1)
+             | .value] | first // empty' "$destination")"
         if [[ -n "$current_value" ]] \
             && ! jq -e '.data.ui_elements[]?
                         | select(.identifier == "Transcript.JumpToBottom")' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -893,28 +893,23 @@ wait_identifier() {
 settle_transcript_at_bottom() {
     local destination="$1" press_result="$2"
     see_main "$destination"
-    if ! jq -e '.data.ui_elements[]?
-                | select(.identifier == "Transcript.JumpToBottom")' \
-        "$destination" >/dev/null; then
-        return
-    fi
-
     # The window can expose both sidebar and transcript scrollbars. Correlate
-    # the transcript bar with its overlay button: it is the first vertical bar
-    # to the button's right. Keep that x-coordinate after the button hides.
+    # the transcript bar with the compose surface: it is the first vertical
+    # bar to the Send button's right. This anchor remains present after the
+    # Jump-to-latest overlay hides.
     local scroll_x before_value
     scroll_x="$(jq -r '
         ([.data.ui_elements[]?
-          | select(.identifier == "Transcript.JumpToBottom")
-          | .bounds.x] | first) as $jump_x
+          | select(.identifier == "ChatView.SendOrStopButton")
+          | .bounds.x] | first) as $compose_x
         | [.data.ui_elements[]?
            | select(.role == "AXScrollBar"
                     and (.value | type) == "number"
                     and .bounds.height > .bounds.width
-                    and .bounds.x > $jump_x)]
+                    and .bounds.x > $compose_x)]
         | sort_by(.bounds.x) | .[0].bounds.x // empty' "$destination")"
     [[ -n "$scroll_x" ]] \
-        || die "could not identify the transcript scrollbar beside Jump to latest"
+        || die "could not identify the transcript scrollbar beside the compose surface"
     before_value="$(jq -r --argjson scroll_x "$scroll_x" '
         [.data.ui_elements[]?
          | select(.role == "AXScrollBar"
@@ -923,8 +918,12 @@ settle_transcript_at_bottom() {
          | .value] | first // empty' "$destination")"
     [[ -n "$before_value" ]] \
         || die "transcript exposes no measurable scroll position before Jump to latest"
-    press "$destination" Transcript.JumpToBottom "$press_result" \
-        || die "transcript was not at its tail and Jump to latest was not pressable"
+    if jq -e '.data.ui_elements[]?
+              | select(.identifier == "Transcript.JumpToBottom")' \
+        "$destination" >/dev/null; then
+        press "$destination" Transcript.JumpToBottom "$press_result" \
+            || die "transcript was not at its tail and Jump to latest was not pressable"
+    fi
     local previous_value="" stable_samples=0
     for _ in {1..60}; do
         see_main "$destination"

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -22,6 +22,7 @@ import json
 import signal
 import subprocess
 import sys
+import textwrap
 import time
 from pathlib import Path
 
@@ -181,18 +182,71 @@ def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():
 def test_fresh_install_settles_transcript_before_structural_baseline():
     """A transient scroll affordance must not become golden structure."""
     source = HARNESS.read_text()
-    helper = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[0]
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
     fresh_install = source.split("flow_fresh_install() {", 1)[1].split("\n}", 1)[0]
 
     assert 'select(.identifier == "Transcript.JumpToBottom")' in helper
     assert 'press "$destination" Transcript.JumpToBottom "$press_result"' in helper
-    assert "sleep 0.1" in helper
-    assert 'die "Jump to latest did not settle the transcript at its tail"' in helper
+    assert 'select(.role == "AXScrollBar"' in helper
+    assert 'die "Jump to latest did not physically settle' in helper
 
     banner = fresh_install.index("wait_identifier TelemetryConsent.PostValueBanner")
     settle = fresh_install.index("settle_transcript_at_bottom")
     baseline = fresh_install.index("baseline fresh-install.post-value-consent")
     assert banner < settle < baseline
+
+
+def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
+    """A hidden button alone is insufficient while the scroll view is moving."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    fixtures = [
+        (0.25, True),
+        (0.45, False),
+        (0.80, False),
+        (1.00, False),
+        (1.00, False),
+    ]
+    for index, (value, has_button) in enumerate(fixtures):
+        elements = [{"role": "AXScrollBar", "value": value}]
+        if has_button:
+            elements.append({"identifier": "Transcript.JumpToBottom"})
+        (tmp_path / f"fixture-{index}.json").write_text(
+            json.dumps({"data": {"ui_elements": elements}})
+        )
+
+    script = textwrap.dedent(
+        f"""
+        set -u
+        fixture_dir={str(tmp_path)!r}
+        calls=0
+        see_main() {{
+            local destination="$1" index="$calls"
+            (( index > 4 )) && index=4
+            cp "$fixture_dir/fixture-$index.json" "$destination"
+            calls=$((calls + 1))
+        }}
+        press() {{ :; }}
+        die() {{ printf '%s\\n' "$*" >&2; return 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
+        printf '%s\\n' "$calls"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "5"
 
 
 def test_each_fault_fails_with_its_own_message():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -322,6 +322,79 @@ def test_transcript_settler_waits_when_jump_button_is_initially_absent(tmp_path)
     assert completed.stdout.strip() == "3"
 
 
+def test_transcript_settler_accepts_stable_visible_tail_after_scrollbar_hides(tmp_path):
+    """A short reply can fit after Jump and make AppKit remove its overlay bar."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    initial_elements = [
+        {
+            "role": "AXButton",
+            "identifier": "ChatView.SendOrStopButton",
+            "bounds": {"x": 658, "y": 546, "width": 28, "height": 28},
+        },
+        {
+            "role": "AXScrollBar",
+            "value": 0.25,
+            "bounds": {"x": 704, "y": 171, "width": 16, "height": 318},
+        },
+        {"role": "AXButton", "identifier": "Transcript.JumpToBottom"},
+    ]
+    settled_elements = [
+        {
+            "role": "AXButton",
+            "identifier": "ChatView.SendOrStopButton",
+            "bounds": {"x": 658, "y": 546, "width": 28, "height": 28},
+        },
+        {
+            "role": "AXScrollArea",
+            "bounds": {"x": 201, "y": 171, "width": 519, "height": 318},
+        },
+        {
+            "role": "AXButton",
+            "identifier": "ChatView.Message.Retry.00000000-0000-0000-0000-000000000000",
+            "bounds": {"x": 277, "y": 383, "width": 24, "height": 24},
+        },
+    ]
+    for index, elements in enumerate(
+        (initial_elements, settled_elements, settled_elements)
+    ):
+        (fixture_dir / f"fixture-{index}.json").write_text(
+            json.dumps({"data": {"ui_elements": elements}})
+        )
+
+    script = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        fixture_dir={str(fixture_dir)!r}
+        index=0
+        calls=0
+        see_main() {{
+            cp "$fixture_dir/fixture-$index.json" "$1"
+            (( index < 2 )) && index=$((index + 1)) || true
+            calls=$((calls + 1))
+        }}
+        press() {{ :; }}
+        die() {{ printf '%s\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
+        printf '%s\n' "$calls"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "3"
+
+
 def test_transcript_settler_rejects_a_stable_intermediate_position(tmp_path):
     """Progress plus a hidden button is not proof that the tail was reached."""
     source = HARNESS.read_text()

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -190,7 +190,8 @@ def test_fresh_install_settles_transcript_before_structural_baseline():
 
     assert 'select(.identifier == "Transcript.JumpToBottom")' in helper
     assert 'press "$destination" Transcript.JumpToBottom "$press_result"' in helper
-    assert ".bounds.x > $jump_x" in helper
+    assert 'select(.identifier == "ChatView.SendOrStopButton")' in helper
+    assert ".bounds.x > $compose_x" in helper
     assert '--argjson scroll_x "$scroll_x"' in helper
     assert 'die "Jump to latest did not physically settle' in helper
 
@@ -226,6 +227,10 @@ def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
                 "role": "AXScrollBar",
                 "value": value,
                 "bounds": {"x": 704, "width": 17, "height": 320},
+            },
+            {
+                "identifier": "ChatView.SendOrStopButton",
+                "bounds": {"x": 658, "width": 28, "height": 28},
             },
         ]
         if has_button:
@@ -266,6 +271,57 @@ def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
     assert completed.stdout.strip() == "5"
 
 
+def test_transcript_settler_waits_when_jump_button_is_initially_absent(tmp_path):
+    """Pinned state can precede AppKit reaching the physical tail."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    for index, value in enumerate((0.80, 1.00, 1.00)):
+        elements = [
+            {
+                "role": "AXScrollBar",
+                "value": value,
+                "bounds": {"x": 704, "width": 17, "height": 320},
+            },
+            {
+                "identifier": "ChatView.SendOrStopButton",
+                "bounds": {"x": 658, "width": 28, "height": 28},
+            },
+        ]
+        (tmp_path / f"fixture-{index}.json").write_text(
+            json.dumps({"data": {"ui_elements": elements}})
+        )
+
+    script = textwrap.dedent(
+        f"""
+        set -u
+        fixture_dir={str(tmp_path)!r}
+        calls=0
+        see_main() {{
+            local destination="$1" index="$calls"
+            (( index > 2 )) && index=2
+            cp "$fixture_dir/fixture-$index.json" "$destination"
+            calls=$((calls + 1))
+        }}
+        press() {{ printf 'unexpected press\\n' >&2; exit 98; }}
+        die() {{ printf '%s\\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
+        printf '%s\\n' "$calls"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "3"
+
+
 def test_transcript_settler_rejects_a_stable_intermediate_position(tmp_path):
     """Progress plus a hidden button is not proof that the tail was reached."""
     source = HARNESS.read_text()
@@ -281,7 +337,11 @@ def test_transcript_settler_rejects_a_stable_intermediate_position(tmp_path):
                 "role": "AXScrollBar",
                 "value": value,
                 "bounds": {"x": 704, "width": 17, "height": 320},
-            }
+            },
+            {
+                "identifier": "ChatView.SendOrStopButton",
+                "bounds": {"x": 658, "width": 28, "height": 28},
+            },
         ]
         if has_button:
             elements.append(

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -178,6 +178,23 @@ def test_fresh_install_proves_the_telemetry_boundary_with_a_loopback_sink():
     assert "activation_seen_desktop_first_chat_reply" in fresh_install
 
 
+def test_fresh_install_settles_transcript_before_structural_baseline():
+    """A transient scroll affordance must not become golden structure."""
+    source = HARNESS.read_text()
+    helper = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[0]
+    fresh_install = source.split("flow_fresh_install() {", 1)[1].split("\n}", 1)[0]
+
+    assert 'select(.identifier == "Transcript.JumpToBottom")' in helper
+    assert 'press "$destination" Transcript.JumpToBottom "$press_result"' in helper
+    assert 'sleep 0.1' in helper
+    assert 'die "Jump to latest did not settle the transcript at its tail"' in helper
+
+    banner = fresh_install.index("wait_identifier TelemetryConsent.PostValueBanner")
+    settle = fresh_install.index("settle_transcript_at_bottom")
+    baseline = fresh_install.index("baseline fresh-install.post-value-consent")
+    assert banner < settle < baseline
+
+
 def test_each_fault_fails_with_its_own_message():
     source = DRIVER.read_text()
     assert source.count("fail(") >= 4

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -190,7 +190,8 @@ def test_fresh_install_settles_transcript_before_structural_baseline():
 
     assert 'select(.identifier == "Transcript.JumpToBottom")' in helper
     assert 'press "$destination" Transcript.JumpToBottom "$press_result"' in helper
-    assert 'select(.role == "AXScrollBar"' in helper
+    assert ".bounds.x > $jump_x" in helper
+    assert '--argjson scroll_x "$scroll_x"' in helper
     assert 'die "Jump to latest did not physically settle' in helper
 
     banner = fresh_install.index("wait_identifier TelemetryConsent.PostValueBanner")
@@ -215,9 +216,25 @@ def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
         (1.00, False),
     ]
     for index, (value, has_button) in enumerate(fixtures):
-        elements = [{"role": "AXScrollBar", "value": value}]
+        elements = [
+            {
+                "role": "AXScrollBar",
+                "value": 1.0,
+                "bounds": {"x": 180, "width": 17, "height": 320},
+            },
+            {
+                "role": "AXScrollBar",
+                "value": value,
+                "bounds": {"x": 704, "width": 17, "height": 320},
+            },
+        ]
         if has_button:
-            elements.append({"identifier": "Transcript.JumpToBottom"})
+            elements.append(
+                {
+                    "identifier": "Transcript.JumpToBottom",
+                    "bounds": {"x": 444.5, "width": 33, "height": 33},
+                }
+            )
         (tmp_path / f"fixture-{index}.json").write_text(
             json.dumps({"data": {"ui_elements": elements}})
         )

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -186,7 +186,7 @@ def test_fresh_install_settles_transcript_before_structural_baseline():
 
     assert 'select(.identifier == "Transcript.JumpToBottom")' in helper
     assert 'press "$destination" Transcript.JumpToBottom "$press_result"' in helper
-    assert 'sleep 0.1' in helper
+    assert "sleep 0.1" in helper
     assert 'die "Jump to latest did not settle the transcript at its tail"' in helper
 
     banner = fresh_install.index("wait_identifier TelemetryConsent.PostValueBanner")

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -251,7 +251,7 @@ def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
             calls=$((calls + 1))
         }}
         press() {{ :; }}
-        die() {{ printf '%s\\n' "$*" >&2; return 97; }}
+        die() {{ printf '%s\\n' "$*" >&2; exit 97; }}
         sleep() {{ :; }}
         {helper}
         settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
@@ -264,6 +264,60 @@ def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):
 
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == "5"
+
+
+def test_transcript_settler_rejects_a_stable_intermediate_position(tmp_path):
+    """Progress plus a hidden button is not proof that the tail was reached."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    fixtures = [(0.25, True), (0.45, False)]
+    for index, (value, has_button) in enumerate(fixtures):
+        elements = [
+            {
+                "role": "AXScrollBar",
+                "value": value,
+                "bounds": {"x": 704, "width": 17, "height": 320},
+            }
+        ]
+        if has_button:
+            elements.append(
+                {
+                    "identifier": "Transcript.JumpToBottom",
+                    "bounds": {"x": 444.5, "width": 33, "height": 33},
+                }
+            )
+        (tmp_path / f"fixture-{index}.json").write_text(
+            json.dumps({"data": {"ui_elements": elements}})
+        )
+
+    script = textwrap.dedent(
+        f"""
+        set -u
+        fixture_dir={str(tmp_path)!r}
+        calls=0
+        see_main() {{
+            local destination="$1" index="$calls"
+            (( index > 1 )) && index=1
+            cp "$fixture_dir/fixture-$index.json" "$destination"
+            calls=$((calls + 1))
+        }}
+        press() {{ :; }}
+        die() {{ printf '%s\\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 97
+    assert "did not physically settle" in completed.stderr
 
 
 def test_each_fault_fails_with_its_own_message():


### PR DESCRIPTION
## Why

The `fresh-install.post-value-consent` golden flow currently captures its structural baseline as soon as the consent banner appears. Streaming completion and transcript scroll anchoring settle independently, so a transient `Transcript.JumpToBottom` button can still be present. This reproduces on the current `main` push and caused the isolated #2812 merge candidate to fail even though the PR did not introduce that UI state.

## What changed

- settle the transcript at its stable tail before capturing the fresh-install structural baseline
- press the existing Jump to latest control only when it is present, then require it to disappear within a bounded interval
- add a static contract that preserves the required ordering: banner visible → transcript settled → baseline captured

The golden baseline is deliberately unchanged: the transient control is not part of the intended settled UI.

## Design precedent

GUI snapshot gates should converge observable asynchronous state before comparison rather than teach the baseline to accept transient structure. The helper reuses the same user-visible control and bounded convergence check already exercised by the message-actions flow.

## Verification

- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `pytest -q tests/test_gui_preflight_contract.py tests/test_gui_golden_ci_coverage.py tests/test_gui_control_behavior_contract.py` (58 passed)
- `git diff --check`
