### PR TITLE
test(mac): sink the message-actions golden journey into swift test

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -550,12 +550,6 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-multimodal-attachments
 
-      - name: 'Golden flow: message-actions'
-        continue-on-error: true
-        run: ./scripts/gui-golden-flows.sh --flow message-actions
-        env:
-          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/message-actions
-
       - name: 'Golden flow: restored-tools'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow restored-tools

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
@@ -3,6 +3,13 @@ import QuartzCore
 import SwiftUI
 
 /// Delivers frame callbacks in sync with the display containing this view.
+///
+/// A view display link only fires while the view's window sits on an active
+/// display. If the window is off every display — restored onto a disconnected
+/// monitor, dragged out of the visible frame, or hosted off-screen by an
+/// in-process test stage — the link stays silent and buffered streaming text
+/// would never reveal. A main-runloop timer stands in for exactly that
+/// condition so the presentation pipeline drains wherever the window lives.
 struct StreamingPresentationDisplayLink: NSViewRepresentable {
     let isActive: Bool
     let onFrame: @MainActor (TimeInterval) -> Void
@@ -12,7 +19,8 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
+        let view = HostView(frame: .zero)
+        view.coordinator = context.coordinator
         context.coordinator.attach(to: view)
         return view
     }
@@ -27,11 +35,31 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
         coordinator.invalidate()
     }
 
+    /// Tells the coordinator when the hosting conditions that decide between
+    /// the display link and the timer fallback may have changed.
+    final class HostView: NSView {
+        weak var coordinator: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            coordinator?.hostingConditionsChanged()
+        }
+    }
+
     @MainActor
     final class Coordinator: NSObject {
+        /// Matches the common display cadence; the presentation buffer paces
+        /// by wall-clock duration, so a display running at another rate only
+        /// changes callback granularity, not reveal speed.
+        private static let fallbackInterval: TimeInterval = 1.0 / 60.0
+
         var onFrame: @MainActor (TimeInterval) -> Void
         private(set) var isActive: Bool
         private var displayLink: CADisplayLink?
+        private var fallbackTimer: Timer?
+        private weak var view: NSView?
+        private var screenObserver: NSObjectProtocol?
+
         var isDisplayLinkPaused: Bool { displayLink?.isPaused ?? !isActive }
 
         init(
@@ -43,6 +71,11 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
         }
 
         func attach(to view: NSView) {
+            if self.view !== view {
+                self.view = view
+                observeScreenChanges()
+            }
+            defer { reconcileFallback() }
             guard displayLink == nil else { return }
             let link = view.displayLink(
                 target: self,
@@ -56,11 +89,23 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
         func setActive(_ isActive: Bool) {
             self.isActive = isActive
             displayLink?.isPaused = !isActive
+            reconcileFallback()
+        }
+
+        func hostingConditionsChanged() {
+            observeScreenChanges()
+            reconcileFallback()
         }
 
         func invalidate() {
             displayLink?.invalidate()
             displayLink = nil
+            fallbackTimer?.invalidate()
+            fallbackTimer = nil
+            if let screenObserver {
+                NotificationCenter.default.removeObserver(screenObserver)
+                self.screenObserver = nil
+            }
         }
 
         @objc private func displayLinkDidFire(_ link: CADisplayLink) {
@@ -68,6 +113,54 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
                 ? link.duration
                 : link.targetTimestamp - link.timestamp
             onFrame(duration)
+        }
+
+        private var needsFallback: Bool {
+            isActive && view?.window?.screen == nil
+        }
+
+        private func reconcileFallback() {
+            guard needsFallback else {
+                fallbackTimer?.invalidate()
+                fallbackTimer = nil
+                return
+            }
+            guard fallbackTimer == nil else { return }
+            let timer = Timer(
+                timeInterval: Self.fallbackInterval,
+                repeats: true
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.fallbackTimerDidFire()
+                }
+            }
+            RunLoop.main.add(timer, forMode: .common)
+            fallbackTimer = timer
+        }
+
+        private func fallbackTimerDidFire() {
+            guard needsFallback else {
+                reconcileFallback()
+                return
+            }
+            onFrame(Self.fallbackInterval)
+        }
+
+        private func observeScreenChanges() {
+            if let screenObserver {
+                NotificationCenter.default.removeObserver(screenObserver)
+                self.screenObserver = nil
+            }
+            guard let window = view?.window else { return }
+            screenObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didChangeScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.hostingConditionsChanged()
+                }
+            }
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/StreamingPresentationDisplayLink.swift
@@ -123,6 +123,7 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
             guard needsFallback else {
                 fallbackTimer?.invalidate()
                 fallbackTimer = nil
+                lastFallbackFire = nil
                 return
             }
             guard fallbackTimer == nil else { return }
@@ -136,14 +137,24 @@ struct StreamingPresentationDisplayLink: NSViewRepresentable {
             }
             RunLoop.main.add(timer, forMode: .common)
             fallbackTimer = timer
+            lastFallbackFire = nil
         }
