### PR TITLE
feat(mac): add experimental Video workspace

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -177,7 +177,14 @@ enum DevSnapshot {
                         maximumArea: nil,
                         alsoSupported: nil
                     ),
-                    seconds: .init(minimum: 1, maximum: 20, default: 4)
+                    seconds: .init(minimum: 1, maximum: 20, default: 4),
+                    fps: .init(minimum: 1, maximum: 60, default: 24, fixed: false),
+                    frames: .init(minimum: 9, maximum: 1201, step: 8, offset: 1),
+                    workload: .init(
+                        metric: "pixel_frames",
+                        maximum: 38_141_952,
+                        dimensionRounding: "multiple_of_64"
+                    )
                 )
             )
             readyViewModel.size = "512x512"

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -48,6 +48,7 @@ enum DevSnapshot {
         // throwaway instance so the view can be evaluated without trapping.
         let imageGen = ImageGenViewModel(server: server)
         let audio = AudioViewModel(server: server)
+        let video = VideoGenViewModel(server: server)
         let dictation = DictationController(server: server, testingEnabled: false)
         // Same rule again, for the connectors stack (issue #1716).
         // ``ContentView`` reads ``MCPCatalog`` and ``MCPToolApprovalStore``
@@ -89,6 +90,144 @@ enum DevSnapshot {
         snapshotPerfDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.perf")
         let snapshotPerfConfig = ModelPerfConfigStore(defaults: snapshotPerfDefaults)
 
+        // Focused gate regression: render only the shipping sidebar and quit.
+        // The full snapshot matrix is intentionally broad and takes minutes;
+        // this lane gives feature-gate work a fast, deterministic visual proof
+        // without weakening the comprehensive run.
+        if ProcessInfo.processInfo.environment["RAPID_DEV_SIDEBAR_ONLY"] == "1" {
+            let videoEnabled = ProcessInfo.processInfo.environment["RAPID_DEV_VIDEO_ENABLED"] == "1"
+                || VideoFeatureConfig.isEnabled()
+            func sidebar() -> AnyView {
+                AnyView(
+                    SidebarView(
+                        selection: .constant(.video),
+                        videoGenerationEnabled: videoEnabled,
+                        chat: chat,
+                        onNewChat: {},
+                        onSelectConversation: { _ in }
+                    )
+                    .frame(width: SidebarView.columnIdealWidth, height: 640)
+                    .background(RapidTheme.surfaceSidebar)
+                    .tint(RapidTheme.brandAmber)
+                )
+            }
+            let size = CGSize(width: SidebarView.columnIdealWidth, height: 640)
+            renderHosted(
+                sidebar(), size: size, appearance: .aqua,
+                to: "\(dir)/video-gate-sidebar-light.png"
+            )
+            renderHosted(
+                sidebar(), size: size, appearance: .darkAqua,
+                to: "\(dir)/video-gate-sidebar-dark.png"
+            )
+            NSApp.terminate(nil)
+            return
+        }
+
+        if ProcessInfo.processInfo.environment["RAPID_DEV_VIDEO_ONLY"] == "1" {
+            let previewServer = ServerManager(
+                testingState: .idle,
+                binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+            )
+            let previewModel = ModelEntry(
+                alias: "ltx-2.3-mlx-q4",
+                hfRepo: "notapalindrome/ltx23-mlx-av-q4",
+                sizeOnDisk: "9.4 GB",
+                cached: true,
+                kind: .video,
+                videoCapabilities: [.textToVideo, .imageToVideo],
+                minimumMemoryGB: 24
+            )
+            func makePreviewViewModel() -> VideoGenViewModel {
+                VideoGenViewModel(
+                    server: previewServer,
+                    physicalRAMGB: 32,
+                    catalogLoader: { _ in [previewModel] }
+                )
+            }
+            let lightViewModel = makePreviewViewModel()
+            let darkViewModel = makePreviewViewModel()
+            let compactLightViewModel = makePreviewViewModel()
+            let compactDarkViewModel = makePreviewViewModel()
+            await lightViewModel.refreshCatalog()
+            await darkViewModel.refreshCatalog()
+            await compactLightViewModel.refreshCatalog()
+            await compactDarkViewModel.refreshCatalog()
+            let readyServer = ServerManager(
+                testingState: .ready(alias: previewModel.alias),
+                binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+                activeBearer: "snapshot-bearer"
+            )
+            let readyViewModel = VideoGenViewModel(
+                server: readyServer,
+                physicalRAMGB: 32,
+                catalogLoader: { _ in [previewModel] }
+            )
+            await readyViewModel.refreshCatalog()
+            readyViewModel.capabilities = VideoCapabilities(
+                model: previewModel.alias,
+                family: "ltx-2.3",
+                modes: [.textToVideo, .imageToVideo],
+                limits: .init(
+                    size: .init(
+                        type: "range",
+                        values: nil,
+                        width: .init(minimum: 256, maximum: 1920, multipleOf: 64),
+                        height: .init(minimum: 256, maximum: 1920, multipleOf: 64),
+                        maximumArea: nil,
+                        alsoSupported: nil
+                    ),
+                    seconds: .init(minimum: 1, maximum: 20, default: 4)
+                )
+            )
+            readyViewModel.size = "512x512"
+            readyViewModel.seconds = 1
+            func videoSurface(
+                _ viewModel: VideoGenViewModel,
+                server: ServerManager = previewServer,
+                width: CGFloat = 1000,
+                height: CGFloat = 700
+            ) -> AnyView {
+                AnyView(
+                    VideoView(viewModel: viewModel, server: server)
+                        .environment(downloads)
+                        .environment(settingsRouter)
+                        .frame(width: width, height: height)
+                        .tint(RapidTheme.brandAmber)
+                )
+            }
+            let size = CGSize(width: 1000, height: 700)
+            renderHosted(
+                videoSurface(lightViewModel), size: size, appearance: .aqua,
+                to: "\(dir)/video-surface-light.png"
+            )
+            renderHosted(
+                videoSurface(darkViewModel), size: size, appearance: .darkAqua,
+                to: "\(dir)/video-surface-dark.png"
+            )
+            let compactSize = CGSize(width: 520, height: 560)
+            renderHosted(
+                videoSurface(compactLightViewModel, width: 520, height: 560),
+                size: compactSize,
+                appearance: .aqua,
+                to: "\(dir)/video-surface-compact-light.png"
+            )
+            renderHosted(
+                videoSurface(compactDarkViewModel, width: 520, height: 560),
+                size: compactSize,
+                appearance: .darkAqua,
+                to: "\(dir)/video-surface-compact-dark.png"
+            )
+            renderHosted(
+                videoSurface(readyViewModel, server: readyServer, width: 520, height: 560),
+                size: compactSize,
+                appearance: .darkAqua,
+                to: "\(dir)/video-surface-ready-compact-dark.png"
+            )
+            NSApp.terminate(nil)
+            return
+        }
+
         // Erase to AnyView so the long environment chain stays cheap to
         // type-check and the render call is monomorphic.
         func contentView(width: CGFloat, height: CGFloat) -> AnyView {
@@ -116,6 +255,7 @@ enum DevSnapshot {
                     .environment(browseApproval)
                     .environment(imageGen)
                     .environment(audio)
+                    .environment(video)
                     .environment(dictation)
                     .environment(snapshotMCPCatalog)
                     .environment(snapshotMCPApproval)
@@ -207,6 +347,7 @@ enum DevSnapshot {
                 HStack(spacing: 0) {
                     SidebarView(
                         selection: .constant(.launch),
+                        videoGenerationEnabled: VideoFeatureConfig.isEnabled(),
                         chat: chat,
                         onNewChat: {},
                         onSelectConversation: { _ in }
@@ -423,6 +564,7 @@ enum DevSnapshot {
             AnyView(
                 SidebarView(
                     selection: .constant(.launch),
+                    videoGenerationEnabled: VideoFeatureConfig.isEnabled(),
                     chat: chat,
                     onNewChat: {},
                     onSelectConversation: { _ in }
@@ -590,6 +732,7 @@ enum DevSnapshot {
             AnyView(
                 SidebarView(
                     selection: .constant(.images),
+                    videoGenerationEnabled: VideoFeatureConfig.isEnabled(),
                     chat: chat,
                     onNewChat: {},
                     onSelectConversation: { _ in }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -77,6 +77,10 @@ struct RapidApp: App {
     /// Local speech-to-text and text-to-speech workflows. Like Images, this
     /// shares the one embedded server and swaps models only on explicit work.
     @State private var audio: AudioViewModel
+    /// Experimental Video-tab state. Creating this controller is inert: no
+    /// catalog lookup, download, or server start occurs until the gated view
+    /// appears and the user explicitly acts.
+    @State private var video: VideoGenViewModel
     /// Owned by the app, not the Audio tab: dictation must keep working
     /// while Rapid's own window is closed.
     @State private var dictation: DictationController
@@ -341,6 +345,7 @@ struct RapidApp: App {
         }
         _imageGen = State(initialValue: imageGenViewModel)
         _audio = State(initialValue: AudioViewModel(server: manager))
+        _video = State(initialValue: VideoGenViewModel(server: manager))
         _dictation = State(initialValue: dictationController)
         _updater = State(initialValue: updateChecker)
         _sparkleUpdater = State(initialValue: sparkleUpdateController)
@@ -375,6 +380,7 @@ struct RapidApp: App {
                 .environment(chatViewModel)
                 .environment(imageGen)
                 .environment(audio)
+                .environment(video)
                 .environment(dictation)
                 .environment(updater)
                 .environment(sparkleUpdater)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -54,7 +54,7 @@ enum ImageModelCapability: String, Sendable, Hashable {
 
 /// Request shapes advertised by a video-generation alias. The engine owns
 /// this metadata; Desktop never infers it from an alias or model family.
-enum VideoModelCapability: String, Sendable, Hashable {
+enum VideoModelCapability: String, Codable, Sendable, Hashable {
     case textToVideo = "text-to-video"
     case imageToVideo = "image-to-video"
 }
@@ -72,6 +72,8 @@ enum ModelSelectionPurpose: Sendable, Hashable {
     case imageEditing
     case speechToText
     case textToSpeech
+    case textToVideo
+    case imageToVideo
 
     func accepts(_ entry: ModelEntry) -> Bool {
         switch self {
@@ -93,6 +95,12 @@ enum ModelSelectionPurpose: Sendable, Hashable {
             return entry.kind == .audio
                 && entry.audioCapability?.supportsPresetSpeech == true
                 && entry.audioFamily == "qwen3_tts"
+        case .textToVideo:
+            return entry.kind == .video
+                && entry.videoCapabilities.contains(.textToVideo)
+        case .imageToVideo:
+            return entry.kind == .video
+                && entry.videoCapabilities.contains(.imageToVideo)
         }
     }
 
@@ -765,7 +773,7 @@ enum ModelCatalog {
         }
     }
 
-    /// Video aliases for the future Video surface. This intentionally uses
+    /// Video aliases for the experimental Video surface. This intentionally uses
     /// the machine-readable catalog: request modes and the physical-memory
     /// floor are serving contracts, not presentation strings that Desktop
     /// should reconstruct from the human-readable table.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -580,7 +580,7 @@ struct ContentView: View {
         return .init(
             isBusy: chat.isStreaming
                 || imageGen.isGenerating
-                || video.hasActiveJobs
+                || video.hasLiveActiveJobs
                 || video.isSubmitting
                 || video.isPreparing
                 || dictationIsBusy,

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -73,6 +73,7 @@ struct ContentView: View {
     @Environment(ChatViewModel.self) private var chat
     @Environment(ImageGenViewModel.self) private var imageGen
     @Environment(AudioViewModel.self) private var audio
+    @Environment(VideoGenViewModel.self) private var video
     @Environment(DictationController.self) private var dictation
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
@@ -93,6 +94,8 @@ struct ContentView: View {
     @State private var userSelectionRevision: UInt = 0
     /// Which detail surface the sidebar shows (chat vs the Launch page).
     @State private var section: SidebarSection = .chat
+    @AppStorage(VideoFeatureConfig.enabledKey)
+    private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
     /// Window-level conversation search, opened from the toolbar.
     @State private var showConversationSearch = false
     // Was @SceneStorage. Moved to @AppStorage so the View menu command in
@@ -217,6 +220,11 @@ struct ContentView: View {
                 // and try to execute — tools with no process behind them.
                 mcpCatalog.clear()
             }
+        }
+        .onChange(of: videoGenerationEnabled) { _, enabled in
+            // Removing an experimental destination while it is active must
+            // never leave an unreachable detail pane on screen.
+            section = Self.sectionAfterVideoGateChange(current: section, enabled: enabled)
         }
         .onChange(of: server.state) { _, newState in
             // Sync the picker breadcrumb when the server lands in
@@ -467,8 +475,9 @@ struct ContentView: View {
             }
             NavigationSplitView {
                 SidebarView(
-                selection: $section,
-                chat: chat,
+                    selection: $section,
+                    videoGenerationEnabled: videoGenerationEnabled,
+                    chat: chat,
                 onNewChat: {
                     chat.newConversation()
                     section = .chat
@@ -569,7 +578,12 @@ struct ContentView: View {
         } ?? false
 
         return .init(
-            isBusy: chat.isStreaming || imageGen.isGenerating || dictationIsBusy,
+            isBusy: chat.isStreaming
+                || imageGen.isGenerating
+                || video.hasActiveJobs
+                || video.isSubmitting
+                || video.isPreparing
+                || dictationIsBusy,
             hasBlockingSurface: quickstartVisible
                 || deferredTelemetryConsent.isPresented
                 || campaignIsVisible
@@ -1021,6 +1035,12 @@ struct ContentView: View {
             ImagesView(viewModel: imageGen, server: server)
         case .audio:
             AudioView(viewModel: audio, server: server)
+        case .video:
+            if videoGenerationEnabled {
+                VideoView(viewModel: video, server: server)
+            } else {
+                mainArea
+            }
         case .launch:
             LaunchView(
                 server: server,
@@ -1226,6 +1246,15 @@ struct ContentView: View {
         })
     }
 
+    /// Route recovery for the experimental gate. Pure so Settings/sidebar
+    /// behavior can be pinned without standing up the full app environment.
+    static func sectionAfterVideoGateChange(
+        current: SidebarSection,
+        enabled: Bool
+    ) -> SidebarSection {
+        !enabled && current == .video ? .chat : current
+    }
+
     /// The chat catalog intentionally omits every media row, so aliases from
     /// independently loaded media catalogs close that negative-information
     /// gap. Dictation publishes its own catalog-proven aliases because it can
@@ -1237,6 +1266,7 @@ struct ContentView: View {
         Set(
             audio.audioModels.map(\.alias)
                 + imageGen.imageModels.map(\.alias)
+                + video.videoModels.map(\.alias)
                 + Array(dictation.knownAudioAliases)
         )
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -378,8 +378,15 @@ struct ContentView: View {
                 // generator; a replacement clears the whole profile via the
                 // existing bearer/session lifecycle.
                 let profile = server.activeModelProfile
-                let mismatched = profile?.id.caseInsensitiveCompare(alias) != .orderedSame
-                let speculativePending = profile?.needsLiveProfileRefresh == true
+                let mismatched: Bool
+                let speculativePending: Bool
+                if let profile {
+                    mismatched = profile.id.caseInsensitiveCompare(alias) != .orderedSame
+                    speculativePending = profile.needsLiveProfileRefresh
+                } else {
+                    mismatched = true
+                    speculativePending = false
+                }
                 if mismatched || speculativePending {
                     await refreshSelectedModelProfile(for: alias)
                 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -45,6 +45,8 @@ struct SettingsView: View {
     @Environment(DeferredTelemetryConsentCoordinator.self) private var deferredTelemetryConsent
     @State private var confirmingSetupRestart = false
     @State private var restartingSetup = false
+    @AppStorage(VideoFeatureConfig.enabledKey)
+    private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
 
     /// Stable reference shared by the sidebar and detail canvas. Keeping the
     /// frequently-mutated category outside this large view's value state means
@@ -88,6 +90,10 @@ struct SettingsView: View {
         /// the same thing. Mixing them would invite the "I moved a slider and
         /// quality changed" confusion the issue is written to avoid.
         case performance
+        /// Resource-intensive product surfaces that are still being validated
+        /// on the range of Macs Rapid supports. Their opt-ins are explicit,
+        /// persistent, and take effect immediately without restarting.
+        case experimentalFeatures
         case appearance
         case privacy
         /// Rapid-MLX Desktop app updates. The .app self-update is the
@@ -110,6 +116,7 @@ struct SettingsView: View {
             case .tools: return "Tools"
             case .connectors: return "Connectors"
             case .performance: return "Performance"
+            case .experimentalFeatures: return "Experimental Features"
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
@@ -126,6 +133,7 @@ struct SettingsView: View {
             case .tools: return "wrench.and.screwdriver.fill"
             case .connectors: return "powerplug.fill"
             case .performance: return "speedometer"
+            case .experimentalFeatures: return "flask.fill"
             case .appearance: return "paintpalette.fill"
             case .privacy: return "lock.shield.fill"
             case .app: return "app.badge.fill"
@@ -492,6 +500,8 @@ struct SettingsView: View {
             SettingsConnectorsPanel()
         case .performance:
             SettingsPerformancePanel()
+        case .experimentalFeatures:
+            experimentalFeaturesPanel
         case .appearance:
             appearancePanel
         case .privacy:
@@ -503,6 +513,27 @@ struct SettingsView: View {
             SettingsDeveloperPanel()
         #endif
         }
+    }
+
+    private var experimentalFeaturesPanel: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Experimental Features",
+                subtitle: "Opt in to features that are still being validated across supported Macs.",
+                emphasis: .page
+            )
+            SettingsSection {
+                Toggle(isOn: $videoGenerationEnabled) {
+                    SettingsRowLabel(
+                        title: "Enable Video Generation",
+                        description: "Shows the Video tab. Video models need Apple silicon, large downloads, and typically 24 GB or more of unified memory. Nothing downloads or starts until you choose a model."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Experimental.VideoGenerationToggle")
+            }
+        }
+        .accessibilityIdentifier("Settings.Experimental.Panel")
     }
 
     private var instructionsPanel: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -7,6 +7,7 @@ enum SidebarSection: Hashable {
     case chat
     case images
     case audio
+    case video
     case launch
 }
 
@@ -31,6 +32,9 @@ struct SidebarView: View {
     static let columnMaxWidth: CGFloat = 260
 
     @Binding var selection: SidebarSection
+    /// Video is intentionally opt-in because its models require substantially
+    /// more unified memory than the app's everyday chat and media workflows.
+    var videoGenerationEnabled: Bool = false
     /// The chat model — source of the conversation history list + the
     /// active conversation id (for highlighting).
     @Bindable var chat: ChatViewModel
@@ -174,6 +178,15 @@ struct SidebarView: View {
                 action: { selection = .audio }
             )
             .accessibilityIdentifier("Sidebar.Audio")
+            if videoGenerationEnabled {
+                row(
+                    title: "Video",
+                    systemImage: "film",
+                    isSelected: selection == .video,
+                    action: { selection = .video }
+                )
+                .accessibilityIdentifier("Sidebar.Video")
+            }
             row(
                 title: "Launch",
                 systemImage: "paperplane",

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 enum VideoReferenceLoaderError: Error, Equatable {
     case notRegularFile
     case tooLarge
+    case unsupportedFormat
 }
 
 enum VideoReferenceLoader {
@@ -114,7 +115,7 @@ struct VideoView: View {
         }
         .fileImporter(
             isPresented: $showingReferenceImporter,
-            allowedContentTypes: [.png, .jpeg, .webP],
+            allowedContentTypes: acceptedReferenceContentTypes,
             allowsMultipleSelection: false,
             onCompletion: importReference
         )
@@ -554,14 +555,43 @@ struct VideoView: View {
         )
     }
 
+    private var acceptedReferenceContentTypes: [UTType] {
+        [
+            ("image/jpeg", UTType.jpeg),
+            ("image/png", UTType.png),
+            ("image/webp", UTType.webP),
+        ].compactMap { mime, type in
+            viewModel.acceptedReferenceMIMETypes.contains(mime) ? type : nil
+        }
+    }
+
     private func importReference(_ result: Result<[URL], Error>) {
         do {
             guard let url = try result.get().first else { return }
             let scoped = url.startAccessingSecurityScopedResource()
-            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            Task {
+                defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+                await loadReference(url)
+            }
+        } catch {
+            viewModel.errorMessage = "Rapid couldn't open that reference image."
+        }
+    }
+
+    private func loadReference(_ url: URL) async {
+        do {
             let maximumBytes = viewModel.referenceMaximumBytes
-            let data = try VideoReferenceLoader.load(from: url, maximumBytes: maximumBytes)
-            guard let mime = VideoReferenceLoader.mimeType(for: data) else {
+            let acceptedMIMETypes = viewModel.acceptedReferenceMIMETypes
+            let (data, mime) = try await Task.detached(priority: .userInitiated) {
+                let data = try VideoReferenceLoader.load(from: url, maximumBytes: maximumBytes)
+                guard let mime = VideoReferenceLoader.mimeType(for: data) else {
+                    throw VideoReferenceLoaderError.unsupportedFormat
+                }
+                return (data, mime)
+            }.value
+            guard maximumBytes == viewModel.referenceMaximumBytes,
+                  acceptedMIMETypes == viewModel.acceptedReferenceMIMETypes else { return }
+            guard acceptedMIMETypes.contains(mime) else {
                 viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."
                 return
             }
@@ -569,6 +599,8 @@ struct VideoView: View {
             viewModel.errorMessage = nil
         } catch VideoReferenceLoaderError.tooLarge {
             viewModel.errorMessage = "That reference image exceeds this model's size limit."
+        } catch VideoReferenceLoaderError.unsupportedFormat {
+            viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."
         } catch {
             viewModel.errorMessage = "Rapid couldn't open that reference image."
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -1,0 +1,592 @@
+import AppKit
+import AVKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+private struct VideoCatalogRefreshKey: Hashable {
+    let cacheGeneration: UInt
+}
+
+struct VideoView: View {
+    @Bindable var viewModel: VideoGenViewModel
+    @Bindable var server: ServerManager
+    @Environment(DownloadManager.self) private var downloads
+    @Environment(SettingsRouter.self) private var settingsRouter
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var showingReferenceImporter = false
+    @State private var pendingDeletion: VideoJob?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: RapidTheme.Space.lg) {
+                    header
+                    stage
+                    if !viewModel.jobs.isEmpty { history }
+                }
+                .frame(maxWidth: RapidTheme.Layout.contentMaxWidth)
+                .padding(RapidTheme.Space.xl)
+                .frame(maxWidth: .infinity)
+            }
+            composer
+        }
+        .background(RapidTheme.surfaceCanvas)
+        .task(id: VideoCatalogRefreshKey(cacheGeneration: downloads.cacheGeneration)) {
+            await viewModel.refreshCatalog()
+            await viewModel.serverStateDidChange()
+        }
+        .onChange(of: server.state) { _, _ in
+            Task { await viewModel.serverStateDidChange() }
+        }
+        .task(id: viewModel.hasActiveJobs) {
+            guard viewModel.hasActiveJobs else { return }
+            while !Task.isCancelled, viewModel.hasActiveJobs {
+                try? await Task.sleep(for: .seconds(1))
+                await viewModel.pollJobs()
+            }
+        }
+        .fileImporter(
+            isPresented: $showingReferenceImporter,
+            allowedContentTypes: [.png, .jpeg, .webP],
+            allowsMultipleSelection: false,
+            onCompletion: importReference
+        )
+        .sheet(item: $pendingDeletion) { job in
+            VideoDeletionSheet(
+                job: job,
+                onKeep: { pendingDeletion = nil },
+                onDelete: {
+                    pendingDeletion = nil
+                    Task { await viewModel.delete(job) }
+                }
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                Text("Video")
+                    .font(RapidFont.pageTitle)
+                    .foregroundStyle(RapidTheme.textPrimary)
+                Text("Generate short videos locally. Start small—video models are large and generation can take several minutes.")
+                    .font(RapidFont.body)
+                    .foregroundStyle(RapidTheme.textSecondary)
+            }
+            Spacer()
+            Text("EXPERIMENTAL")
+                .font(RapidFont.groupLabel)
+                .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                .padding(.horizontal, RapidTheme.Space.sm)
+                .padding(.vertical, RapidTheme.Space.xs)
+                .background(RapidTheme.brandPrimaryTint, in: Capsule())
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Video.Header")
+    }
+
+    @ViewBuilder
+    private var stage: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.panel, style: .continuous)
+                .fill(RapidTheme.surfaceRaised)
+                .overlay {
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.panel, style: .continuous)
+                        .stroke(RapidTheme.hairline, lineWidth: 1)
+                }
+
+            if let url = viewModel.previewURL {
+                VideoPlaybackView(url: url)
+                    .clipShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.panel, style: .continuous))
+                    .overlay(alignment: .topTrailing) { resultActions }
+            } else if let job = viewModel.selectedJob {
+                jobStage(job)
+            } else {
+                emptyStage
+            }
+        }
+        .aspectRatio(16 / 9, contentMode: .fit)
+        .frame(maxHeight: 520)
+        .accessibilityIdentifier("Video.Stage")
+    }
+
+    private var emptyStage: some View {
+        VStack(spacing: RapidTheme.Space.md) {
+            Image(systemName: "film.stack")
+                .font(.system(size: 40, weight: .light))
+                .foregroundStyle(RapidTheme.textTertiary)
+            Text(emptyStageTitle)
+                .font(RapidFont.sectionTitle)
+                .foregroundStyle(RapidTheme.textPrimary)
+            Text(emptyStageMessage)
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+        }
+        .padding(RapidTheme.Space.xl)
+        .accessibilityIdentifier("Video.EmptyState")
+    }
+
+    private var emptyStageTitle: String {
+        if !viewModel.catalogLoaded { return "Finding video models…" }
+        if viewModel.videoModels.isEmpty { return "No supported video models" }
+        if !viewModel.isSelectedModelEligible { return "This model doesn't fit this Mac" }
+        if !viewModel.isServerReady { return "Start a video model" }
+        return "Create your first video"
+    }
+
+    private var emptyStageMessage: String {
+        if !viewModel.catalogLoaded { return "Rapid is reading the local model catalog." }
+        if viewModel.videoModels.isEmpty {
+            return "The signed engine does not currently advertise a compatible video model."
+        }
+        if !viewModel.isSelectedModelEligible {
+            return viewModel.memoryRequirementText ?? "This model's memory requirement couldn't be verified."
+        }
+        if !viewModel.isServerReady {
+            return "Starting is explicit so opening this tab never replaces your current model or allocates memory by surprise."
+        }
+        return "Describe a short scene below. The first generation is safest at the smallest size and duration."
+    }
+
+    @ViewBuilder
+    private var readinessAction: some View {
+        if viewModel.videoModels.isEmpty, viewModel.catalogLoaded {
+            Button("Manage Models") {
+                settingsRouter.route(to: .modelManagement) { openWindow(id: "settings") }
+            }
+            .buttonStyle(.rapidSecondary)
+            .accessibilityIdentifier("Video.ManageModels")
+        } else if let model = viewModel.selectedModel {
+            if downloads.isDownloading(model.alias) {
+                HStack(spacing: RapidTheme.Space.sm) {
+                    ProgressView().controlSize(.small)
+                    Button("Cancel Download") { downloads.cancelDownload(alias: model.alias) }
+                        .buttonStyle(.rapidSecondary)
+                }
+                .accessibilityIdentifier("Video.CancelDownload")
+            } else if !model.cached {
+                Button("Download \(model.alias)") {
+                    _ = downloads.startDownload(alias: model.alias, hfPath: model.hfRepo)
+                }
+                .buttonStyle(.rapidPrimary)
+                .disabled(!viewModel.isSelectedModelEligible)
+                .accessibilityIdentifier("Video.DownloadModel")
+            } else if !viewModel.isServerReady {
+                Button {
+                    Task { await viewModel.prepareSelectedModel() }
+                } label: {
+                    if viewModel.isPreparing {
+                        HStack(spacing: RapidTheme.Space.sm) {
+                            ProgressView().controlSize(.small)
+                            Text("Starting…")
+                        }
+                    } else {
+                        Label("Start Video Model", systemImage: "play.fill")
+                    }
+                }
+                .buttonStyle(.rapidPrimary)
+                .disabled(viewModel.isPreparing || !viewModel.isSelectedModelEligible)
+                .accessibilityIdentifier("Video.StartModel")
+            }
+        }
+    }
+
+    private func jobStage(_ job: VideoJob) -> some View {
+        VStack(spacing: RapidTheme.Space.md) {
+            if job.status == .queued || job.status == .inProgress || viewModel.isLoadingPreview {
+                ProgressView(value: Double(job.progress), total: 100)
+                    .frame(maxWidth: 300)
+            } else {
+                Image(systemName: job.status == .failed ? "exclamationmark.triangle" : "film")
+                    .font(.system(size: 34, weight: .light))
+                    .foregroundStyle(job.status == .failed ? RapidTheme.statusError : RapidTheme.textTertiary)
+            }
+            Text(jobStatusTitle(job))
+                .font(RapidFont.sectionTitle)
+                .foregroundStyle(RapidTheme.textPrimary)
+            Text(job.error?.message ?? job.prompt)
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .frame(maxWidth: 480)
+            if job.status == .queued {
+                Button("Cancel Queued Video", role: .destructive) {
+                    Task { await viewModel.delete(job) }
+                }
+                .buttonStyle(.rapidSecondary)
+                .accessibilityIdentifier("Video.Job.Cancel")
+            } else if job.status == .inProgress {
+                Text("Generation can't be interrupted safely once Metal work begins.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textTertiary)
+            } else if job.status == .completed && viewModel.previewURL == nil {
+                HStack {
+                    Button("Load Preview") { Task { await viewModel.loadSelectedPreview() } }
+                        .buttonStyle(.rapidSecondary)
+                        .accessibilityIdentifier("Video.LoadPreview")
+                    Button("Delete", role: .destructive) { pendingDeletion = job }
+                        .buttonStyle(.rapidDestructive)
+                        .accessibilityIdentifier("Video.Job.Delete")
+                }
+            } else if job.status == .failed {
+                Button("Delete", role: .destructive) { pendingDeletion = job }
+                    .buttonStyle(.rapidDestructive)
+                    .accessibilityIdentifier("Video.Job.Delete")
+            }
+        }
+        .padding(RapidTheme.Space.xl)
+    }
+
+    private func jobStatusTitle(_ job: VideoJob) -> String {
+        switch job.status {
+        case .queued: return "Waiting to generate"
+        case .inProgress: return "Generating · \(job.progress)%"
+        case .completed: return viewModel.isLoadingPreview ? "Loading preview…" : "Video ready"
+        case .failed: return "Generation failed"
+        }
+    }
+
+    private var resultActions: some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            Button { savePreview() } label: { Image(systemName: "square.and.arrow.down") }
+                .buttonStyle(.rapidTertiary)
+                .help("Save video")
+                .accessibilityLabel("Save video")
+                .accessibilityIdentifier("Video.Job.Save")
+            if let job = viewModel.selectedJob {
+                Button(role: .destructive) { pendingDeletion = job } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.rapidTertiary)
+                .help("Delete video")
+                .accessibilityLabel("Delete video")
+                .accessibilityIdentifier("Video.Job.Delete")
+            }
+        }
+        .padding(RapidTheme.Space.md)
+    }
+
+    private var history: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            Text("Recent videos")
+                .font(RapidFont.sectionTitle)
+                .foregroundStyle(RapidTheme.textPrimary)
+            ScrollView(.horizontal) {
+                HStack(spacing: RapidTheme.Space.sm) {
+                    ForEach(viewModel.jobs) { job in
+                        Button {
+                            Task { await viewModel.selectJob(job.id) }
+                        } label: {
+                            VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                                HStack {
+                                    Image(systemName: statusSymbol(job.status))
+                                    Text(jobStatusLabel(job.status))
+                                    Spacer()
+                                    Text("\(job.seconds)s")
+                                }
+                                .font(RapidFont.groupLabel)
+                                Text(job.prompt)
+                                    .font(RapidFont.caption)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            .foregroundStyle(RapidTheme.textPrimary)
+                            .padding(RapidTheme.Space.md)
+                            .frame(width: 210, height: 82, alignment: .leading)
+                            .background(
+                                viewModel.selectedJobID == job.id
+                                    ? RapidTheme.brandPrimaryTint : RapidTheme.surfaceRaised,
+                                in: RoundedRectangle(cornerRadius: RapidTheme.Radius.row)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("\(jobStatusLabel(job.status)): \(job.prompt)")
+                        .accessibilityIdentifier("Video.History.\(job.id)")
+                    }
+                }
+            }
+            .scrollIndicators(.never)
+            .accessibilityIdentifier("Video.History")
+        }
+    }
+
+    private var composer: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+            if let error = viewModel.errorMessage {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.statusError)
+                    .accessibilityIdentifier("Video.Error")
+            }
+            if viewModel.supportedModes.count > 1 {
+                Picker("Source", selection: modeBinding) {
+                    ForEach(viewModel.supportedModes) { mode in Text(mode.title).tag(mode) }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 240)
+                .accessibilityIdentifier("Video.ModePicker")
+            }
+            if viewModel.mode == .image { referenceControls }
+            ZStack(alignment: .topLeading) {
+                if viewModel.prompt.isEmpty {
+                    Text("Describe the motion, subject, camera, and mood…")
+                        .font(RapidFont.body)
+                        .foregroundStyle(RapidTheme.textTertiary)
+                        .padding(.horizontal, RapidTheme.Space.md)
+                        .padding(.vertical, RapidTheme.Space.md + 1)
+                        .accessibilityHidden(true)
+                }
+                TextEditor(text: $viewModel.prompt)
+                    .font(RapidFont.body)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 54, idealHeight: 64, maxHeight: 72)
+                    .padding(RapidTheme.Space.sm)
+                    .accessibilityLabel("Video prompt")
+                    .accessibilityIdentifier("Video.Prompt")
+            }
+            .background(RapidTheme.surfaceRaised, in: RoundedRectangle(cornerRadius: RapidTheme.Radius.input))
+            .overlay {
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            }
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: RapidTheme.Space.md) {
+                    modelMenu
+                    parameterPickers
+                    Spacer()
+                    composerAction
+                }
+                VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                    modelMenu
+                    HStack(spacing: RapidTheme.Space.md) {
+                        parameterPickers
+                        Spacer()
+                        composerAction
+                    }
+                }
+            }
+        }
+        .padding(RapidTheme.Space.lg)
+        .background(RapidTheme.surfaceCanvas)
+        .overlay(alignment: .top) { Divider() }
+        .accessibilityIdentifier("Video.Composer")
+    }
+
+    @ViewBuilder
+    private var parameterPickers: some View {
+        if !viewModel.sizePresets.isEmpty {
+            Picker("Size", selection: $viewModel.size) {
+                ForEach(viewModel.sizePresets, id: \.self) {
+                    Text($0.replacingOccurrences(of: "x", with: " × ")).tag($0)
+                }
+            }
+            .labelsHidden()
+            .accessibilityLabel("Video size")
+            .accessibilityIdentifier("Video.Size")
+        }
+        if !viewModel.durationPresets.isEmpty {
+            Picker("Duration", selection: $viewModel.seconds) {
+                ForEach(viewModel.durationPresets, id: \.self) {
+                    Text("\($0)s").tag($0)
+                }
+            }
+            .labelsHidden()
+            .accessibilityLabel("Video duration")
+            .accessibilityIdentifier("Video.Duration")
+        }
+    }
+
+    @ViewBuilder
+    private var composerAction: some View {
+        if viewModel.isServerReady {
+            Button {
+                Task { await viewModel.submit() }
+            } label: {
+                if viewModel.isSubmitting {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Label("Generate", systemImage: "sparkles")
+                }
+            }
+            .buttonStyle(.rapidPrimary)
+            .disabled(!viewModel.canSubmit)
+            .keyboardShortcut(.return, modifiers: [.command])
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityIdentifier("Video.Generate")
+        } else {
+            readinessAction
+                .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    private var modelMenu: some View {
+        Picker("Model", selection: modelBinding) {
+            if viewModel.videoModels.isEmpty { Text("No video models").tag("") }
+            ForEach(viewModel.videoModels) { model in
+                Text(modelPickerLabel(model))
+                    .tag(model.alias)
+                    .disabled(!viewModel.isModelEligible(model))
+            }
+        }
+        .labelsHidden()
+        .frame(maxWidth: 220)
+        .disabled(viewModel.hasActiveJobs || viewModel.isSubmitting || viewModel.isPreparing)
+        .accessibilityLabel("Video model")
+        .accessibilityIdentifier("Video.ModelMenu")
+    }
+
+    private func modelPickerLabel(_ model: ModelEntry) -> String {
+        guard let minimum = model.minimumMemoryGB else { return model.alias }
+        return "\(model.alias) · \(Int(minimum.rounded())) GB"
+    }
+
+    private var referenceControls: some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            if let reference = viewModel.referenceImage {
+                Label(reference.fileName, systemImage: "photo.fill")
+                    .font(RapidFont.caption)
+                    .lineLimit(1)
+                Button("Remove") { viewModel.setReference(nil) }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(RapidTheme.statusError)
+                    .accessibilityIdentifier("Video.Reference.Remove")
+            } else {
+                Button { showingReferenceImporter = true } label: {
+                    Label("Add reference image", systemImage: "photo.badge.plus")
+                }
+                .buttonStyle(.rapidSecondary)
+                .accessibilityIdentifier("Video.Reference.Add")
+                Text("JPEG, PNG, or WebP · up to 20 MB")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textTertiary)
+            }
+        }
+    }
+
+    private var modelBinding: Binding<String> {
+        Binding(get: { viewModel.selectedAlias }, set: { viewModel.selectModel($0) })
+    }
+
+    private var modeBinding: Binding<VideoGenViewModel.Mode> {
+        Binding(get: { viewModel.mode }, set: { viewModel.selectMode($0) })
+    }
+
+    private func importReference(_ result: Result<[URL], Error>) {
+        do {
+            guard let url = try result.get().first else { return }
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            let data = try Data(contentsOf: url, options: .mappedIfSafe)
+            guard data.count <= VideoClient.maxReferenceBytes else {
+                viewModel.errorMessage = "Reference images must be 20 MB or smaller."
+                return
+            }
+            guard NSImage(data: data) != nil else {
+                viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."
+                return
+            }
+            let ext = url.pathExtension.lowercased()
+            let mime = ext == "jpg" || ext == "jpeg" ? "image/jpeg"
+                : ext == "webp" ? "image/webp" : "image/png"
+            viewModel.setReference(.init(data: data, fileName: url.lastPathComponent, mimeType: mime))
+            viewModel.errorMessage = nil
+        } catch {
+            viewModel.errorMessage = "Rapid couldn't open that reference image."
+        }
+    }
+
+    private func savePreview() {
+        guard let source = viewModel.previewURL else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.mpeg4Movie]
+        panel.nameFieldStringValue = "\(viewModel.selectedJob?.id ?? "rapid-video").mp4"
+        guard panel.runModal() == .OK, let destination = panel.url else { return }
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.copyItem(at: source, to: destination)
+        } catch {
+            viewModel.errorMessage = "Rapid couldn't save the video to that location."
+        }
+    }
+
+    private func statusSymbol(_ status: VideoJobStatus) -> String {
+        switch status {
+        case .queued: return "clock"
+        case .inProgress: return "sparkles"
+        case .completed: return "checkmark.circle.fill"
+        case .failed: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func jobStatusLabel(_ status: VideoJobStatus) -> String {
+        switch status {
+        case .queued: return "Queued"
+        case .inProgress: return "Generating"
+        case .completed: return "Ready"
+        case .failed: return "Failed"
+        }
+    }
+}
+
+private struct VideoPlaybackView: View {
+    let url: URL
+    @State private var player: AVPlayer
+
+    init(url: URL) {
+        self.url = url
+        _player = State(initialValue: AVPlayer(url: url))
+    }
+
+    var body: some View {
+        VideoPlayer(player: player)
+            .onDisappear { player.pause() }
+            .accessibilityLabel("Generated video preview")
+    }
+}
+
+private struct VideoDeletionSheet: View {
+    let job: VideoJob
+    let onKeep: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+            Text(job.status == .queued ? "Cancel queued video?" : "Delete this video?")
+                .font(RapidFont.sectionTitle)
+            Text(deletionMessage)
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
+            HStack {
+                Spacer()
+                Button("Keep", action: onKeep)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("Video.Job.Delete.Keep")
+                Button(job.status == .queued ? "Cancel Video" : "Delete", role: .destructive, action: onDelete)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("Video.Job.Delete.Confirm")
+            }
+        }
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 420)
+    }
+
+    private var deletionMessage: String {
+        switch job.status {
+        case .queued:
+            return "The queued request will be removed before generation begins."
+        case .failed:
+            return "This failed request will be removed from recent videos."
+        case .completed:
+            return "The generated file will be removed from this Mac. This can't be undone."
+        case .inProgress:
+            return "Generation can't be deleted while it is in progress."
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -3,6 +3,42 @@ import AVKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+enum VideoReferenceLoaderError: Error, Equatable {
+    case notRegularFile
+    case tooLarge
+}
+
+enum VideoReferenceLoader {
+    static func load(
+        from url: URL,
+        fileManager: FileManager = .default,
+        maximumBytes: Int = VideoClient.maxReferenceBytes
+    ) throws -> Data {
+        let (readLimit, overflowed) = maximumBytes.addingReportingOverflow(1)
+        guard maximumBytes >= 0, !overflowed else {
+            throw VideoReferenceLoaderError.tooLarge
+        }
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw VideoReferenceLoaderError.notRegularFile
+        }
+        guard let byteCount = (attributes[.size] as? NSNumber)?.uint64Value,
+              byteCount <= UInt64(maximumBytes) else {
+            throw VideoReferenceLoaderError.tooLarge
+        }
+
+        // Read at most one byte past the contract even if the file grows
+        // between metadata inspection and the read.
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: readLimit) ?? Data()
+        guard data.count <= maximumBytes else {
+            throw VideoReferenceLoaderError.tooLarge
+        }
+        return data
+    }
+}
+
 enum VideoPreviewSaver {
     static func save(
         source: URL,
@@ -64,13 +100,6 @@ struct VideoView: View {
         .onChange(of: server.state) { _, _ in
             Task { await viewModel.serverStateDidChange() }
         }
-        .task(id: viewModel.hasActiveJobs) {
-            guard viewModel.hasActiveJobs else { return }
-            while !Task.isCancelled, viewModel.hasActiveJobs {
-                try? await Task.sleep(for: .seconds(1))
-                await viewModel.pollJobs()
-            }
-        }
         .fileImporter(
             isPresented: $showingReferenceImporter,
             allowedContentTypes: [.png, .jpeg, .webP],
@@ -123,6 +152,7 @@ struct VideoView: View {
 
             if let url = viewModel.previewURL {
                 VideoPlaybackView(url: url)
+                    .id(url)
                     .clipShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.panel, style: .continuous))
                     .overlay(alignment: .topTrailing) { resultActions }
             } else if let job = viewModel.selectedJob {
@@ -190,8 +220,8 @@ struct VideoView: View {
                     ProgressView().controlSize(.small)
                     Button("Cancel Download") { downloads.cancelDownload(alias: model.alias) }
                         .buttonStyle(.rapidSecondary)
+                        .accessibilityIdentifier("Video.CancelDownload")
                 }
-                .accessibilityIdentifier("Video.CancelDownload")
             } else if !model.cached {
                 Button("Download \(model.alias)") {
                     _ = downloads.startDownload(alias: model.alias, hfPath: model.hfRepo)
@@ -510,11 +540,7 @@ struct VideoView: View {
             guard let url = try result.get().first else { return }
             let scoped = url.startAccessingSecurityScopedResource()
             defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-            let data = try Data(contentsOf: url, options: .mappedIfSafe)
-            guard data.count <= VideoClient.maxReferenceBytes else {
-                viewModel.errorMessage = "Reference images must be 20 MB or smaller."
-                return
-            }
+            let data = try VideoReferenceLoader.load(from: url)
             guard NSImage(data: data) != nil else {
                 viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."
                 return
@@ -524,6 +550,8 @@ struct VideoView: View {
                 : ext == "webp" ? "image/webp" : "image/png"
             viewModel.setReference(.init(data: data, fileName: url.lastPathComponent, mimeType: mime))
             viewModel.errorMessage = nil
+        } catch VideoReferenceLoaderError.tooLarge {
+            viewModel.errorMessage = "Reference images must be 20 MB or smaller."
         } catch {
             viewModel.errorMessage = "Rapid couldn't open that reference image."
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -385,10 +385,18 @@ struct VideoView: View {
     private var composer: some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
             if let error = viewModel.errorMessage {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(RapidFont.caption)
-                    .foregroundStyle(RapidTheme.statusError)
-                    .accessibilityIdentifier("Video.Error")
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.statusError)
+                        .accessibilityIdentifier("Video.Error")
+                    if viewModel.needsServerRefresh {
+                        Button("Retry") { Task { await viewModel.refreshServerData() } }
+                            .buttonStyle(.rapidSecondary)
+                            .disabled(viewModel.isRefreshing)
+                            .accessibilityIdentifier("Video.RetryServerData")
+                    }
+                }
             }
             if viewModel.supportedModes.count > 1 {
                 Picker("Source", selection: modeBinding) {
@@ -503,7 +511,7 @@ struct VideoView: View {
         }
         .labelsHidden()
         .frame(maxWidth: 220)
-        .disabled(viewModel.hasLiveActiveJobs || viewModel.isSubmitting || viewModel.isPreparing)
+        .disabled(!viewModel.canSwitchModels)
         .accessibilityLabel("Video model")
         .accessibilityIdentifier("Video.ModelMenu")
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -3,6 +3,31 @@ import AVKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+enum VideoPreviewSaver {
+    static func save(
+        source: URL,
+        destination: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let directory = destination.deletingLastPathComponent()
+        let staging = directory.appendingPathComponent(
+            ".rapid-video-save-\(UUID().uuidString).mp4"
+        )
+        defer { try? fileManager.removeItem(at: staging) }
+        try fileManager.copyItem(at: source, to: staging)
+        if fileManager.fileExists(atPath: destination.path) {
+            _ = try fileManager.replaceItemAt(
+                destination,
+                withItemAt: staging,
+                backupItemName: nil,
+                options: []
+            )
+        } else {
+            try fileManager.moveItem(at: staging, to: destination)
+        }
+    }
+}
+
 private struct VideoCatalogRefreshKey: Hashable {
     let cacheGeneration: UInt
 }
@@ -380,7 +405,7 @@ struct VideoView: View {
     @ViewBuilder
     private var parameterPickers: some View {
         if !viewModel.sizePresets.isEmpty {
-            Picker("Size", selection: $viewModel.size) {
+            Picker("Size", selection: sizeBinding) {
                 ForEach(viewModel.sizePresets, id: \.self) {
                     Text($0.replacingOccurrences(of: "x", with: " × ")).tag($0)
                 }
@@ -476,6 +501,10 @@ struct VideoView: View {
         Binding(get: { viewModel.mode }, set: { viewModel.selectMode($0) })
     }
 
+    private var sizeBinding: Binding<String> {
+        Binding(get: { viewModel.size }, set: { viewModel.selectSize($0) })
+    }
+
     private func importReference(_ result: Result<[URL], Error>) {
         do {
             guard let url = try result.get().first else { return }
@@ -507,10 +536,7 @@ struct VideoView: View {
         panel.nameFieldStringValue = "\(viewModel.selectedJob?.id ?? "rapid-video").mp4"
         guard panel.runModal() == .OK, let destination = panel.url else { return }
         do {
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.copyItem(at: source, to: destination)
+            try VideoPreviewSaver.save(source: source, destination: destination)
         } catch {
             viewModel.errorMessage = "Rapid couldn't save the video to that location."
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -90,6 +90,7 @@ struct VideoView: View {
 
     @State private var showingReferenceImporter = false
     @State private var pendingDeletion: VideoJob?
+    @State private var isSavingPreview = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -322,6 +323,7 @@ struct VideoView: View {
         HStack(spacing: RapidTheme.Space.sm) {
             Button { savePreview() } label: { Image(systemName: "square.and.arrow.down") }
                 .buttonStyle(.rapidTertiary)
+                .disabled(isSavingPreview)
                 .help("Save video")
                 .accessibilityLabel("Save video")
                 .accessibilityIdentifier("Video.Job.Save")
@@ -620,10 +622,16 @@ struct VideoView: View {
         panel.allowedContentTypes = [.mpeg4Movie]
         panel.nameFieldStringValue = "\(viewModel.selectedJob?.id ?? "rapid-video").mp4"
         guard panel.runModal() == .OK, let destination = panel.url else { return }
-        do {
-            try VideoPreviewSaver.save(source: source, destination: destination)
-        } catch {
-            viewModel.errorMessage = "Rapid couldn't save the video to that location."
+        isSavingPreview = true
+        Task {
+            defer { isSavingPreview = false }
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try VideoPreviewSaver.save(source: source, destination: destination)
+                }.value
+            } catch {
+                viewModel.errorMessage = "Rapid couldn't save the video to that location."
+            }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AVKit
+import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -36,6 +37,17 @@ enum VideoReferenceLoader {
             throw VideoReferenceLoaderError.tooLarge
         }
         return data
+    }
+
+    static func mimeType(for data: Data) -> String? {
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, options),
+              let identifier = CGImageSourceGetType(source) as String?,
+              let type = UTType(identifier) else { return nil }
+        if type.conforms(to: .jpeg) { return "image/jpeg" }
+        if type.conforms(to: .png) { return "image/png" }
+        if type.conforms(to: .webP) { return "image/webp" }
+        return nil
     }
 }
 
@@ -490,7 +502,7 @@ struct VideoView: View {
         }
         .labelsHidden()
         .frame(maxWidth: 220)
-        .disabled(viewModel.hasActiveJobs || viewModel.isSubmitting || viewModel.isPreparing)
+        .disabled(viewModel.hasLiveActiveJobs || viewModel.isSubmitting || viewModel.isPreparing)
         .accessibilityLabel("Video model")
         .accessibilityIdentifier("Video.ModelMenu")
     }
@@ -516,7 +528,7 @@ struct VideoView: View {
                 }
                 .buttonStyle(.rapidSecondary)
                 .accessibilityIdentifier("Video.Reference.Add")
-                Text("JPEG, PNG, or WebP · up to 20 MB")
+                Text("JPEG, PNG, or WebP · up to \(referenceLimitText)")
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textTertiary)
             }
@@ -535,23 +547,28 @@ struct VideoView: View {
         Binding(get: { viewModel.size }, set: { viewModel.selectSize($0) })
     }
 
+    private var referenceLimitText: String {
+        ByteCountFormatter.string(
+            fromByteCount: Int64(viewModel.referenceMaximumBytes),
+            countStyle: .file
+        )
+    }
+
     private func importReference(_ result: Result<[URL], Error>) {
         do {
             guard let url = try result.get().first else { return }
             let scoped = url.startAccessingSecurityScopedResource()
             defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-            let data = try VideoReferenceLoader.load(from: url)
-            guard NSImage(data: data) != nil else {
+            let maximumBytes = viewModel.referenceMaximumBytes
+            let data = try VideoReferenceLoader.load(from: url, maximumBytes: maximumBytes)
+            guard let mime = VideoReferenceLoader.mimeType(for: data) else {
                 viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."
                 return
             }
-            let ext = url.pathExtension.lowercased()
-            let mime = ext == "jpg" || ext == "jpeg" ? "image/jpeg"
-                : ext == "webp" ? "image/webp" : "image/png"
             viewModel.setReference(.init(data: data, fileName: url.lastPathComponent, mimeType: mime))
             viewModel.errorMessage = nil
         } catch VideoReferenceLoaderError.tooLarge {
-            viewModel.errorMessage = "Reference images must be 20 MB or smaller."
+            viewModel.errorMessage = "That reference image exceeds this model's size limit."
         } catch {
             viewModel.errorMessage = "Rapid couldn't open that reference image."
         }

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -65,8 +65,36 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             let `default`: Int
         }
 
+        struct FPSLimit: Decodable, Sendable, Hashable {
+            let minimum: Int
+            let maximum: Int
+            let `default`: Int
+            let fixed: Bool
+        }
+
+        struct FramesLimit: Decodable, Sendable, Hashable {
+            let minimum: Int
+            let maximum: Int
+            let step: Int
+            let offset: Int
+        }
+
+        struct WorkloadLimit: Decodable, Sendable, Hashable {
+            let metric: String
+            let maximum: Int
+            let dimensionRounding: String
+
+            enum CodingKeys: String, CodingKey {
+                case metric, maximum
+                case dimensionRounding = "dimension_rounding"
+            }
+        }
+
         let size: SizeLimit
         let seconds: SecondsLimit
+        let fps: FPSLimit
+        let frames: FramesLimit
+        let workload: WorkloadLimit
     }
 
     let model: String
@@ -112,12 +140,46 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         }.map { $0.value }
     }
 
-    var durationPresets: [Int] {
+    func durationPresets(for size: String) -> [Int] {
         let candidates = [1, 2, 4]
         let values = candidates.filter {
             (limits.seconds.minimum...limits.seconds.maximum).contains($0)
+                && workloadAllows(seconds: $0, size: size)
         }
-        return values.isEmpty ? [limits.seconds.default] : values
+        if !values.isEmpty { return values }
+        return workloadAllows(seconds: limits.seconds.default, size: size)
+            ? [limits.seconds.default] : []
+    }
+
+    private func workloadAllows(seconds: Int, size: String) -> Bool {
+        guard limits.workload.metric == "pixel_frames",
+              let dimensions = Self.parseSize(size),
+              seconds > 0,
+              limits.fps.default > 0 else { return false }
+        let widthMultiple = limits.size.width?.multipleOf ?? 1
+        let heightMultiple = limits.size.height?.multipleOf ?? 1
+        let width = Self.roundUp(dimensions.width, to: widthMultiple)
+        let height = Self.roundUp(dimensions.height, to: heightMultiple)
+        let frameStep = max(1, limits.frames.step)
+        let frameOffset = limits.frames.offset
+        guard frameOffset >= 0 else { return false }
+        let (requestedFrames, requestOverflow) = seconds.multipliedReportingOverflow(
+            by: limits.fps.default
+        )
+        guard !requestOverflow else { return false }
+        let frameDelta = requestedFrames > frameOffset
+            ? requestedFrames - frameOffset : 0
+        let (roundedDelta, roundingOverflow) = frameDelta.addingReportingOverflow(frameStep - 1)
+        guard !roundingOverflow else { return false }
+        let steps = roundedDelta / frameStep
+        let (steppedFrames, stepOverflow) = steps.multipliedReportingOverflow(by: frameStep)
+        let (normalizedFrames, offsetOverflow) = steppedFrames.addingReportingOverflow(frameOffset)
+        guard !stepOverflow, !offsetOverflow else { return false }
+        let frames = max(limits.frames.minimum, normalizedFrames)
+        guard frames <= limits.frames.maximum else { return false }
+        let (pixelCount, pixelOverflow) = width.multipliedReportingOverflow(by: height)
+        let (workload, workloadOverflow) = pixelCount.multipliedReportingOverflow(by: frames)
+        return !pixelOverflow && !workloadOverflow && workload <= limits.workload.maximum
     }
 
     private static func parseSize(_ value: String) -> (width: Int, height: Int)? {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -271,10 +271,10 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               let dimensions = Self.parseSize(size),
               seconds > 0,
               limits.fps.default > 0 else { return false }
-        let widthMultiple = limits.size.width?.multipleOf ?? 1
-        let heightMultiple = limits.size.height?.multipleOf ?? 1
-        guard let width = Self.roundUp(dimensions.width, to: widthMultiple),
-              let height = Self.roundUp(dimensions.height, to: heightMultiple) else { return false }
+        // Workload normalization is a separate server contract from the
+        // request-size alignment. This client validates only multiple_of_64.
+        guard let width = Self.roundUp(dimensions.width, to: 64),
+              let height = Self.roundUp(dimensions.height, to: 64) else { return false }
         let frameStep = max(1, limits.frames.step)
         let frameOffset = limits.frames.offset
         guard frameOffset >= 0 else { return false }
@@ -446,6 +446,14 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
 
     func delete(id: String, port: Int, bearer: String?) async throws {
         let cached = try cacheURL(for: id)
+        var request = request(path: "v1/videos/\(id)", port: port, bearer: bearer)
+        request.httpMethod = "DELETE"
+        do {
+            _ = try await send(request)
+        } catch let VideoClientError.http(status, _) where status == 404 {
+            // DELETE is idempotent: a prior attempt may have removed the
+            // server job before local cache cleanup failed.
+        }
         if FileManager.default.fileExists(atPath: cached.path) {
             do {
                 try removeCachedItem(cached)
@@ -453,9 +461,6 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
                 throw VideoClientError.cacheRemoval
             }
         }
-        var request = request(path: "v1/videos/\(id)", port: port, bearer: bearer)
-        request.httpMethod = "DELETE"
-        _ = try await send(request)
     }
 
     func content(id: String, port: Int, bearer: String?) async throws -> URL {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 enum VideoJobStatus: String, Codable, Sendable, Hashable {
@@ -206,9 +207,10 @@ struct VideoCreateRequest: Sendable, Equatable {
     let referenceMIMEType: String?
 }
 
-enum VideoClientError: Error, LocalizedError {
+enum VideoClientError: Error, LocalizedError, Equatable {
     case notReady
     case http(status: Int, message: String?)
+    case invalidJobID
     case invalidResponse
     case transport(String)
 
@@ -218,6 +220,8 @@ enum VideoClientError: Error, LocalizedError {
             return "The video model isn't running yet."
         case let .http(status, message):
             return message ?? "Video request failed (HTTP \(status))."
+        case .invalidJobID:
+            return "The video server returned an invalid job identifier."
         case .invalidResponse:
             return "The video server returned an invalid response."
         case let .transport(message):
@@ -282,7 +286,9 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
                 )
             }
         )
-        return try await decode(request)
+        let job: VideoJob = try await decode(request)
+        guard Self.isValidJobID(job.id) else { throw VideoClientError.invalidJobID }
+        return job
     }
 
     func list(port: Int, bearer: String?, limit: Int = 30) async throws -> [VideoJob] {
@@ -295,18 +301,22 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         applyBearer(&request, bearer)
         let envelope: ListEnvelope = try await decode(request)
+        guard envelope.data.allSatisfy({ Self.isValidJobID($0.id) }) else {
+            throw VideoClientError.invalidJobID
+        }
         return envelope.data
     }
 
     func delete(id: String, port: Int, bearer: String?) async throws {
+        let cached = try cacheURL(for: id)
         var request = request(path: "v1/videos/\(id)", port: port, bearer: bearer)
         request.httpMethod = "DELETE"
         _ = try await send(request)
-        try? FileManager.default.removeItem(at: cacheURL(for: id))
+        try? FileManager.default.removeItem(at: cached)
     }
 
     func content(id: String, port: Int, bearer: String?) async throws -> URL {
-        let destination = cacheURL(for: id)
+        let destination = try cacheURL(for: id)
         if FileManager.default.fileExists(atPath: destination.path) { return destination }
         try FileManager.default.createDirectory(
             at: cacheDirectory,
@@ -353,14 +363,56 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
             append("\r\n")
         }
         if let file {
+            let fileName = escapedMultipartFilename(file.name)
             append("--\(boundary)\r\n")
-            append("Content-Disposition: form-data; name=\"\(file.field)\"; filename=\"\(file.name)\"\r\n")
+            append("Content-Disposition: form-data; name=\"\(file.field)\"; filename=\"\(fileName)\"\r\n")
             append("Content-Type: \(file.mime)\r\n\r\n")
             body.append(file.data)
             append("\r\n")
         }
         append("--\(boundary)--\r\n")
         return body
+    }
+
+    /// Multipart quoted strings must not let a local filename terminate the
+    /// header or inject another one. Preserve the user-visible name while
+    /// escaping quoted-string delimiters and replacing control bytes.
+    static func escapedMultipartFilename(_ value: String) -> String {
+        let source = value.isEmpty ? "reference.png" : value
+        var escaped = ""
+        for character in source {
+            if character.unicodeScalars.contains(where: {
+                $0.value < 0x20 || $0.value == 0x7F
+            }) {
+                escaped.append("_")
+            } else {
+                if character == "\"" || character == "\\" {
+                    escaped.append("\\")
+                }
+                escaped.append(character)
+            }
+        }
+        return escaped
+    }
+
+    static func cacheFileName(for id: String) throws -> String {
+        guard isValidJobID(id) else {
+            throw VideoClientError.invalidJobID
+        }
+        let digest = SHA256.hash(data: Data(id.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "\(digest).mp4"
+    }
+
+    private static func isValidJobID(_ id: String) -> Bool {
+        !id.isEmpty && id.utf8.count <= 128
+            && id.utf8.allSatisfy {
+                ($0 >= 48 && $0 <= 57)
+                    || ($0 >= 65 && $0 <= 90)
+                    || ($0 >= 97 && $0 <= 122)
+                    || $0 == 45 || $0 == 95
+            }
     }
 
     private struct ListEnvelope: Decodable { let data: [VideoJob] }
@@ -432,8 +484,7 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
         }
     }
 
-    private func cacheURL(for id: String) -> URL {
-        let safe = id.filter { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" }
-        return cacheDirectory.appendingPathComponent("\(safe).mp4")
+    private func cacheURL(for id: String) throws -> URL {
+        cacheDirectory.appendingPathComponent(try Self.cacheFileName(for: id))
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -1,0 +1,377 @@
+import Foundation
+
+enum VideoJobStatus: String, Codable, Sendable, Hashable {
+    case queued
+    case inProgress = "in_progress"
+    case completed
+    case failed
+}
+
+struct VideoJobError: Codable, Sendable, Hashable {
+    let code: String?
+    let message: String?
+}
+
+struct VideoJob: Identifiable, Codable, Sendable, Hashable {
+    let id: String
+    let model: String
+    let prompt: String
+    let seconds: String
+    let size: String
+    let status: VideoJobStatus
+    let progress: Int
+    let createdAt: Int
+    let completedAt: Int?
+    let error: VideoJobError?
+
+    enum CodingKeys: String, CodingKey {
+        case id, model, prompt, seconds, size, status, progress, error
+        case createdAt = "created_at"
+        case completedAt = "completed_at"
+    }
+}
+
+struct VideoCapabilities: Decodable, Sendable, Hashable {
+    struct Limits: Decodable, Sendable, Hashable {
+        struct Dimension: Decodable, Sendable, Hashable {
+            let minimum: Int
+            let maximum: Int
+            let multipleOf: Int
+
+            enum CodingKeys: String, CodingKey {
+                case minimum, maximum
+                case multipleOf = "multiple_of"
+            }
+        }
+
+        struct SizeLimit: Decodable, Sendable, Hashable {
+            let type: String
+            let values: [String]?
+            let width: Dimension?
+            let height: Dimension?
+            let maximumArea: Int?
+            let alsoSupported: [String]?
+
+            enum CodingKeys: String, CodingKey {
+                case type, values, width, height
+                case maximumArea = "maximum_area"
+                case alsoSupported = "also_supported"
+            }
+        }
+
+        struct SecondsLimit: Decodable, Sendable, Hashable {
+            let minimum: Int
+            let maximum: Int
+            let `default`: Int
+        }
+
+        let size: SizeLimit
+        let seconds: SecondsLimit
+    }
+
+    let model: String
+    let family: String
+    let modes: [VideoModelCapability]
+    let limits: Limits
+
+    /// Conservative, familiar output shapes. The API remains authoritative:
+    /// candidates outside its dimensions, alignment, or area are removed.
+    var sizePresets: [String] {
+        if limits.size.type == "fixed" {
+            return limits.size.values ?? []
+        }
+        let explicitlySupported = Set(limits.size.alsoSupported ?? [])
+        let candidates = ["512x512", "768x512", "512x768"]
+            + (limits.size.alsoSupported ?? [])
+        var seen = Set<String>()
+        var accepted: [(area: Int, order: Int, value: String)] = []
+        for (index, value) in candidates.enumerated() {
+            guard seen.insert(value).inserted,
+                  let dimensions = Self.parseSize(value) else { continue }
+            if explicitlySupported.contains(value) {
+                accepted.append((dimensions.width * dimensions.height, index, value))
+                continue
+            }
+            guard let width = limits.size.width,
+                  let height = limits.size.height,
+                  (width.minimum...width.maximum).contains(dimensions.width),
+                  (height.minimum...height.maximum).contains(dimensions.height),
+                  dimensions.width.isMultiple(of: width.multipleOf),
+                  dimensions.height.isMultiple(of: height.multipleOf) else {
+                continue
+            }
+            if let maximumArea = limits.size.maximumArea {
+                let roundedWidth = Self.roundUp(dimensions.width, to: width.multipleOf)
+                let roundedHeight = Self.roundUp(dimensions.height, to: height.multipleOf)
+                guard roundedWidth * roundedHeight <= maximumArea else { continue }
+            }
+            accepted.append((dimensions.width * dimensions.height, index, value))
+        }
+        return accepted.sorted { lhs, rhs in
+            lhs.0 == rhs.0 ? lhs.1 < rhs.1 : lhs.0 < rhs.0
+        }.map { $0.value }
+    }
+
+    var durationPresets: [Int] {
+        let candidates = [1, 2, 4]
+        let values = candidates.filter {
+            (limits.seconds.minimum...limits.seconds.maximum).contains($0)
+        }
+        return values.isEmpty ? [limits.seconds.default] : values
+    }
+
+    private static func parseSize(_ value: String) -> (width: Int, height: Int)? {
+        let parts = value.lowercased().split(separator: "x", maxSplits: 1)
+        guard parts.count == 2,
+              let width = Int(parts[0]), let height = Int(parts[1]) else { return nil }
+        return (width, height)
+    }
+
+    private static func roundUp(_ value: Int, to multiple: Int) -> Int {
+        guard multiple > 0 else { return value }
+        return ((value + multiple - 1) / multiple) * multiple
+    }
+}
+
+struct VideoCreateRequest: Sendable, Equatable {
+    let prompt: String
+    let model: String
+    let seconds: Int
+    let size: String
+    let seed: Int
+    let reference: Data?
+    let referenceFileName: String?
+    let referenceMIMEType: String?
+}
+
+enum VideoClientError: Error, LocalizedError {
+    case notReady
+    case http(status: Int, message: String?)
+    case invalidResponse
+    case transport(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notReady:
+            return "The video model isn't running yet."
+        case let .http(status, message):
+            return message ?? "Video request failed (HTTP \(status))."
+        case .invalidResponse:
+            return "The video server returned an invalid response."
+        case let .transport(message):
+            return message
+        }
+    }
+}
+
+protocol VideoClientProtocol: Sendable {
+    func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities
+    func create(_ request: VideoCreateRequest, port: Int, bearer: String?) async throws -> VideoJob
+    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob]
+    func delete(id: String, port: Int, bearer: String?) async throws
+    func content(id: String, port: Int, bearer: String?) async throws -> URL
+}
+
+struct VideoClient: VideoClientProtocol, @unchecked Sendable {
+    static let maxReferenceBytes = 20 * 1024 * 1024
+    static let requestTimeout: TimeInterval = 60
+
+    static let sharedSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = requestTimeout
+        configuration.timeoutIntervalForResource = 30 * 60
+        return URLSession(configuration: configuration)
+    }()
+
+    var session: URLSession = sharedSession
+    var cacheDirectory: URL = FileManager.default.urls(
+        for: .cachesDirectory, in: .userDomainMask
+    )[0].appendingPathComponent("Rapid/VideoPreviews", isDirectory: true)
+
+    func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
+        try await decode(request(path: "v1/videos/capabilities", port: port, bearer: bearer))
+    }
+
+    func create(
+        _ value: VideoCreateRequest,
+        port: Int,
+        bearer: String?
+    ) async throws -> VideoJob {
+        var request = request(path: "v1/videos", port: port, bearer: bearer)
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
+        let boundary = "rapid-video-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.multipartBody(
+            boundary: boundary,
+            fields: [
+                ("prompt", value.prompt),
+                ("model", value.model),
+                ("seconds", String(value.seconds)),
+                ("size", value.size),
+                ("seed", String(value.seed)),
+            ],
+            file: value.reference.map {
+                (
+                    field: "input_reference",
+                    name: value.referenceFileName ?? "reference.png",
+                    mime: value.referenceMIMEType ?? "image/png",
+                    data: $0
+                )
+            }
+        )
+        return try await decode(request)
+    }
+
+    func list(port: Int, bearer: String?, limit: Int = 30) async throws -> [VideoJob] {
+        var components = URLComponents(
+            url: Self.loopbackURL(port: port).appendingPathComponent("v1/videos"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        var request = URLRequest(url: components.url!)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&request, bearer)
+        let envelope: ListEnvelope = try await decode(request)
+        return envelope.data
+    }
+
+    func delete(id: String, port: Int, bearer: String?) async throws {
+        var request = request(path: "v1/videos/\(id)", port: port, bearer: bearer)
+        request.httpMethod = "DELETE"
+        _ = try await send(request)
+        try? FileManager.default.removeItem(at: cacheURL(for: id))
+    }
+
+    func content(id: String, port: Int, bearer: String?) async throws -> URL {
+        let destination = cacheURL(for: id)
+        if FileManager.default.fileExists(atPath: destination.path) { return destination }
+        try FileManager.default.createDirectory(
+            at: cacheDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let request = request(path: "v1/videos/\(id)/content", port: port, bearer: bearer)
+        do {
+            let (temporary, response) = try await session.download(for: request)
+            try Self.validate(response: response, data: nil)
+            let staging = cacheDirectory.appendingPathComponent(".\(UUID().uuidString).mp4")
+            try FileManager.default.moveItem(at: temporary, to: staging)
+            do {
+                try FileManager.default.moveItem(at: staging, to: destination)
+            } catch {
+                try? FileManager.default.removeItem(at: staging)
+                guard FileManager.default.fileExists(atPath: destination.path) else {
+                    throw error
+                }
+            }
+            return destination
+        } catch let error as VideoClientError {
+            throw error
+        } catch {
+            throw VideoClientError.transport(error.localizedDescription)
+        }
+    }
+
+    static func loopbackURL(port: Int) -> URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    static func multipartBody(
+        boundary: String,
+        fields: [(String, String)],
+        file: (field: String, name: String, mime: String, data: Data)?
+    ) -> Data {
+        var body = Data()
+        func append(_ string: String) { body.append(Data(string.utf8)) }
+        for (name, value) in fields {
+            append("--\(boundary)\r\n")
+            append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            append(value)
+            append("\r\n")
+        }
+        if let file {
+            append("--\(boundary)\r\n")
+            append("Content-Disposition: form-data; name=\"\(file.field)\"; filename=\"\(file.name)\"\r\n")
+            append("Content-Type: \(file.mime)\r\n\r\n")
+            body.append(file.data)
+            append("\r\n")
+        }
+        append("--\(boundary)--\r\n")
+        return body
+    }
+
+    private struct ListEnvelope: Decodable { let data: [VideoJob] }
+
+    private struct ErrorEnvelope: Decodable {
+        struct Inner: Decodable { let message: String? }
+        struct Detail: Decodable { let error: Inner? }
+        let error: Inner?
+        let detailText: String?
+        let detailObject: Detail?
+
+        enum CodingKeys: String, CodingKey { case error, detail }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            error = try container.decodeIfPresent(Inner.self, forKey: .error)
+            detailText = try? container.decode(String.self, forKey: .detail)
+            detailObject = try? container.decode(Detail.self, forKey: .detail)
+        }
+
+        var message: String? {
+            error?.message ?? detailObject?.error?.message ?? detailText
+        }
+    }
+
+    private func request(path: String, port: Int, bearer: String?) -> URLRequest {
+        var request = URLRequest(url: Self.loopbackURL(port: port).appendingPathComponent(path))
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&request, bearer)
+        return request
+    }
+
+    private func applyBearer(_ request: inout URLRequest, _ bearer: String?) {
+        if let bearer, !bearer.isEmpty {
+            request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    private func decode<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let data = try await send(request)
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw VideoClientError.invalidResponse
+        }
+    }
+
+    private func send(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await session.data(for: request)
+            try Self.validate(response: response, data: data)
+            return data
+        } catch let error as VideoClientError {
+            throw error
+        } catch {
+            throw VideoClientError.transport(error.localizedDescription)
+        }
+    }
+
+    private static func validate(response: URLResponse, data: Data?) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw VideoClientError.invalidResponse
+        }
+        guard (200...299).contains(http.statusCode) else {
+            let message = data.flatMap {
+                try? JSONDecoder().decode(ErrorEnvelope.self, from: $0).message
+            }
+            throw VideoClientError.http(status: http.statusCode, message: message)
+        }
+    }
+
+    private func cacheURL(for id: String) -> URL {
+        let safe = id.filter { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" }
+        return cacheDirectory.appendingPathComponent("\(safe).mp4")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -91,11 +91,44 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             }
         }
 
+        struct InputReferenceLimit: Decodable, Sendable, Hashable {
+            let accepted: Bool
+            let maximumBytes: Int
+            let formats: [String]
+
+            enum CodingKeys: String, CodingKey {
+                case accepted, formats
+                case maximumBytes = "maximum_bytes"
+            }
+        }
+
         let size: SizeLimit
         let seconds: SecondsLimit
         let fps: FPSLimit
         let frames: FramesLimit
         let workload: WorkloadLimit
+        let inputReference: InputReferenceLimit?
+
+        init(
+            size: SizeLimit,
+            seconds: SecondsLimit,
+            fps: FPSLimit,
+            frames: FramesLimit,
+            workload: WorkloadLimit,
+            inputReference: InputReferenceLimit? = nil
+        ) {
+            self.size = size
+            self.seconds = seconds
+            self.fps = fps
+            self.frames = frames
+            self.workload = workload
+            self.inputReference = inputReference
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case size, seconds, fps, frames, workload
+            case inputReference = "input_reference"
+        }
     }
 
     let model: String
@@ -142,14 +175,22 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     }
 
     func durationPresets(for size: String) -> [Int] {
-        let candidates = [1, 2, 4]
+        let candidates = Set([limits.seconds.minimum, 1, 2, 4]).sorted()
         let values = candidates.filter {
             (limits.seconds.minimum...limits.seconds.maximum).contains($0)
                 && workloadAllows(seconds: $0, size: size)
         }
         if !values.isEmpty { return values }
-        return workloadAllows(seconds: limits.seconds.default, size: size)
+        return (limits.seconds.minimum...limits.seconds.maximum).contains(limits.seconds.default)
+            && workloadAllows(seconds: limits.seconds.default, size: size)
             ? [limits.seconds.default] : []
+    }
+
+    var referenceMaximumBytes: Int {
+        guard let inputReference = limits.inputReference,
+              inputReference.accepted,
+              inputReference.maximumBytes > 0 else { return 0 }
+        return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
     }
 
     private func workloadAllows(seconds: Int, size: String) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -259,7 +259,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
-              !workload.dimensionRounding.isEmpty,
+              workload.dimensionRounding == "multiple_of_64",
               validInput else {
             throw VideoClientError.invalidResponse
         }
@@ -338,6 +338,7 @@ struct VideoCreateRequest: Sendable, Equatable {
 enum VideoClientError: Error, LocalizedError, Equatable {
     case notReady
     case http(status: Int, message: String?)
+    case cacheRemoval
     case invalidJobID
     case invalidResponse
     case transport(String)
@@ -348,6 +349,8 @@ enum VideoClientError: Error, LocalizedError, Equatable {
             return "The video model isn't running yet."
         case let .http(status, message):
             return message ?? "Video request failed (HTTP \(status))."
+        case .cacheRemoval:
+            return "Rapid couldn't remove the cached video. Check file access and try again."
         case .invalidJobID:
             return "The video server returned an invalid job identifier."
         case .invalidResponse:
@@ -381,6 +384,9 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
     var cacheDirectory: URL = FileManager.default.urls(
         for: .cachesDirectory, in: .userDomainMask
     )[0].appendingPathComponent("Rapid/VideoPreviews", isDirectory: true)
+    var removeCachedItem: @Sendable (URL) throws -> Void = {
+        try FileManager.default.removeItem(at: $0)
+    }
 
     func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
         let value: VideoCapabilities = try await decode(
@@ -440,10 +446,16 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
 
     func delete(id: String, port: Int, bearer: String?) async throws {
         let cached = try cacheURL(for: id)
+        if FileManager.default.fileExists(atPath: cached.path) {
+            do {
+                try removeCachedItem(cached)
+            } catch {
+                throw VideoClientError.cacheRemoval
+            }
+        }
         var request = request(path: "v1/videos/\(id)", port: port, bearer: bearer)
         request.httpMethod = "DELETE"
         _ = try await send(request)
-        try? FileManager.default.removeItem(at: cached)
     }
 
     func content(id: String, port: Int, bearer: String?) async throws -> URL {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -136,6 +136,24 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     let modes: [VideoModelCapability]
     let limits: Limits
 
+    var acceptedReferenceMIMETypes: Set<String> {
+        guard let input = limits.inputReference, input.accepted else { return [] }
+        return Set(input.formats.compactMap { format in
+            switch format.lowercased() {
+            case "jpeg", "jpg", "image/jpeg": "image/jpeg"
+            case "png", "image/png": "image/png"
+            case "webp", "image/webp": "image/webp"
+            default: nil
+            }
+        })
+    }
+
+    var supportsImageInput: Bool {
+        modes.contains(.imageToVideo)
+            && referenceMaximumBytes > 0
+            && !acceptedReferenceMIMETypes.isEmpty
+    }
+
     /// Conservative, familiar output shapes. The API remains authoritative:
     /// candidates outside its dimensions, alignment, or area are removed.
     var sizePresets: [String] {
@@ -149,25 +167,27 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         var accepted: [(area: Int, order: Int, value: String)] = []
         for (index, value) in candidates.enumerated() {
             guard seen.insert(value).inserted,
-                  let dimensions = Self.parseSize(value) else { continue }
+                  let dimensions = Self.parseSize(value),
+                  let area = Self.product(dimensions.width, dimensions.height) else { continue }
             if explicitlySupported.contains(value) {
-                accepted.append((dimensions.width * dimensions.height, index, value))
+                accepted.append((area, index, value))
                 continue
             }
             guard let width = limits.size.width,
                   let height = limits.size.height,
-                  (width.minimum...width.maximum).contains(dimensions.width),
-                  (height.minimum...height.maximum).contains(dimensions.height),
+                  Self.contains(dimensions.width, minimum: width.minimum, maximum: width.maximum),
+                  Self.contains(dimensions.height, minimum: height.minimum, maximum: height.maximum),
                   dimensions.width.isMultiple(of: width.multipleOf),
                   dimensions.height.isMultiple(of: height.multipleOf) else {
                 continue
             }
             if let maximumArea = limits.size.maximumArea {
-                let roundedWidth = Self.roundUp(dimensions.width, to: width.multipleOf)
-                let roundedHeight = Self.roundUp(dimensions.height, to: height.multipleOf)
-                guard roundedWidth * roundedHeight <= maximumArea else { continue }
+                guard let roundedWidth = Self.roundUp(dimensions.width, to: width.multipleOf),
+                      let roundedHeight = Self.roundUp(dimensions.height, to: height.multipleOf),
+                      let roundedArea = Self.product(roundedWidth, roundedHeight),
+                      roundedArea <= maximumArea else { continue }
             }
-            accepted.append((dimensions.width * dimensions.height, index, value))
+            accepted.append((area, index, value))
         }
         return accepted.sorted { lhs, rhs in
             lhs.0 == rhs.0 ? lhs.1 < rhs.1 : lhs.0 < rhs.0
@@ -177,11 +197,15 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     func durationPresets(for size: String) -> [Int] {
         let candidates = Set([limits.seconds.minimum, 1, 2, 4]).sorted()
         let values = candidates.filter {
-            (limits.seconds.minimum...limits.seconds.maximum).contains($0)
+            Self.contains($0, minimum: limits.seconds.minimum, maximum: limits.seconds.maximum)
                 && workloadAllows(seconds: $0, size: size)
         }
         if !values.isEmpty { return values }
-        return (limits.seconds.minimum...limits.seconds.maximum).contains(limits.seconds.default)
+        return Self.contains(
+            limits.seconds.default,
+            minimum: limits.seconds.minimum,
+            maximum: limits.seconds.maximum
+        )
             && workloadAllows(seconds: limits.seconds.default, size: size)
             ? [limits.seconds.default] : []
     }
@@ -193,6 +217,55 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
     }
 
+    func validated() throws -> Self {
+        let size = limits.size
+        let validDimension: (Limits.Dimension) -> Bool = {
+            $0.minimum > 0 && $0.maximum >= $0.minimum && $0.multipleOf > 0
+        }
+        let validSize: Bool
+        switch size.type {
+        case "fixed":
+            validSize = !(size.values ?? []).isEmpty
+                && (size.values ?? []).allSatisfy { Self.parseSize($0) != nil }
+        case "range":
+            validSize = size.width.map(validDimension) == true
+                && size.height.map(validDimension) == true
+                && (size.maximumArea.map { $0 > 0 } ?? true)
+        default:
+            validSize = false
+        }
+        let seconds = limits.seconds
+        let fps = limits.fps
+        let frames = limits.frames
+        let workload = limits.workload
+        let validInput = limits.inputReference.map {
+            $0.maximumBytes >= 0
+                && (!$0.accepted || ($0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty))
+        } ?? true
+        guard !model.isEmpty,
+              !family.isEmpty,
+              !modes.isEmpty,
+              validSize,
+              seconds.minimum > 0,
+              seconds.maximum >= seconds.minimum,
+              Self.contains(seconds.default, minimum: seconds.minimum, maximum: seconds.maximum),
+              fps.minimum > 0,
+              fps.maximum >= fps.minimum,
+              Self.contains(fps.default, minimum: fps.minimum, maximum: fps.maximum),
+              frames.minimum > 0,
+              frames.maximum >= frames.minimum,
+              frames.step > 0,
+              frames.offset >= 0,
+              frames.offset <= frames.maximum,
+              workload.metric == "pixel_frames",
+              workload.maximum > 0,
+              !workload.dimensionRounding.isEmpty,
+              validInput else {
+            throw VideoClientError.invalidResponse
+        }
+        return self
+    }
+
     private func workloadAllows(seconds: Int, size: String) -> Bool {
         guard limits.workload.metric == "pixel_frames",
               let dimensions = Self.parseSize(size),
@@ -200,8 +273,8 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               limits.fps.default > 0 else { return false }
         let widthMultiple = limits.size.width?.multipleOf ?? 1
         let heightMultiple = limits.size.height?.multipleOf ?? 1
-        let width = Self.roundUp(dimensions.width, to: widthMultiple)
-        let height = Self.roundUp(dimensions.height, to: heightMultiple)
+        guard let width = Self.roundUp(dimensions.width, to: widthMultiple),
+              let height = Self.roundUp(dimensions.height, to: heightMultiple) else { return false }
         let frameStep = max(1, limits.frames.step)
         let frameOffset = limits.frames.offset
         guard frameOffset >= 0 else { return false }
@@ -227,13 +300,27 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     private static func parseSize(_ value: String) -> (width: Int, height: Int)? {
         let parts = value.lowercased().split(separator: "x", maxSplits: 1)
         guard parts.count == 2,
-              let width = Int(parts[0]), let height = Int(parts[1]) else { return nil }
+              let width = Int(parts[0]), let height = Int(parts[1]),
+              width > 0, height > 0 else { return nil }
         return (width, height)
     }
 
-    private static func roundUp(_ value: Int, to multiple: Int) -> Int {
-        guard multiple > 0 else { return value }
-        return ((value + multiple - 1) / multiple) * multiple
+    private static func contains(_ value: Int, minimum: Int, maximum: Int) -> Bool {
+        minimum <= maximum && value >= minimum && value <= maximum
+    }
+
+    private static func product(_ lhs: Int, _ rhs: Int) -> Int? {
+        let (value, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+        return overflow ? nil : value
+    }
+
+    private static func roundUp(_ value: Int, to multiple: Int) -> Int? {
+        guard value >= 0, multiple > 0 else { return nil }
+        let (offsetValue, additionOverflow) = value.addingReportingOverflow(multiple - 1)
+        guard !additionOverflow else { return nil }
+        let quotient = offsetValue / multiple
+        let (result, multiplicationOverflow) = quotient.multipliedReportingOverflow(by: multiple)
+        return multiplicationOverflow ? nil : result
     }
 }
 
@@ -296,7 +383,10 @@ struct VideoClient: VideoClientProtocol, @unchecked Sendable {
     )[0].appendingPathComponent("Rapid/VideoPreviews", isDirectory: true)
 
     func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
-        try await decode(request(path: "v1/videos/capabilities", port: port, bearer: bearer))
+        let value: VideoCapabilities = try await decode(
+            request(path: "v1/videos/capabilities", port: port, bearer: bearer)
+        )
+        return try value.validated()
     }
 
     func create(

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoFeatureConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoFeatureConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// User-controlled opt-in for the resource-intensive Video workspace.
+///
+/// The feature is deliberately absent from the sidebar until the user enables
+/// it in Settings. Reading this key never starts a server or downloads a model;
+/// it controls discoverability only. The actual model lifecycle remains an
+/// explicit action inside ``VideoView``.
+enum VideoFeatureConfig {
+    static let enabledKey = "Rapid.experimental.videoGenerationEnabled"
+    static let defaultEnabled = false
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -49,6 +49,7 @@ final class VideoGenViewModel {
     var isSubmitting = false
     var isRefreshing = false
     var isLoadingPreview = false
+    var jobsAreReconciled = false
     var errorMessage: String?
 
     private let server: ServerManager
@@ -85,9 +86,7 @@ final class VideoGenViewModel {
     }
 
     var selectedJob: VideoJob? {
-        if let selectedJobID, let job = jobs.first(where: { $0.id == selectedJobID }) {
-            return job
-        }
+        if let selectedJobID { return jobs.first { $0.id == selectedJobID } }
         return jobs.first
     }
 
@@ -145,6 +144,17 @@ final class VideoGenViewModel {
         currentServerContext != nil && hasActiveJobs
     }
 
+    var canSwitchModels: Bool {
+        !isSubmitting
+            && !isPreparing
+            && !hasLiveActiveJobs
+            && (!isServerReady || jobsAreReconciled)
+    }
+
+    var needsServerRefresh: Bool {
+        isServerReady && (capabilities == nil || !jobsAreReconciled)
+    }
+
     func isModelEligible(_ model: ModelEntry) -> Bool {
         guard let minimum = model.minimumMemoryGB,
               minimum.isFinite, minimum > 0, physicalRAMGB > 0 else { return false }
@@ -163,8 +173,15 @@ final class VideoGenViewModel {
         }
         let loaded = await catalogLoader(binary)
         guard !Task.isCancelled, generation == catalogRefreshGeneration else { return }
-        let filtered = loaded.filter {
+        let previousModel = selectedModel
+        var filtered = loaded.filter {
             $0.kind == .video && !$0.videoCapabilities.isEmpty
+        }
+        if let previousModel,
+           !canSwitchModels,
+           !filtered.contains(where: { $0.alias == previousModel.alias }) {
+            // A cache/catalog refresh must not orphan live or unreconciled work.
+            filtered.append(previousModel)
         }
         let previousAlias = selectedAlias
         videoModels = filtered
@@ -183,7 +200,9 @@ final class VideoGenViewModel {
     }
 
     func selectModel(_ alias: String) {
-        guard selectedAlias != alias else { return }
+        guard selectedAlias != alias,
+              canSwitchModels,
+              videoModels.contains(where: { $0.alias == alias }) else { return }
         selectedAlias = alias
         selectedModelDidChange()
     }
@@ -244,6 +263,7 @@ final class VideoGenViewModel {
         serverRefreshGeneration &+= 1
         let refreshGeneration = serverRefreshGeneration
         let contextGeneration = serverContextGeneration
+        jobsAreReconciled = false
         isRefreshing = true
         defer {
             if refreshGeneration == serverRefreshGeneration { isRefreshing = false }
@@ -271,6 +291,7 @@ final class VideoGenViewModel {
                     refreshGeneration: refreshGeneration
                 ) else { return }
                 jobs = newJobs
+                jobsAreReconciled = true
                 reconcileSelection()
                 reconcileJobPolling()
             } catch {
@@ -280,6 +301,7 @@ final class VideoGenViewModel {
                     refreshGeneration: refreshGeneration
                 ) else { return }
                 // Controls remain usable when history alone is unavailable.
+                jobsAreReconciled = false
                 errorMessage = "Video controls are ready, but recent videos couldn't be loaded."
             }
         } catch {
@@ -288,6 +310,7 @@ final class VideoGenViewModel {
                 contextGeneration: contextGeneration,
                 refreshGeneration: refreshGeneration
             ) else { return }
+            jobsAreReconciled = false
             errorMessage = error.localizedDescription
         }
     }
@@ -304,6 +327,7 @@ final class VideoGenViewModel {
                 context, contextGeneration: contextGeneration
             ) else { return }
             jobs = newJobs
+            jobsAreReconciled = true
             reconcileSelection()
             if selectedJob?.status == .completed, previous != .completed {
                 await loadSelectedPreview()
@@ -315,6 +339,7 @@ final class VideoGenViewModel {
         } catch {
             // Poll failures are transient during a model stop/restart. The
             // explicit refresh/start actions surface actionable errors.
+            jobsAreReconciled = false
         }
     }
 
@@ -360,6 +385,7 @@ final class VideoGenViewModel {
     }
 
     func selectJob(_ id: String) async {
+        guard jobs.contains(where: { $0.id == id }) else { return }
         selectedJobID = id
         previewURL = nil
         await loadSelectedPreview()
@@ -383,13 +409,16 @@ final class VideoGenViewModel {
             guard generation == previewGeneration,
                   requestIsCurrent(
                     context, contextGeneration: contextGeneration
-                  ) else { return }
+                  ),
+                  selectedJobID == job.id,
+                  jobs.contains(where: { $0.id == job.id }) else { return }
             previewURL = url
         } catch {
             guard generation == previewGeneration,
                   requestIsCurrent(
                     context, contextGeneration: contextGeneration
-                  ) else { return }
+                  ),
+                  selectedJobID == job.id else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -423,6 +452,7 @@ final class VideoGenViewModel {
         invalidateServerContext()
         capabilities = nil
         jobs = []
+        jobsAreReconciled = false
         reconcileJobPolling()
         selectedJobID = nil
         previewURL = nil
@@ -447,12 +477,15 @@ final class VideoGenViewModel {
 
     private func reconcileSelection() {
         guard !jobs.isEmpty else {
+            previewGeneration &+= 1
             selectedJobID = nil
             previewURL = nil
             return
         }
         if selectedJobID == nil || !jobs.contains(where: { $0.id == selectedJobID }) {
+            previewGeneration &+= 1
             selectedJobID = jobs.first?.id
+            previewURL = nil
         }
     }
 
@@ -472,6 +505,7 @@ final class VideoGenViewModel {
         serverRefreshGeneration &+= 1
         previewGeneration &+= 1
         loadedServerContext = nil
+        jobsAreReconciled = false
         isRefreshing = false
         isLoadingPreview = false
         reconcileJobPolling()

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -60,6 +60,7 @@ final class VideoGenViewModel {
     @ObservationIgnored private var serverContextGeneration: UInt = 0
     @ObservationIgnored private var serverRefreshGeneration: UInt = 0
     @ObservationIgnored private var loadedServerContext: ServerRequestContext?
+    @ObservationIgnored private var jobsServerContext: ServerRequestContext?
     @ObservationIgnored private var previewGeneration: UInt = 0
     @ObservationIgnored private var pollingGeneration: UInt = 0
     @ObservationIgnored private var pollingTask: Task<Void, Never>?
@@ -141,7 +142,9 @@ final class VideoGenViewModel {
     /// progressing. Stale history from a stopped or switched process must not
     /// block app shutdown or update coordination indefinitely.
     var hasLiveActiveJobs: Bool {
-        currentServerContext != nil && hasActiveJobs
+        currentServerContext != nil
+            && jobsServerContext == currentServerContext
+            && hasActiveJobs
     }
 
     var canSwitchModels: Bool {
@@ -290,7 +293,8 @@ final class VideoGenViewModel {
                     contextGeneration: contextGeneration,
                     refreshGeneration: refreshGeneration
                 ) else { return }
-                jobs = newJobs
+                jobs = reconciledJobs(from: newJobs, context: context)
+                jobsServerContext = context
                 jobsAreReconciled = true
                 reconcileSelection()
                 reconcileJobPolling()
@@ -326,7 +330,8 @@ final class VideoGenViewModel {
             guard requestIsCurrent(
                 context, contextGeneration: contextGeneration
             ) else { return }
-            jobs = newJobs
+            jobs = reconciledJobs(from: newJobs, context: context)
+            jobsServerContext = context
             jobsAreReconciled = true
             reconcileSelection()
             if selectedJob?.status == .completed, previous != .completed {
@@ -371,6 +376,7 @@ final class VideoGenViewModel {
             ) else { return }
             jobs.removeAll { $0.id == job.id }
             jobs.insert(job, at: 0)
+            jobsServerContext = context
             selectedJobID = job.id
             previewURL = nil
             prompt = ""
@@ -393,7 +399,8 @@ final class VideoGenViewModel {
 
     func loadSelectedPreview() async {
         guard let job = selectedJob, job.status == .completed,
-              let context = currentServerContext else {
+              let context = currentServerContext,
+              jobsServerContext == context else {
             previewURL = nil
             return
         }
@@ -424,7 +431,9 @@ final class VideoGenViewModel {
     }
 
     func delete(_ job: VideoJob) async {
-        guard let context = currentServerContext, job.status != .inProgress else { return }
+        guard let context = currentServerContext,
+              jobsServerContext == context,
+              job.status != .inProgress else { return }
         let contextGeneration = serverContextGeneration
         do {
             try await client.delete(
@@ -452,6 +461,7 @@ final class VideoGenViewModel {
         invalidateServerContext()
         capabilities = nil
         jobs = []
+        jobsServerContext = nil
         jobsAreReconciled = false
         reconcileJobPolling()
         selectedJobID = nil
@@ -487,6 +497,19 @@ final class VideoGenViewModel {
             selectedJobID = jobs.first?.id
             previewURL = nil
         }
+    }
+
+    private func reconciledJobs(
+        from serverJobs: [VideoJob],
+        context: ServerRequestContext
+    ) -> [VideoJob] {
+        guard jobsServerContext == context else { return serverJobs }
+        let reportedIDs = Set(serverJobs.map(\.id))
+        let temporarilyMissingActiveJobs = jobs.filter {
+            ($0.status == .queued || $0.status == .inProgress)
+                && !reportedIDs.contains($0.id)
+        }
+        return serverJobs + temporarilyMissingActiveJobs
     }
 
     private var currentServerContext: ServerRequestContext? {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -4,6 +4,12 @@ import Observation
 @MainActor
 @Observable
 final class VideoGenViewModel {
+    private struct ServerRequestContext: Equatable {
+        let alias: String
+        let port: Int
+        let bearer: String
+    }
+
     enum Mode: String, CaseIterable, Identifiable {
         case text
         case image
@@ -50,6 +56,9 @@ final class VideoGenViewModel {
     @ObservationIgnored private let client: any VideoClientProtocol
     @ObservationIgnored private let catalogLoader: (URL) async -> [ModelEntry]
     @ObservationIgnored private var catalogRefreshGeneration: UInt = 0
+    @ObservationIgnored private var serverContextGeneration: UInt = 0
+    @ObservationIgnored private var serverRefreshGeneration: UInt = 0
+    @ObservationIgnored private var loadedServerContext: ServerRequestContext?
     @ObservationIgnored private var previewGeneration: UInt = 0
 
     init(
@@ -86,7 +95,7 @@ final class VideoGenViewModel {
     }
 
     var sizePresets: [String] { capabilities?.sizePresets ?? [] }
-    var durationPresets: [Int] { capabilities?.durationPresets ?? [] }
+    var durationPresets: [Int] { capabilities?.durationPresets(for: size) ?? [] }
 
     var isSelectedModelEligible: Bool {
         selectedModel.map(isModelEligible) ?? false
@@ -98,7 +107,7 @@ final class VideoGenViewModel {
     }
 
     var isServerReady: Bool {
-        server.servingAlias == selectedAlias && server.activeBearer != nil
+        currentServerContext != nil
     }
 
     var canSubmit: Bool {
@@ -107,7 +116,8 @@ final class VideoGenViewModel {
             && capabilities != nil
             && supportedModes.contains(mode)
             && !trimmed.isEmpty
-            && !size.isEmpty
+            && sizePresets.contains(size)
+            && durationPresets.contains(seconds)
             && !isSubmitting
             && (mode == .text || referenceImage != nil)
     }
@@ -129,6 +139,7 @@ final class VideoGenViewModel {
             catalogLoaded = true
             videoModels = []
             selectedAlias = ""
+            selectedModelDidChange()
             return
         }
         let loaded = await catalogLoader(binary)
@@ -168,6 +179,14 @@ final class VideoGenViewModel {
         referenceImage = reference
     }
 
+    func selectSize(_ value: String) {
+        guard size != value else { return }
+        size = value
+        if !durationPresets.contains(seconds) {
+            seconds = durationPresets.first ?? 0
+        }
+    }
+
     func prepareSelectedModel() async {
         guard !isPreparing, let model = selectedModel, isSelectedModelEligible else { return }
         isPreparing = true
@@ -178,6 +197,7 @@ final class VideoGenViewModel {
             hfPath: model.hfRepo,
             minimumMemoryGB: model.minimumMemoryGB
         )
+        guard selectedAlias == model.alias else { return }
         guard ready else {
             errorMessage = "Rapid couldn't start this video model. Check the memory notice or server log, then try again."
             return
@@ -186,45 +206,84 @@ final class VideoGenViewModel {
     }
 
     func serverStateDidChange() async {
-        if isServerReady {
-            if capabilities == nil { await refreshServerData() }
-        } else {
+        guard let context = currentServerContext else {
+            invalidateServerContext()
             capabilities = nil
+            return
+        }
+        if let loadedServerContext, loadedServerContext != context {
+            invalidateServerContext()
+            capabilities = nil
+        }
+        if capabilities == nil || loadedServerContext != context {
+            await refreshServerData()
         }
     }
 
     func refreshServerData() async {
-        guard isServerReady else { return }
+        guard let context = currentServerContext else { return }
+        serverRefreshGeneration &+= 1
+        let refreshGeneration = serverRefreshGeneration
+        let contextGeneration = serverContextGeneration
         isRefreshing = true
-        defer { isRefreshing = false }
+        defer {
+            if refreshGeneration == serverRefreshGeneration { isRefreshing = false }
+        }
         do {
             let newCapabilities = try await client.capabilities(
-                port: server.activePort, bearer: server.activeBearer
+                port: context.port, bearer: context.bearer
             )
+            guard requestIsCurrent(
+                context,
+                contextGeneration: contextGeneration,
+                refreshGeneration: refreshGeneration
+            ) else { return }
             capabilities = newCapabilities
+            loadedServerContext = context
             reconcileControls()
             errorMessage = nil
             do {
-                jobs = try await client.list(
-                    port: server.activePort, bearer: server.activeBearer, limit: 30
+                let newJobs = try await client.list(
+                    port: context.port, bearer: context.bearer, limit: 30
                 )
+                guard requestIsCurrent(
+                    context,
+                    contextGeneration: contextGeneration,
+                    refreshGeneration: refreshGeneration
+                ) else { return }
+                jobs = newJobs
                 reconcileSelection()
             } catch {
+                guard requestIsCurrent(
+                    context,
+                    contextGeneration: contextGeneration,
+                    refreshGeneration: refreshGeneration
+                ) else { return }
                 // Controls remain usable when history alone is unavailable.
                 errorMessage = "Video controls are ready, but recent videos couldn't be loaded."
             }
         } catch {
+            guard requestIsCurrent(
+                context,
+                contextGeneration: contextGeneration,
+                refreshGeneration: refreshGeneration
+            ) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     func pollJobs() async {
-        guard isServerReady, !isRefreshing else { return }
+        guard let context = currentServerContext, !isRefreshing else { return }
+        let contextGeneration = serverContextGeneration
         do {
             let previous = selectedJob?.status
-            jobs = try await client.list(
-                port: server.activePort, bearer: server.activeBearer, limit: 30
+            let newJobs = try await client.list(
+                port: context.port, bearer: context.bearer, limit: 30
             )
+            guard requestIsCurrent(
+                context, contextGeneration: contextGeneration
+            ) else { return }
+            jobs = newJobs
             reconcileSelection()
             if selectedJob?.status == .completed, previous != .completed {
                 await loadSelectedPreview()
@@ -236,7 +295,8 @@ final class VideoGenViewModel {
     }
 
     func submit() async {
-        guard canSubmit else { return }
+        guard canSubmit, let context = currentServerContext else { return }
+        let contextGeneration = serverContextGeneration
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let reference = mode == .image ? referenceImage : nil
         isSubmitting = true
@@ -254,9 +314,12 @@ final class VideoGenViewModel {
                     referenceFileName: reference?.fileName,
                     referenceMIMEType: reference?.mimeType
                 ),
-                port: server.activePort,
-                bearer: server.activeBearer
+                port: context.port,
+                bearer: context.bearer
             )
+            guard requestIsCurrent(
+                context, contextGeneration: contextGeneration
+            ) else { return }
             jobs.removeAll { $0.id == job.id }
             jobs.insert(job, at: 0)
             selectedJobID = job.id
@@ -264,6 +327,9 @@ final class VideoGenViewModel {
             prompt = ""
             seed = Int.random(in: 1...999_999)
         } catch {
+            guard requestIsCurrent(
+                context, contextGeneration: contextGeneration
+            ) else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -275,32 +341,44 @@ final class VideoGenViewModel {
     }
 
     func loadSelectedPreview() async {
-        guard let job = selectedJob, job.status == .completed, isServerReady else {
+        guard let job = selectedJob, job.status == .completed,
+              let context = currentServerContext else {
             previewURL = nil
             return
         }
+        let contextGeneration = serverContextGeneration
         previewGeneration &+= 1
         let generation = previewGeneration
         isLoadingPreview = true
         defer { if generation == previewGeneration { isLoadingPreview = false } }
         do {
             let url = try await client.content(
-                id: job.id, port: server.activePort, bearer: server.activeBearer
+                id: job.id, port: context.port, bearer: context.bearer
             )
-            guard generation == previewGeneration else { return }
+            guard generation == previewGeneration,
+                  requestIsCurrent(
+                    context, contextGeneration: contextGeneration
+                  ) else { return }
             previewURL = url
         } catch {
-            guard generation == previewGeneration else { return }
+            guard generation == previewGeneration,
+                  requestIsCurrent(
+                    context, contextGeneration: contextGeneration
+                  ) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     func delete(_ job: VideoJob) async {
-        guard isServerReady, job.status != .inProgress else { return }
+        guard let context = currentServerContext, job.status != .inProgress else { return }
+        let contextGeneration = serverContextGeneration
         do {
             try await client.delete(
-                id: job.id, port: server.activePort, bearer: server.activeBearer
+                id: job.id, port: context.port, bearer: context.bearer
             )
+            guard requestIsCurrent(
+                context, contextGeneration: contextGeneration
+            ) else { return }
             jobs.removeAll { $0.id == job.id }
             if selectedJobID == job.id {
                 selectedJobID = jobs.first?.id
@@ -308,11 +386,15 @@ final class VideoGenViewModel {
                 await loadSelectedPreview()
             }
         } catch {
+            guard requestIsCurrent(
+                context, contextGeneration: contextGeneration
+            ) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     private func selectedModelDidChange() {
+        invalidateServerContext()
         capabilities = nil
         jobs = []
         selectedJobID = nil
@@ -330,10 +412,10 @@ final class VideoGenViewModel {
             mode = modes.first ?? supportedModes.first ?? .text
             if mode == .text { referenceImage = nil }
         }
-        if !durationPresets.contains(seconds) {
-            seconds = durationPresets.first ?? capabilities?.limits.seconds.default ?? 1
-        }
         if !sizePresets.contains(size) { size = sizePresets.first ?? "" }
+        if !durationPresets.contains(seconds) {
+            seconds = durationPresets.first ?? 0
+        }
     }
 
     private func reconcileSelection() {
@@ -345,5 +427,35 @@ final class VideoGenViewModel {
         if selectedJobID == nil || !jobs.contains(where: { $0.id == selectedJobID }) {
             selectedJobID = jobs.first?.id
         }
+    }
+
+    private var currentServerContext: ServerRequestContext? {
+        guard !selectedAlias.isEmpty,
+              server.servingAlias == selectedAlias,
+              let bearer = server.activeBearer, !bearer.isEmpty else { return nil }
+        return ServerRequestContext(
+            alias: selectedAlias,
+            port: server.activePort,
+            bearer: bearer
+        )
+    }
+
+    private func invalidateServerContext() {
+        serverContextGeneration &+= 1
+        serverRefreshGeneration &+= 1
+        previewGeneration &+= 1
+        loadedServerContext = nil
+        isRefreshing = false
+        isLoadingPreview = false
+    }
+
+    private func requestIsCurrent(
+        _ context: ServerRequestContext,
+        contextGeneration: UInt,
+        refreshGeneration: UInt? = nil
+    ) -> Bool {
+        guard contextGeneration == serverContextGeneration,
+              currentServerContext == context else { return false }
+        return refreshGeneration.map { $0 == serverRefreshGeneration } ?? true
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -1,0 +1,349 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class VideoGenViewModel {
+    enum Mode: String, CaseIterable, Identifiable {
+        case text
+        case image
+
+        var id: String { rawValue }
+        var title: String { self == .text ? "Text" : "Image" }
+        var capability: VideoModelCapability {
+            self == .text ? .textToVideo : .imageToVideo
+        }
+    }
+
+    struct ReferenceImage: Equatable {
+        let data: Data
+        let fileName: String
+        let mimeType: String
+    }
+
+    var videoModels: [ModelEntry] = []
+    var catalogLoaded = false
+    var selectedAlias = ""
+    var mode: Mode = .text
+
+    var prompt = ""
+    /// Zero is an internal "capabilities not loaded" sentinel. The first
+    /// successful capabilities response replaces it with the shortest safe
+    /// preset before the control or Generate action becomes available.
+    var seconds = 0
+    var size = ""
+    var seed = Int.random(in: 1...999_999)
+    var referenceImage: ReferenceImage?
+
+    var capabilities: VideoCapabilities?
+    var jobs: [VideoJob] = []
+    var selectedJobID: String?
+    var previewURL: URL?
+    var isPreparing = false
+    var isSubmitting = false
+    var isRefreshing = false
+    var isLoadingPreview = false
+    var errorMessage: String?
+
+    private let server: ServerManager
+    private let physicalRAMGB: Double
+    @ObservationIgnored private let client: any VideoClientProtocol
+    @ObservationIgnored private let catalogLoader: (URL) async -> [ModelEntry]
+    @ObservationIgnored private var catalogRefreshGeneration: UInt = 0
+    @ObservationIgnored private var previewGeneration: UInt = 0
+
+    init(
+        server: ServerManager,
+        client: any VideoClientProtocol = VideoClient(),
+        physicalRAMGB: Double = MacHardware.detect().physicalRAMGB,
+        catalogLoader: @escaping (URL) async -> [ModelEntry] = {
+            await ModelCatalog.videoEntries(binary: $0)
+        }
+    ) {
+        self.server = server
+        self.client = client
+        self.physicalRAMGB = physicalRAMGB
+        self.catalogLoader = catalogLoader
+    }
+
+    var selectedModel: ModelEntry? {
+        videoModels.first { $0.alias == selectedAlias }
+    }
+
+    var selectedJob: VideoJob? {
+        if let selectedJobID, let job = jobs.first(where: { $0.id == selectedJobID }) {
+            return job
+        }
+        return jobs.first
+    }
+
+    var supportedModes: [Mode] {
+        guard let model = selectedModel else { return [] }
+        return Mode.allCases.filter { candidate in
+            model.videoCapabilities.contains(candidate.capability)
+                && (capabilities?.modes.contains(candidate.capability) ?? true)
+        }
+    }
+
+    var sizePresets: [String] { capabilities?.sizePresets ?? [] }
+    var durationPresets: [Int] { capabilities?.durationPresets ?? [] }
+
+    var isSelectedModelEligible: Bool {
+        selectedModel.map(isModelEligible) ?? false
+    }
+
+    var memoryRequirementText: String? {
+        guard let minimum = selectedModel?.minimumMemoryGB else { return nil }
+        return "Needs at least \(Int(minimum.rounded())) GB unified memory; this Mac has \(Int(physicalRAMGB.rounded())) GB."
+    }
+
+    var isServerReady: Bool {
+        server.servingAlias == selectedAlias && server.activeBearer != nil
+    }
+
+    var canSubmit: Bool {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return isServerReady
+            && capabilities != nil
+            && supportedModes.contains(mode)
+            && !trimmed.isEmpty
+            && !size.isEmpty
+            && !isSubmitting
+            && (mode == .text || referenceImage != nil)
+    }
+
+    var hasActiveJobs: Bool {
+        jobs.contains { $0.status == .queued || $0.status == .inProgress }
+    }
+
+    func isModelEligible(_ model: ModelEntry) -> Bool {
+        guard let minimum = model.minimumMemoryGB,
+              minimum.isFinite, minimum > 0, physicalRAMGB > 0 else { return false }
+        return physicalRAMGB >= minimum
+    }
+
+    func refreshCatalog() async {
+        catalogRefreshGeneration &+= 1
+        let generation = catalogRefreshGeneration
+        guard let binary = server.binaryPath else {
+            catalogLoaded = true
+            videoModels = []
+            selectedAlias = ""
+            return
+        }
+        let loaded = await catalogLoader(binary)
+        guard !Task.isCancelled, generation == catalogRefreshGeneration else { return }
+        let filtered = loaded.filter {
+            $0.kind == .video && !$0.videoCapabilities.isEmpty
+        }
+        let previousAlias = selectedAlias
+        videoModels = filtered
+        catalogLoaded = true
+        let stillValid = filtered.contains { $0.alias == selectedAlias }
+        if selectedAlias.isEmpty || !stillValid {
+            selectedAlias = (filtered.first { $0.cached && isModelEligible($0) }
+                ?? filtered.first(where: isModelEligible)
+                ?? filtered.first)?.alias ?? ""
+        }
+        if previousAlias != selectedAlias {
+            selectedModelDidChange()
+        } else if !supportedModes.contains(mode) {
+            mode = supportedModes.first ?? .text
+        }
+    }
+
+    func selectModel(_ alias: String) {
+        guard selectedAlias != alias else { return }
+        selectedAlias = alias
+        selectedModelDidChange()
+    }
+
+    func selectMode(_ next: Mode) {
+        guard supportedModes.contains(next) else { return }
+        mode = next
+        if next == .text { referenceImage = nil }
+    }
+
+    func setReference(_ reference: ReferenceImage?) {
+        referenceImage = reference
+    }
+
+    func prepareSelectedModel() async {
+        guard !isPreparing, let model = selectedModel, isSelectedModelEligible else { return }
+        isPreparing = true
+        errorMessage = nil
+        defer { isPreparing = false }
+        let ready = await server.ensureVideoServing(
+            alias: model.alias,
+            hfPath: model.hfRepo,
+            minimumMemoryGB: model.minimumMemoryGB
+        )
+        guard ready else {
+            errorMessage = "Rapid couldn't start this video model. Check the memory notice or server log, then try again."
+            return
+        }
+        await refreshServerData()
+    }
+
+    func serverStateDidChange() async {
+        if isServerReady {
+            if capabilities == nil { await refreshServerData() }
+        } else {
+            capabilities = nil
+        }
+    }
+
+    func refreshServerData() async {
+        guard isServerReady else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        do {
+            let newCapabilities = try await client.capabilities(
+                port: server.activePort, bearer: server.activeBearer
+            )
+            capabilities = newCapabilities
+            reconcileControls()
+            errorMessage = nil
+            do {
+                jobs = try await client.list(
+                    port: server.activePort, bearer: server.activeBearer, limit: 30
+                )
+                reconcileSelection()
+            } catch {
+                // Controls remain usable when history alone is unavailable.
+                errorMessage = "Video controls are ready, but recent videos couldn't be loaded."
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func pollJobs() async {
+        guard isServerReady, !isRefreshing else { return }
+        do {
+            let previous = selectedJob?.status
+            jobs = try await client.list(
+                port: server.activePort, bearer: server.activeBearer, limit: 30
+            )
+            reconcileSelection()
+            if selectedJob?.status == .completed, previous != .completed {
+                await loadSelectedPreview()
+            }
+        } catch {
+            // Poll failures are transient during a model stop/restart. The
+            // explicit refresh/start actions surface actionable errors.
+        }
+    }
+
+    func submit() async {
+        guard canSubmit else { return }
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let reference = mode == .image ? referenceImage : nil
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+        do {
+            let job = try await client.create(
+                VideoCreateRequest(
+                    prompt: trimmed,
+                    model: selectedAlias,
+                    seconds: seconds,
+                    size: size,
+                    seed: seed,
+                    reference: reference?.data,
+                    referenceFileName: reference?.fileName,
+                    referenceMIMEType: reference?.mimeType
+                ),
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+            jobs.removeAll { $0.id == job.id }
+            jobs.insert(job, at: 0)
+            selectedJobID = job.id
+            previewURL = nil
+            prompt = ""
+            seed = Int.random(in: 1...999_999)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func selectJob(_ id: String) async {
+        selectedJobID = id
+        previewURL = nil
+        await loadSelectedPreview()
+    }
+
+    func loadSelectedPreview() async {
+        guard let job = selectedJob, job.status == .completed, isServerReady else {
+            previewURL = nil
+            return
+        }
+        previewGeneration &+= 1
+        let generation = previewGeneration
+        isLoadingPreview = true
+        defer { if generation == previewGeneration { isLoadingPreview = false } }
+        do {
+            let url = try await client.content(
+                id: job.id, port: server.activePort, bearer: server.activeBearer
+            )
+            guard generation == previewGeneration else { return }
+            previewURL = url
+        } catch {
+            guard generation == previewGeneration else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func delete(_ job: VideoJob) async {
+        guard isServerReady, job.status != .inProgress else { return }
+        do {
+            try await client.delete(
+                id: job.id, port: server.activePort, bearer: server.activeBearer
+            )
+            jobs.removeAll { $0.id == job.id }
+            if selectedJobID == job.id {
+                selectedJobID = jobs.first?.id
+                previewURL = nil
+                await loadSelectedPreview()
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func selectedModelDidChange() {
+        capabilities = nil
+        jobs = []
+        selectedJobID = nil
+        previewURL = nil
+        referenceImage = nil
+        errorMessage = nil
+        if !supportedModes.contains(mode) { mode = supportedModes.first ?? .text }
+    }
+
+    private func reconcileControls() {
+        let modes = supportedModes.filter {
+            capabilities?.modes.contains($0.capability) == true
+        }
+        if !modes.contains(mode) {
+            mode = modes.first ?? supportedModes.first ?? .text
+            if mode == .text { referenceImage = nil }
+        }
+        if !durationPresets.contains(seconds) {
+            seconds = durationPresets.first ?? capabilities?.limits.seconds.default ?? 1
+        }
+        if !sizePresets.contains(size) { size = sizePresets.first ?? "" }
+    }
+
+    private func reconcileSelection() {
+        guard !jobs.isEmpty else {
+            selectedJobID = nil
+            previewURL = nil
+            return
+        }
+        if selectedJobID == nil || !jobs.contains(where: { $0.id == selectedJobID }) {
+            selectedJobID = jobs.first?.id
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -101,6 +101,7 @@ final class VideoGenViewModel {
 
     var sizePresets: [String] { capabilities?.sizePresets ?? [] }
     var durationPresets: [Int] { capabilities?.durationPresets(for: size) ?? [] }
+    var referenceMaximumBytes: Int { capabilities?.referenceMaximumBytes ?? 0 }
 
     var isSelectedModelEligible: Bool {
         selectedModel.map(isModelEligible) ?? false

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -94,14 +94,20 @@ final class VideoGenViewModel {
     var supportedModes: [Mode] {
         guard let model = selectedModel else { return [] }
         return Mode.allCases.filter { candidate in
-            model.videoCapabilities.contains(candidate.capability)
-                && (capabilities?.modes.contains(candidate.capability) ?? true)
+            guard model.videoCapabilities.contains(candidate.capability) else { return false }
+            if candidate == .image {
+                return capabilities?.supportsImageInput == true
+            }
+            return capabilities?.modes.contains(candidate.capability) ?? true
         }
     }
 
     var sizePresets: [String] { capabilities?.sizePresets ?? [] }
     var durationPresets: [Int] { capabilities?.durationPresets(for: size) ?? [] }
     var referenceMaximumBytes: Int { capabilities?.referenceMaximumBytes ?? 0 }
+    var acceptedReferenceMIMETypes: Set<String> {
+        capabilities?.acceptedReferenceMIMETypes ?? []
+    }
 
     var isSelectedModelEligible: Bool {
         selectedModel.map(isModelEligible) ?? false

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -60,11 +60,15 @@ final class VideoGenViewModel {
     @ObservationIgnored private var serverRefreshGeneration: UInt = 0
     @ObservationIgnored private var loadedServerContext: ServerRequestContext?
     @ObservationIgnored private var previewGeneration: UInt = 0
+    @ObservationIgnored private var pollingGeneration: UInt = 0
+    @ObservationIgnored private var pollingTask: Task<Void, Never>?
+    @ObservationIgnored private let pollingInterval: Duration
 
     init(
         server: ServerManager,
         client: any VideoClientProtocol = VideoClient(),
         physicalRAMGB: Double = MacHardware.detect().physicalRAMGB,
+        pollingInterval: Duration = .seconds(1),
         catalogLoader: @escaping (URL) async -> [ModelEntry] = {
             await ModelCatalog.videoEntries(binary: $0)
         }
@@ -72,6 +76,7 @@ final class VideoGenViewModel {
         self.server = server
         self.client = client
         self.physicalRAMGB = physicalRAMGB
+        self.pollingInterval = pollingInterval
         self.catalogLoader = catalogLoader
     }
 
@@ -124,6 +129,13 @@ final class VideoGenViewModel {
 
     var hasActiveJobs: Bool {
         jobs.contains { $0.status == .queued || $0.status == .inProgress }
+    }
+
+    /// Only a live matching server can prove that an active job is still
+    /// progressing. Stale history from a stopped or switched process must not
+    /// block app shutdown or update coordination indefinitely.
+    var hasLiveActiveJobs: Bool {
+        currentServerContext != nil && hasActiveJobs
     }
 
     func isModelEligible(_ model: ModelEntry) -> Bool {
@@ -253,6 +265,7 @@ final class VideoGenViewModel {
                 ) else { return }
                 jobs = newJobs
                 reconcileSelection()
+                reconcileJobPolling()
             } catch {
                 guard requestIsCurrent(
                     context,
@@ -288,6 +301,10 @@ final class VideoGenViewModel {
             if selectedJob?.status == .completed, previous != .completed {
                 await loadSelectedPreview()
             }
+            // Stop the owner task only after a newly-completed preview has
+            // finished downloading; cancelling it earlier would cancel that
+            // URLSession request along with the polling loop.
+            reconcileJobPolling()
         } catch {
             // Poll failures are transient during a model stop/restart. The
             // explicit refresh/start actions surface actionable errors.
@@ -326,6 +343,7 @@ final class VideoGenViewModel {
             previewURL = nil
             prompt = ""
             seed = Int.random(in: 1...999_999)
+            reconcileJobPolling()
         } catch {
             guard requestIsCurrent(
                 context, contextGeneration: contextGeneration
@@ -380,6 +398,7 @@ final class VideoGenViewModel {
                 context, contextGeneration: contextGeneration
             ) else { return }
             jobs.removeAll { $0.id == job.id }
+            reconcileJobPolling()
             if selectedJobID == job.id {
                 selectedJobID = jobs.first?.id
                 previewURL = nil
@@ -397,6 +416,7 @@ final class VideoGenViewModel {
         invalidateServerContext()
         capabilities = nil
         jobs = []
+        reconcileJobPolling()
         selectedJobID = nil
         previewURL = nil
         referenceImage = nil
@@ -447,6 +467,38 @@ final class VideoGenViewModel {
         loadedServerContext = nil
         isRefreshing = false
         isLoadingPreview = false
+        reconcileJobPolling()
+    }
+
+    /// Polling belongs to the long-lived view model, not the Video view. Jobs
+    /// therefore keep progressing when the user visits another tab or hides
+    /// the experimental surface. A server switch cancels the loop and leaves
+    /// history intact for reconciliation if that video model is started again.
+    private func reconcileJobPolling() {
+        guard hasLiveActiveJobs else {
+            pollingGeneration &+= 1
+            pollingTask?.cancel()
+            pollingTask = nil
+            return
+        }
+        guard pollingTask == nil else { return }
+        pollingGeneration &+= 1
+        let generation = pollingGeneration
+        let interval = pollingInterval
+        pollingTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: interval)
+                } catch {
+                    break
+                }
+                guard let self else { break }
+                await self.pollJobs()
+                guard self.hasLiveActiveJobs else { break }
+            }
+            guard let self, self.pollingGeneration == generation else { return }
+            self.pollingTask = nil
+        }
     }
 
     private func requestIsCurrent(

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -65,6 +65,9 @@ final class VideoGenViewModel {
     @ObservationIgnored private var pollingGeneration: UInt = 0
     @ObservationIgnored private var pollingTask: Task<Void, Never>?
     @ObservationIgnored private let pollingInterval: Duration
+    @ObservationIgnored private var missingActivePollCounts: [String: Int] = [:]
+    private var pendingCacheCleanupJobIDs = Set<String>()
+    private static let maximumMissingActivePolls = 5
 
     init(
         server: ServerManager,
@@ -126,6 +129,7 @@ final class VideoGenViewModel {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         return isServerReady
             && capabilities != nil
+            && isSelectedModelEligible
             && supportedModes.contains(mode)
             && !trimmed.isEmpty
             && sizePresets.contains(size)
@@ -135,7 +139,10 @@ final class VideoGenViewModel {
     }
 
     var hasActiveJobs: Bool {
-        jobs.contains { $0.status == .queued || $0.status == .inProgress }
+        jobs.contains {
+            ($0.status == .queued || $0.status == .inProgress)
+                && !pendingCacheCleanupJobIDs.contains($0.id)
+        }
     }
 
     /// Only a live matching server can prove that an active job is still
@@ -151,6 +158,7 @@ final class VideoGenViewModel {
         !isSubmitting
             && !isPreparing
             && !hasLiveActiveJobs
+            && pendingCacheCleanupJobIDs.isEmpty
             && (!isServerReady || jobsAreReconciled)
     }
 
@@ -377,6 +385,8 @@ final class VideoGenViewModel {
             jobs.removeAll { $0.id == job.id }
             jobs.insert(job, at: 0)
             jobsServerContext = context
+            missingActivePollCounts[job.id] = 0
+            pendingCacheCleanupJobIDs.remove(job.id)
             selectedJobID = job.id
             previewURL = nil
             prompt = ""
@@ -432,7 +442,7 @@ final class VideoGenViewModel {
 
     func delete(_ job: VideoJob) async {
         guard let context = currentServerContext,
-              jobsServerContext == context,
+              (jobsServerContext == context || pendingCacheCleanupJobIDs.contains(job.id)),
               job.status != .inProgress else { return }
         let contextGeneration = serverContextGeneration
         do {
@@ -442,6 +452,8 @@ final class VideoGenViewModel {
             guard requestIsCurrent(
                 context, contextGeneration: contextGeneration
             ) else { return }
+            pendingCacheCleanupJobIDs.remove(job.id)
+            missingActivePollCounts.removeValue(forKey: job.id)
             jobs.removeAll { $0.id == job.id }
             reconcileJobPolling()
             if selectedJobID == job.id {
@@ -453,6 +465,10 @@ final class VideoGenViewModel {
             guard requestIsCurrent(
                 context, contextGeneration: contextGeneration
             ) else { return }
+            if error as? VideoClientError == .cacheRemoval {
+                pendingCacheCleanupJobIDs.insert(job.id)
+                reconcileJobPolling()
+            }
             errorMessage = error.localizedDescription
         }
     }
@@ -462,6 +478,8 @@ final class VideoGenViewModel {
         capabilities = nil
         jobs = []
         jobsServerContext = nil
+        missingActivePollCounts = [:]
+        pendingCacheCleanupJobIDs = []
         jobsAreReconciled = false
         reconcileJobPolling()
         selectedJobID = nil
@@ -503,13 +521,35 @@ final class VideoGenViewModel {
         from serverJobs: [VideoJob],
         context: ServerRequestContext
     ) -> [VideoJob] {
-        guard jobsServerContext == context else { return serverJobs }
         let reportedIDs = Set(serverJobs.map(\.id))
-        let temporarilyMissingActiveJobs = jobs.filter {
-            ($0.status == .queued || $0.status == .inProgress)
-                && !reportedIDs.contains($0.id)
+        for id in reportedIDs {
+            missingActivePollCounts.removeValue(forKey: id)
         }
-        return serverJobs + temporarilyMissingActiveJobs
+        guard jobsServerContext == context else {
+            missingActivePollCounts = [:]
+            let pendingCleanup = jobs.filter {
+                pendingCacheCleanupJobIDs.contains($0.id)
+                    && !reportedIDs.contains($0.id)
+            }
+            return serverJobs + pendingCleanup
+        }
+        var retained: [VideoJob] = []
+        for job in jobs where !reportedIDs.contains(job.id) {
+            if pendingCacheCleanupJobIDs.contains(job.id) {
+                retained.append(job)
+            } else if job.status == .queued || job.status == .inProgress {
+                let misses = (missingActivePollCounts[job.id] ?? 0) + 1
+                if misses <= Self.maximumMissingActivePolls {
+                    missingActivePollCounts[job.id] = misses
+                    retained.append(job)
+                } else {
+                    missingActivePollCounts.removeValue(forKey: job.id)
+                }
+            } else {
+                missingActivePollCounts.removeValue(forKey: job.id)
+            }
+        }
+        return serverJobs + retained
     }
 
     private var currentServerContext: ServerRequestContext? {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -64,6 +64,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -504,6 +504,7 @@ struct CoreWorkspaceVisualFoundationTests {
                 "Sidebar.NewChat",
                 "Sidebar.Images",
                 "Sidebar.Audio",
+                "Sidebar.Video",
                 "Sidebar.Launch",
                 "Sidebar.Residency",
                 "Toolbar.SearchChats",

--- a/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
@@ -51,7 +51,7 @@ struct LaunchMediaResidencyTests {
 
     @Test("Server transitions outside Chat never replace its selection")
     func nonChatSectionsNeverSync() {
-        for section in [SidebarSection.audio, .images, .launch] {
+        for section in [SidebarSection.audio, .images, .video, .launch] {
             #expect(!ContentView.shouldSyncChatAlias(
                 serving: "org/unknown-media-model",
                 catalogEntries: entries,

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -448,7 +448,7 @@ final class ServerModelProfileTests {
         )
         let pendingRuntimeRetry = try #require(
             source.range(
-                of: "profile?.needsLiveProfileRefresh == true",
+                of: "profile?.needsLiveProfileRefresh ?? false",
                 range: residencyRefresh.lowerBound..<retry.lowerBound
             )
         )

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -448,7 +448,7 @@ final class ServerModelProfileTests {
         )
         let pendingRuntimeRetry = try #require(
             source.range(
-                of: "profile?.needsLiveProfileRefresh ?? false",
+                of: "speculativePending = profile.needsLiveProfileRefresh",
                 range: residencyRefresh.lowerBound..<retry.lowerBound
             )
         )

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -82,7 +82,7 @@ struct SettingsVisualFoundationTests {
         // update this literal alongside the enum when a feature adds one.
         var expected: Set<String> = [
             "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
-            "appearance", "privacy", "app",
+            "experimentalFeatures", "appearance", "privacy", "app",
         ]
         // `swift test` builds debug, so the debug-only category is present
         // here and absent from the shipped binary. Conditioning the literal
@@ -105,11 +105,11 @@ struct SettingsVisualFoundationTests {
     }
 
     @MainActor
-    @Test("Category order is unchanged, so arrow-key navigation is unchanged")
+    @Test("Category order is deliberate, so arrow-key navigation stays stable")
     func categoryOrderIsStable() {
         var expectedOrder = [
             "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
-            "appearance", "privacy", "app",
+            "experimentalFeatures", "appearance", "privacy", "app",
         ]
         #if DEBUG
         expectedOrder.append("developer")
@@ -119,7 +119,8 @@ struct SettingsVisualFoundationTests {
         // "what the engine is wired to do", ahead of the presentation and
         // app-level sections.
         #expect(SettingsView.category(.connectors, movedBy: 1) == .performance)
-        #expect(SettingsView.category(.performance, movedBy: 1) == .appearance)
+        #expect(SettingsView.category(.performance, movedBy: 1) == .experimentalFeatures)
+        #expect(SettingsView.category(.experimentalFeatures, movedBy: 1) == .appearance)
         // The rail's ↑/↓ handler walks this order and clamps at the ends.
         #expect(SettingsView.category(.modelManagement, movedBy: -1) == nil)
         // Developer sits after App in debug, so App is only the last row in

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -41,6 +41,38 @@ struct VideoClientTests {
         #expect(value.durationPresets(for: "512x512") == [3, 4])
     }
 
+    @Test("Malformed capability ranges fail closed")
+    func malformedCapabilitiesFailClosed() async {
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""minimum":1,"maximum":20,"default":4"#,
+            with: #""minimum":5,"maximum":3,"default":4"#
+        )
+        VideoStubProtocol.response = (200, Data(json.utf8))
+
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
+    }
+
+    @Test("Image input follows advertised formats and acceptance")
+    func imageInputUsesCapabilityContract() throws {
+        let jpegOnly = Self.capabilitiesJSON.replacingOccurrences(
+            of: #"["jpeg","png","webp"]"#,
+            with: #"["jpeg"]"#
+        )
+        let value = try JSONDecoder().decode(VideoCapabilities.self, from: Data(jpegOnly.utf8))
+        #expect(value.supportsImageInput)
+        #expect(value.acceptedReferenceMIMETypes == ["image/jpeg"])
+
+        let rejected = jpegOnly.replacingOccurrences(of: #""accepted":true"#, with: #""accepted":false"#)
+        let rejectedValue = try JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(rejected.utf8)
+        )
+        #expect(!rejectedValue.supportsImageInput)
+        #expect(rejectedValue.acceptedReferenceMIMETypes.isEmpty)
+    }
+
     @Test("Reference MIME type is detected from bytes, not the filename")
     func referenceMIMETypeUsesBytes() throws {
         let png = try #require(Data(base64Encoded:

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -69,6 +69,19 @@ struct VideoClientTests {
         }
     }
 
+    @Test("Workload uses 64-pixel rounding independently of size alignment")
+    func workloadRoundingIsIndependent() throws {
+        let json = Self.capabilitiesJSON
+            .replacingOccurrences(of: #""multiple_of":64"#, with: #""multiple_of":16"#)
+            .replacingOccurrences(
+                of: #"["1280x720","720x1280"]"#,
+                with: #"["592x592"]"#
+            )
+        let value = try JSONDecoder().decode(VideoCapabilities.self, from: Data(json.utf8))
+
+        #expect(value.durationPresets(for: "592x592") == [1, 2])
+    }
+
     @Test("Image input follows advertised formats and acceptance")
     func imageInputUsesCapabilityContract() throws {
         let jpegOnly = Self.capabilitiesJSON.replacingOccurrences(
@@ -186,8 +199,8 @@ struct VideoClientTests {
         #expect(VideoStubProtocol.requests.isEmpty)
     }
 
-    @Test("Cache cleanup failure keeps the server job available for retry")
-    func cacheCleanupFailureStopsDelete() async throws {
+    @Test("Cache cleanup failure is retryable after server deletion")
+    func cacheCleanupFailureIsRetryable() async throws {
         VideoStubProtocol.reset()
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [VideoStubProtocol.self]
@@ -209,7 +222,40 @@ struct VideoClientTests {
             try await client.delete(id: id, port: 8123, bearer: nil)
         }
         #expect(FileManager.default.fileExists(atPath: cached.path))
-        #expect(VideoStubProtocol.requests.isEmpty)
+        #expect(VideoStubProtocol.requests.count == 1)
+        #expect(VideoStubProtocol.requests.first?.httpMethod == "DELETE")
+
+        VideoStubProtocol.response = (404, Data())
+        let retryClient = VideoClient(
+            session: URLSession(configuration: configuration),
+            cacheDirectory: directory
+        )
+        try await retryClient.delete(id: id, port: 8123, bearer: nil)
+        #expect(!FileManager.default.fileExists(atPath: cached.path))
+    }
+
+    @Test("Server deletion failure preserves an available cached preview")
+    func serverDeleteFailurePreservesCache() async throws {
+        VideoStubProtocol.reset()
+        VideoStubProtocol.response = (500, Data())
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [VideoStubProtocol.self]
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-delete-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "video_0123456789abcdef0123456789abcdef"
+        let cached = directory.appendingPathComponent(try VideoClient.cacheFileName(for: id))
+        try Data("video".utf8).write(to: cached)
+        let client = VideoClient(
+            session: URLSession(configuration: configuration), cacheDirectory: directory
+        )
+
+        await #expect(throws: VideoClientError.self) {
+            try await client.delete(id: id, port: 8123, bearer: nil)
+        }
+        #expect(FileManager.default.fileExists(atPath: cached.path))
     }
 
     @Test("Reference loader rejects an oversized file before allocating it")

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -76,6 +76,67 @@ struct VideoClientTests {
         }
     }
 
+    @Test("Multipart filenames cannot inject headers")
+    func multipartFilenameEscaping() {
+        let body = VideoClient.multipartBody(
+            boundary: "test-boundary",
+            fields: [],
+            file: (
+                field: "input_reference",
+                name: "fox\"\\\r\nX-Injected: yes.png",
+                mime: "image/png",
+                data: Data()
+            )
+        )
+        let text = String(decoding: body, as: UTF8.self)
+
+        #expect(text.contains(#"filename="fox\"\\_X-Injected: yes.png""#))
+        #expect(!text.contains("\r\nX-Injected:"))
+    }
+
+    @Test("Preview cache keys preserve complete validated job identity")
+    func previewCacheIdentity() throws {
+        let dashed = try VideoClient.cacheFileName(for: "a-b")
+        let plain = try VideoClient.cacheFileName(for: "ab")
+
+        #expect(dashed != plain)
+        #expect(dashed.hasSuffix(".mp4"))
+        #expect(throws: VideoClientError.invalidJobID) {
+            _ = try VideoClient.cacheFileName(for: "a/b")
+        }
+        #expect(throws: VideoClientError.invalidJobID) {
+            _ = try VideoClient.cacheFileName(for: "")
+        }
+    }
+
+    @Test("Invalid job IDs fail before a cache or network lookup")
+    func invalidJobIDStopsContentLookup() async {
+        let client = makeClient()
+
+        await #expect(throws: VideoClientError.invalidJobID) {
+            _ = try await client.content(id: "../another-job", port: 8123, bearer: "secret")
+        }
+        #expect(VideoStubProtocol.requests.isEmpty)
+    }
+
+    @Test("Reference loader rejects an oversized file before allocating it")
+    func oversizedReferenceIsRejected() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-reference-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("oversized.png")
+        _ = FileManager.default.createFile(atPath: source.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: source)
+        try handle.truncate(atOffset: UInt64(VideoClient.maxReferenceBytes + 1))
+        try handle.close()
+
+        #expect(throws: VideoReferenceLoaderError.tooLarge) {
+            _ = try VideoReferenceLoader.load(from: source)
+        }
+    }
+
     @Test("Failed save leaves an existing destination untouched")
     func failedSavePreservesDestination() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("VideoClient wire contract", .serialized)
+struct VideoClientTests {
+    private func makeClient() -> VideoClient {
+        VideoStubProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [VideoStubProtocol.self]
+        return VideoClient(session: URLSession(configuration: configuration))
+    }
+
+    @Test("Capabilities authenticate and produce conservative controls")
+    func capabilities() async throws {
+        let client = makeClient()
+        VideoStubProtocol.response = (200, Data(Self.capabilitiesJSON.utf8))
+
+        let value = try await client.capabilities(port: 8123, bearer: "secret")
+
+        #expect(value.modes == [.textToVideo, .imageToVideo])
+        #expect(value.sizePresets == [
+            "512x512", "768x512", "512x768", "1280x720", "720x1280",
+        ])
+        #expect(value.durationPresets == [1, 2, 4])
+        let request = try #require(VideoStubProtocol.requests.first)
+        #expect(request.url?.path == "/v1/videos/capabilities")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+    }
+
+    @Test("Create uses the documented multipart fields and reference name")
+    func createMultipart() async throws {
+        let client = makeClient()
+        VideoStubProtocol.response = (200, Data(Self.jobJSON.utf8))
+
+        let job = try await client.create(
+            VideoCreateRequest(
+                prompt: "A fox runs through snow",
+                model: "ltx-2.3-mlx-q4",
+                seconds: 2,
+                size: "768x512",
+                seed: 42,
+                reference: Data("reference-bytes".utf8),
+                referenceFileName: "fox.png",
+                referenceMIMEType: "image/png"
+            ),
+            port: 8123,
+            bearer: "secret"
+        )
+
+        #expect(job.status == .queued)
+        let body = String(decoding: try #require(VideoStubProtocol.bodies.first), as: UTF8.self)
+        #expect(body.contains("name=\"prompt\"\r\n\r\nA fox runs through snow"))
+        #expect(body.contains("name=\"model\"\r\n\r\nltx-2.3-mlx-q4"))
+        #expect(body.contains("name=\"seconds\"\r\n\r\n2"))
+        #expect(body.contains("name=\"size\"\r\n\r\n768x512"))
+        #expect(body.contains("name=\"seed\"\r\n\r\n42"))
+        #expect(body.contains("name=\"input_reference\"; filename=\"fox.png\""))
+        #expect(body.contains("reference-bytes"))
+    }
+
+    @Test("Nested server errors remain actionable")
+    func nestedError() async throws {
+        let client = makeClient()
+        VideoStubProtocol.response = (
+            409,
+            Data(#"{"detail":{"error":{"message":"start a video model"}}}"#.utf8)
+        )
+
+        do {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+            Issue.record("Expected an HTTP error")
+        } catch let error as VideoClientError {
+            #expect(error.errorDescription == "start a video model")
+        }
+    }
+
+    private static let capabilitiesJSON = #"""
+    {
+      "object":"video.capabilities","model":"ltx","modality":"video-gen","family":"ltx-2.3",
+      "modes":["text-to-video","image-to-video"],
+      "limits":{
+        "size":{"type":"range","width":{"minimum":256,"maximum":1920,"multiple_of":64},"height":{"minimum":256,"maximum":1920,"multiple_of":64},"also_supported":["1280x720","720x1280"]},
+        "seconds":{"minimum":1,"maximum":20,"default":4},
+        "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
+        "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
+        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+      },
+      "controls":{}
+    }
+    """#
+
+    private static let jobJSON = #"""
+    {"id":"video_0123456789abcdef0123456789abcdef","model":"ltx-2.3-mlx-q4","prompt":"A fox runs through snow","seconds":"2","size":"768x512","status":"queued","progress":0,"created_at":123,"completed_at":null,"error":null,"object":"video"}
+    """#
+}
+
+private final class VideoStubProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var bodies: [Data] = []
+    nonisolated(unsafe) static var response: (Int, Data) = (200, Data())
+
+    static func reset() {
+        requests = []
+        bodies = []
+        response = (200, Data())
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requests.append(request)
+        Self.bodies.append(Self.readBody(from: request))
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.response.0,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.response.1)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -24,9 +24,30 @@ struct VideoClientTests {
         ])
         #expect(value.durationPresets(for: "512x512") == [1, 2, 4])
         #expect(value.durationPresets(for: "1280x720") == [1])
+        #expect(value.referenceMaximumBytes == 20 * 1024 * 1024)
         let request = try #require(VideoStubProtocol.requests.first)
         #expect(request.url?.path == "/v1/videos/capabilities")
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+    }
+
+    @Test("Duration presets include the shortest server-supported duration")
+    func durationPresetsIncludeServerMinimum() throws {
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""minimum":1,"maximum":20,"default":4"#,
+            with: #""minimum":3,"maximum":20,"default":4"#
+        )
+        let value = try JSONDecoder().decode(VideoCapabilities.self, from: Data(json.utf8))
+
+        #expect(value.durationPresets(for: "512x512") == [3, 4])
+    }
+
+    @Test("Reference MIME type is detected from bytes, not the filename")
+    func referenceMIMETypeUsesBytes() throws {
+        let png = try #require(Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        ))
+
+        #expect(VideoReferenceLoader.mimeType(for: png) == "image/png")
     }
 
     @Test("Create uses the documented multipart fields and reference name")

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -22,7 +22,8 @@ struct VideoClientTests {
         #expect(value.sizePresets == [
             "512x512", "768x512", "512x768", "1280x720", "720x1280",
         ])
-        #expect(value.durationPresets == [1, 2, 4])
+        #expect(value.durationPresets(for: "512x512") == [1, 2, 4])
+        #expect(value.durationPresets(for: "1280x720") == [1])
         let request = try #require(VideoStubProtocol.requests.first)
         #expect(request.url?.path == "/v1/videos/capabilities")
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
@@ -73,6 +74,44 @@ struct VideoClientTests {
         } catch let error as VideoClientError {
             #expect(error.errorDescription == "start a video model")
         }
+    }
+
+    @Test("Failed save leaves an existing destination untouched")
+    func failedSavePreservesDestination() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-save-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let destination = directory.appendingPathComponent("kept.mp4")
+        try Data("original".utf8).write(to: destination)
+
+        do {
+            try VideoPreviewSaver.save(
+                source: directory.appendingPathComponent("missing.mp4"),
+                destination: destination
+            )
+            Issue.record("Expected a missing-source failure")
+        } catch {}
+
+        #expect(try Data(contentsOf: destination) == Data("original".utf8))
+    }
+
+    @Test("Successful save atomically replaces an existing destination")
+    func successfulSaveReplacesDestination() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-save-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("preview.mp4")
+        let destination = directory.appendingPathComponent("saved.mp4")
+        try Data("new video".utf8).write(to: source)
+        try Data("old video".utf8).write(to: destination)
+
+        try VideoPreviewSaver.save(source: source, destination: destination)
+
+        #expect(try Data(contentsOf: destination) == Data("new video".utf8))
     }
 
     private static let capabilitiesJSON = #"""

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -55,6 +55,20 @@ struct VideoClientTests {
         }
     }
 
+    @Test("Unsupported workload rounding fails closed")
+    func unsupportedRoundingFailsClosed() async {
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""dimension_rounding":"multiple_of_64""#,
+            with: #""dimension_rounding":"floor""#
+        )
+        VideoStubProtocol.response = (200, Data(json.utf8))
+
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
+    }
+
     @Test("Image input follows advertised formats and acceptance")
     func imageInputUsesCapabilityContract() throws {
         let jpegOnly = Self.capabilitiesJSON.replacingOccurrences(
@@ -169,6 +183,32 @@ struct VideoClientTests {
         await #expect(throws: VideoClientError.invalidJobID) {
             _ = try await client.content(id: "../another-job", port: 8123, bearer: "secret")
         }
+        #expect(VideoStubProtocol.requests.isEmpty)
+    }
+
+    @Test("Cache cleanup failure keeps the server job available for retry")
+    func cacheCleanupFailureStopsDelete() async throws {
+        VideoStubProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [VideoStubProtocol.self]
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-delete-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "video_0123456789abcdef0123456789abcdef"
+        let cached = directory.appendingPathComponent(try VideoClient.cacheFileName(for: id))
+        try Data("video".utf8).write(to: cached)
+        let client = VideoClient(
+            session: URLSession(configuration: configuration),
+            cacheDirectory: directory,
+            removeCachedItem: { _ in throw CocoaError(.fileWriteNoPermission) }
+        )
+
+        await #expect(throws: VideoClientError.cacheRemoval) {
+            try await client.delete(id: id, port: 8123, bearer: nil)
+        }
+        #expect(FileManager.default.fileExists(atPath: cached.path))
         #expect(VideoStubProtocol.requests.isEmpty)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/VideoFeatureGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoFeatureGateTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Experimental Video gate", .serialized)
+struct VideoFeatureGateTests {
+    @Test("Video is opt-in when no preference exists")
+    func defaultsOff() throws {
+        let suite = "rapid.video-gate-tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(!VideoFeatureConfig.isEnabled(in: defaults))
+        defaults.set(true, forKey: VideoFeatureConfig.enabledKey)
+        #expect(VideoFeatureConfig.isEnabled(in: defaults))
+    }
+
+    @MainActor
+    @Test("Disabling while Video is active returns to Chat")
+    func disablingRecoversNavigation() {
+        #expect(ContentView.sectionAfterVideoGateChange(current: .video, enabled: false) == .chat)
+        #expect(ContentView.sectionAfterVideoGateChange(current: .video, enabled: true) == .video)
+        #expect(ContentView.sectionAfterVideoGateChange(current: .images, enabled: false) == .images)
+    }
+
+    @Test("Video purposes accept only explicit matching capabilities")
+    func capabilityFiltering() {
+        let chat = ModelEntry(alias: "chat", hfRepo: nil, sizeOnDisk: nil, cached: true)
+        let textVideo = ModelEntry(
+            alias: "t2v", hfRepo: nil, sizeOnDisk: nil, cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let imageVideo = ModelEntry(
+            alias: "i2v", hfRepo: nil, sizeOnDisk: nil, cached: true,
+            kind: .video, videoCapabilities: [.imageToVideo], minimumMemoryGB: 32
+        )
+
+        #expect(ModelSelectionPurpose.textToVideo.entries(in: [chat, textVideo, imageVideo]) == [textVideo])
+        #expect(ModelSelectionPurpose.imageToVideo.entries(in: [chat, textVideo, imageVideo]) == [imageVideo])
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -61,6 +61,10 @@ struct VideoGenViewModelTests {
         await viewModel.refreshServerData()
         #expect(viewModel.size == "512x512")
         #expect(viewModel.seconds == 1)
+        viewModel.seconds = 4
+        viewModel.selectSize("1280x720")
+        #expect(viewModel.durationPresets == [1])
+        #expect(viewModel.seconds == 1)
 
         viewModel.selectMode(.image)
         viewModel.prompt = "Ocean waves moving around a black rock"
@@ -75,10 +79,49 @@ struct VideoGenViewModelTests {
         let requests = await client.recordedRequests()
         let request = try #require(requests.first)
         #expect(request.model == model.alias)
+        #expect(request.size == "1280x720")
+        #expect(request.seconds == 1)
         #expect(request.reference == Data("png".utf8))
         #expect(request.referenceFileName == "rock.png")
         #expect(viewModel.jobs.first?.status == .queued)
         #expect(viewModel.prompt.isEmpty)
+    }
+
+    @Test("A late response cannot repopulate a newly selected model")
+    func staleCapabilitiesAreDiscarded() async throws {
+        let first = ModelEntry(
+            alias: "video-a", hfRepo: "org/a", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let second = ModelEntry(
+            alias: "video-b", hfRepo: "org/b", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let client = VideoSuspendingClient(
+            capabilities: try VideoFakeClient.capabilitiesValue()
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: first.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: client,
+            physicalRAMGB: 32,
+            catalogLoader: { _ in [first, second] }
+        )
+        await viewModel.refreshCatalog()
+
+        let refresh = Task { await viewModel.refreshServerData() }
+        await client.waitUntilCapabilitiesRequested()
+        viewModel.selectModel(second.alias)
+        await client.resumeCapabilities()
+        await refresh.value
+
+        #expect(viewModel.selectedAlias == second.alias)
+        #expect(viewModel.capabilities == nil)
+        #expect(viewModel.jobs.isEmpty)
     }
 }
 
@@ -117,14 +160,61 @@ private actor VideoFakeClient: VideoClientProtocol {
 
     func recordedRequests() -> [VideoCreateRequest] { requests }
 
+    nonisolated static func capabilitiesValue() throws -> VideoCapabilities {
+        try JSONDecoder().decode(VideoCapabilities.self, from: Data(capabilitiesJSON.utf8))
+    }
+
     private static let capabilitiesJSON = #"""
     {
       "model":"org/ltx","family":"ltx-2.3",
       "modes":["text-to-video","image-to-video"],
       "limits":{
-        "size":{"type":"range","width":{"minimum":256,"maximum":1920,"multiple_of":64},"height":{"minimum":256,"maximum":1920,"multiple_of":64}},
-        "seconds":{"minimum":1,"maximum":20,"default":4}
+        "size":{"type":"range","width":{"minimum":256,"maximum":1920,"multiple_of":64},"height":{"minimum":256,"maximum":1920,"multiple_of":64},"also_supported":["1280x720","720x1280"]},
+        "seconds":{"minimum":1,"maximum":20,"default":4},
+        "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
+        "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"}
       }
     }
     """#
+}
+
+private actor VideoSuspendingClient: VideoClientProtocol {
+    private let value: VideoCapabilities
+    private var capabilitiesRequested = false
+    private var capabilitiesContinuation: CheckedContinuation<VideoCapabilities, Error>?
+
+    init(capabilities: VideoCapabilities) {
+        value = capabilities
+    }
+
+    func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
+        capabilitiesRequested = true
+        return try await withCheckedThrowingContinuation { continuation in
+            capabilitiesContinuation = continuation
+        }
+    }
+
+    func waitUntilCapabilitiesRequested() async {
+        while !capabilitiesRequested { await Task.yield() }
+    }
+
+    func resumeCapabilities() {
+        capabilitiesContinuation?.resume(returning: value)
+        capabilitiesContinuation = nil
+    }
+
+    func create(
+        _ request: VideoCreateRequest,
+        port: Int,
+        bearer: String?
+    ) async throws -> VideoJob {
+        throw VideoClientError.invalidResponse
+    }
+
+    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] { [] }
+    func delete(id: String, port: Int, bearer: String?) async throws {}
+    func content(id: String, port: Int, bearer: String?) async throws -> URL {
+        throw VideoClientError.invalidResponse
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("VideoGenViewModel")
+struct VideoGenViewModelTests {
+    @Test("Catalog fails closed to explicit Video rows and chooses a model that fits")
+    func catalogFilteringAndMemoryChoice() async {
+        let chat = ModelEntry(alias: "chat", hfRepo: nil, sizeOnDisk: nil, cached: true)
+        let tooLarge = ModelEntry(
+            alias: "video-32", hfRepo: "org/large", sizeOnDisk: nil, cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 32
+        )
+        let fitting = ModelEntry(
+            alias: "video-24", hfRepo: "org/fitting", sizeOnDisk: nil, cached: true,
+            kind: .video,
+            videoCapabilities: [.textToVideo, .imageToVideo], minimumMemoryGB: 24
+        )
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: VideoFakeClient(),
+            physicalRAMGB: 24,
+            catalogLoader: { _ in [chat, tooLarge, fitting] }
+        )
+
+        await viewModel.refreshCatalog()
+
+        #expect(viewModel.videoModels == [tooLarge, fitting])
+        #expect(viewModel.selectedAlias == "video-24")
+        #expect(viewModel.isSelectedModelEligible)
+        #expect(!viewModel.isModelEligible(tooLarge))
+        #expect(viewModel.supportedModes == [.text, .image])
+    }
+
+    @Test("Live capabilities gate Image mode and submission carries the reference")
+    func capabilityDrivenSubmission() async throws {
+        let model = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video,
+            videoCapabilities: [.textToVideo, .imageToVideo], minimumMemoryGB: 24
+        )
+        let client = VideoFakeClient()
+        let server = ServerManager(
+            testingState: .ready(alias: model.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: client,
+            physicalRAMGB: 32,
+            catalogLoader: { _ in [model] }
+        )
+
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+        #expect(viewModel.size == "512x512")
+        #expect(viewModel.seconds == 1)
+
+        viewModel.selectMode(.image)
+        viewModel.prompt = "Ocean waves moving around a black rock"
+        #expect(!viewModel.canSubmit)
+        viewModel.setReference(.init(
+            data: Data("png".utf8), fileName: "rock.png", mimeType: "image/png"
+        ))
+        #expect(viewModel.canSubmit)
+
+        await viewModel.submit()
+
+        let requests = await client.recordedRequests()
+        let request = try #require(requests.first)
+        #expect(request.model == model.alias)
+        #expect(request.reference == Data("png".utf8))
+        #expect(request.referenceFileName == "rock.png")
+        #expect(viewModel.jobs.first?.status == .queued)
+        #expect(viewModel.prompt.isEmpty)
+    }
+}
+
+private actor VideoFakeClient: VideoClientProtocol {
+    private var requests: [VideoCreateRequest] = []
+
+    func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
+        try JSONDecoder().decode(VideoCapabilities.self, from: Data(Self.capabilitiesJSON.utf8))
+    }
+
+    func create(
+        _ request: VideoCreateRequest,
+        port: Int,
+        bearer: String?
+    ) async throws -> VideoJob {
+        requests.append(request)
+        return VideoJob(
+            id: "video_0123456789abcdef0123456789abcdef",
+            model: request.model,
+            prompt: request.prompt,
+            seconds: String(request.seconds),
+            size: request.size,
+            status: .queued,
+            progress: 0,
+            createdAt: 123,
+            completedAt: nil,
+            error: nil
+        )
+    }
+
+    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] { [] }
+    func delete(id: String, port: Int, bearer: String?) async throws {}
+    func content(id: String, port: Int, bearer: String?) async throws -> URL {
+        URL(fileURLWithPath: "/tmp/\(id).mp4")
+    }
+
+    func recordedRequests() -> [VideoCreateRequest] { requests }
+
+    private static let capabilitiesJSON = #"""
+    {
+      "model":"org/ltx","family":"ltx-2.3",
+      "modes":["text-to-video","image-to-video"],
+      "limits":{
+        "size":{"type":"range","width":{"minimum":256,"maximum":1920,"multiple_of":64},"height":{"minimum":256,"maximum":1920,"multiple_of":64}},
+        "seconds":{"minimum":1,"maximum":20,"default":4}
+      }
+    }
+    """#
+}

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -115,13 +115,72 @@ struct VideoGenViewModelTests {
 
         let refresh = Task { await viewModel.refreshServerData() }
         await client.waitUntilCapabilitiesRequested()
-        viewModel.selectModel(second.alias)
+        server._testSetState(.ready(alias: second.alias))
+        await viewModel.serverStateDidChange()
         await client.resumeCapabilities()
         await refresh.value
 
-        #expect(viewModel.selectedAlias == second.alias)
+        #expect(viewModel.selectedAlias == first.alias)
         #expect(viewModel.capabilities == nil)
         #expect(viewModel.jobs.isEmpty)
+    }
+
+    @Test("Unreconciled history blocks model switching until retry succeeds")
+    func historyFailureBlocksModelSwitch() async {
+        let first = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let second = ModelEntry(
+            alias: "video-b", hfRepo: "org/b", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let client = VideoFakeClient(listFailures: 1)
+        let server = ServerManager(
+            testingState: .ready(alias: first.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: client,
+            physicalRAMGB: 32,
+            catalogLoader: { _ in [first, second] }
+        )
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+
+        #expect(viewModel.needsServerRefresh)
+        #expect(!viewModel.canSwitchModels)
+        viewModel.selectModel(second.alias)
+        #expect(viewModel.selectedAlias == first.alias)
+
+        await viewModel.refreshServerData()
+        #expect(viewModel.jobsAreReconciled)
+        #expect(viewModel.canSwitchModels)
+        viewModel.selectModel(second.alias)
+        #expect(viewModel.selectedAlias == second.alias)
+    }
+
+    @Test("A stale history selection cannot display a different job")
+    func staleHistorySelectionIsIgnored() async {
+        let server = ServerManager(
+            testingState: .idle,
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true")
+        )
+        let viewModel = VideoGenViewModel(server: server, client: VideoFakeClient())
+        let job = VideoJob(
+            id: "video_0123456789abcdef0123456789abcdef",
+            model: "ltx", prompt: "first", seconds: "1", size: "512x512",
+            status: .completed, progress: 100, createdAt: 1, completedAt: 2, error: nil
+        )
+        viewModel.jobs = [job]
+        viewModel.selectedJobID = job.id
+
+        await viewModel.selectJob("video_stale")
+
+        #expect(viewModel.selectedJobID == job.id)
+        #expect(viewModel.selectedJob == job)
     }
 
     @Test("Active jobs keep polling without a mounted Video view")
@@ -238,6 +297,11 @@ private actor VideoPollingClient: VideoClientProtocol {
 
 private actor VideoFakeClient: VideoClientProtocol {
     private var requests: [VideoCreateRequest] = []
+    private var listFailures: Int
+
+    init(listFailures: Int = 0) {
+        self.listFailures = listFailures
+    }
 
     func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
         try JSONDecoder().decode(VideoCapabilities.self, from: Data(Self.capabilitiesJSON.utf8))
@@ -263,7 +327,13 @@ private actor VideoFakeClient: VideoClientProtocol {
         )
     }
 
-    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] { [] }
+    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] {
+        if listFailures > 0 {
+            listFailures -= 1
+            throw VideoClientError.transport("history unavailable")
+        }
+        return []
+    }
     func delete(id: String, port: Int, bearer: String?) async throws {}
     func content(id: String, port: Int, bearer: String?) async throws -> URL {
         URL(fileURLWithPath: "/tmp/\(id).mp4")

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -216,7 +216,7 @@ struct VideoGenViewModelTests {
         #expect(viewModel.jobs.first?.status == .completed)
         #expect(!viewModel.hasLiveActiveJobs)
         #expect(viewModel.previewURL?.lastPathComponent == "finished.mp4")
-        #expect(await client.listCallCount() >= 2)
+        #expect(await client.listCallCount() >= 3)
     }
 
     @Test("A stale active job stops blocking global busy after a server switch")
@@ -268,7 +268,7 @@ private actor VideoPollingClient: VideoClientProtocol {
 
     func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] {
         listCalls += 1
-        return listCalls == 1 ? [] : [Self.job(status: .completed, progress: 100)]
+        return listCalls <= 2 ? [] : [Self.job(status: .completed, progress: 100)]
     }
 
     func delete(id: String, port: Int, bearer: String?) async throws {}

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -87,6 +87,32 @@ struct VideoGenViewModelTests {
         #expect(viewModel.prompt.isEmpty)
     }
 
+    @Test("A running model that exceeds this Mac's memory remains ineligible")
+    func runningIneligibleModelCannotSubmit() async {
+        let model = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 64
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: model.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: VideoFakeClient(),
+            physicalRAMGB: 32,
+            catalogLoader: { _ in [model] }
+        )
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+        viewModel.prompt = "A short scene"
+
+        #expect(viewModel.isServerReady)
+        #expect(!viewModel.isSelectedModelEligible)
+        #expect(!viewModel.canSubmit)
+    }
+
     @Test("A late response cannot repopulate a newly selected model")
     func staleCapabilitiesAreDiscarded() async throws {
         let first = ModelEntry(
@@ -219,6 +245,39 @@ struct VideoGenViewModelTests {
         #expect(await client.listCallCount() >= 3)
     }
 
+    @Test("A persistently missing active job expires after bounded polling")
+    func missingActiveJobEventuallyExpires() async throws {
+        let model = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let client = VideoFakeClient()
+        let server = ServerManager(
+            testingState: .ready(alias: model.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: client,
+            physicalRAMGB: 32,
+            pollingInterval: .milliseconds(5),
+            catalogLoader: { _ in [model] }
+        )
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+        viewModel.prompt = "A fox runs through snow"
+        await viewModel.submit()
+
+        for _ in 0..<100 where viewModel.hasActiveJobs {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(!viewModel.hasActiveJobs)
+        #expect(viewModel.jobs.isEmpty)
+        #expect(await client.listCallCount() >= 7)
+    }
+
     @Test("A stale active job stops blocking global busy after a server switch")
     func staleJobIsNotGloballyBusy() async {
         let model = ModelEntry(
@@ -298,6 +357,7 @@ private actor VideoPollingClient: VideoClientProtocol {
 private actor VideoFakeClient: VideoClientProtocol {
     private var requests: [VideoCreateRequest] = []
     private var listFailures: Int
+    private var listCalls = 0
 
     init(listFailures: Int = 0) {
         self.listFailures = listFailures
@@ -328,6 +388,7 @@ private actor VideoFakeClient: VideoClientProtocol {
     }
 
     func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] {
+        listCalls += 1
         if listFailures > 0 {
             listFailures -= 1
             throw VideoClientError.transport("history unavailable")
@@ -340,6 +401,7 @@ private actor VideoFakeClient: VideoClientProtocol {
     }
 
     func recordedRequests() -> [VideoCreateRequest] { requests }
+    func listCallCount() -> Int { listCalls }
 
     nonisolated static func capabilitiesValue() throws -> VideoCapabilities {
         try JSONDecoder().decode(VideoCapabilities.self, from: Data(capabilitiesJSON.utf8))

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -34,7 +34,7 @@ struct VideoGenViewModelTests {
         #expect(viewModel.selectedAlias == "video-24")
         #expect(viewModel.isSelectedModelEligible)
         #expect(!viewModel.isModelEligible(tooLarge))
-        #expect(viewModel.supportedModes == [.text, .image])
+        #expect(viewModel.supportedModes == [.text])
     }
 
     @Test("Live capabilities gate Image mode and submission carries the reference")
@@ -284,7 +284,8 @@ private actor VideoFakeClient: VideoClientProtocol {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
+        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
       }
     }
     """#

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -123,6 +123,117 @@ struct VideoGenViewModelTests {
         #expect(viewModel.capabilities == nil)
         #expect(viewModel.jobs.isEmpty)
     }
+
+    @Test("Active jobs keep polling without a mounted Video view")
+    func pollingOutlivesView() async throws {
+        let model = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let client = VideoPollingClient()
+        let server = ServerManager(
+            testingState: .ready(alias: model.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: client,
+            physicalRAMGB: 32,
+            pollingInterval: .milliseconds(5),
+            catalogLoader: { _ in [model] }
+        )
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+        viewModel.prompt = "A fox runs through snow"
+
+        await viewModel.submit()
+        #expect(viewModel.hasLiveActiveJobs)
+
+        for _ in 0..<100 where viewModel.hasActiveJobs {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(viewModel.jobs.first?.status == .completed)
+        #expect(!viewModel.hasLiveActiveJobs)
+        #expect(viewModel.previewURL?.lastPathComponent == "finished.mp4")
+        #expect(await client.listCallCount() >= 2)
+    }
+
+    @Test("A stale active job stops blocking global busy after a server switch")
+    func staleJobIsNotGloballyBusy() async {
+        let model = ModelEntry(
+            alias: "ltx-2.3-mlx-q4", hfRepo: "org/ltx", sizeOnDisk: "9 GB", cached: true,
+            kind: .video, videoCapabilities: [.textToVideo], minimumMemoryGB: 24
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: model.alias),
+            binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+            activeBearer: "test-bearer"
+        )
+        let viewModel = VideoGenViewModel(
+            server: server,
+            client: VideoFakeClient(),
+            physicalRAMGB: 32,
+            pollingInterval: .seconds(60),
+            catalogLoader: { _ in [model] }
+        )
+        await viewModel.refreshCatalog()
+        await viewModel.refreshServerData()
+        viewModel.prompt = "A fox runs through snow"
+        await viewModel.submit()
+        #expect(viewModel.hasLiveActiveJobs)
+
+        server._testSetState(.ready(alias: "chat-model"))
+        await viewModel.serverStateDidChange()
+
+        #expect(viewModel.hasActiveJobs)
+        #expect(!viewModel.hasLiveActiveJobs)
+    }
+}
+
+private actor VideoPollingClient: VideoClientProtocol {
+    private var listCalls = 0
+
+    func capabilities(port: Int, bearer: String?) async throws -> VideoCapabilities {
+        try VideoFakeClient.capabilitiesValue()
+    }
+
+    func create(
+        _ request: VideoCreateRequest,
+        port: Int,
+        bearer: String?
+    ) async throws -> VideoJob {
+        Self.job(status: .queued, progress: 0)
+    }
+
+    func list(port: Int, bearer: String?, limit: Int) async throws -> [VideoJob] {
+        listCalls += 1
+        return listCalls == 1 ? [] : [Self.job(status: .completed, progress: 100)]
+    }
+
+    func delete(id: String, port: Int, bearer: String?) async throws {}
+
+    func content(id: String, port: Int, bearer: String?) async throws -> URL {
+        URL(fileURLWithPath: "/tmp/finished.mp4")
+    }
+
+    func listCallCount() -> Int { listCalls }
+
+    private nonisolated static func job(status: VideoJobStatus, progress: Int) -> VideoJob {
+        VideoJob(
+            id: "video_0123456789abcdef0123456789abcdef",
+            model: "ltx-2.3-mlx-q4",
+            prompt: "A fox runs through snow",
+            seconds: "1",
+            size: "512x512",
+            status: status,
+            progress: progress,
+            createdAt: 123,
+            completedAt: status == .completed ? 456 : nil,
+            error: nil
+        )
+    }
 }
 
 private actor VideoFakeClient: VideoClientProtocol {


### PR DESCRIPTION
## Why

The Desktop video-serving foundation has no user-facing workflow. Video generation also has unusually high hardware and download costs, so exposing it to every Mac by default would create a misleading and disruptive experience.

## Scope

- Add a persistent, default-off Enable Video Generation toggle under Settings > Experimental Features.
- Show the Video sidebar destination only while that opt-in is enabled, and return to Chat if it is disabled while active.
- Add a native Video workspace for capability-filtered model selection, explicit download/start, text-to-video and image-to-video input, workload-safe size/duration choices, job polling, preview, save, cancel-queued, and delete.
- Enforce catalog-declared video capabilities and physical-memory eligibility before model preparation.
- Add focused wire-contract, view-model, feature-gate, navigation, accessibility, and visual-regression coverage.

## Non-goals

- Enabling Video by default.
- Downloading or starting a model when the tab opens or the setting changes.
- Changing the server video API, model catalog, memory policy, or timeout values.
- Interrupting an in-progress Metal generation; only queued work can be cancelled safely.
- Exposing advanced controls such as manual seed, frame rate, frame count, guidance, or negative prompt in this first UI.

## Acceptance

- A fresh install has no Video sidebar item.
- Enabling the Experimental setting reveals Video immediately; disabling it hides Video and safely routes an active Video workspace back to Chat.
- Only explicit video-capability models appear, models that do not fit the Mac are disabled, and no model lifecycle action happens without a user click.
- The first request defaults to the smallest supported preset and shortest supported duration; invalid size/duration workload combinations are unavailable.
- Completed jobs can be previewed, saved without destructive overwrite behavior, and deleted; queued jobs can be cancelled; failures remain actionable.
- Compact and regular macOS windows remain usable in light and dark appearance.

## Verification

- swift test --no-parallel --filter Video: 18 tests in 6 suites passed.
- swift test --no-parallel: 3245 tests in 277 suites passed.
- swift build: passed.
- swift build -c release: passed; only pre-existing warnings outside this diff.
- Focused gate snapshots: opt-out and opt-in sidebars passed in light and dark appearance.
- Focused Video snapshots: 1000x700 and 520x560 layouts passed in light and dark appearance, including a ready compact state.
- PR description validation: MERGE-SAFE.
- git diff --check: passed.

## Behaviour delta

Before: Desktop has no Video workspace. After: users who explicitly opt in under Experimental Features receive a capability-, workload-, and memory-gated Video workspace; all other users see no Video tab and incur no download or server-start side effects.

## AI assistance disclosure

Codex authored and reviewed the Desktop implementation and tests under human-directed product constraints. Every changed path was reviewed against the server contract and repository conventions, then verified with the focused and full Swift suites, debug and release builds, isolated app startup checks, and light/dark compact visual snapshots.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated or scaffolded sections, I can describe how they were verified.

## Checklist

- Tests and release build pass locally.
- No Python dependency, engine API, or public compatibility change.
- No new dependency or credential-bearing file.
- Full PR validation and a final convergent Codex review will be recorded after the foundation dependency lands on main.