### PR TITLE
docs: refresh recent large-model benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,35 @@ Also compatible with OpenAI-compatible clients that allow direct local endpoints
 
 ---
 
+## Latest Large-Model Benchmarks
+
+Single-request (`B=1`) serving on a 256 GB M3 Ultra, with one 4-bit model
+resident. Each row is the median of three measured runs after model warmup.
+These are local serving measurements, not model quality scores. The two 8K
+rows share the same 8,156 → 256 token workload; GLM uses the longer
+47 → 512 decode workload shown in the table.
+
+| Model | Shape | Workload | Median TTFT | Prefill | Decode | MLX active memory |
+|---|---|---:|---:|---:|---:|---:|
+| `qwen3.8-27b-4bit` | 27B dense | 8,156 → 256 | 24.25s | 336 tok/s | **37.4 tok/s** | 17.6 GB |
+| `qwen3.8-flash-next-4bit` | 180B total / 6B active¹ | 8,156 → 256 | **9.24s** | **883 tok/s** | 23.4 tok/s AR; **32.2 tok/s MTP K=1**² | 103–107.5 GB² |
+| `glm5.3-flash-4bit` | 320B total / 18B active | 47 → 512 | —³ | —³ | **29.2 tok/s** | 165.4 GB |
+
+¹ Flash-Next comprises a 125B language model, 51B n-gram embedding, and 4B
+MTP head. ² MTP is an explicit opt-in, measured on a separate same-box run;
+ordinary autoregressive decode remains the default. ³ The GLM qualification
+run captured sustained decode and memory, not TTFT/prefill.
+
+Flash-Next's optimized prefill reaches 266 / 889 / 883 / 733 tok/s at
+128 / 2K / 8K / 32K prompts; median TTFT is 0.35 / 2.26 / 9.24 / 44.66s.
+Its 99 GB quantized weights make **192 GB the practical recommended tier**;
+128 GB is tight and was not physically tested. GLM-5.3-Flash also requires the
+192 GB tier. Qwen3.8-27B remains the 32 GB recommendation.
+
+→ [Environment, exact methods, full context curves, and qualification notes](docs/benchmarks/recent-large-models-m3-ultra.md)
+
+---
+
 ## Choose Your Model
 
 The installer and desktop app use the same RAM-tier recommendation catalog. Run `rapid-mlx recipe` to see its Smart and Fast picks for this Mac (`--max-ram 32` simulates another tier; `--json` is machine-readable). If you want to shop the full catalog: `rapid-mlx models` lists every alias, `rapid-mlx info <alias>` shows the per-alias profile (parser, MoE / hybrid flags, KV codec eligibility, speculative-decoding gates).
