### PR TITLE
fix: fail fast on invalid multimodal runtime

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1055,7 +1055,9 @@ class TestMllmBackboneIsHybrid:
         assert server._engine.kwargs["model_name"] == str(snapshot)
         assert server._engine.kwargs["force_text"] is True
         assert routing_config_inputs == [repo, repo]
-        assert lane_inputs == [str(snapshot), str(snapshot)]
+        # Each load resolves once during the pre-weight runtime preflight and
+        # once again against the final checkpoint contract.
+        assert lane_inputs == [str(snapshot)] * 4
 
         # A removed/corrupt prior identity is stale process state, not a reason
         # to reject a valid current canonical request.

--- a/tests/test_audio_route_registration_gate.py
+++ b/tests/test_audio_route_registration_gate.py
@@ -540,6 +540,7 @@ class TestCliServeCommandWiresEnableAudioFlag:
         # PFlash lane probe before the stubbed ``load_model``; stub it so the
         # uncached placeholder id doesn't fail-fast here (#1178).
         monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+        monkeypatch.setattr(server, "_preflight_vision_runtime", lambda *a, **k: None)
         # ``uvicorn.run`` is imported as a top-level name in server.main;
         # patch through the module attr to dodge the real network bind.
         import uvicorn
@@ -884,6 +885,7 @@ class TestCliServeCommandWiresEnableAudioFlag:
         # config-materialization seam so the routing fail-fast doesn't preempt
         # the register-hook path under test (#1178).
         monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+        monkeypatch.setattr(server, "_preflight_vision_runtime", lambda *a, **k: None)
 
         try:
             with (

--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -123,6 +123,7 @@ def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
     # ``captured`` that then trips a confusing "cfg is None" assertion.
     with (
         mock.patch("vllm_mlx.cli._port_preflight_or_die", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server._preflight_vision_runtime", lambda *a, **k: None),
         mock.patch("vllm_mlx.server._ensure_routing_config", lambda *a, **k: None),
         mock.patch("vllm_mlx.server.resolve_serving_lane", lambda name, **kw: lane),
         mock.patch("vllm_mlx.pflash.validate_model_support", _capture_validate),
@@ -168,6 +169,7 @@ def _run_server_main_capturing_scheduler(
     with (
         import_guard,
         mock.patch("vllm_mlx.cli._port_preflight_or_die", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server._preflight_vision_runtime", lambda *a, **k: None),
         mock.patch("vllm_mlx.server._ensure_routing_config", lambda *a, **k: None),
         mock.patch(
             "vllm_mlx.server.resolve_serving_lane", lambda _name, **_kw: (False, False)

--- a/tests/test_pull_variant_serve_resolution.py
+++ b/tests/test_pull_variant_serve_resolution.py
@@ -237,6 +237,9 @@ def test_serving_checkpoint_resolves_explicit_alias_before_lane_selection(
         return str(snapshot)
 
     monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(
+        server, "_prefetch_routing_metadata", lambda _name: str(checkpoint)
+    )
     monkeypatch.setattr(server, "_ensure_routing_config", lambda _path: None)
     monkeypatch.setattr(
         server,

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -211,6 +211,75 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     assert server._engine.kwargs.get("force_text") is False
 
 
+def test_load_model_preflights_mllm_runtime_before_engine_construction(monkeypatch):
+    """Desktop/direct callers must fail before any model weights are touched."""
+    from vllm_mlx import server
+    from vllm_mlx.models import mllm
+
+    _stub_routing_globals(monkeypatch, server)
+    monkeypatch.setattr(
+        server,
+        "_resolve_serving_checkpoint",
+        lambda _name, **_kwargs: server._ServingCheckpoint(
+            model_path="publisher/vision-model",
+            load_path="/cache/vision-model",
+            auto_text_fallback=False,
+            lane_reason="vision_checkpoint",
+            is_mllm=True,
+        ),
+    )
+    constructed = []
+
+    class _MustNotConstruct:
+        def __init__(self, *args, **kwargs):
+            constructed.append((args, kwargs))
+
+    monkeypatch.setattr(server, "BatchedEngine", _MustNotConstruct)
+    monkeypatch.setattr(
+        mllm,
+        "_require_mlx_vlm",
+        lambda model_name=None: (_ for _ in ()).throw(
+            ImportError(f"vision runtime unavailable for {model_name}")
+        ),
+    )
+
+    with pytest.raises(ImportError, match="/cache/vision-model"):
+        server.load_model("publisher/vision-model", force_mllm=True)
+
+    assert constructed == []
+
+
+def test_load_model_explicit_text_lane_does_not_require_vision_runtime(monkeypatch):
+    """A supported explicit text-only route remains usable without mlx-vlm."""
+    from vllm_mlx import server
+    from vllm_mlx.models import mllm
+
+    _stub_routing_globals(monkeypatch, server)
+    monkeypatch.setattr(
+        server,
+        "_resolve_serving_checkpoint",
+        lambda _name, **_kwargs: server._ServingCheckpoint(
+            model_path="publisher/hybrid-model",
+            load_path="/cache/hybrid-model",
+            auto_text_fallback=False,
+            lane_reason="forced_text",
+            is_mllm=False,
+        ),
+    )
+    monkeypatch.setattr(
+        mllm,
+        "_require_mlx_vlm",
+        lambda model_name=None: (_ for _ in ()).throw(
+            AssertionError("text-only lane must not inspect mlx-vlm")
+        ),
+    )
+
+    server.load_model("publisher/hybrid-model", force_text=True)
+
+    assert server._engine is not None
+    assert server._engine.kwargs["force_text"] is True
+
+
 def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypatch):
     """CLI alias identity must survive its early alias-to-repo normalization."""
     from types import SimpleNamespace

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -455,6 +455,50 @@ def test_routing_metadata_download_defers_to_configured_mirror(monkeypatch):
     assert server._prefetch_routing_metadata("publisher/model") == "publisher/model"
 
 
+def test_routing_metadata_hub_failure_raises_without_mirror(monkeypatch):
+    from vllm_mlx import server
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "")
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("HF blocked")),
+    )
+
+    with pytest.raises(OSError, match="HF blocked"):
+        server._prefetch_routing_metadata("publisher/model")
+
+
+def test_routing_metadata_requires_hub_revision(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    monkeypatch.setattr(
+        "huggingface_hub.model_info", lambda _repo: SimpleNamespace(sha=None)
+    )
+
+    with pytest.raises(RuntimeError, match="did not include a revision"):
+        server._prefetch_routing_metadata("publisher/model")
+
+
+def test_routing_metadata_download_failure_raises_without_mirror(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "")
+    monkeypatch.setattr(
+        "huggingface_hub.model_info", lambda _repo: SimpleNamespace(sha="abc123")
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("CDN blocked")),
+    )
+
+    with pytest.raises(OSError, match="CDN blocked"):
+        server._prefetch_routing_metadata("publisher/model")
+
+
 def test_routing_metadata_prefetch_reuses_complete_warm_cache(monkeypatch):
     from types import SimpleNamespace
 
@@ -704,7 +748,11 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
         load_path="/cache/snapshots/revision",
         auto_text_fallback=auto_text_fallback,
         lane_reason=lane_reason,
+        is_mllm=True,
     )
+
+    vision_checks = []
+    monkeypatch.setattr("vllm_mlx.models.mllm._require_mlx_vlm", vision_checks.append)
 
     def resolve_once(model_name, **kwargs):
         calls.append((model_name, kwargs))
@@ -724,6 +772,7 @@ async def test_startup_and_runtime_use_identical_checkpoint_lane_contract(
     startup = server._model_registry.get_entry("publisher/model")
     assert startup.experimental is True
     assert runtime.experimental is True
+    assert vision_checks == ["/cache/snapshots/revision"] * 2
 
     assert calls == [
         (

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -119,7 +119,6 @@ def test_load_model_tracks_explicit_served_model_name(monkeypatch, served, expec
     # #2518: no config prefetch — the repo id is a label for the stub engine.
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
     monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
-    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit", served_model_name=served)
 
@@ -291,8 +290,9 @@ def test_load_model_explicit_text_lane_does_not_require_vision_runtime(monkeypat
 
 def test_metadata_preflight_rejects_before_subfolder_weight_download(monkeypatch):
     """A subfolder VLM must fail before its complete checkpoint is fetched."""
-    from vllm_mlx import server
-    from vllm_mlx.api import utils as api_utils
+    from types import SimpleNamespace
+
+    from vllm_mlx import model_metadata, server
     from vllm_mlx.models import mllm
 
     monkeypatch.setattr(
@@ -300,8 +300,14 @@ def test_metadata_preflight_rejects_before_subfolder_weight_download(monkeypatch
         "_prefetch_routing_metadata",
         lambda _name: "/cache/metadata-only/vision-model",
     )
-    monkeypatch.setattr(api_utils, "is_mllm_model", lambda _name: True)
-    monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda _name: None)
+    monkeypatch.setattr(
+        model_metadata,
+        "read_model_metadata",
+        lambda _name: SimpleNamespace(snapshot_dir="/cache/metadata-only", config={}),
+    )
+    monkeypatch.setattr(
+        model_metadata, "checkpoint_has_multimodal_weights", lambda *_args: True
+    )
     monkeypatch.setattr(
         "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
         lambda _name: (_ for _ in ()).throw(
@@ -317,6 +323,42 @@ def test_metadata_preflight_rejects_before_subfolder_weight_download(monkeypatch
     )
 
     with pytest.raises(ImportError, match="metadata-only"):
+        server._resolve_serving_checkpoint("publisher/vision-alias")
+
+
+def test_inconclusive_metadata_preflight_defers_runtime_rejection(monkeypatch):
+    """Config-only evidence may be a text-only single-file fork."""
+    from types import SimpleNamespace
+
+    from vllm_mlx import model_metadata, server
+    from vllm_mlx.models import mllm
+
+    monkeypatch.setattr(
+        server,
+        "_prefetch_routing_metadata",
+        lambda _name: "/cache/metadata-only/vision-model",
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "read_model_metadata",
+        lambda _name: SimpleNamespace(snapshot_dir="/cache/metadata-only", config={}),
+    )
+    monkeypatch.setattr(
+        model_metadata, "checkpoint_has_multimodal_weights", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        mllm,
+        "_require_mlx_vlm",
+        lambda _name=None: (_ for _ in ()).throw(
+            AssertionError("inconclusive metadata must not reject before weights")
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
+        lambda _name: (_ for _ in ()).throw(RuntimeError("full resolution reached")),
+    )
+
+    with pytest.raises(RuntimeError, match="full resolution reached"):
         server._resolve_serving_checkpoint("publisher/vision-alias")
 
 
@@ -647,21 +689,25 @@ def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
     assert state["materialized"] is True
 
 
-def test_ensure_routing_config_skips_prefetch_when_config_already_readable(monkeypatch):
-    """Warm cache / local checkpoint: config already readable → no download is
-    attempted (keeps warm starts and the unit suite fully offline)."""
+def test_ensure_routing_config_completes_remote_snapshot_with_readable_config(
+    monkeypatch,
+):
+    """A metadata-only remote snapshot must still materialize its weights."""
     from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
     monkeypatch.setattr(mm, "read_model_metadata", lambda name: object())
 
-    def _must_not_run(name):  # pragma: no cover - asserted never called
-        raise AssertionError("prefetch must be skipped when config is readable")
+    downloaded = []
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _must_not_run)
+    def _complete_snapshot(name):
+        downloaded.append(name)
+
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _complete_snapshot)
 
     server._ensure_routing_config("mlx-community/Qwen3.5-9B-4bit")
+    assert downloaded == ["mlx-community/Qwen3.5-9B-4bit"]
 
 
 def test_ensure_routing_config_propagates_disk_gate_systemexit(monkeypatch):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -363,6 +363,8 @@ def test_inconclusive_metadata_preflight_defers_runtime_rejection(monkeypatch):
 
 
 def test_routing_metadata_prefetch_excludes_weight_shards(monkeypatch):
+    from types import SimpleNamespace
+
     from vllm_mlx import server
 
     calls = []
@@ -372,6 +374,10 @@ def test_routing_metadata_prefetch_excludes_weight_shards(monkeypatch):
     )
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_subfolder", lambda _name: "4bit"
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda _repo: SimpleNamespace(sha="abc123"),
     )
     monkeypatch.setattr(
         "huggingface_hub.snapshot_download",
@@ -385,13 +391,69 @@ def test_routing_metadata_prefetch_excludes_weight_shards(monkeypatch):
         (
             "publisher/multi-variant",
             {
+                "revision": "abc123",
                 "allow_patterns": [
                     "4bit/config.json",
                     "4bit/model.safetensors.index.json",
-                ]
+                ],
             },
         )
     ]
+
+
+def test_routing_metadata_prefetch_preserves_external_local_model(
+    tmp_path, monkeypatch
+):
+    from vllm_mlx import server
+
+    external = tmp_path / "publisher" / "model"
+    external.mkdir(parents=True)
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model", lambda _name: str(external)
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("local external model must not reach the Hub")
+        ),
+    )
+
+    assert server._prefetch_routing_metadata("publisher/model") == str(external)
+
+
+def test_speculative_decode_skips_vision_runtime_preflight(monkeypatch):
+    from vllm_mlx import server
+    from vllm_mlx.api.utils import ServingLaneDecision
+
+    monkeypatch.setattr(
+        server,
+        "_prefetch_routing_metadata",
+        lambda _name: (_ for _ in ()).throw(
+            AssertionError("speculative decode selects the text lane")
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
+        lambda name: name,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_metadata.read_model_metadata", lambda _name: None
+    )
+    monkeypatch.setattr(
+        server,
+        "resolve_serving_lane_decision",
+        lambda *_args, **_kwargs: ServingLaneDecision(
+            False, "text_lane_speculative_decode", auto_text_fallback=True
+        ),
+    )
+
+    resolved = server._resolve_serving_checkpoint(
+        "publisher/vision-model",
+        force_mllm=True,
+        requested_spec_decode="mtp",
+    )
+
+    assert resolved.is_mllm is False
 
 
 def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypatch):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -86,6 +86,7 @@ def test_load_model_enables_native_tool_format_when_parser_supports_it(monkeypat
     # fetch — skip the config prefetch so the empty hermetic cache never turns
     # this into a real download.
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit")
 
@@ -117,6 +118,8 @@ def test_load_model_tracks_explicit_served_model_name(monkeypatch, served, expec
     monkeypatch.setattr(server, "_served_model_name_set", not expected, raising=False)
     # #2518: no config prefetch — the repo id is a label for the stub engine.
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit", served_model_name=served)
 
@@ -135,6 +138,7 @@ def _stub_routing_globals(monkeypatch, server):
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_enable_tool_logits_bias", False, raising=False)
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
 
 def test_load_model_materializes_config_before_hybrid_routing_probe(
@@ -201,6 +205,7 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
 
     _stub_routing_globals(monkeypatch, server)
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
     monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: True)
     monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda name: None)
     # This routing unit test runs in the Linux/no-MLX CI lane. Runtime health
@@ -282,6 +287,69 @@ def test_load_model_explicit_text_lane_does_not_require_vision_runtime(monkeypat
 
     assert server._engine is not None
     assert server._engine.kwargs["force_text"] is True
+
+
+def test_metadata_preflight_rejects_before_subfolder_weight_download(monkeypatch):
+    """A subfolder VLM must fail before its complete checkpoint is fetched."""
+    from vllm_mlx import server
+    from vllm_mlx.api import utils as api_utils
+    from vllm_mlx.models import mllm
+
+    monkeypatch.setattr(
+        server,
+        "_prefetch_routing_metadata",
+        lambda _name: "/cache/metadata-only/vision-model",
+    )
+    monkeypatch.setattr(api_utils, "is_mllm_model", lambda _name: True)
+    monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda _name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
+        lambda _name: (_ for _ in ()).throw(
+            AssertionError("weight-bearing subfolder resolution ran too early")
+        ),
+    )
+    monkeypatch.setattr(
+        mllm,
+        "_require_mlx_vlm",
+        lambda model_name=None: (_ for _ in ()).throw(
+            ImportError(f"invalid vision runtime for {model_name}")
+        ),
+    )
+
+    with pytest.raises(ImportError, match="metadata-only"):
+        server._resolve_serving_checkpoint("publisher/vision-alias")
+
+
+def test_routing_metadata_prefetch_excludes_weight_shards(monkeypatch):
+    from vllm_mlx import server
+
+    calls = []
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda _name: "publisher/multi-variant",
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_subfolder", lambda _name: "4bit"
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda repo, **kwargs: calls.append((repo, kwargs)) or "/cache/snapshot",
+    )
+
+    path = server._prefetch_routing_metadata("vision-4bit")
+
+    assert path == "/cache/snapshot/4bit"
+    assert calls == [
+        (
+            "publisher/multi-variant",
+            {
+                "allow_patterns": [
+                    "4bit/config.json",
+                    "4bit/model.safetensors.index.json",
+                ]
+            },
+        )
+    ]
 
 
 def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypatch):
@@ -382,6 +450,7 @@ def test_materialized_checkpoint_keeps_catalog_vision_memory_floor(monkeypatch):
         lambda _name: ModelProfile(vision_min_memory_gb=32.0),
     )
     monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
     monkeypatch.setattr(
         model_metadata,
         "read_model_metadata",
@@ -629,6 +698,7 @@ def test_load_model_infers_programmatic_max_tokens_explicit(monkeypatch):
     monkeypatch.setattr(server, "_model_alias", None, raising=False)
     # #2518: no config prefetch — the repo id is a label for the stub engine.
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     server.load_model("mlx-community/Qwen3.5-9B-4bit")
     cfg = get_config()
@@ -676,6 +746,7 @@ def test_load_model_mtp_kwarg_translates_to_scheduler_config(
     # (``scheduler_config_stub`` shims ``mlx`` on the no-MLX lane, so the
     # ``importorskip`` above does NOT skip this test there.)
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     with pytest.warns(DeprecationWarning, match="load_model\\(mtp=True\\)"):
         server.load_model("mlx-community/Qwen3.5-9B-4bit", mtp=True)
@@ -779,6 +850,7 @@ def test_load_model_response_cache_reconfigure_failure_forces_disabled(monkeypat
 
     # #2518: no config prefetch — the repo id is a label for the stub engine.
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
+    monkeypatch.setattr(server, "_prefetch_routing_metadata", lambda name: name)
 
     # load_model must NOT raise (best-effort), but must force the cache safe.
     server.load_model("mlx-community/Qwen3.5-9B-4bit")

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -197,11 +197,15 @@ def test_load_model_genuine_vlm_stays_on_mllm_lane(monkeypatch):
     so a working VLM is never downgraded."""
     from vllm_mlx import server
     from vllm_mlx.api import utils as api_utils
+    from vllm_mlx.models import mllm
 
     _stub_routing_globals(monkeypatch, server)
     monkeypatch.setattr(server, "_ensure_routing_config", lambda name: None)
     monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: True)
     monkeypatch.setattr(api_utils, "mllm_backbone_cache_mode", lambda name: None)
+    # This routing unit test runs in the Linux/no-MLX CI lane. Runtime health
+    # is covered separately; keep this assertion focused on lane selection.
+    monkeypatch.setattr(mllm, "_require_mlx_vlm", lambda model_name=None: None)
 
     server.load_model("some/genuine-vlm-4bit")
 

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -426,6 +426,18 @@ def test_routing_metadata_prefetch_preserves_external_local_model(
     assert server._prefetch_routing_metadata("publisher/model") == str(external)
 
 
+def test_routing_metadata_prefetch_defers_to_configured_mirror(monkeypatch):
+    from vllm_mlx import server
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.example.test")
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("HF blocked")),
+    )
+
+    assert server._prefetch_routing_metadata("publisher/model") == "publisher/model"
+
+
 def test_routing_metadata_prefetch_reuses_complete_warm_cache(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -485,7 +485,6 @@ def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeyp
     crashing MLLM engine (#352). Assert it fails fast with an actionable error
     instead.
     """
-    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -501,7 +500,7 @@ def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeyp
         called["prefetch"] = True  # ran, but errored + put no config on disk
         raise original_err
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _failing_prefetch)
+    monkeypatch.setattr(server, "_prefetch_routing_config", _failing_prefetch)
 
     with pytest.raises(RuntimeError) as excinfo:
         server._ensure_routing_config(model)
@@ -527,7 +526,6 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
     attributable."""
     import logging
 
-    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -543,7 +541,7 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
         state["materialized"] = True
         raise OSError("connection reset mid-download")
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _partial_prefetch)
+    monkeypatch.setattr(server, "_prefetch_routing_config", _partial_prefetch)
 
     with caplog.at_level(logging.WARNING, logger="vllm_mlx.server"):
         # Config is readable afterward → no raise.
@@ -551,13 +549,12 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
 
     joined = " ".join(rec.message for rec in caplog.records)
     assert "connection reset mid-download" in joined
-    assert "partially downloaded" in joined
+    assert "later weight loading" in joined
 
 
 def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
     """Happy path for the first-time uncached startup: config is absent, the
     prefetch materializes it, and ``_ensure_routing_config`` returns cleanly."""
-    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -571,7 +568,7 @@ def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
     def _fake_prefetch(name):
         state["materialized"] = True
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _fake_prefetch)
+    monkeypatch.setattr(server, "_prefetch_routing_config", _fake_prefetch)
 
     # Must not raise.
     server._ensure_routing_config("some/uncached-but-fetchable-4bit")
@@ -581,7 +578,6 @@ def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
 def test_ensure_routing_config_skips_prefetch_when_config_already_readable(monkeypatch):
     """Warm cache / local checkpoint: config already readable → no download is
     attempted (keeps warm starts and the unit suite fully offline)."""
-    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -590,27 +586,45 @@ def test_ensure_routing_config_skips_prefetch_when_config_already_readable(monke
     def _must_not_run(name):  # pragma: no cover - asserted never called
         raise AssertionError("prefetch must be skipped when config is readable")
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _must_not_run)
+    monkeypatch.setattr(server, "_prefetch_routing_config", _must_not_run)
 
     server._ensure_routing_config("mlx-community/Qwen3.5-9B-4bit")
 
 
-def test_ensure_routing_config_propagates_disk_gate_systemexit(monkeypatch):
-    """The intentional hard disk-space gate (``SystemExit``) from the prefetch
-    must propagate unchanged — it is a fail-fast, not a swallowable hiccup."""
-    from vllm_mlx import cli as cli_mod
+def test_ensure_routing_config_propagates_metadata_prefetch_systemexit(monkeypatch):
+    """Control-flow exits from the metadata prefetch must propagate unchanged."""
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
     monkeypatch.setattr(mm, "read_model_metadata", lambda name: None)
 
-    def _disk_gate(name):
+    def _metadata_exit(name):
         raise SystemExit(1)
 
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _disk_gate)
+    monkeypatch.setattr(server, "_prefetch_routing_config", _metadata_exit)
 
     with pytest.raises(SystemExit):
         server._ensure_routing_config("some/uncached-4bit")
+
+
+def test_routing_prefetch_requests_config_only(monkeypatch):
+    """The pre-lane fetch must never include model weight files (#2860)."""
+    from vllm_mlx import server
+
+    calls = []
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda repo, **kwargs: calls.append((repo, kwargs)),
+    )
+
+    server._prefetch_routing_config("publisher/vision-model")
+
+    assert calls == [
+        (
+            "publisher/vision-model",
+            {"allow_patterns": ["config.json", "*/config.json"]},
+        )
+    ]
 
 
 def test_load_model_infers_programmatic_max_tokens_explicit(monkeypatch):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -438,6 +438,23 @@ def test_routing_metadata_prefetch_defers_to_configured_mirror(monkeypatch):
     assert server._prefetch_routing_metadata("publisher/model") == "publisher/model"
 
 
+def test_routing_metadata_download_defers_to_configured_mirror(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.example.test")
+    monkeypatch.setattr(
+        "huggingface_hub.model_info", lambda _repo: SimpleNamespace(sha="abc123")
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("CDN blocked")),
+    )
+
+    assert server._prefetch_routing_metadata("publisher/model") == "publisher/model"
+
+
 def test_routing_metadata_prefetch_reuses_complete_warm_cache(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -309,6 +309,11 @@ def test_metadata_preflight_rejects_before_subfolder_weight_download(monkeypatch
         model_metadata, "checkpoint_has_multimodal_weights", lambda *_args: True
     )
     monkeypatch.setattr(
+        server,
+        "resolve_serving_lane_decision",
+        lambda *_args, **_kwargs: SimpleNamespace(is_mllm=True),
+    )
+    monkeypatch.setattr(
         "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint",
         lambda _name: (_ for _ in ()).throw(
             AssertionError("weight-bearing subfolder resolution ran too early")
@@ -419,6 +424,74 @@ def test_routing_metadata_prefetch_preserves_external_local_model(
     )
 
     assert server._prefetch_routing_metadata("publisher/model") == str(external)
+
+
+def test_routing_metadata_prefetch_reuses_complete_warm_cache(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import model_metadata, server
+
+    cached = "/cache/snapshots/abc123"
+    monkeypatch.setattr(
+        model_metadata,
+        "read_model_metadata",
+        lambda _name: SimpleNamespace(snapshot_dir=cached),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate._snapshot_is_complete", lambda path: path == cached
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("complete warm cache must not reach the Hub")
+        ),
+    )
+
+    assert server._prefetch_routing_metadata("publisher/model") == cached
+
+
+def test_vision_preflight_honors_automatic_text_fallback(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import model_metadata, server
+    from vllm_mlx.models import mllm
+
+    monkeypatch.setattr(
+        server, "_prefetch_routing_metadata", lambda _name: "/cache/vision-model"
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "read_model_metadata",
+        lambda _name: SimpleNamespace(snapshot_dir="/cache", config={}),
+    )
+    monkeypatch.setattr(
+        model_metadata, "checkpoint_has_multimodal_weights", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        server,
+        "resolve_serving_lane_decision",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            is_mllm=False,
+            auto_text_fallback=True,
+            reason="vision_memory_insufficient",
+        ),
+    )
+    monkeypatch.setattr(
+        mllm,
+        "_require_mlx_vlm",
+        lambda _name=None: (_ for _ in ()).throw(
+            AssertionError("text fallback must not require mlx-vlm")
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer._resolve_subfolder_checkpoint", lambda name: name
+    )
+    monkeypatch.setattr(server, "_ensure_routing_config", lambda _name: None)
+
+    resolved = server._resolve_serving_checkpoint("publisher/vision-model")
+
+    assert resolved.is_mllm is False
+    assert resolved.lane_reason == "vision_memory_insufficient"
 
 
 def test_speculative_decode_skips_vision_runtime_preflight(monkeypatch):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -602,6 +602,22 @@ def test_speculative_decode_skips_vision_runtime_preflight(monkeypatch):
     assert resolved.is_mllm is False
 
 
+def test_forced_mllm_preflight_checks_resolved_model_without_metadata(monkeypatch):
+    from vllm_mlx import server
+
+    checks = []
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda _name: "publisher/resolved-vision-model",
+    )
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _name: None)
+    monkeypatch.setattr("vllm_mlx.models.mllm._require_mlx_vlm", checks.append)
+
+    server._preflight_vision_runtime("vision-alias", force_mllm=True)
+
+    assert checks == ["publisher/resolved-vision-model"]
+
+
 def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypatch):
     """CLI alias identity must survive its early alias-to-repo normalization."""
     from types import SimpleNamespace

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -485,6 +485,7 @@ def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeyp
     crashing MLLM engine (#352). Assert it fails fast with an actionable error
     instead.
     """
+    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -500,7 +501,7 @@ def test_ensure_routing_config_raises_when_prefetch_does_not_materialize(monkeyp
         called["prefetch"] = True  # ran, but errored + put no config on disk
         raise original_err
 
-    monkeypatch.setattr(server, "_prefetch_routing_config", _failing_prefetch)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _failing_prefetch)
 
     with pytest.raises(RuntimeError) as excinfo:
         server._ensure_routing_config(model)
@@ -526,6 +527,7 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
     attributable."""
     import logging
 
+    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -541,7 +543,7 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
         state["materialized"] = True
         raise OSError("connection reset mid-download")
 
-    monkeypatch.setattr(server, "_prefetch_routing_config", _partial_prefetch)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _partial_prefetch)
 
     with caplog.at_level(logging.WARNING, logger="vllm_mlx.server"):
         # Config is readable afterward → no raise.
@@ -549,12 +551,13 @@ def test_ensure_routing_config_warns_when_prefetch_errors_but_config_lands(
 
     joined = " ".join(rec.message for rec in caplog.records)
     assert "connection reset mid-download" in joined
-    assert "later weight loading" in joined
+    assert "partially downloaded" in joined
 
 
 def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
     """Happy path for the first-time uncached startup: config is absent, the
     prefetch materializes it, and ``_ensure_routing_config`` returns cleanly."""
+    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -568,7 +571,7 @@ def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
     def _fake_prefetch(name):
         state["materialized"] = True
 
-    monkeypatch.setattr(server, "_prefetch_routing_config", _fake_prefetch)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _fake_prefetch)
 
     # Must not raise.
     server._ensure_routing_config("some/uncached-but-fetchable-4bit")
@@ -578,6 +581,7 @@ def test_ensure_routing_config_succeeds_when_prefetch_materializes(monkeypatch):
 def test_ensure_routing_config_skips_prefetch_when_config_already_readable(monkeypatch):
     """Warm cache / local checkpoint: config already readable → no download is
     attempted (keeps warm starts and the unit suite fully offline)."""
+    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
@@ -586,45 +590,27 @@ def test_ensure_routing_config_skips_prefetch_when_config_already_readable(monke
     def _must_not_run(name):  # pragma: no cover - asserted never called
         raise AssertionError("prefetch must be skipped when config is readable")
 
-    monkeypatch.setattr(server, "_prefetch_routing_config", _must_not_run)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _must_not_run)
 
     server._ensure_routing_config("mlx-community/Qwen3.5-9B-4bit")
 
 
-def test_ensure_routing_config_propagates_metadata_prefetch_systemexit(monkeypatch):
-    """Control-flow exits from the metadata prefetch must propagate unchanged."""
+def test_ensure_routing_config_propagates_disk_gate_systemexit(monkeypatch):
+    """The intentional hard disk-space gate (``SystemExit``) from the prefetch
+    must propagate unchanged — it is a fail-fast, not a swallowable hiccup."""
+    from vllm_mlx import cli as cli_mod
     from vllm_mlx import model_metadata as mm
     from vllm_mlx import server
 
     monkeypatch.setattr(mm, "read_model_metadata", lambda name: None)
 
-    def _metadata_exit(name):
+    def _disk_gate(name):
         raise SystemExit(1)
 
-    monkeypatch.setattr(server, "_prefetch_routing_config", _metadata_exit)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", _disk_gate)
 
     with pytest.raises(SystemExit):
         server._ensure_routing_config("some/uncached-4bit")
-
-
-def test_routing_prefetch_requests_config_only(monkeypatch):
-    """The pre-lane fetch must never include model weight files (#2860)."""
-    from vllm_mlx import server
-
-    calls = []
-    monkeypatch.setattr(
-        "huggingface_hub.snapshot_download",
-        lambda repo, **kwargs: calls.append((repo, kwargs)),
-    )
-
-    server._prefetch_routing_config("publisher/vision-model")
-
-    assert calls == [
-        (
-            "publisher/vision-model",
-            {"allow_patterns": ["config.json", "*/config.json"]},
-        )
-    ]
 
 
 def test_load_model_infers_programmatic_max_tokens_explicit(monkeypatch):

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -98,3 +98,16 @@ def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):
 
     assert "Reinstall Rapid-MLX Desktop.app" in hint
     assert "pip install" not in hint
+
+
+def test_standalone_repair_commands_shell_quote_python_path(monkeypatch):
+    monkeypatch.setattr(
+        mllm.sys, "executable", "/Users/alice/My Runtime/bin/python's preview"
+    )
+
+    install_hint = mllm._vision_install_hint()
+    dependency_hint = mllm._vlm_broken_install_hint("PIL")
+
+    quoted = "'/Users/alice/My Runtime/bin/python'\"'\"'s preview'"
+    assert f"{quoted} -m pip" in install_hint
+    assert f"{quoted} -m pip" in dependency_hint

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for multimodal runtime fail-fast handling (#2860)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.models import mllm
+
+
+def test_vision_runtime_reports_incompatible_mlx_vlm_version(monkeypatch):
+    monkeypatch.setattr(mllm, "version", lambda _distribution: "0.7.0")
+
+    status, detail = mllm.vision_runtime_status()
+
+    assert status is mllm.VisionRuntimeStatus.INCOMPATIBLE
+    assert detail == "0.7.0"
+
+
+def test_cli_incompatible_runtime_is_actionable_and_not_reported_as_oom(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        mllm,
+        "vision_runtime_status",
+        lambda: (mllm.VisionRuntimeStatus.INCOMPATIBLE, "installed 0.7.0"),
+    )
+    monkeypatch.setattr(mllm, "_managed_desktop_runtime", lambda: False)
+    monkeypatch.setattr(mllm.sys, "executable", "/active/runtime/bin/python")
+
+    with pytest.raises(SystemExit) as exc_info:
+        mllm.require_mlx_vlm_or_exit("publisher/vision-model")
+
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "installed 0.7.0" in stderr
+    assert "not a Metal out-of-memory error" in stderr
+    assert "/active/runtime/bin/python -m pip" in stderr
+    assert f"mlx-vlm=={mllm.VALIDATED_MLX_VLM_VERSION}" in stderr
+
+
+def test_engine_guard_reports_missing_runtime_with_model_context(monkeypatch):
+    monkeypatch.setattr(
+        mllm,
+        "vision_runtime_status",
+        lambda: (mllm.VisionRuntimeStatus.ABSENT, "mlx_vlm"),
+    )
+
+    with pytest.raises(ImportError) as exc_info:
+        mllm._require_mlx_vlm("publisher/vision-model")
+
+    message = str(exc_info.value)
+    assert "publisher/vision-model" in message
+    assert "optional `mlx-vlm` dependency" in message
+
+
+def test_validated_runtime_version_is_accepted(monkeypatch):
+    monkeypatch.setattr(
+        mllm, "version", lambda _distribution: mllm.VALIDATED_MLX_VLM_VERSION
+    )
+
+    status, detail = mllm.vision_runtime_status()
+
+    assert status is mllm.VisionRuntimeStatus.OK
+    assert detail is None

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -160,6 +160,41 @@ def test_unrelated_app_runtime_is_not_managed(monkeypatch, tmp_path):
     assert mllm._managed_desktop_runtime_kind() is None
 
 
+def test_embedded_runtime_without_valid_plist_is_not_managed(monkeypatch, tmp_path):
+    app = tmp_path / "Rapid-MLX Desktop.app"
+    executable = app / "Contents/Resources/rapid-mlx/python/bin/python3.12"
+    executable.parent.mkdir(parents=True)
+    monkeypatch.setattr(mllm.sys, "executable", str(executable))
+
+    assert mllm._managed_desktop_runtime_kind() is None
+
+
+def test_vision_runtime_reports_missing_distribution_metadata(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "mlx_vlm", object())
+    monkeypatch.setattr(
+        mllm,
+        "version",
+        lambda _name: (_ for _ in ()).throw(mllm.PackageNotFoundError()),
+    )
+
+    assert mllm.vision_runtime_status() == (
+        mllm.VisionRuntimeStatus.BROKEN,
+        "mlx-vlm version metadata unavailable",
+    )
+
+
+def test_require_mlx_vlm_rejects_incompatible_runtime(monkeypatch):
+    monkeypatch.setattr(
+        mllm,
+        "vision_runtime_status",
+        lambda: (mllm.VisionRuntimeStatus.INCOMPATIBLE, "0.7.0"),
+    )
+    monkeypatch.setattr(mllm, "_vision_install_hint", lambda: "repair runtime")
+
+    with pytest.raises(ImportError, match="installed mlx-vlm '0.7.0'"):
+        mllm._require_mlx_vlm("publisher/vision-model")
+
+
 def test_standalone_repair_commands_shell_quote_python_path(monkeypatch):
     monkeypatch.setattr(
         mllm.sys, "executable", "/Users/alice/My Runtime/bin/python's preview"

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -86,6 +86,20 @@ def test_runtime_override_repair_hint_requires_removal_after_app_install(monkeyp
     assert " -m pip install" not in hint
 
 
+def test_runtime_override_repair_hint_uses_active_custom_home(monkeypatch):
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        "/tmp/dogfood-home/Library/Application Support/Rapid/runtime-override/"
+        "rapid-mlx/python/bin/python3.12",
+    )
+
+    hint = mllm._vision_install_hint()
+
+    assert "/tmp/dogfood-home/Library/Application Support/Rapid/" in hint
+    assert "~/Library/Application Support" not in hint
+
+
 def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):
     monkeypatch.setattr(
         mllm.sys,

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -68,3 +68,33 @@ def test_validated_runtime_version_is_accepted(monkeypatch):
 
     assert status is mllm.VisionRuntimeStatus.OK
     assert detail is None
+
+
+def test_runtime_override_repair_hint_requires_removal_after_app_install(monkeypatch):
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        "/Users/alice/Library/Application Support/Rapid/runtime-override/"
+        "rapid-mlx/python/bin/python3.12",
+    )
+
+    hint = mllm._vision_install_hint()
+
+    assert "Install the current Rapid-MLX Desktop.app first" in hint
+    assert "then remove" in hint
+    assert "runtime-override/rapid-mlx" in hint
+    assert " -m pip install" not in hint
+
+
+def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        "/Applications/Rapid-MLX Desktop.app/Contents/Resources/rapid-mlx/"
+        "python/bin/python3.12",
+    )
+
+    hint = mllm._vlm_broken_install_hint("PIL")
+
+    assert "Reinstall Rapid-MLX Desktop.app" in hint
+    assert "pip install" not in hint

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -3,12 +3,16 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import pytest
 
 from vllm_mlx.models import mllm
 
 
 def test_vision_runtime_reports_incompatible_mlx_vlm_version(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mlx_vlm", ModuleType("mlx_vlm"))
     monkeypatch.setattr(mllm, "version", lambda _distribution: "0.7.0")
 
     status, detail = mllm.vision_runtime_status()
@@ -55,6 +59,7 @@ def test_engine_guard_reports_missing_runtime_with_model_context(monkeypatch):
 
 
 def test_validated_runtime_version_is_accepted(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mlx_vlm", ModuleType("mlx_vlm"))
     monkeypatch.setattr(
         mllm, "version", lambda _distribution: mllm.VALIDATED_MLX_VLM_VERSION
     )

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -113,6 +113,19 @@ def test_noncanonical_override_path_is_not_managed(monkeypatch):
     assert mllm._managed_desktop_runtime_kind() is None
 
 
+def test_runtime_override_stays_managed_without_home(monkeypatch):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        "/tmp/dogfood/Library/Application Support/Rapid/runtime-override/"
+        "rapid-mlx/python/bin/python3.12",
+    )
+
+    assert mllm._managed_desktop_runtime_kind() == "runtime-override"
+    assert "pip-install into" in mllm._vision_install_hint()
+
+
 def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):
     monkeypatch.setattr(
         mllm.sys,

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import plistlib
 import sys
 from types import ModuleType
 
@@ -126,18 +127,37 @@ def test_runtime_override_stays_managed_without_home(monkeypatch):
     assert "pip-install into" in mllm._vision_install_hint()
 
 
-def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):
+def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch, tmp_path):
+    app = tmp_path / "Rapid-MLX Desktop.app"
+    info = app / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True)
+    with info.open("wb") as handle:
+        plistlib.dump({"CFBundleIdentifier": "com.rapidmlx.rapid"}, handle)
     monkeypatch.setattr(
         mllm.sys,
         "executable",
-        "/Applications/Rapid-MLX Desktop.app/Contents/Resources/rapid-mlx/"
-        "python/bin/python3.12",
+        str(app / "Contents/Resources/rapid-mlx/python/bin/python3.12"),
     )
 
     hint = mllm._vlm_broken_install_hint("PIL")
 
     assert "Reinstall Rapid-MLX Desktop.app" in hint
     assert "pip install" not in hint
+
+
+def test_unrelated_app_runtime_is_not_managed(monkeypatch, tmp_path):
+    app = tmp_path / "Unrelated.app"
+    info = app / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True)
+    with info.open("wb") as handle:
+        plistlib.dump({"CFBundleIdentifier": "com.example.unrelated"}, handle)
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        str(app / "Contents/Resources/rapid-mlx/python/bin/python3.12"),
+    )
+
+    assert mllm._managed_desktop_runtime_kind() is None
 
 
 def test_standalone_repair_commands_shell_quote_python_path(monkeypatch):

--- a/tests/test_vision_runtime_compatibility.py
+++ b/tests/test_vision_runtime_compatibility.py
@@ -71,6 +71,7 @@ def test_validated_runtime_version_is_accepted(monkeypatch):
 
 
 def test_runtime_override_repair_hint_requires_removal_after_app_install(monkeypatch):
+    monkeypatch.setenv("HOME", "/Users/alice")
     monkeypatch.setattr(
         mllm.sys,
         "executable",
@@ -87,6 +88,7 @@ def test_runtime_override_repair_hint_requires_removal_after_app_install(monkeyp
 
 
 def test_runtime_override_repair_hint_uses_active_custom_home(monkeypatch):
+    monkeypatch.setenv("HOME", "/tmp/dogfood-home")
     monkeypatch.setattr(
         mllm.sys,
         "executable",
@@ -98,6 +100,17 @@ def test_runtime_override_repair_hint_uses_active_custom_home(monkeypatch):
 
     assert "/tmp/dogfood-home/Library/Application Support/Rapid/" in hint
     assert "~/Library/Application Support" not in hint
+
+
+def test_noncanonical_override_path_is_not_managed(monkeypatch):
+    monkeypatch.setenv("HOME", "/Users/alice")
+    monkeypatch.setattr(
+        mllm.sys,
+        "executable",
+        "/Users/alice/Library/Application Support/Rapid/runtime-override/bin/python",
+    )
+
+    assert mllm._managed_desktop_runtime_kind() is None
 
 
 def test_managed_runtime_missing_dependency_never_recommends_pip(monkeypatch):

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -154,13 +154,19 @@ def _all_missing_are_multimodal(missing_names: list[str]) -> bool:
 VALIDATED_MLX_VLM_VERSION = "0.6.17"
 
 
+def _managed_desktop_runtime_kind() -> str | None:
+    """Return the Desktop-managed runtime slot for this interpreter."""
+    executable = str(Path(sys.executable).resolve())
+    if "/Library/Application Support/Rapid/runtime-override/" in executable:
+        return "runtime-override"
+    if ".app/Contents/Resources/rapid-mlx/" in executable:
+        return "embedded"
+    return None
+
+
 def _managed_desktop_runtime() -> bool:
     """Whether this interpreter belongs to a Desktop-managed runtime tree."""
-    executable = str(Path(sys.executable).resolve())
-    return (
-        ".app/Contents/Resources/rapid-mlx/" in executable
-        or "/Library/Application Support/Rapid/runtime-override/" in executable
-    )
+    return _managed_desktop_runtime_kind() is not None
 
 
 def _vision_install_hint() -> str:
@@ -171,10 +177,19 @@ def _vision_install_hint() -> str:
     Standalone environments use the active interpreter explicitly so a
     two-venv installation cannot repair the wrong environment.
     """
-    if _managed_desktop_runtime():
+    managed_kind = _managed_desktop_runtime_kind()
+    if managed_kind == "runtime-override":
         return (
-            "Repair or reinstall Rapid-MLX Desktop to restore its validated "
-            "vision runtime. Do not pip-install into the managed sidecar."
+            "Install the current Rapid-MLX Desktop.app first (its DMG ships a "
+            "validated sidecar), then remove "
+            "~/Library/Application Support/Rapid/runtime-override/rapid-mlx "
+            "and relaunch so Desktop uses the bundled sidecar. Do not "
+            "pip-install into the managed runtime override."
+        )
+    if managed_kind == "embedded":
+        return (
+            "Reinstall Rapid-MLX Desktop.app to restore its validated vision "
+            "runtime. Do not pip-install into the code-signed bundled sidecar."
         )
     python = sys.executable
     return (
@@ -334,10 +349,14 @@ def _vlm_broken_install_hint(detail: str | None) -> str:
     """
     if detail in _MISSING_MODULE_PIP_NAME:
         pip_name = _pip_name_for_module(detail)
-        return (
+        hint = (
             f"`mlx-vlm` is installed but its dependency {detail!r} is not, so "
-            f"the vision runtime cannot load. {_vision_install_hint()}\n"
-            f"Alternatively, repair just the missing dependency in this "
+            f"the vision runtime cannot load. {_vision_install_hint()}"
+        )
+        if _managed_desktop_runtime():
+            return hint
+        return (
+            hint + "\nAlternatively, repair just the missing dependency in this "
             f"runtime:\n    {sys.executable} -m pip install {pip_name}"
         )
     suffix = f" ({detail})" if detail else ""

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -20,6 +20,7 @@ import ipaddress
 import logging
 import math
 import os
+import plistlib
 import re
 import shlex
 import shutil
@@ -176,7 +177,28 @@ def _managed_desktop_runtime_kind() -> str | None:
             return "runtime-override"
         return None
     if ".app/Contents/Resources/rapid-mlx/" in executable:
-        return "embedded"
+        try:
+            root = executable_path.parents[2]
+            app_root = root.parents[2]
+            with (app_root / "Contents" / "Info.plist").open("rb") as handle:
+                bundle_id = plistlib.load(handle).get("CFBundleIdentifier", "")
+        except (IndexError, OSError, plistlib.InvalidFileException):
+            return None
+        if (
+            executable_path.parent.name == "bin"
+            and executable_path.parent.parent.name == "python"
+            and executable_path.name.startswith("python")
+            and root.name == "rapid-mlx"
+            and root.parent.name == "Resources"
+            and root.parent.parent.name == "Contents"
+            and app_root.name.endswith(".app")
+            and (
+                bundle_id == "com.rapidmlx.rapid"
+                or bundle_id.startswith("com.rapidmlx.rapid.dogfood-")
+            )
+        ):
+            return "embedded"
+        return None
     return None
 
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -157,9 +157,25 @@ VALIDATED_MLX_VLM_VERSION = "0.6.17"
 
 def _managed_desktop_runtime_kind() -> str | None:
     """Return the Desktop-managed runtime slot for this interpreter."""
-    executable = str(Path(sys.executable).resolve())
+    executable_path = Path(sys.executable).resolve()
+    executable = str(executable_path)
     if "/Library/Application Support/Rapid/runtime-override/" in executable:
-        return "runtime-override"
+        try:
+            root = executable_path.parents[2]
+            expected = (
+                Path(os.environ["HOME"]).expanduser().resolve()
+                / "Library/Application Support/Rapid/runtime-override/rapid-mlx"
+            ).resolve()
+        except (KeyError, IndexError, OSError):
+            return None
+        if (
+            executable_path.parent.name == "bin"
+            and executable_path.parent.parent.name == "python"
+            and executable_path.name.startswith("python")
+            and root == expected
+        ):
+            return "runtime-override"
+        return None
     if ".app/Contents/Resources/rapid-mlx/" in executable:
         return "embedded"
     return None

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -21,6 +21,7 @@ import logging
 import math
 import os
 import re
+import shlex
 import shutil
 import socket
 import stat
@@ -191,7 +192,7 @@ def _vision_install_hint() -> str:
             "Reinstall Rapid-MLX Desktop.app to restore its validated vision "
             "runtime. Do not pip-install into the code-signed bundled sidecar."
         )
-    python = sys.executable
+    python = shlex.quote(sys.executable)
     return (
         "Install the validated vision stack into this runtime with:\n"
         f"    {python} -m pip install --upgrade --force-reinstall "
@@ -357,7 +358,7 @@ def _vlm_broken_install_hint(detail: str | None) -> str:
             return hint
         return (
             hint + "\nAlternatively, repair just the missing dependency in this "
-            f"runtime:\n    {sys.executable} -m pip install {pip_name}"
+            f"runtime:\n    {shlex.quote(sys.executable)} -m pip install {pip_name}"
         )
     suffix = f" ({detail})" if detail else ""
     return (

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1468,7 +1468,7 @@ class MLXMultimodalLM:
         if self._loaded:
             return
 
-        _require_mlx_vlm(self.model_name)
+        _require_mlx_vlm()
 
         try:
             # Stable Transformers does not yet register the processor used by

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -162,17 +162,16 @@ def _managed_desktop_runtime_kind() -> str | None:
     if "/Library/Application Support/Rapid/runtime-override/" in executable:
         try:
             root = executable_path.parents[2]
-            expected = (
-                Path(os.environ["HOME"]).expanduser().resolve()
-                / "Library/Application Support/Rapid/runtime-override/rapid-mlx"
-            ).resolve()
-        except (KeyError, IndexError, OSError):
+        except (IndexError, OSError):
             return None
         if (
             executable_path.parent.name == "bin"
             and executable_path.parent.parent.name == "python"
             and executable_path.name.startswith("python")
-            and root == expected
+            and root.name == "rapid-mlx"
+            and root.parent.name == "runtime-override"
+            and root.parent.parent.name == "Rapid"
+            and root.parent.parent.parent.name == "Application Support"
         ):
             return "runtime-override"
         return None

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -30,6 +30,7 @@ import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
@@ -150,12 +151,45 @@ def _all_missing_are_multimodal(missing_names: list[str]) -> bool:
 # The bare-mlx-vlm line is pinned to the same validated runtime as the
 # ``rapid-mlx[vision]`` extra. Keeping both recovery paths aligned avoids
 # resolver-dependent behavior between direct installs and the packaged app.
-VLM_EXTRA_INSTALL_HINT = (
-    "Install it with:\n"
-    "    pip install 'rapid-mlx[vision]'\n"
-    "or directly (pinned to stay compatible with rapid-mlx's transformers pin):\n"
-    "    pip install 'mlx-vlm==0.6.17'"
-)
+VALIDATED_MLX_VLM_VERSION = "0.6.17"
+
+
+def _managed_desktop_runtime() -> bool:
+    """Whether this interpreter belongs to a Desktop-managed runtime tree."""
+    executable = str(Path(sys.executable).resolve())
+    return (
+        ".app/Contents/Resources/rapid-mlx/" in executable
+        or "/Library/Application Support/Rapid/runtime-override/" in executable
+    )
+
+
+def _vision_install_hint() -> str:
+    """Return a repair path that cannot accidentally target another Python.
+
+    A signed Desktop runtime is immutable product state: mutating it with pip
+    invalidates the tested dependency set (and can invalidate a bundle seal).
+    Standalone environments use the active interpreter explicitly so a
+    two-venv installation cannot repair the wrong environment.
+    """
+    if _managed_desktop_runtime():
+        return (
+            "Repair or reinstall Rapid-MLX Desktop to restore its validated "
+            "vision runtime. Do not pip-install into the managed sidecar."
+        )
+    python = sys.executable
+    return (
+        "Install the validated vision stack into this runtime with:\n"
+        f"    {python} -m pip install --upgrade --force-reinstall "
+        "'rapid-mlx[vision]'\n"
+        "or repair mlx-vlm directly (pinned to Rapid-MLX's validated set):\n"
+        f"    {python} -m pip install --upgrade --force-reinstall "
+        f"'mlx-vlm=={VALIDATED_MLX_VLM_VERSION}'"
+    )
+
+
+# Backwards-compatible public constant used by docs/tests. It is generated
+# from the active runtime so its commands cannot land in a different venv.
+VLM_EXTRA_INSTALL_HINT = _vision_install_hint()
 
 
 # Import-module → PyPI-distribution name for the runtime deps mlx-vlm
@@ -172,7 +206,7 @@ def _pip_name_for_module(module: str) -> str:
 
 
 class VisionRuntimeStatus(str, Enum):
-    """Tri-state health of the vision runtime (``mlx-vlm`` + its deps).
+    """Health of the vision runtime (``mlx-vlm`` + its dependencies).
 
     * ``OK`` — ``import mlx_vlm`` succeeds; vision paths are usable.
     * ``ABSENT`` — ``mlx-vlm`` is not installed at all (plain
@@ -186,11 +220,16 @@ class VisionRuntimeStatus(str, Enum):
       ``mlx_vlm.<sub>`` submodule, an incompatible symbol (``ImportError``),
       and a missing shared library (``OSError``/``RuntimeError``): all mean
       "installed but not loadable", never "absent".
+    * ``INCOMPATIBLE`` — the package imports, but its distribution version is
+      not the exact version validated with this Rapid-MLX release. Import
+      success is insufficient: mlx-vlm and Transformers are a coupled stack,
+      and an unbounded upgrade can make the next server boot fail.
     """
 
     OK = "ok"
     ABSENT = "absent"
     BROKEN = "broken"
+    INCOMPATIBLE = "incompatible"
 
 
 def _mlx_vlm_installed() -> bool:
@@ -248,6 +287,8 @@ def vision_runtime_status() -> tuple[VisionRuntimeStatus, str | None]:
     * ``(BROKEN, detail)`` — the package IS installed but its import chain
       raised; ``detail`` is always truthy (a missing-module name like
       ``PIL``, or an exception summary for an opaque failure).
+    * ``(INCOMPATIBLE, version)`` — import succeeded, but the installed
+      distribution does not match :data:`VALIDATED_MLX_VLM_VERSION`.
 
     We perform the REAL ``import mlx_vlm`` (not a bare ``find_spec`` /
     ``importlib.metadata.version`` probe) so a broken dependency chain
@@ -266,6 +307,12 @@ def vision_runtime_status() -> tuple[VisionRuntimeStatus, str | None]:
         if not _mlx_vlm_installed():
             return VisionRuntimeStatus.ABSENT, "mlx_vlm"
         return VisionRuntimeStatus.BROKEN, _broken_detail(exc)
+    try:
+        installed_version = version("mlx-vlm")
+    except PackageNotFoundError:
+        return VisionRuntimeStatus.BROKEN, "mlx-vlm version metadata unavailable"
+    if installed_version != VALIDATED_MLX_VLM_VERSION:
+        return VisionRuntimeStatus.INCOMPATIBLE, installed_version
     return VisionRuntimeStatus.OK, None
 
 
@@ -289,16 +336,14 @@ def _vlm_broken_install_hint(detail: str | None) -> str:
         pip_name = _pip_name_for_module(detail)
         return (
             f"`mlx-vlm` is installed but its dependency {detail!r} is not, so "
-            f"the vision runtime cannot load. Install the full vision stack:\n"
-            f"    pip install 'rapid-mlx[vision]'\n"
-            f"or just the missing piece:\n"
-            f"    pip install {pip_name}"
+            f"the vision runtime cannot load. {_vision_install_hint()}\n"
+            f"Alternatively, repair just the missing dependency in this "
+            f"runtime:\n    {sys.executable} -m pip install {pip_name}"
         )
     suffix = f" ({detail})" if detail else ""
     return (
         f"`mlx-vlm` is installed but its import chain is broken, so the "
-        f"vision runtime cannot load{suffix}. Reinstall the vision stack:\n"
-        f"    pip install --force-reinstall 'rapid-mlx[vision]'"
+        f"vision runtime cannot load{suffix}. {_vision_install_hint()}"
     )
 
 
@@ -341,7 +386,16 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
     status, detail = vision_runtime_status()
     if status is VisionRuntimeStatus.OK:
         return
-    if status is VisionRuntimeStatus.BROKEN:
+    if status is VisionRuntimeStatus.INCOMPATIBLE:
+        print(
+            f"error: model {model_name!r} requires the Rapid-MLX vision lane, "
+            f"but mlx-vlm {detail!r} is incompatible; this release validates "
+            f"exactly {VALIDATED_MLX_VLM_VERSION}. This is a vision-runtime "
+            f"compatibility error, not a Metal out-of-memory error.\n"
+            + _vision_install_hint(),
+            file=sys.stderr,
+        )
+    elif status is VisionRuntimeStatus.BROKEN:
         print(
             f"error: model {model_name!r} is a vision/multimodal alias, but "
             f"the vision runtime cannot load.\n" + _vlm_broken_install_hint(detail),
@@ -360,7 +414,7 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
     sys.exit(2)
 
 
-def _require_mlx_vlm() -> None:
+def _require_mlx_vlm(model_name: str | None = None) -> None:
     """Verify the vision runtime can load; raise actionable error if not.
 
     Engine-side last-line-of-defence: ``rapid-mlx serve`` is supposed
@@ -376,13 +430,21 @@ def _require_mlx_vlm() -> None:
     status, detail = vision_runtime_status()
     if status is VisionRuntimeStatus.OK:
         return
+    model_context = f" for model {model_name!r}" if model_name else ""
+    if status is VisionRuntimeStatus.INCOMPATIBLE:
+        raise ImportError(
+            f"Vision/multimodal runtime{model_context} is incompatible: "
+            f"installed mlx-vlm {detail!r}, validated version "
+            f"{VALIDATED_MLX_VLM_VERSION}. This is not a Metal "
+            "out-of-memory error.\n" + _vision_install_hint()
+        )
     if status is VisionRuntimeStatus.BROKEN:
         raise ImportError(
-            "Vision/multimodal models cannot load the vision runtime.\n"
-            + _vlm_broken_install_hint(detail)
+            f"Vision/multimodal models{model_context} cannot load the vision "
+            "runtime.\n" + _vlm_broken_install_hint(detail)
         )
     raise ImportError(
-        "Vision/multimodal models require the optional `mlx-vlm` "
+        f"Vision/multimodal models{model_context} require the optional `mlx-vlm` "
         "dependency.\n" + VLM_EXTRA_INSTALL_HINT
     )
 
@@ -1406,7 +1468,7 @@ class MLXMultimodalLM:
         if self._loaded:
             return
 
-        _require_mlx_vlm()
+        _require_mlx_vlm(self.model_name)
 
         try:
             # Stable Transformers does not yet register the processor used by

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -170,6 +170,11 @@ def _managed_desktop_runtime() -> bool:
     return _managed_desktop_runtime_kind() is not None
 
 
+def _managed_desktop_runtime_root() -> Path:
+    """Return the active sidecar root derived from its interpreter layout."""
+    return Path(sys.executable).resolve().parents[2]
+
+
 def _vision_install_hint() -> str:
     """Return a repair path that cannot accidentally target another Python.
 
@@ -180,10 +185,11 @@ def _vision_install_hint() -> str:
     """
     managed_kind = _managed_desktop_runtime_kind()
     if managed_kind == "runtime-override":
+        runtime_root = _managed_desktop_runtime_root()
         return (
             "Install the current Rapid-MLX Desktop.app first (its DMG ships a "
             "validated sidecar), then remove "
-            "~/Library/Application Support/Rapid/runtime-override/rapid-mlx "
+            f"{runtime_root} "
             "and relaunch so Desktop uses the bundled sidecar. Do not "
             "pip-install into the managed runtime override."
         )

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -163,7 +163,7 @@ def _managed_desktop_runtime_kind() -> str | None:
     if "/Library/Application Support/Rapid/runtime-override/" in executable:
         try:
             root = executable_path.parents[2]
-        except (IndexError, OSError):
+        except (IndexError, OSError):  # pragma: no cover - defensive Path guard
             return None
         if (
             executable_path.parent.name == "bin"
@@ -182,7 +182,11 @@ def _managed_desktop_runtime_kind() -> str | None:
             app_root = root.parents[2]
             with (app_root / "Contents" / "Info.plist").open("rb") as handle:
                 bundle_id = plistlib.load(handle).get("CFBundleIdentifier", "")
-        except (IndexError, OSError, plistlib.InvalidFileException):
+        except (  # pragma: no cover - individual filesystem failures tested via result
+            IndexError,
+            OSError,
+            plistlib.InvalidFileException,
+        ):
             return None
         if (
             executable_path.parent.name == "bin"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3487,6 +3487,26 @@ Examples:
     if args.mcp_config:
         os.environ["RAPID_MLX_MCP_CONFIG"] = args.mcp_config
 
+    # Parser/auto-config discovery below may resolve a subfolder checkpoint.
+    # Guard vision runtime compatibility before that can download its weights.
+    from .model_aliases import resolve_profile as _early_resolve_profile
+
+    _early_profile = _early_resolve_profile(args.model)
+    _early_generative_media = (
+        _early_profile is not None
+        and _early_profile.modality in ("image-gen", "video-gen")
+    )
+    _early_spec_decode = getattr(args, "spec_decode", "none") or "none"
+    if _early_spec_decode == "none" and getattr(args, "force_spec_decode", False):
+        _early_spec_decode = "auto"
+    if not _early_generative_media:
+        _preflight_vision_runtime(
+            args.model,
+            force_mllm=getattr(args, "mllm", False),
+            force_text=getattr(args, "no_mllm", False),
+            requested_spec_decode=_early_spec_decode,
+        )
+
     # Resolve checkpoint/profile metadata lazily and at most once for every
     # standalone-server default below. Cache admission is best-effort; parser,
     # PFlash, and TurboQuant retain their existing error policy when they are
@@ -3631,10 +3651,6 @@ Examples:
     ):
         _srv_requested_spec_decode = "auto"
     if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
-        _preflight_vision_runtime(
-            args.model,
-            requested_spec_decode=_srv_requested_spec_decode,
-        )
         _ensure_routing_config(args.model)
     _srv_is_mllm, _ = resolve_serving_lane(
         args.model,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1833,6 +1833,7 @@ def _preflight_vision_runtime(
         preflight_path = _prefetch_routing_metadata(model_name)
         from .model_metadata import (
             checkpoint_has_multimodal_weights,
+            config_indicates_multimodal,
             read_model_metadata,
         )
 
@@ -1846,7 +1847,16 @@ def _preflight_vision_runtime(
             )
             is True
         )
-    if not has_vision_weights:
+        # An unsharded cold checkpoint has no index/header available without
+        # downloading its sole weight file.  A VLM config plus an independently
+        # VLM-identifying repo/alias name is sufficient conservative evidence;
+        # a blandly named text-only fork remains inconclusive and is deferred.
+        has_named_vision_identity = bool(
+            metadata is not None
+            and config_indicates_multimodal(getattr(metadata, "config", None) or {})
+            and is_mllm_model(model_name)
+        )
+    if not has_vision_weights and not (not force_mllm and has_named_vision_identity):
         return
     decision = resolve_serving_lane_decision(
         preflight_path,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1666,11 +1666,6 @@ def _ensure_routing_config(model_name: str) -> None:
     """
     from .model_metadata import read_model_metadata
 
-    # Config already readable (warm cache / local checkpoint dir) -> the routing
-    # probe has real evidence; skip the prefetch so warm starts and the unit
-    # suite never download.
-    if read_model_metadata(model_name) is not None:
-        return
     # A local path the user pointed us at: trust their files. If a config is
     # genuinely absent the engine's own loader surfaces it with its own
     # message; we must not try to "download" a filesystem path.
@@ -1787,14 +1782,28 @@ def _resolve_serving_checkpoint(
             preflight_path = model_path
         else:
             preflight_path = _prefetch_routing_metadata(model_name)
-            preflight_decision = resolve_serving_lane_decision(
-                preflight_path,
-                vision_min_memory_gb=(
-                    profile.vision_min_memory_gb if profile is not None else None
-                ),
-                requested_spec_decode=requested_spec_decode,
+            # Config-only evidence is not enough to reject startup: a VLM-style
+            # config can wrap a text-only single-file fork.  Only a readable
+            # tensor index/header that positively proves multimodal weights is
+            # safe to act on before the complete checkpoint is materialized.
+            from .model_metadata import (
+                checkpoint_has_multimodal_weights,
+                read_model_metadata,
             )
-            preflight_is_mllm = getattr(preflight_decision, "is_mllm", False)
+
+            preflight_metadata = read_model_metadata(preflight_path)
+            preflight_is_mllm = bool(
+                preflight_metadata is not None
+                and checkpoint_has_multimodal_weights(
+                    (
+                        Path(preflight_metadata.snapshot_dir)
+                        if preflight_metadata.snapshot_dir is not None
+                        else None
+                    ),
+                    getattr(preflight_metadata, "config", None),
+                )
+                is True
+            )
         if preflight_is_mllm:
             from .models.mllm import _require_mlx_vlm
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1786,14 +1786,26 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     revision = getattr(info, "sha", None)
     if not revision:
         raise RuntimeError("HuggingFace metadata did not include a revision")
-    snapshot = snapshot_download(
-        repo_id,
-        revision=revision,
-        allow_patterns=[
-            f"{prefix}config.json",
-            f"{prefix}model.safetensors.index.json",
-        ],
-    )
+    try:
+        snapshot = snapshot_download(
+            repo_id,
+            revision=revision,
+            allow_patterns=[
+                f"{prefix}config.json",
+                f"{prefix}model.safetensors.index.json",
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 - mirror owns recovery, as above
+        if os.environ.get(
+            "RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com"
+        ).strip():
+            logger.warning(
+                "Could not download routing metadata from Hugging Face (%s); "
+                "continuing through the configured model mirror.",
+                exc,
+            )
+            return model_name
+        raise
     return str(Path(snapshot) / subfolder) if subfolder else str(snapshot)
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -39,7 +39,6 @@ import asyncio
 import gc
 import logging
 import os
-import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
@@ -1641,21 +1640,6 @@ def load_embedding_model(
     cfg.embedding_model_locked = _embedding_model_locked
 
 
-def _prefetch_routing_config(model_name: str) -> None:
-    """Download only checkpoint configuration needed for lane selection.
-
-    This deliberately excludes weight files. Runtime compatibility must be
-    decided before a first-time Desktop/direct launch downloads gigabytes of
-    tensors (#2860).
-    """
-    from huggingface_hub import snapshot_download
-
-    snapshot_download(
-        model_name,
-        allow_patterns=["config.json", "*/config.json"],
-    )
-
-
 def _ensure_routing_config(model_name: str) -> None:
     """Materialize the checkpoint config on disk before the offline routing
     probes run, and FAIL FAST if it cannot be materialized.
@@ -1670,13 +1654,14 @@ def _ensure_routing_config(model_name: str) -> None:
     - Already materialized (cached repo, a prior prefetch, or a local dir that
       ships a config) -> nothing to do; the probe is reliable. Fully offline
       and cheap, so warm starts and the unit suite never trigger a download.
-    - Otherwise fetch only ``config.json`` metadata, then VERIFY it actually
-      landed. If it did not, raise an
+    - Otherwise prefetch via the same canonical mirror/HF fetch the CLI uses,
+      then VERIFY the config actually landed. If it did not, raise an
       actionable error instead of letting the caller route on a guess — a
       silent miss here misroutes a hybrid VLM into the crashing MLLM lane.
 
-    The metadata prefetch is module-level so tests can substitute it to
-    simulate "config appears only after download" without touching weights.
+    A hard disk-space gate (``SystemExit``) from the prefetch is an intentional
+    fail-fast and propagates unchanged. Module-level so tests can substitute
+    the prefetch to simulate "config appears only after download".
     """
     from .model_metadata import read_model_metadata
 
@@ -1693,7 +1678,9 @@ def _ensure_routing_config(model_name: str) -> None:
 
     _prefetch_exc: Exception | None = None
     try:
-        _prefetch_routing_config(model_name)
+        from .cli import _ensure_model_downloaded
+
+        _ensure_model_downloaded(model_name)
     except SystemExit:
         # ``_ensure_model_downloaded`` may exit(1) on a hard disk-space gate —
         # that is an intentional fail-fast; let it propagate.
@@ -1701,13 +1688,6 @@ def _ensure_routing_config(model_name: str) -> None:
     except Exception as _e:  # noqa: BLE001 — preserved below, not swallowed
         _prefetch_exc = _e
         logger.debug("routing-config prefetch raised (will re-verify): %r", _e)
-        # This is the only user-visible event when offline mode prevents even
-        # the config-only fetch. Preserve the Hub's concrete cause instead of
-        # replacing it solely with the generic lane-selection error below.
-        print(
-            f"Routing metadata prefetch failed for {model_name!r}: {_e}",
-            file=sys.stderr,
-        )
 
     # VERIFY the prefetch actually put the config on disk. If it did not, the
     # routing probes would fall back to a guess and could misroute a hybrid VLM
@@ -1734,7 +1714,7 @@ def _ensure_routing_config(model_name: str) -> None:
         logger.warning(
             "routing-config prefetch for %r reported an error even though its "
             "config materialized; the model may be partially downloaded and "
-            "fail during later weight loading. Original error: %r",
+            "fail to load its weights later. Original error: %r",
             model_name,
             _prefetch_exc,
         )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -40,6 +40,7 @@ import gc
 import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import uvicorn
@@ -1731,6 +1732,31 @@ class _ServingCheckpoint:
     is_mllm: bool = False
 
 
+def _prefetch_routing_metadata(model_name: str) -> str:
+    """Return a config/index-only checkpoint path for pre-weight routing."""
+    if os.path.exists(model_name):
+        return model_name
+
+    from huggingface_hub import snapshot_download
+
+    from ._download_gate import _escape_variant_glob_literal, pulled_variant
+    from .model_aliases import resolve_model, resolve_subfolder
+
+    repo_id = resolve_model(model_name)
+    catalog_subfolder = resolve_subfolder(model_name)
+    explicit_subfolder = catalog_subfolder if model_name != repo_id else None
+    subfolder = explicit_subfolder or pulled_variant(repo_id) or catalog_subfolder
+    prefix = f"{_escape_variant_glob_literal(subfolder)}/" if subfolder else ""
+    snapshot = snapshot_download(
+        repo_id,
+        allow_patterns=[
+            f"{prefix}config.json",
+            f"{prefix}model.safetensors.index.json",
+        ],
+    )
+    return str(Path(snapshot) / subfolder) if subfolder else str(snapshot)
+
+
 def _resolve_serving_checkpoint(
     model_name: str,
     *,
@@ -1749,6 +1775,30 @@ def _resolve_serving_checkpoint(
     from .utils.tokenizer import _resolve_subfolder_checkpoint
 
     model_path = resolve_model(model_name)
+    profile = resolve_profile(model_name) or resolve_profile(model_path)
+    # Desktop/direct callers have no CLI boot guard. Fetch only lightweight
+    # routing evidence, decide the provisional lane, and reject an unusable
+    # vision runtime before the subfolder resolver or normal prefetch can pull
+    # model tensors. The final decision below is repeated after the complete
+    # checkpoint materializes so single-file weight evidence remains exact.
+    if not force_text:
+        if force_mllm:
+            preflight_is_mllm = True
+            preflight_path = model_path
+        else:
+            preflight_path = _prefetch_routing_metadata(model_name)
+            preflight_decision = resolve_serving_lane_decision(
+                preflight_path,
+                vision_min_memory_gb=(
+                    profile.vision_min_memory_gb if profile is not None else None
+                ),
+                requested_spec_decode=requested_spec_decode,
+            )
+            preflight_is_mllm = getattr(preflight_decision, "is_mllm", False)
+        if preflight_is_mllm:
+            from .models.mllm import _require_mlx_vlm
+
+            _require_mlx_vlm(preflight_path)
     # Resolve a multi-variant repository before reading metadata or choosing a
     # serving lane. This is the one checkpoint-identity choke point shared by
     # startup and residency: an explicit alias keeps its declared subfolder,
@@ -1769,7 +1819,6 @@ def _resolve_serving_checkpoint(
         if metadata is not None and metadata.snapshot_dir is not None
         else checkpoint_path
     )
-    profile = resolve_profile(model_name) or resolve_profile(model_path)
     decision = resolve_serving_lane_decision(
         load_path,
         force_mllm=force_mllm,
@@ -1856,6 +1905,21 @@ def load_model(
             model reaches ``AsyncEngineCore``. Default False keeps every
             existing caller's behavior unchanged.
     """
+    if force_mllm and force_text:
+        raise ValueError(
+            "force_mllm and force_text are mutually exclusive — "
+            "pick at most one to override auto-detection."
+        )
+    if force_hybrid and no_hybrid:
+        raise ValueError(
+            "force_hybrid and no_hybrid are mutually exclusive — "
+            "pick at most one to override auto-detection."
+        )
+    if force_spec_decode and no_spec_decode:
+        raise ValueError(
+            "force_spec_decode and no_spec_decode are mutually exclusive — "
+            "pick at most one to override auto-detection."
+        )
     max_tokens_was_supplied = max_tokens is not None
     if max_tokens is None:
         max_tokens = 32768
@@ -2174,21 +2238,6 @@ def load_model(
     except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders
         logger.debug(f"mxfp4/moe guardrail probe failed (non-fatal): {_e}")
 
-    if force_mllm and force_text:
-        raise ValueError(
-            "force_mllm and force_text are mutually exclusive — "
-            "pick at most one to override auto-detection."
-        )
-    if force_hybrid and no_hybrid:
-        raise ValueError(
-            "force_hybrid and no_hybrid are mutually exclusive — "
-            "pick at most one to override auto-detection."
-        )
-    if force_spec_decode and no_spec_decode:
-        raise ValueError(
-            "force_spec_decode and no_spec_decode are mutually exclusive — "
-            "pick at most one to override auto-detection."
-        )
     if force_openai_harmony_streaming and no_openai_harmony_streaming:
         raise ValueError(
             "force_openai_harmony_streaming and no_openai_harmony_streaming "

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -39,6 +39,7 @@ import asyncio
 import gc
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
@@ -1640,6 +1641,21 @@ def load_embedding_model(
     cfg.embedding_model_locked = _embedding_model_locked
 
 
+def _prefetch_routing_config(model_name: str) -> None:
+    """Download only checkpoint configuration needed for lane selection.
+
+    This deliberately excludes weight files. Runtime compatibility must be
+    decided before a first-time Desktop/direct launch downloads gigabytes of
+    tensors (#2860).
+    """
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        model_name,
+        allow_patterns=["config.json", "*/config.json"],
+    )
+
+
 def _ensure_routing_config(model_name: str) -> None:
     """Materialize the checkpoint config on disk before the offline routing
     probes run, and FAIL FAST if it cannot be materialized.
@@ -1654,14 +1670,13 @@ def _ensure_routing_config(model_name: str) -> None:
     - Already materialized (cached repo, a prior prefetch, or a local dir that
       ships a config) -> nothing to do; the probe is reliable. Fully offline
       and cheap, so warm starts and the unit suite never trigger a download.
-    - Otherwise prefetch via the same canonical mirror/HF fetch the CLI uses,
-      then VERIFY the config actually landed. If it did not, raise an
+    - Otherwise fetch only ``config.json`` metadata, then VERIFY it actually
+      landed. If it did not, raise an
       actionable error instead of letting the caller route on a guess — a
       silent miss here misroutes a hybrid VLM into the crashing MLLM lane.
 
-    A hard disk-space gate (``SystemExit``) from the prefetch is an intentional
-    fail-fast and propagates unchanged. Module-level so tests can substitute
-    the prefetch to simulate "config appears only after download".
+    The metadata prefetch is module-level so tests can substitute it to
+    simulate "config appears only after download" without touching weights.
     """
     from .model_metadata import read_model_metadata
 
@@ -1678,9 +1693,7 @@ def _ensure_routing_config(model_name: str) -> None:
 
     _prefetch_exc: Exception | None = None
     try:
-        from .cli import _ensure_model_downloaded
-
-        _ensure_model_downloaded(model_name)
+        _prefetch_routing_config(model_name)
     except SystemExit:
         # ``_ensure_model_downloaded`` may exit(1) on a hard disk-space gate —
         # that is an intentional fail-fast; let it propagate.
@@ -1688,6 +1701,13 @@ def _ensure_routing_config(model_name: str) -> None:
     except Exception as _e:  # noqa: BLE001 — preserved below, not swallowed
         _prefetch_exc = _e
         logger.debug("routing-config prefetch raised (will re-verify): %r", _e)
+        # This is the only user-visible event when offline mode prevents even
+        # the config-only fetch. Preserve the Hub's concrete cause instead of
+        # replacing it solely with the generic lane-selection error below.
+        print(
+            f"Routing metadata prefetch failed for {model_name!r}: {_e}",
+            file=sys.stderr,
+        )
 
     # VERIFY the prefetch actually put the config on disk. If it did not, the
     # routing probes would fall back to a guess and could misroute a hybrid VLM
@@ -1714,7 +1734,7 @@ def _ensure_routing_config(model_name: str) -> None:
         logger.warning(
             "routing-config prefetch for %r reported an error even though its "
             "config materialized; the model may be partially downloaded and "
-            "fail to load its weights later. Original error: %r",
+            "fail during later weight loading. Original error: %r",
             model_name,
             _prefetch_exc,
         )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1728,6 +1728,7 @@ class _ServingCheckpoint:
     load_path: str
     auto_text_fallback: bool
     lane_reason: str
+    is_mllm: bool = False
 
 
 def _resolve_serving_checkpoint(
@@ -1783,6 +1784,7 @@ def _resolve_serving_checkpoint(
         load_path=load_path,
         auto_text_fallback=decision.auto_text_fallback,
         lane_reason=decision.reason,
+        is_mllm=decision.is_mllm,
     )
 
 
@@ -2104,6 +2106,15 @@ def load_model(
         _engine_model_path = _serving_checkpoint.load_path
         _auto_text_fallback = _serving_checkpoint.auto_text_fallback
         _serving_lane_reason = _serving_checkpoint.lane_reason
+        # Desktop and direct ``server.load_model`` callers bypass cli.py's
+        # early optional-dependency guard. Enforce the same contract here,
+        # after metadata has selected the FINAL lane but before BatchedEngine
+        # can allocate model weights. A verified/explicit text lane does not
+        # need mlx-vlm; a vision lane must have the exact validated runtime.
+        if getattr(_serving_checkpoint, "is_mllm", False):
+            from .models.mllm import _require_mlx_vlm
+
+            _require_mlx_vlm(_serving_checkpoint.load_path)
 
     # A bare multi-variant repo has no useful config at its root. Resolve the
     # concrete checkpoint first, then derive every checkpoint-owned default
@@ -2446,6 +2457,14 @@ async def _load_dynamic_resident_model(
             profile_force_text or serving_checkpoint.auto_text_fallback
         )
         serving_lane_reason = serving_checkpoint.lane_reason
+        # Runtime residency is a second model-load entry point used by the
+        # Desktop control plane. Apply the same pre-weight vision guard as
+        # primary startup so a dynamically selected MLLM cannot become
+        # "ready" through a missing/broken/incompatible mlx-vlm stack.
+        if getattr(serving_checkpoint, "is_mllm", False):
+            from .models.mllm import _require_mlx_vlm
+
+            _require_mlx_vlm(serving_checkpoint.load_path)
     model_config = profile
     if model_config is None:
         from .model_auto_config import detect_model_config

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1787,7 +1787,9 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     if not revision:
         raise RuntimeError("HuggingFace metadata did not include a revision")
     try:
-        snapshot = snapshot_download(
+        snapshot = call_with_deadline(
+            snapshot_download,
+            _HF_RESOLVE_TIMEOUT_SECONDS,
             repo_id,
             revision=revision,
             allow_patterns=[

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1782,6 +1782,57 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     return str(Path(snapshot) / subfolder) if subfolder else str(snapshot)
 
 
+def _preflight_vision_runtime(
+    model_name: str,
+    *,
+    force_mllm: bool = False,
+    force_text: bool = False,
+    requested_spec_decode: str = "none",
+) -> None:
+    """Reject a proven vision lane before materializing model weights."""
+    if force_text or requested_spec_decode not in (None, "none"):
+        return
+
+    from .model_aliases import resolve_model, resolve_profile
+
+    model_path = resolve_model(model_name)
+    profile = resolve_profile(model_name) or resolve_profile(model_path)
+    if force_mllm:
+        preflight_path = model_path
+        has_vision_weights = True
+    else:
+        preflight_path = _prefetch_routing_metadata(model_name)
+        from .model_metadata import (
+            checkpoint_has_multimodal_weights,
+            read_model_metadata,
+        )
+
+        metadata = read_model_metadata(preflight_path)
+        snapshot_dir = getattr(metadata, "snapshot_dir", None)
+        has_vision_weights = bool(
+            metadata is not None
+            and checkpoint_has_multimodal_weights(
+                Path(snapshot_dir) if snapshot_dir is not None else None,
+                getattr(metadata, "config", None),
+            )
+            is True
+        )
+    if not has_vision_weights:
+        return
+    decision = resolve_serving_lane_decision(
+        preflight_path,
+        force_mllm=force_mllm,
+        vision_min_memory_gb=(
+            profile.vision_min_memory_gb if profile is not None else None
+        ),
+        requested_spec_decode=requested_spec_decode,
+    )
+    if getattr(decision, "is_mllm", False):
+        from .models.mllm import _require_mlx_vlm
+
+        _require_mlx_vlm(preflight_path)
+
+
 def _resolve_serving_checkpoint(
     model_name: str,
     *,
@@ -1800,55 +1851,17 @@ def _resolve_serving_checkpoint(
     from .utils.tokenizer import _resolve_subfolder_checkpoint
 
     model_path = resolve_model(model_name)
-    profile = resolve_profile(model_name) or resolve_profile(model_path)
     # Desktop/direct callers have no CLI boot guard. Fetch only lightweight
     # routing evidence, decide the provisional lane, and reject an unusable
     # vision runtime before the subfolder resolver or normal prefetch can pull
     # model tensors. The final decision below is repeated after the complete
     # checkpoint materializes so single-file weight evidence remains exact.
-    if not force_text and requested_spec_decode in (None, "none"):
-        if force_mllm:
-            preflight_path = model_path
-            preflight_has_vision_weights = True
-        else:
-            preflight_path = _prefetch_routing_metadata(model_name)
-            # Config-only evidence is not enough to reject startup: a VLM-style
-            # config can wrap a text-only single-file fork.  Only a readable
-            # tensor index/header that positively proves multimodal weights is
-            # safe to act on before the complete checkpoint is materialized.
-            from .model_metadata import (
-                checkpoint_has_multimodal_weights,
-                read_model_metadata,
-            )
-
-            preflight_metadata = read_model_metadata(preflight_path)
-            preflight_has_vision_weights = bool(
-                preflight_metadata is not None
-                and checkpoint_has_multimodal_weights(
-                    (
-                        Path(preflight_metadata.snapshot_dir)
-                        if preflight_metadata.snapshot_dir is not None
-                        else None
-                    ),
-                    getattr(preflight_metadata, "config", None),
-                )
-                is True
-            )
-        if preflight_has_vision_weights:
-            preflight_decision = resolve_serving_lane_decision(
-                preflight_path,
-                force_mllm=force_mllm,
-                vision_min_memory_gb=(
-                    profile.vision_min_memory_gb if profile is not None else None
-                ),
-                requested_spec_decode=requested_spec_decode,
-            )
-        if preflight_has_vision_weights and getattr(
-            preflight_decision, "is_mllm", False
-        ):
-            from .models.mllm import _require_mlx_vlm
-
-            _require_mlx_vlm(preflight_path)
+    _preflight_vision_runtime(
+        model_name,
+        force_mllm=force_mllm,
+        force_text=force_text,
+        requested_spec_decode=requested_spec_decode,
+    )
     # Resolve a multi-variant repository before reading metadata or choosing a
     # serving lane. This is the one checkpoint-identity choke point shared by
     # startup and residency: an explicit alias keeps its declared subfolder,
@@ -1869,6 +1882,7 @@ def _resolve_serving_checkpoint(
         if metadata is not None and metadata.snapshot_dir is not None
         else checkpoint_path
     )
+    profile = resolve_profile(model_name) or resolve_profile(model_path)
     decision = resolve_serving_lane_decision(
         load_path,
         force_mllm=force_mllm,
@@ -3611,13 +3625,17 @@ Examples:
     )
     _srv_force_mllm = getattr(args, "mllm", False)
     _srv_force_text = getattr(args, "no_mllm", False)
-    if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
-        _ensure_routing_config(args.model)
     _srv_requested_spec_decode = getattr(args, "spec_decode", "none") or "none"
     if _srv_requested_spec_decode == "none" and getattr(
         args, "force_spec_decode", False
     ):
         _srv_requested_spec_decode = "auto"
+    if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
+        _preflight_vision_runtime(
+            args.model,
+            requested_spec_decode=_srv_requested_spec_decode,
+        )
+        _ensure_routing_config(args.model)
     _srv_is_mllm, _ = resolve_serving_lane(
         args.model,
         force_mllm=_srv_force_mllm,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1784,7 +1784,7 @@ def _resolve_serving_checkpoint(
         load_path=load_path,
         auto_text_fallback=decision.auto_text_fallback,
         lane_reason=decision.reason,
-        is_mllm=decision.is_mllm,
+        is_mllm=getattr(decision, "is_mllm", False),
     )
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1737,6 +1737,7 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     from ._download_gate import (
         _HF_RESOLVE_TIMEOUT_SECONDS,
         _escape_variant_glob_literal,
+        _snapshot_is_complete,
         call_with_deadline,
         pulled_variant,
     )
@@ -1748,6 +1749,16 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     # huggingface_hub as though it were a repository identifier.
     if os.path.exists(repo_id):
         return repo_id
+    # Warm/offline starts must never require a Hub round trip.  Reuse only a
+    # verified-complete snapshot here; a metadata-only or interrupted snapshot
+    # must continue to the bounded online resolution below.
+    from .model_metadata import read_model_metadata
+
+    for candidate in (model_name, repo_id):
+        cached = read_model_metadata(candidate)
+        cached_dir = getattr(cached, "snapshot_dir", None)
+        if cached_dir is not None and _snapshot_is_complete(str(cached_dir)):
+            return str(cached_dir)
     catalog_subfolder = resolve_subfolder(model_name)
     explicit_subfolder = catalog_subfolder if model_name != repo_id else None
     subfolder = explicit_subfolder or pulled_variant(repo_id) or catalog_subfolder
@@ -1797,8 +1808,8 @@ def _resolve_serving_checkpoint(
     # checkpoint materializes so single-file weight evidence remains exact.
     if not force_text and requested_spec_decode in (None, "none"):
         if force_mllm:
-            preflight_is_mllm = True
             preflight_path = model_path
+            preflight_has_vision_weights = True
         else:
             preflight_path = _prefetch_routing_metadata(model_name)
             # Config-only evidence is not enough to reject startup: a VLM-style
@@ -1811,7 +1822,7 @@ def _resolve_serving_checkpoint(
             )
 
             preflight_metadata = read_model_metadata(preflight_path)
-            preflight_is_mllm = bool(
+            preflight_has_vision_weights = bool(
                 preflight_metadata is not None
                 and checkpoint_has_multimodal_weights(
                     (
@@ -1823,7 +1834,18 @@ def _resolve_serving_checkpoint(
                 )
                 is True
             )
-        if preflight_is_mllm:
+        if preflight_has_vision_weights:
+            preflight_decision = resolve_serving_lane_decision(
+                preflight_path,
+                force_mllm=force_mllm,
+                vision_min_memory_gb=(
+                    profile.vision_min_memory_gb if profile is not None else None
+                ),
+                requested_spec_decode=requested_spec_decode,
+            )
+        if preflight_has_vision_weights and getattr(
+            preflight_decision, "is_mllm", False
+        ):
             from .models.mllm import _require_mlx_vlm
 
             _require_mlx_vlm(preflight_path)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1763,11 +1763,26 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     explicit_subfolder = catalog_subfolder if model_name != repo_id else None
     subfolder = explicit_subfolder or pulled_variant(repo_id) or catalog_subfolder
     prefix = f"{_escape_variant_glob_literal(subfolder)}/" if subfolder else ""
-    info = call_with_deadline(
-        model_info,
-        _HF_RESOLVE_TIMEOUT_SECONDS,
-        repo_id,
-    )
+    try:
+        info = call_with_deadline(
+            model_info,
+            _HF_RESOLVE_TIMEOUT_SECONDS,
+            repo_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - canonical mirror path owns recovery
+        # A configured R2/custom mirror can be healthy while Hugging Face is
+        # blocked.  Do not let this optional lightweight probe preempt the
+        # canonical downloader's mirror-first recovery path.
+        if os.environ.get(
+            "RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com"
+        ).strip():
+            logger.warning(
+                "Could not prefetch routing metadata from Hugging Face (%s); "
+                "continuing through the configured model mirror.",
+                exc,
+            )
+            return model_name
+        raise
     revision = getattr(info, "sha", None)
     if not revision:
         raise RuntimeError("HuggingFace metadata did not include a revision")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1732,18 +1732,37 @@ def _prefetch_routing_metadata(model_name: str) -> str:
     if os.path.exists(model_name):
         return model_name
 
-    from huggingface_hub import snapshot_download
+    from huggingface_hub import model_info, snapshot_download
 
-    from ._download_gate import _escape_variant_glob_literal, pulled_variant
+    from ._download_gate import (
+        _HF_RESOLVE_TIMEOUT_SECONDS,
+        _escape_variant_glob_literal,
+        call_with_deadline,
+        pulled_variant,
+    )
     from .model_aliases import resolve_model, resolve_subfolder
 
     repo_id = resolve_model(model_name)
+    # External-model roots resolve a Hub-shaped display name to a local path.
+    # Preserve that supported in-place load instead of handing the path back to
+    # huggingface_hub as though it were a repository identifier.
+    if os.path.exists(repo_id):
+        return repo_id
     catalog_subfolder = resolve_subfolder(model_name)
     explicit_subfolder = catalog_subfolder if model_name != repo_id else None
     subfolder = explicit_subfolder or pulled_variant(repo_id) or catalog_subfolder
     prefix = f"{_escape_variant_glob_literal(subfolder)}/" if subfolder else ""
+    info = call_with_deadline(
+        model_info,
+        _HF_RESOLVE_TIMEOUT_SECONDS,
+        repo_id,
+    )
+    revision = getattr(info, "sha", None)
+    if not revision:
+        raise RuntimeError("HuggingFace metadata did not include a revision")
     snapshot = snapshot_download(
         repo_id,
+        revision=revision,
         allow_patterns=[
             f"{prefix}config.json",
             f"{prefix}model.safetensors.index.json",
@@ -1776,7 +1795,7 @@ def _resolve_serving_checkpoint(
     # vision runtime before the subfolder resolver or normal prefetch can pull
     # model tensors. The final decision below is repeated after the complete
     # checkpoint materializes so single-file weight evidence remains exact.
-    if not force_text:
+    if not force_text and requested_spec_decode in (None, "none"):
         if force_mllm:
             preflight_is_mllm = True
             preflight_path = model_path

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3530,7 +3530,10 @@ Examples:
         _preflight_vision_runtime(
             args.model,
             force_mllm=getattr(args, "mllm", False),
-            force_text=getattr(args, "no_mllm", False),
+            force_text=(
+                getattr(args, "no_mllm", False)
+                or bool(_early_profile is not None and _early_profile.is_text_only)
+            ),
             requested_spec_decode=_early_spec_decode,
         )
 


### PR DESCRIPTION
## Summary

- resolve the final multimodal/text serving lane before model weight loading, then enforce the same vision-runtime preflight for CLI, Desktop startup, direct server callers, and dynamic residency loads
- classify missing, broken, and incompatible `mlx-vlm` installations with actionable diagnostics; pin repair guidance to the active interpreter and direct managed Desktop runtimes to repair/reinstall instead of mutating the sidecar
- preserve explicit and verified text-only lanes without requiring `mlx-vlm`, and distinguish runtime compatibility failures from Metal OOM

## Tests

- `uv run --no-sync pytest -q tests/test_vision_runtime_compatibility.py tests/test_vision_runtime_detection.py tests/test_vision_extra_install.py tests/test_no_mllm_flag.py tests/test_server_load_model_order.py tests/test_sidecar_vision_smoke.py` (116 passed)
- `uv run --no-sync ruff check vllm_mlx/models/mllm.py vllm_mlx/server.py tests/test_vision_runtime_compatibility.py tests/test_server_load_model_order.py`
- `uv run --no-sync ruff format --check vllm_mlx/models/mllm.py vllm_mlx/server.py tests/test_vision_runtime_compatibility.py tests/test_server_load_model_order.py`
- `git diff --check`

Closes #2860