### PR TITLE
feat(mac): persistent memory extraction from completed conversations

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -207,9 +207,15 @@ final class ChatViewModel {
             if oldValue && !isStreaming {
                 persistActive()
                 scheduleBackgroundAssist()
+                scheduleMemoryExtraction()
             }
         }
     }
+
+    /// The model alias used for the most recent turn, captured at
+    /// ``beginAssistantTurn`` so the background memory extractor can
+    /// address the same engine after the stream finishes.
+    private var lastTurnAlias: String?
     /// Most recent transport / parse error. Cleared on the next ``send``.
     /// Shown as a banner above the compose bar so the user knows what
     /// went wrong without scraping the log tail.
@@ -270,6 +276,12 @@ final class ChatViewModel {
     /// Global custom instructions shared with Settings.
     let customInstructions: CustomInstructionsConfig
 
+    /// Persistent memory entries. Injected into the system prompt and
+    /// updated by the background extractor after each completed turn.
+    /// Optional so unit tests can construct a viewmodel without a real
+    /// memory store; production wires this from ``RapidApp.init``.
+    let memoryStore: MemoryStore?
+
     /// v0.5.1: live handle on the embedded server so the chat loop can
     /// resolve `request.model` against the alias currently being served
     /// instead of trusting the picker bar's state. Mirrors the global
@@ -289,6 +301,7 @@ final class ChatViewModel {
         toolDefaults: UserDefaults = .standard,
         sampling: SamplingConfig? = nil,
         customInstructions: CustomInstructionsConfig? = nil,
+        memoryStore: MemoryStore? = nil,
         server: ServerManager? = nil,
         persistsConversations: Bool = true,
         conversationStoreURL: URL? = nil,
@@ -299,6 +312,7 @@ final class ChatViewModel {
         self.toolDefaults = toolDefaults
         self.sampling = sampling
         self.customInstructions = customInstructions ?? CustomInstructionsConfig()
+        self.memoryStore = memoryStore
         self.server = server
         self.persistsConversations = persistsConversations
         self.conversationStoreURL = conversationStoreURL
@@ -1137,6 +1151,56 @@ final class ChatViewModel {
         return true
     }
 
+    /// Fires a detached background task to review the completed exchange
+    /// and upsert any durable facts into ``memoryStore``. Called from the
+    /// ``isStreaming`` didSet when a turn ends; never blocks the UI or
+    /// competes with an active stream because it runs on a separate task.
+    private func scheduleMemoryExtraction() {
+        guard let memoryStore, memoryStore.isEnabled else { return }
+        guard let alias = lastTurnAlias else { return }
+        guard messages.count >= 2 else { return }
+        let conversationID = activeConversationID
+        let turnMessages: [(role: String, content: String)] = messages
+            .filter { $0.role == .user || $0.role == .assistant }
+            .map { (role: $0.role.rawValue, content: $0.content) }
+        let baseURL = client.baseURL
+
+        Task { [weak self] in
+            // The network call hops off MainActor via URLSession's async
+            // implementation; we only return to the main actor for the
+            // store mutation below.
+            guard !Task.isCancelled else { return }
+            let extractor = MemoryExtractor(
+                baseURL: baseURL,
+                bearerToken: nil
+            )
+            do {
+                let operations = try await extractor.extract(
+                    model: alias,
+                    messages: turnMessages
+                )
+                for operation in operations {
+                    switch operation {
+                    case .add(let content):
+                        memoryStore.upsert(content: content, conversationID: conversationID)
+                    case .remove(let content):
+                        let matching = memoryStore.entries.first {
+                            $0.content.localizedCaseInsensitiveContains(content)
+                                || content.localizedCaseInsensitiveContains($0.content)
+                        }
+                        if let match = matching {
+                            memoryStore.remove(id: match.id)
+                        }
+                    }
+                }
+            } catch {
+                // Memory extraction is best-effort; a failure here is
+                // invisible to the user and logged only if diagnostics
+                // capture it. The next completed turn gets another chance.
+            }
+        }
+    }
+
     /// Append the user message, open a placeholder assistant row, and
     /// kick off the streaming task. The text field clears immediately on
     /// the caller's side.
@@ -1207,6 +1271,7 @@ final class ChatViewModel {
         lastError = nil
         lastFailureKind = nil
         lastFailureAlias = nil
+        lastTurnAlias = alias
         isStreaming = true
 
         let epoch = conversationEpoch
@@ -1215,6 +1280,7 @@ final class ChatViewModel {
         // multi-round tool exchange.
         let globalInstruction = customInstructions.global
         let chatInstruction = conversationInstructions
+        let memoryContext = memoryStore?.formattedForPrompt()
         inflight = Task { [weak self] in
             guard let self else { return }
 
@@ -1280,7 +1346,8 @@ final class ChatViewModel {
                 epoch: epoch,
                 supportsImageInput: supportsImageInput,
                 globalInstruction: globalInstruction,
-                conversationInstruction: chatInstruction
+                conversationInstruction: chatInstruction,
+                memoryContext: memoryContext
             )
         }
     }
@@ -2226,7 +2293,8 @@ final class ChatViewModel {
         epoch: Int,
         supportsImageInput: Bool,
         globalInstruction: String = "",
-        conversationInstruction: String = ""
+        conversationInstruction: String = "",
+        memoryContext: String? = nil
     ) async {
         var currentPlaceholder = initialPlaceholder
         var usedImageInput = false
@@ -2302,6 +2370,7 @@ final class ChatViewModel {
                 to: history,
                 ambientPreamble: ambientPreamble,
                 dateContext: ChatViewModel.currentDateTimeContext(),
+                memoryContext: memoryContext,
                 global: globalInstruction,
                 conversation: conversationInstruction
             )
@@ -2716,6 +2785,7 @@ final class ChatViewModel {
         to messages: [ChatMessage],
         ambientPreamble: String?,
         dateContext: String? = nil,
+        memoryContext: String? = nil,
         global: String,
         conversation: String
     ) -> [ChatMessage] {
@@ -2727,6 +2797,9 @@ final class ChatViewModel {
         // rides below it because it is valid regardless of tool presence.
         var parts = [ambientPreamble, dateContext, existing]
             .compactMap { $0.flatMap(normalizedInstruction) }
+        if let memoryContext, let memory = normalizedInstruction(memoryContext) {
+            parts.append(memory)
+        }
         if let global = normalizedInstruction(global) {
             parts.append("""
             [GLOBAL USER INSTRUCTIONS]
@@ -2755,6 +2828,7 @@ final class ChatViewModel {
     /// automatic context cannot drift from what Rapid sends.
     nonisolated static func effectiveSystemPrompt(
         dateContext: String? = nil,
+        memoryContext: String? = nil,
         global: String,
         conversation: String
     ) -> String {
@@ -2762,6 +2836,7 @@ final class ChatViewModel {
             to: [],
             ambientPreamble: nil,
             dateContext: dateContext ?? currentDateTimeContext(),
+            memoryContext: memoryContext,
             global: global,
             conversation: conversation
         ).first?.content ?? ""

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1164,6 +1164,7 @@ final class ChatViewModel {
             .filter { $0.role == .user || $0.role == .assistant }
             .map { (role: $0.role.rawValue, content: $0.content) }
         let baseURL = client.baseURL
+        let bearer = server?.activeBearer
 
         Task { [weak self] in
             // The network call hops off MainActor via URLSession's async
@@ -1172,7 +1173,7 @@ final class ChatViewModel {
             guard !Task.isCancelled else { return }
             let extractor = MemoryExtractor(
                 baseURL: baseURL,
-                bearerToken: nil
+                bearerToken: bearer
             )
             do {
                 let operations = try await extractor.extract(

--- a/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
@@ -195,13 +195,18 @@ struct MemoryExtractor {
         else { return [] }
 
         return array.compactMap { item in
-            guard let action = item["action"] as? String,
-                  let opContent = item["content"] as? String,
+            let action = item["action"] as? String
+            let opContent = (item["content"] as? String)
+                ?? (item["fact"] as? String)
+                ?? (item["memory"] as? String)
+            guard let opContent,
                   !opContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             else { return nil }
 
             switch action {
-            case "add":
+            case "add", nil:
+                // Some models omit "action" and just emit {"fact": "..."}.
+                // Treat a bare fact as an implicit add.
                 return .add(opContent)
             case "remove":
                 return .remove(opContent)

--- a/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/MemoryExtractor.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Extracts durable user memories from a completed conversation turn by
+/// asking the active model to review the recent messages and return a
+/// structured JSON list of operations.
+///
+/// The review call is a single non-streaming POST to the same
+/// ``v1/chat/completions`` endpoint the chat already uses. It runs in a
+/// background task after ``isStreaming`` transitions to ``false``, so it
+/// never blocks the UI or competes with an active stream.
+struct MemoryExtractor {
+    /// Maximum characters per message included in the review prompt.
+    /// Open WebUI truncates at 1600 chars (1000 head + 400 tail); we
+    /// use a similar bound so a long paste or code block doesn't blow
+    /// the small model's context window.
+    static let maximumMessageCharacters = 1_200
+    /// Maximum number of recent messages included in the review prompt.
+    static let maximumReviewedMessages = 16
+    /// Upper bound on the non-streaming review request. Memory extraction
+    /// is a short single-turn completion; 60 s is generous for a 4B model
+    /// on a ~2K-token prompt.
+    static let requestTimeout: TimeInterval = 60
+
+    /// Errors surfaced to the caller for logging; never shown to the user
+    /// as a banner because memory extraction is a background best-effort.
+    enum ExtractError: Error, LocalizedError {
+        case serverNotReady
+        case httpStatus(Int)
+        case emptyResponse
+        case parseFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .serverNotReady: return "Memory extraction skipped: server not ready"
+            case .httpStatus(let code): return "Memory extraction HTTP \(code)"
+            case .emptyResponse: return "Memory extraction returned an empty response"
+            case .parseFailed: return "Memory extraction could not parse model output"
+            }
+        }
+    }
+
+    /// A structured operation the review model returned.
+    enum Operation: Equatable, Sendable {
+        case add(String)
+        case remove(String)
+    }
+
+    let baseURL: URL
+    let bearerToken: String?
+
+    init(baseURL: URL, bearerToken: String? = nil) {
+        self.baseURL = baseURL
+        self.bearerToken = bearerToken
+    }
+
+    /// Runs the review and returns the parsed operations. The caller
+    /// decides how to apply them (typically via ``MemoryStore.upsert``).
+    func extract(
+        model: String,
+        messages: [(role: String, content: String)]
+    ) async throws -> [Operation] {
+        let transcript = Self.buildTranscript(from: messages)
+        guard !transcript.isEmpty else { return [] }
+
+        let prompt = Self.reviewPrompt(transcript: transcript)
+        let response = try await Self.sendCompletion(
+            baseURL: baseURL,
+            bearerToken: bearerToken,
+            model: model,
+            prompt: prompt
+        )
+        return Self.parseOperations(from: response)
+    }
+
+    // MARK: - Prompt Construction
+
+    /// Formats recent messages into a compact transcript for the review
+    /// prompt. Tool messages and system rows are excluded — they are not
+    /// user-authored content and would dilute the reviewer's signal.
+    static func buildTranscript(
+        from messages: [(role: String, content: String)]
+    ) -> String {
+        let relevant = messages
+            .filter { $0.role == "user" || $0.role == "assistant" }
+            .suffix(maximumReviewedMessages)
+        guard !relevant.isEmpty else { return "" }
+
+        return relevant.map { message in
+            let content = message.content.count > maximumMessageCharacters
+                ? String(message.content.prefix(maximumMessageCharacters)) + "…"
+                : message.content
+            return "\(message.role): \(content)"
+        }.joined(separator: "\n")
+    }
+
+    /// The system-level prompt sent to the reviewer model. Mirrors Open
+    /// WebUI's approach: strict JSON schema, conservative rules about
+    /// what to remember, and an explicit "return empty" path.
+    static func reviewPrompt(transcript: String) -> String {
+        """
+        Review the following conversation and decide whether any durable user preference or fact should be remembered for future conversations.
+
+        Rules:
+        - Save only enduring details: preferences, recurring tasks, environment quirks, long-term context.
+        - Do NOT save one-off questions, temporary states, secrets, or transient task steps.
+        - Do NOT save anything the user did not explicitly say or confirm.
+        - Return ONLY a JSON array. Each element is either:
+          {"action": "add", "content": "..."} or {"action": "remove", "content": "..."}
+        - "add" saves a new fact. "remove" removes a previously saved fact that is now wrong.
+        - Return [] if nothing should change.
+
+        Conversation:
+        \(transcript)
+        """
+    }
+
+    // MARK: - HTTP
+
+    /// Non-streaming POST to the chat-completions endpoint. Reuses the
+    /// same URL shape and auth pattern as ``ChatStreamClient`` but
+    /// avoids SSE parsing because the memory review doesn't need
+    /// progressive output.
+    static func sendCompletion(
+        baseURL: URL,
+        bearerToken: String?,
+        model: String,
+        prompt: String
+    ) async throws -> String {
+        let url = ChatStreamClient.chatCompletionsURL(base: baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = requestTimeout
+
+        if let bearerToken, !bearerToken.isEmpty {
+            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": "You are a memory reviewer. Return only valid JSON."
+                ],
+                ["role": "user", "content": prompt]
+            ],
+            "stream": false,
+            "max_tokens": 512,
+            "temperature": 0.1
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ExtractError.serverNotReady
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw ExtractError.httpStatus(httpResponse.statusCode)
+        }
+
+        struct CompletionResponse: Decodable {
+            struct Choice: Decodable {
+                struct Message: Decodable {
+                    let content: String?
+                }
+                let message: Message
+            }
+            let choices: [Choice]
+        }
+
+        guard let decoded = try? JSONDecoder().decode(CompletionResponse.self, from: data),
+              let content = decoded.choices.first?.message.content,
+              !content.isEmpty
+        else {
+            throw ExtractError.emptyResponse
+        }
+        return content
+    }
+
+    // MARK: - Parsing
+
+    /// Extracts operations from the model's JSON output. Tolerates
+    /// leading/trailing prose (some models wrap JSON in markdown code
+    /// fences) by scanning for the first `[` and last `]`.
+    static func parseOperations(from content: String) -> [Operation] {
+        guard let start = content.firstIndex(of: "["),
+              let end = content.lastIndex(of: "]"),
+              start < end
+        else { return [] }
+
+        let jsonString = String(content[start...end])
+        guard let data = jsonString.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+
+        return array.compactMap { item in
+            guard let action = item["action"] as? String,
+                  let opContent = item["content"] as? String,
+                  !opContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { return nil }
+
+            switch action {
+            case "add":
+                return .add(opContent)
+            case "remove":
+                return .remove(opContent)
+            default:
+                return nil
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Chat/MemoryStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/MemoryStore.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Observation
+
+/// A single durable fact the assistant has learned about the user across
+/// conversations. Backed by the Open WebUI memory-review pattern: after a
+/// conversation turn completes, a lightweight background pass decides
+/// whether anything enduring should be saved.
+struct MemoryEntry: Codable, Equatable, Hashable, Identifiable, Sendable {
+    let id: UUID
+    var content: String
+    var evidenceCount: Int
+    var sourceConversationIDs: [UUID]
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        content: String,
+        evidenceCount: Int = 1,
+        sourceConversationIDs: [UUID] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.content = content
+        self.evidenceCount = evidenceCount
+        self.sourceConversationIDs = sourceConversationIDs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Schema version marker so future migrations can distinguish disk shapes.
+struct MemoryLibrary: Codable, Sendable {
+    var schemaVersion: Int = 1
+    var entries: [MemoryEntry] = []
+}
+
+/// Stores and manages persistent memory entries. The store is the single
+/// point of truth for what the assistant knows about the user; the
+/// extractor proposes entries, the user can edit or delete them in
+/// Settings, and the system prompt builder reads a formatted subset for
+/// injection.
+@MainActor
+@Observable
+final class MemoryStore {
+    /// Maximum entries kept on disk. Older entries beyond this cap are
+    /// dropped from the LOWEST ``evidenceCount`` first, then oldest
+    /// ``updatedAt``, so frequently-corroborated facts survive pruning.
+    static let maximumEntries = 80
+
+    /// Maximum characters across all injected memories. Small models
+    /// (4B–9B) have limited context windows; the memory block must stay
+    /// well under the room the date context and instructions already use.
+    static let maximumInjectedCharacters = 2_000
+
+    /// File layout lives next to ``ConversationStore``'s JSON under
+    /// Application Support/Rapid, keeping all user data in one directory.
+    private static let storageKey = "memory-library-v1"
+
+    private(set) var entries: [MemoryEntry] = []
+    private let fileURL: URL
+    private let defaults: UserDefaults
+
+    /// Whether automatic memory extraction is enabled. Persisted so the
+    /// user's choice survives relaunches. Defaults to off — memory is an
+    /// opt-in feature the user enables in Settings, not something that
+    /// silently collects data.
+    var isEnabled: Bool {
+        get { defaults.bool(forKey: "rapid.memory.enabled") }
+        set { defaults.set(newValue, forKey: "rapid.memory.enabled") }
+    }
+
+    init(fileURL: URL? = nil, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let fileURL {
+            self.fileURL = fileURL
+        } else {
+            self.fileURL = ApplicationSupportLocator.applicationSupportRoot()
+                .appendingPathComponent(Self.storageKey + ".json")
+        }
+        load()
+    }
+
+    // MARK: - CRUD
+
+    /// Adds a new memory entry or increments the evidence count on a
+    /// semantically identical one. Returns the affected entry.
+    @discardableResult
+    func upsert(content: String, conversationID: UUID) -> MemoryEntry {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            // Return a placeholder rather than force-unwrapping; callers
+            // check the returned entry's content before using it.
+            return MemoryEntry(content: "", createdAt: .distantPast, updatedAt: .distantPast)
+        }
+
+        // Case-insensitive substring match for dedup. A future NLP pass
+        // can improve this, but substring catches the common case of the
+        // same preference restated verbatim.
+        if let existingIndex = entries.firstIndex(where: {
+            $0.content.localizedCaseInsensitiveContains(trimmed)
+                || trimmed.localizedCaseInsensitiveContains($0.content)
+        }) {
+            entries[existingIndex].evidenceCount += 1
+            entries[existingIndex].updatedAt = Date()
+            if !entries[existingIndex].sourceConversationIDs.contains(conversationID) {
+                entries[existingIndex].sourceConversationIDs.append(conversationID)
+            }
+            persist()
+            return entries[existingIndex]
+        }
+
+        let entry = MemoryEntry(
+            content: trimmed,
+            sourceConversationIDs: [conversationID]
+        )
+        entries.insert(entry, at: 0)
+        prune()
+        persist()
+        return entry
+    }
+
+    func remove(id: UUID) {
+        entries.removeAll { $0.id == id }
+        persist()
+    }
+
+    func update(id: UUID, content: String) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        entries[index].content = trimmed
+        entries[index].updatedAt = Date()
+        persist()
+    }
+
+    func removeAll() {
+        entries.removeAll()
+        persist()
+    }
+
+    // MARK: - Prompt Injection
+
+    /// Formatted memory block for system-prompt injection. Returns `nil`
+    /// when there are no entries or the store is disabled, so the caller
+    /// skips the block rather than emitting an empty tag.
+    func formattedForPrompt() -> String? {
+        guard isEnabled, !entries.isEmpty else { return nil }
+
+        var lines: [String] = []
+        var characterBudget = Self.maximumInjectedCharacters
+        // Most-recently-updated first; small models benefit from seeing
+        // the freshest context closest to the prompt tail.
+        for entry in entries.sorted(by: { $0.updatedAt > $1.updatedAt }) {
+            let line = "- \(entry.content)"
+            guard line.count <= characterBudget else { break }
+            lines.append(line)
+            characterBudget -= line.count
+        }
+        guard !lines.isEmpty else { return nil }
+
+        return """
+        <memory_context>
+        Durable facts and preferences learned from previous conversations:
+        \(lines.joined(separator: "\n"))
+        </memory_context>
+        """
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let library = try JSONDecoder().decode(MemoryLibrary.self, from: data)
+            entries = library.entries
+        } catch {
+            // A corrupted memory file should never prevent the app from
+            // launching; start fresh rather than crashing on read.
+            entries = []
+        }
+    }
+
+    private func persist() {
+        let library = MemoryLibrary(entries: entries)
+        do {
+            let directory = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(library)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // Persistence failure is non-fatal; the in-memory state is
+            // still usable for this session.
+        }
+    }
+
+    /// Drops entries beyond ``maximumEntries``, evicting the lowest-
+    /// evidence items first so corroboration acts as a retention signal.
+    private func prune() {
+        guard entries.count > Self.maximumEntries else { return }
+        let sorted = entries.sorted { a, b in
+            if a.evidenceCount != b.evidenceCount { return a.evidenceCount > b.evidenceCount }
+            return a.updatedAt > b.updatedAt
+        }
+        entries = Array(sorted.prefix(Self.maximumEntries))
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -92,6 +92,8 @@ struct RapidApp: App {
     @State private var sampling: SamplingConfig
     /// App-wide custom instructions shared by Settings and every chat turn.
     @State private var customInstructions: CustomInstructionsConfig
+    /// Persistent memory entries shared by chat injection and Settings.
+    @State private var memoryStore: MemoryStore
     /// Persisted theme override exposed via Settings → Appearance.
     @State private var appearance: AppearanceConfig
     /// Deep-link channel into the Settings window.
@@ -175,6 +177,7 @@ struct RapidApp: App {
         let manager = ServerManager()
         let samplingConfig = SamplingConfig()
         let customInstructionsConfig = CustomInstructionsConfig()
+        let memoryStore = MemoryStore()
         let appearanceConfig = AppearanceConfig()
         // Apply the persisted theme override before the first window
         // renders so the user doesn't see a flash of the wrong mode.
@@ -263,6 +266,7 @@ struct RapidApp: App {
             tools: toolRegistry,
             sampling: samplingConfig,
             customInstructions: customInstructionsConfig,
+            memoryStore: memoryStore,
             server: manager,
             onProductValueDelivered: { [weak consentCoordinator, weak starPromptCoordinator] kind in
                 consentCoordinator?.productValueDelivered(kind)
@@ -341,6 +345,7 @@ struct RapidApp: App {
         _sparkleUpdater = State(initialValue: sparkleUpdateController)
         _sampling = State(initialValue: samplingConfig)
         _customInstructions = State(initialValue: customInstructionsConfig)
+        _memoryStore = State(initialValue: memoryStore)
         _appearance = State(initialValue: appearanceConfig)
         _settingsRouter = State(initialValue: SettingsRouter())
         _deferredTelemetryConsent = State(initialValue: consentCoordinator)
@@ -374,6 +379,7 @@ struct RapidApp: App {
                 .environment(sparkleUpdater)
                 .environment(sampling)
                 .environment(customInstructions)
+                .environment(memoryStore)
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(deferredTelemetryConsent)
@@ -527,6 +533,7 @@ struct RapidApp: App {
                 .environment(chatViewModel)
                 .environment(sampling)
                 .environment(customInstructions)
+                .environment(memoryStore)
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(server)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// Settings → Memory panel. Users can toggle extraction on/off, browse
+/// learned entries, edit or delete individual ones, and clear the store.
+@MainActor
+struct SettingsMemoryPanel: View {
+    @Environment(MemoryStore.self) private var memoryStore
+    @State private var editingEntry: MemoryEntry?
+    @State private var editDraft = ""
+    @State private var confirmingClear = false
+
+    var body: some View {
+        @Bindable var store = memoryStore
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Memory",
+                subtitle: "The assistant learns your preferences across conversations. It never sends data off this Mac.",
+                emphasis: .page
+            )
+
+            Toggle(isOn: Binding(
+                get: { memoryStore.isEnabled },
+                set: { memoryStore.isEnabled = $0 }
+            )) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Automatic memory")
+                        .font(.body)
+                    Text("Review completed conversations and save durable preferences. Disabled by default.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+
+            if memoryStore.isEnabled && !memoryStore.entries.isEmpty {
+                HStack {
+                    Text("\(memoryStore.entries.count) saved memor\(memoryStore.entries.count == 1 ? "y" : "ies")")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Clear All", role: .destructive) {
+                        confirmingClear = true
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.callout)
+                }
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(memoryStore.entries) { entry in
+                            memoryRow(entry)
+                        }
+                    }
+                }
+                .frame(minHeight: 200)
+            } else if memoryStore.isEnabled {
+                Text("No memories yet. They appear here after the assistant completes a conversation.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .alert("Clear all memories?", isPresented: $confirmingClear) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive) {
+                memoryStore.removeAll()
+            }
+        } message: {
+            Text("This removes every learned fact. It cannot be undone.")
+        }
+        .sheet(item: $editingEntry) { entry in
+            editSheet(entry)
+        }
+    }
+
+    private func memoryRow(_ entry: MemoryEntry) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.content)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                Text("\(entry.evidenceCount)× seen · \(entry.updatedAt, style: .relative)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Button("Edit") {
+                editDraft = entry.content
+                editingEntry = entry
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+            Button(role: .destructive) {
+                memoryStore.remove(id: entry.id)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func editSheet(_ entry: MemoryEntry) -> some View {
+        NavigationStack {
+            Form {
+                TextField("Memory", text: $editDraft, axis: .vertical)
+                    .lineLimit(3...10)
+            }
+            .navigationTitle("Edit Memory")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { editingEntry = nil }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        memoryStore.update(id: entry.id, content: editDraft)
+                        editingEntry = nil
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 380, minHeight: 200)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsMemoryPanel.swift
@@ -31,6 +31,7 @@ struct SettingsMemoryPanel: View {
                 }
             }
             .toggleStyle(.switch)
+            .accessibilityIdentifier("Settings.Memory.EnableToggle")
 
             if memoryStore.isEnabled && !memoryStore.entries.isEmpty {
                 HStack {
@@ -43,6 +44,7 @@ struct SettingsMemoryPanel: View {
                     }
                     .buttonStyle(.borderless)
                     .font(.callout)
+                    .accessibilityIdentifier("Settings.Memory.ClearAll")
                 }
 
                 ScrollView {
@@ -64,9 +66,11 @@ struct SettingsMemoryPanel: View {
         .padding()
         .alert("Clear all memories?", isPresented: $confirmingClear) {
             Button("Cancel", role: .cancel) {}
+                .accessibilityIdentifier("Settings.Memory.ClearAlert.Cancel")
             Button("Clear", role: .destructive) {
                 memoryStore.removeAll()
             }
+            .accessibilityIdentifier("Settings.Memory.ClearAlert.Confirm")
         } message: {
             Text("This removes every learned fact. It cannot be undone.")
         }
@@ -92,6 +96,7 @@ struct SettingsMemoryPanel: View {
             }
             .buttonStyle(.borderless)
             .font(.caption)
+            .accessibilityIdentifier("Settings.Memory.Row.Edit")
             Button(role: .destructive) {
                 memoryStore.remove(id: entry.id)
             } label: {
@@ -99,6 +104,7 @@ struct SettingsMemoryPanel: View {
             }
             .buttonStyle(.borderless)
             .font(.caption)
+            .accessibilityIdentifier("Settings.Memory.Row.Delete")
         }
         .padding(.vertical, 4)
     }
@@ -108,17 +114,20 @@ struct SettingsMemoryPanel: View {
             Form {
                 TextField("Memory", text: $editDraft, axis: .vertical)
                     .lineLimit(3...10)
+                    .accessibilityIdentifier("Settings.Memory.EditSheet.Field")
             }
             .navigationTitle("Edit Memory")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { editingEntry = nil }
+                        .accessibilityIdentifier("Settings.Memory.EditSheet.Cancel")
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
                         memoryStore.update(id: entry.id, content: editDraft)
                         editingEntry = nil
                     }
+                    .accessibilityIdentifier("Settings.Memory.EditSheet.Save")
                 }
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -70,6 +70,8 @@ struct SettingsView: View {
         /// Global system-prompt default applied before any conversation-specific
         /// override. Stored locally in UserDefaults under the legacy key.
         case instructions
+        /// Persistent memory entries learned from conversations.
+        case memory
         /// Built-in tools the model can call: on/off per tool, the
         /// web-search backend + key, and the browse approval mode.
         case tools
@@ -104,6 +106,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "Model Management"
             case .instructions: return "System Prompt"
+            case .memory: return "Memory"
             case .tools: return "Tools"
             case .connectors: return "Connectors"
             case .performance: return "Performance"
@@ -119,6 +122,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "externaldrive.fill"
             case .instructions: return "text.bubble.fill"
+            case .memory: return "brain"
             case .tools: return "wrench.and.screwdriver.fill"
             case .connectors: return "powerplug.fill"
             case .performance: return "speedometer"
@@ -480,6 +484,8 @@ struct SettingsView: View {
             SettingsModelManagementPanel()
         case .instructions:
             instructionsPanel
+        case .memory:
+            SettingsMemoryPanel()
         case .tools:
             SettingsToolsPanel()
         case .connectors:

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -52,6 +52,9 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.instructions" desc="System Prompt" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
+              AXButton id="Settings.Category.memory" desc="Memory" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Memory store")
+struct MemoryStoreTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-memory-test-\(UUID().uuidString).json")
+    }
+
+    private func freshDefaults() -> (UserDefaults, String) {
+        let name = "rapid-memory-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return (defaults, name)
+    }
+
+    @Test("Empty store formats to nil")
+    func emptyFormattedNil() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        #expect(store.formattedForPrompt() == nil)
+    }
+
+    @Test("Disabled store formats to nil even with entries")
+    func disabledFormattedNil() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(false, forKey: "rapid.memory.enabled")
+        let url = tempURL()
+        let store = MemoryStore(fileURL: url, defaults: defaults)
+        store.upsert(content: "Prefers TypeScript", conversationID: UUID())
+        #expect(store.formattedForPrompt() == nil)
+    }
+
+    @Test("Upsert adds entry and formats for prompt")
+    func upsertAndFormat() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        store.upsert(content: "Prefers TypeScript over JavaScript", conversationID: UUID())
+
+        let formatted = store.formattedForPrompt()
+        #expect(formatted != nil)
+        #expect(formatted!.contains("Prefers TypeScript"))
+        #expect(formatted!.contains("<memory_context>"))
+    }
+
+    @Test("Upsert deduplicates semantically identical content")
+    func dedup() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        store.upsert(content: "Uses pnpm", conversationID: UUID())
+        store.upsert(content: "Uses pnpm", conversationID: UUID())
+        #expect(store.entries.count == 1)
+        #expect(store.entries[0].evidenceCount == 2)
+    }
+
+    @Test("Remove deletes a single entry")
+    func removeSingle() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        let entry = store.upsert(content: "Test fact", conversationID: UUID())
+        store.remove(id: entry.id)
+        #expect(store.entries.isEmpty)
+    }
+
+    @Test("Update modifies content")
+    func updateContent() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        let entry = store.upsert(content: "Old content", conversationID: UUID())
+        store.update(id: entry.id, content: "New content")
+        #expect(store.entries.first?.content == "New content")
+    }
+
+    @Test("Persistence round-trips through disk")
+    func persistence() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let url = tempURL()
+        let store = MemoryStore(fileURL: url, defaults: defaults)
+        store.upsert(content: "Durable fact", conversationID: UUID())
+
+        let reloaded = MemoryStore(fileURL: url, defaults: defaults)
+        #expect(reloaded.entries.count == 1)
+        #expect(reloaded.entries[0].content == "Durable fact")
+    }
+
+    @Test("Prune caps at maximum entries")
+    func prune() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        for index in 0..<MemoryStore.maximumEntries + 10 {
+            let unique = String(format: "entry-%03d", index)
+            store.upsert(content: unique, conversationID: UUID())
+        }
+        #expect(store.entries.count == MemoryStore.maximumEntries)
+    }
+
+    @Test("Formatted output respects character budget")
+    func characterBudget() {
+        let (defaults, domain) = freshDefaults()
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(true, forKey: "rapid.memory.enabled")
+        let store = MemoryStore(fileURL: tempURL(), defaults: defaults)
+        for index in 0..<200 {
+            store.upsert(content: String(repeating: "x", count: 100) + " \(index)", conversationID: UUID())
+        }
+        let formatted = store.formattedForPrompt()
+        #expect(formatted != nil)
+        #expect(formatted!.count <= MemoryStore.maximumInjectedCharacters + 50)
+    }
+}
+
+@Suite("Memory extractor")
+struct MemoryExtractorTests {
+    @Test("buildTranscript filters tool and system messages")
+    func transcriptFiltering() {
+        let messages: [(role: String, content: String)] = [
+            ("system", "You are helpful."),
+            ("user", "Hello"),
+            ("tool", "tool result data"),
+            ("assistant", "Hi there!")
+        ]
+        let transcript = MemoryExtractor.buildTranscript(from: messages)
+        #expect(transcript.contains("user: Hello"))
+        #expect(transcript.contains("assistant: Hi there!"))
+        #expect(!transcript.contains("system"))
+        #expect(!transcript.contains("tool"))
+    }
+
+    @Test("buildTranscript truncates long messages")
+    func transcriptTruncation() {
+        let longContent = String(repeating: "a", count: MemoryExtractor.maximumMessageCharacters + 500)
+        let messages: [(role: String, content: String)] = [
+            ("user", longContent)
+        ]
+        let transcript = MemoryExtractor.buildTranscript(from: messages)
+        #expect(transcript.count < MemoryExtractor.maximumMessageCharacters + 20)
+        #expect(transcript.hasSuffix("…"))
+    }
+
+    @Test("parseOperations handles well-formed JSON array")
+    func parseValid() {
+        let content = """
+        Here is my analysis:
+        [{"action": "add", "content": "Prefers Swift"}, {"action": "remove", "content": "Old pref"}]
+        """
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 2)
+        #expect(operations[0] == .add("Prefers Swift"))
+        #expect(operations[1] == .remove("Old pref"))
+    }
+
+    @Test("parseOperations returns empty on malformed output")
+    func parseMalformed() {
+        #expect(MemoryExtractor.parseOperations(from: "no JSON here").isEmpty)
+        #expect(MemoryExtractor.parseOperations(from: "[broken").isEmpty)
+        #expect(MemoryExtractor.parseOperations(from: "").isEmpty)
+    }
+
+    @Test("parseOperations tolerates markdown fences")
+    func parseFenced() {
+        let content = """
+        ```json
+        [{"action": "add", "content": "Test"}]
+        ```
+        """
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 1)
+        #expect(operations[0] == .add("Test"))
+    }
+
+    @Test("parseOperations ignores unknown actions")
+    func parseUnknownAction() {
+        let content = "[{\"action\": \"merge\", \"content\": \"test\"}]" 
+        #expect(MemoryExtractor.parseOperations(from: content).isEmpty)
+    }
+
+    @Test("reviewPrompt includes transcript and rules")
+    func reviewPromptShape() {
+        let prompt = MemoryExtractor.reviewPrompt(transcript: "user: Hello")
+        #expect(prompt.contains("user: Hello"))
+        #expect(prompt.contains("Return ONLY a JSON array"))
+        #expect(prompt.contains("Do NOT save one-off"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MemoryStoreTests.swift
@@ -195,3 +195,21 @@ struct MemoryExtractorTests {
         #expect(prompt.contains("Do NOT save one-off"))
     }
 }
+
+extension MemoryExtractorTests {
+    @Test("parseOperations treats bare fact as implicit add")
+    func parseBareFact() {
+        let content = "[{\"fact\": \"User switched from pnpm to bun.\"}]"
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 1)
+        #expect(operations[0] == .add("User switched from pnpm to bun."))
+    }
+
+    @Test("parseOperations treats bare memory as implicit add")
+    func parseBareMemory() {
+        let content = "[{\"memory\": \"Uses Neovim.\"}]"
+        let operations = MemoryExtractor.parseOperations(from: content)
+        #expect(operations.count == 1)
+        #expect(operations[0] == .add("Uses Neovim."))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -81,7 +81,7 @@ struct SettingsVisualFoundationTests {
         // change deliberate and reviewed, not to freeze the list forever —
         // update this literal alongside the enum when a feature adds one.
         var expected: Set<String> = [
-            "modelManagement", "instructions", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
         ]
         // `swift test` builds debug, so the debug-only category is present
@@ -108,7 +108,7 @@ struct SettingsVisualFoundationTests {
     @Test("Category order is unchanged, so arrow-key navigation is unchanged")
     func categoryOrderIsStable() {
         var expectedOrder = [
-            "modelManagement", "instructions", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
         ]
         #if DEBUG


### PR DESCRIPTION
## Summary

Adds an opt-in persistent memory system following the Open WebUI background-review pattern. After each conversation turn completes, a lightweight reviewer call asks the active local model whether any durable user preference should be saved. Extracted facts persist as a JSON file, inject into the system prompt on the next conversation, and remain user-editable in Settings → Memory.

Supersedes #2811 (rebased onto latest main, resolves conflict with `scheduleBackgroundAssist`).

## Changes

- **MemoryStore** (`MemoryStore.swift`): JSON-persisted entry list with case-insensitive dedup, evidence counting, character-budget pruning (80 entries max, ~2K chars injected), and `<memory_context>` prompt formatting
- **MemoryExtractor** (`MemoryExtractor.swift`): non-streaming reviewer call to the same `v1/chat/completions` endpoint the chat uses, with JSON operation parsing that tolerates markdown fences and prose wrapping
- **SettingsMemoryPanel** (`SettingsMemoryPanel.swift`): enable/disable toggle (off by default), per-entry view/edit/delete, clear-all with confirmation
- **ChatViewModel**: memory context injected into system prompt via `addingInstructionLayers`, background extraction triggered on `isStreaming → false` transition
- **SettingsView**: new "Memory" category (brain icon)

## Design decisions

- Disabled by default — memory is opt-in, not something that silently collects data
- No data leaves the Mac — extraction uses the local model, storage is a local JSON file
- Background extraction uses a regular `Task` (inherits MainActor) so store mutations stay on the main actor; the network call hops off via `URLSession.data`'s async implementation
- Evidence-count-based pruning: frequently corroborated facts survive the 80-entry cap longer than one-off observations
- Character budget (2K) keeps the memory block well under the context window on 4B models

## Testing

- 16 new unit tests in `MemoryStoreTests.swift` covering store CRUD, dedup, persistence round-trip, prune, character budget, transcript filtering, operation parsing, and review prompt shape
- Full suite: 3242 tests, 0 memory-related failures (4 flaky `ServerRuntimeCapabilitiesTests` timing tests pass on re-run — pre-existing, unrelated)