@@ -298,9 +327,10 @@ scores 52 on the Artificial Analysis Intelligence Index (2026-08-18) —
 GPT-5.6-class, the highest of any open-weights model we serve, ahead of the
 much larger 122B (33) and 35B (32) it replaces (the index scores the
 full-precision release; our 4-bit build's deltas are unmeasured — the
-standing caveat for every quantized pick here). Multi-token prediction is on by
-default (~40 tok/s decode, 8K prefill at ~324 tok/s, zero swap at every tier
-budget).
+standing caveat for every quantized pick here). On the measured 8K workload it
+prefills at 336 tok/s and decodes at 37.4 tok/s, with zero new swap. Its MTP
+sidecar is available only by explicit speculative-decoding opt-in; the table
+above reports ordinary decode for the default path.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
 → [Every alias, quant, and family (170 text + 2 text-diffusion + 2 image + 8 video + 44 audio aliases, 226 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -5,6 +5,12 @@ Performance benchmarks for rapid-mlx on Apple Silicon.
 ## Benchmark Types
 
 - [LLM Benchmarks](llm.md) - Text generation performance
+- [Recent large models on M3 Ultra](recent-large-models-m3-ultra.md) - Qwen3.8
+  27B, Qwen3.8 Flash-Next, and GLM-5.3-Flash
+- [Qwen3.8 Flash-Next on M3 Ultra](qwen38-flash-next-m3-ultra.md) -
+  correctness, context curves, and QSA prefill follow-ups
+- [Qwen3.8 Flash-Next native MTP](qwen38-flash-next-mtp-m3-ultra.md) -
+  opt-in decode acceleration and correctness qualification
 - [Image Benchmarks](image.md) - Image understanding performance
 - [Video Benchmarks](video.md) - Video understanding performance
 

--- a/docs/benchmarks/recent-large-models-m3-ultra.md
+++ b/docs/benchmarks/recent-large-models-m3-ultra.md
@@ -127,11 +127,24 @@ The target process reported 165.4 GB MLX active memory and approximately
 This short-prompt qualification did not capture TTFT or prefill, so the README
 leaves those cells blank instead of deriving them from wall time.
 
-The serving shape can be reproduced after the GLM support change is present:
+Resolve the exact measured checkpoint revision first, then serve that immutable
+local snapshot. This avoids accidentally benchmarking a newer cached revision:
 
 ```bash
+MODEL_DIR="$(
+  python - <<'PY'
+from huggingface_hub import snapshot_download
+
+print(snapshot_download(
+    repo_id="Vontra/GLM-5.3-Flash-MLX-4bit-MTP",
+    revision="06d6c7530e8290e20fabdc37a825ce07bdfc490c",
+))
+PY
+)"
+
 HF_HUB_OFFLINE=1 rapid-mlx serve \
-  glm5.3-flash-4bit --host 127.0.0.1 --port 8465 --no-thinking
+  "$MODEL_DIR" --served-model-name glm5.3-flash-4bit \
+  --host 127.0.0.1 --port 8465 --no-thinking
 ```
 
 In another shell, send one discarded warmup followed by three identical

--- a/docs/benchmarks/recent-large-models-m3-ultra.md
+++ b/docs/benchmarks/recent-large-models-m3-ultra.md
@@ -1,0 +1,147 @@
+# Recent large models on M3 Ultra
+
+This note is the evidence behind the concise large-model table in the project
+README. It brings the latest measured Qwen3.8-27B, Qwen3.8-Flash-Next, and
+GLM-5.3-Flash serving results together without pretending that unlike
+workloads are directly comparable.
+
+## Environment
+
+| Component | Value |
+| --- | --- |
+| Machine | Mac Studio (`Mac15,14`) |
+| Chip | Apple M3 Ultra, 28 CPU cores |
+| Unified memory | 256 GB |
+| macOS | 26.5.2 (25F84) |
+| Architecture | arm64 |
+| Serving shape | Batch size 1; one model resident |
+| Quantization | The Rapid-MLX 4-bit alias named in each row |
+
+All rates are medians of three measured requests after model warmup. TTFT is
+measured to the first visible streamed token. Prefill is server-reported
+prompt tokens divided by TTFT. Decode excludes TTFT. MLX active memory is
+allocator-active unified memory, not process RSS; RSS materially undercounts
+Metal allocations.
+
+The Qwen context curves use temperature zero, thinking disabled, a cold prefix
+cache for every request, and 256 requested decode tokens. The harness targets
+128, 2,048, 8,192, and 32,768 prompt tokens; after applying the chat template,
+the server reports 92, 2,012, 8,156, and 32,732 tokens.
+
+## At a glance
+
+| Model | Model shape | Measured workload | Median TTFT | Median prefill | Median decode | Maximum MLX active memory for row |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `qwen3.8-27b-4bit` | 27B dense | 8,156 → 256 | 24.246s | 336.4 tok/s | 37.38 tok/s | 17.6 GB |
+| `qwen3.8-flash-next-4bit` | 180B total / 6B active | 8,156 → 256 | 9.236s | 883.1 tok/s | 23.40 tok/s | about 103.4 GB |
+| `qwen3.8-flash-next-4bit`, fixed MTP K=1 | Same checkpoint and target model | 8,156 → 256 | 14.581s | 559.4 tok/s | 32.20 tok/s | 107.2–107.5 GB |
+| `glm5.3-flash-4bit` | 320B total / 18B active | 47 → 512 | Not captured | Not captured | 29.20 tok/s | 165.4 GB |
+
+The Flash-Next parameter total is 125B language-model parameters plus a 51B
+n-gram embedding and 4B MTP head; 6B language-model parameters are active per
+token. The GLM shape is 320B total and 18B active. Those figures describe the
+upstream architectures; throughput and memory in this document are Rapid-MLX
+measurements. See the official model cards for the
+[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B),
+[Qwen3.8-Flash-Next](https://huggingface.co/Qwen/Qwen3.8-Flash-Next), and
+[GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash) architecture
+descriptions.
+
+The Flash-Next MTP row is a separate same-machine, same-checkpoint experiment
+on the optimized sparse-mask engine. It is not paired with the later batched
+compressed-key prefill result. MTP is an explicit opt-in and ordinary
+autoregressive decode remains the default.
+
+## Qwen3.8-27B context curve
+
+Artifact: `rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX` at
+`aa985c29ff5b334cbfdcbbc787d47e66e9d9e456`. The reference server used the
+Rapid-MLX 0.13.1 release commit `819db66767ac7e16722315122600d0855a6981c8`
+with speculative decoding off.
+
+| Target (reported) prompt tokens | Median TTFT | Median prefill | Median decode | MLX active memory |
+| ---: | ---: | ---: | ---: | ---: |
+| 128 (92) | 0.429s | 214.6 tok/s | 40.29 tok/s | 15.6 GB |
+| 2,048 (2,012) | 5.904s | 340.8 tok/s | 39.50 tok/s | 16.0 GB |
+| 8,192 (8,156) | 24.246s | 336.4 tok/s | 37.38 tok/s | 17.6 GB |
+| 32,768 (32,732) | 107.244s | 305.2 tok/s | 32.58 tok/s | 24.1 GB |
+
+The model-recommendation qualification used the same M3 Ultra and measured a
+20.0 GB peak for the complete server process tree at roughly 8K, with zero new
+swap. That is intentionally a different memory boundary from MLX allocator
+active memory.
+
+## Qwen3.8-Flash-Next context curve
+
+Artifact: `rapid-mlx/Qwen3.8-Flash-Next-4bit` at
+`dcf657e4acda2aae72da99cde65b6c491cd96998`. The rows below are the final
+batched compressed-key result delivered in Rapid-MLX 0.13.2. They retain the
+same checkpoint, prompts, cache-clear procedure, and three-run methodology as
+the release baseline.
+
+| Target (reported) prompt tokens | Median TTFT | Median prefill | Median decode |
+| ---: | ---: | ---: | ---: |
+| 128 (92) | 0.346s | 266.3 tok/s | 25.67 tok/s |
+| 2,048 (2,012) | 2.262s | 889.4 tok/s | 24.27 tok/s |
+| 8,192 (8,156) | 9.236s | 883.1 tok/s | 23.40 tok/s |
+| 32,768 (32,732) | 44.659s | 732.9 tok/s | 21.72 tok/s |
+
+MLX active memory remained approximately 102.8–103.8 GB. The process also
+reported a 148.1 GB allocator peak inherited from model loading; it is not the
+steady active footprint.
+
+The separate fixed-K=1 MTP qualification measured decode at 34.85, 33.53,
+32.20, and 28.82 tok/s at the same four prompt lengths: a 36–42% improvement
+over its exact-run ordinary-decode baseline. All 45 functional outcomes
+matched ordinary decode, with a 76.41% aggregate proposal acceptance ratio.
+MTP added as much as 6.6 GB of active memory and increased 2K–32K TTFT by
+5–8%, so it remains an explicit workload-dependent choice.
+
+The model's quantized weights occupy about 99 GB before cache and allocator
+headroom. A 192 GB Mac is the practical recommended tier. A 128 GB Mac is
+tight and was not physically tested.
+
+Full Flash-Next methodology and correctness evidence:
+
+- [ordinary decode and QSA prefill](qwen38-flash-next-m3-ultra.md)
+- [native MTP qualification](qwen38-flash-next-mtp-m3-ultra.md)
+
+## GLM-5.3-Flash qualification row
+
+Artifact: `Vontra/GLM-5.3-Flash-MLX-4bit-MTP` at
+`06d6c7530e8290e20fabdc37a825ce07bdfc490c`. Rapid-MLX implementation:
+`9e55e4b735b791127b2cc34e9384f84ebaf78aad`.
+
+The server ran with thinking and speculative decoding disabled and temperature
+zero. After warmup, three 512-token requests decoded at 26.11, 29.20, and
+30.70 tok/s; the median is 29.20 tok/s. The prompt was 47 server-reported
+tokens:
+
+> You are a senior software engineer writing a blog post. Explain the
+> difference between threads and processes in operating systems, covering
+> address space, scheduling, context switch cost, IPC, and a worked example of
+> when each is appropriate. Be concrete and specific.
+
+The target process reported 165.4 GB MLX active memory and approximately
+167.9 GB peak during the run. The alias therefore has a 192 GB memory floor.
+This short-prompt qualification did not capture TTFT or prefill, so the README
+leaves those cells blank instead of deriving them from wall time.
+
+The serving shape can be reproduced after the GLM support change is present:
+
+```bash
+HF_HUB_OFFLINE=1 rapid-mlx serve \
+  glm5.3-flash-4bit --host 127.0.0.1 --port 8465 --no-thinking
+```
+
+Send one discarded warmup followed by three identical OpenAI chat-completion
+requests with `temperature=0` and `max_tokens=512`, reading the per-request
+generation rate and Metal memory fields from the server status surface. Do not
+run another model server concurrently.
+
+The checkpoint contains a native MTP head, but the qualification experiment
+did not produce a speedup: 32.00 tok/s ordinary decode versus 31.65 tok/s with
+MTP for the sustained 512-token comparison, despite 72.97% acceptance and
+5.71 GB additional active memory. GLM MTP is therefore disabled for this
+alias; neither that no-go result nor an unqualified acceleration mode is used
+in the README headline.

--- a/docs/benchmarks/recent-large-models-m3-ultra.md
+++ b/docs/benchmarks/recent-large-models-m3-ultra.md
@@ -134,9 +134,39 @@ HF_HUB_OFFLINE=1 rapid-mlx serve \
   glm5.3-flash-4bit --host 127.0.0.1 --port 8465 --no-thinking
 ```
 
-Send one discarded warmup followed by three identical OpenAI chat-completion
-requests with `temperature=0` and `max_tokens=512`, reading the per-request
-generation rate and Metal memory fields from the server status surface. Do not
+In another shell, send one discarded warmup followed by three identical
+requests. This is the exact payload shape; set `run=warmup` for the discarded
+request and then repeat it with `run=1`, `run=2`, and `run=3` so the output can
+be archived separately:
+
+```bash
+PROMPT='You are a senior software engineer writing a blog post. Explain the difference between threads and processes in operating systems, covering address space, scheduling, context switch cost, IPC, and a worked example of when each is appropriate. Be concrete and specific.'
+run=warmup
+
+jq -nc --arg prompt "$PROMPT" '{
+  model: "glm5.3-flash-4bit",
+  messages: [{role: "user", content: $prompt}],
+  temperature: 0,
+  max_tokens: 512,
+  enable_thinking: false,
+  stream: true,
+  stream_options: {include_usage: true}
+}' | curl --no-buffer --silent --show-error \
+  http://127.0.0.1:8465/v1/chat/completions \
+  -H 'Content-Type: application/json' --data-binary @- \
+  | tee "glm53-${run}.sse"
+
+curl --silent http://127.0.0.1:8465/v1/status | jq '{
+  generation_tps,
+  prompt_tps,
+  active_memory_gb: .metal.active_memory_gb,
+  peak_memory_gb: .metal.peak_memory_gb
+}'
+```
+
+The streamed final usage event supplies the prompt and completion token
+counts. `/v1/status` supplies `generation_tps`, `prompt_tps`, and the
+`metal.active_memory_gb` / `metal.peak_memory_gb` allocator readings. Do not
 run another model server concurrently.
 
 The checkpoint contains a native MTP head, but the qualification experiment

--- a/docs/benchmarks/recent-large-models-m3-ultra.md
+++ b/docs/benchmarks/recent-large-models-m3-ultra.md
@@ -110,7 +110,7 @@ Full Flash-Next methodology and correctness evidence:
 
 Artifact: `Vontra/GLM-5.3-Flash-MLX-4bit-MTP` at
 `06d6c7530e8290e20fabdc37a825ce07bdfc490c`. Rapid-MLX implementation:
-`9e55e4b735b791127b2cc34e9384f84ebaf78aad`.
+`4acffa71df832eb7865e5c76e1ce8295bd6f074b`.
 
 The server ran with thinking and speculative decoding disabled and temperature
 zero. After warmup, three 512-token requests decoded at 26.11, 29.20, and


### PR DESCRIPTION
## Summary

- add a prominent, reproducible M3 Ultra benchmark table for Qwen3.8-27B, Qwen3.8-Flash-Next, and GLM-5.3-Flash
- publish the full Qwen context curves, Flash-Next MTP qualification, GLM sustained-decode evidence, and unified-memory boundaries in one detailed benchmark note
- correct the stale README claim that Qwen3.8-27B MTP is default-on; the headline now reports the ordinary default path and labels MTP opt-in results separately
- index the existing Flash-Next correctness/performance reports from the benchmark landing page

## Dependency

Depends on #2792 for the `glm5.3-flash-4bit` alias. This PR must not enter the merge queue until that support PR lands and this branch is rebased onto its merge commit.

## Design precedent

The presentation follows the established benchmark-report pattern: headline rows remain compact, exact environment and method live in a durable evidence note, unlike workloads are explicitly separated, acceleration modes are identified as separate runs, and unified-memory sizing uses MLX active memory rather than process RSS.

## User verification

Read the README as a new M3 Ultra owner choosing among the three current large-model families. The table identifies the default path, explicit MTP option, prompt/output shape, memory requirement, and the missing GLM TTFT measurement without implying an apples-to-apples result that was not run. Every local Markdown target resolves.

## Verification

- `python3.12 -m pytest -q tests/test_branding.py tests/test_ram_tier_recommendations_agree.py` — 23 passed
- local Markdown target check — passed
- `git diff --check` — passed

No model was loaded for this docs-only change; the numbers are reconciled from the checked-in benchmark evidence and the exact-head GLM qualification.
