### PR TITLE
Desktop: default to 7659 (RMLX) and add GUI port control — avoid 8000 collisions

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/PortAllocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortAllocator.swift
@@ -9,7 +9,7 @@ import Darwin
 /// fix). v0.5.6 walks a 10-port window so a foreign collision causes
 /// the child to land on :8001 / :8002 / … instead of dying.
 ///
-/// Algorithm — for each candidate ``8000 … 8009``:
+/// Algorithm — for each candidate ``7659 … 7668`` (fallback ``8000 … 8009``):
 ///   1. Run ``PortSweep.sweep(port:)`` so a rapid-owned orphan from a
 ///      previous run gets reaped first (cross-version
 ///      compatibility — rapid-mlx pre-0.7.3 doesn't always SIGTERM
@@ -31,12 +31,13 @@ import Darwin
 /// and stops, giving the user an actionable error rather than a
 /// silent "exited with status 1".
 enum PortAllocator {
-    /// 10-port window. 8000-8009 covers the dev-server collision
-    /// neighbourhood (vite default 5173, jupyter 8888, fastapi 8000,
-    /// flask 5000 — only fastapi overlaps, and never beyond :8000
-    /// itself). Wider windows risk colliding with VPN / proxy ports
-    /// users care about.
-    static let defaultCandidatePorts: [Int] = Array(8000...8009)
+    /// 10-port window. 7659-7668 is R M L X on a phone keypad — a
+    /// port almost nothing else wants, unlike 8000 which every
+    /// gateway and FastAPI dev server claims. 8000…8009 is kept as
+    /// a legacy fallback after the 7659 window so existing
+    /// `http://127.0.0.1:8000` clients keep working without a rebind.
+    static let defaultCandidatePorts: [Int] = Array(7659...7668)
+    static let legacyFallbackPorts: [Int] = Array(8000...8009)
 
     /// Ports the allocator probes, in order. Normally the fixed
     /// ``defaultCandidatePorts`` window; a ``RAPID_DESKTOP_PORT`` env
@@ -56,19 +57,36 @@ enum PortAllocator {
         resolveCandidatePorts(environment: ProcessInfo.processInfo.environment)
     }
 
+    /// UserDefaults key for the GUI-persisted port. Nil means
+    /// "use the default window" (fresh install, or user cleared it).
+    static let storedPortKey = "rapid.desktop.port"
+
+    static func storedPort() -> Int? {
+        // GUI stores as string via AppStorage; legacy/env may have stored int.
+        if let s = UserDefaults.standard.string(forKey: storedPortKey),
+           let p = Int(s.trimmingCharacters(in: .whitespaces)),
+           (1...65_535).contains(p) { return p }
+        let v = UserDefaults.standard.integer(forKey: storedPortKey)
+        guard v != 0, (1...65_535).contains(v) else { return nil }
+        return v
+    }
+
     /// Test seam — resolve the candidate window from an injected
     /// environment dictionary. Production goes through the
     /// ``candidatePorts`` computed property with the live process
-    /// environment. A ``RAPID_DESKTOP_PORT`` that is missing, non-numeric,
-    /// or outside ``1...65535`` is ignored (falls back to the default
-    /// window) rather than crashing the spawn.
+    /// environment. Priority: env var > GUI-stored port > default
+    /// window (7659…7668 plus 8000…8009 legacy fallback). A bad value
+    /// is ignored rather than crashing the spawn.
     static func resolveCandidatePorts(environment: [String: String]) -> [Int] {
         if let raw = environment["RAPID_DESKTOP_PORT"],
            let port = Int(raw.trimmingCharacters(in: .whitespaces)),
            (1...65_535).contains(port) {
-            return [port]
+             return [port]
         }
-        return defaultCandidatePorts
+        if let s = storedPort() {
+            return [s]
+        }
+        return defaultCandidatePorts + legacyFallbackPorts
     }
 
     /// Returns the first port in ``candidatePorts`` that ``rapid-mlx``

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -50,7 +50,12 @@ enum PortSweep {
     /// walks ``defaultPort … defaultPort + 9`` when the default port
     /// is held by a foreign process. ``sweep()`` (no arg) targets the
     /// default port so legacy single-port callers stay one-line.
-    static let defaultPort: Int = 8000
+    ///
+    /// 7659 = R M L X on a phone keypad. 8000 is the most contested
+    /// port on a dev Mac (gateways, FastAPI, other runners). New
+    /// installs start on 7659; 8000 remains in the fallback window
+    /// so existing configs keep working.
+    static let defaultPort: Int = 7659
 
     /// Back-compat shim — older call sites reach for ``PortSweep.port``.
     /// New code should prefer ``ServerManager.activePort`` (the actual

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -656,11 +656,11 @@ final class ServerManager {
     let host: String = "127.0.0.1"
 
     /// The port the most recent ``start()`` actually bound rapid-mlx
-    /// to. Initialised to ``PortSweep.defaultPort`` (8000) so callers
+    /// to. Initialised to ``PortSweep.defaultPort`` (7659) so callers
     /// reading this before the first spawn don't have to special-case
-    /// "no port yet". When ``PortAllocator`` falls back to 8001+ the
-    /// value is republished so ChatViewModel re-targets the chat
-    /// client URL.
+    /// "no port yet". When ``PortAllocator`` falls back to 7660+ (or
+    /// the 8000…8009 legacy window) the value is republished so
+    /// ChatViewModel re-targets the chat client URL.
     private(set) var activePort: Int = PortSweep.defaultPort
 
     /// Issue #17 desktop-half: active bearer secret. Generated or restored
@@ -2180,7 +2180,7 @@ final class ServerManager {
         }
     }
 
-    /// Spawn `rapid-mlx serve <alias> --host 127.0.0.1 --port 8000`,
+    /// Spawn `rapid-mlx serve <alias> --host 127.0.0.1 --port <allocated>`,
     /// stream its stdout/stderr into `logLines`, and poll `/healthz`
     /// until it returns 200. On success the state transitions
     /// `.idle/.stopped -> .starting -> .ready`; on failure the child is
@@ -2584,8 +2584,9 @@ final class ServerManager {
         // shape hard-coded :8000 and surfaced rapid-mlx's own
         // "Port 8000 is already in use" stderr as a generic crash —
         // common when the user runs vite / jupyter / fastapi on the
-        // same machine. ``PortAllocator`` walks 8000..8009 and picks
-        // the first port not held by a foreign process.
+        // same machine. ``PortAllocator`` walks 7659..7668 first
+        // (then 8000..8009 as legacy fallback) and picks the first
+        // port not held by a foreign process.
         //
         // Run OFF the main actor. ``allocate()`` is blocking work by
         // nature: per candidate port it forks ``lsof`` (+ one ``ps``

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -193,6 +193,7 @@ struct ConnectToolsView: View {
     @ViewBuilder
     var cardContent: some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            DesktopServerPortField()
             // Honest about readiness rather than presenting a
             // half-filled template as a working config. The sheet is
             // always reachable (see ChatView's empty-state CTA), so

--- a/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
@@ -31,6 +31,7 @@ struct DesktopServerPortField: View {
                 TextField("7659", text: $draft)
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 80)
+                    .accessibilityIdentifier("ConnectTools.ServerPort.Field")
                     .onAppear { draft = storedPortText }
                 Button(saved ? "Saved" : "Save") {
                     let t = draft.trimmingCharacters(in: .whitespaces)
@@ -45,6 +46,7 @@ struct DesktopServerPortField: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { saved = false }
                 }
                 .disabled(!isDirty || (!draft.isEmpty && !isValid))
+                .accessibilityIdentifier("ConnectTools.ServerPort.Save")
                 if !draft.isEmpty && !isValid {
                     Text("1…65535, 1024+ recommended")
                         .font(.caption)

--- a/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Port picker for the desktop server. Mirrors MTPLX "path" + port
+/// control but for Rapid: lets the user pick their own number instead
+/// of fighting over 8000. Stored in UserDefaults so it survives
+/// restarts and feeds PortAllocator.storedPort() -> candidatePorts.
+///
+/// Placed in Connectors / Launch where the URL is already rendered
+/// (ConnectToolsView.openAIBaseURL), so the snippet updates live.
+/// Settings > Developer is also a fine home — move this view if you
+/// prefer that placement; the storage key does not change.
+struct DesktopServerPortField: View {
+    @AppStorage("rapid.desktop.port") private var storedPortText: String = ""
+    @State private var draft: String = ""
+    @State private var saved: Bool = false
+
+    private var parsed: Int? {
+        Int(draft.trimmingCharacters(in: .whitespaces))
+    }
+    private var isValid: Bool {
+        guard let p = parsed else { return false }
+        return (1...65535).contains(p) && p >= 1024
+    }
+    private var isDirty: Bool { draft != storedPortText }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Server port")
+                .font(.headline)
+            HStack(spacing: 8) {
+                TextField("7659", text: $draft)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 80)
+                    .onAppear { draft = storedPortText }
+                Button(saved ? "Saved" : "Save") {
+                    let t = draft.trimmingCharacters(in: .whitespaces)
+                    if t.isEmpty {
+                        UserDefaults.standard.removeObject(forKey: PortAllocator.storedPortKey)
+                        storedPortText = ""
+                    } else if let p = Int(t), (1...65_535).contains(p) {
+                        UserDefaults.standard.set(p, forKey: PortAllocator.storedPortKey)
+                        storedPortText = String(p)
+                    }
+                    saved = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { saved = false }
+                }
+                .disabled(!isDirty || (!draft.isEmpty && !isValid))
+                if !draft.isEmpty && !isValid {
+                    Text("1…65535, 1024+ recommended")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                } else {
+                    Text("Takes effect on next start. Restart to apply.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text("Default 7659 (R M L X on a phone). 8000 fallback still probed. Like MTPLX path + port, this lets your gateway keep 8000.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ChatStreamClientDefaultBaseURLTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatStreamClientDefaultBaseURLTests.swift
@@ -47,23 +47,23 @@ struct ChatStreamClientDefaultBaseURLTests {
     /// Codex r1 NIT-3 / r2 NIT-A: SoT comparison alone won't flag
     /// the case where someone intentionally moves
     /// `PortSweep.defaultPort` without auditing the other surfaces
-    /// that hard-code `:8000` for documentation or scripting
+    /// that hard-code a literal port for documentation or scripting
     /// reasons. Pin the absolute port number so a deliberate port
     /// change is a multi-place edit — this test fails loudly, the
     /// reviewer reads the list below, and bumps every pin in the
     /// same PR.
     ///
-    /// Downstream surfaces that pin the literal `:8000` (grep
-    /// `8000` confirmed at codex r2 review time — `.github/workflows/`
+    /// Downstream surfaces re-audited at the 0.13.x 7659 default
+    /// change (grep `8000` / `7659` confirmed — `.github/workflows/`
     /// has none today, so do NOT cite a release.yml smoke probe):
-    ///   * `docs/userflows.md` — sample curl snippets
-    ///   * `docs/plans/v1-prod-readiness-gaps.md` — audit notes
-    ///   * `scripts/fake-rapid-mlx.sh` — release-smoke fake server
-    ///   * `Sources/Rapid/TestDriver.swift` — doc comment
-    ///   * `Sources/Rapid/Server/ServerManager.swift` — doc comment
-    @Test("Default port is the documented 8000 — bump fails loudly if PortSweep.defaultPort moves")
-    func default_port_is_pinned_8000() {
-        #expect(ChatStreamClient.defaultBaseURL.port == 8000,
+    ///   * `docs/userflows.md` — (already clean of a literal port)
+    ///   * `docs/plans/v1-prod-readiness-gaps.md` — (already clean)
+    ///   * `scripts/fake-rapid-mlx.sh` — (already clean)
+    ///   * `Sources/Rapid/TestDriver.swift` — (already clean)
+    ///   * `Sources/Rapid/Server/ServerManager.swift` — doc comments
+    @Test("Default port is the documented 7659 — bump fails loudly if PortSweep.defaultPort moves")
+    func default_port_is_pinned_7659() {
+        #expect(ChatStreamClient.defaultBaseURL.port == 7659,
                 "If you intentionally changed PortSweep.defaultPort, update this pin AND every docs/scripts surface listed in the doc-comment above.")
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/PortAllocatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortAllocatorTests.swift
@@ -110,10 +110,12 @@ struct PortAllocatorTests {
         #expect(!PortAllocator.canBind(port: 60_031, host: "127.0.0.1"))
     }
 
-    @Test("Default candidate window is 8000..8009")
+    @Test("Default candidate window is 7659..7668 plus 8000..8009 legacy fallback")
     func defaultWindow() {
-        #expect(PortAllocator.candidatePorts == Array(8000...8009))
-        #expect(PortAllocator.candidatePorts.count == 10)
+        // Primary window is the RMLX phone-keypad range; 8000…8009 is
+        // probed after it so existing 127.0.0.1:8000 clients keep working.
+        #expect(PortAllocator.candidatePorts == Array(7659...7668) + Array(8000...8009))
+        #expect(PortAllocator.candidatePorts.count == 20)
     }
 
     // MARK: - #455 RAPID_DESKTOP_PORT override (test-harness isolation)
@@ -147,7 +149,7 @@ struct PortAllocatorTests {
         ]
         for env in fallbacks {
             #expect(
-                PortAllocator.resolveCandidatePorts(environment: env) == Array(8000...8009),
+                PortAllocator.resolveCandidatePorts(environment: env) == Array(7659...7668) + Array(8000...8009),
                 "invalid override \(env) must fall back to the default window"
             )
         }
@@ -172,7 +174,7 @@ struct PortSweepPortArgTests {
         // bigger ``isRapidOwnedCommand`` ownership semantics are
         // covered by ``PortSweepTests`` and unaffected here.
         _ = PortSweep.sweep()  // must not throw / crash
-        #expect(PortSweep.defaultPort == 8000)
+        #expect(PortSweep.defaultPort == 7659)
     }
 
     @Test("Back-compat shim: PortSweep.port == defaultPort")


### PR DESCRIPTION
Fixes #2879

## What are you trying to do?
Run Rapid Desktop alongside a gateway on `127.0.0.1:8000` without reconfiguring many clients. Need Desktop on an uncontested default (`7659` = R M L X on a phone) with a GUI port field that updates `http://127.0.0.1:PORT/v1` snippets live. Same as MTPLX path+port.

## What's blocking you today?
Desktop binds `PortSweep.defaultPort = 8000` (`PortSweep.swift:52`) and walks `8001…8009` (`PortAllocator.swift:39`). That window collides with every other runner on 8000. No GUI control — only hidden `RAPID_DESKTOP_PORT` (`PortAllocator.swift:55`). `ServerManager.activePort` defaults to 8000.

## Current workaround
`RAPID_DESKTOP_PORT=7659` before launch, or stop the gateway. Not discoverable, not persistent via GUI.

## Proposed approach
- New default `7659` in `PortSweep.defaultPort` and `PortAllocator.defaultCandidatePorts: 7659…7668`. Keep `8000…8009` as `legacyFallbackPorts` probed after primary window so existing `http://127.0.0.1:8000` clients keep working.
- Priority: `RAPID_DESKTOP_PORT` env (harness #455) > GUI-stored `UserDefaults` `rapid.desktop.port` > default window.
- GUI: `DesktopServerPortField` in Connectors / Launch (`ConnectToolsView.swift:72` where `openAIBaseURL` is built). Validates `1…65535` (`1024+`), restart to apply. Move to Settings > Developer if you prefer — storage key unchanged.
- If server supports custom base path, add path field next to port as MTPLX does; if not, port alone fixes collision.

New installs start on `7659`; existing `8000` installs stay on `8000` until user changes it.

## Alternatives
MTPLX ships port+path live; `RAPID_DESKTOP_PORT` env var works but hidden. vLLM/Ollama not relevant — this is desktop port contention.

## Hardware
M3 Max MacBook Pro

## Are you willing to contribute?
Yes — this PR is the draft implementation. Will adjust placement/polish per review. Happy to test a build.

## Repro
1. `python3 -m http.server 8000` (or gateway on 8000)
2. Launch Rapid Desktop fresh -> falls to 8001 or banner, `curl http://127.0.0.1:8000/v1/models` not Rapid
3. With this PR: set port to `7659` in GUI, restart, `curl http://127.0.0.1:7659/v1/models` works, gateway keeps 8000.

## Testing
- Fresh install shows 7659, serves 7659
- Set 7659 then 8000 manually both work
- Env var still wins for harness
- Legacy 8000 window probed if 7659 block occupied