+
+        private var lastFallbackFire: TimeInterval?
 
         private func fallbackTimerDidFire() {
             guard needsFallback else {
                 reconcileFallback()
                 return
             }
-            onFrame(Self.fallbackInterval)
+            // Report the measured gap, not the nominal interval: a busy main
+            // run loop delays or coalesces timer firings, and the buffer
+            // paces reveal by the durations it is told, so under-reporting
+            // would reveal text slower than wall-clock.
+            let now = ProcessInfo.processInfo.systemUptime
+            let duration = lastFallbackFire.map { now - $0 } ?? Self.fallbackInterval
+            lastFallbackFire = now
+            onFrame(duration)
         }
 
         private func observeScreenChanges() {

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -342,7 +342,16 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
 
         private func updateBottomTarget(animated: Bool) {
             guard let target = constrainedBottomOrigin() else { return }
-            if !animated {
+            // A view display link only fires while the window sits on an
+            // active display. In a window that is off every display there is
+            // nothing to animate on — parking the target would leave the
+            // transcript stranded mid-document forever — so land instantly.
+            // No window at all stays on the animated path: deterministic
+            // tests drive `advanceScrollFrame` directly against unhosted
+            // scroll views, and a production view without a window has
+            // `attach` re-anchoring it the moment one arrives.
+            let window = scrollView?.window
+            if !animated || (window != nil && window?.screen == nil) {
                 applyScroll(to: target)
                 cancelScrollTarget()
                 return

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -77,10 +77,13 @@ journeys:
     fixtures: [fake-sidecar, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Chat/, apps/rapid-mac/Sources/Rapid/UI/ChatView.swift]
     owns_baseline: true
+  # Sunk into `swift test`: driver `swift` journeys run in-process on a
+  # GoldenStage inside the build job's test suite (`@Suite("Golden journey:
+  # <name>")` in Tests/RapidTests), not as a bash shard flow.
   - name: message-actions
     group: chat
     risk: medium
-    driver: ax
+    driver: swift
     ci_tier: pr
     fixtures: [fake-sidecar, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Chat/]

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
@@ -279,6 +279,9 @@ struct ChatMessageActionsGoldenTests {
         )
         try stage.press("ChatView.Message.CancelEdit.\(editSuffix)")
         try await stage.waitForIdentifier(editID)
+        // A wrongly-scheduled asynchronous send would leave the process a
+        // beat after Cancel; give it that beat so the assertion can catch it.
+        try await Task.sleep(nanoseconds: 300_000_000)
         #expect(
             !RecordingSSEProtocol.recordedPrompts().contains { $0.contains("cancelled edit must not send") },
             "cancelling a message edit sent the draft"

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
@@ -1,0 +1,297 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Rapid
+
+/// The `message-actions` golden journey, sunk from the AX bash harness
+/// (`gui-golden-flows.sh`) into `swift test`: every inline message action
+/// must produce its advertised result. The real ``ChatView`` is mounted on
+/// a ``GoldenStage`` and driven through the same accessibility identifiers
+/// the out-of-process flow used; the streaming backend is a recording SSE
+/// fake standing in for the fake sidecar, so the "a request actually left
+/// the process" assertions keep an independent witness.
+///
+/// Journey inventory: `Tests/GUIGoldenFlows/journeys.yaml` lists this as
+/// `driver: swift`; the GUI coverage contract maps that driver to this
+/// suite's presence instead of a bash dispatcher case.
+@MainActor
+@Suite("Golden journey: message-actions", .serialized)
+struct ChatMessageActionsGoldenTests {
+
+    // MARK: - Recording SSE fake (in-process fake sidecar)
+
+    /// Streams a deterministic multi-chunk assistant reply for every chat
+    /// completion request and records each request body, mirroring the fake
+    /// sidecar's `chat_request` event log that the bash flow counted.
+    final class RecordingSSEProtocol: URLProtocol, @unchecked Sendable {
+        private static let lock = NSLock()
+        nonisolated(unsafe) private static var bodies: [Data] = []
+
+        /// Chunked mid-sentence like the fake sidecar's CONTENT_CHUNKS so
+        /// the transcript assertions ("deterministic content") stay
+        /// word-for-word compatible with the bash journey.
+        static let replyChunks = [
+            "Hello", " from", " the", " fake", " rapid-mlx", " mock.",
+            " I", " return", " deterministic", " content", " so", " the",
+            " golden", " journey", " has", " something", " to", " assert", " on.",
+        ]
+
+        static func reset() {
+            lock.lock()
+            bodies = []
+            lock.unlock()
+        }
+
+        static func recordedBodies() -> [Data] {
+            lock.lock()
+            defer { lock.unlock() }
+            return bodies
+        }
+
+        static func recordedPrompts() -> [String] {
+            recordedBodies().compactMap { body in
+                guard
+                    let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                    let messages = object["messages"] as? [[String: Any]]
+                else { return nil }
+                return messages.last { ($0["role"] as? String) == "user" }
+                    .flatMap { $0["content"] as? String }
+            }
+        }
+
+        static func session() -> URLSession {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [RecordingSSEProtocol.self]
+            return URLSession(configuration: configuration)
+        }
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            if let stream = request.httpBodyStream {
+                stream.open()
+                var body = Data()
+                let bufferSize = 64 * 1024
+                var buffer = [UInt8](repeating: 0, count: bufferSize)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(&buffer, maxLength: bufferSize)
+                    guard read > 0 else { break }
+                    body.append(buffer, count: read)
+                }
+                stream.close()
+                Self.lock.lock()
+                Self.bodies.append(body)
+                Self.lock.unlock()
+            }
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/event-stream"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            for chunk in Self.replyChunks {
+                let payload: [String: Any] = [
+                    "choices": [["delta": ["content": chunk], "finish_reason": NSNull()]]
+                ]
+                let json = try! JSONSerialization.data(withJSONObject: payload)
+                client?.urlProtocol(self, didLoad: Data("data: ".utf8) + json + Data("\n\n".utf8))
+            }
+            let finish: [String: Any] = [
+                "choices": [["delta": [String: Any](), "finish_reason": "stop"]]
+            ]
+            let finishJSON = try! JSONSerialization.data(withJSONObject: finish)
+            client?.urlProtocol(self, didLoad: Data("data: ".utf8) + finishJSON + Data("\n\n".utf8))
+            client?.urlProtocol(self, didLoad: Data("data: [DONE]\n\n".utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    // MARK: - Stage assembly
+
+    static let alias = "fake-alias"
+
+    @MainActor
+    struct Mounted {
+        let stage: GoldenStage
+        let chat: ChatViewModel
+        let server: ServerManager
+    }
+
+    /// Mount the real chat surface the way ``ContentView`` hosts it, with
+    /// the smallest honest dependency set: a ready fake server, an SSE
+    /// recording client, and throwaway stores. No conversation persists.
+    static func mountChatSurface() -> Mounted {
+        RecordingSSEProtocol.reset()
+        let server = ServerManager(testingState: .ready(alias: alias))
+        let chat = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://golden-message-actions")!,
+                session: RecordingSSEProtocol.session()
+            ),
+            server: server,
+            persistsConversations: false
+        )
+        let downloads = DownloadManager()
+        let quickstart = QuickstartCoordinator()
+
+        let view = ChatView(
+            viewModel: chat,
+            server: server,
+            alias: .constant(alias),
+            readiness: .ready(alias: alias)
+        )
+        .environment(downloads)
+        .environment(quickstart)
+
+        let stage = GoldenStage(view)
+        return Mounted(stage: stage, chat: chat, server: server)
+    }
+
+    /// `send_prompt` from the bash harness: type into the composer via AX
+    /// set-value, press send, then require BOTH the drained composer and
+    /// the recorded request — the composer clearing is the app's story
+    /// about itself; the recorded body is the independent witness that a
+    /// request actually left the process.
+    static func sendPrompt(_ prompt: String, on stage: GoldenStage) async throws {
+        let requestsBefore = RecordingSSEProtocol.recordedBodies().count
+        try stage.setValue(prompt, for: "rapid.chat.compose")
+        try stage.press("ChatView.SendOrStopButton")
+        try await stage.wait(for: "composer to drain and the request to be recorded") {
+            stage.value(of: "rapid.chat.compose") == ""
+                && RecordingSSEProtocol.recordedBodies().count > requestsBefore
+        }
+    }
+
+    static func waitForSettledReply(on stage: GoldenStage) async throws {
+        try await stage.waitForText("deterministic content")
+        // The reply streams in many chunks; settle on the final words so
+        // later assertions see the finished turn, not a partial one.
+        try await stage.waitForText("to assert on.")
+        // `wait_send_idle` from the bash harness: the drained text can land
+        // a beat before the stream formally completes, and several message
+        // actions (Edit, Retry) are disabled while streaming — a press on a
+        // disabled control no-ops silently. The send button relabelling
+        // back from "Stop generating" is the AX-visible idle signal.
+        try await stage.wait(for: "composer to settle into a ready, non-streaming state") {
+            stage.tree().contains {
+                $0.id == "ChatView.SendOrStopButton" && $0.text == "Send message"
+            }
+        }
+    }
+
+    // MARK: - The journey
+
+    @Test("Every inline message action produces its advertised result")
+    func messageActionsJourney() async throws {
+        let mounted = Self.mountChatSurface()
+        let stage = mounted.stage
+
+        try await Self.sendPrompt("original message action prompt", on: stage)
+        try await Self.waitForSettledReply(on: stage)
+
+        // Discover the per-message action identifiers from the live tree,
+        // exactly as the bash flow did — no test-only entry points.
+        guard let copyID = stage.identifier(withPrefix: "ChatView.Message.Copy.", last: true) else {
+            Issue.record("completed turn exposes no assistant Copy action: \(stage.identifiers())")
+            return
+        }
+        let selectID = copyID.replacingOccurrences(of: "Message.Copy.", with: "Message.SelectText.")
+        let retryID = copyID.replacingOccurrences(of: "Message.Copy.", with: "Message.Retry.")
+        guard let editID = stage.identifier(withPrefix: "ChatView.Message.Edit.") else {
+            Issue.record("completed turn exposes no user Edit action: \(stage.identifiers())")
+            return
+        }
+
+        // Copy response fills the pasteboard.
+        NSPasteboard.general.clearContents()
+        try stage.press(copyID)
+        try await stage.wait(for: "pasteboard content after Copy") {
+            (NSPasteboard.general.string(forType: .string) ?? "").isEmpty == false
+        }
+        #expect(
+            NSPasteboard.general.string(forType: .string)?.contains("deterministic content") == true,
+            "Copy response did not place the assistant reply on the pasteboard"
+        )
+
+        // Select text opens its sheet; Done dismisses it.
+        try stage.press(selectID)
+        try await stage.waitForIdentifier("SelectText.Done")
+        #expect(stage.treeText().contains("Selection here crosses paragraphs"))
+        try stage.press("SelectText.Done")
+        try await stage.waitForIdentifierGone("SelectText.Done")
+
+        // Edit, then cancel: the draft must never be sent.
+        let editSuffix = String(editID.dropFirst("ChatView.Message.Edit.".count))
+        try stage.press(editID)
+        try await stage.waitForIdentifier("ChatView.Message.EditField.\(editSuffix)")
+        try stage.setValue(
+            "cancelled edit must not send",
+            for: "ChatView.Message.EditField.\(editSuffix)"
+        )
+        try stage.press("ChatView.Message.CancelEdit.\(editSuffix)")
+        try await stage.waitForIdentifier(editID)
+        #expect(
+            !RecordingSSEProtocol.recordedPrompts().contains { $0.contains("cancelled edit must not send") },
+            "cancelling a message edit sent the draft"
+        )
+
+        // Retry sends a replacement request.
+        let requestsBeforeRetry = RecordingSSEProtocol.recordedBodies().count
+        try stage.press(retryID)
+        try await stage.wait(for: "replacement request after Retry") {
+            RecordingSSEProtocol.recordedBodies().count > requestsBeforeRetry
+        }
+        try await Self.waitForSettledReply(on: stage)
+
+        // Edit, then save: the edited prompt replaces the turn and sends.
+        guard let editAfterRetry = stage.identifier(withPrefix: "ChatView.Message.Edit.") else {
+            Issue.record("retried turn exposes no Edit action: \(stage.identifiers())")
+            return
+        }
+        let saveSuffix = String(editAfterRetry.dropFirst("ChatView.Message.Edit.".count))
+        try stage.press(editAfterRetry)
+        try await stage.waitForIdentifier("ChatView.Message.EditField.\(saveSuffix)")
+        try stage.setValue(
+            "saved edited message prompt",
+            for: "ChatView.Message.EditField.\(saveSuffix)"
+        )
+        try stage.press("ChatView.Message.SaveEdit.\(saveSuffix)")
+        try await stage.wait(for: "the edited prompt to be sent") {
+            RecordingSSEProtocol.recordedPrompts().contains("saved edited message prompt")
+        }
+        try await Self.waitForSettledReply(on: stage)
+        #expect(stage.treeText().contains("saved edited message prompt"))
+    }
+
+    @Test("Model info opens from its anchor, dismisses, and can reopen")
+    func modelInfoPopoverRoundTrip() async throws {
+        let mounted = Self.mountChatSurface()
+        let stage = mounted.stage
+
+        try stage.press("ModelPickerBar.ModelInfo")
+        try await stage.waitForText("Parameters")
+        #expect(stage.treeText().contains(Self.alias))
+        // Esc is the user's dismissal gesture for a transient popover.
+        // Dismiss-then-reopen proves it is not a one-way overlay that traps
+        // the rest of the composer, and that the anchor stays live — the
+        // bash journey only ever asserted the anchor's second press
+        // succeeded, so this is a strictly stronger contract.
+        stage.pressEscape()
+        try await stage.wait(for: "model info popover to close") {
+            !stage.treeText().contains("Parameters")
+        }
+        try stage.press("ModelPickerBar.ModelInfo")
+        try await stage.waitForText("Parameters")
+        stage.pressEscape()
+        try await stage.wait(for: "model info popover to close again") {
+            !stage.treeText().contains("Parameters")
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
@@ -38,6 +38,24 @@ struct ChatMessageActionsGoldenTests {
             " golden", " journey", " has", " something", " to", " assert", " on.",
         ]
 
+        /// The fake sidecar shapes its answer by prompt keywords; mirror the
+        /// one shape this suite needs: `shape:long` yields an answer taller
+        /// than the stage viewport so scroll journeys have somewhere to go.
+        static let longReplyChunks: [String] =
+            (1...48).map { paragraph in
+                "Paragraph \(paragraph) of the long settled answer that "
+                    + "overflows the stage viewport.\n\n"
+            } + ["END-OF-LONG-ANSWER"]
+
+        private static func chunks(forPromptIn body: Data) -> [String] {
+            guard
+                let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                let messages = object["messages"] as? [[String: Any]],
+                let prompt = messages.last(where: { ($0["role"] as? String) == "user" })?["content"] as? String
+            else { return replyChunks }
+            return prompt.contains("shape:long") ? longReplyChunks : replyChunks
+        }
+
         static func reset() {
             lock.lock()
             bodies = []
@@ -71,6 +89,7 @@ struct ChatMessageActionsGoldenTests {
         override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
         override func startLoading() {
+            var chunks = Self.replyChunks
             if let stream = request.httpBodyStream {
                 stream.open()
                 var body = Data()
@@ -85,6 +104,7 @@ struct ChatMessageActionsGoldenTests {
                 Self.lock.lock()
                 Self.bodies.append(body)
                 Self.lock.unlock()
+                chunks = Self.chunks(forPromptIn: body)
             }
 
             let response = HTTPURLResponse(
@@ -94,7 +114,7 @@ struct ChatMessageActionsGoldenTests {
                 headerFields: ["Content-Type": "text/event-stream"]
             )!
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            for chunk in Self.replyChunks {
+            for chunk in chunks {
                 let payload: [String: Any] = [
                     "choices": [["delta": ["content": chunk], "finish_reason": NSNull()]]
                 ]
@@ -169,21 +189,25 @@ struct ChatMessageActionsGoldenTests {
         }
     }
 
-    static func waitForSettledReply(on stage: GoldenStage) async throws {
-        try await stage.waitForText("deterministic content")
-        // The reply streams in many chunks; settle on the final words so
-        // later assertions see the finished turn, not a partial one.
-        try await stage.waitForText("to assert on.")
-        // `wait_send_idle` from the bash harness: the drained text can land
-        // a beat before the stream formally completes, and several message
-        // actions (Edit, Retry) are disabled while streaming — a press on a
-        // disabled control no-ops silently. The send button relabelling
-        // back from "Stop generating" is the AX-visible idle signal.
+    /// `wait_send_idle` from the bash harness: the drained text can land a
+    /// beat before the stream formally completes, and several message
+    /// actions (Edit, Retry) are disabled while streaming — a press on a
+    /// disabled control no-ops silently. The send button relabelling back
+    /// from "Stop generating" is the AX-visible idle signal.
+    static func waitForSendIdle(on stage: GoldenStage) async throws {
         try await stage.wait(for: "composer to settle into a ready, non-streaming state") {
             stage.tree().contains {
                 $0.id == "ChatView.SendOrStopButton" && $0.text == "Send message"
             }
         }
+    }
+
+    static func waitForSettledReply(on stage: GoldenStage) async throws {
+        try await stage.waitForText("deterministic content")
+        // The reply streams in many chunks; settle on the final words so
+        // later assertions see the finished turn, not a partial one.
+        try await stage.waitForText("to assert on.")
+        try await Self.waitForSendIdle(on: stage)
     }
 
     // MARK: - The journey
@@ -209,7 +233,25 @@ struct ChatMessageActionsGoldenTests {
             return
         }
 
-        // Copy response fills the pasteboard.
+        // Copy response fills the pasteboard. The general pasteboard belongs
+        // to whoever runs this suite, so snapshot it and put their contents
+        // back afterwards.
+        let savedPasteboardItems = (NSPasteboard.general.pasteboardItems ?? []).map {
+            item -> NSPasteboardItem in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+        defer {
+            NSPasteboard.general.clearContents()
+            if !savedPasteboardItems.isEmpty {
+                NSPasteboard.general.writeObjects(savedPasteboardItems)
+            }
+        }
         NSPasteboard.general.clearContents()
         try stage.press(copyID)
         try await stage.wait(for: "pasteboard content after Copy") {
@@ -268,6 +310,38 @@ struct ChatMessageActionsGoldenTests {
         }
         try await Self.waitForSettledReply(on: stage)
         #expect(stage.treeText().contains("saved edited message prompt"))
+    }
+
+    @Test("Jump to latest returns a settled transcript to its tail")
+    func jumpToLatestOnSettledTranscript() async throws {
+        let mounted = Self.mountChatSurface()
+        let stage = mounted.stage
+
+        // #1904 regression shape: a long, fully settled answer, moved away
+        // from its tail. Jump to latest used to re-pin the follow flag but
+        // leave the transcript physically scrolled up, because nothing was
+        // streaming and no document-frame change would ever fire again.
+        try await Self.sendPrompt("shape:long finished answer for jump-to-bottom", on: stage)
+        try await stage.waitForText("END-OF-LONG-ANSWER")
+        try await Self.waitForSendIdle(on: stage)
+        try await stage.wait(for: "the settled transcript to rest at its tail") {
+            (stage.scrollFraction() ?? 0) > 0.97
+        }
+        let bottom = try #require(stage.scrollFraction())
+
+        try stage.setScrollFraction(0)
+        try await stage.waitForIdentifier("Transcript.JumpToBottom")
+        let scrolled = try #require(stage.scrollFraction())
+        #expect(
+            scrolled < bottom - 0.02,
+            "scroll fixture did not move away from the settled transcript tail"
+        )
+
+        try stage.press("Transcript.JumpToBottom")
+        try await stage.wait(for: "the transcript to return to its tail") {
+            (stage.scrollFraction() ?? 0) > scrolled + 0.02
+        }
+        try await stage.waitForIdentifierGone("Transcript.JumpToBottom")
     }
 
     @Test("Model info opens from its anchor, dismisses, and can reopen")

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
@@ -88,19 +88,29 @@ struct ChatMessageActionsGoldenTests {
         override class func canInit(with request: URLRequest) -> Bool { true }
         override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+        /// URLSession surfaces an upload body as either `httpBody` or a
+        /// stream depending on how the request was built; missing one form
+        /// would silently drop the "a request actually left the process"
+        /// witness for those requests.
+        private func requestBody() -> Data? {
+            if let body = request.httpBody { return body }
+            guard let stream = request.httpBodyStream else { return nil }
+            stream.open()
+            defer { stream.close() }
+            var body = Data()
+            let bufferSize = 64 * 1024
+            var buffer = [UInt8](repeating: 0, count: bufferSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buffer, maxLength: bufferSize)
+                guard read > 0 else { break }
+                body.append(buffer, count: read)
+            }
+            return body
+        }
+
         override func startLoading() {
             var chunks = Self.replyChunks
-            if let stream = request.httpBodyStream {
-                stream.open()
-                var body = Data()
-                let bufferSize = 64 * 1024
-                var buffer = [UInt8](repeating: 0, count: bufferSize)
-                while stream.hasBytesAvailable {
-                    let read = stream.read(&buffer, maxLength: bufferSize)
-                    guard read > 0 else { break }
-                    body.append(buffer, count: read)
-                }
-                stream.close()
+            if let body = requestBody() {
                 Self.lock.lock()
                 Self.bodies.append(body)
                 Self.lock.unlock()

--- a/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
@@ -1,0 +1,339 @@
+import AppKit
+import SwiftUI
+import Testing
+
+/// In-process stage for golden-flow tests: mounts a real SwiftUI view in a
+/// window the user never sees and drives it through the same accessibility
+/// surface the out-of-process AX golden flows use — find by identifier,
+/// press, set value, wait for tree state — without launching the app,
+/// taking the OS foreground, or needing a TCC Accessibility grant.
+///
+/// Recipe (each ingredient is load-bearing; discovered empirically on
+/// macOS 26 during the golden-flow sink spike):
+///
+/// 1. The window sits at far off-screen coordinates and is ordered **back**,
+///    never front and never key. Ordering it in (vs. never showing it) is
+///    what lets AppKit present real `.popover` and `.sheet` windows, which
+///    several journeys assert on. It still steals no focus and paints no
+///    pixels on any display.
+/// 2. A bare hosting view — even inside a window — reports zero AX children:
+///    SwiftUI materializes its `AccessibilityNode` tree only when it
+///    believes an assistive client is attached. The
+///    `accessibilityEnhancedUserInterface` toggle simulates that client
+///    (it is the flag VoiceOver sets over the AX wire).
+/// 3. The materialized nodes are `SwiftUI.AccessibilityNode` instances,
+///    which implement the AX getters/actions but are not KVC-compliant and
+///    do not conform to `NSAccessibilityProtocol`; they must be driven via
+///    `responds(to:)`/`perform(_:)`.
+///
+/// Sheets and popovers arrive as additional windows (`SheetPresentationWindow`,
+/// `_NSPopoverWindow`), so every query walks all of the app's windows, not
+/// just the stage's own.
+@MainActor
+final class GoldenStage {
+    /// One (identifier, role, text) triple per AX node — the same currency
+    /// the bash flows' `see_main` JSON captures per element.
+    struct Node {
+        let id: String
+        let role: String
+        let text: String
+    }
+
+    struct StageError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    private let window: NSWindow
+    private let host: NSView
+
+    /// Default per-wait budget. Generous relative to the tens of
+    /// milliseconds a settled tree usually takes, tiny relative to the
+    /// bash flows' multi-second polling loops.
+    static let defaultTimeout: TimeInterval = 10
+
+    init<Content: View>(_ content: Content, size: CGSize = CGSize(width: 1024, height: 700)) {
+        let host = NSHostingView(rootView: content)
+        host.frame = CGRect(origin: .zero, size: size)
+        // Off-screen on both axes so a popover clamped toward the screen on
+        // one axis (observed: x is clamped, y is not) still never enters any
+        // display's visible frame.
+        let window = NSWindow(
+            contentRect: CGRect(origin: CGPoint(x: -8000, y: -8000), size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        window.isReleasedWhenClosed = false
+        window.orderBack(nil)
+        self.window = window
+        self.host = host
+
+        NSApplication.shared.setValue(true, forKey: "accessibilityEnhancedUserInterface")
+        host.layoutSubtreeIfNeeded()
+        Self.turnRunLoop()
+    }
+
+    deinit {
+        let window = self.window
+        Task { @MainActor in
+            window.orderOut(nil)
+            window.close()
+        }
+    }
+
+    // MARK: - Tree access
+
+    /// The stage's window plus every presentation window it spawned —
+    /// sheets attach via ``NSWindow/sheetParent`` and popovers via
+    /// ``NSWindow/parent``, both possibly nested (a sheet's popover). Scoped
+    /// this way so concurrent stages in one test process can never satisfy
+    /// each other's queries through same-named identifiers.
+    private func stageWindows() -> [NSWindow] {
+        var scope: Set<ObjectIdentifier> = [ObjectIdentifier(window)]
+        var result: [NSWindow] = [window]
+        var grew = true
+        while grew {
+            grew = false
+            for candidate in NSApplication.shared.windows {
+                guard !scope.contains(ObjectIdentifier(candidate)) else { continue }
+                let attachedTo = candidate.sheetParent ?? candidate.parent
+                if let attachedTo, scope.contains(ObjectIdentifier(attachedTo)) {
+                    scope.insert(ObjectIdentifier(candidate))
+                    result.append(candidate)
+                    grew = true
+                }
+            }
+        }
+        return result
+    }
+
+    /// Depth-first (id, role, text) triples across the stage's windows, so
+    /// sheet and popover content participates in assertions exactly like
+    /// main-window content does in the bash flows' full-tree walks.
+    func tree() -> [Node] {
+        var nodes: [Node] = []
+        for window in stageWindows() {
+            Self.walk(window, into: &nodes)
+        }
+        return nodes
+    }
+
+    /// Every text fragment on the stage, for substring assertions
+    /// (`assert_tree_text` in the bash harness).
+    func treeText() -> String {
+        tree().map(\.text).filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    func identifiers() -> [String] {
+        tree().map(\.id).filter { !$0.isEmpty }
+    }
+
+    /// First identifier matching a prefix — how the bash flows discover
+    /// per-message identifiers with dynamic UUID suffixes.
+    func identifier(withPrefix prefix: String, last: Bool = false) -> String? {
+        let matches = identifiers().filter { $0.hasPrefix(prefix) }
+        return last ? matches.last : matches.first
+    }
+
+    // MARK: - Driving
+
+    func press(_ identifier: String) throws {
+        guard let node = findNode(identifier) else {
+            throw StageError(description: "press: no AX node with identifier \(identifier)")
+        }
+        let sel = NSSelectorFromString("accessibilityPerformPress")
+        guard node.responds(to: sel) else {
+            throw StageError(description: "press: \(identifier) does not support press")
+        }
+        _ = node.perform(sel)
+        Self.turnRunLoop()
+    }
+
+    /// AX value replacement — the analog of the AX driver's `set-value`
+    /// (which the bash flows use for composer and editor text entry).
+    func setValue(_ value: String, for identifier: String) throws {
+        guard let node = findNode(identifier) else {
+            throw StageError(description: "setValue: no AX node with identifier \(identifier)")
+        }
+        let sel = NSSelectorFromString("setAccessibilityValue:")
+        guard node.responds(to: sel) else {
+            throw StageError(description: "setValue: \(identifier) does not accept a value")
+        }
+        _ = node.perform(sel, with: value as NSString)
+        Self.turnRunLoop()
+    }
+
+    /// The user's Esc key, delivered to the most recently attached stage
+    /// window. This is how a user dismisses a transient popover or sheet;
+    /// an AX press on the popover's anchor cannot stand in for it, because
+    /// the transient-dismissal half of that gesture happens inside AppKit's
+    /// event routing, before any button action runs.
+    func pressEscape() {
+        guard let target = stageWindows().last else { return }
+        let escape = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: target.windowNumber,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        )
+        if let escape {
+            target.sendEvent(escape)
+        }
+        Self.turnRunLoop()
+    }
+
+    func value(of identifier: String) -> String? {
+        guard let node = findNode(identifier) else { return nil }
+        let sel = NSSelectorFromString("accessibilityValue")
+        guard node.responds(to: sel), let result = node.perform(sel) else { return nil }
+        return result.takeUnretainedValue() as? String
+    }
+
+    // MARK: - Waiting
+
+    /// Pump the main runloop until `condition` holds. Async so in-flight
+    /// main-actor work (streaming callbacks, @Published mutations) can
+    /// interleave with the polling instead of deadlocking behind it.
+    func wait(
+        for what: String,
+        timeout: TimeInterval = GoldenStage.defaultTimeout,
+        until condition: () -> Bool
+    ) async throws {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if condition() { return }
+            // Suspend rather than pump: an awaited sleep releases the main
+            // actor, so the process's own main runloop turns (timers, AppKit
+            // presentation) while other suites' main-actor work proceeds
+            // undisturbed. A nested `RunLoop.main.run` here measurably
+            // altered concurrent timing-sensitive tests' batching cadence
+            // when the package test suite runs parallel.
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        if condition() { return }
+        throw StageError(description: "timed out waiting for \(what)")
+    }
+
+    func waitForIdentifier(
+        _ identifier: String,
+        timeout: TimeInterval = GoldenStage.defaultTimeout
+    ) async throws {
+        try await wait(for: "identifier \(identifier)", timeout: timeout) {
+            findNode(identifier) != nil
+        }
+    }
+
+    func waitForIdentifierGone(
+        _ identifier: String,
+        timeout: TimeInterval = GoldenStage.defaultTimeout
+    ) async throws {
+        try await wait(for: "identifier \(identifier) to disappear", timeout: timeout) {
+            findNode(identifier) == nil
+        }
+    }
+
+    func waitForText(
+        _ text: String,
+        timeout: TimeInterval = GoldenStage.defaultTimeout
+    ) async throws {
+        try await wait(for: "tree text containing \(text)", timeout: timeout) {
+            treeText().contains(text)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func findNode(_ identifier: String) -> NSObject? {
+        for window in stageWindows() {
+            if let hit = Self.find(window, id: identifier) { return hit }
+        }
+        return nil
+    }
+
+    private static func turnRunLoop(_ seconds: TimeInterval = 0.05) {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+
+    private static func string(_ obj: NSObject, _ selector: String) -> String {
+        let sel = NSSelectorFromString(selector)
+        guard obj.responds(to: sel), let result = obj.perform(sel) else { return "" }
+        return (result.takeUnretainedValue() as? String) ?? ""
+    }
+
+    private static func children(_ obj: NSObject) -> [NSObject] {
+        let sel = NSSelectorFromString("accessibilityChildren")
+        guard obj.responds(to: sel), let result = obj.perform(sel) else { return [] }
+        return (result.takeUnretainedValue() as? [NSObject]) ?? []
+    }
+
+    /// AX children plus, for AppKit views, their subviews. SwiftUI's node
+    /// tree omits the content of some `NSViewRepresentable`s (observed: the
+    /// TextKit streaming-markdown body — its action buttons appear, its
+    /// text does not), while the real AX server the bash flows talk to
+    /// walks the NSView hierarchy and sees it. Merging both, deduplicated,
+    /// restores parity with what assistive clients actually read.
+    private static func branches(_ obj: NSObject, visited: inout Set<ObjectIdentifier>) -> [NSObject] {
+        var next: [NSObject] = []
+        for child in children(obj) where visited.insert(ObjectIdentifier(child)).inserted {
+            next.append(child)
+        }
+        if let view = obj as? NSView {
+            for subview in view.subviews where visited.insert(ObjectIdentifier(subview)).inserted {
+                next.append(subview)
+            }
+        }
+        return next
+    }
+
+    private static func find(_ obj: NSObject, id target: String) -> NSObject? {
+        var visited: Set<ObjectIdentifier> = [ObjectIdentifier(obj)]
+        return find(obj, id: target, visited: &visited)
+    }
+
+    private static func find(
+        _ obj: NSObject,
+        id target: String,
+        visited: inout Set<ObjectIdentifier>
+    ) -> NSObject? {
+        if string(obj, "accessibilityIdentifier") == target { return obj }
+        for child in branches(obj, visited: &visited) {
+            if let hit = find(child, id: target, visited: &visited) { return hit }
+        }
+        return nil
+    }
+
+    private static func walk(_ obj: NSObject, into out: inout [Node]) {
+        var visited: Set<ObjectIdentifier> = [ObjectIdentifier(obj)]
+        walk(obj, into: &out, visited: &visited)
+    }
+
+    private static func walk(
+        _ obj: NSObject,
+        into out: inout [Node],
+        visited: inout Set<ObjectIdentifier>
+    ) {
+        let id = string(obj, "accessibilityIdentifier")
+        let role = string(obj, "accessibilityRole")
+        var text = ""
+        let valueSel = NSSelectorFromString("accessibilityValue")
+        if obj.responds(to: valueSel), let value = obj.perform(valueSel) {
+            let raw = value.takeUnretainedValue()
+            text = (raw as? String) ?? (raw as? NSAttributedString)?.string ?? ""
+        }
+        if text.isEmpty { text = string(obj, "accessibilityLabel") }
+        if text.isEmpty { text = string(obj, "accessibilityTitle") }
+        if !id.isEmpty || !text.isEmpty {
+            out.append(Node(id: id, role: role, text: text))
+        }
+        for child in branches(obj, visited: &visited) {
+            walk(child, into: &out, visited: &visited)
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
@@ -168,7 +168,12 @@ final class GoldenStage {
         guard node.responds(to: sel) else {
             throw StageError(description: "press: \(identifier) does not support press")
         }
-        _ = node.perform(sel)
+        // `accessibilityPerformPress` returns BOOL. `perform(_:)` is only
+        // defined for object-returning selectors, so call through a typed
+        // IMP instead of relying on the scalar riding home in a pointer.
+        typealias PressIMP = @convention(c) (NSObject, Selector) -> Bool
+        let imp = unsafeBitCast(node.method(for: sel), to: PressIMP.self)
+        _ = imp(node, sel)
         Self.turnRunLoop()
     }
 
@@ -182,7 +187,10 @@ final class GoldenStage {
         guard node.responds(to: sel) else {
             throw StageError(description: "setValue: \(identifier) does not accept a value")
         }
-        _ = node.perform(sel, with: value as NSString)
+        // Void-returning — same typed-IMP treatment as `press(_:)`.
+        typealias SetValueIMP = @convention(c) (NSObject, Selector, NSString) -> Void
+        let imp = unsafeBitCast(node.method(for: sel), to: SetValueIMP.self)
+        imp(node, sel, value as NSString)
         Self.turnRunLoop()
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
@@ -46,6 +46,14 @@ final class GoldenStage {
     private let window: NSWindow
     private let host: NSView
 
+    /// `accessibilityEnhancedUserInterface` is process-global, so stages
+    /// reference-count it: the first live stage records the pre-existing
+    /// value and turns it on, the last one restores what it found. Without
+    /// this every stage would leave the whole test process permanently in
+    /// assistive-client mode.
+    private static var liveStageCount = 0
+    private static var enhancedUIWasEnabled = false
+
     /// Default per-wait budget. Generous relative to the tens of
     /// milliseconds a settled tree usually takes, tiny relative to the
     /// bash flows' multi-second polling loops.
@@ -69,7 +77,15 @@ final class GoldenStage {
         self.window = window
         self.host = host
 
-        NSApplication.shared.setValue(true, forKey: "accessibilityEnhancedUserInterface")
+        if Self.liveStageCount == 0 {
+            let current = NSApplication.shared
+                .value(forKey: "accessibilityEnhancedUserInterface") as? Bool
+            Self.enhancedUIWasEnabled = current ?? false
+            NSApplication.shared.setValue(
+                true, forKey: "accessibilityEnhancedUserInterface"
+            )
+        }
+        Self.liveStageCount += 1
         host.layoutSubtreeIfNeeded()
         Self.turnRunLoop()
     }
@@ -77,6 +93,12 @@ final class GoldenStage {
     deinit {
         let window = self.window
         Task { @MainActor in
+            Self.liveStageCount -= 1
+            if Self.liveStageCount == 0, !Self.enhancedUIWasEnabled {
+                NSApplication.shared.setValue(
+                    false, forKey: "accessibilityEnhancedUserInterface"
+                )
+            }
             window.orderOut(nil)
             window.close()
         }
@@ -194,6 +216,65 @@ final class GoldenStage {
         let sel = NSSelectorFromString("accessibilityValue")
         guard node.responds(to: sel), let result = node.perform(sel) else { return nil }
         return result.takeUnretainedValue() as? String
+    }
+
+    // MARK: - Scrolling
+
+    /// The stage's first scroll position as a 0 (top) … 1 (bottom) fraction —
+    /// the same currency as the AX driver's scroll-bar value that the bash
+    /// flows asserted on. Nil while nothing on the stage scrolls.
+    func scrollFraction() -> Double? {
+        guard let scrollView = firstScrollView(),
+              let document = scrollView.documentView else { return nil }
+        let clip = scrollView.contentView
+        let travel = document.bounds.height - clip.bounds.height
+        guard travel > 0 else { return nil }
+        let fromTop = (clip.bounds.minY - document.bounds.minY) / travel
+        let clamped = max(0, min(1, fromTop))
+        return document.isFlipped ? clamped : 1 - clamped
+    }
+
+    /// Programmatic analog of the AX driver's `set-scroll-value`. The scroll
+    /// arrives unbracketed by live-scroll notifications — exactly what a
+    /// legacy mouse wheel produces — which the transcript's follow-mode probe
+    /// deliberately treats as user intent.
+    func setScrollFraction(_ fraction: Double) throws {
+        guard let scrollView = firstScrollView(),
+              let document = scrollView.documentView else {
+            throw StageError(description: "setScrollFraction: no scroll view on the stage")
+        }
+        let clip = scrollView.contentView
+        let travel = document.bounds.height - clip.bounds.height
+        guard travel > 0 else {
+            throw StageError(description: "setScrollFraction: stage content does not scroll")
+        }
+        let fromTop = document.isFlipped ? fraction : 1 - fraction
+        let proposed = NSRect(
+            origin: NSPoint(
+                x: clip.bounds.minX,
+                y: document.bounds.minY + travel * fromTop
+            ),
+            size: clip.bounds.size
+        )
+        clip.scroll(to: clip.constrainBoundsRect(proposed).origin)
+        scrollView.reflectScrolledClipView(clip)
+        Self.turnRunLoop()
+    }
+
+    private func firstScrollView() -> NSScrollView? {
+        for window in stageWindows() {
+            guard let root = window.contentView else { continue }
+            if let hit = Self.firstScrollView(in: root) { return hit }
+        }
+        return nil
+    }
+
+    private static func firstScrollView(in view: NSView) -> NSScrollView? {
+        if let scrollView = view as? NSScrollView { return scrollView }
+        for subview in view.subviews {
+            if let hit = firstScrollView(in: subview) { return hit }
+        }
+        return nil
     }
 
     // MARK: - Waiting

--- a/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenStage.swift
@@ -295,8 +295,10 @@ final class GoldenStage {
             // presentation) while other suites' main-actor work proceeds
             // undisturbed. A nested `RunLoop.main.run` here measurably
             // altered concurrent timing-sensitive tests' batching cadence
-            // when the package test suite runs parallel.
-            try? await Task.sleep(nanoseconds: 20_000_000)
+            // when the package test suite runs parallel. The sleep's
+            // cancellation error propagates so a cancelled test stops
+            // polling instead of riding out the full timeout.
+            try await Task.sleep(nanoseconds: 20_000_000)
         }
         if condition() { return }
         throw StageError(description: "timed out waiting for \(what)")

--- a/apps/rapid-mac/Tests/RapidTests/InProcessAXSpikeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InProcessAXSpikeTests.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+import Testing
+
+/// SPIKE (golden-flow sink pilot): prove that a SwiftUI view mounted in a
+/// never-shown ``NSWindow`` exposes a walkable accessibility hierarchy and
+/// honors ``accessibilityPerformPress()`` — the two capabilities the
+/// AX-driven golden flows rely on via the out-of-process driver. Both
+/// holding in-process means chat-shard journeys can run inside
+/// `swift test` without launching the app or taking the OS foreground.
+///
+/// Two non-obvious ingredients, discovered empirically (macOS 26):
+///
+/// 1. A bare ``NSHostingView`` — even inside a window — reports zero AX
+///    children. SwiftUI materializes its ``AccessibilityNode`` tree only
+///    when it believes an assistive client is attached, which the
+///    `accessibilityEnhancedUserInterface` KVC toggle simulates (the same
+///    flag VoiceOver sets over the AX wire; snapshot-testing tools use the
+///    UIKit twin for the same purpose).
+/// 2. The materialized children are `SwiftUI.AccessibilityNode` instances,
+///    which implement the AX getters/actions but are NOT KVC-compliant and
+///    do not conform to ``NSAccessibilityProtocol``. They must be driven
+///    through `responds(to:)`/`perform(_:)`.
+@MainActor
+private final class SpikeModel: ObservableObject {
+    @Published var label = "before-press"
+    var pressed = false
+}
+
+private struct SpikeView: View {
+    @ObservedObject var model: SpikeModel
+
+    var body: some View {
+        VStack {
+            Text(model.label)
+                .accessibilityIdentifier("Spike.Label")
+            Button("Press Me") {
+                model.pressed = true
+                model.label = "after-press"
+            }
+            .accessibilityIdentifier("Spike.Button")
+        }
+        .frame(width: 300, height: 200)
+    }
+}
+
+/// Selector-based AX surface reader for SwiftUI's private node class.
+@MainActor
+private enum AXProbe {
+    static func string(_ obj: NSObject, _ selector: String) -> String {
+        let sel = NSSelectorFromString(selector)
+        guard obj.responds(to: sel), let result = obj.perform(sel) else { return "" }
+        return (result.takeUnretainedValue() as? String) ?? ""
+    }
+
+    static func children(_ obj: NSObject) -> [NSObject] {
+        let sel = NSSelectorFromString("accessibilityChildren")
+        guard obj.responds(to: sel), let result = obj.perform(sel) else { return [] }
+        return (result.takeUnretainedValue() as? [NSObject]) ?? []
+    }
+
+    static func find(_ obj: NSObject, id target: String) -> NSObject? {
+        if string(obj, "accessibilityIdentifier") == target { return obj }
+        for child in children(obj) {
+            if let hit = find(child, id: target) { return hit }
+        }
+        return nil
+    }
+
+    /// (identifier, role, text) triples in depth-first order — the same
+    /// currency the bash flows' `see_main` JSON captures.
+    static func walk(_ obj: NSObject, into out: inout [(id: String, role: String, text: String)]) {
+        let id = string(obj, "accessibilityIdentifier")
+        let role = string(obj, "accessibilityRole")
+        var text = ""
+        let valueSel = NSSelectorFromString("accessibilityValue")
+        if obj.responds(to: valueSel), let value = obj.perform(valueSel) {
+            text = (value.takeUnretainedValue() as? String) ?? ""
+        }
+        if text.isEmpty { text = string(obj, "accessibilityLabel") }
+        if !id.isEmpty || !text.isEmpty {
+            out.append((id: id, role: role, text: text))
+        }
+        for child in children(obj) {
+            walk(child, into: &out)
+        }
+    }
+}
+
+@MainActor
+@Suite("In-process AX spike")
+struct InProcessAXSpikeTests {
+    @Test("Never-shown window exposes AX identifiers and presses in-process")
+    func offscreenHostExposesAXAndPress() {
+        let model = SpikeModel()
+        let host = NSHostingView(rootView: SpikeView(model: model))
+        host.frame = CGRect(x: 0, y: 0, width: 300, height: 200)
+        // The window is created but never ordered in: no screen presence,
+        // no foreground, no Dock churn — the property the sink depends on.
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.layoutSubtreeIfNeeded()
+
+        // Ingredient 1: simulate an attached assistive client, then give
+        // SwiftUI one runloop turn to build its AccessibilityNode tree.
+        NSApplication.shared.setValue(true, forKey: "accessibilityEnhancedUserInterface")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        var tree: [(id: String, role: String, text: String)] = []
+        AXProbe.walk(host, into: &tree)
+        let ids = tree.map(\.id)
+        #expect(ids.contains("Spike.Label"), "label identifier missing from AX tree: \(tree)")
+        #expect(ids.contains("Spike.Button"), "button identifier missing from AX tree: \(tree)")
+        #expect(tree.contains { $0.text.contains("before-press") },
+                "label text missing from AX tree: \(tree)")
+
+        guard let button = AXProbe.find(host, id: "Spike.Button") else {
+            Issue.record("button not findable by identifier")
+            return
+        }
+        let pressSel = NSSelectorFromString("accessibilityPerformPress")
+        #expect(button.responds(to: pressSel), "AccessibilityNode lost accessibilityPerformPress")
+        _ = button.perform(pressSel)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        #expect(model.pressed, "press action did not reach the SwiftUI action closure")
+
+        host.layoutSubtreeIfNeeded()
+        var after: [(id: String, role: String, text: String)] = []
+        AXProbe.walk(host, into: &after)
+        #expect(after.contains { $0.text.contains("after-press") },
+                "state change did not surface in the re-walked AX tree: \(after)")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/InProcessAXSpikeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InProcessAXSpikeTests.swift
@@ -2,137 +2,103 @@ import AppKit
 import SwiftUI
 import Testing
 
-/// SPIKE (golden-flow sink pilot): prove that a SwiftUI view mounted in a
-/// never-shown ``NSWindow`` exposes a walkable accessibility hierarchy and
-/// honors ``accessibilityPerformPress()`` — the two capabilities the
-/// AX-driven golden flows rely on via the out-of-process driver. Both
-/// holding in-process means chat-shard journeys can run inside
-/// `swift test` without launching the app or taking the OS foreground.
-///
-/// Two non-obvious ingredients, discovered empirically (macOS 26):
-///
-/// 1. A bare ``NSHostingView`` — even inside a window — reports zero AX
-///    children. SwiftUI materializes its ``AccessibilityNode`` tree only
-///    when it believes an assistive client is attached, which the
-///    `accessibilityEnhancedUserInterface` KVC toggle simulates (the same
-///    flag VoiceOver sets over the AX wire; snapshot-testing tools use the
-///    UIKit twin for the same purpose).
-/// 2. The materialized children are `SwiftUI.AccessibilityNode` instances,
-///    which implement the AX getters/actions but are NOT KVC-compliant and
-///    do not conform to ``NSAccessibilityProtocol``. They must be driven
-///    through `responds(to:)`/`perform(_:)`.
+/// Contract tests for ``GoldenStage``: the stage must expose a walkable AX
+/// tree, deliver presses into real SwiftUI action closures, surface state
+/// changes back through the tree, and materialize sheet and popover
+/// windows — all without the window ever being visible or key. Sunk golden
+/// flows depend on exactly these guarantees, so a macOS update that breaks
+/// one should fail here, in a test that names the broken ingredient,
+/// rather than inside a ported product journey.
 @MainActor
-private final class SpikeModel: ObservableObject {
+private final class StageProbeModel: ObservableObject {
     @Published var label = "before-press"
+    @Published var showsPopover = false
+    @Published var showsSheet = false
     var pressed = false
 }
 
-private struct SpikeView: View {
-    @ObservedObject var model: SpikeModel
+private struct StageProbeView: View {
+    @ObservedObject var model: StageProbeModel
 
     var body: some View {
         VStack {
             Text(model.label)
-                .accessibilityIdentifier("Spike.Label")
+                .accessibilityIdentifier("StageProbe.Label")
             Button("Press Me") {
                 model.pressed = true
                 model.label = "after-press"
             }
-            .accessibilityIdentifier("Spike.Button")
+            .accessibilityIdentifier("StageProbe.Button")
+            Button("Popover") { model.showsPopover.toggle() }
+                .accessibilityIdentifier("StageProbe.PopoverAnchor")
+                .popover(isPresented: $model.showsPopover) {
+                    Text("popover-content")
+                        .accessibilityIdentifier("StageProbe.PopoverContent")
+                        .padding()
+                }
+            Button("Sheet") { model.showsSheet = true }
+                .accessibilityIdentifier("StageProbe.SheetAnchor")
+                .sheet(isPresented: $model.showsSheet) {
+                    Button("Done") { model.showsSheet = false }
+                        .accessibilityIdentifier("StageProbe.SheetDone")
+                        .padding()
+                }
+            TextField("Draft", text: .constant(""))
+                .accessibilityIdentifier("StageProbe.Field")
         }
-        .frame(width: 300, height: 200)
-    }
-}
-
-/// Selector-based AX surface reader for SwiftUI's private node class.
-@MainActor
-private enum AXProbe {
-    static func string(_ obj: NSObject, _ selector: String) -> String {
-        let sel = NSSelectorFromString(selector)
-        guard obj.responds(to: sel), let result = obj.perform(sel) else { return "" }
-        return (result.takeUnretainedValue() as? String) ?? ""
-    }
-
-    static func children(_ obj: NSObject) -> [NSObject] {
-        let sel = NSSelectorFromString("accessibilityChildren")
-        guard obj.responds(to: sel), let result = obj.perform(sel) else { return [] }
-        return (result.takeUnretainedValue() as? [NSObject]) ?? []
-    }
-
-    static func find(_ obj: NSObject, id target: String) -> NSObject? {
-        if string(obj, "accessibilityIdentifier") == target { return obj }
-        for child in children(obj) {
-            if let hit = find(child, id: target) { return hit }
-        }
-        return nil
-    }
-
-    /// (identifier, role, text) triples in depth-first order — the same
-    /// currency the bash flows' `see_main` JSON captures.
-    static func walk(_ obj: NSObject, into out: inout [(id: String, role: String, text: String)]) {
-        let id = string(obj, "accessibilityIdentifier")
-        let role = string(obj, "accessibilityRole")
-        var text = ""
-        let valueSel = NSSelectorFromString("accessibilityValue")
-        if obj.responds(to: valueSel), let value = obj.perform(valueSel) {
-            text = (value.takeUnretainedValue() as? String) ?? ""
-        }
-        if text.isEmpty { text = string(obj, "accessibilityLabel") }
-        if !id.isEmpty || !text.isEmpty {
-            out.append((id: id, role: role, text: text))
-        }
-        for child in children(obj) {
-            walk(child, into: &out)
-        }
+        .frame(width: 400, height: 300)
     }
 }
 
 @MainActor
-@Suite("In-process AX spike")
+@Suite("GoldenStage contract", .serialized)
 struct InProcessAXSpikeTests {
-    @Test("Never-shown window exposes AX identifiers and presses in-process")
-    func offscreenHostExposesAXAndPress() {
-        let model = SpikeModel()
-        let host = NSHostingView(rootView: SpikeView(model: model))
-        host.frame = CGRect(x: 0, y: 0, width: 300, height: 200)
-        // The window is created but never ordered in: no screen presence,
-        // no foreground, no Dock churn — the property the sink depends on.
-        let window = NSWindow(
-            contentRect: host.frame,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
-        )
-        window.contentView = host
-        host.layoutSubtreeIfNeeded()
+    @Test("The stage walks identifiers, presses, and observes state changes")
+    func walkPressObserve() async throws {
+        let model = StageProbeModel()
+        let stage = GoldenStage(StageProbeView(model: model), size: CGSize(width: 400, height: 300))
 
-        // Ingredient 1: simulate an attached assistive client, then give
-        // SwiftUI one runloop turn to build its AccessibilityNode tree.
-        NSApplication.shared.setValue(true, forKey: "accessibilityEnhancedUserInterface")
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        let ids = stage.identifiers()
+        #expect(ids.contains("StageProbe.Label"), "AX tree missing label: \(ids)")
+        #expect(ids.contains("StageProbe.Button"), "AX tree missing button: \(ids)")
+        #expect(stage.treeText().contains("before-press"))
 
-        var tree: [(id: String, role: String, text: String)] = []
-        AXProbe.walk(host, into: &tree)
-        let ids = tree.map(\.id)
-        #expect(ids.contains("Spike.Label"), "label identifier missing from AX tree: \(tree)")
-        #expect(ids.contains("Spike.Button"), "button identifier missing from AX tree: \(tree)")
-        #expect(tree.contains { $0.text.contains("before-press") },
-                "label text missing from AX tree: \(tree)")
+        try stage.press("StageProbe.Button")
+        #expect(model.pressed, "press did not reach the SwiftUI action closure")
+        try await stage.waitForText("after-press")
+    }
 
-        guard let button = AXProbe.find(host, id: "Spike.Button") else {
-            Issue.record("button not findable by identifier")
-            return
+    @Test("Sheets materialize as walkable windows and dismiss on press")
+    func sheetRoundTrip() async throws {
+        let model = StageProbeModel()
+        let stage = GoldenStage(StageProbeView(model: model), size: CGSize(width: 400, height: 300))
+
+        try stage.press("StageProbe.SheetAnchor")
+        try await stage.waitForIdentifier("StageProbe.SheetDone")
+        try stage.press("StageProbe.SheetDone")
+        try await stage.waitForIdentifierGone("StageProbe.SheetDone")
+        #expect(!model.showsSheet)
+    }
+
+    @Test("Popovers materialize because the stage window is ordered in")
+    func popoverRoundTrip() async throws {
+        let model = StageProbeModel()
+        let stage = GoldenStage(StageProbeView(model: model), size: CGSize(width: 400, height: 300))
+
+        try stage.press("StageProbe.PopoverAnchor")
+        try await stage.waitForIdentifier("StageProbe.PopoverContent")
+        try stage.press("StageProbe.PopoverAnchor")
+        try await stage.waitForIdentifierGone("StageProbe.PopoverContent")
+    }
+
+    @Test("setValue drives text fields the way the AX driver's set-value does")
+    func setValueOnField() async throws {
+        let model = StageProbeModel()
+        let stage = GoldenStage(StageProbeView(model: model), size: CGSize(width: 400, height: 300))
+
+        try stage.setValue("typed via AX", for: "StageProbe.Field")
+        try await stage.wait(for: "field value") {
+            stage.value(of: "StageProbe.Field") == "typed via AX"
         }
-        let pressSel = NSSelectorFromString("accessibilityPerformPress")
-        #expect(button.responds(to: pressSel), "AccessibilityNode lost accessibilityPerformPress")
-        _ = button.perform(pressSel)
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
-        #expect(model.pressed, "press action did not reach the SwiftUI action closure")
-
-        host.layoutSubtreeIfNeeded()
-        var after: [(id: String, role: String, text: String)] = []
-        AXProbe.walk(host, into: &after)
-        #expect(after.contains { $0.text.contains("after-press") },
-                "state change did not surface in the re-walked AX tree: \(after)")
     }
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -58,7 +58,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, cached-curated-tradeup, cached-variant-collapse, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
+Flows: fresh-install, cached-quickstart, cached-curated-tradeup, cached-variant-collapse, download-progress, settings-persistence, settings-mtp, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, update-busy, campaign-banner, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -402,7 +402,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
+        fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
         slow-stream-stop|model-switch-active-request|model-crash-recovery|low-memory-choice|chat-document-attachment|chat-multimodal-attachments|image-generation|dictation|dictation-rc2-upgrade|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
@@ -2690,218 +2690,6 @@ flow_chat_restore() {
            | length == 0' "$OUT/search-new-chat-landed.json" >/dev/null \
         || die "New chat did not dismiss conversation search"
     log "  conversation Pin/Unpin and search Clear/Close/New chat all produced effects"
-    cleanup_persona
-}
-
-flow_message_actions() {
-    # Every inline message action must produce its advertised result. Dynamic
-    # UUID suffixes are discovered from the live tree so this drives the same
-    # controls a user sees instead of a test-only entry point.
-    start_persona message-actions
-    dismiss_first_run
-    start_model
-    see_main "$OUT/message-actions-model-info-before.json"
-    press "$OUT/message-actions-model-info-before.json" ModelPickerBar.ModelInfo \
-        "$OUT/message-actions-model-info-press.json" \
-        || die "Model info button is not pressable"
-    wait_tree_text "Parameters" "$OUT/message-actions-model-info-open.json" 40
-    assert_tree_text "$OUT/message-actions-model-info-open.json" "$FAKE_ALIAS"
-    # Clicking the anchor again dismisses its popover and proves it is not a
-    # one-way overlay that traps the rest of the composer.
-    press "$OUT/message-actions-model-info-open.json" ModelPickerBar.ModelInfo \
-        "$OUT/message-actions-model-info-close-press.json" \
-        || die "Model info popover cannot be dismissed from its anchor"
-    send_prompt "original message action prompt" message-actions
-    wait_send_idle "$OUT/message-actions-settled.json"
-    see_main "$OUT/message-actions-before.json"
-
-    local assistant_copy assistant_select assistant_retry user_edit suffix
-    assistant_copy="$(jq -r '.data.ui_elements[]? | (.identifier // "")
-        | select(startswith("ChatView.Message.Copy."))' \
-        "$OUT/message-actions-before.json" | tail -1)"
-    assistant_select="${assistant_copy/Message.Copy./Message.SelectText.}"
-    assistant_retry="${assistant_copy/Message.Copy./Message.Retry.}"
-    user_edit="$(jq -r '.data.ui_elements[]? | (.identifier // "")
-        | select(startswith("ChatView.Message.Edit."))' \
-        "$OUT/message-actions-before.json" | head -1)"
-    [[ -n "$assistant_copy" && -n "$user_edit" ]] \
-        || die "completed turn exposes no assistant and user message actions"
-
-    pbcopy < /dev/null
-    press "$OUT/message-actions-before.json" "$assistant_copy" \
-        "$OUT/message-actions-copy-press.json" \
-        || die "Copy response is not pressable"
-    [[ -n "$(pbpaste)" ]] || die "Copy response left the pasteboard empty"
-
-    see_main "$OUT/message-actions-after-copy.json"
-    press "$OUT/message-actions-after-copy.json" "$assistant_select" \
-        "$OUT/message-actions-select-press.json" \
-        || die "Select text is not pressable"
-    wait_identifier SelectText.Done "$OUT/message-actions-select-sheet.json"
-    press "$OUT/message-actions-select-sheet.json" SelectText.Done \
-        "$OUT/message-actions-select-done-press.json" \
-        || die "Select text sheet cannot be dismissed"
-    for _ in {1..40}; do
-        see_main "$OUT/message-actions-select-closed.json"
-        if jq -e '.data.walk.complete == true
-                  and ([.data.ui_elements[]? | .identifier // ""]
-                       | index("SelectText.Done")) == null' \
-            "$OUT/message-actions-select-closed.json" >/dev/null; then break; fi
-        sleep 0.1
-    done
-    jq -e '([.data.ui_elements[]? | .identifier // ""]
-            | index("SelectText.Done")) == null' \
-        "$OUT/message-actions-select-closed.json" >/dev/null \
-        || die "Done did not dismiss the Select text sheet"
-
-    # Copy's checkmark reverts after 1.2s. SwiftUI may replace the action-row
-    # backing elements during that symbol transition; wait for the stable copy
-    # state so this journey measures Edit itself rather than an intentionally
-    # transient sibling animation.
-    for _ in {1..40}; do
-        see_main "$OUT/message-actions-copy-settled.json"
-        if jq -e --arg identifier "$assistant_copy" \
-            '.data.ui_elements[]? | select(.identifier == $identifier)
-             | select(.selected != true)' \
-            "$OUT/message-actions-copy-settled.json" >/dev/null; then break; fi
-        sleep 0.1
-    done
-    see_main "$OUT/message-actions-before-edit.json"
-    suffix="${user_edit##*.}"
-    if ! press "$OUT/message-actions-before-edit.json" "$user_edit" \
-        "$OUT/message-actions-edit-press.json"; then
-        # AXUIElementPerformAction may report cannotComplete even if SwiftUI
-        # committed the synchronous state mutation. Read the outcome before
-        # calling it dead; if no editor appeared, this is a product failure.
-        sleep 0.2
-        see_main "$OUT/message-actions-edit-failed-outcome.json"
-        jq -e --arg identifier "ChatView.Message.EditField.$suffix" \
-            '.data.ui_elements[]? | select(.identifier == $identifier)' \
-            "$OUT/message-actions-edit-failed-outcome.json" >/dev/null \
-            || die "Edit message is not pressable"
-    fi
-    wait_identifier "ChatView.Message.EditField.$suffix" \
-        "$OUT/message-actions-editor.json"
-    "$AX_DRIVER" set-value "$APP_PID" "ChatView.Message.EditField.$suffix" \
-        "cancelled edit must not send" > "$OUT/message-actions-edit-type.json"
-    see_main "$OUT/message-actions-edit-draft.json"
-    press "$OUT/message-actions-edit-draft.json" \
-        "ChatView.Message.CancelEdit.$suffix" \
-        "$OUT/message-actions-edit-cancel-press.json" \
-        || die "Cancel editing is not pressable"
-    wait_identifier "$user_edit" "$OUT/message-actions-edit-cancelled.json"
-    grep -q 'cancelled edit must not send' "$OUT/fake-events.jsonl" 2>/dev/null \
-        && die "cancelling a message edit sent the draft"
-
-    local requests_before requests_after
-    requests_before="$(jq -s '[.[] | select(.event == "chat_request"
-        and .request_origin != "background_assist")] | length' "$OUT/fake-events.jsonl")"
-    see_main "$OUT/message-actions-before-retry.json"
-    press "$OUT/message-actions-before-retry.json" "$assistant_retry" \
-        "$OUT/message-actions-retry-press.json" \
-        || die "Retry response is not pressable"
-    for _ in {1..80}; do
-        requests_after="$(jq -s '[.[] | select(.event == "chat_request"
-            and .request_origin != "background_assist")] | length' "$OUT/fake-events.jsonl")"
-        [[ "$requests_after" -gt "$requests_before" ]] && break
-        sleep 0.1
-    done
-    [[ "$requests_after" -gt "$requests_before" ]] \
-        || die "Retry response did not send a replacement request"
-    wait_send_idle "$OUT/message-actions-retried.json"
-
-    see_main "$OUT/message-actions-before-save-edit.json"
-    user_edit="$(jq -r '.data.ui_elements[]? | (.identifier // "")
-        | select(startswith("ChatView.Message.Edit."))' \
-        "$OUT/message-actions-before-save-edit.json" | head -1)"
-    [[ -n "$user_edit" ]] || die "retried turn exposes no Edit message action"
-    suffix="${user_edit##*.}"
-    press "$OUT/message-actions-before-save-edit.json" "$user_edit" \
-        "$OUT/message-actions-save-edit-open-press.json" || true
-    wait_identifier "ChatView.Message.EditField.$suffix" \
-        "$OUT/message-actions-save-editor.json"
-    "$AX_DRIVER" set-value "$APP_PID" "ChatView.Message.EditField.$suffix" \
-        "saved edited message prompt" > "$OUT/message-actions-save-edit-type.json"
-    see_main "$OUT/message-actions-save-edit-draft.json"
-    press "$OUT/message-actions-save-edit-draft.json" \
-        "ChatView.Message.SaveEdit.$suffix" \
-        "$OUT/message-actions-save-edit-press.json" \
-        || die "Save edited message is not pressable"
-    for _ in {1..80}; do
-        if jq -e 'select(.event == "chat_request")
-                  | select(.user_texts | index("saved edited message prompt"))' \
-            "$OUT/fake-events.jsonl" >/dev/null 2>&1; then break; fi
-        sleep 0.1
-    done
-    jq -e 'select(.event == "chat_request")
-           | select(.user_texts | index("saved edited message prompt"))' \
-        "$OUT/fake-events.jsonl" >/dev/null \
-        || die "Save edited message did not resend the edited turn"
-    wait_send_idle "$OUT/message-actions-saved-edit-settled.json"
-
-    # A finished answer no longer emits document-frame changes. This is the
-    # exact state where Jump to latest used to set the pinned flag but leave
-    # the transcript physically scrolled up. Drive a long, fully settled
-    # answer, move away from its tail, then require the same last-message
-    # action to return after pressing the button.
-    send_prompt "shape:long finished answer for jump-to-bottom" message-actions-long
-    wait_send_idle "$OUT/message-actions-long-settled.json"
-    local bottom_scroll_value
-    bottom_scroll_value="$(jq -r '[.data.ui_elements[]?
-        | select(.role == "AXScrollBar" and (.value | type) == "number")
-        | .value] | max // empty' "$OUT/message-actions-long-settled.json")"
-    [[ -n "$bottom_scroll_value" ]] \
-        || die "long settled transcript exposes no measurable scroll position"
-    "$AX_DRIVER" set-scroll-value "$APP_PID" 0 \
-        > "$OUT/message-actions-scroll-up.json" \
-        || die "could not move the settled transcript away from its tail"
-    local jump_visible=0
-    for _ in {1..60}; do
-        see_main "$OUT/message-actions-scrolled.json"
-        if jq -e '.data.ui_elements[]?
-                  | select(.identifier == "Transcript.JumpToBottom")' \
-            "$OUT/message-actions-scrolled.json" >/dev/null; then
-            jump_visible=1; break
-        fi
-        sleep 0.1
-    done
-    [[ "$jump_visible" == 1 ]] \
-        || die "scrolling up a settled transcript never exposed Jump to latest"
-    local scrolled_value
-    scrolled_value="$(jq -r '[.data.ui_elements[]?
-        | select(.role == "AXScrollBar" and (.value | type) == "number")
-        | .value] | min // empty' "$OUT/message-actions-scrolled.json")"
-    [[ -n "$scrolled_value" ]] \
-        || die "scrolled transcript exposes no measurable scroll position"
-    awk -v before="$bottom_scroll_value" -v after="$scrolled_value" \
-        'BEGIN { exit !(after < before - 0.02) }' \
-        || die "scroll fixture did not move away from the settled transcript tail"
-    press "$OUT/message-actions-scrolled.json" Transcript.JumpToBottom \
-        "$OUT/message-actions-jump-press.json" \
-        || die "Jump to latest is not pressable on a settled transcript"
-    local jumped=0
-    for _ in {1..60}; do
-        see_main "$OUT/message-actions-jumped.json"
-        local jumped_value
-        jumped_value="$(jq -r '[.data.ui_elements[]?
-            | select(.role == "AXScrollBar" and (.value | type) == "number")
-            | .value] | max // empty' "$OUT/message-actions-jumped.json")"
-        if [[ -n "$jumped_value" ]] \
-            && awk -v before="$scrolled_value" -v after="$jumped_value" \
-                'BEGIN { exit !(after > before + 0.02) }' \
-            && ! jq -e '.data.ui_elements[]?
-                        | select(.identifier == "Transcript.JumpToBottom")' \
-                "$OUT/message-actions-jumped.json" >/dev/null; then
-            jumped=1; break
-        fi
-        sleep 0.1
-    done
-    [[ "$jumped" == 1 ]] \
-        || die "Jump to latest hid itself without returning the settled transcript to its tail"
-    jq -n '{success: true,
-            assertion: "a finished transcript scrolls back to its final answer"}' \
-        > "$OUT/message-actions-jump-assertion.json"
-    log "  message actions and finished-answer Jump to latest all produced effects"
     cleanup_persona
 }
 
@@ -5982,7 +5770,6 @@ case "$FLOW" in
     settings-persistence) flow_settings_persistence ;;
     settings-mtp) flow_settings_mtp ;;
     chat-restore) flow_chat_restore ;;
-    message-actions) flow_message_actions ;;
     restored-tools) flow_restored_tools ;;
     tool-loop-budget) flow_tool_loop_budget ;;
     chat-depth) flow_chat_depth ;;
@@ -6015,7 +5802,6 @@ case "$FLOW" in
         flow_settings_persistence
         flow_settings_mtp
         flow_chat_restore
-        flow_message_actions
         flow_restored_tools
         flow_tool_loop_budget
         flow_chat_depth

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -59,7 +59,7 @@ def _manifest() -> list[dict[str, object]]:
         lines = block.splitlines()
         values: dict[str, object] = {"name": lines[0].strip()}
         for line in lines[1:]:
-            match = re.match(r"^    (group|ci_tier): ([a-z-]+)\s*$", line)
+            match = re.match(r"^    (group|ci_tier|driver): ([a-z-]+)\s*$", line)
             if match:
                 values[match.group(1)] = match.group(2)
                 continue
@@ -68,7 +68,7 @@ def _manifest() -> list[dict[str, object]]:
                 values["source_paths"] = [
                     item.strip() for item in match.group(1).split(",") if item.strip()
                 ]
-        required = {"name", "group", "ci_tier", "source_paths"}
+        required = {"name", "group", "ci_tier", "driver", "source_paths"}
         if set(values) != required or not values["source_paths"]:
             raise ValueError(f"malformed GUI journey routing fields: {values['name']}")
         journeys.append(values)
@@ -78,7 +78,18 @@ def _manifest() -> list[dict[str, object]]:
 
 
 def _pr_journeys() -> list[dict[str, object]]:
-    return [journey for journey in _manifest() if journey["ci_tier"] == "pr"]
+    """PR journeys that the bash harness runs.
+
+    `driver: swift` journeys are covered in-process by the build job's
+    `swift test` on every PR, so they never occupy a GUI shard and must not
+    be offered to `gui-golden-flows.sh`, which has no case for them.
+    """
+
+    return [
+        journey
+        for journey in _manifest()
+        if journey["ci_tier"] == "pr" and journey["driver"] != "swift"
+    ]
 
 
 def all_flows() -> list[str]:

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -24,7 +24,9 @@ def _groups() -> dict[str, set[str]]:
     journeys = yaml.safe_load(MANIFEST.read_text())["journeys"]
     result: dict[str, set[str]] = {}
     for journey in journeys:
-        if journey["ci_tier"] == "pr":
+        # `driver: swift` journeys run in the build job's `swift test`, not
+        # in a GUI shard, so the selector never offers them to the harness.
+        if journey["ci_tier"] == "pr" and journey["driver"] != "swift":
             result.setdefault(journey["group"], set()).add(journey["name"])
     return result
 

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -98,11 +98,18 @@ def swift_suite_titles() -> set[str]:
     the manifest inventory and the code that honours it.
     """
 
+    # Commented-out code must not satisfy a coverage gate. A live but empty
+    # suite is out of scope for a source-level check; the Swift build itself
+    # is what keeps the named suite compiling and running.
     titles: set[str] = set()
     for path in SWIFT_TESTS.glob("*.swift"):
-        titles.update(
-            re.findall(r'@Suite\("Golden journey: ([a-z0-9-]+)"', path.read_text())
-        )
+        for line in path.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            match = re.match(r'@Suite\("Golden journey: ([a-z0-9-]+)"', stripped)
+            if match:
+                titles.add(match.group(1))
     return titles
 
 

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parent.parent
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
 MANIFEST = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml"
+SWIFT_TESTS = ROOT / "apps/rapid-mac/Tests/RapidTests"
 
 # `chat-depth` requires all five turns to be simultaneously realised in AX.
 # The hosted runner's 1024x681 app window virtualises the oldest messages, so
@@ -81,11 +82,39 @@ def test_every_named_flow_is_gated_or_explicitly_excluded():
     assert not gated - named
 
 
+def swift_journeys() -> set[str]:
+    return {
+        str(journey["name"])
+        for journey in manifest_journeys()
+        if journey["driver"] == "swift"
+    }
+
+
+def swift_suite_titles() -> set[str]:
+    """Journeys carried by in-process `swift test` suites.
+
+    A `driver: swift` journey's coverage lives in a Swift Testing suite named
+    `Golden journey: <name>`; the title is the machine-checkable link between
+    the manifest inventory and the code that honours it.
+    """
+
+    titles: set[str] = set()
+    for path in SWIFT_TESTS.glob("*.swift"):
+        titles.update(
+            re.findall(r'@Suite\("Golden journey: ([a-z0-9-]+)"', path.read_text())
+        )
+    return titles
+
+
 def test_manifest_is_the_complete_unique_flow_inventory():
     journeys = manifest_journeys()
     names = [str(journey["name"]) for journey in journeys]
     assert len(names) == len(set(names))
-    assert set(names) == harness_flows()
+    assert set(names) - swift_journeys() == harness_flows()
+
+
+def test_swift_driver_journeys_have_their_golden_suite():
+    assert swift_journeys() == swift_suite_titles()
 
 
 def test_manifest_fields_are_valid_and_fail_closed():
@@ -98,7 +127,7 @@ def test_manifest_fields_are_valid_and_fail_closed():
         "app-lifecycle",
     }
     allowed_risks = {"low", "medium", "high"}
-    allowed_drivers = {"ax", "xcuitest", "hybrid"}
+    allowed_drivers = {"ax", "xcuitest", "hybrid", "swift"}
     allowed_tiers = {"pr", "local"}
     allowed_fixtures = {
         "audio-models",
@@ -156,11 +185,13 @@ def test_manifest_fields_are_valid_and_fail_closed():
 
 
 def test_manifest_ci_tiers_match_the_workflow_contract():
+    # `driver: swift` journeys ride the build job's `swift test`, which runs
+    # on every PR; they must not also occupy a GUI shard step.
     pr_flows = {
         str(journey["name"])
         for journey in manifest_journeys()
         if journey["ci_tier"] == "pr"
-    }
+    } - swift_journeys()
     local_flows = {
         str(journey["name"])
         for journey in manifest_journeys()

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -98,18 +98,26 @@ def swift_suite_titles() -> set[str]:
     the manifest inventory and the code that honours it.
     """
 
-    # Commented-out code must not satisfy a coverage gate. A live but empty
-    # suite is out of scope for a source-level check; the Swift build itself
-    # is what keeps the named suite compiling and running.
+    # Commented-out code must not satisfy a coverage gate, and a named suite
+    # only counts when its file also declares at least one live @Test —
+    # source-level approximations of "this journey actually executes".
+    # Anything subtler (a @Test that compiles but asserts nothing) is the
+    # Swift build's and reviewer's territory, not a regex's.
     titles: set[str] = set()
     for path in SWIFT_TESTS.glob("*.swift"):
+        file_titles: set[str] = set()
+        has_live_test = False
         for line in path.read_text().splitlines():
             stripped = line.strip()
             if stripped.startswith("//"):
                 continue
+            if stripped.startswith("@Test"):
+                has_live_test = True
             match = re.match(r'@Suite\("Golden journey: ([a-z0-9-]+)"', stripped)
             if match:
-                titles.add(match.group(1))
+                file_titles.add(match.group(1))
+        if has_live_test:
+            titles.update(file_titles)
     return titles
 
 

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -512,7 +512,6 @@ def test_peekaboo_requirement_is_default_deny():
     peekaboo_free = {
         "chat-restore",
         "fresh-install",
-        "message-actions",
         "cached-quickstart",
         "cached-curated-tradeup",
         "cached-variant-collapse",


### PR DESCRIPTION
## Summary

First "sink a GUI golden flow into `swift test`" PR: an in-process AX test harness (`GoldenStage`) plus the `message-actions` journey ported from the bash AX harness to a Swift Testing suite, with the manifest/CI/routing contracts taught the new `driver: swift` semantics.

**Why**: the chat GUI shard costs ~14.5 min on a hosted macOS runner per PR; the message-actions journey re-implemented here runs in ~4 s inside the existing `swift test` job, drives the exact same accessibility identifiers against the real `ChatView`, and never takes the OS foreground or needs a TCC grant.

### 1. `GoldenStage` (Tests/RapidTests/GoldenStage.swift)

Mounts a real SwiftUI view in an off-screen, ordered-back, never-key window and drives it through the same AX surface the out-of-process golden flows use: find-by-identifier, press, set-value, Esc, wait-for-tree-state. The load-bearing recipe (each ingredient discovered empirically on macOS 26, verified by the `GoldenStage contract` suite):

1. Off-screen coordinates + `orderBack(nil)` — real `.popover`/`.sheet` presentation windows materialize, zero focus steal, zero pixels.
2. `accessibilityEnhancedUserInterface` — SwiftUI materializes its AX node tree only when it believes an assistive client is attached.
3. Nodes are private `SwiftUI.AccessibilityNode`s — driven via `responds(to:)`/`perform(_:)`, not KVC.
4. Tree walks merge AX children with NSView subviews (SwiftUI's node tree omits some `NSViewRepresentable` content that the real AX server does expose).
5. Queries are scoped to the stage's own window plus windows attached via `sheetParent`/`parent`, so concurrent stages can't satisfy each other's identifier queries.

### 2. `message-actions` journey port (Tests/RapidTests/ChatMessageActionsGoldenTests.swift)

The full bash journey, one-for-one: copy→pasteboard (snapshotting and restoring the developer's clipboard), select-text sheet round-trip, edit-cancel (draft must not send), retry (replacement request), edit-save, model-info popover, and the finished-answer Jump-to-latest scroll regression (#1904 shape: long settled reply, scroll away, press, return to tail). The fake sidecar is replaced by a recording `URLProtocol` SSE fake, so the "a request actually left the process" assertions keep an independent witness (`recordedBodies`), and `wait_send_idle` is mirrored via the send button's AX relabel. The popover check is strictly stronger than the bash flow's (which only asserted the anchor's second press succeeded): Esc-dismiss, then reopen.

### 3. Product fix: `StreamingPresentationDisplayLink` timer fallback

A view display link only fires while the window sits on an active display. Off every display (disconnected monitor restore, or this stage), streamed text would buffer forever and never render — the presentation pipeline drains only on frame callbacks. A main-runloop timer now stands in exactly when `isActive && window?.screen == nil`, reconciled on window/screen changes. `TranscriptScrollPositionProbe` had the same gap — its animated scroll-to-bottom is display-link-driven — and now lands instantly when its window sits on no display (unhosted scroll views keep the animated path for the deterministic frame-driven tests). Normal on-screen behavior is unchanged (neither fallback engages).

### 4. Contract plumbing for `driver: swift`

- `journeys.yaml`: `message-actions` → `driver: swift` (inventory entry retained; coverage now lives in the suite titled `Golden journey: message-actions`).
- `gui-golden-flows.sh`: `flow_message_actions` + dispatcher case + `all` entry removed.
- `rapid-mac-ci.yml`: the per-flow step removed; the journey now rides the `build` job's `swift test`, which is gated on the same `desktop == 'true'` condition as the GUI shards, so coverage parity per PR is unchanged.
- `scripts/select_gui_flows.py`: parses `driver`, excludes `swift` journeys from bash shards (chat shard drops from 8 to 7 flows).
- `tests/test_gui_golden_ci_coverage.py`: new fail-closed link — every `driver: swift` journey must have a matching `@Suite("Golden journey: <name>")` under Tests/RapidTests, and vice versa.
- `tests/test_gui_flow_routing.py`, `tests/test_gui_preflight_contract.py`: swift journeys excluded from bash-harness expectations.

## Test plan

- [x] `swift test --filter ChatMessageActionsGoldenTests` (journey + jump-to-latest + popover) — 5 consecutive green runs, ~3 s each (M3 Ultra)
- [x] `GoldenStage` restores the process-global `accessibilityEnhancedUserInterface` flag (reference-counted) and the journey restores `NSPasteboard.general`
- [x] `swift test --filter InProcessAXSpikeTests` (GoldenStage contract: walk/press/observe, sheet, popover, set-value) — green
- [x] Full `./scripts/desktop-test-timeout.sh` (the CI entrypoint, `--no-parallel`) — green
- [x] `pytest tests/test_gui_golden_ci_coverage.py tests/test_gui_flow_routing.py tests/test_gui_preflight_contract.py tests/test_ci_lane_promotion.py tests/test_classify_ci_changes.py tests/test_gui_app_artifact.py tests/test_gui_control_behavior_contract.py tests/test_gui_walk_completeness.py tests/test_host_prechecks.py tests/test_rapid_mac_xcui_target.py tests/test_train_gates_matches_ci.py tests/test_fake_sidecar_image_catalog.py` — 194 passed
- [x] `select_gui_flows.py` spot-check: `message-actions` absent from `all_flows()` and from the chat shard matrix; chat-component selection intact
- [x] `bash -n gui-golden-flows.sh` + `--help` after flow removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
