### PR TITLE
fix(ci): follow model memory confirmations in GUI flows

### DIFF
--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -4,6 +4,26 @@ import XCTest
 
 @MainActor
 final class ImageGenerationPixelTests: XCTestCase {
+    func testMemoryConfirmationRetriesAreSpacedBoundedAndRearmed() {
+        var policy = MemoryConfirmationRetryPolicy()
+
+        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
+            XCTAssertFalse(policy.shouldClick(isVisible: true))
+        }
+        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
+            XCTAssertFalse(policy.shouldClick(isVisible: true))
+        }
+        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        for _ in 0..<(MemoryConfirmationRetryPolicy.retryPollInterval * 2) {
+            XCTAssertFalse(policy.shouldClick(isVisible: true))
+        }
+
+        XCTAssertFalse(policy.shouldClick(isVisible: false))
+        XCTAssertTrue(policy.shouldClick(isVisible: true))
+    }
+
     func testTwoImageRendersDrawDistinctThumbnailPixels() throws {
         continueAfterFailure = false
         let testHome = FileManager.default.temporaryDirectory
@@ -71,10 +91,17 @@ final class ImageGenerationPixelTests: XCTestCase {
         let readiness = element("Readiness.Action", in: app)
         XCTAssertTrue(readiness.waitForExistence(timeout: 20))
         readiness.click()
+        let memoryConfirmation = element("MemoryWarning.Confirm", in: app)
+        var memoryConfirmationPolicy = MemoryConfirmationRetryPolicy()
         XCTAssertTrue(waitUntil(timeout: 30) {
-            guard let events = try? String(contentsOf: eventLog, encoding: .utf8) else { return false }
-            return events.contains(#""event": "server_started""#)
+            let serverStarted = {
+                guard let events = try? String(contentsOf: eventLog, encoding: .utf8) else { return false }
+                return events.contains(#""event": "server_started""#)
                 && events.contains(#""alias": "fake-image-alias""#)
+            }
+            if serverStarted() { return true }
+            memoryConfirmationPolicy.follow(memoryConfirmation)
+            return serverStarted()
         })
 
         let prompt = element("Images.Prompt", in: app)

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -7,22 +7,23 @@ final class ImageGenerationPixelTests: XCTestCase {
     func testMemoryConfirmationRetriesAreSpacedBoundedAndRearmed() {
         var policy = MemoryConfirmationRetryPolicy()
 
-        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
+        XCTAssertTrue(policy.shouldClick(signature: "load", isEnabled: true))
         for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
-            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
+            XCTAssertFalse(policy.shouldClick(signature: "load", isEnabled: true))
         }
-        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
+        XCTAssertTrue(policy.shouldClick(signature: "load", isEnabled: true))
         for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
-            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
+            XCTAssertFalse(policy.shouldClick(signature: "load", isEnabled: true))
         }
-        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
+        XCTAssertTrue(policy.shouldClick(signature: "load", isEnabled: true))
         for _ in 0..<(MemoryConfirmationRetryPolicy.retryPollInterval * 2) {
-            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: false))
-            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
+            XCTAssertFalse(policy.shouldClick(signature: "load", isEnabled: false))
+            XCTAssertFalse(policy.shouldClick(signature: "load", isEnabled: true))
         }
 
-        XCTAssertFalse(policy.shouldClick(isPresent: false, isEnabled: false))
-        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
+        XCTAssertTrue(policy.shouldClick(signature: "load-anyway", isEnabled: true))
+        XCTAssertFalse(policy.shouldClick(signature: nil, isEnabled: false))
+        XCTAssertTrue(policy.shouldClick(signature: "load-anyway", isEnabled: true))
     }
 
     func testTwoImageRendersDrawDistinctThumbnailPixels() throws {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -7,21 +7,22 @@ final class ImageGenerationPixelTests: XCTestCase {
     func testMemoryConfirmationRetriesAreSpacedBoundedAndRearmed() {
         var policy = MemoryConfirmationRetryPolicy()
 
-        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
         for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
-            XCTAssertFalse(policy.shouldClick(isVisible: true))
+            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
         }
-        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
         for _ in 1..<MemoryConfirmationRetryPolicy.retryPollInterval {
-            XCTAssertFalse(policy.shouldClick(isVisible: true))
+            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
         }
-        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
         for _ in 0..<(MemoryConfirmationRetryPolicy.retryPollInterval * 2) {
-            XCTAssertFalse(policy.shouldClick(isVisible: true))
+            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: false))
+            XCTAssertFalse(policy.shouldClick(isPresent: true, isEnabled: true))
         }
 
-        XCTAssertFalse(policy.shouldClick(isVisible: false))
-        XCTAssertTrue(policy.shouldClick(isVisible: true))
+        XCTAssertFalse(policy.shouldClick(isPresent: false, isEnabled: false))
+        XCTAssertTrue(policy.shouldClick(isPresent: true, isEnabled: true))
     }
 
     func testTwoImageRendersDrawDistinctThumbnailPixels() throws {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -2,6 +2,42 @@ import AppKit
 import Darwin
 import XCTest
 
+/// Bounded edge follower for the production memory confirmation presented to
+/// native GUI tests on a busy hosted Mac. A posted click is not proof SwiftUI
+/// consumed it, so an unchanged presentation gets spaced retries. The cap
+/// prevents a stuck alert from being hammered for the whole readiness timeout.
+struct MemoryConfirmationRetryPolicy {
+    static let maximumAttempts = 3
+    static let retryPollInterval = 10
+
+    private(set) var attempts = 0
+    private var pollsSinceAttempt = 0
+
+    mutating func shouldClick(isVisible: Bool) -> Bool {
+        guard isVisible else {
+            attempts = 0
+            pollsSinceAttempt = 0
+            return false
+        }
+        pollsSinceAttempt += 1
+        guard attempts < Self.maximumAttempts,
+              attempts == 0 || pollsSinceAttempt >= Self.retryPollInterval else {
+            return false
+        }
+        attempts += 1
+        pollsSinceAttempt = 0
+        return true
+    }
+
+    @MainActor
+    mutating func follow(_ confirmation: XCUIElement) {
+        let isVisible = confirmation.exists && confirmation.isEnabled
+        if shouldClick(isVisible: isVisible) {
+            confirmation.click()
+        }
+    }
+}
+
 @MainActor
 final class RapidUITestHarness {
     let app: XCUIApplication
@@ -139,14 +175,10 @@ final class RapidUITestHarness {
         releasePortReservation()
         readiness.click()
         let memoryConfirmation = element("MemoryWarning.Confirm")
-        var confirmedMemoryWarning = false
+        var memoryConfirmationPolicy = MemoryConfirmationRetryPolicy()
         XCTAssertTrue(waitUntil(timeout: 60) {
-            if !confirmedMemoryWarning,
-               memoryConfirmation.exists,
-               memoryConfirmation.isEnabled {
-                memoryConfirmation.click()
-                confirmedMemoryWarning = true
-            }
+            if self.serverStartCount() > priorServerStartCount { return true }
+            memoryConfirmationPolicy.follow(memoryConfirmation)
             return self.serverStartCount() > priorServerStartCount
         })
     }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -13,14 +13,15 @@ struct MemoryConfirmationRetryPolicy {
     private(set) var attempts = 0
     private var pollsSinceAttempt = 0
 
-    mutating func shouldClick(isVisible: Bool) -> Bool {
-        guard isVisible else {
+    mutating func shouldClick(isPresent: Bool, isEnabled: Bool) -> Bool {
+        guard isPresent else {
             attempts = 0
             pollsSinceAttempt = 0
             return false
         }
         pollsSinceAttempt += 1
-        guard attempts < Self.maximumAttempts,
+        guard isEnabled,
+              attempts < Self.maximumAttempts,
               attempts == 0 || pollsSinceAttempt >= Self.retryPollInterval else {
             return false
         }
@@ -31,8 +32,11 @@ struct MemoryConfirmationRetryPolicy {
 
     @MainActor
     mutating func follow(_ confirmation: XCUIElement) {
-        let isVisible = confirmation.exists && confirmation.isEnabled
-        if shouldClick(isVisible: isVisible) {
+        let isPresent = confirmation.exists
+        if shouldClick(
+            isPresent: isPresent,
+            isEnabled: isPresent && confirmation.isEnabled
+        ) {
             confirmation.click()
         }
     }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -12,12 +12,19 @@ struct MemoryConfirmationRetryPolicy {
 
     private(set) var attempts = 0
     private var pollsSinceAttempt = 0
+    private var presentationSignature: String?
 
-    mutating func shouldClick(isPresent: Bool, isEnabled: Bool) -> Bool {
-        guard isPresent else {
+    mutating func shouldClick(signature: String?, isEnabled: Bool) -> Bool {
+        guard let signature else {
             attempts = 0
             pollsSinceAttempt = 0
+            presentationSignature = nil
             return false
+        }
+        if signature != presentationSignature {
+            attempts = 0
+            pollsSinceAttempt = 0
+            presentationSignature = signature
         }
         pollsSinceAttempt += 1
         guard isEnabled,
@@ -33,8 +40,15 @@ struct MemoryConfirmationRetryPolicy {
     @MainActor
     mutating func follow(_ confirmation: XCUIElement) {
         let isPresent = confirmation.exists
+        let signature = isPresent
+            ? [
+                confirmation.identifier,
+                confirmation.label,
+                String(describing: confirmation.value),
+            ].joined(separator: "\u{1F}")
+            : nil
         if shouldClick(
-            isPresent: isPresent,
+            signature: signature,
             isEnabled: isPresent && confirmation.isEnabled
         ) {
             confirmation.click()

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1491,15 +1491,21 @@ follow_memory_confirmation_edge() {
         # click-center proves that mouse events were posted, not that SwiftUI
         # consumed them. Retry a still-identical presentation after one second,
         # but cap attempts so a stuck alert cannot be hammered every poll.
+        # Product-side confirmPendingMemoryLoad claims the warning synchronously
+        # before async revalidation, so a repeated delivery while it is checking
+        # cannot enqueue a duplicate launch.
         if [[ -n "$signature" \
               && "$MEMORY_CONFIRMATION_ATTEMPTS" -lt 3 \
               && ( "$MEMORY_CONFIRMATION_ATTEMPTS" == 0 \
-                   || "$MEMORY_CONFIRMATION_POLLS" -ge 4 ) ]] \
-            && confirm_memory_warning_from_tree "$tree" "$evidence" "$identifier"; then
+                   || "$MEMORY_CONFIRMATION_POLLS" -ge 4 ) ]]; then
+            # Consume the budget before posting the click. Driver failures must
+            # be spaced and capped just like successfully posted mouse events.
             MEMORY_CONFIRMATION_SIGNATURE="$signature"
             MEMORY_CONFIRMATION_POLLS=0
             MEMORY_CONFIRMATION_ATTEMPTS=$((MEMORY_CONFIRMATION_ATTEMPTS + 1))
-            MEMORY_CONFIRMATION_CLICKED=1
+            if confirm_memory_warning_from_tree "$tree" "$evidence" "$identifier"; then
+                MEMORY_CONFIRMATION_CLICKED=1
+            fi
         fi
     else
         MEMORY_CONFIRMATION_SIGNATURE=""

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1437,25 +1437,56 @@ press() {
 # that real confirmation branch before it can use a wire event or readiness
 # state as its independent proof.  Keep the action generic because Quickstart
 # presents its warning inside onboarding with a different AX identifier.
+memory_confirmation_enabled() {
+    local tree="$1" identifier="$2"
+    jq -e --arg id "$identifier" \
+       '.data.ui_elements[]?
+        | select(.identifier == $id and .enabled == true)' \
+       "$tree" >/dev/null
+}
+
+memory_confirmation_signature() {
+    local tree="$1" identifier="$2"
+    jq -cS --arg id "$identifier" \
+       '.data.ui_elements[]?
+        | select(.identifier == $id and .enabled == true)
+        | {identifier, label, title, value, description, help}' \
+       "$tree" | head -1
+}
+
 confirm_memory_warning_from_tree() {
-    local tree="$1" evidence="$2"
-    shift 2
-    local identifiers=("$@") identifier
-    if [[ "${#identifiers[@]}" == 0 ]]; then
-        identifiers=(MemoryWarning.Confirm)
-    fi
-    for identifier in "${identifiers[@]}"; do
-        if jq -e --arg id "$identifier" \
-               '.data.ui_elements[]?
-                | select(.identifier == $id and .enabled == true)' \
-               "$tree" >/dev/null; then
-            "$AX_DRIVER" click-center "$APP_PID" "$identifier" > "$evidence" \
-                || die "$identifier was visible but could not be confirmed"
-            log "  confirmed hosted-runner memory warning through $identifier"
-            return 0
+    local tree="$1" evidence="$2" identifier="$3"
+    memory_confirmation_enabled "$tree" "$identifier" || return 1
+    # The live AX tree can change between observation and click while the
+    # app revalidates memory. Treat that as a retryable transition, not a
+    # product failure; the next poll will inspect the new tree.
+    "$AX_DRIVER" click-center "$APP_PID" "$identifier" > "$evidence" \
+        || return 1
+    log "  confirmed hosted-runner memory warning through $identifier"
+}
+
+# Report visibility/click state through globals so Bash 3.2 callers can keep
+# one semantic-presentation latch per AX identifier without namerefs or eval.
+# A warning that remains mounted is clicked once. Disappearance re-arms it;
+# a changed label/message also counts as a new presentation so a tight warning
+# restored as unsafe by activation-time memory revalidation can be confirmed.
+follow_memory_confirmation_edge() {
+    local tree="$1" evidence="$2" previous_signature="$3" identifier="$4"
+    local signature=""
+    MEMORY_CONFIRMATION_SIGNATURE="$previous_signature"
+    MEMORY_CONFIRMATION_VISIBLE=0
+    MEMORY_CONFIRMATION_CLICKED=0
+    if memory_confirmation_enabled "$tree" "$identifier"; then
+        MEMORY_CONFIRMATION_VISIBLE=1
+        signature="$(memory_confirmation_signature "$tree" "$identifier")"
+        if [[ -n "$signature" && "$signature" != "$previous_signature" ]] \
+            && confirm_memory_warning_from_tree "$tree" "$evidence" "$identifier"; then
+            MEMORY_CONFIRMATION_SIGNATURE="$signature"
+            MEMORY_CONFIRMATION_CLICKED=1
         fi
-    done
-    return 1
+    else
+        MEMORY_CONFIRMATION_SIGNATURE=""
+    fi
 }
 
 round_trip_toggle() {
@@ -1727,6 +1758,7 @@ baseline() {
 # button, so a single dump can be a hybrid of two states.
 wait_send_idle() {
     local destination="$1" attempts="${2:-160}" stable=0
+    local memory_confirmation_signature=""
     local confirmation_evidence="${destination%.json}-memory-confirm.json"
     for ((i=0; i<attempts; i++)); do
         see_main "$destination"
@@ -1735,8 +1767,11 @@ wait_send_idle() {
         # hosted runner.  Waiting for an idle composer means this journey has
         # already requested the model, so follow the explicit confirmation
         # branch before continuing to wait for independent UI readiness.
-        if confirm_memory_warning_from_tree \
-            "$destination" "$confirmation_evidence"; then
+        follow_memory_confirmation_edge \
+            "$destination" "$confirmation_evidence" \
+            "$memory_confirmation_signature" MemoryWarning.Confirm
+        memory_confirmation_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+        if [[ "$MEMORY_CONFIRMATION_VISIBLE" == 1 ]]; then
             stable=0
             sleep 0.25
             continue
@@ -4205,7 +4240,13 @@ wait_fake_event() {
 wait_fake_event_after_start() {
     local predicate="$1" what="$2" prefix="$3"
     shift 3
-    local confirmation_identifiers=("$@") i
+    local confirmation_identifiers=("$@") confirmation_signatures=() i j
+    if [[ "${#confirmation_identifiers[@]}" == 0 ]]; then
+        confirmation_identifiers=(MemoryWarning.Confirm)
+    fi
+    for ((j=0; j<${#confirmation_identifiers[@]}; j++)); do
+        confirmation_signatures[$j]=""
+    done
     for ((i=0; i<240; i++)); do
         if [[ -s "$OUT/fake-events.jsonl" ]] \
            && jq -e -s "any(.[]; $predicate)" \
@@ -4213,10 +4254,15 @@ wait_fake_event_after_start() {
             return 0
         fi
         see_main "$OUT/${prefix}-after-start.json"
-        confirm_memory_warning_from_tree \
-            "$OUT/${prefix}-after-start.json" \
-            "$OUT/${prefix}-memory-confirm.json" \
-            "${confirmation_identifiers[@]}" || true
+        for ((j=0; j<${#confirmation_identifiers[@]}; j++)); do
+            follow_memory_confirmation_edge \
+                "$OUT/${prefix}-after-start.json" \
+                "$OUT/${prefix}-memory-confirm.json" \
+                "${confirmation_signatures[$j]}" \
+                "${confirmation_identifiers[$j]}"
+            confirmation_signatures[$j]="$MEMORY_CONFIRMATION_SIGNATURE"
+            [[ "$MEMORY_CONFIRMATION_CLICKED" == 0 ]] || break
+        done
         sleep 0.25
     done
     die "$what"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1467,25 +1467,44 @@ confirm_memory_warning_from_tree() {
 
 # Report visibility/click state through globals so Bash 3.2 callers can keep
 # one semantic-presentation latch per AX identifier without namerefs or eval.
-# A warning that remains mounted is clicked once. Disappearance re-arms it;
-# a changed label/message also counts as a new presentation so a tight warning
-# restored as unsafe by activation-time memory revalidation can be confirmed.
+# A warning that remains mounted gets bounded, spaced retries. Disappearance
+# re-arms it; a changed label/message also counts as a new presentation so a
+# tight warning restored as unsafe by memory revalidation can be confirmed.
 follow_memory_confirmation_edge() {
-    local tree="$1" evidence="$2" previous_signature="$3" identifier="$4"
+    local tree="$1" evidence="$2" previous_signature="$3"
+    local previous_polls="$4" previous_attempts="$5" identifier="$6"
     local signature=""
     MEMORY_CONFIRMATION_SIGNATURE="$previous_signature"
+    MEMORY_CONFIRMATION_POLLS="$previous_polls"
+    MEMORY_CONFIRMATION_ATTEMPTS="$previous_attempts"
     MEMORY_CONFIRMATION_VISIBLE=0
     MEMORY_CONFIRMATION_CLICKED=0
     if memory_confirmation_enabled "$tree" "$identifier"; then
         MEMORY_CONFIRMATION_VISIBLE=1
         signature="$(memory_confirmation_signature "$tree" "$identifier")"
-        if [[ -n "$signature" && "$signature" != "$previous_signature" ]] \
+        if [[ "$signature" != "$previous_signature" ]]; then
+            MEMORY_CONFIRMATION_POLLS=0
+            MEMORY_CONFIRMATION_ATTEMPTS=0
+        else
+            MEMORY_CONFIRMATION_POLLS=$((previous_polls + 1))
+        fi
+        # click-center proves that mouse events were posted, not that SwiftUI
+        # consumed them. Retry a still-identical presentation after one second,
+        # but cap attempts so a stuck alert cannot be hammered every poll.
+        if [[ -n "$signature" \
+              && "$MEMORY_CONFIRMATION_ATTEMPTS" -lt 3 \
+              && ( "$MEMORY_CONFIRMATION_ATTEMPTS" == 0 \
+                   || "$MEMORY_CONFIRMATION_POLLS" -ge 4 ) ]] \
             && confirm_memory_warning_from_tree "$tree" "$evidence" "$identifier"; then
             MEMORY_CONFIRMATION_SIGNATURE="$signature"
+            MEMORY_CONFIRMATION_POLLS=0
+            MEMORY_CONFIRMATION_ATTEMPTS=$((MEMORY_CONFIRMATION_ATTEMPTS + 1))
             MEMORY_CONFIRMATION_CLICKED=1
         fi
     else
         MEMORY_CONFIRMATION_SIGNATURE=""
+        MEMORY_CONFIRMATION_POLLS=0
+        MEMORY_CONFIRMATION_ATTEMPTS=0
     fi
 }
 
@@ -1758,7 +1777,8 @@ baseline() {
 # button, so a single dump can be a hybrid of two states.
 wait_send_idle() {
     local destination="$1" attempts="${2:-160}" stable=0
-    local memory_confirmation_signature=""
+    local memory_confirmation_signature="" memory_confirmation_polls=0
+    local memory_confirmation_attempts=0
     local confirmation_evidence="${destination%.json}-memory-confirm.json"
     for ((i=0; i<attempts; i++)); do
         see_main "$destination"
@@ -1769,8 +1789,13 @@ wait_send_idle() {
         # branch before continuing to wait for independent UI readiness.
         follow_memory_confirmation_edge \
             "$destination" "$confirmation_evidence" \
-            "$memory_confirmation_signature" MemoryWarning.Confirm
+            "$memory_confirmation_signature" \
+            "$memory_confirmation_polls" \
+            "$memory_confirmation_attempts" \
+            MemoryWarning.Confirm
         memory_confirmation_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+        memory_confirmation_polls="$MEMORY_CONFIRMATION_POLLS"
+        memory_confirmation_attempts="$MEMORY_CONFIRMATION_ATTEMPTS"
         if [[ "$MEMORY_CONFIRMATION_VISIBLE" == 1 ]]; then
             stable=0
             sleep 0.25
@@ -4240,12 +4265,15 @@ wait_fake_event() {
 wait_fake_event_after_start() {
     local predicate="$1" what="$2" prefix="$3"
     shift 3
-    local confirmation_identifiers=("$@") confirmation_signatures=() i j
+    local confirmation_identifiers=("$@") confirmation_signatures=()
+    local confirmation_polls=() confirmation_attempts=() i j
     if [[ "${#confirmation_identifiers[@]}" == 0 ]]; then
         confirmation_identifiers=(MemoryWarning.Confirm)
     fi
     for ((j=0; j<${#confirmation_identifiers[@]}; j++)); do
         confirmation_signatures[$j]=""
+        confirmation_polls[$j]=0
+        confirmation_attempts[$j]=0
     done
     for ((i=0; i<240; i++)); do
         if [[ -s "$OUT/fake-events.jsonl" ]] \
@@ -4259,8 +4287,12 @@ wait_fake_event_after_start() {
                 "$OUT/${prefix}-after-start.json" \
                 "$OUT/${prefix}-memory-confirm.json" \
                 "${confirmation_signatures[$j]}" \
+                "${confirmation_polls[$j]}" \
+                "${confirmation_attempts[$j]}" \
                 "${confirmation_identifiers[$j]}"
             confirmation_signatures[$j]="$MEMORY_CONFIRMATION_SIGNATURE"
+            confirmation_polls[$j]="$MEMORY_CONFIRMATION_POLLS"
+            confirmation_attempts[$j]="$MEMORY_CONFIRMATION_ATTEMPTS"
             [[ "$MEMORY_CONFIRMATION_CLICKED" == 0 ]] || break
         done
         sleep 0.25

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1438,16 +1438,23 @@ press() {
 # state as its independent proof.  Keep the action generic because Quickstart
 # presents its warning inside onboarding with a different AX identifier.
 confirm_memory_warning_from_tree() {
-    local tree="$1" evidence="$2" identifier="${3:-MemoryWarning.Confirm}"
-    if jq -e --arg id "$identifier" \
-           '.data.ui_elements[]?
-            | select(.identifier == $id and .enabled == true)' \
-           "$tree" >/dev/null; then
-        "$AX_DRIVER" click-center "$APP_PID" "$identifier" > "$evidence" \
-            || die "$identifier was visible but could not be confirmed"
-        log "  confirmed hosted-runner memory warning through $identifier"
-        return 0
+    local tree="$1" evidence="$2"
+    shift 2
+    local identifiers=("$@") identifier
+    if [[ "${#identifiers[@]}" == 0 ]]; then
+        identifiers=(MemoryWarning.Confirm)
     fi
+    for identifier in "${identifiers[@]}"; do
+        if jq -e --arg id "$identifier" \
+               '.data.ui_elements[]?
+                | select(.identifier == $id and .enabled == true)' \
+               "$tree" >/dev/null; then
+            "$AX_DRIVER" click-center "$APP_PID" "$identifier" > "$evidence" \
+                || die "$identifier was visible but could not be confirmed"
+            log "  confirmed hosted-runner memory warning through $identifier"
+            return 0
+        fi
+    done
     return 1
 }
 
@@ -1719,7 +1726,7 @@ baseline() {
 # consecutive dumps. The dump walks the readiness banner before the send
 # button, so a single dump can be a hybrid of two states.
 wait_send_idle() {
-    local destination="$1" attempts="${2:-160}" stable=0 memory_confirmed=0
+    local destination="$1" attempts="${2:-160}" stable=0
     local confirmation_evidence="${destination%.json}-memory-confirm.json"
     for ((i=0; i<attempts; i++)); do
         see_main "$destination"
@@ -1728,10 +1735,8 @@ wait_send_idle() {
         # hosted runner.  Waiting for an idle composer means this journey has
         # already requested the model, so follow the explicit confirmation
         # branch before continuing to wait for independent UI readiness.
-        if [[ "$memory_confirmed" == 0 ]] \
-            && confirm_memory_warning_from_tree \
-                "$destination" "$confirmation_evidence"; then
-            memory_confirmed=1
+        if confirm_memory_warning_from_tree \
+            "$destination" "$confirmation_evidence"; then
             stable=0
             sleep 0.25
             continue
@@ -2012,6 +2017,7 @@ flow_cached_quickstart() {
         ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
         "cached Quickstart did not start the selected model" \
         cached-quickstart \
+        Quickstart.Memory.Load \
         Quickstart.Memory.LoadAnyway
     jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias"
               and .port >= 49152 and .port <= 65535)' \
@@ -2070,34 +2076,13 @@ flow_cached_curated_tradeup() {
     # The 16 GB fixture owns recommendation policy, not the host's live
     # pressure. A busy hosted runner can therefore (correctly) ask for the
     # existing explicit memory confirmation before it starts this zero-weight
-    # fake. Handle that real branch exactly as start_model does: confirm only
-    # when the enabled warning is present, then still require the independent
-    # sidecar event. Without this, ambient runner pressure made the flow wait
-    # for a start the app was intentionally holding for user consent.
-    local memory_confirmed=0 starter_started=0
-    for _ in {1..240}; do
-        if [[ -s "$OUT/fake-events.jsonl" ]] \
-           && jq -e -s 'any(.[]; .event == "server_started"
-                                   and .alias == "qwen3.5-4b-4bit")' \
-                "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
-            starter_started=1
-            break
-        fi
-        if [[ "$memory_confirmed" == 0 ]]; then
-            see_main "$OUT/starter-after-start.json"
-            if jq -e '.data.ui_elements[]?
-                      | select(.identifier == "Quickstart.Memory.LoadAnyway"
-                               and .enabled == true)' \
-                "$OUT/starter-after-start.json" >/dev/null; then
-                "$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway \
-                    > "$OUT/starter-memory-confirm.json"
-                memory_confirmed=1
-                log "  confirmed hosted-runner memory warning for cached starter"
-            fi
-        fi
-        sleep 0.25
-    done
-    [[ "$starter_started" == 1 ]] || die "cached 16 GB starter did not start"
+    # fake. Success still requires the exact independent sidecar event.
+    wait_fake_event_after_start \
+        '.event == "server_started" and .alias == "qwen3.5-4b-4bit"' \
+        "cached 16 GB starter did not start" \
+        starter \
+        Quickstart.Memory.Load \
+        Quickstart.Memory.LoadAnyway
     wait_fake_sidecar_health "qwen3.5-4b-4bit" "cached 16 GB starter"
     # ``server_started`` is emitted before the fake binds HTTP, and a
     # constrained hosted runner can spend more than the default 20-second AX
@@ -4219,23 +4204,19 @@ wait_fake_event() {
 # present, and success still requires the caller's independent event predicate.
 wait_fake_event_after_start() {
     local predicate="$1" what="$2" prefix="$3"
-    local confirmation_identifier="${4:-MemoryWarning.Confirm}"
-    local memory_confirmed=0 i
+    shift 3
+    local confirmation_identifiers=("$@") i
     for ((i=0; i<240; i++)); do
         if [[ -s "$OUT/fake-events.jsonl" ]] \
            && jq -e -s "any(.[]; $predicate)" \
                 "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
             return 0
         fi
-        if [[ "$memory_confirmed" == 0 ]]; then
-            see_main "$OUT/${prefix}-after-start.json"
-            if confirm_memory_warning_from_tree \
-                "$OUT/${prefix}-after-start.json" \
-                "$OUT/${prefix}-memory-confirm.json" \
-                "$confirmation_identifier"; then
-                memory_confirmed=1
-            fi
-        fi
+        see_main "$OUT/${prefix}-after-start.json"
+        confirm_memory_warning_from_tree \
+            "$OUT/${prefix}-after-start.json" \
+            "$OUT/${prefix}-memory-confirm.json" \
+            "${confirmation_identifiers[@]}" || true
         sleep 0.25
     done
     die "$what"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1431,6 +1431,26 @@ press() {
     return 1
 }
 
+# Hosted runners exercise the production memory guard against their real
+# ambient pressure even though golden journeys launch a zero-weight fake
+# sidecar.  A journey that has explicitly asked to start a model must follow
+# that real confirmation branch before it can use a wire event or readiness
+# state as its independent proof.  Keep the action generic because Quickstart
+# presents its warning inside onboarding with a different AX identifier.
+confirm_memory_warning_from_tree() {
+    local tree="$1" evidence="$2" identifier="${3:-MemoryWarning.Confirm}"
+    if jq -e --arg id "$identifier" \
+           '.data.ui_elements[]?
+            | select(.identifier == $id and .enabled == true)' \
+           "$tree" >/dev/null; then
+        "$AX_DRIVER" click-center "$APP_PID" "$identifier" > "$evidence" \
+            || die "$identifier was visible but could not be confirmed"
+        log "  confirmed hosted-runner memory warning through $identifier"
+        return 0
+    fi
+    return 1
+}
+
 round_trip_toggle() {
     local identifier="$1" stem="$2"
     local before after restored
@@ -1612,30 +1632,10 @@ start_model() {
     # Hosted macOS runners can spend more than 30 seconds cold-starting the
     # bundled fake sidecar after a full release build. Keep the event-based
     # readiness proof, but allow 60 seconds before declaring startup broken.
-    local memory_confirmed=0
-    for _ in {1..240}; do
-        grep -q '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null && break
-        # Authoritative aliases retain their production footprint estimate
-        # even though this journey launches the zero-weight fake sidecar.  A
-        # memory-constrained hosted runner can therefore present the real
-        # safety confirmation after Start.  Confirm only when that explicit
-        # sheet exists; this keeps the product gate covered without leaving a
-        # fake-model GUI journey dependent on the runner's ambient pressure.
-        if [[ "$memory_confirmed" == 0 ]]; then
-            see_main "$OUT/readiness-after-start.json"
-            if jq -e '.data.ui_elements[]?
-                      | select(.identifier == "MemoryWarning.Confirm" and .enabled == true)' \
-                "$OUT/readiness-after-start.json" >/dev/null; then
-                "$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm \
-                    > "$OUT/readiness-memory-confirm.json"
-                memory_confirmed=1
-                log "  confirmed hosted-runner memory warning for fake sidecar"
-            fi
-        fi
-        sleep 0.25
-    done
-    grep -q '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null \
-        || die "fake model did not become ready"
+    wait_fake_event_after_start \
+        ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
+        "fake model did not become ready" \
+        readiness
     wait_send_idle "$OUT/readiness-ready.json"
 }
 
@@ -1719,9 +1719,23 @@ baseline() {
 # consecutive dumps. The dump walks the readiness banner before the send
 # button, so a single dump can be a hybrid of two states.
 wait_send_idle() {
-    local destination="$1" attempts="${2:-160}" stable=0
+    local destination="$1" attempts="${2:-160}" stable=0 memory_confirmed=0
+    local confirmation_evidence="${destination%.json}-memory-confirm.json"
     for ((i=0; i<attempts; i++)); do
         see_main "$destination"
+        # Relaunch/session-restore paths do not pass through start_model(), but
+        # they can still hit the same production memory warning on a busy
+        # hosted runner.  Waiting for an idle composer means this journey has
+        # already requested the model, so follow the explicit confirmation
+        # branch before continuing to wait for independent UI readiness.
+        if [[ "$memory_confirmed" == 0 ]] \
+            && confirm_memory_warning_from_tree \
+                "$destination" "$confirmation_evidence"; then
+            memory_confirmed=1
+            stable=0
+            sleep 0.25
+            continue
+        fi
         if jq -e '.data.ui_elements[]? | select(.identifier == "ChatView.SendOrStopButton"
                   and has("description") and .description == "Send message"
                   and has("enabled") and (has("help") | not))' \
@@ -1994,9 +2008,11 @@ flow_cached_quickstart() {
     assert_tree_text "$OUT/selected.json" "Start existing model"
     press "$OUT/selected.json" Quickstart.Footer.Primary "$OUT/start-existing.json"
 
-    wait_fake_event \
+    wait_fake_event_after_start \
         ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
-        "cached Quickstart did not start the selected model"
+        "cached Quickstart did not start the selected model" \
+        cached-quickstart \
+        Quickstart.Memory.LoadAnyway
     jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias"
               and .port >= 49152 and .port <= 65535)' \
         "$OUT/fake-events.jsonl" >/dev/null \
@@ -4197,6 +4213,34 @@ wait_fake_event() {
     die "$what"
 }
 
+# Wait for the wire proof of a model-start action while also following the
+# real memory-confirmation sheet when host pressure makes it appear.  The
+# confirmation is never accepted speculatively: the enabled AX action must be
+# present, and success still requires the caller's independent event predicate.
+wait_fake_event_after_start() {
+    local predicate="$1" what="$2" prefix="$3"
+    local confirmation_identifier="${4:-MemoryWarning.Confirm}"
+    local memory_confirmed=0 i
+    for ((i=0; i<240; i++)); do
+        if [[ -s "$OUT/fake-events.jsonl" ]] \
+           && jq -e -s "any(.[]; $predicate)" \
+                "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [[ "$memory_confirmed" == 0 ]]; then
+            see_main "$OUT/${prefix}-after-start.json"
+            if confirm_memory_warning_from_tree \
+                "$OUT/${prefix}-after-start.json" \
+                "$OUT/${prefix}-memory-confirm.json" \
+                "$confirmation_identifier"; then
+                memory_confirmed=1
+            fi
+        fi
+        sleep 0.25
+    done
+    die "$what"
+}
+
 # Put text in the Images composer and PROVE it arrived.
 #
 # ``set-value`` reports success on whatever element carries the identifier,
@@ -4341,9 +4385,10 @@ flow_image_generation() {
     # Match the ALIAS, not merely "a server started": the app may already have
     # started one on the chat alias at launch, and that event would satisfy a
     # bare grep while the image model never loaded at all.
-    wait_fake_event \
+    wait_fake_event_after_start \
         ".event == \"server_started\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
-        "the image model never started — Readiness.Action did not switch the server"
+        "the image model never started — Readiness.Action did not switch the server" \
+        image-generation
 
     # ``help`` distinguishes "not ready" from "ready with an empty prompt":
     # the button is disabled in both, and only the hint separates them.
@@ -4906,9 +4951,10 @@ flow_resident_load_rejected() {
         || die "chat Readiness.Action is not pressable - could not start the resident chat model"
     # Match the ALIAS, not merely "a server started": the fake must be serving
     # the chat alias so the residency snapshot reports it resident.
-    wait_fake_event \
+    wait_fake_event_after_start \
         ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
-        "the chat model never started - no resident sidecar to reject against"
+        "the chat model never started - no resident sidecar to reject against" \
+        resident-chat
     # The chat sidecar must actually reach .ready (with a child) in the app's
     # state machine BEFORE the Images load: ``ensureServing`` only takes the
     # in-process ``/v1/models/load`` path when ``readyWithChild`` is true, i.e.
@@ -4962,8 +5008,10 @@ flow_resident_load_rejected() {
     press "$OUT/rlr-ig-readiness.json" Readiness.Action "$OUT/rlr-ig-start.json" \
         || die "Images Readiness.Action is not pressable - the load button is dead"
 
-    wait_fake_event ".event == \"server_start_rejected\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
-        "the fake never rejected the dedicated image sidecar"
+    wait_fake_event_after_start \
+        ".event == \"server_start_rejected\" and .alias == \"$FAKE_IMAGE_ALIAS\"" \
+        "the fake never rejected the dedicated image sidecar" \
+        resident-image
     if jq -e 'select(.event == "model_load")' "$OUT/fake-events.jsonl" >/dev/null 2>&1; then
         die "Images incorrectly issued an in-process /v1/models/load"
     fi
@@ -5216,9 +5264,10 @@ flow_audio_readiness() {
         "$OUT/fake-events.jsonl" 0 "" "Speech after download-only action"
     press "$OUT/speech-downloaded.json" Readiness.Action "$OUT/speech-start.json" \
         || die "Speech Start is not pressable after download"
-    wait_fake_event \
+    wait_fake_event_after_start \
         '.event == "server_started" and .alias == "fake-qwen3-tts"' \
-        "Speech did not start after the explicit Start action"
+        "Speech did not start after the explicit Start action" \
+        speech
     local speech_loaded=0
     for ((i=0; i<80; i++)); do
         see_main "$OUT/speech-loaded.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1449,7 +1449,7 @@ memory_confirmation_signature() {
     local tree="$1" identifier="$2"
     jq -cS --arg id "$identifier" \
        '.data.ui_elements[]?
-        | select(.identifier == $id and .enabled == true)
+        | select(.identifier == $id)
         | {identifier, label, title, value, description, help}' \
        "$tree" | head -1
 }
@@ -1479,9 +1479,9 @@ follow_memory_confirmation_edge() {
     MEMORY_CONFIRMATION_ATTEMPTS="$previous_attempts"
     MEMORY_CONFIRMATION_VISIBLE=0
     MEMORY_CONFIRMATION_CLICKED=0
-    if memory_confirmation_enabled "$tree" "$identifier"; then
+    signature="$(memory_confirmation_signature "$tree" "$identifier")"
+    if [[ -n "$signature" ]]; then
         MEMORY_CONFIRMATION_VISIBLE=1
-        signature="$(memory_confirmation_signature "$tree" "$identifier")"
         if [[ "$signature" != "$previous_signature" ]]; then
             MEMORY_CONFIRMATION_POLLS=0
             MEMORY_CONFIRMATION_ATTEMPTS=0
@@ -1494,10 +1494,10 @@ follow_memory_confirmation_edge() {
         # Product-side confirmPendingMemoryLoad claims the warning synchronously
         # before async revalidation, so a repeated delivery while it is checking
         # cannot enqueue a duplicate launch.
-        if [[ -n "$signature" \
-              && "$MEMORY_CONFIRMATION_ATTEMPTS" -lt 3 \
-              && ( "$MEMORY_CONFIRMATION_ATTEMPTS" == 0 \
-                   || "$MEMORY_CONFIRMATION_POLLS" -ge 4 ) ]]; then
+        if memory_confirmation_enabled "$tree" "$identifier" \
+           && [[ "$MEMORY_CONFIRMATION_ATTEMPTS" -lt 3 \
+                 && ( "$MEMORY_CONFIRMATION_ATTEMPTS" == 0 \
+                      || "$MEMORY_CONFIRMATION_POLLS" -ge 4 ) ]]; then
             # Consume the budget before posting the click. Driver failures must
             # be spaced and capped just like successfully posted mouse events.
             MEMORY_CONFIRMATION_SIGNATURE="$signature"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1665,7 +1665,11 @@ start_model() {
     # user needs before clicking it.
     wait_identifier_enabled Readiness.Action "$OUT/readiness-start.json"
     local initial_action
+    local selected_alias
     initial_action="$(element_field "$OUT/readiness-start.json" Readiness.Action description)"
+    selected_alias="$(element_field "$OUT/readiness-start.json" ModelPickerBar.ModelMenu value)"
+    [[ -n "$selected_alias" ]] \
+        || die "the readiness action exposed no selected model alias"
     press "$OUT/readiness-start.json" Readiness.Action "$OUT/start-model.json"
     if [[ "$initial_action" == "Download" ]]; then
         local download_ready=0
@@ -1696,7 +1700,7 @@ start_model() {
     # bundled fake sidecar after a full release build. Keep the event-based
     # readiness proof, but allow 60 seconds before declaring startup broken.
     wait_fake_event_after_start \
-        ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
+        ".event == \"server_started\" and .alias == \"$selected_alias\"" \
         "fake model did not become ready" \
         readiness
     wait_send_idle "$OUT/readiness-ready.json"

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -207,9 +207,9 @@ def test_cached_curated_tradeup_confirms_the_quickstart_memory_sheet():
     source = HARNESS.read_text()
     flow = source.split("flow_cached_curated_tradeup() {", 1)[1].split("\n}", 1)[0]
 
-    assert 'identifier == "Quickstart.Memory.LoadAnyway"' in flow
-    assert '"$AX_DRIVER" click-center "$APP_PID" Quickstart.Memory.LoadAnyway' in flow
-    assert 'identifier == "MemoryWarning.Confirm"' not in flow
+    assert "wait_fake_event_after_start" in flow
+    assert "Quickstart.Memory.Load" in flow
+    assert "Quickstart.Memory.LoadAnyway" in flow
 
 
 def test_cached_curated_tradeup_waits_for_health_and_bounded_ui_readiness():
@@ -574,7 +574,7 @@ def test_start_model_waits_for_an_interactive_readiness_action():
         'press "$OUT/readiness-start.json" Readiness.Action'
     )
     assert "wait_fake_event_after_start" in helper
-    assert r'and .alias == \"$FAKE_ALIAS\"' in helper
+    assert r"and .alias == \"$FAKE_ALIAS\"" in helper
 
     driver = DRIVER.read_text()
     click = driver.split('case "click-center":', 1)[1].split(
@@ -590,26 +590,26 @@ def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
     confirm = source.split("confirm_memory_warning_from_tree() {", 1)[1].split(
         "\n}", 1
     )[0]
-    assert '.identifier == $id and .enabled == true' in confirm
+    assert ".identifier == $id and .enabled == true" in confirm
     assert 'click-center "$APP_PID" "$identifier"' in confirm
+    assert 'for identifier in "${identifiers[@]}"' in confirm
 
     wait = source.split("wait_fake_event_after_start() {", 1)[1].split("\n}", 1)[0]
     assert 'jq -e -s "any(.[]; $predicate)"' in wait
     assert "confirm_memory_warning_from_tree" in wait
-    assert "memory_confirmed=1" in wait
+    assert "memory_confirmed" not in wait
     assert wait.index("confirm_memory_warning_from_tree") < wait.index('die "$what"')
 
     cached = source.split("flow_cached_quickstart() {", 1)[1].split("\n}", 1)[0]
     assert "wait_fake_event_after_start" in cached
+    assert "Quickstart.Memory.Load" in cached
     assert "Quickstart.Memory.LoadAnyway" in cached
 
     image = source.split("flow_image_generation() {", 1)[1].split("\n}", 1)[0]
     assert "wait_fake_event_after_start" in image
-    assert r'and .alias == \"$FAKE_IMAGE_ALIAS\"' in image
+    assert r"and .alias == \"$FAKE_IMAGE_ALIAS\"" in image
 
-    resident = source.split("flow_resident_load_rejected() {", 1)[1].split(
-        "\n}", 1
-    )[0]
+    resident = source.split("flow_resident_load_rejected() {", 1)[1].split("\n}", 1)[0]
     assert resident.count("wait_fake_event_after_start") == 2
     assert "resident-chat" in resident
     assert "resident-image" in resident
@@ -617,6 +617,86 @@ def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
     audio = source.split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
     assert "wait_fake_event_after_start" in audio
     assert 'and .alias == "fake-qwen3-tts"' in audio
+
+
+def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
+    """A tight confirmation may return as unsafe after live-memory revalidation."""
+    source = HARNESS.read_text()
+    helper = (
+        "confirm_memory_warning_from_tree() {"
+        + source.split("confirm_memory_warning_from_tree() {", 1)[1].split("\n}", 1)[0]
+        + "\n}"
+    )
+
+    driver = tmp_path / "driver.sh"
+    driver.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$3" >> "$CLICKS"\n'
+        "printf '{\"success\":true}\\n'\n"
+    )
+    driver.chmod(0o755)
+    tight = tmp_path / "tight.json"
+    unsafe = tmp_path / "unsafe.json"
+    tight.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {"identifier": "Quickstart.Memory.Load", "enabled": True}
+                    ]
+                }
+            }
+        )
+    )
+    unsafe.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "Quickstart.Memory.LoadAnyway",
+                            "enabled": True,
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    evidence = tmp_path / "evidence.json"
+    clicks = tmp_path / "clicks.txt"
+    script = f"""
+set -euo pipefail
+AX_DRIVER="$1"
+APP_PID=42
+export CLICKS="$5"
+log() {{ :; }}
+die() {{ printf '%s\\n' "$*" >&2; exit 1; }}
+{helper}
+confirm_memory_warning_from_tree "$2" "$4" \\
+    Quickstart.Memory.Load Quickstart.Memory.LoadAnyway
+confirm_memory_warning_from_tree "$3" "$4" \\
+    Quickstart.Memory.Load Quickstart.Memory.LoadAnyway
+"""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            script,
+            "confirmation-contract",
+            str(driver),
+            str(tight),
+            str(unsafe),
+            str(evidence),
+            str(clicks),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+    assert clicks.read_text().splitlines() == [
+        "Quickstart.Memory.Load",
+        "Quickstart.Memory.LoadAnyway",
+    ]
 
 
 def test_ready_wait_confirms_memory_warning_after_session_restore():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -573,8 +573,8 @@ def test_start_model_waits_for_an_interactive_readiness_action():
     assert helper.index("wait_identifier_enabled Readiness.Action") < helper.index(
         'press "$OUT/readiness-start.json" Readiness.Action'
     )
-    assert 'identifier == "MemoryWarning.Confirm" and .enabled == true' in helper
-    assert '"$AX_DRIVER" click-center "$APP_PID" MemoryWarning.Confirm' in helper
+    assert "wait_fake_event_after_start" in helper
+    assert r'and .alias == \"$FAKE_ALIAS\"' in helper
 
     driver = DRIVER.read_text()
     click = driver.split('case "click-center":', 1)[1].split(
@@ -582,6 +582,52 @@ def test_start_model_waits_for_an_interactive_readiness_action():
     )[0]
     assert "kAXPositionAttribute" in click and "kAXSizeAttribute" in click
     assert ".leftMouseDown" in click and ".leftMouseUp" in click
+
+
+def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
+    """Every explicit fake-sidecar start must tolerate real host pressure."""
+    source = HARNESS.read_text()
+    confirm = source.split("confirm_memory_warning_from_tree() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert '.identifier == $id and .enabled == true' in confirm
+    assert 'click-center "$APP_PID" "$identifier"' in confirm
+
+    wait = source.split("wait_fake_event_after_start() {", 1)[1].split("\n}", 1)[0]
+    assert 'jq -e -s "any(.[]; $predicate)"' in wait
+    assert "confirm_memory_warning_from_tree" in wait
+    assert "memory_confirmed=1" in wait
+    assert wait.index("confirm_memory_warning_from_tree") < wait.index('die "$what"')
+
+    cached = source.split("flow_cached_quickstart() {", 1)[1].split("\n}", 1)[0]
+    assert "wait_fake_event_after_start" in cached
+    assert "Quickstart.Memory.LoadAnyway" in cached
+
+    image = source.split("flow_image_generation() {", 1)[1].split("\n}", 1)[0]
+    assert "wait_fake_event_after_start" in image
+    assert r'and .alias == \"$FAKE_IMAGE_ALIAS\"' in image
+
+    resident = source.split("flow_resident_load_rejected() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert resident.count("wait_fake_event_after_start") == 2
+    assert "resident-chat" in resident
+    assert "resident-image" in resident
+
+    audio = source.split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
+    assert "wait_fake_event_after_start" in audio
+    assert 'and .alias == "fake-qwen3-tts"' in audio
+
+
+def test_ready_wait_confirms_memory_warning_after_session_restore():
+    """Automatic restore can show the same sheet without calling start_model."""
+    source = HARNESS.read_text()
+    wait = source.split("wait_send_idle() {", 1)[1].split("\n}", 1)[0]
+    assert "confirm_memory_warning_from_tree" in wait
+    assert wait.index("confirm_memory_warning_from_tree") < wait.index(
+        'identifier == "ChatView.SendOrStopButton"'
+    )
+    assert "continue" in wait
 
 
 def test_image_inflight_baseline_uses_an_event_backed_warmup_phase():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -587,18 +587,19 @@ def test_start_model_waits_for_an_interactive_readiness_action():
 def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
     """Every explicit fake-sidecar start must tolerate real host pressure."""
     source = HARNESS.read_text()
+    enabled = source.split("memory_confirmation_enabled() {", 1)[1].split("\n}", 1)[0]
     confirm = source.split("confirm_memory_warning_from_tree() {", 1)[1].split(
         "\n}", 1
     )[0]
-    assert ".identifier == $id and .enabled == true" in confirm
+    assert ".identifier == $id and .enabled == true" in enabled
     assert 'click-center "$APP_PID" "$identifier"' in confirm
-    assert 'for identifier in "${identifiers[@]}"' in confirm
+    assert "|| return 1" in confirm
 
     wait = source.split("wait_fake_event_after_start() {", 1)[1].split("\n}", 1)[0]
     assert 'jq -e -s "any(.[]; $predicate)"' in wait
-    assert "confirm_memory_warning_from_tree" in wait
-    assert "memory_confirmed" not in wait
-    assert wait.index("confirm_memory_warning_from_tree") < wait.index('die "$what"')
+    assert "follow_memory_confirmation_edge" in wait
+    assert "confirmation_signatures" in wait
+    assert wait.index("follow_memory_confirmation_edge") < wait.index('die "$what"')
 
     cached = source.split("flow_cached_quickstart() {", 1)[1].split("\n}", 1)[0]
     assert "wait_fake_event_after_start" in cached
@@ -622,10 +623,20 @@ def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
 def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
     """A tight confirmation may return as unsafe after live-memory revalidation."""
     source = HARNESS.read_text()
-    helper = (
-        "confirm_memory_warning_from_tree() {"
-        + source.split("confirm_memory_warning_from_tree() {", 1)[1].split("\n}", 1)[0]
-        + "\n}"
+
+    def shell_function(name: str) -> str:
+        return (
+            name + "() {" + source.split(name + "() {", 1)[1].split("\n}", 1)[0] + "\n}"
+        )
+
+    helpers = "\n".join(
+        shell_function(name)
+        for name in (
+            "memory_confirmation_enabled",
+            "memory_confirmation_signature",
+            "confirm_memory_warning_from_tree",
+            "follow_memory_confirmation_edge",
+        )
     )
 
     driver = tmp_path / "driver.sh"
@@ -661,20 +672,73 @@ def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
             }
         )
     )
+    absent = tmp_path / "absent.json"
+    absent.write_text(json.dumps({"data": {"ui_elements": []}}))
+    main_tight = tmp_path / "main-tight.json"
+    main_unsafe = tmp_path / "main-unsafe.json"
+    main_tight.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "MemoryWarning.Confirm",
+                            "enabled": True,
+                            "label": "Load model",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    main_unsafe.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "MemoryWarning.Confirm",
+                            "enabled": True,
+                            "label": "Load anyway (risky)",
+                        }
+                    ]
+                }
+            }
+        )
+    )
     evidence = tmp_path / "evidence.json"
     clicks = tmp_path / "clicks.txt"
     script = f"""
 set -euo pipefail
 AX_DRIVER="$1"
 APP_PID=42
-export CLICKS="$5"
+EVIDENCE="$7"
+export CLICKS="$8"
 log() {{ :; }}
 die() {{ printf '%s\\n' "$*" >&2; exit 1; }}
-{helper}
-confirm_memory_warning_from_tree "$2" "$4" \\
-    Quickstart.Memory.Load Quickstart.Memory.LoadAnyway
-confirm_memory_warning_from_tree "$3" "$4" \\
-    Quickstart.Memory.Load Quickstart.Memory.LoadAnyway
+{helpers}
+load_signature=""
+anyway_signature=""
+scan_quickstart() {{
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$load_signature" Quickstart.Memory.Load
+    load_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$anyway_signature" Quickstart.Memory.LoadAnyway
+    anyway_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+}}
+scan_quickstart "$2"
+scan_quickstart "$2"
+scan_quickstart "$4"
+scan_quickstart "$3"
+scan_quickstart "$3"
+main_signature=""
+scan_main() {{
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$main_signature" MemoryWarning.Confirm
+    main_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+}}
+scan_main "$5"
+scan_main "$5"
+scan_main "$6"
+scan_main "$6"
 """
     result = subprocess.run(
         [
@@ -685,6 +749,9 @@ confirm_memory_warning_from_tree "$3" "$4" \\
             str(driver),
             str(tight),
             str(unsafe),
+            str(absent),
+            str(main_tight),
+            str(main_unsafe),
             str(evidence),
             str(clicks),
         ],
@@ -696,6 +763,8 @@ confirm_memory_warning_from_tree "$3" "$4" \\
     assert clicks.read_text().splitlines() == [
         "Quickstart.Memory.Load",
         "Quickstart.Memory.LoadAnyway",
+        "MemoryWarning.Confirm",
+        "MemoryWarning.Confirm",
     ]
 
 
@@ -703,8 +772,10 @@ def test_ready_wait_confirms_memory_warning_after_session_restore():
     """Automatic restore can show the same sheet without calling start_model."""
     source = HARNESS.read_text()
     wait = source.split("wait_send_idle() {", 1)[1].split("\n}", 1)[0]
-    assert "confirm_memory_warning_from_tree" in wait
-    assert wait.index("confirm_memory_warning_from_tree") < wait.index(
+    assert "follow_memory_confirmation_edge" in wait
+    assert "memory_confirmation_signature" in wait
+    assert 'MEMORY_CONFIRMATION_VISIBLE" == 1' in wait
+    assert wait.index("follow_memory_confirmation_edge") < wait.index(
         'identifier == "ChatView.SendOrStopButton"'
     )
     assert "continue" in wait

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -599,6 +599,7 @@ def test_direct_model_starts_follow_enabled_memory_confirmation_branches():
     assert 'jq -e -s "any(.[]; $predicate)"' in wait
     assert "follow_memory_confirmation_edge" in wait
     assert "confirmation_signatures" in wait
+    assert "confirmation_attempts" in wait
     assert wait.index("follow_memory_confirmation_edge") < wait.index('die "$what"')
 
     cached = source.split("flow_cached_quickstart() {", 1)[1].split("\n}", 1)[0]
@@ -717,28 +718,38 @@ export CLICKS="$8"
 log() {{ :; }}
 die() {{ printf '%s\\n' "$*" >&2; exit 1; }}
 {helpers}
-load_signature=""
-anyway_signature=""
+load_signature=""; load_polls=0; load_attempts=0
+anyway_signature=""; anyway_polls=0; anyway_attempts=0
 scan_quickstart() {{
-    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$load_signature" Quickstart.Memory.Load
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" \\
+        "$load_signature" "$load_polls" "$load_attempts" Quickstart.Memory.Load
     load_signature="$MEMORY_CONFIRMATION_SIGNATURE"
-    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$anyway_signature" Quickstart.Memory.LoadAnyway
+    load_polls="$MEMORY_CONFIRMATION_POLLS"
+    load_attempts="$MEMORY_CONFIRMATION_ATTEMPTS"
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" \\
+        "$anyway_signature" "$anyway_polls" "$anyway_attempts" Quickstart.Memory.LoadAnyway
     anyway_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+    anyway_polls="$MEMORY_CONFIRMATION_POLLS"
+    anyway_attempts="$MEMORY_CONFIRMATION_ATTEMPTS"
 }}
 scan_quickstart "$2"
 scan_quickstart "$2"
 scan_quickstart "$4"
 scan_quickstart "$3"
 scan_quickstart "$3"
-main_signature=""
+main_signature=""; main_polls=0; main_attempts=0
 scan_main() {{
-    follow_memory_confirmation_edge "$1" "$EVIDENCE" "$main_signature" MemoryWarning.Confirm
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" \\
+        "$main_signature" "$main_polls" "$main_attempts" MemoryWarning.Confirm
     main_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+    main_polls="$MEMORY_CONFIRMATION_POLLS"
+    main_attempts="$MEMORY_CONFIRMATION_ATTEMPTS"
 }}
 scan_main "$5"
 scan_main "$5"
 scan_main "$6"
 scan_main "$6"
+for _ in {{1..20}}; do scan_main "$6"; done
 """
     result = subprocess.run(
         [
@@ -760,12 +771,14 @@ scan_main "$6"
         timeout=5,
     )
     assert result.returncode == 0, result.stderr
-    assert clicks.read_text().splitlines() == [
+    recorded = clicks.read_text().splitlines()
+    assert recorded[:2] == [
         "Quickstart.Memory.Load",
         "Quickstart.Memory.LoadAnyway",
-        "MemoryWarning.Confirm",
-        "MemoryWarning.Confirm",
     ]
+    # Tight is clicked once, then the semantically new unsafe presentation
+    # gets at most three spaced delivery attempts despite remaining visible.
+    assert recorded[2:] == ["MemoryWarning.Confirm"] * 4
 
 
 def test_ready_wait_confirms_memory_warning_after_session_restore():
@@ -774,6 +787,7 @@ def test_ready_wait_confirms_memory_warning_after_session_restore():
     wait = source.split("wait_send_idle() {", 1)[1].split("\n}", 1)[0]
     assert "follow_memory_confirmation_edge" in wait
     assert "memory_confirmation_signature" in wait
+    assert "memory_confirmation_attempts" in wait
     assert 'MEMORY_CONFIRMATION_VISIBLE" == 1' in wait
     assert wait.index("follow_memory_confirmation_edge") < wait.index(
         'identifier == "ChatView.SendOrStopButton"'

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -643,6 +643,7 @@ def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
     driver = tmp_path / "driver.sh"
     driver.write_text(
         '#!/usr/bin/env bash\nprintf \'%s\\n\' "$3" >> "$CLICKS"\n'
+        '[[ "$3" != "MemoryWarning.Fail" ]] || exit 1\n'
         "printf '{\"success\":true}\\n'\n"
     )
     driver.chmod(0o755)
@@ -707,6 +708,22 @@ def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
             }
         )
     )
+    failed_delivery = tmp_path / "failed-delivery.json"
+    failed_delivery.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "MemoryWarning.Fail",
+                            "enabled": True,
+                            "label": "Load model",
+                        }
+                    ]
+                }
+            }
+        )
+    )
     evidence = tmp_path / "evidence.json"
     clicks = tmp_path / "clicks.txt"
     script = f"""
@@ -714,7 +731,7 @@ set -euo pipefail
 AX_DRIVER="$1"
 APP_PID=42
 EVIDENCE="$7"
-export CLICKS="$8"
+export CLICKS="$9"
 log() {{ :; }}
 die() {{ printf '%s\\n' "$*" >&2; exit 1; }}
 {helpers}
@@ -750,6 +767,15 @@ scan_main "$5"
 scan_main "$6"
 scan_main "$6"
 for _ in {{1..20}}; do scan_main "$6"; done
+fail_signature=""; fail_polls=0; fail_attempts=0
+scan_failure() {{
+    follow_memory_confirmation_edge "$1" "$EVIDENCE" \\
+        "$fail_signature" "$fail_polls" "$fail_attempts" MemoryWarning.Fail
+    fail_signature="$MEMORY_CONFIRMATION_SIGNATURE"
+    fail_polls="$MEMORY_CONFIRMATION_POLLS"
+    fail_attempts="$MEMORY_CONFIRMATION_ATTEMPTS"
+}}
+for _ in {{1..20}}; do scan_failure "$8"; done
 """
     result = subprocess.run(
         [
@@ -764,6 +790,7 @@ for _ in {{1..20}}; do scan_main "$6"; done
             str(main_tight),
             str(main_unsafe),
             str(evidence),
+            str(failed_delivery),
             str(clicks),
         ],
         capture_output=True,
@@ -778,7 +805,10 @@ for _ in {{1..20}}; do scan_main "$6"; done
     ]
     # Tight is clicked once, then the semantically new unsafe presentation
     # gets at most three spaced delivery attempts despite remaining visible.
-    assert recorded[2:] == ["MemoryWarning.Confirm"] * 4
+    assert recorded[2:6] == ["MemoryWarning.Confirm"] * 4
+    # A failing driver consumes the same spaced budget instead of retrying on
+    # every 250 ms poll forever.
+    assert recorded[6:] == ["MemoryWarning.Fail"] * 3
 
 
 def test_ready_wait_confirms_memory_warning_after_session_restore():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -566,7 +566,7 @@ def test_fresh_install_fixture_contains_the_real_starter():
 
 
 def test_start_model_waits_for_an_interactive_readiness_action():
-    """A mounted SwiftUI button can still reject an AX press while disabled."""
+    """Start waits for an interactive action and its actually selected alias."""
     source = HARNESS.read_text()
     helper = source.split("start_model() {", 1)[1].split("\n}", 1)[0]
     assert "wait_identifier_enabled Readiness.Action" in helper
@@ -574,7 +574,12 @@ def test_start_model_waits_for_an_interactive_readiness_action():
         'press "$OUT/readiness-start.json" Readiness.Action'
     )
     assert "wait_fake_event_after_start" in helper
-    assert r"and .alias == \"$FAKE_ALIAS\"" in helper
+    assert (
+        'selected_alias="$(element_field "$OUT/readiness-start.json" '
+        'ModelPickerBar.ModelMenu value)"'
+    ) in helper
+    assert r"and .alias == \"$selected_alias\"" in helper
+    assert r"and .alias == \"$FAKE_ALIAS\"" not in helper
 
     driver = DRIVER.read_text()
     click = driver.split('case "click-center":', 1)[1].split(
@@ -582,6 +587,50 @@ def test_start_model_waits_for_an_interactive_readiness_action():
     )[0]
     assert "kAXPositionAttribute" in click and "kAXSizeAttribute" in click
     assert ".leftMouseDown" in click and ".leftMouseUp" in click
+
+
+def test_start_model_witnesses_the_selected_download_alias(tmp_path):
+    """Fresh install starts the downloaded pick, not the persona's fallback."""
+    source = HARNESS.read_text()
+    helper = "start_model() {" + source.split("start_model() {", 1)[1].split(
+        "\n}", 1
+    )[0] + "\n}"
+    capture = tmp_path / "predicate.txt"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            helper
+            + r'''
+set -euo pipefail
+OUT="$1"
+CAPTURE="$2"
+wait_identifier_enabled() { :; }
+element_field() {
+    if [[ "$2" == "Readiness.Action" ]]; then
+        printf 'Start\n'
+    else
+        printf 'lfm2.5-1b-4bit\n'
+    fi
+}
+press() { :; }
+wait_fake_event_after_start() { printf '%s\n' "$1" > "$CAPTURE"; }
+wait_send_idle() { :; }
+die() { printf '%s\n' "$*" >&2; exit 1; }
+start_model
+''',
+            "start-model-selected-alias",
+            str(tmp_path),
+            str(capture),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+    assert capture.read_text().strip() == (
+        '.event == "server_started" and .alias == "lfm2.5-1b-4bit"'
+    )
 
 
 def test_direct_model_starts_follow_enabled_memory_confirmation_branches():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -592,16 +592,18 @@ def test_start_model_waits_for_an_interactive_readiness_action():
 def test_start_model_witnesses_the_selected_download_alias(tmp_path):
     """Fresh install starts the downloaded pick, not the persona's fallback."""
     source = HARNESS.read_text()
-    helper = "start_model() {" + source.split("start_model() {", 1)[1].split(
-        "\n}", 1
-    )[0] + "\n}"
+    helper = (
+        "start_model() {"
+        + source.split("start_model() {", 1)[1].split("\n}", 1)[0]
+        + "\n}"
+    )
     capture = tmp_path / "predicate.txt"
     result = subprocess.run(
         [
             "bash",
             "-c",
             helper
-            + r'''
+            + r"""
 set -euo pipefail
 OUT="$1"
 CAPTURE="$2"
@@ -618,7 +620,7 @@ wait_fake_event_after_start() { printf '%s\n' "$1" > "$CAPTURE"; }
 wait_send_idle() { :; }
 die() { printf '%s\n' "$*" >&2; exit 1; }
 start_model
-''',
+""",
             "start-model-selected-alias",
             str(tmp_path),
             str(capture),

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -708,6 +708,22 @@ def test_memory_confirmation_helper_handles_quickstart_revalidation(tmp_path):
             }
         )
     )
+    main_unsafe_disabled = tmp_path / "main-unsafe-disabled.json"
+    main_unsafe_disabled.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "identifier": "MemoryWarning.Confirm",
+                            "enabled": False,
+                            "label": "Load anyway (risky)",
+                        }
+                    ]
+                }
+            }
+        )
+    )
     failed_delivery = tmp_path / "failed-delivery.json"
     failed_delivery.write_text(
         json.dumps(
@@ -767,6 +783,10 @@ scan_main "$5"
 scan_main "$6"
 scan_main "$6"
 for _ in {{1..20}}; do scan_main "$6"; done
+# Disabling and re-enabling the same mounted semantic decision must not mint a
+# fresh delivery budget after the three-attempt cap has been consumed.
+scan_main "${{10}}"
+for _ in {{1..20}}; do scan_main "$6"; done
 fail_signature=""; fail_polls=0; fail_attempts=0
 scan_failure() {{
     follow_memory_confirmation_edge "$1" "$EVIDENCE" \\
@@ -792,6 +812,7 @@ for _ in {{1..20}}; do scan_failure "$8"; done
             str(evidence),
             str(failed_delivery),
             str(clicks),
+            str(main_unsafe_disabled),
         ],
         capture_output=True,
         text=True,
@@ -804,7 +825,8 @@ for _ in {{1..20}}; do scan_failure "$8"; done
         "Quickstart.Memory.LoadAnyway",
     ]
     # Tight is clicked once, then the semantically new unsafe presentation
-    # gets at most three spaced delivery attempts despite remaining visible.
+    # gets at most three spaced delivery attempts despite remaining visible or
+    # temporarily disabled before it becomes interactive again.
     assert recorded[2:6] == ["MemoryWarning.Confirm"] * 4
     # A failing driver consumes the same spaced budget instead of retrying on
     # every 250 ms poll forever.


### PR DESCRIPTION
## Why

The managed macOS batch can correctly present the production memory-safety confirmation after a GUI journey requests a model start. Several direct-start journeys did not follow that branch, so they timed out without observing the sidecar event even though the app was waiting for an explicit confirmation. Session restoration had the same gap after relaunch.

## Scope

- Centralize enabled memory-confirmation detection and interaction in the GUI golden harness.
- Apply it to direct Quickstart, Images, Audio, and resident-model start paths.
- Apply it while waiting for Chat readiness after session restoration.
- Keep independent fake-sidecar events and UI readiness as the success criteria.
- Add executable and static contract coverage for every affected journey.

## Non-goals

- No app runtime or product UI changes.
- No changes to memory policy, thresholds, timeout policy, workflow topology, video foundation code, or transcript-tail behavior.

## Acceptance

- A direct GUI model start follows an enabled memory confirmation when it appears.
- Quickstart follows both its ordinary and unsafe onboarding confirmation actions.
- One semantic decision gets at most three delivery attempts, spaced one second apart; the product synchronously claims the decision before asynchronous revalidation, so a repeated delivery cannot enqueue a duplicate start.
- A disappearing or semantically changed decision begins a new bounded delivery budget.
- Session restoration can follow the confirmation after relaunch.
- A confirmation alone never counts as success; the expected model alias event or ready UI state remains required.
- Normal starts without a confirmation retain their existing behavior.

## Verification

- bash -n apps/rapid-mac/scripts/gui-golden-flows.sh
- git diff --check
- ruff check and ruff format --check on the changed Python test
- Focused contract suite — 60 passed
- Full Python unit suite through PR validation — 19,961 passed, 116 skipped, 22 deselected, 6 xfailed, 1 xpassed
- SKIP_SIDECAR=1 RAPID_BUILD_CONFIG=release ./scripts/build.sh — passed
- GUI golden flows: cached-quickstart, cached-curated-tradeup, image-generation, audio-readiness, resident-load-rejected, and dictation — passed

## Behaviour delta

GUI test journeys previously waited until timeout when a real enabled memory confirmation appeared after their model-start action. They now follow each semantic decision with a bounded delivery budget and still require the original event/UI proof before passing. Product behavior is unchanged.

## AI assistance disclosure

Codex implemented and reviewed the two touched test-harness files. I reviewed the complete diff, ran the focused and full contract suites, built the release app, and exercised all affected GUI journeys locally.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] Self-validated with python3 -m scripts.pr_validate.pr_validate; findings addressed and final MERGE-SAFE pass completed on head 4581e0d41
- [x] If new tests touch a critical code path, not applicable: test harness only
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author


