### PR TITLE
chore: bump version to 0.13.3

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,47 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.3] — 2026-08-31
+
+Rapid-MLX 0.13.3 adds production-safe GLM-5.3-Flash serving, reuses text
+prefixes on hybrid vision models, and improves Desktop navigation, video-job
+recovery, streaming presentation, and failure diagnosis.
+
+### Added
+
+- **GLM-5.3-Flash runs locally through the normal serving path.** The new
+  `glm5.3-flash-4bit` alias includes the processor, quantization, image-layout,
+  and runtime compatibility needed for text and multimodal requests. The
+  qualified 4-bit checkpoint decoded a sustained 512-token response at a
+  median 29.2 tok/s on an M3 Ultra and requires the 192 GB memory tier.
+- **Desktop commands are easier to reach.** A native command palette exposes
+  common actions from the keyboard, completed interactions can offer a
+  lightweight feedback entry, and failure diagnostics have a direct shortcut.
+
+### Changed
+
+- **Hybrid vision conversations reuse eligible text prefixes.** Repeated
+  text-only phases on the multimodal lane retain compatible prefix state
+  instead of recomputing it, while media-bearing requests continue through
+  their validated vision path.
+- **Large-model performance claims are reproducible.** The README now links
+  exact M3 Ultra workloads, checkpoint revisions, memory measurements, and
+  ordinary-versus-MTP results for Qwen3.8 and GLM-5.3-Flash.
+- GUI regression coverage begins moving deterministic journeys into the Swift
+  test process, shortening the expensive hosted-Mac merge lane without
+  dropping the accessibility contracts those journeys enforce.
+
+### Fixed
+
+- Completed video jobs survive server restarts, and video capabilities are
+  available before a model is loaded so clients can reject unsupported work
+  early.
+- Model pickers stay scoped to the active task, streaming Markdown reveals
+  smoothly, and packaged Desktop builds can recover the engine after a failed
+  post-DMG installation.
+- Native XCUITest bootstrap and merge-queue dependency evidence are more
+  reliable, reducing false release blocks without weakening required checks.
+
 ## [0.13.2] — 2026-08-30
 
 Rapid-MLX 0.13.2 makes long-running local assistants faster and more reliable,
@@ -3614,7 +3655,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.3...HEAD
+[0.13.3]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...rapid-mac-v0.13.3
 [0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...rapid-mac-v0.13.2
 [0.13.2-rc1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2-rc1
 [0.13.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.0...rapid-mac-v0.13.1

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.2</string>
+	<string>0.13.3</string>
 	<key>CFBundleVersion</key>
-	<string>168</string>
+	<string>169</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.13.3.md
+++ b/docs/release-notes/v0.13.3.md
@@ -1,0 +1,57 @@
+# Rapid-MLX 0.13.3
+
+Rapid-MLX 0.13.3 brings GLM-5.3-Flash to the production serving path, makes
+hybrid multimodal conversations reuse eligible text prefixes, and improves the
+Desktop workflows around navigation, video generation, streaming output, and
+failure recovery.
+
+## Highlights
+
+### GLM-5.3-Flash support
+
+Use `glm5.3-flash-4bit` from the CLI, OpenAI-compatible server, or Desktop. The
+release includes the processor and runtime compatibility required by the
+checkpoint, preserves explicit image-channel layouts, rejects malformed media
+before model execution, and keeps speculative decoding disabled because its
+qualification run did not improve throughput.
+
+On a 256 GB M3 Ultra, the qualified 4-bit checkpoint decoded a sustained
+512-token response at a median **29.2 tok/s** and used 165.4 GB of active MLX
+memory. The alias therefore requires the **192 GB** memory tier. The README's
+benchmark link records the exact checkpoint revision, request payload, and
+reproduction command.
+
+### Faster repeated work on hybrid vision models
+
+Compatible text-only phases on a hybrid multimodal lane can reuse their text
+prefix state instead of recomputing it. Cache identity includes the rendered
+request and model state, while media-bearing requests continue through the
+validated vision path. This improves repeated background and conversation work
+without treating an image request as a text-only cache hit.
+
+### Desktop workflow improvements
+
+- A native command palette makes common actions available from the keyboard.
+- Completed interactions can expose a lightweight feedback entry, while a
+  direct diagnostics shortcut makes failures easier to investigate.
+- Model pickers remain scoped to the active task instead of leaking selection
+  state across unrelated surfaces.
+- Streaming Markdown presentation is smoother and remains live when a window
+  is restored away from an attached display.
+
+### More resilient video and release workflows
+
+Completed video jobs persist across server restarts, and clients can inspect
+video capabilities before loading a model. Packaged Desktop builds can recover
+the engine after a failed post-DMG installation. The merge lane also gains a
+more reliable native-test bootstrap, dependency-bound evidence, and a faster
+in-process accessibility journey without reducing required coverage.
+
+## Upgrade
+
+```bash
+pip install -U rapid-mlx
+```
+
+Homebrew follows the PyPI release through its normal autobump process. Desktop
+users receive the signed and notarized update through the production appcast.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.2"
+version = "0.13.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut Rapid-MLX 0.13.3 from the immutable release boundary at `4c03e3dd1cbf927dc06733125c1dcc44da082099` after the required GLM-5.3-Flash implementation, reproducible benchmark documentation, and CI acceleration pilot landed.

## Scope

- bump the Python package version to 0.13.3
- bump Desktop marketing version to 0.13.3 and build number to 169
- add curated 0.13.3 Desktop changelog and release notes
- advance changelog comparison links to the 0.13.3 tags

## Non-goals

- no engine, server, or Desktop behavior changes
- no release publication from this PR itself
- no commits after the pinned release boundary

## Acceptance criteria

- engine and Desktop versions agree on 0.13.3
- release-note inputs and exact bump subject pass preflight validation
- release smoke imports every published Python surface
- required exact-head checks are green and the PR is 0-behind before merge

## Verification

- `make release-smoke`
- `python3 scripts/check_version_sync.py`
- `python3 scripts/validate_release_subject.py --subject 'chore: bump version to 0.13.3'`
- `python3 scripts/check_release_notes.py --version 0.13.3 --changelog apps/rapid-mac/CHANGELOG.md --notes-dir docs/release-notes`
- `python3 -m pytest -q tests/test_version_sync.py tests/test_check_release_notes.py` (43 passed)
- `bash tests/release/test_build_release_notes.sh` (63 passed)
- `git diff --check`


Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/33453222465